### PR TITLE
feat: V0.5 — Maison view & UI restructuring

### DIFF
--- a/specs/005-V0.5-ui-restructuring/architecture.md
+++ b/specs/005-V0.5-ui-restructuring/architecture.md
@@ -1,0 +1,101 @@
+# Architecture: V0.5 UI Restructuring
+
+## Data Model Changes
+
+No backend data model changes. All changes are frontend-only.
+
+## Event Bus Events
+
+No new events. Consumes existing events:
+- `zone.created`, `zone.updated`, `zone.removed` — to refresh sidebar treeview
+- `equipment.data.changed` — to update equipment values in zone view
+- `equipment.created`, `equipment.updated`, `equipment.removed` — to refresh zone view
+
+## MQTT Topics
+
+No changes.
+
+## API Changes
+
+No new endpoints. Uses existing:
+- `GET /api/v1/zones` — load zone tree for sidebar
+- `GET /api/v1/equipments` — load all equipments (filtered client-side by zoneId)
+- `POST /api/v1/equipments/:id/orders/:alias` — execute equipment orders
+
+## UI Changes
+
+### New Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `SidebarZoneTree` | `ui/src/components/layout/SidebarZoneTree.tsx` | Compact zone treeview for the sidebar, with expand/collapse and selection state |
+| `ZoneEquipmentsView` | `ui/src/components/maison/ZoneEquipmentsView.tsx` | Main panel: displays equipments for a zone, grouped by type |
+| `CompactEquipmentCard` | `ui/src/components/maison/CompactEquipmentCard.tsx` | One-line card: icon + name + primary value + inline control (toggle/slider) |
+| `MaisonPage` | `ui/src/pages/MaisonPage.tsx` | Route handler for `/maison/:zoneId`, loads zone + renders ZoneEquipmentsView |
+
+### Modified Components
+
+| Component | Changes |
+|-----------|---------|
+| `Sidebar.tsx` | Complete restructure: two sections (Maison with SidebarZoneTree, Settings with nav links). Remove Dashboard. Add Scenarios (disabled) to Settings. |
+| `App.tsx` | Add `/maison/:zoneId` route. Change default redirect from `/devices` to `/maison`. |
+
+### Store Changes
+
+| Store | Changes |
+|-------|---------|
+| `useZones.ts` | Already has `tree` and `fetchZones()`. No changes needed — reuse existing store. |
+| `useEquipments.ts` | Already has `equipments` and `fetchEquipments()`. Add a `getByZoneId(zoneId)` selector. No API changes. |
+
+### Routing
+
+| Route | Component | Description |
+|-------|-----------|-------------|
+| `/maison` | `MaisonPage` | Redirects to first zone or shows empty state |
+| `/maison/:zoneId` | `MaisonPage` | Zone view with equipments |
+| `/devices` | `DevicesPage` | Unchanged |
+| `/devices/:id` | `DeviceDetailPage` | Unchanged |
+| `/equipments` | `EquipmentsPage` | Unchanged |
+| `/equipments/:id` | `EquipmentDetailPage` | Unchanged |
+| `/zones` | `ZonesPage` | Unchanged (Home Topology config) |
+| `/zones/:id` | `ZoneDetailPage` | Unchanged |
+| `*` | Redirect to `/maison` | Default route |
+
+### Equipment Type Grouping
+
+Group equipments by these categories for display:
+
+| Group Label | Equipment Types |
+|-------------|----------------|
+| Eclairages | `light_onoff`, `light_dimmable`, `light_color` |
+| Volets | `shutter` |
+| Capteurs | `sensor`, `motion_sensor`, `contact_sensor` |
+| Climat | `thermostat` |
+| Securite | `lock`, `alarm` |
+| Multimedia | `media_player`, `camera` |
+| Autres | `switch`, `generic` |
+
+### Compact Equipment Card Design
+
+```
+┌─────────────────────────────────────────────────┐
+│ 💡  Spots Salon          ON    [━━━━━●━] 70%   │
+└─────────────────────────────────────────────────┘
+```
+
+Single row layout:
+- Left: type icon (from existing TYPE_ICONS)
+- Name: equipment name, truncated if needed
+- Value: primary data value (state badge for booleans, number+unit for numeric)
+- Control: inline toggle for on/off, compact slider for dimmable
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `ui/src/components/layout/Sidebar.tsx` | Restructure into Maison + Settings sections |
+| `ui/src/components/layout/SidebarZoneTree.tsx` | New: compact zone treeview for sidebar |
+| `ui/src/components/maison/ZoneEquipmentsView.tsx` | New: zone equipment grid grouped by type |
+| `ui/src/components/maison/CompactEquipmentCard.tsx` | New: one-line equipment card with controls |
+| `ui/src/pages/MaisonPage.tsx` | New: route handler for /maison/:zoneId |
+| `ui/src/App.tsx` | Add maison routes, change default redirect |

--- a/specs/005-V0.5-ui-restructuring/plan.md
+++ b/specs/005-V0.5-ui-restructuring/plan.md
@@ -1,0 +1,30 @@
+# Implementation Plan: V0.5 UI Restructuring
+
+## Dependencies
+
+- Requires V0.3 (Equipments) to be completed — Done
+- Uses existing zone tree API and equipment API
+- Uses existing WebSocket event handlers
+
+## Tasks
+
+1. [ ] Create `SidebarZoneTree` component — compact treeview with expand/collapse and NavLink selection
+2. [ ] Restructure `Sidebar.tsx` — two sections (Maison with zone tree, Settings with config links)
+3. [ ] Create `CompactEquipmentCard` component — one-line card with icon, name, value, inline controls
+4. [ ] Create `ZoneEquipmentsView` component — equipment list grouped by type for a given zone
+5. [ ] Create `MaisonPage` — route handler loading zone and rendering equipment view
+6. [ ] Update `App.tsx` — add `/maison` routes, change default redirect
+7. [ ] Handle edge cases — empty zones, no zones, zone deleted while viewing
+8. [ ] TypeScript compilation check (zero errors)
+9. [ ] Run existing tests (all pass)
+
+## Testing
+
+- Manual verification:
+  - Navigate sidebar treeview, expand/collapse zones
+  - Click zone → see its equipments grouped by type
+  - Toggle a light from the compact card → verify MQTT command sent
+  - Adjust brightness slider → verify real-time update
+  - Create a new zone in Settings > Home Topology → appears in sidebar treeview
+  - Delete a zone → sidebar updates, redirect if viewing deleted zone
+  - WebSocket disconnect/reconnect → equipment values recover

--- a/specs/005-V0.5-ui-restructuring/spec.md
+++ b/specs/005-V0.5-ui-restructuring/spec.md
@@ -1,0 +1,59 @@
+# V0.5: UI Restructuring
+
+## Summary
+
+Reorganize the UI sidebar into two distinct sections: **Maison** (a dynamic zone treeview for daily use) and **Settings** (configuration pages). When the user selects a zone in the Maison treeview, the main panel displays its equipments as compact cards grouped by type, with live state and controls.
+
+## Reference
+
+- Spec sections: V0.5 (corbel-spec.md lines 1241-1257)
+- Design system: §15 (corbel-spec.md)
+
+## Acceptance Criteria
+
+- [ ] Sidebar has two visually separated sections: "Maison" and "Settings"
+- [ ] Maison section shows a dynamic zone treeview loaded from the API
+- [ ] Zone treeview supports expand/collapse for nested zones
+- [ ] Clicking a zone in the treeview navigates to a zone view in the main panel
+- [ ] Zone view displays equipments as compact cards (icon + name + primary value + control)
+- [ ] Equipments in zone view are grouped by type (Eclairages, Volets, Capteurs...)
+- [ ] Equipment controls work in-place (toggle, slider) with live WebSocket updates
+- [ ] Settings section contains: Devices, Equipments, Home Topology
+- [ ] Scenarios item appears in Settings section, disabled/grayed
+- [ ] Dashboard item is removed from navigation
+- [ ] Zone treeview updates in real-time when zones are created/updated/removed via WebSocket
+- [ ] Default route redirects to Maison (first zone or empty state)
+- [ ] TypeScript compiles with zero errors
+- [ ] All existing tests pass
+
+## Scope
+
+### In Scope
+
+- Sidebar restructuring (two sections with visual separator)
+- Dynamic zone treeview in sidebar (loaded from zones API, expand/collapse)
+- New zone view page (`/maison/:zoneId`) showing equipments
+- Compact equipment card component (one-line: icon + name + value + control)
+- Equipment grouping by type in zone view
+- Live equipment state via existing WebSocket events
+- Routing changes: `/maison/:zoneId` for zone views, default redirect
+- Existing Settings pages (Devices, Equipments, Home Topology) unchanged
+
+### Out of Scope
+
+- Computed Data / expression engine (deferred to V0.6)
+- Internal Rules (deferred)
+- Renaming "Data Bindings" / "Order Bindings"
+- Dark mode
+- Responsive mobile layout
+- Backend API changes (filter client-side)
+- Zone aggregation data in zone headers (no aggregation engine yet)
+
+## Edge Cases
+
+- Zone with no equipments: show empty state message ("No equipments in this zone yet")
+- Zone deleted while viewing it: redirect to parent zone or Maison root
+- No zones exist: show empty state in sidebar treeview ("Create your first zone in Settings > Home Topology")
+- Equipment with no data bindings: show card with name + type icon, no value
+- Sidebar collapsed mode: treeview hidden, show only icons for Settings items
+- WebSocket disconnect: equipment values freeze (existing behavior), reconnect restores

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,19 +6,27 @@ import { ZonesPage } from "./pages/ZonesPage";
 import { ZoneDetailPage } from "./pages/ZoneDetailPage";
 import { EquipmentsPage } from "./pages/EquipmentsPage";
 import { EquipmentDetailPage } from "./pages/EquipmentDetailPage";
+import { MaisonPage } from "./pages/MaisonPage";
 
 export default function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route element={<AppLayout />}>
+          {/* Maison — primary daily view */}
+          <Route path="/maison" element={<MaisonPage />} />
+          <Route path="/maison/:zoneId" element={<MaisonPage />} />
+
+          {/* Settings pages */}
           <Route path="/devices" element={<DevicesPage />} />
           <Route path="/devices/:id" element={<DeviceDetailPage />} />
           <Route path="/equipments" element={<EquipmentsPage />} />
           <Route path="/equipments/:id" element={<EquipmentDetailPage />} />
           <Route path="/zones" element={<ZonesPage />} />
           <Route path="/zones/:id" element={<ZoneDetailPage />} />
-          <Route path="*" element={<Navigate to="/devices" replace />} />
+
+          {/* Default redirect to Maison */}
+          <Route path="*" element={<Navigate to="/maison" replace />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -71,14 +71,14 @@ export function EquipmentCard({ equipment, onExecuteOrder }: EquipmentCardProps)
       className={`
         flex items-center gap-3 px-4 py-3 bg-surface rounded-[10px] border
         transition-colors duration-150
-        ${isOn ? "border-primary/30 bg-primary-light/20" : "border-border"}
+        border-border
       `}
     >
       {/* Icon */}
       <div
         className={`
           flex-shrink-0 w-9 h-9 rounded-[6px] flex items-center justify-center
-          ${isOn ? "bg-primary/10 text-primary" : "bg-border-light text-text-tertiary"}
+          ${isLight && isOn ? "bg-amber-400/15 text-amber-500" : isOn ? "bg-primary/10 text-primary" : "bg-border-light text-text-tertiary"}
         `}
       >
         {TYPE_ICONS[equipment.type]}

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -4,17 +4,23 @@ import { Sidebar } from "./Sidebar";
 import { ConnectionStatus } from "./ConnectionStatus";
 import { useWebSocket } from "../../store/useWebSocket";
 import { useDevices } from "../../store/useDevices";
+import { useZones } from "../../store/useZones";
+import { useEquipments } from "../../store/useEquipments";
 
 export function AppLayout() {
   const connect = useWebSocket((s) => s.connect);
   const disconnect = useWebSocket((s) => s.disconnect);
   const fetchDevices = useDevices((s) => s.fetchDevices);
+  const fetchZones = useZones((s) => s.fetchZones);
+  const fetchEquipments = useEquipments((s) => s.fetchEquipments);
 
   useEffect(() => {
     fetchDevices();
+    fetchZones();
+    fetchEquipments();
     connect();
     return () => disconnect();
-  }, [fetchDevices, connect, disconnect]);
+  }, [fetchDevices, fetchZones, fetchEquipments, connect, disconnect]);
 
   return (
     <div className="flex h-screen overflow-hidden">
@@ -54,10 +60,10 @@ export function AppLayout() {
 function MobileNav() {
   return (
     <nav className="flex md:hidden items-center justify-around h-[56px] border-t border-border bg-surface px-2">
-      <MobileNavLink to="/devices" label="Devices" active />
-      <MobileNavLink to="/" label="Dashboard" disabled />
-      <MobileNavLink to="/equipments" label="Equip." disabled />
-      <MobileNavLink to="/zones" label="Zones" disabled />
+      <MobileNavLink to="/maison" label="Maison" active />
+      <MobileNavLink to="/devices" label="Devices" />
+      <MobileNavLink to="/equipments" label="Equip." />
+      <MobileNavLink to="/zones" label="Zones" />
     </nav>
   );
 }

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -1,14 +1,16 @@
 import { NavLink } from "react-router-dom";
 import {
   Radio,
-  LayoutDashboard,
   Box,
   Map,
   Workflow,
+  Settings,
+  Home,
   ChevronLeft,
   ChevronRight,
 } from "lucide-react";
 import { useState } from "react";
+import { SidebarZoneTree } from "./SidebarZoneTree";
 
 interface NavItem {
   to: string;
@@ -17,12 +19,11 @@ interface NavItem {
   disabled?: boolean;
 }
 
-const NAV_ITEMS: NavItem[] = [
-  { to: "/", label: "Dashboard", icon: <LayoutDashboard size={20} strokeWidth={1.5} />, disabled: true },
-  { to: "/devices", label: "Devices", icon: <Radio size={20} strokeWidth={1.5} /> },
-  { to: "/equipments", label: "Equipments", icon: <Box size={20} strokeWidth={1.5} /> },
-  { to: "/zones", label: "Home Topology", icon: <Map size={20} strokeWidth={1.5} /> },
-  { to: "/scenarios", label: "Scenarios", icon: <Workflow size={20} strokeWidth={1.5} />, disabled: true },
+const SETTINGS_ITEMS: NavItem[] = [
+  { to: "/devices", label: "Devices", icon: <Radio size={18} strokeWidth={1.5} /> },
+  { to: "/equipments", label: "Equipments", icon: <Box size={18} strokeWidth={1.5} /> },
+  { to: "/zones", label: "Home Topology", icon: <Map size={18} strokeWidth={1.5} /> },
+  { to: "/scenarios", label: "Scenarios", icon: <Workflow size={18} strokeWidth={1.5} />, disabled: true },
 ];
 
 export function Sidebar() {
@@ -33,7 +34,7 @@ export function Sidebar() {
       className={`
         flex flex-col h-full bg-surface border-r border-border
         transition-all duration-200 ease-out
-        ${collapsed ? "w-[68px]" : "w-[240px]"}
+        ${collapsed ? "w-[68px]" : "w-[260px]"}
       `}
     >
       {/* Logo area */}
@@ -50,50 +51,90 @@ export function Sidebar() {
         </div>
       </div>
 
-      {/* Navigation */}
-      <nav className="flex-1 py-3 px-2 space-y-0.5">
-        {NAV_ITEMS.map((item) => {
-          if (item.disabled) {
+      {/* Maison section — scrollable */}
+      <div className="flex-1 overflow-y-auto py-3 px-2">
+        {!collapsed && (
+          <div className="flex items-center gap-2 px-3 mb-2">
+            <Home size={14} strokeWidth={1.5} className="text-text-tertiary" />
+            <span className="text-[11px] font-semibold text-text-tertiary uppercase tracking-wider">
+              Maison
+            </span>
+          </div>
+        )}
+        {collapsed ? (
+          <NavLink
+            to="/maison"
+            className={({ isActive }) => `
+              flex items-center justify-center px-3 py-2.5 rounded-[6px]
+              transition-colors duration-150 ease-out
+              ${isActive
+                ? "bg-primary-light text-primary font-medium"
+                : "text-text-secondary hover:bg-border-light hover:text-text"
+              }
+            `}
+            title="Maison"
+          >
+            <Home size={20} strokeWidth={1.5} />
+          </NavLink>
+        ) : (
+          <SidebarZoneTree collapsed={collapsed} />
+        )}
+      </div>
+
+      {/* Settings section — pinned at bottom */}
+      <div className="border-t border-border-light py-2 px-2">
+        {!collapsed && (
+          <div className="flex items-center gap-2 px-3 mb-1.5">
+            <Settings size={14} strokeWidth={1.5} className="text-text-tertiary" />
+            <span className="text-[11px] font-semibold text-text-tertiary uppercase tracking-wider">
+              Settings
+            </span>
+          </div>
+        )}
+        <nav className="space-y-0.5">
+          {SETTINGS_ITEMS.map((item) => {
+            if (item.disabled) {
+              return (
+                <div
+                  key={item.to}
+                  className={`
+                    flex items-center gap-3 px-3 py-1.5 rounded-[6px]
+                    text-text-tertiary cursor-not-allowed
+                    ${collapsed ? "justify-center" : ""}
+                  `}
+                  title={collapsed ? item.label : undefined}
+                >
+                  <span className="flex-shrink-0 opacity-40">{item.icon}</span>
+                  {!collapsed && (
+                    <span className="text-[12px] font-medium opacity-40">{item.label}</span>
+                  )}
+                </div>
+              );
+            }
+
             return (
-              <div
+              <NavLink
                 key={item.to}
-                className={`
-                  flex items-center gap-3 px-3 py-2.5 rounded-[6px]
-                  text-text-tertiary cursor-not-allowed
+                to={item.to}
+                className={({ isActive }) => `
+                  flex items-center gap-3 px-3 py-1.5 rounded-[6px]
+                  transition-colors duration-150 ease-out
                   ${collapsed ? "justify-center" : ""}
+                  ${
+                    isActive
+                      ? "bg-primary-light text-primary font-medium"
+                      : "text-text-secondary hover:bg-border-light hover:text-text"
+                  }
                 `}
                 title={collapsed ? item.label : undefined}
               >
-                <span className="flex-shrink-0 opacity-40">{item.icon}</span>
-                {!collapsed && (
-                  <span className="text-[13px] font-medium opacity-40">{item.label}</span>
-                )}
-              </div>
+                <span className="flex-shrink-0">{item.icon}</span>
+                {!collapsed && <span className="text-[12px] font-medium">{item.label}</span>}
+              </NavLink>
             );
-          }
-
-          return (
-            <NavLink
-              key={item.to}
-              to={item.to}
-              className={({ isActive }) => `
-                flex items-center gap-3 px-3 py-2.5 rounded-[6px]
-                transition-colors duration-150 ease-out
-                ${collapsed ? "justify-center" : ""}
-                ${
-                  isActive
-                    ? "bg-primary-light text-primary font-medium"
-                    : "text-text-secondary hover:bg-border-light hover:text-text"
-                }
-              `}
-              title={collapsed ? item.label : undefined}
-            >
-              <span className="flex-shrink-0">{item.icon}</span>
-              {!collapsed && <span className="text-[13px] font-medium">{item.label}</span>}
-            </NavLink>
-          );
-        })}
-      </nav>
+          })}
+        </nav>
+      </div>
 
       {/* Collapse toggle */}
       <div className="border-t border-border-light p-2">
@@ -102,7 +143,7 @@ export function Sidebar() {
           className={`
             flex items-center justify-center w-full py-2 rounded-[6px]
             text-text-tertiary hover:text-text-secondary hover:bg-border-light
-            transition-colors duration-150 ease-out
+            transition-colors duration-150 ease-out cursor-pointer
           `}
         >
           {collapsed ? (

--- a/ui/src/components/layout/SidebarZoneTree.tsx
+++ b/ui/src/components/layout/SidebarZoneTree.tsx
@@ -1,0 +1,114 @@
+import { useState, useEffect } from "react";
+import { NavLink, useParams } from "react-router-dom";
+import { ChevronRight, ChevronDown, Building2, Layers, DoorOpen } from "lucide-react";
+import type { ZoneWithChildren } from "../../types";
+import { useZones } from "../../store/useZones";
+
+export function SidebarZoneTree({ collapsed }: { collapsed: boolean }) {
+  const tree = useZones((s) => s.tree);
+  const fetchZones = useZones((s) => s.fetchZones);
+
+  useEffect(() => {
+    fetchZones();
+  }, [fetchZones]);
+
+  if (collapsed) return null;
+
+  if (tree.length === 0) {
+    return (
+      <div className="px-3 py-2">
+        <p className="text-[11px] text-text-tertiary leading-tight">
+          No zones yet. Create zones in Settings.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-0.5">
+      {tree.map((zone) => (
+        <SidebarZoneNode key={zone.id} zone={zone} depth={0} />
+      ))}
+    </div>
+  );
+}
+
+function SidebarZoneNode({ zone, depth }: { zone: ZoneWithChildren; depth: number }) {
+  const { zoneId } = useParams();
+  const [expanded, setExpanded] = useState(depth < 1);
+  const hasChildren = zone.children.length > 0;
+  const isActive = zoneId === zone.id;
+
+  // Auto-expand when a child is active
+  useEffect(() => {
+    if (zoneId && hasZoneInTree(zone, zoneId)) {
+      setExpanded(true);
+    }
+  }, [zoneId, zone]);
+
+  const icon = depth === 0
+    ? <Building2 size={15} strokeWidth={1.5} />
+    : hasChildren
+      ? <Layers size={15} strokeWidth={1.5} />
+      : <DoorOpen size={15} strokeWidth={1.5} />;
+
+  return (
+    <div>
+      <div
+        className="flex items-center gap-1"
+        style={{ paddingLeft: `${8 + depth * 12}px` }}
+      >
+        {/* Expand/collapse */}
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (hasChildren) setExpanded(!expanded);
+          }}
+          className={`flex-shrink-0 w-4 h-4 flex items-center justify-center rounded ${
+            hasChildren
+              ? "text-text-tertiary hover:text-text-secondary"
+              : "text-transparent"
+          }`}
+        >
+          {hasChildren &&
+            (expanded ? (
+              <ChevronDown size={11} strokeWidth={1.5} />
+            ) : (
+              <ChevronRight size={11} strokeWidth={1.5} />
+            ))}
+        </button>
+
+        {/* Zone link */}
+        <NavLink
+          to={`/maison/${zone.id}`}
+          className={`
+            flex-1 flex items-center gap-2 px-2 py-1.5 rounded-[6px] min-w-0
+            text-[13px] transition-colors duration-150 ease-out
+            ${isActive
+              ? "bg-primary-light text-primary font-medium"
+              : "text-text-secondary hover:bg-border-light hover:text-text"
+            }
+          `}
+        >
+          <span className="flex-shrink-0">{icon}</span>
+          <span className="truncate">{zone.name}</span>
+        </NavLink>
+      </div>
+
+      {/* Children */}
+      {expanded && hasChildren && (
+        <div>
+          {zone.children.map((child) => (
+            <SidebarZoneNode key={child.id} zone={child} depth={depth + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function hasZoneInTree(zone: ZoneWithChildren, targetId: string): boolean {
+  if (zone.id === targetId) return true;
+  return zone.children.some((child) => hasZoneInTree(child, targetId));
+}

--- a/ui/src/components/maison/CompactEquipmentCard.tsx
+++ b/ui/src/components/maison/CompactEquipmentCard.tsx
@@ -1,0 +1,201 @@
+import { useState, useRef } from "react";
+import { Link } from "react-router-dom";
+import { Power } from "lucide-react";
+import type { EquipmentWithDetails } from "../../types";
+import { TYPE_ICONS } from "../equipments/EquipmentCard";
+
+const SETTLE_DELAY_MS = 2000;
+
+interface CompactEquipmentCardProps {
+  equipment: EquipmentWithDetails;
+  onExecuteOrder: (equipmentId: string, alias: string, value: unknown) => Promise<void>;
+}
+
+export function CompactEquipmentCard({ equipment, onExecuteOrder }: CompactEquipmentCardProps) {
+  const [executing, setExecuting] = useState(false);
+  const [, forceRender] = useState(0);
+  const localBrightness = useRef<number | null>(null);
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const isLight =
+    equipment.type === "light_onoff" ||
+    equipment.type === "light_dimmable" ||
+    equipment.type === "light_color";
+
+  const stateBinding = equipment.dataBindings.find(
+    (db) => db.alias === "state" || db.category === "light_state"
+  );
+  const brightnessBinding = equipment.dataBindings.find(
+    (db) => db.alias === "brightness" || db.category === "light_brightness"
+  );
+
+  const isOn = stateBinding
+    ? stateBinding.value === true || stateBinding.value === "ON"
+    : false;
+
+  const deviceBrightness = brightnessBinding
+    ? typeof brightnessBinding.value === "number"
+      ? brightnessBinding.value
+      : null
+    : null;
+
+  const brightness =
+    localBrightness.current !== null ? localBrightness.current : deviceBrightness;
+
+  const hasToggle = equipment.orderBindings.some(
+    (ob) => ob.alias === "state" || ob.alias === "turn_on"
+  );
+  const hasBrightness = equipment.orderBindings.some(
+    (ob) => ob.alias === "brightness"
+  );
+
+  // Find primary data value for non-light equipments
+  const primaryBinding = !isLight
+    ? equipment.dataBindings[0] ?? null
+    : null;
+
+  const handleToggle = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (executing || !hasToggle) return;
+    setExecuting(true);
+    try {
+      const alias = equipment.orderBindings.find((ob) => ob.alias === "state")
+        ? "state"
+        : "turn_on";
+      const value = isOn
+        ? alias === "state" ? "OFF" : false
+        : alias === "state" ? "ON" : true;
+      await onExecuteOrder(equipment.id, alias, value);
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  const handleBrightnessChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    if (settleTimer.current) clearTimeout(settleTimer.current);
+    localBrightness.current = Number(e.target.value);
+    forceRender((n) => n + 1);
+  };
+
+  const handleBrightnessCommit = async () => {
+    const commitValue = localBrightness.current;
+    if (!hasBrightness || commitValue === null) return;
+    try {
+      await onExecuteOrder(equipment.id, "brightness", commitValue);
+    } catch {
+      // Ignore
+    }
+    settleTimer.current = setTimeout(() => {
+      localBrightness.current = null;
+      settleTimer.current = null;
+      forceRender((n) => n + 1);
+    }, SETTLE_DELAY_MS);
+  };
+
+  return (
+    <div
+      className={`
+        flex items-center gap-3 px-3 py-2.5 rounded-[8px] border
+        transition-colors duration-150
+        border-border bg-surface
+      `}
+    >
+      {/* Icon */}
+      <div
+        className={`
+          flex-shrink-0 w-8 h-8 rounded-[6px] flex items-center justify-center
+          ${isLight && isOn ? "bg-amber-400/15 text-amber-500" : isOn ? "bg-primary/10 text-primary" : "bg-border-light text-text-tertiary"}
+        `}
+      >
+        {TYPE_ICONS[equipment.type]}
+      </div>
+
+      {/* Name — links to detail */}
+      <Link
+        to={`/equipments/${equipment.id}`}
+        className="flex-1 min-w-0 text-[13px] font-medium text-text truncate hover:text-primary transition-colors"
+      >
+        {equipment.name}
+      </Link>
+
+      {/* Primary value for non-light equipments */}
+      {primaryBinding && !isLight && (
+        <span className="text-[13px] text-text-secondary tabular-nums flex-shrink-0">
+          {formatValue(primaryBinding.value, primaryBinding.unit)}
+        </span>
+      )}
+
+      {/* Light controls */}
+      {isLight && equipment.enabled && (
+        <div
+          className="flex items-center gap-2 flex-shrink-0"
+          onClick={(e) => e.preventDefault()}
+        >
+          {hasBrightness && brightness !== null && (
+            <div className="flex items-center gap-1.5">
+              <input
+                type="range"
+                min={0}
+                max={254}
+                value={brightness}
+                onChange={handleBrightnessChange}
+                onMouseUp={handleBrightnessCommit}
+                onTouchEnd={handleBrightnessCommit}
+                onClick={(e) => e.stopPropagation()}
+                className="w-[60px] accent-primary h-1"
+              />
+              <span className="text-[11px] text-text-tertiary w-6 text-right tabular-nums">
+                {Math.round((brightness / 254) * 100)}%
+              </span>
+            </div>
+          )}
+          <div className="w-px h-5 bg-border" />
+          {hasToggle && (
+            <button
+              onClick={handleToggle}
+              disabled={executing}
+              className={`
+                p-1.5 rounded-[5px] transition-colors duration-150 cursor-pointer
+                ${isOn
+                  ? "bg-primary text-white hover:bg-primary-hover"
+                  : "bg-border-light text-text-tertiary hover:bg-border hover:text-text-secondary"
+                }
+                disabled:opacity-50 disabled:cursor-not-allowed
+              `}
+              title={isOn ? "Turn off" : "Turn on"}
+            >
+              <Power size={14} strokeWidth={1.5} />
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Boolean state badge for non-light equipments */}
+      {!isLight && stateBinding && (
+        <span
+          className={`
+            text-[11px] font-medium px-2 py-0.5 rounded-full flex-shrink-0
+            ${isOn
+              ? "bg-success/10 text-success"
+              : "bg-border-light text-text-tertiary"
+            }
+          `}
+        >
+          {isOn ? "ON" : "OFF"}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function formatValue(value: unknown, unit?: string): string {
+  if (value === null || value === undefined) return "\u2014";
+  if (typeof value === "boolean") return value ? "ON" : "OFF";
+  if (typeof value === "number") {
+    const formatted = Number.isInteger(value) ? String(value) : value.toFixed(1);
+    return unit ? `${formatted}${unit}` : formatted;
+  }
+  return String(value);
+}

--- a/ui/src/components/maison/ZoneEquipmentsView.tsx
+++ b/ui/src/components/maison/ZoneEquipmentsView.tsx
@@ -1,0 +1,75 @@
+import { Box } from "lucide-react";
+import type { EquipmentType, EquipmentWithDetails } from "../../types";
+import { CompactEquipmentCard } from "./CompactEquipmentCard";
+
+interface EquipmentGroup {
+  label: string;
+  types: EquipmentType[];
+}
+
+const EQUIPMENT_GROUPS: EquipmentGroup[] = [
+  { label: "Eclairages", types: ["light_onoff", "light_dimmable", "light_color"] },
+  { label: "Volets", types: ["shutter"] },
+  { label: "Capteurs", types: ["sensor", "motion_sensor", "contact_sensor"] },
+  { label: "Climat", types: ["thermostat"] },
+  { label: "Securite", types: ["lock", "alarm"] },
+  { label: "Multimedia", types: ["media_player", "camera"] },
+  { label: "Autres", types: ["switch", "generic"] },
+];
+
+interface ZoneEquipmentsViewProps {
+  zoneName: string;
+  equipments: EquipmentWithDetails[];
+  onExecuteOrder: (equipmentId: string, alias: string, value: unknown) => Promise<void>;
+}
+
+export function ZoneEquipmentsView({
+  zoneName,
+  equipments,
+  onExecuteOrder,
+}: ZoneEquipmentsViewProps) {
+  if (equipments.length === 0) {
+    return <EmptyZone zoneName={zoneName} />;
+  }
+
+  // Group equipments by type category
+  const grouped = EQUIPMENT_GROUPS.map((group) => ({
+    ...group,
+    equipments: equipments.filter((eq) => group.types.includes(eq.type)),
+  })).filter((g) => g.equipments.length > 0);
+
+  return (
+    <div className="space-y-6">
+      {grouped.map((group) => (
+        <div key={group.label}>
+          <h3 className="text-[12px] font-semibold text-text-tertiary uppercase tracking-wider mb-2 px-1">
+            {group.label}
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2">
+            {group.equipments.map((eq) => (
+              <CompactEquipmentCard
+                key={eq.id}
+                equipment={eq}
+                onExecuteOrder={onExecuteOrder}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyZone({ zoneName }: { zoneName: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="w-14 h-14 rounded-full bg-border-light flex items-center justify-center mb-3">
+        <Box size={24} strokeWidth={1.5} className="text-text-tertiary" />
+      </div>
+      <h3 className="text-[15px] font-medium text-text mb-1">No equipments</h3>
+      <p className="text-[13px] text-text-secondary max-w-[280px]">
+        {zoneName} has no equipments yet. Add equipments in Settings &gt; Equipments.
+      </p>
+    </div>
+  );
+}

--- a/ui/src/pages/MaisonPage.tsx
+++ b/ui/src/pages/MaisonPage.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useMemo } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { Loader2, Home } from "lucide-react";
+import { useZones } from "../store/useZones";
+import { useEquipments } from "../store/useEquipments";
+import { ZoneEquipmentsView } from "../components/maison/ZoneEquipmentsView";
+import type { ZoneWithChildren } from "../types";
+
+export function MaisonPage() {
+  const { zoneId } = useParams();
+  const navigate = useNavigate();
+  const tree = useZones((s) => s.tree);
+  const zonesLoading = useZones((s) => s.loading);
+  const fetchZones = useZones((s) => s.fetchZones);
+  const equipments = useEquipments((s) => s.equipments);
+  const equipmentsLoading = useEquipments((s) => s.loading);
+  const fetchEquipments = useEquipments((s) => s.fetchEquipments);
+  const executeOrder = useEquipments((s) => s.executeOrder);
+
+  useEffect(() => {
+    fetchZones();
+    fetchEquipments();
+  }, [fetchZones, fetchEquipments]);
+
+  // If no zoneId in URL, redirect to first zone
+  useEffect(() => {
+    if (!zoneId && !zonesLoading && tree.length > 0) {
+      const firstZone = getFirstLeafZone(tree);
+      if (firstZone) {
+        navigate(`/maison/${firstZone.id}`, { replace: true });
+      }
+    }
+  }, [zoneId, zonesLoading, tree, navigate]);
+
+  // Find the current zone in tree
+  const currentZone = useMemo(() => {
+    if (!zoneId) return null;
+    return findZoneById(tree, zoneId);
+  }, [tree, zoneId]);
+
+  // Filter equipments for this zone
+  const zoneEquipments = useMemo(() => {
+    if (!zoneId) return [];
+    return equipments.filter((eq) => eq.zoneId === zoneId);
+  }, [equipments, zoneId]);
+
+  const loading = zonesLoading || equipmentsLoading;
+
+  // No zone ID and no zones exist
+  if (!zoneId && !zonesLoading && tree.length === 0) {
+    return <NoZonesState />;
+  }
+
+  // Loading
+  if (loading && !currentZone) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 size={24} className="animate-spin text-text-tertiary" />
+      </div>
+    );
+  }
+
+  // Zone not found (may have been deleted)
+  if (zoneId && !currentZone && !zonesLoading) {
+    return <ZoneNotFound />;
+  }
+
+  if (!currentZone) return null;
+
+  return (
+    <div className="p-6">
+      {/* Zone header */}
+      <div className="mb-6">
+        <h1 className="text-[24px] font-semibold text-text leading-[32px]">
+          {currentZone.name}
+        </h1>
+        {currentZone.description && (
+          <p className="text-[13px] text-text-secondary mt-0.5">
+            {currentZone.description}
+          </p>
+        )}
+        <p className="text-[13px] text-text-tertiary mt-0.5">
+          {zoneEquipments.length === 0
+            ? "No equipments"
+            : `${zoneEquipments.length} equipment${zoneEquipments.length !== 1 ? "s" : ""}`}
+        </p>
+      </div>
+
+      {/* Equipments grouped by type */}
+      <ZoneEquipmentsView
+        zoneName={currentZone.name}
+        equipments={zoneEquipments}
+        onExecuteOrder={executeOrder}
+      />
+    </div>
+  );
+}
+
+function NoZonesState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="w-16 h-16 rounded-full bg-border-light flex items-center justify-center mb-4">
+        <Home size={28} strokeWidth={1.5} className="text-text-tertiary" />
+      </div>
+      <h3 className="text-[16px] font-medium text-text mb-1">Welcome to Maison</h3>
+      <p className="text-[13px] text-text-secondary max-w-[320px]">
+        Create your first zone in Settings &gt; Home Topology to get started.
+      </p>
+    </div>
+  );
+}
+
+function ZoneNotFound() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="w-16 h-16 rounded-full bg-error/10 flex items-center justify-center mb-4">
+        <Home size={28} strokeWidth={1.5} className="text-error" />
+      </div>
+      <h3 className="text-[16px] font-medium text-text mb-1">Zone not found</h3>
+      <p className="text-[13px] text-text-secondary max-w-[320px] mb-4">
+        This zone may have been deleted.
+      </p>
+      <button
+        onClick={() => navigate("/maison")}
+        className="px-4 py-2 bg-primary text-white text-[13px] font-medium rounded-[6px] hover:bg-primary-hover transition-colors duration-150"
+      >
+        Back to Maison
+      </button>
+    </div>
+  );
+}
+
+function findZoneById(zones: ZoneWithChildren[], id: string): ZoneWithChildren | null {
+  for (const zone of zones) {
+    if (zone.id === id) return zone;
+    const found = findZoneById(zone.children, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+function getFirstLeafZone(zones: ZoneWithChildren[]): ZoneWithChildren | null {
+  if (zones.length === 0) return null;
+  const first = zones[0];
+  if (first.children.length > 0) {
+    return first.children[0];
+  }
+  return first;
+}


### PR DESCRIPTION
## Summary
- Reorganize sidebar: **Maison** section (zone treeview, scrollable) + **Settings** section (pinned at bottom)
- New `/maison/:zoneId` route as default landing page with compact equipment cards grouped by type
- Responsive grid layout (`1 / 2 / 3` columns)
- Unified visual charter: neutral cards, amber icon for lights ON, primary for other equipment ON
- Remove Dashboard from navigation, keep Scenarios disabled

## Changes
- **New**: `SidebarZoneTree.tsx` — dynamic zone treeview with expand/collapse
- **New**: `CompactEquipmentCard.tsx` — compact one-line equipment card with light controls
- **New**: `ZoneEquipmentsView.tsx` — equipment grouping by type category
- **New**: `MaisonPage.tsx` — zone view with client-side equipment filtering
- **Modified**: `Sidebar.tsx` — two-section layout (Maison + Settings)
- **Modified**: `AppLayout.tsx` — fetch zones/equipments on mount, updated mobile nav
- **Modified**: `App.tsx` — new routes, default redirect to `/maison`
- **Modified**: `EquipmentCard.tsx` — aligned visual charter (neutral card, amber light icon)

## Test plan
- [x] TypeScript compiles (zero errors)
- [x] All 114 tests pass
- [x] Sidebar shows zone tree with expand/collapse
- [x] Clicking zone shows filtered equipments grouped by type
- [x] Light icons are amber when ON, other equipment icons green
- [x] Cards remain neutral (no border/bg change on ON state)
- [x] Responsive grid adapts to screen width

## Roadmap
- Implements V0.5 (UI Restructuring) from corbel-spec.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)