### PR TITLE
feat: V0.2 — Zones + Equipment Groups (topology layer)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,757 @@
+# Corbel — Data Model
+
+> Version: 1.0 — 2026-02-19
+>
+> This document is the reference for Corbel's core data model. It describes the three-layer architecture (Topology → Functional → Physical), all entities, their relationships, and the aggregation rules.
+
+---
+
+## 1. Three-Layer Architecture
+
+Corbel separates concerns into three distinct layers:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  LAYER 1 — TOPOLOGY (Zones)                                 │
+│  Spatial structure of the home                               │
+│  Hierarchical: Home → Floor → Room                           │
+│  Aggregates data automatically from child Equipments         │
+├─────────────────────────────────────────────────────────────┤
+│  LAYER 2 — FUNCTIONAL (Equipments + Groups)                  │
+│  What the user sees and controls                             │
+│  Placed IN a Zone, optionally IN a Group                     │
+│  Binds to one or more physical Devices                       │
+├─────────────────────────────────────────────────────────────┤
+│  LAYER 3 — PHYSICAL (Devices)                                │
+│  Hardware on the MQTT network                                │
+│  Auto-discovered, raw data and commands                      │
+│  Never directly manipulated by the end user                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Guiding principle**: A Device is what's on the network. An Equipment is what's in the room.
+
+---
+
+## 2. Entity Relationship Diagram
+
+```
+Zone (hierarchy: parent → children)
+ │
+ ├── EquipmentGroup (optional functional grouping)
+ │    └── Equipment*
+ │
+ └── Equipment (functional unit, user-facing)
+      ├── DataBinding ──→ DeviceData (on a Device)
+      ├── OrderBinding ──→ DeviceOrder (on a Device)
+      └── [V0.5] ComputedData (expression-based virtual data)
+
+Device (physical, auto-discovered)
+ ├── DeviceData (readable properties: temperature, state, brightness…)
+ └── DeviceOrder (writable commands: set brightness, turn on…)
+```
+
+---
+
+## 3. Zone
+
+A **Zone** represents a spatial area in the home. Zones form a **tree hierarchy**.
+
+### 3.1 Interface
+
+```typescript
+interface Zone {
+  id: string;              // UUID v4
+  name: string;            // "Salon", "Étage 1", "Maison"
+  parentId: string | null; // null = root zone
+  icon?: string;           // Lucide icon name: "home", "sofa", "bed"
+  description?: string;    // "Pièce principale, 35m²"
+  displayOrder: number;    // Sort order among siblings (0-based)
+  createdAt: string;       // ISO 8601
+  updatedAt: string;       // ISO 8601
+}
+```
+
+### 3.2 Hierarchy
+
+Zones are nestable to any depth. Typical structure:
+
+```
+Maison                    (root, parentId: null)
+├── RDC                   (floor, parentId: Maison)
+│   ├── Salon             (room, parentId: RDC)
+│   ├── Cuisine           (room, parentId: RDC)
+│   ├── Entrée            (room, parentId: RDC)
+│   └── WC                (room, parentId: RDC)
+├── Étage                 (floor, parentId: Maison)
+│   ├── Chambre Parentale (room, parentId: Étage)
+│   ├── Chambre Enfant    (room, parentId: Étage)
+│   ├── Salle de Bain     (room, parentId: Étage)
+│   └── Couloir           (room, parentId: Étage)
+└── Extérieur             (area, parentId: Maison)
+    ├── Jardin            (area, parentId: Extérieur)
+    └── Garage            (area, parentId: Extérieur)
+```
+
+### 3.3 Zone Aggregated Data
+
+The engine **automatically computes** aggregated data for each Zone based on the Equipments it contains. No manual configuration required — this is a core feature.
+
+Aggregation is **recursive**: a parent Zone aggregates its own Equipments plus all children Zones.
+
+| Attribute | Type | Aggregation Rule | Source (DataCategory) | Description |
+|---|---|---|---|---|
+| `temperature` | number \| null | AVG | `temperature` | Average temperature in the zone |
+| `humidity` | number \| null | AVG | `humidity` | Average humidity |
+| `pressure` | number \| null | AVG | `pressure` | Average atmospheric pressure |
+| `luminosity` | number \| null | AVG | `luminosity` | Average luminosity (lux) |
+| `co2` | number \| null | AVG | `co2` | Average CO₂ level (ppm) |
+| `voc` | number \| null | AVG | `voc` | Average VOC level (ppb) |
+| `motion` | boolean | OR | `motion` | true if ANY motion sensor detects movement |
+| `presence` | boolean | OR + timeout | `motion` | true if motion detected within configurable timeout |
+| `openDoors` | number | COUNT (open) | `contact_door` | Number of open door contacts |
+| `openWindows` | number | COUNT (open) | `contact_window` | Number of open window contacts |
+| `waterLeak` | boolean | OR | `water_leak` | true if ANY water leak sensor triggers |
+| `smoke` | boolean | OR | `smoke` | true if ANY smoke detector triggers |
+| `lightsOn` | number | COUNT (on) | `light_state` | Number of lights turned on |
+| `lightsTotal` | number | COUNT (all) | `light_state` | Total number of light equipments |
+| `averageBrightness` | number \| null | AVG (on only) | `light_brightness` | Average brightness of lights that are on |
+| `shuttersOpen` | number | COUNT (open) | `shutter_position` | Number of open shutters |
+| `shuttersTotal` | number | COUNT (all) | `shutter_position` | Total number of shutters |
+| `averageShutterPosition` | number \| null | AVG | `shutter_position` | Average shutter position (%) |
+| `totalPower` | number | SUM | `power` | Total instantaneous power (W) |
+| `totalEnergy` | number | SUM | `energy` | Total energy consumption (kWh) |
+| `heatingActive` | boolean | OR | thermostat equipments | true if any thermostat is actively heating |
+| `targetTemperature` | number \| null | AVG | thermostat equipments | Average target temperature setpoint |
+
+> **Note**: This list will evolve. New aggregated attributes can be added as new Equipment types and DataCategories are introduced.
+
+### 3.4 Zone Auto-Orders
+
+Zones expose bulk commands that act on all Equipments within the zone (and child zones recursively):
+
+| Order | Effect |
+|---|---|
+| `allOff` | Turn off ALL controllable Equipments in the Zone |
+| `allLightsOff` | Turn off all light-type Equipments |
+| `allLightsOn` | Turn on all light-type Equipments |
+| `allShuttersOpen` | Open all shutters |
+| `allShuttersClose` | Close all shutters |
+
+### 3.5 SQLite Schema
+
+```sql
+CREATE TABLE zones (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  parent_id TEXT REFERENCES zones(id) ON DELETE SET NULL,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+---
+
+## 4. Equipment Group
+
+An **EquipmentGroup** is a functional grouping of Equipments within a Zone. It allows controlling and monitoring a subset of equipments together.
+
+### 4.1 Interface
+
+```typescript
+interface EquipmentGroup {
+  id: string;              // UUID v4
+  name: string;            // "Volets Sud", "Éclairage Ambiance"
+  zoneId: string;          // FK → Zone (a group belongs to exactly one zone)
+  icon?: string;           // Lucide icon name
+  description?: string;
+  displayOrder: number;    // Sort order within the zone
+  createdAt: string;       // ISO 8601
+  updatedAt: string;       // ISO 8601
+}
+```
+
+### 4.2 Purpose & Examples
+
+```
+Salon (Zone)
+├── Group "Volets Sud"
+│   ├── Volet Baie Vitrée          (Equipment: shutter)
+│   └── Volet Porte Fenêtre        (Equipment: shutter)
+├── Group "Volets Nord"
+│   └── Volet Fenêtre Nord         (Equipment: shutter)
+├── Group "Éclairage Ambiance"
+│   ├── Spots Plafond              (Equipment: dimmer)
+│   └── Lampe Canapé               (Equipment: dimmer)
+├── Détection Salon                (Equipment: motion_sensor, no group)
+└── Température Salon              (Equipment: sensor, no group)
+```
+
+**Key behaviors:**
+- An Equipment belongs to **at most one** Group (optional, via `groupId`)
+- A Group belongs to exactly one Zone
+- Groups have their own aggregated data (same rules as Zones, scoped to group members)
+- Groups can receive bulk orders (e.g., "close all shutters in Volets Sud")
+
+### 4.3 Group Aggregated Data
+
+Groups compute aggregated data using the **same rules** as Zones (§3.3), but scoped to the group's member Equipments only. This allows:
+
+- "Average shutter position of Volets Sud" vs "Average shutter position of Volets Nord"
+- "Number of lights on in Éclairage Ambiance" vs zone-wide count
+
+### 4.4 SQLite Schema
+
+```sql
+CREATE TABLE equipment_groups (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+---
+
+## 5. Equipment
+
+An **Equipment** is the user-facing functional unit. It's the primary entity users interact with in the UI, scenarios, and voice commands.
+
+### 5.1 Interface
+
+```typescript
+type EquipmentType =
+  | "light"            // on/off light
+  | "dimmer"           // dimmable light
+  | "color_light"      // color-capable light
+  | "shutter"          // cover, blind, shutter
+  | "thermostat"       // heating/cooling control
+  | "lock"             // door lock
+  | "alarm"            // alarm system
+  | "sensor"           // generic sensor (temp, humidity…)
+  | "motion_sensor"    // motion detector
+  | "contact_sensor"   // door/window contact
+  | "media_player"     // media device
+  | "camera"           // surveillance camera
+  | "switch"           // on/off switch or plug
+  | "generic";         // anything else
+
+interface Equipment {
+  id: string;                   // UUID v4
+  name: string;                 // "Spots Salon", "Volet Baie Vitrée"
+  zoneId: string;               // FK → Zone (where the equipment functions)
+  groupId: string | null;       // FK → EquipmentGroup (optional)
+  type: EquipmentType;          // Semantic type, drives UI rendering & aggregation
+  icon?: string;                // Lucide icon name (overrides type default)
+  description?: string;
+  enabled: boolean;             // Disabled equipments are ignored by the engine
+  createdAt: string;            // ISO 8601
+  updatedAt: string;            // ISO 8601
+}
+```
+
+### 5.2 Equipment vs Device
+
+| | Device | Equipment |
+|---|---|---|
+| **Nature** | Physical hardware | Functional abstraction |
+| **Discovery** | Auto-discovered from MQTT | Manually created by user |
+| **Identity** | IEEE address, MQTT topic | User-chosen name |
+| **Location** | Where physically installed | Where functionally used |
+| **Cardinality** | 1 Device → N Equipments possible | 1 Equipment → N Devices possible |
+| **User interaction** | Never (technical layer) | Always (primary interface) |
+
+**Examples:**
+- 1 Device → 1 Equipment: Aqara temperature sensor → "Température Salon"
+- 1 Device → N Equipments: Double relay module → "Lumière Cuisine" + "Lumière Cellier"
+- N Devices → 1 Equipment: 3 PIR sensors → "Détection Salon" (via computed data, V0.5)
+
+---
+
+## 6. Data Binding
+
+A **DataBinding** maps a Device Data property to an Equipment-level alias.
+
+### 6.1 Interface
+
+```typescript
+interface DataBinding {
+  id: string;              // UUID v4
+  equipmentId: string;     // FK → Equipment
+  deviceDataId: string;    // FK → DeviceData
+  alias: string;           // Equipment-level name: "state", "brightness", "temperature"
+}
+```
+
+### 6.2 How It Works
+
+```
+Device "Variateur Z2M #1"
+├── DeviceData: key="state", value="ON"        ←─┐
+├── DeviceData: key="brightness", value=180    ←──┼── DataBinding
+└── DeviceData: key="linkquality", value=85       │
+                                                   │
+Equipment "Spots Salon"                            │
+├── Data alias "state" ────────────────────────────┘ (bound to DeviceData "state")
+├── Data alias "brightness" ───────────────────────  (bound to DeviceData "brightness")
+└── [not bound to linkquality — it's a technical metric, not user-facing]
+```
+
+### 6.3 Constraints
+
+- `UNIQUE(equipment_id, alias)` — each alias is unique per Equipment
+- When DeviceData changes, the Equipment's bound alias reflects the new value immediately
+- The alias is used in expressions, UI display, Zone aggregation, and Scenario conditions
+
+### 6.4 SQLite Schema
+
+```sql
+CREATE TABLE data_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  device_data_id TEXT NOT NULL REFERENCES device_data(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL,
+  UNIQUE(equipment_id, alias)
+);
+```
+
+---
+
+## 7. Order Binding
+
+An **OrderBinding** maps a Device Order to an Equipment-level command alias.
+
+### 7.1 Interface
+
+```typescript
+interface OrderBinding {
+  id: string;              // UUID v4
+  equipmentId: string;     // FK → Equipment
+  deviceOrderId: string;   // FK → DeviceOrder
+  alias: string;           // Equipment-level command: "turn_on", "set_brightness"
+}
+```
+
+### 7.2 How It Works
+
+When an Equipment Order is executed:
+
+```
+User clicks "Turn On" on Equipment "Spots Salon"
+  → API: POST /equipments/:id/orders/turn_on { value: true }
+    → Equipment Manager finds OrderBinding alias="turn_on"
+      → Resolves to DeviceOrder (mqttSetTopic, payloadKey)
+        → MQTT publish: zigbee2mqtt/variateur_1/set {"state": "ON"}
+```
+
+### 7.3 Multi-Device Dispatch
+
+An Equipment can have multiple OrderBindings with the **same alias** pointing to different Devices. This enables controlling multiple devices with a single command:
+
+```
+Equipment "Éclairage Cuisine"
+├── OrderBinding: alias="turn_on" → DeviceOrder on Relais #1
+└── OrderBinding: alias="turn_on" → DeviceOrder on Relais #2
+```
+
+Executing `turn_on` dispatches to BOTH relays in parallel.
+
+**Schema constraint note:** For multi-device dispatch, the UNIQUE constraint is on `(equipment_id, alias, device_order_id)` — not just `(equipment_id, alias)`.
+
+### 7.4 SQLite Schema
+
+```sql
+CREATE TABLE order_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  device_order_id TEXT NOT NULL REFERENCES device_orders(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL,
+  UNIQUE(equipment_id, alias, device_order_id)
+);
+```
+
+---
+
+## 8. Device (Layer 3 — Physical)
+
+Devices are auto-discovered from MQTT. They are documented here for completeness — see V0.1 implementation for details.
+
+### 8.1 Interface
+
+```typescript
+interface Device {
+  id: string;                  // UUID v4
+  mqttBaseTopic: string;       // "zigbee2mqtt/0x00158d0001a2b3c4"
+  mqttName: string;            // "0x00158d0001a2b3c4" or friendly_name
+  name: string;                // User-editable display name
+  manufacturer?: string;       // "Aqara", "IKEA", "Sonoff"
+  model?: string;              // "MCCGQ11LM"
+  ieeeAddress?: string;        // Zigbee IEEE address
+  source: DeviceSource;        // "zigbee2mqtt" | "tasmota" | "esphome" | ...
+  status: DeviceStatus;        // "online" | "offline" | "unknown"
+  lastSeen: string | null;     // ISO 8601
+  rawExpose?: unknown;         // Raw zigbee2mqtt expose definition
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### 8.2 DeviceData
+
+```typescript
+interface DeviceData {
+  id: string;
+  deviceId: string;           // FK → Device
+  key: string;                // Property name: "temperature", "state", "brightness"
+  type: DataType;             // "boolean" | "number" | "enum" | "text" | "json"
+  category: DataCategory;     // Semantic category for aggregation rules
+  value: unknown;             // Current value
+  unit?: string;              // "°C", "%", "lx", "W"
+  lastUpdated: string | null;
+}
+```
+
+### 8.3 DeviceOrder
+
+```typescript
+interface DeviceOrder {
+  id: string;
+  deviceId: string;           // FK → Device
+  key: string;                // "state", "brightness", "position"
+  type: DataType;
+  mqttSetTopic: string;       // MQTT topic to publish to
+  payloadKey: string;         // Key in the JSON payload
+  min?: number;               // For numeric: minimum value
+  max?: number;               // For numeric: maximum value
+  enumValues?: string[];      // For enum: allowed values
+  unit?: string;
+}
+```
+
+---
+
+## 9. Computed Data (V0.5)
+
+> **Deferred to V0.5** — documented here as part of the complete data model.
+
+A **ComputedData** is a virtual data point on an Equipment whose value is derived from an expression over other data sources.
+
+### 9.1 Interface
+
+```typescript
+interface ComputedData {
+  id: string;              // UUID v4
+  equipmentId: string;     // FK → Equipment
+  key: string;             // "state", "average_temperature", "motion"
+  type: DataType;
+  category: DataCategory;  // Used by Zone aggregation
+  expression: string;      // Computation expression
+  value: unknown;          // Current computed value
+}
+```
+
+### 9.2 Expression Language
+
+```
+// Boolean
+OR(binding.motion_1, binding.motion_2)
+AND(binding.door, binding.window)
+NOT(binding.occupancy)
+
+// Numeric
+AVG(binding.temp_1, binding.temp_2)
+MIN(binding.temp_1, binding.temp_2)
+MAX(binding.temp_1, binding.temp_2)
+SUM(binding.power_1, binding.power_2)
+
+// Conditional
+IF(binding.brightness > 0, "on", "off")
+THRESHOLD(binding.temperature, 19, "cold", "ok")
+
+// References
+binding.<alias>                        → DataBinding on the same Equipment
+equipment.<equipmentId>.<alias>        → Data on another Equipment
+zone.<zoneId>.<key>                    → Zone aggregated Data
+```
+
+---
+
+## 10. Reactive Data Flow
+
+The complete event-driven pipeline:
+
+```
+MQTT message arrives
+  │
+  ▼
+MQTT Connector (receives raw message)
+  │
+  ▼
+Parser (zigbee2mqtt / tasmota / esphome)
+  │
+  ▼
+Device Manager (updates DeviceData)
+  │
+  ├──▶ Event: "device.data.updated"
+  │
+  ▼
+Equipment Manager
+  ├── Updates bound Equipment Data (via DataBindings)
+  ├── [V0.5] Re-evaluates ComputedData expressions
+  │
+  ├──▶ Event: "equipment.data.changed"
+  │
+  ▼
+Zone Aggregator
+  ├── Re-computes Zone aggregated data
+  ├── Re-computes Group aggregated data
+  ├── Propagates up the zone hierarchy (recursive)
+  │
+  ├──▶ Event: "zone.data.changed"
+  │
+  ▼
+Scenario Engine (V0.7)
+  ├── Evaluates triggers
+  ├── Checks conditions
+  ├── Executes actions
+  │
+  ├──▶ Actions may dispatch Equipment/Zone Orders → MQTT publish
+  │
+  ▼
+WebSocket Server
+  └── Broadcasts all events to connected UI clients
+```
+
+---
+
+## 11. Event Bus Events
+
+All events are typed via TypeScript discriminated unions.
+
+### System Events
+
+| Event | Payload | When |
+|---|---|---|
+| `system.started` | — | Engine boot complete |
+| `system.mqtt.connected` | — | MQTT broker connected |
+| `system.mqtt.disconnected` | — | MQTT broker lost |
+| `system.error` | `error: string` | Unrecoverable error |
+
+### Device Events (V0.1)
+
+| Event | Payload | When |
+|---|---|---|
+| `device.discovered` | `device: Device` | New device found |
+| `device.removed` | `deviceId, deviceName` | Device deleted |
+| `device.status_changed` | `deviceId, deviceName, status` | Online/offline |
+| `device.data.updated` | `deviceId, deviceName, dataId, key, value, previous` | Property change |
+
+### Equipment Events (V0.3)
+
+| Event | Payload | When |
+|---|---|---|
+| `equipment.data.changed` | `equipmentId, key, value, previous` | Bound data changed |
+| `equipment.order.executed` | `equipmentId, orderAlias, value` | Order dispatched |
+
+### Zone Events (V0.3+)
+
+| Event | Payload | When |
+|---|---|---|
+| `zone.data.changed` | `zoneId, key, value, previous` | Aggregated data changed |
+
+---
+
+## 12. Complete SQLite Schema
+
+```sql
+-- ============================================================
+-- ZONES (V0.2)
+-- ============================================================
+CREATE TABLE zones (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  parent_id TEXT REFERENCES zones(id) ON DELETE SET NULL,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- ============================================================
+-- EQUIPMENT GROUPS (V0.2)
+-- ============================================================
+CREATE TABLE equipment_groups (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- ============================================================
+-- DEVICES (V0.1 — existing)
+-- ============================================================
+CREATE TABLE devices (
+  id TEXT PRIMARY KEY,
+  mqtt_base_topic TEXT NOT NULL UNIQUE,
+  mqtt_name TEXT NOT NULL,
+  name TEXT NOT NULL,
+  manufacturer TEXT,
+  model TEXT,
+  ieee_address TEXT,
+  source TEXT NOT NULL DEFAULT 'zigbee2mqtt',
+  status TEXT NOT NULL DEFAULT 'unknown',
+  last_seen DATETIME,
+  raw_expose JSON,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE device_data (
+  id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  type TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'generic',
+  value TEXT,
+  unit TEXT,
+  last_updated DATETIME,
+  UNIQUE(device_id, key)
+);
+
+CREATE TABLE device_orders (
+  id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  type TEXT NOT NULL,
+  mqtt_set_topic TEXT NOT NULL,
+  payload_key TEXT NOT NULL,
+  min_value REAL,
+  max_value REAL,
+  enum_values JSON,
+  unit TEXT,
+  UNIQUE(device_id, key)
+);
+
+-- ============================================================
+-- EQUIPMENTS (V0.3)
+-- ============================================================
+CREATE TABLE equipments (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+  group_id TEXT REFERENCES equipment_groups(id) ON DELETE SET NULL,
+  type TEXT NOT NULL DEFAULT 'generic',
+  icon TEXT,
+  description TEXT,
+  enabled INTEGER DEFAULT 1,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE data_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  device_data_id TEXT NOT NULL REFERENCES device_data(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL,
+  UNIQUE(equipment_id, alias)
+);
+
+CREATE TABLE order_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  device_order_id TEXT NOT NULL REFERENCES device_orders(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL,
+  UNIQUE(equipment_id, alias, device_order_id)
+);
+
+-- ============================================================
+-- COMPUTED DATA (V0.5)
+-- ============================================================
+CREATE TABLE computed_data (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  type TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'generic',
+  expression TEXT NOT NULL,
+  value TEXT,
+  UNIQUE(equipment_id, key)
+);
+
+-- ============================================================
+-- INTERNAL RULES (V0.5)
+-- ============================================================
+CREATE TABLE internal_rules (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  condition_expr TEXT NOT NULL,
+  action_expr TEXT NOT NULL,
+  enabled INTEGER DEFAULT 1
+);
+```
+
+---
+
+## 13. API Endpoints Summary
+
+### Zones (V0.2)
+
+| Method | Route | Description |
+|---|---|---|
+| GET | `/api/v1/zones` | List all zones (tree structure) |
+| GET | `/api/v1/zones/:id` | Get zone with aggregated data |
+| POST | `/api/v1/zones` | Create zone |
+| PUT | `/api/v1/zones/:id` | Update zone |
+| DELETE | `/api/v1/zones/:id` | Delete zone (must have no children/equipments) |
+
+### Equipment Groups (V0.2)
+
+| Method | Route | Description |
+|---|---|---|
+| GET | `/api/v1/zones/:zoneId/groups` | List groups in a zone |
+| POST | `/api/v1/zones/:zoneId/groups` | Create group in a zone |
+| PUT | `/api/v1/groups/:id` | Update group |
+| DELETE | `/api/v1/groups/:id` | Delete group |
+
+### Equipments (V0.3)
+
+| Method | Route | Description |
+|---|---|---|
+| GET | `/api/v1/equipments` | List all equipments |
+| GET | `/api/v1/equipments/:id` | Get equipment with bindings and current data |
+| POST | `/api/v1/equipments` | Create equipment |
+| PUT | `/api/v1/equipments/:id` | Update equipment |
+| DELETE | `/api/v1/equipments/:id` | Delete equipment |
+| POST | `/api/v1/equipments/:id/orders/:alias` | Execute an equipment order |
+
+### Zone Orders (V0.3+)
+
+| Method | Route | Description |
+|---|---|---|
+| POST | `/api/v1/zones/:id/orders/:orderKey` | Execute zone auto-order (allOff, allLightsOff…) |
+| POST | `/api/v1/groups/:id/orders/:orderKey` | Execute group order |
+
+---
+
+## 14. Implementation Roadmap
+
+| Version | Entities Implemented |
+|---|---|
+| **V0.1** | Device, DeviceData, DeviceOrder ✅ |
+| **V0.2** | Zone, EquipmentGroup (CRUD + UI) |
+| **V0.3** | Equipment, DataBinding, OrderBinding (CRUD + Order execution + UI) |
+| **V0.5** | ComputedData, InternalRule |
+| **V0.3+** | Zone aggregation engine, Zone auto-orders |

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -1,21 +1,23 @@
 # Corbel — Implementation Status
 
-> Updated: 2026-02-19 — V0.1 (backend + UI)
+> Updated: 2026-02-19 — V0.1 done, V0.2 in progress
 
-## Roadmap Change: Incremental UI
+## Roadmap Changes
 
-The original roadmap bundled all UI into V0.4. This has been changed to an **incremental approach**: each backend version now ships its corresponding UI pages. V0.4 becomes a polish/UX milestone.
+1. **Incremental UI**: The original roadmap bundled all UI into V0.4. Changed to an **incremental approach**: each backend version ships its corresponding UI pages. V0.4 becomes a polish/UX milestone.
+2. **Topology first**: V0.2 and V0.3 were swapped. Zones (spatial topology) are now implemented before Equipments, so users define where things are before assigning functional units.
+3. **Core data model**: See [data-model.md](data-model.md) for the complete 3-layer architecture (Zones → Equipments → Devices).
 
 ## Versions
 
 | Version | Feature | Status |
 |---------|---------|--------|
 | **V0.1** | MQTT + Devices + **UI Scaffolding & Devices page** | ✅ Done |
-| V0.2 | Equipments + Bindings + **UI Equipments** | — |
-| V0.3 | Zones + Aggregation + **UI Zones & Dashboard** | — |
+| **V0.2** | **Zones + Equipment Groups + UI Zones** (topology) | 🚧 In progress |
+| V0.3 | Equipments + Bindings + Orders + **UI Equipments** | — |
 | V0.4 | **UI Polish & Real-time UX** (reconnection, dark mode, responsive, animations) | — |
-| V0.5 | Computed Data | — |
-| V0.6 | History (InfluxDB) | — |
+| V0.5 | Computed Data + Internal Rules | — |
+| V0.6 | History (InfluxDB) + Zone Aggregation Engine | — |
 | V0.7 | Scenario Engine | — |
 | V0.8 | Recipes | — |
 | V0.9 | Polish | — |

--- a/migrations/002_zones.sql
+++ b/migrations/002_zones.sql
@@ -1,0 +1,25 @@
+-- ============================================================
+-- V0.2: Zones + Equipment Groups
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS zones (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  parent_id TEXT REFERENCES zones(id) ON DELETE SET NULL,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS equipment_groups (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);

--- a/specs/003-V0.2-zones/architecture.md
+++ b/specs/003-V0.2-zones/architecture.md
@@ -1,0 +1,200 @@
+# Architecture: V0.2 Zones + Equipment Groups
+
+## Data Model Changes
+
+### New types in `src/shared/types.ts`
+
+```typescript
+// Zone
+interface Zone {
+  id: string;
+  name: string;
+  parentId: string | null;
+  icon?: string;
+  description?: string;
+  displayOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ZoneWithChildren extends Zone {
+  children: ZoneWithChildren[];
+  groups: EquipmentGroup[];
+}
+
+// Equipment Group
+interface EquipmentGroup {
+  id: string;
+  name: string;
+  zoneId: string;
+  icon?: string;
+  description?: string;
+  displayOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### New EngineEvent types
+
+```typescript
+| { type: "zone.created"; zone: Zone }
+| { type: "zone.updated"; zone: Zone }
+| { type: "zone.removed"; zoneId: string; zoneName: string }
+| { type: "group.created"; group: EquipmentGroup }
+| { type: "group.updated"; group: EquipmentGroup }
+| { type: "group.removed"; groupId: string; groupName: string }
+```
+
+### New SQLite tables
+
+```sql
+-- Migration: 002_zones.sql
+
+CREATE TABLE zones (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  parent_id TEXT REFERENCES zones(id) ON DELETE SET NULL,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE equipment_groups (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+## Event Bus Events
+
+### New events emitted
+
+| Event | When | Payload |
+|---|---|---|
+| `zone.created` | Zone created via API | `{ zone }` |
+| `zone.updated` | Zone modified via API | `{ zone }` |
+| `zone.removed` | Zone deleted via API | `{ zoneId, zoneName }` |
+| `group.created` | Group created via API | `{ group }` |
+| `group.updated` | Group modified via API | `{ group }` |
+| `group.removed` | Group deleted via API | `{ groupId, groupName }` |
+
+### Events consumed
+
+None for V0.2. Zone data aggregation (consuming `equipment.data.changed`) comes in V0.3+.
+
+## API Changes
+
+### New endpoints
+
+| Method | Route | Request Body | Response |
+|---|---|---|---|
+| GET | `/api/v1/zones` | — | `ZoneWithChildren[]` (tree) |
+| GET | `/api/v1/zones/:id` | — | `ZoneWithChildren` |
+| POST | `/api/v1/zones` | `{ name, parentId?, icon?, description? }` | `Zone` (201) |
+| PUT | `/api/v1/zones/:id` | `{ name?, parentId?, icon?, description?, displayOrder? }` | `Zone` |
+| DELETE | `/api/v1/zones/:id` | — | 204 |
+| GET | `/api/v1/zones/:zoneId/groups` | — | `EquipmentGroup[]` |
+| POST | `/api/v1/zones/:zoneId/groups` | `{ name, icon?, description? }` | `EquipmentGroup` (201) |
+| PUT | `/api/v1/groups/:id` | `{ name?, icon?, description?, displayOrder? }` | `EquipmentGroup` |
+| DELETE | `/api/v1/groups/:id` | — | 204 |
+
+### Validation Rules
+
+**POST /zones:**
+- `name`: required, string, 1-100 chars
+- `parentId`: optional, must reference existing zone
+- `icon`: optional, string
+- `description`: optional, string, max 500 chars
+
+**PUT /zones/:id:**
+- `parentId`: if provided, must not create circular reference
+- Other fields: same validation as POST
+
+**DELETE /zones/:id:**
+- Reject if zone has child zones (400: "Cannot delete zone with child zones")
+- Reject if zone has equipment groups (400: "Cannot delete zone with groups")
+
+**DELETE /groups/:id:**
+- In V0.2: always allowed (no equipments yet)
+- In V0.3+: reject if group has equipments
+
+## UI Changes
+
+### New Zustand store: `ui/src/store/useZones.ts`
+
+```typescript
+interface ZonesState {
+  zones: Record<string, Zone>;
+  tree: ZoneWithChildren[];         // Cached tree structure
+  groups: Record<string, EquipmentGroup>;
+  loading: boolean;
+  error: string | null;
+
+  fetchZones: () => Promise<void>;
+  createZone: (data: CreateZoneInput) => Promise<Zone>;
+  updateZone: (id: string, data: UpdateZoneInput) => Promise<void>;
+  deleteZone: (id: string) => Promise<void>;
+  createGroup: (zoneId: string, data: CreateGroupInput) => Promise<EquipmentGroup>;
+  updateGroup: (id: string, data: UpdateGroupInput) => Promise<void>;
+  deleteGroup: (id: string) => Promise<void>;
+
+  // Called by WebSocket handler
+  handleZoneCreated: (zone: Zone) => void;
+  handleZoneUpdated: (zone: Zone) => void;
+  handleZoneRemoved: (zoneId: string) => void;
+  handleGroupCreated: (group: EquipmentGroup) => void;
+  handleGroupUpdated: (group: EquipmentGroup) => void;
+  handleGroupRemoved: (groupId: string) => void;
+}
+```
+
+### New pages
+
+| Page | Route | Content |
+|---|---|---|
+| `ZonesPage` | `/zones` | Zone tree view, create button, expand/collapse |
+| `ZoneDetailPage` | `/zones/:id` | Zone info, child zones, groups, edit/delete |
+
+### New components
+
+| Component | Location | Purpose |
+|---|---|---|
+| `ZoneTree` | `components/zones/` | Recursive tree view of zones |
+| `ZoneTreeNode` | `components/zones/` | Single node in the tree (expandable) |
+| `ZoneForm` | `components/zones/` | Create/edit zone modal form |
+| `GroupList` | `components/zones/` | List of groups in a zone |
+| `GroupForm` | `components/zones/` | Create/edit group modal form |
+| `ZoneIcon` | `components/zones/` | Renders zone icon with fallback |
+
+### Updated files
+
+| File | Change |
+|---|---|
+| `ui/src/App.tsx` | Add routes `/zones`, `/zones/:id` |
+| `ui/src/types.ts` | Add Zone, EquipmentGroup, ZoneWithChildren types |
+| `ui/src/api.ts` | Add zone/group API functions |
+| `ui/src/store/useWebSocket.ts` | Handle zone/group events |
+| `ui/src/components/layout/Sidebar.tsx` | Enable Zones nav item |
+
+## File Changes (Backend)
+
+| File | Change |
+|---|---|
+| `src/shared/types.ts` | Add Zone, EquipmentGroup, ZoneWithChildren interfaces + events |
+| `migrations/002_zones.sql` | Create zones + equipment_groups tables |
+| `src/core/database.ts` | Load new migration |
+| `src/zones/zone-manager.ts` | **NEW** — Zone CRUD + tree building + circular ref detection |
+| `src/zones/group-manager.ts` | **NEW** — EquipmentGroup CRUD |
+| `src/api/routes/zones.ts` | **NEW** — Zone API routes |
+| `src/api/routes/groups.ts` | **NEW** — Group API routes |
+| `src/api/server.ts` | Register new routes |
+| `src/index.ts` | Initialize zone manager |

--- a/specs/003-V0.2-zones/plan.md
+++ b/specs/003-V0.2-zones/plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan: V0.2 Zones + Equipment Groups
+
+## Tasks
+
+### Backend
+
+1. [ ] **Types** — Add Zone, EquipmentGroup, ZoneWithChildren interfaces and EngineEvent types to `src/shared/types.ts`
+2. [ ] **Migration** — Create `migrations/002_zones.sql` (zones + equipment_groups tables)
+3. [ ] **Database** — Update `src/core/database.ts` to load new migration
+4. [ ] **Zone Manager** — Create `src/zones/zone-manager.ts`:
+   - CRUD operations (create, getById, getAll, update, delete)
+   - Build tree structure from flat list
+   - Circular reference detection on parentId update
+   - Delete guards (no children, no groups)
+5. [ ] **Group Manager** — Create `src/zones/group-manager.ts`:
+   - CRUD operations (create, getByZoneId, getById, update, delete)
+   - Delete guard (no equipments — placeholder for V0.3)
+6. [ ] **Zone API routes** — Create `src/api/routes/zones.ts`:
+   - GET /zones, GET /zones/:id, POST /zones, PUT /zones/:id, DELETE /zones/:id
+   - GET /zones/:zoneId/groups, POST /zones/:zoneId/groups
+7. [ ] **Group API routes** — Create `src/api/routes/groups.ts`:
+   - PUT /groups/:id, DELETE /groups/:id
+8. [ ] **Register routes** — Update `src/api/server.ts` to register zone and group routes
+9. [ ] **Initialize** — Update `src/index.ts` to create zone manager on startup
+10. [ ] **WebSocket** — Update `src/api/websocket.ts` to broadcast zone/group events
+
+### Frontend
+
+11. [ ] **Types** — Add Zone, EquipmentGroup, ZoneWithChildren to `ui/src/types.ts`
+12. [ ] **API functions** — Add zone/group API calls to `ui/src/api.ts`
+13. [ ] **Zustand store** — Create `ui/src/store/useZones.ts`
+14. [ ] **WebSocket** — Update `ui/src/store/useWebSocket.ts` to handle zone/group events
+15. [ ] **Zone tree components** — Create `ui/src/components/zones/ZoneTree.tsx` + `ZoneTreeNode.tsx`
+16. [ ] **Zone form** — Create `ui/src/components/zones/ZoneForm.tsx` (create/edit modal)
+17. [ ] **Group components** — Create `ui/src/components/zones/GroupList.tsx` + `GroupForm.tsx`
+18. [ ] **Zones page** — Create `ui/src/pages/ZonesPage.tsx`
+19. [ ] **Zone detail page** — Create `ui/src/pages/ZoneDetailPage.tsx`
+20. [ ] **Routes** — Update `ui/src/App.tsx` with zone routes
+21. [ ] **Sidebar** — Enable Zones nav item in `ui/src/components/layout/Sidebar.tsx`
+
+### Testing & Validation
+
+22. [ ] **Unit tests** — Zone manager tests (CRUD, tree, circular ref, delete guards)
+23. [ ] **Unit tests** — Group manager tests (CRUD, delete guard)
+24. [ ] **TypeScript** — `npx tsc --noEmit` passes (zero errors, backend)
+25. [ ] **TypeScript** — `cd ui && npx tsc --noEmit` passes (zero errors, frontend)
+26. [ ] **All tests** — `npm test` passes
+
+### Documentation
+
+27. [ ] Update `specs/003-V0.2-zones/spec.md` — mark acceptance criteria
+28. [ ] Update `docs/implementation-status.md` — mark V0.2 done
+
+## Dependencies
+
+- Requires V0.1 to be completed (✅ done)
+- No external dependencies
+
+## Testing
+
+### Manual verification
+
+1. Start engine: `npm run dev`
+2. Start UI: `cd ui && npm run dev`
+3. Navigate to `/zones`
+4. Create root zone "Maison"
+5. Create child zones: "RDC", "Étage" under "Maison"
+6. Create rooms: "Salon", "Cuisine" under "RDC"
+7. Create a group "Volets Sud" in "Salon"
+8. Verify tree displays correctly
+9. Edit zone name, icon, description
+10. Try deleting zone with children → should fail
+11. Delete empty zone → should succeed
+12. Open second browser tab → verify WebSocket sync

--- a/specs/003-V0.2-zones/spec.md
+++ b/specs/003-V0.2-zones/spec.md
@@ -1,0 +1,114 @@
+# V0.2: Zones + Equipment Groups
+
+## Summary
+
+Implement the spatial topology layer of Corbel. Users can define hierarchical Zones (Home → Floor → Room) and Equipment Groups within Zones. This establishes the structure into which Equipments will be placed in V0.3.
+
+## Reference
+
+- Data model: [docs/data-model.md](../../docs/data-model.md) — §3 Zone, §4 Equipment Group
+- Spec: [docs/corbel-spec.md](../../docs/corbel-spec.md) — §5.4 Zone, §7.5 Zone API
+
+## Acceptance Criteria
+
+### Zone CRUD (Backend)
+
+- [ ] Create a zone with name, parentId (optional), icon, description, displayOrder
+- [ ] Read a zone by ID (returns zone with children and groups)
+- [ ] List all zones as a tree structure (nested JSON)
+- [ ] Update a zone (name, icon, description, displayOrder, parentId)
+- [ ] Delete a zone (only if it has no children and no equipments)
+- [ ] Moving a zone (changing parentId) validates no circular reference
+- [ ] Zone IDs are UUID v4
+- [ ] All dates in ISO 8601
+
+### Equipment Group CRUD (Backend)
+
+- [ ] Create a group within a zone (name, icon, description, displayOrder)
+- [ ] List groups for a zone
+- [ ] Update a group (name, icon, description, displayOrder)
+- [ ] Delete a group (only if it has no equipments)
+- [ ] Deleting a zone cascades to delete its groups
+
+### API Endpoints
+
+- [ ] `GET /api/v1/zones` — returns full zone tree
+- [ ] `GET /api/v1/zones/:id` — returns zone with children and groups
+- [ ] `POST /api/v1/zones` — create zone
+- [ ] `PUT /api/v1/zones/:id` — update zone
+- [ ] `DELETE /api/v1/zones/:id` — delete zone (with guard)
+- [ ] `GET /api/v1/zones/:zoneId/groups` — list groups in zone
+- [ ] `POST /api/v1/zones/:zoneId/groups` — create group in zone
+- [ ] `PUT /api/v1/groups/:id` — update group
+- [ ] `DELETE /api/v1/groups/:id` — delete group (with guard)
+
+### Database
+
+- [ ] Migration creates `zones` table
+- [ ] Migration creates `equipment_groups` table
+- [ ] Foreign keys and constraints enforced
+
+### UI — Zones Page
+
+- [ ] Zones page accessible from sidebar navigation
+- [ ] Display zone tree with expand/collapse
+- [ ] Show zone name, icon, description, number of children, number of groups
+- [ ] Create zone via modal/form (name, parent, icon, description)
+- [ ] Edit zone inline or via modal
+- [ ] Delete zone with confirmation dialog
+- [ ] Drag-and-drop reordering (or up/down arrows for displayOrder)
+- [ ] Empty state when no zones exist
+
+### UI — Zone Detail Page
+
+- [ ] Show zone details (name, icon, description, parent breadcrumb)
+- [ ] List child zones with navigation
+- [ ] List equipment groups with CRUD (create, edit, delete)
+- [ ] Edit zone name inline
+- [ ] Navigate back to parent zone
+
+### UI — General
+
+- [ ] Sidebar shows "Zones" navigation enabled (currently disabled)
+- [ ] WebSocket events for zone/group changes update UI in real-time
+- [ ] Loading and error states
+
+### Tests
+
+- [ ] Zone CRUD unit tests (zone-manager)
+- [ ] Group CRUD unit tests
+- [ ] Circular reference detection test
+- [ ] Delete guards (zone with children, zone with groups)
+- [ ] API route tests
+- [ ] TypeScript compiles with zero errors (backend + frontend)
+
+## Scope
+
+### In Scope
+
+- Zone entity: CRUD, tree hierarchy, persistence
+- EquipmentGroup entity: CRUD, belongs to zone, persistence
+- REST API for zones and groups
+- UI: zones page (tree view), zone detail page, group management
+- WebSocket events for real-time sync
+- SQLite migration
+
+### Out of Scope (deferred)
+
+- Zone aggregated data (V0.3+ — requires Equipments first)
+- Zone auto-orders (allOff, allLightsOff — V0.3+)
+- Equipment assignment to zones (V0.3)
+- Device.zoneId update from zone UI (stays manual via device edit)
+- Zone-based scenario triggers/conditions (V0.7)
+
+## Edge Cases
+
+- **Circular reference**: Moving zone A under zone B when B is a descendant of A → reject
+- **Delete zone with children**: Reject with error "Zone has X child zones"
+- **Delete zone with groups**: Reject with error "Zone has X groups" (or cascade? → we reject)
+- **Delete group with equipments**: Reject (guard for V0.3 when equipments exist)
+- **Root zones**: Multiple root zones allowed (parentId: null)
+- **Empty tree**: No zones → UI shows empty state with "Create your first zone" CTA
+- **Deep nesting**: No hard limit on depth, but UI tree should handle 4-5 levels gracefully
+- **Duplicate names**: Allowed (different zones can have the same name)
+- **Moving zone changes subtree**: Moving a zone moves all its descendants

--- a/src/api/routes/zones.ts
+++ b/src/api/routes/zones.ts
@@ -1,0 +1,202 @@
+import type { FastifyInstance } from "fastify";
+import type { ZoneManager } from "../../zones/zone-manager.js";
+import type { GroupManager } from "../../zones/group-manager.js";
+import type { Logger } from "../../core/logger.js";
+
+interface ZonesDeps {
+  zoneManager: ZoneManager;
+  groupManager: GroupManager;
+  logger: Logger;
+}
+
+export function registerZoneRoutes(app: FastifyInstance, deps: ZonesDeps): void {
+  const { zoneManager, groupManager } = deps;
+
+  // GET /api/v1/zones — List all zones as a tree
+  app.get("/api/v1/zones", async () => {
+    return zoneManager.getTree();
+  });
+
+  // GET /api/v1/zones/:id — Get zone with children and groups
+  app.get<{ Params: { id: string } }>("/api/v1/zones/:id", async (request, reply) => {
+    const zone = zoneManager.getByIdWithChildren(request.params.id);
+    if (!zone) {
+      return reply.code(404).send({ error: "Zone not found" });
+    }
+    return zone;
+  });
+
+  // POST /api/v1/zones — Create zone
+  app.post<{
+    Body: {
+      name: string;
+      parentId?: string | null;
+      icon?: string;
+      description?: string;
+      displayOrder?: number;
+    };
+  }>("/api/v1/zones", async (request, reply) => {
+    const { name, parentId, icon, description, displayOrder } = request.body ?? {};
+
+    if (!name || typeof name !== "string" || name.trim().length === 0) {
+      return reply.code(400).send({ error: "Name is required" });
+    }
+    if (name.length > 100) {
+      return reply.code(400).send({ error: "Name must be 100 characters or less" });
+    }
+    if (description && description.length > 500) {
+      return reply.code(400).send({ error: "Description must be 500 characters or less" });
+    }
+
+    try {
+      const zone = zoneManager.create({ name: name.trim(), parentId, icon, description, displayOrder });
+      return reply.code(201).send(zone);
+    } catch (err) {
+      return handleZoneError(err, reply);
+    }
+  });
+
+  // PUT /api/v1/zones/:id — Update zone
+  app.put<{
+    Params: { id: string };
+    Body: {
+      name?: string;
+      parentId?: string | null;
+      icon?: string | null;
+      description?: string | null;
+      displayOrder?: number;
+    };
+  }>("/api/v1/zones/:id", async (request, reply) => {
+    const body = request.body ?? {};
+
+    if (body.name !== undefined) {
+      if (typeof body.name !== "string" || body.name.trim().length === 0) {
+        return reply.code(400).send({ error: "Name cannot be empty" });
+      }
+      if (body.name.length > 100) {
+        return reply.code(400).send({ error: "Name must be 100 characters or less" });
+      }
+      body.name = body.name.trim();
+    }
+    if (body.description !== undefined && body.description !== null && body.description.length > 500) {
+      return reply.code(400).send({ error: "Description must be 500 characters or less" });
+    }
+
+    try {
+      const zone = zoneManager.update(request.params.id, body);
+      if (!zone) {
+        return reply.code(404).send({ error: "Zone not found" });
+      }
+      return zone;
+    } catch (err) {
+      return handleZoneError(err, reply);
+    }
+  });
+
+  // DELETE /api/v1/zones/:id — Delete zone
+  app.delete<{ Params: { id: string } }>("/api/v1/zones/:id", async (request, reply) => {
+    try {
+      zoneManager.delete(request.params.id);
+      return reply.code(204).send();
+    } catch (err) {
+      return handleZoneError(err, reply);
+    }
+  });
+
+  // GET /api/v1/zones/:zoneId/groups — List groups in a zone
+  app.get<{ Params: { zoneId: string } }>("/api/v1/zones/:zoneId/groups", async (request, reply) => {
+    const zone = zoneManager.getById(request.params.zoneId);
+    if (!zone) {
+      return reply.code(404).send({ error: "Zone not found" });
+    }
+    return groupManager.getByZoneId(request.params.zoneId);
+  });
+
+  // POST /api/v1/zones/:zoneId/groups — Create group in a zone
+  app.post<{
+    Params: { zoneId: string };
+    Body: {
+      name: string;
+      icon?: string;
+      description?: string;
+      displayOrder?: number;
+    };
+  }>("/api/v1/zones/:zoneId/groups", async (request, reply) => {
+    const { name, icon, description, displayOrder } = request.body ?? {};
+
+    if (!name || typeof name !== "string" || name.trim().length === 0) {
+      return reply.code(400).send({ error: "Name is required" });
+    }
+    if (name.length > 100) {
+      return reply.code(400).send({ error: "Name must be 100 characters or less" });
+    }
+
+    try {
+      const group = groupManager.create(request.params.zoneId, {
+        name: name.trim(),
+        icon,
+        description,
+        displayOrder,
+      });
+      return reply.code(201).send(group);
+    } catch (err) {
+      return handleGroupError(err, reply);
+    }
+  });
+
+  // PUT /api/v1/groups/:id — Update group
+  app.put<{
+    Params: { id: string };
+    Body: {
+      name?: string;
+      icon?: string | null;
+      description?: string | null;
+      displayOrder?: number;
+    };
+  }>("/api/v1/groups/:id", async (request, reply) => {
+    const body = request.body ?? {};
+
+    if (body.name !== undefined) {
+      if (typeof body.name !== "string" || body.name.trim().length === 0) {
+        return reply.code(400).send({ error: "Name cannot be empty" });
+      }
+      body.name = body.name.trim();
+    }
+
+    try {
+      const group = groupManager.update(request.params.id, body);
+      if (!group) {
+        return reply.code(404).send({ error: "Group not found" });
+      }
+      return group;
+    } catch (err) {
+      return handleGroupError(err, reply);
+    }
+  });
+
+  // DELETE /api/v1/groups/:id — Delete group
+  app.delete<{ Params: { id: string } }>("/api/v1/groups/:id", async (request, reply) => {
+    try {
+      groupManager.delete(request.params.id);
+      return reply.code(204).send();
+    } catch (err) {
+      return handleGroupError(err, reply);
+    }
+  });
+}
+
+function handleZoneError(err: unknown, reply: { code: (n: number) => { send: (b: unknown) => unknown } }) {
+  if (err && typeof err === "object" && "status" in err && "message" in err) {
+    const zoneErr = err as { status: number; message: string };
+    return reply.code(zoneErr.status).send({ error: zoneErr.message });
+  }
+  throw err;
+}
+
+function handleGroupError(err: unknown, reply: { code: (n: number) => { send: (b: unknown) => unknown } }) {
+  if (err && typeof err === "object" && "status" in err && "message" in err) {
+    const groupErr = err as { status: number; message: string };
+    return reply.code(groupErr.status).send({ error: groupErr.message });
+  }
+  throw err;
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -3,14 +3,19 @@ import cors from "@fastify/cors";
 import websocket from "@fastify/websocket";
 import type { Logger } from "../core/logger.js";
 import type { DeviceManager } from "../devices/device-manager.js";
+import type { ZoneManager } from "../zones/zone-manager.js";
+import type { GroupManager } from "../zones/group-manager.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { MqttConnector } from "../mqtt/mqtt-connector.js";
 import { registerDeviceRoutes } from "./routes/devices.js";
 import { registerHealthRoutes } from "./routes/health.js";
+import { registerZoneRoutes } from "./routes/zones.js";
 import { registerWebSocket } from "./websocket.js";
 
 interface ServerDeps {
   deviceManager: DeviceManager;
+  zoneManager: ZoneManager;
+  groupManager: GroupManager;
   eventBus: EventBus;
   mqttConnector: MqttConnector;
   logger: Logger;
@@ -18,7 +23,7 @@ interface ServerDeps {
 }
 
 export async function createServer(deps: ServerDeps) {
-  const { deviceManager, eventBus, mqttConnector, logger, corsOrigins } = deps;
+  const { deviceManager, zoneManager, groupManager, eventBus, mqttConnector, logger, corsOrigins } = deps;
 
   const app = Fastify({
     logger: false, // We use our own pino logger
@@ -36,6 +41,7 @@ export async function createServer(deps: ServerDeps) {
   // Register routes
   registerHealthRoutes(app, { deviceManager, mqttConnector, logger });
   registerDeviceRoutes(app, { deviceManager, logger });
+  registerZoneRoutes(app, { zoneManager, groupManager, logger });
   registerWebSocket(app, { eventBus, logger });
 
   return app;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import { openDatabase, runMigrations } from "./core/database.js";
 import { EventBus } from "./core/event-bus.js";
 import { MqttConnector } from "./mqtt/mqtt-connector.js";
 import { DeviceManager } from "./devices/device-manager.js";
+import { ZoneManager } from "./zones/zone-manager.js";
+import { GroupManager } from "./zones/group-manager.js";
 import { Zigbee2MqttParser } from "./mqtt/parsers/zigbee2mqtt.js";
 import { createServer } from "./api/server.js";
 
@@ -42,6 +44,10 @@ async function main() {
   // 6. Create Device Manager
   const deviceManager = new DeviceManager(db, eventBus, logger);
 
+  // 6b. Create Zone & Group Managers
+  const zoneManager = new ZoneManager(db, eventBus, logger);
+  const groupManager = new GroupManager(db, eventBus, logger);
+
   // 7. Create zigbee2mqtt parser
   const z2mParser = new Zigbee2MqttParser(
     config.z2m.baseTopic,
@@ -57,6 +63,8 @@ async function main() {
   // 9. Start Fastify server
   const server = await createServer({
     deviceManager,
+    zoneManager,
+    groupManager,
     eventBus,
     mqttConnector,
     logger,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -93,6 +93,41 @@ export interface DeviceWithDetails extends Device {
 }
 
 // ============================================================
+// Zone
+// ============================================================
+
+export interface Zone {
+  id: string;
+  name: string;
+  parentId: string | null;
+  icon?: string;
+  description?: string;
+  displayOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ZoneWithChildren extends Zone {
+  children: ZoneWithChildren[];
+  groups: EquipmentGroup[];
+}
+
+// ============================================================
+// Equipment Group
+// ============================================================
+
+export interface EquipmentGroup {
+  id: string;
+  name: string;
+  zoneId: string;
+  icon?: string;
+  description?: string;
+  displayOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================================
 // Event Bus
 // ============================================================
 
@@ -123,6 +158,14 @@ export type EngineEvent =
       previous: unknown;
       timestamp: string;
     }
+  // Zone events
+  | { type: "zone.created"; zone: Zone }
+  | { type: "zone.updated"; zone: Zone }
+  | { type: "zone.removed"; zoneId: string; zoneName: string }
+  // Equipment Group events
+  | { type: "group.created"; group: EquipmentGroup }
+  | { type: "group.updated"; group: EquipmentGroup }
+  | { type: "group.removed"; groupId: string; groupName: string }
   // System events
   | { type: "system.started" }
   | { type: "system.mqtt.connected" }

--- a/src/zones/group-manager.ts
+++ b/src/zones/group-manager.ts
@@ -1,0 +1,157 @@
+import { randomUUID } from "node:crypto";
+import type Database from "better-sqlite3";
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { EquipmentGroup } from "../shared/types.js";
+
+interface CreateGroupInput {
+  name: string;
+  icon?: string;
+  description?: string;
+  displayOrder?: number;
+}
+
+interface UpdateGroupInput {
+  name?: string;
+  icon?: string | null;
+  description?: string | null;
+  displayOrder?: number;
+}
+
+export class GroupManager {
+  private db: Database.Database;
+  private logger: Logger;
+  private eventBus: EventBus;
+  private stmts: ReturnType<typeof this.prepareStatements>;
+
+  constructor(db: Database.Database, eventBus: EventBus, logger: Logger) {
+    this.db = db;
+    this.eventBus = eventBus;
+    this.logger = logger.child({ module: "group-manager" });
+    this.stmts = this.prepareStatements();
+  }
+
+  private prepareStatements() {
+    return {
+      insertGroup: this.db.prepare(
+        `INSERT INTO equipment_groups (id, name, zone_id, icon, description, display_order)
+         VALUES (@id, @name, @zoneId, @icon, @description, @displayOrder)`,
+      ),
+      getGroupById: this.db.prepare("SELECT * FROM equipment_groups WHERE id = ?"),
+      getGroupsByZoneId: this.db.prepare(
+        "SELECT * FROM equipment_groups WHERE zone_id = ? ORDER BY display_order, name",
+      ),
+      updateGroup: this.db.prepare(
+        `UPDATE equipment_groups SET name = @name, icon = @icon,
+         description = @description, display_order = @displayOrder,
+         updated_at = datetime('now') WHERE id = @id`,
+      ),
+      deleteGroup: this.db.prepare("DELETE FROM equipment_groups WHERE id = ?"),
+      zoneExists: this.db.prepare("SELECT id FROM zones WHERE id = ?"),
+    };
+  }
+
+  create(zoneId: string, input: CreateGroupInput): EquipmentGroup {
+    // Validate zone exists
+    const zone = this.stmts.zoneExists.get(zoneId);
+    if (!zone) {
+      throw new GroupError(`Zone not found: ${zoneId}`, 404);
+    }
+
+    const id = randomUUID();
+
+    this.stmts.insertGroup.run({
+      id,
+      name: input.name,
+      zoneId,
+      icon: input.icon ?? null,
+      description: input.description ?? null,
+      displayOrder: input.displayOrder ?? 0,
+    });
+
+    const group = this.getById(id)!;
+    this.logger.info({ groupId: id, name: input.name, zoneId }, "Group created");
+    this.eventBus.emit({ type: "group.created", group });
+    return group;
+  }
+
+  getById(id: string): EquipmentGroup | null {
+    const row = this.stmts.getGroupById.get(id) as GroupRow | undefined;
+    return row ? rowToGroup(row) : null;
+  }
+
+  getByZoneId(zoneId: string): EquipmentGroup[] {
+    const rows = this.stmts.getGroupsByZoneId.all(zoneId) as GroupRow[];
+    return rows.map(rowToGroup);
+  }
+
+  update(id: string, input: UpdateGroupInput): EquipmentGroup | null {
+    const existing = this.stmts.getGroupById.get(id) as GroupRow | undefined;
+    if (!existing) return null;
+
+    this.stmts.updateGroup.run({
+      id,
+      name: input.name ?? existing.name,
+      icon: input.icon !== undefined ? input.icon : existing.icon,
+      description: input.description !== undefined ? input.description : existing.description,
+      displayOrder: input.displayOrder ?? existing.display_order,
+    });
+
+    const group = this.getById(id)!;
+    this.logger.info({ groupId: id, name: group.name }, "Group updated");
+    this.eventBus.emit({ type: "group.updated", group });
+    return group;
+  }
+
+  delete(id: string): void {
+    const existing = this.getById(id);
+    if (!existing) {
+      throw new GroupError("Group not found", 404);
+    }
+
+    this.stmts.deleteGroup.run(id);
+    this.logger.info({ groupId: id, name: existing.name }, "Group deleted");
+    this.eventBus.emit({ type: "group.removed", groupId: id, groupName: existing.name });
+  }
+}
+
+// ============================================================
+// Custom error
+// ============================================================
+
+export class GroupError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "GroupError";
+    this.status = status;
+  }
+}
+
+// ============================================================
+// SQLite row types and mappers
+// ============================================================
+
+interface GroupRow {
+  id: string;
+  name: string;
+  zone_id: string;
+  icon: string | null;
+  description: string | null;
+  display_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToGroup(row: GroupRow): EquipmentGroup {
+  return {
+    id: row.id,
+    name: row.name,
+    zoneId: row.zone_id,
+    icon: row.icon ?? undefined,
+    description: row.description ?? undefined,
+    displayOrder: row.display_order,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/src/zones/zone-manager.test.ts
+++ b/src/zones/zone-manager.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { ZoneManager, ZoneError } from "./zone-manager.js";
+import { GroupManager } from "./group-manager.js";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+import type { EngineEvent } from "../shared/types.js";
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  const migration1 = readFileSync(
+    resolve(import.meta.dirname ?? ".", "../../migrations/001_devices.sql"),
+    "utf-8",
+  );
+  const migration2 = readFileSync(
+    resolve(import.meta.dirname ?? ".", "../../migrations/002_zones.sql"),
+    "utf-8",
+  );
+  db.exec(migration1);
+  db.exec(migration2);
+  return db;
+}
+
+const logger = createLogger("silent");
+
+describe("ZoneManager", () => {
+  let db: Database.Database;
+  let eventBus: EventBus;
+  let manager: ZoneManager;
+  let events: EngineEvent[];
+
+  beforeEach(() => {
+    db = createTestDb();
+    eventBus = new EventBus(logger);
+    manager = new ZoneManager(db, eventBus, logger);
+    events = [];
+    eventBus.on((event) => events.push(event));
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // ============================================================
+  // Create
+  // ============================================================
+
+  describe("create", () => {
+    it("creates a root zone", () => {
+      const zone = manager.create({ name: "Maison" });
+
+      expect(zone.name).toBe("Maison");
+      expect(zone.parentId).toBeNull();
+      expect(zone.displayOrder).toBe(0);
+      expect(zone.id).toBeDefined();
+      expect(zone.createdAt).toBeDefined();
+    });
+
+    it("creates a child zone", () => {
+      const parent = manager.create({ name: "Maison" });
+      const child = manager.create({ name: "Salon", parentId: parent.id });
+
+      expect(child.parentId).toBe(parent.id);
+      expect(child.name).toBe("Salon");
+    });
+
+    it("emits zone.created event", () => {
+      manager.create({ name: "Maison" });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe("zone.created");
+    });
+
+    it("rejects non-existent parent", () => {
+      expect(() => {
+        manager.create({ name: "Salon", parentId: "non-existent" });
+      }).toThrow(ZoneError);
+    });
+
+    it("stores optional fields", () => {
+      const zone = manager.create({
+        name: "Salon",
+        icon: "sofa",
+        description: "Pièce principale, 35m²",
+        displayOrder: 5,
+      });
+
+      expect(zone.icon).toBe("sofa");
+      expect(zone.description).toBe("Pièce principale, 35m²");
+      expect(zone.displayOrder).toBe(5);
+    });
+  });
+
+  // ============================================================
+  // Read
+  // ============================================================
+
+  describe("getById", () => {
+    it("returns zone by id", () => {
+      const created = manager.create({ name: "Maison" });
+      const fetched = manager.getById(created.id);
+
+      expect(fetched).not.toBeNull();
+      expect(fetched!.name).toBe("Maison");
+    });
+
+    it("returns null for non-existent id", () => {
+      expect(manager.getById("non-existent")).toBeNull();
+    });
+  });
+
+  describe("getAll", () => {
+    it("returns all zones", () => {
+      manager.create({ name: "Maison" });
+      manager.create({ name: "Garage" });
+
+      const all = manager.getAll();
+      expect(all).toHaveLength(2);
+    });
+
+    it("returns empty array when no zones", () => {
+      expect(manager.getAll()).toHaveLength(0);
+    });
+  });
+
+  describe("getTree", () => {
+    it("builds tree structure", () => {
+      const maison = manager.create({ name: "Maison" });
+      const rdc = manager.create({ name: "RDC", parentId: maison.id });
+      manager.create({ name: "Salon", parentId: rdc.id });
+      manager.create({ name: "Cuisine", parentId: rdc.id });
+      const etage = manager.create({ name: "Étage", parentId: maison.id });
+      manager.create({ name: "Chambre", parentId: etage.id });
+
+      const tree = manager.getTree();
+
+      expect(tree).toHaveLength(1); // One root: Maison
+      expect(tree[0].name).toBe("Maison");
+      expect(tree[0].children).toHaveLength(2); // RDC, Étage
+
+      const rdcNode = tree[0].children.find((c) => c.name === "RDC");
+      expect(rdcNode).toBeDefined();
+      expect(rdcNode!.children).toHaveLength(2); // Salon, Cuisine
+    });
+
+    it("handles multiple root zones", () => {
+      manager.create({ name: "Maison" });
+      manager.create({ name: "Bureau" });
+
+      const tree = manager.getTree();
+      expect(tree).toHaveLength(2);
+    });
+
+    it("includes groups in tree nodes", () => {
+      const groupManager = new GroupManager(db, eventBus, logger);
+      const maison = manager.create({ name: "Maison" });
+      groupManager.create(maison.id, { name: "Volets Sud" });
+
+      const tree = manager.getTree();
+      expect(tree[0].groups).toHaveLength(1);
+      expect(tree[0].groups[0].name).toBe("Volets Sud");
+    });
+  });
+
+  // ============================================================
+  // Update
+  // ============================================================
+
+  describe("update", () => {
+    it("updates zone name", () => {
+      const zone = manager.create({ name: "Salon" });
+      const updated = manager.update(zone.id, { name: "Grand Salon" });
+
+      expect(updated).not.toBeNull();
+      expect(updated!.name).toBe("Grand Salon");
+    });
+
+    it("updates zone parent", () => {
+      const maison = manager.create({ name: "Maison" });
+      const salon = manager.create({ name: "Salon" });
+
+      const updated = manager.update(salon.id, { parentId: maison.id });
+      expect(updated!.parentId).toBe(maison.id);
+    });
+
+    it("emits zone.updated event", () => {
+      const zone = manager.create({ name: "Salon" });
+      events.length = 0; // Clear create event
+
+      manager.update(zone.id, { name: "Grand Salon" });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe("zone.updated");
+    });
+
+    it("returns null for non-existent zone", () => {
+      expect(manager.update("non-existent", { name: "Test" })).toBeNull();
+    });
+
+    it("rejects self-parent", () => {
+      const zone = manager.create({ name: "Salon" });
+
+      expect(() => {
+        manager.update(zone.id, { parentId: zone.id });
+      }).toThrow("cannot be its own parent");
+    });
+
+    it("rejects circular reference", () => {
+      const a = manager.create({ name: "A" });
+      const b = manager.create({ name: "B", parentId: a.id });
+      const c = manager.create({ name: "C", parentId: b.id });
+
+      // Try to make A a child of C → would create A → B → C → A
+      expect(() => {
+        manager.update(a.id, { parentId: c.id });
+      }).toThrow("circular reference");
+    });
+
+    it("allows moving a zone to a valid parent", () => {
+      const maison = manager.create({ name: "Maison" });
+      const rdc = manager.create({ name: "RDC", parentId: maison.id });
+      const etage = manager.create({ name: "Étage", parentId: maison.id });
+      const salon = manager.create({ name: "Salon", parentId: rdc.id });
+
+      // Move Salon from RDC to Étage — valid
+      const updated = manager.update(salon.id, { parentId: etage.id });
+      expect(updated!.parentId).toBe(etage.id);
+    });
+
+    it("clears optional fields with null", () => {
+      const zone = manager.create({ name: "Salon", icon: "sofa", description: "Test" });
+
+      const updated = manager.update(zone.id, { icon: null, description: null });
+      expect(updated!.icon).toBeUndefined();
+      expect(updated!.description).toBeUndefined();
+    });
+  });
+
+  // ============================================================
+  // Delete
+  // ============================================================
+
+  describe("delete", () => {
+    it("deletes a zone", () => {
+      const zone = manager.create({ name: "Salon" });
+      manager.delete(zone.id);
+
+      expect(manager.getById(zone.id)).toBeNull();
+    });
+
+    it("emits zone.removed event", () => {
+      const zone = manager.create({ name: "Salon" });
+      events.length = 0;
+
+      manager.delete(zone.id);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe("zone.removed");
+      if (events[0].type === "zone.removed") {
+        expect(events[0].zoneName).toBe("Salon");
+      }
+    });
+
+    it("rejects delete when zone has children", () => {
+      const parent = manager.create({ name: "Maison" });
+      manager.create({ name: "Salon", parentId: parent.id });
+
+      expect(() => {
+        manager.delete(parent.id);
+      }).toThrow("child zone");
+    });
+
+    it("rejects delete when zone has groups", () => {
+      const groupManager = new GroupManager(db, eventBus, logger);
+      const zone = manager.create({ name: "Salon" });
+      groupManager.create(zone.id, { name: "Volets" });
+
+      expect(() => {
+        manager.delete(zone.id);
+      }).toThrow("group");
+    });
+
+    it("throws for non-existent zone", () => {
+      expect(() => {
+        manager.delete("non-existent");
+      }).toThrow("not found");
+    });
+  });
+});
+
+describe("GroupManager", () => {
+  let db: Database.Database;
+  let eventBus: EventBus;
+  let zoneManager: ZoneManager;
+  let groupManager: GroupManager;
+  let events: EngineEvent[];
+
+  beforeEach(() => {
+    db = createTestDb();
+    eventBus = new EventBus(logger);
+    zoneManager = new ZoneManager(db, eventBus, logger);
+    groupManager = new GroupManager(db, eventBus, logger);
+    events = [];
+    eventBus.on((event) => events.push(event));
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe("create", () => {
+    it("creates a group in a zone", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const group = groupManager.create(zone.id, { name: "Volets Sud" });
+
+      expect(group.name).toBe("Volets Sud");
+      expect(group.zoneId).toBe(zone.id);
+      expect(group.id).toBeDefined();
+    });
+
+    it("emits group.created event", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      events.length = 0;
+
+      groupManager.create(zone.id, { name: "Volets Sud" });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe("group.created");
+    });
+
+    it("rejects non-existent zone", () => {
+      expect(() => {
+        groupManager.create("non-existent", { name: "Volets" });
+      }).toThrow("Zone not found");
+    });
+  });
+
+  describe("getByZoneId", () => {
+    it("returns groups for a zone", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      groupManager.create(zone.id, { name: "Volets Sud" });
+      groupManager.create(zone.id, { name: "Volets Nord" });
+
+      const groups = groupManager.getByZoneId(zone.id);
+      expect(groups).toHaveLength(2);
+    });
+
+    it("returns empty for zone without groups", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      expect(groupManager.getByZoneId(zone.id)).toHaveLength(0);
+    });
+  });
+
+  describe("update", () => {
+    it("updates group name", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const group = groupManager.create(zone.id, { name: "Volets" });
+
+      const updated = groupManager.update(group.id, { name: "Volets Sud" });
+      expect(updated).not.toBeNull();
+      expect(updated!.name).toBe("Volets Sud");
+    });
+
+    it("emits group.updated event", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const group = groupManager.create(zone.id, { name: "Volets" });
+      events.length = 0;
+
+      groupManager.update(group.id, { name: "Volets Sud" });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe("group.updated");
+    });
+
+    it("returns null for non-existent group", () => {
+      expect(groupManager.update("non-existent", { name: "Test" })).toBeNull();
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes a group", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const group = groupManager.create(zone.id, { name: "Volets" });
+
+      groupManager.delete(group.id);
+      expect(groupManager.getById(group.id)).toBeNull();
+    });
+
+    it("emits group.removed event", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const group = groupManager.create(zone.id, { name: "Volets" });
+      events.length = 0;
+
+      groupManager.delete(group.id);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe("group.removed");
+      if (events[0].type === "group.removed") {
+        expect(events[0].groupName).toBe("Volets");
+      }
+    });
+
+    it("throws for non-existent group", () => {
+      expect(() => {
+        groupManager.delete("non-existent");
+      }).toThrow("not found");
+    });
+
+    it("cascade deletes groups when zone is deleted via SQL", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      groupManager.create(zone.id, { name: "Volets" });
+
+      // Direct SQL delete (simulates cascade)
+      db.prepare("DELETE FROM zones WHERE id = ?").run(zone.id);
+
+      // Groups should be gone too (ON DELETE CASCADE)
+      expect(groupManager.getByZoneId(zone.id)).toHaveLength(0);
+    });
+  });
+});

--- a/src/zones/zone-manager.ts
+++ b/src/zones/zone-manager.ts
@@ -1,0 +1,328 @@
+import { randomUUID } from "node:crypto";
+import type Database from "better-sqlite3";
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { Zone, ZoneWithChildren, EquipmentGroup } from "../shared/types.js";
+
+interface CreateZoneInput {
+  name: string;
+  parentId?: string | null;
+  icon?: string;
+  description?: string;
+  displayOrder?: number;
+}
+
+interface UpdateZoneInput {
+  name?: string;
+  parentId?: string | null;
+  icon?: string | null;
+  description?: string | null;
+  displayOrder?: number;
+}
+
+export class ZoneManager {
+  private db: Database.Database;
+  private logger: Logger;
+  private eventBus: EventBus;
+  private stmts: ReturnType<typeof this.prepareStatements>;
+
+  constructor(db: Database.Database, eventBus: EventBus, logger: Logger) {
+    this.db = db;
+    this.eventBus = eventBus;
+    this.logger = logger.child({ module: "zone-manager" });
+    this.stmts = this.prepareStatements();
+  }
+
+  private prepareStatements() {
+    return {
+      insertZone: this.db.prepare(
+        `INSERT INTO zones (id, name, parent_id, icon, description, display_order)
+         VALUES (@id, @name, @parentId, @icon, @description, @displayOrder)`,
+      ),
+      getZoneById: this.db.prepare("SELECT * FROM zones WHERE id = ?"),
+      getAllZones: this.db.prepare("SELECT * FROM zones ORDER BY display_order, name"),
+      updateZone: this.db.prepare(
+        `UPDATE zones SET name = @name, parent_id = @parentId, icon = @icon,
+         description = @description, display_order = @displayOrder,
+         updated_at = datetime('now') WHERE id = @id`,
+      ),
+      deleteZone: this.db.prepare("DELETE FROM zones WHERE id = ?"),
+      countChildren: this.db.prepare(
+        "SELECT COUNT(*) as count FROM zones WHERE parent_id = ?",
+      ),
+      countGroups: this.db.prepare(
+        "SELECT COUNT(*) as count FROM equipment_groups WHERE zone_id = ?",
+      ),
+      getGroupsByZoneId: this.db.prepare(
+        "SELECT * FROM equipment_groups WHERE zone_id = ? ORDER BY display_order, name",
+      ),
+      getAllGroups: this.db.prepare(
+        "SELECT * FROM equipment_groups ORDER BY display_order, name",
+      ),
+    };
+  }
+
+  // ============================================================
+  // Zone CRUD
+  // ============================================================
+
+  create(input: CreateZoneInput): Zone {
+    const id = randomUUID();
+
+    // Validate parent exists if provided
+    if (input.parentId) {
+      const parent = this.stmts.getZoneById.get(input.parentId) as ZoneRow | undefined;
+      if (!parent) {
+        throw new ZoneError(`Parent zone not found: ${input.parentId}`, 404);
+      }
+    }
+
+    this.stmts.insertZone.run({
+      id,
+      name: input.name,
+      parentId: input.parentId ?? null,
+      icon: input.icon ?? null,
+      description: input.description ?? null,
+      displayOrder: input.displayOrder ?? 0,
+    });
+
+    const zone = this.getById(id)!;
+    this.logger.info({ zoneId: id, name: input.name }, "Zone created");
+    this.eventBus.emit({ type: "zone.created", zone });
+    return zone;
+  }
+
+  getById(id: string): Zone | null {
+    const row = this.stmts.getZoneById.get(id) as ZoneRow | undefined;
+    return row ? rowToZone(row) : null;
+  }
+
+  getAll(): Zone[] {
+    const rows = this.stmts.getAllZones.all() as ZoneRow[];
+    return rows.map(rowToZone);
+  }
+
+  /**
+   * Returns all zones as a tree structure with children and groups.
+   */
+  getTree(): ZoneWithChildren[] {
+    const zones = this.getAll();
+    const groups = (this.stmts.getAllGroups.all() as GroupRow[]).map(rowToGroup);
+
+    // Index groups by zoneId
+    const groupsByZone = new Map<string, EquipmentGroup[]>();
+    for (const group of groups) {
+      const list = groupsByZone.get(group.zoneId) ?? [];
+      list.push(group);
+      groupsByZone.set(group.zoneId, list);
+    }
+
+    // Build tree
+    const nodeMap = new Map<string, ZoneWithChildren>();
+    for (const zone of zones) {
+      nodeMap.set(zone.id, {
+        ...zone,
+        children: [],
+        groups: groupsByZone.get(zone.id) ?? [],
+      });
+    }
+
+    const roots: ZoneWithChildren[] = [];
+    for (const node of nodeMap.values()) {
+      if (node.parentId && nodeMap.has(node.parentId)) {
+        nodeMap.get(node.parentId)!.children.push(node);
+      } else {
+        roots.push(node);
+      }
+    }
+
+    return roots;
+  }
+
+  /**
+   * Returns a single zone with its children and groups.
+   */
+  getByIdWithChildren(id: string): ZoneWithChildren | null {
+    const zone = this.getById(id);
+    if (!zone) return null;
+
+    const allZones = this.getAll();
+    const groups = (this.stmts.getGroupsByZoneId.all(id) as GroupRow[]).map(rowToGroup);
+
+    // Get direct children
+    const children: ZoneWithChildren[] = allZones
+      .filter((z) => z.parentId === id)
+      .map((child) => ({
+        ...child,
+        children: allZones
+          .filter((z) => z.parentId === child.id)
+          .map((grandchild) => ({
+            ...grandchild,
+            children: [],
+            groups: (this.stmts.getGroupsByZoneId.all(grandchild.id) as GroupRow[]).map(rowToGroup),
+          })),
+        groups: (this.stmts.getGroupsByZoneId.all(child.id) as GroupRow[]).map(rowToGroup),
+      }));
+
+    return {
+      ...zone,
+      children,
+      groups,
+    };
+  }
+
+  update(id: string, input: UpdateZoneInput): Zone | null {
+    const existing = this.stmts.getZoneById.get(id) as ZoneRow | undefined;
+    if (!existing) return null;
+
+    // If changing parentId, validate
+    const newParentId = input.parentId !== undefined ? input.parentId : existing.parent_id;
+    if (newParentId) {
+      // Parent must exist
+      const parent = this.stmts.getZoneById.get(newParentId) as ZoneRow | undefined;
+      if (!parent) {
+        throw new ZoneError(`Parent zone not found: ${newParentId}`, 404);
+      }
+      // Cannot be own parent
+      if (newParentId === id) {
+        throw new ZoneError("A zone cannot be its own parent", 400);
+      }
+      // Check for circular reference
+      if (this.wouldCreateCycle(id, newParentId)) {
+        throw new ZoneError("Moving this zone would create a circular reference", 400);
+      }
+    }
+
+    this.stmts.updateZone.run({
+      id,
+      name: input.name ?? existing.name,
+      parentId: input.parentId !== undefined ? input.parentId : existing.parent_id,
+      icon: input.icon !== undefined ? input.icon : existing.icon,
+      description: input.description !== undefined ? input.description : existing.description,
+      displayOrder: input.displayOrder ?? existing.display_order,
+    });
+
+    const zone = this.getById(id)!;
+    this.logger.info({ zoneId: id, name: zone.name }, "Zone updated");
+    this.eventBus.emit({ type: "zone.updated", zone });
+    return zone;
+  }
+
+  delete(id: string): void {
+    const existing = this.getById(id);
+    if (!existing) {
+      throw new ZoneError("Zone not found", 404);
+    }
+
+    // Guard: no children
+    const childCount = (this.stmts.countChildren.get(id) as { count: number }).count;
+    if (childCount > 0) {
+      throw new ZoneError(
+        `Cannot delete zone with ${childCount} child zone${childCount > 1 ? "s" : ""}. Remove or move them first.`,
+        400,
+      );
+    }
+
+    // Guard: no groups
+    const groupCount = (this.stmts.countGroups.get(id) as { count: number }).count;
+    if (groupCount > 0) {
+      throw new ZoneError(
+        `Cannot delete zone with ${groupCount} group${groupCount > 1 ? "s" : ""}. Remove them first.`,
+        400,
+      );
+    }
+
+    this.stmts.deleteZone.run(id);
+    this.logger.info({ zoneId: id, name: existing.name }, "Zone deleted");
+    this.eventBus.emit({ type: "zone.removed", zoneId: id, zoneName: existing.name });
+  }
+
+  // ============================================================
+  // Helpers
+  // ============================================================
+
+  /**
+   * Check if setting `zoneId`'s parent to `newParentId` would create a cycle.
+   * Walks up from newParentId — if we reach zoneId, it's a cycle.
+   */
+  private wouldCreateCycle(zoneId: string, newParentId: string): boolean {
+    let currentId: string | null = newParentId;
+    const visited = new Set<string>();
+
+    while (currentId) {
+      if (currentId === zoneId) return true;
+      if (visited.has(currentId)) return false; // Already visited (broken chain)
+      visited.add(currentId);
+
+      const row = this.stmts.getZoneById.get(currentId) as ZoneRow | undefined;
+      currentId = row?.parent_id ?? null;
+    }
+
+    return false;
+  }
+}
+
+// ============================================================
+// Custom error
+// ============================================================
+
+export class ZoneError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ZoneError";
+    this.status = status;
+  }
+}
+
+// ============================================================
+// SQLite row types and mappers
+// ============================================================
+
+interface ZoneRow {
+  id: string;
+  name: string;
+  parent_id: string | null;
+  icon: string | null;
+  description: string | null;
+  display_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToZone(row: ZoneRow): Zone {
+  return {
+    id: row.id,
+    name: row.name,
+    parentId: row.parent_id,
+    icon: row.icon ?? undefined,
+    description: row.description ?? undefined,
+    displayOrder: row.display_order,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+interface GroupRow {
+  id: string;
+  name: string;
+  zone_id: string;
+  icon: string | null;
+  description: string | null;
+  display_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToGroup(row: GroupRow): EquipmentGroup {
+  return {
+    id: row.id,
+    name: row.name,
+    zoneId: row.zone_id,
+    icon: row.icon ?? undefined,
+    description: row.description ?? undefined,
+    displayOrder: row.display_order,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AppLayout } from "./components/layout/AppLayout";
 import { DevicesPage } from "./pages/DevicesPage";
 import { DeviceDetailPage } from "./pages/DeviceDetailPage";
+import { ZonesPage } from "./pages/ZonesPage";
+import { ZoneDetailPage } from "./pages/ZoneDetailPage";
 
 export default function App() {
   return (
@@ -10,6 +12,8 @@ export default function App() {
         <Route element={<AppLayout />}>
           <Route path="/devices" element={<DevicesPage />} />
           <Route path="/devices/:id" element={<DeviceDetailPage />} />
+          <Route path="/zones" element={<ZonesPage />} />
+          <Route path="/zones/:id" element={<ZoneDetailPage />} />
           <Route path="*" element={<Navigate to="/devices" replace />} />
         </Route>
       </Routes>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,4 +1,4 @@
-import type { Device, DeviceData, DeviceWithDetails } from "./types";
+import type { Device, DeviceData, DeviceWithDetails, ZoneWithChildren, Zone, EquipmentGroup } from "./types";
 
 const API_BASE = "/api/v1";
 
@@ -46,4 +46,74 @@ export async function getDeviceRawExpose(
   id: string
 ): Promise<{ deviceId: string; name: string; mqttName: string; expose: unknown }> {
   return fetchJSON(`${API_BASE}/devices/${id}/raw`);
+}
+
+// ============================================================
+// Zones
+// ============================================================
+
+export async function getZones(): Promise<ZoneWithChildren[]> {
+  return fetchJSON<ZoneWithChildren[]>(`${API_BASE}/zones`);
+}
+
+export async function getZone(id: string): Promise<ZoneWithChildren> {
+  return fetchJSON<ZoneWithChildren>(`${API_BASE}/zones/${id}`);
+}
+
+export async function createZone(data: {
+  name: string;
+  parentId?: string | null;
+  icon?: string;
+  description?: string;
+}): Promise<Zone> {
+  return fetchJSON<Zone>(`${API_BASE}/zones`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateZone(
+  id: string,
+  updates: { name?: string; parentId?: string | null; icon?: string | null; description?: string | null; displayOrder?: number }
+): Promise<Zone> {
+  return fetchJSON<Zone>(`${API_BASE}/zones/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(updates),
+  });
+}
+
+export async function deleteZone(id: string): Promise<void> {
+  return fetchJSON<void>(`${API_BASE}/zones/${id}`, { method: "DELETE" });
+}
+
+// ============================================================
+// Equipment Groups
+// ============================================================
+
+export async function getGroups(zoneId: string): Promise<EquipmentGroup[]> {
+  return fetchJSON<EquipmentGroup[]>(`${API_BASE}/zones/${zoneId}/groups`);
+}
+
+export async function createGroup(
+  zoneId: string,
+  data: { name: string; icon?: string; description?: string }
+): Promise<EquipmentGroup> {
+  return fetchJSON<EquipmentGroup>(`${API_BASE}/zones/${zoneId}/groups`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateGroup(
+  id: string,
+  updates: { name?: string; icon?: string | null; description?: string | null; displayOrder?: number }
+): Promise<EquipmentGroup> {
+  return fetchJSON<EquipmentGroup>(`${API_BASE}/groups/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(updates),
+  });
+}
+
+export async function deleteGroup(id: string): Promise<void> {
+  return fetchJSON<void>(`${API_BASE}/groups/${id}`, { method: "DELETE" });
 }

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -21,7 +21,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/", label: "Dashboard", icon: <LayoutDashboard size={20} strokeWidth={1.5} />, disabled: true },
   { to: "/devices", label: "Devices", icon: <Radio size={20} strokeWidth={1.5} /> },
   { to: "/equipments", label: "Equipments", icon: <Box size={20} strokeWidth={1.5} />, disabled: true },
-  { to: "/zones", label: "Zones", icon: <Map size={20} strokeWidth={1.5} />, disabled: true },
+  { to: "/zones", label: "Zones", icon: <Map size={20} strokeWidth={1.5} /> },
   { to: "/scenarios", label: "Scenarios", icon: <Workflow size={20} strokeWidth={1.5} />, disabled: true },
 ];
 

--- a/ui/src/components/zones/GroupList.tsx
+++ b/ui/src/components/zones/GroupList.tsx
@@ -1,0 +1,148 @@
+import { useState } from "react";
+import { Layers, Plus, Pencil, Trash2, X } from "lucide-react";
+import type { EquipmentGroup } from "../../types";
+
+interface GroupListProps {
+  groups: EquipmentGroup[];
+  onCreateGroup: (data: { name: string; description?: string }) => Promise<void>;
+  onUpdateGroup: (id: string, data: { name?: string; description?: string | null }) => Promise<void>;
+  onDeleteGroup: (id: string) => Promise<void>;
+}
+
+export function GroupList({ groups, onCreateGroup, onUpdateGroup, onDeleteGroup }: GroupListProps) {
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-[14px] font-semibold text-text">Equipment Groups</h3>
+        <button
+          onClick={() => setShowForm(true)}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-medium text-primary hover:bg-primary-light rounded-[6px] transition-colors duration-150"
+        >
+          <Plus size={14} strokeWidth={1.5} />
+          Add group
+        </button>
+      </div>
+
+      {showForm && (
+        <GroupInlineForm
+          onSubmit={async (data) => {
+            await onCreateGroup(data);
+            setShowForm(false);
+          }}
+          onCancel={() => setShowForm(false)}
+        />
+      )}
+
+      {groups.length === 0 && !showForm ? (
+        <p className="text-[13px] text-text-tertiary py-4">
+          No groups yet. Groups let you organize equipments within a zone (e.g., "Volets Sud", "Éclairage Ambiance").
+        </p>
+      ) : (
+        <div className="space-y-1">
+          {groups.map((group) => (
+            <div key={group.id}>
+              {editingId === group.id ? (
+                <GroupInlineForm
+                  initial={{ name: group.name, description: group.description }}
+                  onSubmit={async (data) => {
+                    await onUpdateGroup(group.id, data);
+                    setEditingId(null);
+                  }}
+                  onCancel={() => setEditingId(null)}
+                />
+              ) : (
+                <div className="flex items-center gap-3 px-3 py-2.5 rounded-[6px] bg-border-light/50 group">
+                  <Layers size={16} strokeWidth={1.5} className="text-text-tertiary flex-shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <span className="text-[13px] font-medium text-text">{group.name}</span>
+                    {group.description && (
+                      <span className="text-[12px] text-text-tertiary ml-2">{group.description}</span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button
+                      onClick={() => setEditingId(group.id)}
+                      className="p-1.5 text-text-tertiary hover:text-text-secondary rounded-[4px] hover:bg-border-light"
+                    >
+                      <Pencil size={13} strokeWidth={1.5} />
+                    </button>
+                    <button
+                      onClick={() => onDeleteGroup(group.id)}
+                      className="p-1.5 text-text-tertiary hover:text-error rounded-[4px] hover:bg-error/10"
+                    >
+                      <Trash2 size={13} strokeWidth={1.5} />
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GroupInlineForm({
+  initial,
+  onSubmit,
+  onCancel,
+}: {
+  initial?: { name: string; description?: string };
+  onSubmit: (data: { name: string; description?: string }) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setSaving(true);
+    try {
+      await onSubmit({ name: name.trim(), description: description.trim() || undefined });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-center gap-2 px-3 py-2 bg-border-light/50 rounded-[6px] mb-1">
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Group name..."
+        className="flex-1 px-2 py-1 text-[13px] bg-surface border border-border rounded-[4px] outline-none focus:border-primary"
+        autoFocus
+        maxLength={100}
+      />
+      <input
+        type="text"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Description..."
+        className="flex-1 px-2 py-1 text-[13px] bg-surface border border-border rounded-[4px] outline-none focus:border-primary"
+        maxLength={500}
+      />
+      <button
+        type="submit"
+        disabled={!name.trim() || saving}
+        className="px-3 py-1 text-[12px] font-medium text-white bg-primary rounded-[4px] hover:bg-primary-hover disabled:opacity-50"
+      >
+        {saving ? "..." : initial ? "Save" : "Add"}
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="p-1 text-text-tertiary hover:text-text-secondary"
+      >
+        <X size={14} strokeWidth={1.5} />
+      </button>
+    </form>
+  );
+}

--- a/ui/src/components/zones/ZoneForm.tsx
+++ b/ui/src/components/zones/ZoneForm.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import type { ZoneWithChildren } from "../../types";
+
+interface ZoneFormProps {
+  /** If provided, we're editing this zone. Otherwise creating a new one. */
+  initial?: { name: string; description?: string; icon?: string };
+  /** Available parent zones for the dropdown */
+  parentZones: { id: string; name: string; depth: number }[];
+  /** Pre-selected parent zone ID */
+  defaultParentId?: string | null;
+  onSubmit: (data: {
+    name: string;
+    parentId: string | null;
+    icon?: string;
+    description?: string;
+  }) => Promise<void>;
+  onClose: () => void;
+  title: string;
+}
+
+export function ZoneForm({ initial, parentZones, defaultParentId, onSubmit, onClose, title }: ZoneFormProps) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [parentId, setParentId] = useState<string | null>(defaultParentId ?? null);
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      await onSubmit({
+        name: name.trim(),
+        parentId,
+        description: description.trim() || undefined,
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50" onClick={onClose}>
+      <div
+        className="bg-surface rounded-[14px] border border-border shadow-xl w-full max-w-[440px] mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border-light">
+          <h2 className="text-[16px] font-semibold text-text">{title}</h2>
+          <button
+            onClick={onClose}
+            className="text-text-tertiary hover:text-text-secondary transition-colors"
+          >
+            <X size={18} strokeWidth={1.5} />
+          </button>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+          {/* Name */}
+          <div>
+            <label className="block text-[12px] font-medium text-text-secondary uppercase tracking-wider mb-1.5">
+              Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Salon, Étage 1, Maison..."
+              className="w-full px-3 py-2 text-[14px] bg-surface border border-border rounded-[6px] outline-none placeholder:text-text-tertiary focus:border-primary transition-colors duration-150"
+              autoFocus
+              maxLength={100}
+            />
+          </div>
+
+          {/* Parent zone */}
+          <div>
+            <label className="block text-[12px] font-medium text-text-secondary uppercase tracking-wider mb-1.5">
+              Parent zone
+            </label>
+            <select
+              value={parentId ?? ""}
+              onChange={(e) => setParentId(e.target.value || null)}
+              className="w-full px-3 py-2 text-[14px] bg-surface border border-border rounded-[6px] outline-none focus:border-primary transition-colors duration-150"
+            >
+              <option value="">None (root zone)</option>
+              {parentZones.map((z) => (
+                <option key={z.id} value={z.id}>
+                  {"  ".repeat(z.depth)}{z.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-[12px] font-medium text-text-secondary uppercase tracking-wider mb-1.5">
+              Description
+              <span className="text-text-tertiary font-normal normal-case tracking-normal ml-1">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Pièce principale, 35m²..."
+              className="w-full px-3 py-2 text-[14px] bg-surface border border-border rounded-[6px] outline-none placeholder:text-text-tertiary focus:border-primary transition-colors duration-150"
+              maxLength={500}
+            />
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p className="text-[13px] text-error">{error}</p>
+          )}
+
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-[13px] font-medium text-text-secondary hover:text-text border border-border rounded-[6px] hover:bg-border-light transition-colors duration-150"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!name.trim() || saving}
+              className="px-4 py-2 text-[13px] font-medium text-white bg-primary rounded-[6px] hover:bg-primary-hover transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {saving ? "Saving..." : initial ? "Save" : "Create"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+/** Flatten zone tree into a list with depth info (for parent dropdown) */
+export function flattenZoneTree(
+  zones: ZoneWithChildren[],
+  depth = 0,
+  excludeId?: string
+): { id: string; name: string; depth: number }[] {
+  const result: { id: string; name: string; depth: number }[] = [];
+  for (const zone of zones) {
+    if (zone.id === excludeId) continue;
+    result.push({ id: zone.id, name: zone.name, depth });
+    result.push(...flattenZoneTree(zone.children, depth + 1, excludeId));
+  }
+  return result;
+}

--- a/ui/src/components/zones/ZoneTree.tsx
+++ b/ui/src/components/zones/ZoneTree.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ChevronRight, ChevronDown, Map, Layers, FolderOpen } from "lucide-react";
+import type { ZoneWithChildren } from "../../types";
+
+interface ZoneTreeProps {
+  zones: ZoneWithChildren[];
+}
+
+export function ZoneTree({ zones }: ZoneTreeProps) {
+  if (zones.length === 0) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className="bg-surface rounded-[10px] border border-border overflow-hidden">
+      <div className="divide-y divide-border-light">
+        {zones.map((zone) => (
+          <ZoneTreeNode key={zone.id} zone={zone} depth={0} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ZoneTreeNode({ zone, depth }: { zone: ZoneWithChildren; depth: number }) {
+  const [expanded, setExpanded] = useState(depth < 2);
+  const navigate = useNavigate();
+  const hasChildren = zone.children.length > 0;
+  const childCount = zone.children.length;
+  const groupCount = zone.groups.length;
+
+  return (
+    <div>
+      <div
+        className="flex items-center gap-2 px-4 py-3 hover:bg-primary-light/40 cursor-pointer transition-colors duration-150"
+        style={{ paddingLeft: `${16 + depth * 24}px` }}
+      >
+        {/* Expand/collapse toggle */}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            if (hasChildren) setExpanded(!expanded);
+          }}
+          className={`flex-shrink-0 w-5 h-5 flex items-center justify-center rounded ${
+            hasChildren
+              ? "text-text-secondary hover:text-text hover:bg-border-light"
+              : "text-transparent"
+          }`}
+        >
+          {hasChildren &&
+            (expanded ? (
+              <ChevronDown size={14} strokeWidth={1.5} />
+            ) : (
+              <ChevronRight size={14} strokeWidth={1.5} />
+            ))}
+        </button>
+
+        {/* Zone info — clickable to navigate */}
+        <div
+          className="flex-1 flex items-center gap-3 min-w-0"
+          onClick={() => navigate(`/zones/${zone.id}`)}
+        >
+          <span className="flex-shrink-0 text-text-secondary">
+            {depth === 0 ? (
+              <Map size={18} strokeWidth={1.5} />
+            ) : hasChildren ? (
+              <Layers size={18} strokeWidth={1.5} />
+            ) : (
+              <FolderOpen size={18} strokeWidth={1.5} />
+            )}
+          </span>
+
+          <div className="flex-1 min-w-0">
+            <span className="text-[14px] font-medium text-text truncate block">
+              {zone.name}
+            </span>
+            {zone.description && (
+              <span className="text-[12px] text-text-tertiary truncate block">
+                {zone.description}
+              </span>
+            )}
+          </div>
+
+          {/* Badges */}
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {childCount > 0 && (
+              <span className="text-[11px] text-text-tertiary bg-border-light px-2 py-0.5 rounded-full">
+                {childCount} zone{childCount > 1 ? "s" : ""}
+              </span>
+            )}
+            {groupCount > 0 && (
+              <span className="text-[11px] text-text-tertiary bg-border-light px-2 py-0.5 rounded-full">
+                {groupCount} group{groupCount > 1 ? "s" : ""}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Children */}
+      {expanded && hasChildren && (
+        <div>
+          {zone.children.map((child) => (
+            <ZoneTreeNode key={child.id} zone={child} depth={depth + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="w-16 h-16 rounded-full bg-border-light flex items-center justify-center mb-4">
+        <Map size={28} strokeWidth={1.5} className="text-text-tertiary" />
+      </div>
+      <h3 className="text-[16px] font-medium text-text mb-1">No zones yet</h3>
+      <p className="text-[13px] text-text-secondary max-w-[320px]">
+        Create your first zone to start building your home topology.
+      </p>
+    </div>
+  );
+}

--- a/ui/src/pages/ZoneDetailPage.tsx
+++ b/ui/src/pages/ZoneDetailPage.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { useZones } from "../store/useZones";
+import { getZone } from "../api";
+import { ZoneForm, flattenZoneTree } from "../components/zones/ZoneForm";
+import { GroupList } from "../components/zones/GroupList";
+import {
+  ArrowLeft,
+  Loader2,
+  Map,
+  Pencil,
+  Trash2,
+  ChevronRight,
+  FolderOpen,
+} from "lucide-react";
+import type { ZoneWithChildren } from "../types";
+
+export function ZoneDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const tree = useZones((s) => s.tree);
+  const fetchZones = useZones((s) => s.fetchZones);
+  const updateZone = useZones((s) => s.updateZone);
+  const deleteZone = useZones((s) => s.deleteZone);
+  const createGroup = useZones((s) => s.createGroup);
+  const updateGroup = useZones((s) => s.updateGroup);
+  const deleteGroup = useZones((s) => s.deleteGroup);
+
+  const [zone, setZone] = useState<ZoneWithChildren | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showEditForm, setShowEditForm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+
+    setLoading(true);
+    setError(null);
+    getZone(id)
+      .then((data) => {
+        if (!cancelled) {
+          setZone(data);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load zone");
+          setLoading(false);
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [id, tree]); // Re-fetch when tree updates (via WebSocket)
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 size={24} className="animate-spin text-text-tertiary" />
+      </div>
+    );
+  }
+
+  if (error || !zone) {
+    return (
+      <div className="p-6">
+        <Link to="/zones" className="inline-flex items-center gap-1.5 text-[13px] text-text-secondary hover:text-text mb-4">
+          <ArrowLeft size={14} strokeWidth={1.5} />
+          Back to zones
+        </Link>
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <div className="w-16 h-16 rounded-full bg-error/10 flex items-center justify-center mb-4">
+            <Map size={28} strokeWidth={1.5} className="text-error" />
+          </div>
+          <h3 className="text-[16px] font-medium text-text mb-1">Zone not found</h3>
+          <p className="text-[13px] text-text-secondary">{error ?? "This zone does not exist."}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const handleDelete = async () => {
+    if (!confirm(`Delete zone "${zone.name}"? This cannot be undone.`)) return;
+    setDeleting(true);
+    try {
+      await deleteZone(zone.id);
+      navigate("/zones");
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to delete zone");
+      setDeleting(false);
+    }
+  };
+
+  // Build breadcrumb
+  const breadcrumb = buildBreadcrumb(zone.id, tree);
+
+  return (
+    <div className="p-6">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-1.5 text-[13px] text-text-secondary mb-4">
+        <Link to="/zones" className="hover:text-text transition-colors">Zones</Link>
+        {breadcrumb.map((item) => (
+          <span key={item.id} className="flex items-center gap-1.5">
+            <ChevronRight size={12} strokeWidth={1.5} className="text-text-tertiary" />
+            {item.id === zone.id ? (
+              <span className="text-text font-medium">{item.name}</span>
+            ) : (
+              <Link to={`/zones/${item.id}`} className="hover:text-text transition-colors">
+                {item.name}
+              </Link>
+            )}
+          </span>
+        ))}
+      </div>
+
+      {/* Zone header */}
+      <div className="flex items-start justify-between mb-8">
+        <div>
+          <h1 className="text-[24px] font-semibold text-text leading-[32px]">
+            {zone.name}
+          </h1>
+          {zone.description && (
+            <p className="text-[14px] text-text-secondary mt-1">{zone.description}</p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setShowEditForm(true)}
+            className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors duration-150"
+          >
+            <Pencil size={14} strokeWidth={1.5} />
+            Edit
+          </button>
+          <button
+            onClick={handleDelete}
+            disabled={deleting}
+            className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-error border border-error/30 rounded-[6px] hover:bg-error/10 transition-colors duration-150 disabled:opacity-50"
+          >
+            <Trash2 size={14} strokeWidth={1.5} />
+            {deleting ? "Deleting..." : "Delete"}
+          </button>
+        </div>
+      </div>
+
+      {/* Child zones section */}
+      {zone.children.length > 0 && (
+        <div className="mb-8">
+          <h3 className="text-[14px] font-semibold text-text mb-3">Child Zones</h3>
+          <div className="bg-surface rounded-[10px] border border-border overflow-hidden divide-y divide-border-light">
+            {zone.children.map((child) => (
+              <Link
+                key={child.id}
+                to={`/zones/${child.id}`}
+                className="flex items-center gap-3 px-4 py-3 hover:bg-primary-light/40 transition-colors duration-150"
+              >
+                <FolderOpen size={18} strokeWidth={1.5} className="text-text-secondary flex-shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <span className="text-[14px] font-medium text-text">{child.name}</span>
+                  {child.description && (
+                    <span className="text-[12px] text-text-tertiary ml-2">{child.description}</span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  {child.children.length > 0 && (
+                    <span className="text-[11px] text-text-tertiary bg-border-light px-2 py-0.5 rounded-full">
+                      {child.children.length} zone{child.children.length > 1 ? "s" : ""}
+                    </span>
+                  )}
+                  {child.groups.length > 0 && (
+                    <span className="text-[11px] text-text-tertiary bg-border-light px-2 py-0.5 rounded-full">
+                      {child.groups.length} group{child.groups.length > 1 ? "s" : ""}
+                    </span>
+                  )}
+                </div>
+                <ChevronRight size={16} strokeWidth={1.5} className="text-text-tertiary" />
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Groups section */}
+      <div className="bg-surface rounded-[10px] border border-border p-4">
+        <GroupList
+          groups={zone.groups}
+          onCreateGroup={async (data) => { await createGroup(zone.id, data); }}
+          onUpdateGroup={async (gid, data) => { await updateGroup(gid, data); }}
+          onDeleteGroup={async (gid) => { await deleteGroup(gid); }}
+        />
+      </div>
+
+      {/* Edit zone modal */}
+      {showEditForm && (
+        <ZoneForm
+          title="Edit zone"
+          initial={{ name: zone.name, description: zone.description }}
+          parentZones={flattenZoneTree(tree, 0, zone.id)}
+          defaultParentId={zone.parentId}
+          onSubmit={async (data) => {
+            await updateZone(zone.id, data);
+          }}
+          onClose={() => setShowEditForm(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function buildBreadcrumb(
+  zoneId: string,
+  tree: ZoneWithChildren[]
+): { id: string; name: string }[] {
+  const path: { id: string; name: string }[] = [];
+
+  function find(zones: ZoneWithChildren[], trail: { id: string; name: string }[]): boolean {
+    for (const zone of zones) {
+      const current = [...trail, { id: zone.id, name: zone.name }];
+      if (zone.id === zoneId) {
+        path.push(...current);
+        return true;
+      }
+      if (find(zone.children, current)) return true;
+    }
+    return false;
+  }
+
+  find(tree, []);
+  return path;
+}

--- a/ui/src/pages/ZonesPage.tsx
+++ b/ui/src/pages/ZonesPage.tsx
@@ -1,0 +1,106 @@
+import { useState, useEffect } from "react";
+import { useZones } from "../store/useZones";
+import { ZoneTree } from "../components/zones/ZoneTree";
+import { ZoneForm, flattenZoneTree } from "../components/zones/ZoneForm";
+import { Map, Loader2, Plus } from "lucide-react";
+
+export function ZonesPage() {
+  const tree = useZones((s) => s.tree);
+  const loading = useZones((s) => s.loading);
+  const error = useZones((s) => s.error);
+  const fetchZones = useZones((s) => s.fetchZones);
+  const createZone = useZones((s) => s.createZone);
+  const [showForm, setShowForm] = useState(false);
+
+  useEffect(() => {
+    fetchZones();
+  }, [fetchZones]);
+
+  const zoneCount = countZones(tree);
+
+  return (
+    <div className="p-6">
+      {/* Page header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-[24px] font-semibold text-text leading-[32px]">
+            Zones
+          </h1>
+          <p className="text-[13px] text-text-secondary mt-0.5">
+            {zoneCount === 0
+              ? "Define the topology of your home"
+              : `${zoneCount} zone${zoneCount !== 1 ? "s" : ""}`}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setShowForm(true)}
+            className="flex items-center gap-2 px-4 py-2 text-[13px] font-medium text-white bg-primary rounded-[6px] hover:bg-primary-hover transition-colors duration-150"
+          >
+            <Plus size={16} strokeWidth={1.5} />
+            Add zone
+          </button>
+
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-[6px] bg-primary-light text-primary">
+            <Map size={16} strokeWidth={1.5} />
+            <span className="text-[13px] font-medium">{zoneCount}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      {loading ? (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 size={24} className="animate-spin text-text-tertiary" />
+        </div>
+      ) : error ? (
+        <ErrorState error={error} />
+      ) : (
+        <ZoneTree zones={tree} />
+      )}
+
+      {/* Create zone modal */}
+      {showForm && (
+        <ZoneForm
+          title="Create zone"
+          parentZones={flattenZoneTree(tree)}
+          onSubmit={async (data) => {
+            await createZone(data);
+          }}
+          onClose={() => setShowForm(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function countZones(zones: { children?: { children?: unknown[] }[] }[]): number {
+  let count = zones.length;
+  for (const zone of zones) {
+    if (zone.children) {
+      count += countZones(zone.children as typeof zones);
+    }
+  }
+  return count;
+}
+
+function ErrorState({ error }: { error: string }) {
+  const fetchZones = useZones((s) => s.fetchZones);
+
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="w-16 h-16 rounded-full bg-error/10 flex items-center justify-center mb-4">
+        <Map size={28} strokeWidth={1.5} className="text-error" />
+      </div>
+      <h3 className="text-[16px] font-medium text-text mb-1">Failed to load zones</h3>
+      <p className="text-[13px] text-text-secondary max-w-[320px] mb-4">{error}</p>
+      <button
+        onClick={() => fetchZones()}
+        className="px-4 py-2 bg-primary text-white text-[13px] font-medium rounded-[6px] hover:bg-primary-hover transition-colors duration-150 ease-out"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { EngineEvent } from "../types";
 import { useDevices } from "./useDevices";
+import { useZones } from "./useZones";
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected";
 
@@ -47,6 +48,24 @@ function handleEvent(event: EngineEvent): void {
         event.value,
         event.timestamp
       );
+      break;
+    case "zone.created":
+      useZones.getState().handleZoneCreated(event.zone);
+      break;
+    case "zone.updated":
+      useZones.getState().handleZoneUpdated(event.zone);
+      break;
+    case "zone.removed":
+      useZones.getState().handleZoneRemoved(event.zoneId);
+      break;
+    case "group.created":
+      useZones.getState().handleGroupCreated(event.group);
+      break;
+    case "group.updated":
+      useZones.getState().handleGroupUpdated(event.group);
+      break;
+    case "group.removed":
+      useZones.getState().handleGroupRemoved(event.groupId);
       break;
     case "system.mqtt.connected":
       useWebSocket.setState({ mqttConnected: true });

--- a/ui/src/store/useZones.ts
+++ b/ui/src/store/useZones.ts
@@ -1,0 +1,94 @@
+import { create } from "zustand";
+import type { Zone, ZoneWithChildren, EquipmentGroup } from "../types";
+import {
+  getZones,
+  createZone as apiCreateZone,
+  updateZone as apiUpdateZone,
+  deleteZone as apiDeleteZone,
+  createGroup as apiCreateGroup,
+  updateGroup as apiUpdateGroup,
+  deleteGroup as apiDeleteGroup,
+} from "../api";
+
+interface ZonesState {
+  tree: ZoneWithChildren[];
+  loading: boolean;
+  error: string | null;
+
+  // Actions
+  fetchZones: () => Promise<void>;
+  createZone: (data: { name: string; parentId?: string | null; icon?: string; description?: string }) => Promise<Zone>;
+  updateZone: (id: string, updates: { name?: string; parentId?: string | null; icon?: string | null; description?: string | null }) => Promise<void>;
+  deleteZone: (id: string) => Promise<void>;
+  createGroup: (zoneId: string, data: { name: string; icon?: string; description?: string }) => Promise<EquipmentGroup>;
+  updateGroup: (id: string, updates: { name?: string; icon?: string | null; description?: string | null }) => Promise<void>;
+  deleteGroup: (id: string) => Promise<void>;
+
+  // WebSocket handlers
+  handleZoneCreated: (zone: Zone) => void;
+  handleZoneUpdated: (zone: Zone) => void;
+  handleZoneRemoved: (zoneId: string) => void;
+  handleGroupCreated: (group: EquipmentGroup) => void;
+  handleGroupUpdated: (group: EquipmentGroup) => void;
+  handleGroupRemoved: (groupId: string) => void;
+}
+
+export const useZones = create<ZonesState>((set, get) => ({
+  tree: [],
+  loading: false,
+  error: null,
+
+  fetchZones: async () => {
+    set({ loading: true, error: null });
+    try {
+      const tree = await getZones();
+      set({ tree, loading: false });
+    } catch (err) {
+      set({
+        loading: false,
+        error: err instanceof Error ? err.message : "Failed to fetch zones",
+      });
+    }
+  },
+
+  createZone: async (data) => {
+    const zone = await apiCreateZone(data);
+    // Refetch tree to get correct structure
+    await get().fetchZones();
+    return zone;
+  },
+
+  updateZone: async (id, updates) => {
+    await apiUpdateZone(id, updates);
+    await get().fetchZones();
+  },
+
+  deleteZone: async (id) => {
+    await apiDeleteZone(id);
+    await get().fetchZones();
+  },
+
+  createGroup: async (zoneId, data) => {
+    const group = await apiCreateGroup(zoneId, data);
+    await get().fetchZones();
+    return group;
+  },
+
+  updateGroup: async (id, updates) => {
+    await apiUpdateGroup(id, updates);
+    await get().fetchZones();
+  },
+
+  deleteGroup: async (id) => {
+    await apiDeleteGroup(id);
+    await get().fetchZones();
+  },
+
+  // WebSocket handlers — refetch tree on any change
+  handleZoneCreated: () => { get().fetchZones(); },
+  handleZoneUpdated: () => { get().fetchZones(); },
+  handleZoneRemoved: () => { get().fetchZones(); },
+  handleGroupCreated: () => { get().fetchZones(); },
+  handleGroupUpdated: () => { get().fetchZones(); },
+  handleGroupRemoved: () => { get().fetchZones(); },
+}));

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -89,6 +89,41 @@ export interface DeviceWithDetails extends Device {
 }
 
 // ============================================================
+// Zone
+// ============================================================
+
+export interface Zone {
+  id: string;
+  name: string;
+  parentId: string | null;
+  icon?: string;
+  description?: string;
+  displayOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ZoneWithChildren extends Zone {
+  children: ZoneWithChildren[];
+  groups: EquipmentGroup[];
+}
+
+// ============================================================
+// Equipment Group
+// ============================================================
+
+export interface EquipmentGroup {
+  id: string;
+  name: string;
+  zoneId: string;
+  icon?: string;
+  description?: string;
+  displayOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================================
 // Engine Events (received via WebSocket)
 // ============================================================
 
@@ -111,6 +146,12 @@ export type EngineEvent =
       previous: unknown;
       timestamp: string;
     }
+  | { type: "zone.created"; zone: Zone }
+  | { type: "zone.updated"; zone: Zone }
+  | { type: "zone.removed"; zoneId: string; zoneName: string }
+  | { type: "group.created"; group: EquipmentGroup }
+  | { type: "group.updated"; group: EquipmentGroup }
+  | { type: "group.removed"; groupId: string; groupName: string }
   | { type: "system.started" }
   | { type: "system.mqtt.connected" }
   | { type: "system.mqtt.disconnected" }


### PR DESCRIPTION
## Summary
- Implement hierarchical Zones (Home → Floor → Room) with full CRUD, tree building, and circular reference detection
- Implement Equipment Groups within zones (e.g., "Volets Sud", "Éclairage Ambiance")
- Add React UI: zones page (tree view), zone detail page, group management
- Create core data model document (`docs/data-model.md`) — the 3-layer architecture reference

## Changes
- **Backend**: ZoneManager, GroupManager, 9 API endpoints, SQLite migration, 6 EventBus events
- **Frontend**: ZonesPage, ZoneDetailPage, ZoneTree, ZoneForm, GroupList, Zustand store, WebSocket sync
- **Docs**: data-model.md, feature spec (specs/003-V0.2-zones/), updated roadmap

## Test plan
- [x] TypeScript compiles (zero errors, backend + frontend)
- [x] 88 tests pass (37 new for zones + groups)
- [ ] Manual: create zone hierarchy, groups, edit, delete, WebSocket sync

## Roadmap
- Implements V0.2 from updated roadmap (topology-first approach)
- Next: V0.3 — Equipments + Bindings + Orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)