### PR TITLE
feat: V0.7 — Zone aggregation engine with real-time UI

### DIFF
--- a/specs/007-V0.7-zone-aggregation/architecture.md
+++ b/specs/007-V0.7-zone-aggregation/architecture.md
@@ -1,0 +1,144 @@
+# Architecture: V0.7 Zone Aggregation Engine
+
+## Data Model Changes
+
+### New type: `ZoneAggregatedData`
+
+Added to `src/shared/types.ts` and `ui/src/types.ts`:
+
+```typescript
+interface ZoneAggregatedData {
+  temperature: number | null;
+  humidity: number | null;
+  motion: boolean;
+  openDoors: number;
+  openWindows: number;
+  waterLeak: boolean;
+  smoke: boolean;
+  lightsOn: number;
+  lightsTotal: number;
+}
+```
+
+### New event: `zone.data.changed`
+
+```typescript
+| {
+    type: "zone.data.changed";
+    zoneId: string;
+    aggregatedData: ZoneAggregatedData;
+  }
+```
+
+### No database changes
+
+Aggregated data is cached in memory only (as per spec §Zone Aggregation: "Cache aggregated values in memory (not in SQLite) for performance").
+
+## Aggregation Rules
+
+| Key | Type | Strategy | Source DataCategory | Logic |
+|-----|------|----------|-------------------|-------|
+| `temperature` | number \| null | AVG | `temperature` | Average of all non-null values |
+| `humidity` | number \| null | AVG | `humidity` | Average of all non-null values |
+| `motion` | boolean | OR | `motion` | true if ANY binding is true/ON |
+| `openDoors` | number | COUNT | `contact_door` | Count where value = false/OFF (open) |
+| `openWindows` | number | COUNT | `contact_window` | Count where value = false/OFF (open) |
+| `waterLeak` | boolean | OR | `water_leak` | true if ANY binding is true/ON |
+| `smoke` | boolean | OR | `smoke` | true if ANY binding is true/ON |
+| `lightsOn` | number | COUNT | `light_state` | Count where value = true/ON |
+| `lightsTotal` | number | COUNT | `light_state` | Count of all light_state bindings |
+
+### Recursive strategy
+
+- AVG: weighted average (zone AVG * count + child AVGs * child counts) / total count
+- OR: true if zone OR any child is true
+- COUNT: zone count + sum of child counts
+
+## Event Flow
+
+```
+equipment.data.changed
+  → ZoneAggregator.handleEquipmentDataChanged()
+    → Look up equipment's zoneId
+    → Recompute zone aggregation (direct equipments)
+    → Walk up parent chain, recompute each parent (includes children)
+    → For each zone where aggregation changed:
+      → Emit zone.data.changed { zoneId, aggregatedData }
+        → WebSocket broadcasts to UI clients
+        → UI store updates in-memory cache
+        → ZoneAggregationHeader re-renders
+
+equipment.created / equipment.updated / equipment.removed
+  → ZoneAggregator.handleEquipmentChanged()
+    → Recompute affected zone chain
+
+system.started
+  → ZoneAggregator.computeAll()
+    → Compute aggregation for ALL zones bottom-up
+```
+
+## API Changes
+
+### New endpoint
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/zones/aggregation` | Returns aggregated data for all zones |
+
+**Response format:**
+```json
+{
+  "zone-id-1": { "temperature": 21.5, "humidity": 45, "motion": false, ... },
+  "zone-id-2": { "temperature": null, "humidity": null, "motion": true, ... }
+}
+```
+
+## UI Changes
+
+### New component: `ZoneAggregationHeader`
+
+Location: `ui/src/components/maison/ZoneAggregationHeader.tsx`
+
+Displays a horizontal bar of pills/badges above the equipment list:
+
+```
+21.5°C  💧 45%  🟢 Mouvement  💡 2/4  🚪 1 ouverte
+```
+
+Rules:
+- Only show pills for values that have data (not null, not zero count for contacts)
+- Temperature: `{value}°C` with Thermometer icon
+- Humidity: `{value}%` with Droplets icon
+- Motion: green dot + "Mouvement" if true, gray "Calme" if false (only if zone has motion sensors)
+- Lights: `{on}/{total}` with Lightbulb icon (only if zone has lights)
+- Doors: `{count} ouverte(s)` with DoorOpen icon (only if count > 0)
+- Windows: `{count} ouverte(s)` with window icon (only if count > 0)
+- Water leak: red alert badge (only if true)
+- Smoke: red alert badge (only if true)
+
+### New store: `useZoneAggregation`
+
+Location: `ui/src/store/useZoneAggregation.ts`
+
+```typescript
+interface ZoneAggregationState {
+  data: Record<string, ZoneAggregatedData>;
+  fetchAggregation: () => Promise<void>;
+  handleZoneDataChanged: (zoneId: string, aggregatedData: ZoneAggregatedData) => void;
+}
+```
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/shared/types.ts` | Add `ZoneAggregatedData` interface, `zone.data.changed` event |
+| `ui/src/types.ts` | Mirror `ZoneAggregatedData`, `zone.data.changed` event |
+| `src/zones/zone-aggregator.ts` | **New** — Aggregation engine |
+| `src/index.ts` | Wire up ZoneAggregator |
+| `src/api/routes/zones.ts` | Add GET `/zones/aggregation` endpoint |
+| `ui/src/store/useZoneAggregation.ts` | **New** — Zustand store |
+| `ui/src/store/useWebSocket.ts` | Handle `zone.data.changed` event |
+| `ui/src/api.ts` | Add `getZoneAggregation()` API function |
+| `ui/src/components/maison/ZoneAggregationHeader.tsx` | **New** — Header component |
+| `ui/src/pages/MaisonPage.tsx` | Add `ZoneAggregationHeader` above equipments |

--- a/specs/007-V0.7-zone-aggregation/plan.md
+++ b/specs/007-V0.7-zone-aggregation/plan.md
@@ -1,0 +1,26 @@
+# Implementation Plan: V0.7 Zone Aggregation Engine
+
+## Tasks
+
+1. [ ] Add `ZoneAggregatedData` type and `zone.data.changed` event to `src/shared/types.ts`
+2. [ ] Mirror types in `ui/src/types.ts`
+3. [ ] Implement `src/zones/zone-aggregator.ts` — aggregation engine
+4. [ ] Wire up ZoneAggregator in `src/index.ts`
+5. [ ] Add `GET /api/v1/zones/aggregation` route
+6. [ ] Write unit tests for zone-aggregator
+7. [ ] Add `getZoneAggregation()` to `ui/src/api.ts`
+8. [ ] Create `ui/src/store/useZoneAggregation.ts` — Zustand store
+9. [ ] Handle `zone.data.changed` in `ui/src/store/useWebSocket.ts`
+10. [ ] Create `ui/src/components/maison/ZoneAggregationHeader.tsx`
+11. [ ] Integrate header in `ui/src/pages/MaisonPage.tsx`
+12. [ ] TypeScript compilation check (backend + frontend)
+13. [ ] Run all tests
+
+## Dependencies
+
+- Requires V0.6 sensor equipment support (equipment data bindings for sensors)
+
+## Testing
+
+- Unit tests: zone-aggregator logic (AVG, OR, COUNT strategies, recursive, edge cases)
+- Manual: create sensor + light equipments in a zone, verify header updates in real-time

--- a/specs/007-V0.7-zone-aggregation/spec.md
+++ b/specs/007-V0.7-zone-aggregation/spec.md
@@ -1,0 +1,66 @@
+# V0.7: Zone Aggregation Engine
+
+## Summary
+
+Implement automatic zone-level data aggregation. When a zone contains sensor or light equipments, the engine computes consolidated values (average temperature, motion detected, lights on count, etc.) and exposes them in the Maison page header. Aggregation is recursive: parent zones include data from child zones.
+
+## Reference
+
+- Spec sections: corbel-spec.md §Zone auto-aggregation, data-model.md §3.3
+
+## Acceptance Criteria
+
+- [ ] Backend zone aggregator computes aggregated data from equipment bindings
+- [ ] Aggregation is recursive (parent zone = own equipments + child zones)
+- [ ] Aggregated data updates in real-time on `equipment.data.changed` events
+- [ ] New `zone.data.changed` event emitted when aggregated values change
+- [ ] API endpoint returns aggregated data for all zones
+- [ ] WebSocket broadcasts `zone.data.changed` to connected UI clients
+- [ ] Maison page displays aggregation header above equipment list
+- [ ] Header shows: temperature, humidity, motion, lights count, open doors/windows, alerts
+- [ ] Only non-empty values shown (no "0 doors open" if no door sensors)
+- [ ] TypeScript compiles with zero errors (backend + frontend)
+- [ ] All existing tests pass + new unit tests for aggregator
+
+## Scope
+
+### In Scope
+
+- Backend aggregation engine (`src/zones/zone-aggregator.ts`)
+- Aggregation rules for sensors + lights:
+  - `temperature` — AVG of temperature-category bindings
+  - `humidity` — AVG of humidity-category bindings
+  - `motion` — OR of motion-category bindings
+  - `openDoors` — COUNT of contact_door where open (value = false/OFF)
+  - `openWindows` — COUNT of contact_window where open (value = false/OFF)
+  - `waterLeak` — OR of water_leak-category bindings
+  - `smoke` — OR of smoke-category bindings
+  - `lightsOn` — COUNT of light equipments where state = ON
+  - `lightsTotal` — COUNT of all light equipments
+- Recursive aggregation: parent zones aggregate own equipments + child zone aggregations
+- New `zone.data.changed` event type
+- New REST endpoint `GET /api/v1/zones/aggregation`
+- UI aggregation header component in Maison page
+- WebSocket propagation of zone.data.changed events
+- Unit tests for aggregator logic
+
+### Out of Scope
+
+- `presence` (motion + timeout) — requires timer mechanism, deferred
+- `averageBrightness`, `shuttersOpen`, `shuttersTotal` — deferred (no shutter equipments yet)
+- `totalPower`, `totalEnergy` — deferred (no energy monitoring yet)
+- `heatingActive`, `targetTemperature` — deferred (no thermostat equipments yet)
+- Zone auto-orders (`allOff`, `allLightsOff`, `allLightsOn`) — separate feature
+- InfluxDB history for zone aggregated data
+
+## Edge Cases
+
+- Zone with no equipments → all values null/0/false, header hidden
+- Zone with only lights (no sensors) → show only lightsOn/lightsTotal
+- Zone with only sensors (no lights) → show only sensor values
+- Equipment moved to another zone → recompute both old and new zone
+- Equipment deleted → recompute zone
+- Multiple sensor equipments with same category → AVG for numeric, OR for boolean
+- Null/undefined values in bindings → excluded from AVG calculation
+- Parent zone with no direct equipments but children with equipments → aggregates children
+- Deeply nested zones → recursive bottom-up computation

--- a/src/api/routes/zones.ts
+++ b/src/api/routes/zones.ts
@@ -1,18 +1,25 @@
 import type { FastifyInstance } from "fastify";
 import type { ZoneManager } from "../../zones/zone-manager.js";
+import type { ZoneAggregator } from "../../zones/zone-aggregator.js";
 import type { Logger } from "../../core/logger.js";
 
 interface ZonesDeps {
   zoneManager: ZoneManager;
+  zoneAggregator: ZoneAggregator;
   logger: Logger;
 }
 
 export function registerZoneRoutes(app: FastifyInstance, deps: ZonesDeps): void {
-  const { zoneManager } = deps;
+  const { zoneManager, zoneAggregator } = deps;
 
   // GET /api/v1/zones — List all zones as a tree
   app.get("/api/v1/zones", async () => {
     return zoneManager.getTree();
+  });
+
+  // GET /api/v1/zones/aggregation — Get aggregated data for all zones
+  app.get("/api/v1/zones/aggregation", async () => {
+    return zoneAggregator.getAll();
   });
 
   // GET /api/v1/zones/:id — Get zone with children

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -4,6 +4,7 @@ import websocket from "@fastify/websocket";
 import type { Logger } from "../core/logger.js";
 import type { DeviceManager } from "../devices/device-manager.js";
 import type { ZoneManager } from "../zones/zone-manager.js";
+import type { ZoneAggregator } from "../zones/zone-aggregator.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { MqttConnector } from "../mqtt/mqtt-connector.js";
@@ -16,6 +17,7 @@ import { registerWebSocket } from "./websocket.js";
 interface ServerDeps {
   deviceManager: DeviceManager;
   zoneManager: ZoneManager;
+  zoneAggregator: ZoneAggregator;
   equipmentManager: EquipmentManager;
   eventBus: EventBus;
   mqttConnector: MqttConnector;
@@ -24,7 +26,7 @@ interface ServerDeps {
 }
 
 export async function createServer(deps: ServerDeps) {
-  const { deviceManager, zoneManager, equipmentManager, eventBus, mqttConnector, logger, corsOrigins } = deps;
+  const { deviceManager, zoneManager, zoneAggregator, equipmentManager, eventBus, mqttConnector, logger, corsOrigins } = deps;
 
   const app = Fastify({
     logger: false, // We use our own pino logger
@@ -42,7 +44,7 @@ export async function createServer(deps: ServerDeps) {
   // Register routes
   registerHealthRoutes(app, { deviceManager, mqttConnector, logger });
   registerDeviceRoutes(app, { deviceManager, logger });
-  registerZoneRoutes(app, { zoneManager, logger });
+  registerZoneRoutes(app, { zoneManager, zoneAggregator, logger });
   registerEquipmentRoutes(app, { equipmentManager, logger });
   registerWebSocket(app, { eventBus, logger });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { DeviceManager } from "./devices/device-manager.js";
 import { ZoneManager } from "./zones/zone-manager.js";
 import { EquipmentManager } from "./equipments/equipment-manager.js";
 import { Zigbee2MqttParser } from "./mqtt/parsers/zigbee2mqtt.js";
+import { ZoneAggregator } from "./zones/zone-aggregator.js";
 import { createServer } from "./api/server.js";
 
 async function main() {
@@ -50,6 +51,9 @@ async function main() {
   // 6c. Create Equipment Manager
   const equipmentManager = new EquipmentManager(db, eventBus, mqttConnector, logger);
 
+  // 6d. Create Zone Aggregator
+  const zoneAggregator = new ZoneAggregator(zoneManager, equipmentManager, eventBus, logger);
+
   // 7. Create zigbee2mqtt parser
   const z2mParser = new Zigbee2MqttParser(
     config.z2m.baseTopic,
@@ -66,6 +70,7 @@ async function main() {
   const server = await createServer({
     deviceManager,
     zoneManager,
+    zoneAggregator,
     equipmentManager,
     eventBus,
     mqttConnector,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -111,6 +111,18 @@ export interface ZoneWithChildren extends Zone {
   children: ZoneWithChildren[];
 }
 
+export interface ZoneAggregatedData {
+  temperature: number | null;
+  humidity: number | null;
+  motion: boolean;
+  openDoors: number;
+  openWindows: number;
+  waterLeak: boolean;
+  smoke: boolean;
+  lightsOn: number;
+  lightsTotal: number;
+}
+
 // ============================================================
 // Equipment
 // ============================================================
@@ -221,6 +233,7 @@ export type EngineEvent =
   | { type: "zone.created"; zone: Zone }
   | { type: "zone.updated"; zone: Zone }
   | { type: "zone.removed"; zoneId: string; zoneName: string }
+  | { type: "zone.data.changed"; zoneId: string; aggregatedData: ZoneAggregatedData }
   // Equipment events
   | { type: "equipment.created"; equipment: Equipment }
   | { type: "equipment.updated"; equipment: Equipment }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -115,6 +115,7 @@ export interface ZoneAggregatedData {
   temperature: number | null;
   humidity: number | null;
   motion: boolean;
+  motionSensors: number;
   openDoors: number;
   openWindows: number;
   waterLeak: boolean;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -116,6 +116,7 @@ export interface ZoneAggregatedData {
   humidity: number | null;
   motion: boolean;
   motionSensors: number;
+  motionSince: string | null;
   openDoors: number;
   openWindows: number;
   waterLeak: boolean;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -114,6 +114,7 @@ export interface ZoneWithChildren extends Zone {
 export interface ZoneAggregatedData {
   temperature: number | null;
   humidity: number | null;
+  luminosity: number | null;
   motion: boolean;
   motionSensors: number;
   motionSince: string | null;

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -112,6 +112,7 @@ describe("ZoneAggregator", () => {
         humidity: null,
         motion: false,
         motionSensors: 0,
+        motionSince: null,
         openDoors: 0,
         openWindows: 0,
         waterLeak: false,
@@ -188,6 +189,7 @@ describe("ZoneAggregator", () => {
       const data = aggregator.getByZoneId(zone.id);
       expect(data?.motion).toBe(true);
       expect(data?.motionSensors).toBe(2);
+      expect(data?.motionSince).toEqual(expect.any(String));
     });
 
     it("aggregates motion as OR (false if all inactive)", () => {
@@ -206,6 +208,7 @@ describe("ZoneAggregator", () => {
       const data = aggregator.getByZoneId(zone.id);
       expect(data?.motion).toBe(false);
       expect(data?.motionSensors).toBe(1);
+      expect(data?.motionSince).toEqual(expect.any(String));
     });
 
     it("counts open doors from contact_door category", () => {
@@ -505,6 +508,59 @@ describe("ZoneAggregator", () => {
       // Both zones should have emitted zone.data.changed
       const zoneEvents = events.filter((e) => e.type === "zone.data.changed");
       expect(zoneEvents).toHaveLength(2);
+    });
+
+    it("updates motionSince on motion state transition", () => {
+      const zone = zoneManager.create({ name: "Entrée" });
+
+      const dev = seedDevice(db, {
+        name: "PIR1",
+        dataKeys: [{ key: "occupancy", type: "boolean", category: "motion", value: "false" }],
+      });
+      const eq = equipmentManager.create({ name: "PIR", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "occupancy");
+
+      aggregator.computeAll();
+      const initialSince = aggregator.getByZoneId(zone.id)?.motionSince;
+      expect(initialSince).toEqual(expect.any(String));
+
+      // Simulate same-value update (no motion change) — motionSince should be preserved
+      eventBus.emit({
+        type: "equipment.data.changed",
+        equipmentId: eq.id,
+        alias: "occupancy",
+        value: false,
+        previous: false,
+      });
+      expect(aggregator.getByZoneId(zone.id)?.motionSince).toBe(initialSince);
+
+      // Now motion detected — motionSince should change
+      db.prepare("UPDATE device_data SET value = ? WHERE id = ?").run("true", dev.dataIds[0]);
+      eventBus.emit({
+        type: "equipment.data.changed",
+        equipmentId: eq.id,
+        alias: "occupancy",
+        value: true,
+        previous: false,
+      });
+
+      const newSince = aggregator.getByZoneId(zone.id)?.motionSince;
+      expect(newSince).toEqual(expect.any(String));
+      expect(aggregator.getByZoneId(zone.id)?.motion).toBe(true);
+    });
+
+    it("motionSince is null for zones without motion sensors", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+
+      const dev = seedDevice(db, {
+        name: "Temp1",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "20" }],
+      });
+      const eq = equipmentManager.create({ name: "Sensor", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "temperature");
+
+      aggregator.computeAll();
+      expect(aggregator.getByZoneId(zone.id)?.motionSince).toBeNull();
     });
   });
 

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -1,0 +1,578 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { ZoneManager } from "./zone-manager.js";
+import { ZoneAggregator } from "./zone-aggregator.js";
+import { EquipmentManager } from "../equipments/equipment-manager.js";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+import type { EngineEvent } from "../shared/types.js";
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  const migration1 = readFileSync(
+    resolve(import.meta.dirname ?? ".", "../../migrations/001_devices.sql"),
+    "utf-8",
+  );
+  const migration2 = readFileSync(
+    resolve(import.meta.dirname ?? ".", "../../migrations/002_zones.sql"),
+    "utf-8",
+  );
+  const migration3 = readFileSync(
+    resolve(import.meta.dirname ?? ".", "../../migrations/003_equipments.sql"),
+    "utf-8",
+  );
+  db.exec(migration1);
+  db.exec(migration2);
+  db.exec(migration3);
+  return db;
+}
+
+const logger = createLogger("silent");
+
+function seedDevice(
+  db: Database.Database,
+  opts: {
+    deviceId?: string;
+    name?: string;
+    dataKeys?: { id?: string; key: string; type?: string; category?: string; value?: string }[];
+    orderKeys?: { id?: string; key: string; type?: string; payloadKey?: string }[];
+  } = {},
+) {
+  const deviceId = opts.deviceId ?? crypto.randomUUID();
+  const name = opts.name ?? "Test Device";
+  db.prepare(
+    `INSERT INTO devices (id, mqtt_base_topic, mqtt_name, name, source, status)
+     VALUES (?, ?, ?, ?, 'zigbee2mqtt', 'online')`,
+  ).run(deviceId, `z2m/${name}`, name, name);
+
+  const dataIds: string[] = [];
+  for (const d of opts.dataKeys ?? []) {
+    const id = d.id ?? crypto.randomUUID();
+    db.prepare(
+      `INSERT INTO device_data (id, device_id, key, type, category, value)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(id, deviceId, d.key, d.type ?? "boolean", d.category ?? "generic", d.value ?? null);
+    dataIds.push(id);
+  }
+
+  const orderIds: string[] = [];
+  for (const o of opts.orderKeys ?? []) {
+    const id = o.id ?? crypto.randomUUID();
+    db.prepare(
+      `INSERT INTO device_orders (id, device_id, key, type, mqtt_set_topic, payload_key)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(id, deviceId, o.key, o.type ?? "boolean", `z2m/${name}/set`, o.payloadKey ?? o.key);
+    orderIds.push(id);
+  }
+
+  return { deviceId, dataIds, orderIds };
+}
+
+describe("ZoneAggregator", () => {
+  let db: Database.Database;
+  let eventBus: EventBus;
+  let zoneManager: ZoneManager;
+  let equipmentManager: EquipmentManager;
+  let aggregator: ZoneAggregator;
+  let events: EngineEvent[];
+  const mockMqtt = {
+    publish: () => {},
+    isConnected: () => true,
+  };
+
+  beforeEach(() => {
+    db = createTestDb();
+    eventBus = new EventBus(logger);
+    zoneManager = new ZoneManager(db, eventBus, logger);
+    equipmentManager = new EquipmentManager(db, eventBus, mockMqtt as never, logger);
+    aggregator = new ZoneAggregator(zoneManager, equipmentManager, eventBus, logger);
+    events = [];
+    eventBus.on((event) => events.push(event));
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // ============================================================
+  // computeAll
+  // ============================================================
+
+  describe("computeAll", () => {
+    it("returns empty data for a zone with no equipments", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data).toEqual({
+        temperature: null,
+        humidity: null,
+        motion: false,
+        openDoors: 0,
+        openWindows: 0,
+        waterLeak: false,
+        smoke: false,
+        lightsOn: 0,
+        lightsTotal: 0,
+      });
+    });
+
+    it("aggregates temperature as AVG", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+
+      // Create two temperature sensors
+      const dev1 = seedDevice(db, {
+        name: "Temp1",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "20" }],
+      });
+      const dev2 = seedDevice(db, {
+        name: "Temp2",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "22" }],
+      });
+
+      const eq1 = equipmentManager.create({ name: "Sensor 1", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq1.id, dev1.dataIds[0], "temperature");
+
+      const eq2 = equipmentManager.create({ name: "Sensor 2", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq2.id, dev2.dataIds[0], "temperature");
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.temperature).toBe(21);
+    });
+
+    it("aggregates humidity as AVG", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+
+      const dev = seedDevice(db, {
+        name: "TH1",
+        dataKeys: [
+          { key: "humidity", type: "number", category: "humidity", value: "45" },
+        ],
+      });
+
+      const eq = equipmentManager.create({ name: "Sensor", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "humidity");
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.humidity).toBe(45);
+    });
+
+    it("aggregates motion as OR (true if any active)", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+
+      const dev1 = seedDevice(db, {
+        name: "PIR1",
+        dataKeys: [{ key: "occupancy", type: "boolean", category: "motion", value: "false" }],
+      });
+      const dev2 = seedDevice(db, {
+        name: "PIR2",
+        dataKeys: [{ key: "occupancy", type: "boolean", category: "motion", value: "true" }],
+      });
+
+      const eq1 = equipmentManager.create({ name: "PIR 1", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq1.id, dev1.dataIds[0], "occupancy");
+
+      const eq2 = equipmentManager.create({ name: "PIR 2", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq2.id, dev2.dataIds[0], "occupancy");
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.motion).toBe(true);
+    });
+
+    it("aggregates motion as OR (false if all inactive)", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+
+      const dev1 = seedDevice(db, {
+        name: "PIR1",
+        dataKeys: [{ key: "occupancy", type: "boolean", category: "motion", value: "false" }],
+      });
+
+      const eq1 = equipmentManager.create({ name: "PIR 1", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq1.id, dev1.dataIds[0], "occupancy");
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.motion).toBe(false);
+    });
+
+    it("counts open doors from contact_door category", () => {
+      const zone = zoneManager.create({ name: "Entrée" });
+
+      // contact=false means open, contact=true means closed
+      const dev1 = seedDevice(db, {
+        name: "Door1",
+        dataKeys: [{ key: "contact", type: "boolean", category: "contact_door", value: "false" }],
+      });
+      const dev2 = seedDevice(db, {
+        name: "Door2",
+        dataKeys: [{ key: "contact", type: "boolean", category: "contact_door", value: "true" }],
+      });
+
+      const eq1 = equipmentManager.create({ name: "Porte entrée", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq1.id, dev1.dataIds[0], "contact");
+
+      const eq2 = equipmentManager.create({ name: "Porte garage", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq2.id, dev2.dataIds[0], "contact");
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.openDoors).toBe(1);
+    });
+
+    it("counts open windows from contact_window category", () => {
+      const zone = zoneManager.create({ name: "Chambre" });
+
+      const dev = seedDevice(db, {
+        name: "Window1",
+        dataKeys: [{ key: "contact", type: "boolean", category: "contact_window", value: "false" }],
+      });
+
+      const eq = equipmentManager.create({ name: "Fenêtre", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "contact");
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.openWindows).toBe(1);
+    });
+
+    it("aggregates water_leak as OR", () => {
+      const zone = zoneManager.create({ name: "Cuisine" });
+
+      const dev = seedDevice(db, {
+        name: "Leak1",
+        dataKeys: [{ key: "water_leak", type: "boolean", category: "water_leak", value: "true" }],
+      });
+
+      const eq = equipmentManager.create({ name: "Fuite eau", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "water_leak");
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.waterLeak).toBe(true);
+    });
+
+    it("aggregates smoke as OR", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+
+      const dev = seedDevice(db, {
+        name: "Smoke1",
+        dataKeys: [{ key: "smoke", type: "boolean", category: "smoke", value: "false" }],
+      });
+
+      const eq = equipmentManager.create({ name: "Détecteur fumée", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "smoke");
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.smoke).toBe(false);
+    });
+
+    it("counts lights on and total from light_state category", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+
+      const dev1 = seedDevice(db, {
+        name: "Light1",
+        dataKeys: [{ key: "state", type: "boolean", category: "light_state", value: JSON.stringify("ON") }],
+        orderKeys: [{ key: "state", payloadKey: "state" }],
+      });
+      const dev2 = seedDevice(db, {
+        name: "Light2",
+        dataKeys: [{ key: "state", type: "boolean", category: "light_state", value: JSON.stringify("OFF") }],
+        orderKeys: [{ key: "state", payloadKey: "state" }],
+      });
+
+      const eq1 = equipmentManager.create({ name: "Spots", type: "light_onoff", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq1.id, dev1.dataIds[0], "state");
+
+      const eq2 = equipmentManager.create({ name: "Lampe", type: "light_onoff", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq2.id, dev2.dataIds[0], "state");
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.lightsOn).toBe(1);
+      expect(data?.lightsTotal).toBe(2);
+    });
+  });
+
+  // ============================================================
+  // Recursive aggregation
+  // ============================================================
+
+  describe("recursive aggregation", () => {
+    it("parent zone aggregates children data", () => {
+      const parent = zoneManager.create({ name: "Étage 1" });
+      const child1 = zoneManager.create({ name: "Salon", parentId: parent.id });
+      const child2 = zoneManager.create({ name: "Cuisine", parentId: parent.id });
+
+      // Salon: temperature 20
+      const dev1 = seedDevice(db, {
+        name: "TempSalon",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "20" }],
+      });
+      const eq1 = equipmentManager.create({ name: "Temp Salon", type: "sensor", zoneId: child1.id });
+      equipmentManager.addDataBinding(eq1.id, dev1.dataIds[0], "temperature");
+
+      // Cuisine: temperature 22
+      const dev2 = seedDevice(db, {
+        name: "TempCuisine",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "22" }],
+      });
+      const eq2 = equipmentManager.create({ name: "Temp Cuisine", type: "sensor", zoneId: child2.id });
+      equipmentManager.addDataBinding(eq2.id, dev2.dataIds[0], "temperature");
+
+      aggregator.computeAll();
+
+      // Parent should have AVG of 20 and 22 = 21
+      const parentData = aggregator.getByZoneId(parent.id);
+      expect(parentData?.temperature).toBe(21);
+
+      // Children should have their own values
+      expect(aggregator.getByZoneId(child1.id)?.temperature).toBe(20);
+      expect(aggregator.getByZoneId(child2.id)?.temperature).toBe(22);
+    });
+
+    it("parent aggregates motion OR across children", () => {
+      const parent = zoneManager.create({ name: "Étage 1" });
+      const child1 = zoneManager.create({ name: "Salon", parentId: parent.id });
+      const child2 = zoneManager.create({ name: "Cuisine", parentId: parent.id });
+
+      // Salon: no motion
+      const dev1 = seedDevice(db, {
+        name: "PIRSalon",
+        dataKeys: [{ key: "occupancy", type: "boolean", category: "motion", value: "false" }],
+      });
+      const eq1 = equipmentManager.create({ name: "PIR Salon", type: "sensor", zoneId: child1.id });
+      equipmentManager.addDataBinding(eq1.id, dev1.dataIds[0], "occupancy");
+
+      // Cuisine: motion detected
+      const dev2 = seedDevice(db, {
+        name: "PIRCuisine",
+        dataKeys: [{ key: "occupancy", type: "boolean", category: "motion", value: "true" }],
+      });
+      const eq2 = equipmentManager.create({ name: "PIR Cuisine", type: "sensor", zoneId: child2.id });
+      equipmentManager.addDataBinding(eq2.id, dev2.dataIds[0], "occupancy");
+
+      aggregator.computeAll();
+
+      // Parent has motion because Cuisine has motion
+      expect(aggregator.getByZoneId(parent.id)?.motion).toBe(true);
+      expect(aggregator.getByZoneId(child1.id)?.motion).toBe(false);
+      expect(aggregator.getByZoneId(child2.id)?.motion).toBe(true);
+    });
+
+    it("parent sums light counts from children", () => {
+      const parent = zoneManager.create({ name: "Maison" });
+      const child1 = zoneManager.create({ name: "Salon", parentId: parent.id });
+      const child2 = zoneManager.create({ name: "Cuisine", parentId: parent.id });
+
+      // Salon: 1 light on
+      const dev1 = seedDevice(db, {
+        name: "Light1",
+        dataKeys: [{ key: "state", type: "boolean", category: "light_state", value: JSON.stringify("ON") }],
+      });
+      const eq1 = equipmentManager.create({ name: "Spots Salon", type: "light_onoff", zoneId: child1.id });
+      equipmentManager.addDataBinding(eq1.id, dev1.dataIds[0], "state");
+
+      // Cuisine: 1 light off
+      const dev2 = seedDevice(db, {
+        name: "Light2",
+        dataKeys: [{ key: "state", type: "boolean", category: "light_state", value: JSON.stringify("OFF") }],
+      });
+      const eq2 = equipmentManager.create({ name: "Plafonnier Cuisine", type: "light_onoff", zoneId: child2.id });
+      equipmentManager.addDataBinding(eq2.id, dev2.dataIds[0], "state");
+
+      aggregator.computeAll();
+
+      const parentData = aggregator.getByZoneId(parent.id);
+      expect(parentData?.lightsOn).toBe(1);
+      expect(parentData?.lightsTotal).toBe(2);
+    });
+  });
+
+  // ============================================================
+  // Reactive updates via equipment.data.changed
+  // ============================================================
+
+  describe("reactive updates", () => {
+    it("updates aggregation when equipment data changes", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+
+      const dev = seedDevice(db, {
+        name: "Temp1",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "20" }],
+      });
+      const eq = equipmentManager.create({ name: "Sensor", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "temperature");
+
+      aggregator.computeAll();
+      expect(aggregator.getByZoneId(zone.id)?.temperature).toBe(20);
+
+      // Simulate device data update → equipment.data.changed
+      db.prepare("UPDATE device_data SET value = ? WHERE id = ?").run("25", dev.dataIds[0]);
+      events.length = 0;
+
+      eventBus.emit({
+        type: "equipment.data.changed",
+        equipmentId: eq.id,
+        alias: "temperature",
+        value: 25,
+        previous: 20,
+      });
+
+      expect(aggregator.getByZoneId(zone.id)?.temperature).toBe(25);
+
+      // Should have emitted zone.data.changed
+      const zoneEvents = events.filter((e) => e.type === "zone.data.changed");
+      expect(zoneEvents.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("does not emit zone.data.changed when aggregation is unchanged", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+
+      const dev = seedDevice(db, {
+        name: "Temp1",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "20" }],
+      });
+      const eq = equipmentManager.create({ name: "Sensor", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "temperature");
+
+      aggregator.computeAll();
+      events.length = 0;
+
+      // Emit equipment.data.changed but value didn't actually change in DB
+      eventBus.emit({
+        type: "equipment.data.changed",
+        equipmentId: eq.id,
+        alias: "temperature",
+        value: 20,
+        previous: 20,
+      });
+
+      const zoneEvents = events.filter((e) => e.type === "zone.data.changed");
+      expect(zoneEvents).toHaveLength(0);
+    });
+
+    it("propagates changes up the parent chain", () => {
+      const parent = zoneManager.create({ name: "Étage" });
+      const child = zoneManager.create({ name: "Salon", parentId: parent.id });
+
+      const dev = seedDevice(db, {
+        name: "PIR1",
+        dataKeys: [{ key: "occupancy", type: "boolean", category: "motion", value: "false" }],
+      });
+      const eq = equipmentManager.create({ name: "PIR", type: "sensor", zoneId: child.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "occupancy");
+
+      aggregator.computeAll();
+      expect(aggregator.getByZoneId(parent.id)?.motion).toBe(false);
+
+      // Motion detected
+      db.prepare("UPDATE device_data SET value = ? WHERE id = ?").run("true", dev.dataIds[0]);
+      events.length = 0;
+
+      eventBus.emit({
+        type: "equipment.data.changed",
+        equipmentId: eq.id,
+        alias: "occupancy",
+        value: true,
+        previous: false,
+      });
+
+      expect(aggregator.getByZoneId(child.id)?.motion).toBe(true);
+      expect(aggregator.getByZoneId(parent.id)?.motion).toBe(true);
+
+      // Both zones should have emitted zone.data.changed
+      const zoneEvents = events.filter((e) => e.type === "zone.data.changed");
+      expect(zoneEvents).toHaveLength(2);
+    });
+  });
+
+  // ============================================================
+  // Edge cases
+  // ============================================================
+
+  describe("edge cases", () => {
+    it("handles null values in bindings (excluded from AVG)", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+
+      // One sensor with value, one with null
+      const dev1 = seedDevice(db, {
+        name: "Temp1",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "20" }],
+      });
+      const dev2 = seedDevice(db, {
+        name: "Temp2",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: null as unknown as string }],
+      });
+
+      const eq1 = equipmentManager.create({ name: "Sensor 1", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq1.id, dev1.dataIds[0], "temperature");
+
+      const eq2 = equipmentManager.create({ name: "Sensor 2", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq2.id, dev2.dataIds[0], "temperature");
+
+      aggregator.computeAll();
+
+      // Should only use the non-null value
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.temperature).toBe(20);
+    });
+
+    it("getAll returns data for all zones", () => {
+      const z1 = zoneManager.create({ name: "Salon" });
+      const z2 = zoneManager.create({ name: "Cuisine" });
+
+      aggregator.computeAll();
+
+      const all = aggregator.getAll();
+      expect(Object.keys(all)).toHaveLength(2);
+      expect(all[z1.id]).toBeDefined();
+      expect(all[z2.id]).toBeDefined();
+    });
+
+    it("returns null for unknown zone", () => {
+      expect(aggregator.getByZoneId("unknown")).toBeNull();
+    });
+
+    it("handles mixed sensor and light data in same zone", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+
+      const devTemp = seedDevice(db, {
+        name: "Temp1",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "21.5" }],
+      });
+      const devLight = seedDevice(db, {
+        name: "Light1",
+        dataKeys: [{ key: "state", type: "boolean", category: "light_state", value: JSON.stringify("ON") }],
+      });
+
+      const eqTemp = equipmentManager.create({ name: "Temp", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eqTemp.id, devTemp.dataIds[0], "temperature");
+
+      const eqLight = equipmentManager.create({ name: "Spots", type: "light_onoff", zoneId: zone.id });
+      equipmentManager.addDataBinding(eqLight.id, devLight.dataIds[0], "state");
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.temperature).toBe(21.5);
+      expect(data?.lightsOn).toBe(1);
+      expect(data?.lightsTotal).toBe(1);
+    });
+  });
+});

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -111,6 +111,7 @@ describe("ZoneAggregator", () => {
         temperature: null,
         humidity: null,
         motion: false,
+        motionSensors: 0,
         openDoors: 0,
         openWindows: 0,
         waterLeak: false,
@@ -186,6 +187,7 @@ describe("ZoneAggregator", () => {
 
       const data = aggregator.getByZoneId(zone.id);
       expect(data?.motion).toBe(true);
+      expect(data?.motionSensors).toBe(2);
     });
 
     it("aggregates motion as OR (false if all inactive)", () => {
@@ -203,6 +205,7 @@ describe("ZoneAggregator", () => {
 
       const data = aggregator.getByZoneId(zone.id);
       expect(data?.motion).toBe(false);
+      expect(data?.motionSensors).toBe(1);
     });
 
     it("counts open doors from contact_door category", () => {
@@ -371,8 +374,11 @@ describe("ZoneAggregator", () => {
 
       // Parent has motion because Cuisine has motion
       expect(aggregator.getByZoneId(parent.id)?.motion).toBe(true);
+      expect(aggregator.getByZoneId(parent.id)?.motionSensors).toBe(2);
       expect(aggregator.getByZoneId(child1.id)?.motion).toBe(false);
+      expect(aggregator.getByZoneId(child1.id)?.motionSensors).toBe(1);
       expect(aggregator.getByZoneId(child2.id)?.motion).toBe(true);
+      expect(aggregator.getByZoneId(child2.id)?.motionSensors).toBe(1);
     });
 
     it("parent sums light counts from children", () => {

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -110,6 +110,7 @@ describe("ZoneAggregator", () => {
       expect(data).toEqual({
         temperature: null,
         humidity: null,
+        luminosity: null,
         motion: false,
         motionSensors: 0,
         motionSince: null,

--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -19,6 +19,7 @@ interface Accumulator {
   humiditySum: number;
   humidityCount: number;
   motion: boolean;
+  motionSensors: number;
   openDoors: number;
   openWindows: number;
   waterLeak: boolean;
@@ -34,6 +35,7 @@ function emptyAccumulator(): Accumulator {
     humiditySum: 0,
     humidityCount: 0,
     motion: false,
+    motionSensors: 0,
     openDoors: 0,
     openWindows: 0,
     waterLeak: false,
@@ -50,6 +52,7 @@ function mergeAccumulators(a: Accumulator, b: Accumulator): Accumulator {
     humiditySum: a.humiditySum + b.humiditySum,
     humidityCount: a.humidityCount + b.humidityCount,
     motion: a.motion || b.motion,
+    motionSensors: a.motionSensors + b.motionSensors,
     openDoors: a.openDoors + b.openDoors,
     openWindows: a.openWindows + b.openWindows,
     waterLeak: a.waterLeak || b.waterLeak,
@@ -68,6 +71,7 @@ function accumulatorToPublic(acc: Accumulator): ZoneAggregatedData {
       ? Math.round((acc.humiditySum / acc.humidityCount) * 10) / 10
       : null,
     motion: acc.motion,
+    motionSensors: acc.motionSensors,
     openDoors: acc.openDoors,
     openWindows: acc.openWindows,
     waterLeak: acc.waterLeak,
@@ -82,6 +86,7 @@ function aggregatedDataEqual(a: ZoneAggregatedData, b: ZoneAggregatedData): bool
     a.temperature === b.temperature &&
     a.humidity === b.humidity &&
     a.motion === b.motion &&
+    a.motionSensors === b.motionSensors &&
     a.openDoors === b.openDoors &&
     a.openWindows === b.openWindows &&
     a.waterLeak === b.waterLeak &&
@@ -349,6 +354,7 @@ export class ZoneAggregator {
           break;
 
         case "motion":
+          acc.motionSensors += 1;
           if (isBooleanActive(value)) {
             acc.motion = true;
           }

--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -72,6 +72,7 @@ function accumulatorToPublic(acc: Accumulator): ZoneAggregatedData {
       : null,
     motion: acc.motion,
     motionSensors: acc.motionSensors,
+    motionSince: null, // Set separately — not accumulated
     openDoors: acc.openDoors,
     openWindows: acc.openWindows,
     waterLeak: acc.waterLeak,
@@ -81,6 +82,9 @@ function accumulatorToPublic(acc: Accumulator): ZoneAggregatedData {
   };
 }
 
+/**
+ * Compare aggregated data excluding motionSince (which is derived, not accumulated).
+ */
 function aggregatedDataEqual(a: ZoneAggregatedData, b: ZoneAggregatedData): boolean {
   return (
     a.temperature === b.temperature &&
@@ -94,6 +98,24 @@ function aggregatedDataEqual(a: ZoneAggregatedData, b: ZoneAggregatedData): bool
     a.lightsOn === b.lightsOn &&
     a.lightsTotal === b.lightsTotal
   );
+}
+
+/**
+ * Compute motionSince for a zone based on current vs previous motion state.
+ * Only updates the timestamp on actual motion state transitions.
+ */
+function resolveMotionSince(
+  newData: ZoneAggregatedData,
+  oldData: ZoneAggregatedData | undefined,
+  now: string,
+): string | null {
+  if (newData.motionSensors === 0) return null;
+  // If previous data exists and motion state is unchanged, keep the old timestamp
+  if (oldData && oldData.motionSince && oldData.motion === newData.motion) {
+    return oldData.motionSince;
+  }
+  // Motion state changed (or first computation) — record transition time
+  return now;
 }
 
 // ============================================================
@@ -199,10 +221,14 @@ export class ZoneAggregator {
       }
 
       this.mergedCache.set(zoneId, merged);
-      this.publicCache.set(zoneId, accumulatorToPublic(merged));
+      const pub = accumulatorToPublic(merged);
+      const oldPub = this.publicCache.get(zoneId);
+      pub.motionSince = resolveMotionSince(pub, oldPub, now);
+      this.publicCache.set(zoneId, pub);
       computed.add(zoneId);
     };
 
+    const now = new Date().toISOString();
     for (const zone of zones) {
       computeZone(zone.id);
     }
@@ -276,6 +302,7 @@ export class ZoneAggregator {
 
     let currentId: string | null = zoneId;
     let recomputeDirect = true;
+    const now = new Date().toISOString();
 
     while (currentId) {
       const zone = zoneMap.get(currentId);
@@ -301,6 +328,9 @@ export class ZoneAggregator {
       const newPublic = accumulatorToPublic(merged);
       const oldPublic = this.publicCache.get(currentId);
 
+      // Resolve motionSince before equality check
+      newPublic.motionSince = resolveMotionSince(newPublic, oldPublic, now);
+
       if (!oldPublic || !aggregatedDataEqual(oldPublic, newPublic)) {
         this.publicCache.set(currentId, newPublic);
         this.eventBus.emit({
@@ -309,6 +339,9 @@ export class ZoneAggregator {
           aggregatedData: newPublic,
         });
         this.logger.debug({ zoneId: currentId, aggregatedData: newPublic }, "Zone aggregation updated");
+      } else {
+        // Even if aggregation data is unchanged, update cache with motionSince
+        this.publicCache.set(currentId, newPublic);
       }
 
       currentId = zone.parentId;

--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -1,0 +1,390 @@
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { ZoneManager } from "./zone-manager.js";
+import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import type {
+  DataCategory,
+  ZoneAggregatedData,
+  DataBindingWithValue,
+  Zone,
+} from "../shared/types.js";
+
+// ============================================================
+// Internal accumulator for aggregation (tracks sums + counts)
+// ============================================================
+
+interface Accumulator {
+  temperatureSum: number;
+  temperatureCount: number;
+  humiditySum: number;
+  humidityCount: number;
+  motion: boolean;
+  openDoors: number;
+  openWindows: number;
+  waterLeak: boolean;
+  smoke: boolean;
+  lightsOn: number;
+  lightsTotal: number;
+}
+
+function emptyAccumulator(): Accumulator {
+  return {
+    temperatureSum: 0,
+    temperatureCount: 0,
+    humiditySum: 0,
+    humidityCount: 0,
+    motion: false,
+    openDoors: 0,
+    openWindows: 0,
+    waterLeak: false,
+    smoke: false,
+    lightsOn: 0,
+    lightsTotal: 0,
+  };
+}
+
+function mergeAccumulators(a: Accumulator, b: Accumulator): Accumulator {
+  return {
+    temperatureSum: a.temperatureSum + b.temperatureSum,
+    temperatureCount: a.temperatureCount + b.temperatureCount,
+    humiditySum: a.humiditySum + b.humiditySum,
+    humidityCount: a.humidityCount + b.humidityCount,
+    motion: a.motion || b.motion,
+    openDoors: a.openDoors + b.openDoors,
+    openWindows: a.openWindows + b.openWindows,
+    waterLeak: a.waterLeak || b.waterLeak,
+    smoke: a.smoke || b.smoke,
+    lightsOn: a.lightsOn + b.lightsOn,
+    lightsTotal: a.lightsTotal + b.lightsTotal,
+  };
+}
+
+function accumulatorToPublic(acc: Accumulator): ZoneAggregatedData {
+  return {
+    temperature: acc.temperatureCount > 0
+      ? Math.round((acc.temperatureSum / acc.temperatureCount) * 10) / 10
+      : null,
+    humidity: acc.humidityCount > 0
+      ? Math.round((acc.humiditySum / acc.humidityCount) * 10) / 10
+      : null,
+    motion: acc.motion,
+    openDoors: acc.openDoors,
+    openWindows: acc.openWindows,
+    waterLeak: acc.waterLeak,
+    smoke: acc.smoke,
+    lightsOn: acc.lightsOn,
+    lightsTotal: acc.lightsTotal,
+  };
+}
+
+function aggregatedDataEqual(a: ZoneAggregatedData, b: ZoneAggregatedData): boolean {
+  return (
+    a.temperature === b.temperature &&
+    a.humidity === b.humidity &&
+    a.motion === b.motion &&
+    a.openDoors === b.openDoors &&
+    a.openWindows === b.openWindows &&
+    a.waterLeak === b.waterLeak &&
+    a.smoke === b.smoke &&
+    a.lightsOn === b.lightsOn &&
+    a.lightsTotal === b.lightsTotal
+  );
+}
+
+// ============================================================
+// Helpers to check boolean active state
+// ============================================================
+
+function isBooleanActive(value: unknown): boolean {
+  return value === true || value === "ON";
+}
+
+function isContactOpen(value: unknown): boolean {
+  return value === false || value === "OFF";
+}
+
+// ============================================================
+// Zone Aggregator
+// ============================================================
+
+export class ZoneAggregator {
+  private logger: Logger;
+  private eventBus: EventBus;
+  private zoneManager: ZoneManager;
+  private equipmentManager: EquipmentManager;
+
+  // Cache: per-zone accumulators and public data
+  private directCache = new Map<string, Accumulator>();
+  private mergedCache = new Map<string, Accumulator>();
+  private publicCache = new Map<string, ZoneAggregatedData>();
+
+  constructor(
+    zoneManager: ZoneManager,
+    equipmentManager: EquipmentManager,
+    eventBus: EventBus,
+    logger: Logger,
+  ) {
+    this.zoneManager = zoneManager;
+    this.equipmentManager = equipmentManager;
+    this.eventBus = eventBus;
+    this.logger = logger.child({ module: "zone-aggregator" });
+
+    this.setupEventListeners();
+  }
+
+  // ============================================================
+  // Public API
+  // ============================================================
+
+  /**
+   * Get all zone aggregated data.
+   */
+  getAll(): Record<string, ZoneAggregatedData> {
+    const result: Record<string, ZoneAggregatedData> = {};
+    for (const [zoneId, data] of this.publicCache) {
+      result[zoneId] = data;
+    }
+    return result;
+  }
+
+  /**
+   * Get aggregated data for a single zone.
+   */
+  getByZoneId(zoneId: string): ZoneAggregatedData | null {
+    return this.publicCache.get(zoneId) ?? null;
+  }
+
+  /**
+   * Compute aggregation for all zones (called on startup).
+   */
+  computeAll(): void {
+    const zones = this.zoneManager.getAll();
+
+    // Build parent→children map
+    const childrenMap = new Map<string | null, Zone[]>();
+    for (const zone of zones) {
+      const siblings = childrenMap.get(zone.parentId) ?? [];
+      siblings.push(zone);
+      childrenMap.set(zone.parentId, siblings);
+    }
+
+    // Compute direct accumulators for all zones
+    for (const zone of zones) {
+      this.directCache.set(zone.id, this.computeDirectAccumulator(zone.id));
+    }
+
+    // Compute merged accumulators bottom-up (process leaves first)
+    const computed = new Set<string>();
+    const computeZone = (zoneId: string): void => {
+      if (computed.has(zoneId)) return;
+
+      // Compute children first
+      const children = childrenMap.get(zoneId) ?? [];
+      for (const child of children) {
+        computeZone(child.id);
+      }
+
+      // Merge direct + all children
+      let merged = this.directCache.get(zoneId) ?? emptyAccumulator();
+      for (const child of children) {
+        const childMerged = this.mergedCache.get(child.id);
+        if (childMerged) {
+          merged = mergeAccumulators(merged, childMerged);
+        }
+      }
+
+      this.mergedCache.set(zoneId, merged);
+      this.publicCache.set(zoneId, accumulatorToPublic(merged));
+      computed.add(zoneId);
+    };
+
+    for (const zone of zones) {
+      computeZone(zone.id);
+    }
+
+    this.logger.info({ zoneCount: zones.length }, "Zone aggregation computed for all zones");
+  }
+
+  // ============================================================
+  // Event listeners
+  // ============================================================
+
+  private setupEventListeners(): void {
+    this.eventBus.on((event) => {
+      try {
+        switch (event.type) {
+          case "equipment.data.changed":
+            this.handleEquipmentDataChanged(event.equipmentId);
+            break;
+          case "equipment.created":
+          case "equipment.updated":
+            this.handleEquipmentChanged(event.equipment.zoneId);
+            break;
+          case "equipment.removed":
+            // On removal, recompute all (we don't know which zone it was in)
+            this.computeAll();
+            break;
+          case "zone.created":
+          case "zone.updated":
+          case "zone.removed":
+            this.computeAll();
+            break;
+          case "system.started":
+            this.computeAll();
+            break;
+        }
+      } catch (err) {
+        this.logger.error({ err, eventType: event.type }, "Error in zone aggregator event handler");
+      }
+    });
+  }
+
+  // ============================================================
+  // Recomputation logic
+  // ============================================================
+
+  private handleEquipmentDataChanged(equipmentId: string): void {
+    const equipment = this.equipmentManager.getById(equipmentId);
+    if (!equipment) return;
+
+    this.recomputeZoneChain(equipment.zoneId);
+  }
+
+  private handleEquipmentChanged(zoneId: string): void {
+    this.recomputeZoneChain(zoneId);
+  }
+
+  /**
+   * Recompute a zone and walk up the parent chain.
+   */
+  private recomputeZoneChain(zoneId: string): void {
+    const zones = this.zoneManager.getAll();
+    const zoneMap = new Map(zones.map((z) => [z.id, z]));
+    const childrenMap = new Map<string, Zone[]>();
+    for (const zone of zones) {
+      if (zone.parentId) {
+        const siblings = childrenMap.get(zone.parentId) ?? [];
+        siblings.push(zone);
+        childrenMap.set(zone.parentId, siblings);
+      }
+    }
+
+    let currentId: string | null = zoneId;
+    let recomputeDirect = true;
+
+    while (currentId) {
+      const zone = zoneMap.get(currentId);
+      if (!zone) break;
+
+      // Only recompute direct accumulator for the originating zone
+      if (recomputeDirect) {
+        this.directCache.set(currentId, this.computeDirectAccumulator(currentId));
+        recomputeDirect = false;
+      }
+
+      // Merge direct + all children
+      let merged = this.directCache.get(currentId) ?? emptyAccumulator();
+      const children = childrenMap.get(currentId) ?? [];
+      for (const child of children) {
+        const childMerged = this.mergedCache.get(child.id);
+        if (childMerged) {
+          merged = mergeAccumulators(merged, childMerged);
+        }
+      }
+
+      this.mergedCache.set(currentId, merged);
+      const newPublic = accumulatorToPublic(merged);
+      const oldPublic = this.publicCache.get(currentId);
+
+      if (!oldPublic || !aggregatedDataEqual(oldPublic, newPublic)) {
+        this.publicCache.set(currentId, newPublic);
+        this.eventBus.emit({
+          type: "zone.data.changed",
+          zoneId: currentId,
+          aggregatedData: newPublic,
+        });
+        this.logger.debug({ zoneId: currentId, aggregatedData: newPublic }, "Zone aggregation updated");
+      }
+
+      currentId = zone.parentId;
+    }
+  }
+
+  /**
+   * Compute the direct accumulator for a zone from its own equipments.
+   */
+  private computeDirectAccumulator(zoneId: string): Accumulator {
+    const equipments = this.equipmentManager.getByZone(zoneId);
+    const acc = emptyAccumulator();
+
+    for (const equipment of equipments) {
+      const bindings = this.equipmentManager.getDataBindingsWithValues(equipment.id);
+      this.accumulateBindings(acc, bindings);
+    }
+
+    return acc;
+  }
+
+  /**
+   * Accumulate data bindings into an accumulator.
+   */
+  private accumulateBindings(acc: Accumulator, bindings: DataBindingWithValue[]): void {
+    for (const binding of bindings) {
+      const category: DataCategory = binding.category;
+      const value = binding.value;
+
+      switch (category) {
+        case "temperature":
+          if (typeof value === "number") {
+            acc.temperatureSum += value;
+            acc.temperatureCount += 1;
+          }
+          break;
+
+        case "humidity":
+          if (typeof value === "number") {
+            acc.humiditySum += value;
+            acc.humidityCount += 1;
+          }
+          break;
+
+        case "motion":
+          if (isBooleanActive(value)) {
+            acc.motion = true;
+          }
+          break;
+
+        case "contact_door":
+          if (isContactOpen(value)) {
+            acc.openDoors += 1;
+          }
+          break;
+
+        case "contact_window":
+          if (isContactOpen(value)) {
+            acc.openWindows += 1;
+          }
+          break;
+
+        case "water_leak":
+          if (isBooleanActive(value)) {
+            acc.waterLeak = true;
+          }
+          break;
+
+        case "smoke":
+          if (isBooleanActive(value)) {
+            acc.smoke = true;
+          }
+          break;
+
+        case "light_state":
+          acc.lightsTotal += 1;
+          if (isBooleanActive(value)) {
+            acc.lightsOn += 1;
+          }
+          break;
+      }
+    }
+  }
+}

--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -18,6 +18,8 @@ interface Accumulator {
   temperatureCount: number;
   humiditySum: number;
   humidityCount: number;
+  luminositySum: number;
+  luminosityCount: number;
   motion: boolean;
   motionSensors: number;
   openDoors: number;
@@ -34,6 +36,8 @@ function emptyAccumulator(): Accumulator {
     temperatureCount: 0,
     humiditySum: 0,
     humidityCount: 0,
+    luminositySum: 0,
+    luminosityCount: 0,
     motion: false,
     motionSensors: 0,
     openDoors: 0,
@@ -51,6 +55,8 @@ function mergeAccumulators(a: Accumulator, b: Accumulator): Accumulator {
     temperatureCount: a.temperatureCount + b.temperatureCount,
     humiditySum: a.humiditySum + b.humiditySum,
     humidityCount: a.humidityCount + b.humidityCount,
+    luminositySum: a.luminositySum + b.luminositySum,
+    luminosityCount: a.luminosityCount + b.luminosityCount,
     motion: a.motion || b.motion,
     motionSensors: a.motionSensors + b.motionSensors,
     openDoors: a.openDoors + b.openDoors,
@@ -69,6 +75,9 @@ function accumulatorToPublic(acc: Accumulator): ZoneAggregatedData {
       : null,
     humidity: acc.humidityCount > 0
       ? Math.round((acc.humiditySum / acc.humidityCount) * 10) / 10
+      : null,
+    luminosity: acc.luminosityCount > 0
+      ? Math.round(acc.luminositySum / acc.luminosityCount)
       : null,
     motion: acc.motion,
     motionSensors: acc.motionSensors,
@@ -89,6 +98,7 @@ function aggregatedDataEqual(a: ZoneAggregatedData, b: ZoneAggregatedData): bool
   return (
     a.temperature === b.temperature &&
     a.humidity === b.humidity &&
+    a.luminosity === b.luminosity &&
     a.motion === b.motion &&
     a.motionSensors === b.motionSensors &&
     a.openDoors === b.openDoors &&
@@ -383,6 +393,13 @@ export class ZoneAggregator {
           if (typeof value === "number") {
             acc.humiditySum += value;
             acc.humidityCount += 1;
+          }
+          break;
+
+        case "luminosity":
+          if (typeof value === "number") {
+            acc.luminositySum += value;
+            acc.luminosityCount += 1;
           }
           break;
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,6 +1,6 @@
 import type {
   Device, DeviceData, DeviceWithDetails,
-  ZoneWithChildren, Zone,
+  ZoneWithChildren, Zone, ZoneAggregatedData,
   Equipment, EquipmentType, EquipmentWithDetails,
   DataBinding, OrderBinding,
 } from "./types";
@@ -64,6 +64,10 @@ export async function getDeviceRawExpose(
 
 export async function getZones(): Promise<ZoneWithChildren[]> {
   return fetchJSON<ZoneWithChildren[]>(`${API_BASE}/zones`);
+}
+
+export async function getZoneAggregation(): Promise<Record<string, ZoneAggregatedData>> {
+  return fetchJSON<Record<string, ZoneAggregatedData>>(`${API_BASE}/zones/aggregation`);
 }
 
 export async function getZone(id: string): Promise<ZoneWithChildren> {

--- a/ui/src/components/maison/CompactEquipmentCard.tsx
+++ b/ui/src/components/maison/CompactEquipmentCard.tsx
@@ -131,9 +131,9 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder }: CompactEquip
   return (
     <div
       className={`
-        flex items-center gap-3 px-3 py-2.5 rounded-[8px] border
+        flex items-center gap-3 px-4 py-2.5
         transition-colors duration-150
-        border-border bg-surface
+        hover:bg-border-light/40
       `}
     >
       {/* Icon */}

--- a/ui/src/components/maison/ZoneAggregationHeader.tsx
+++ b/ui/src/components/maison/ZoneAggregationHeader.tsx
@@ -1,0 +1,134 @@
+import {
+  Thermometer,
+  Droplets,
+  PersonStanding,
+  Lightbulb,
+  DoorOpen,
+  SquareStack,
+  Droplet,
+  Flame,
+} from "lucide-react";
+import type { ZoneAggregatedData } from "../../types";
+
+interface ZoneAggregationHeaderProps {
+  data: ZoneAggregatedData;
+}
+
+export function ZoneAggregationHeader({ data }: ZoneAggregationHeaderProps) {
+  const pills: React.ReactNode[] = [];
+
+  // Temperature
+  if (data.temperature !== null) {
+    pills.push(
+      <Pill key="temp" icon={<Thermometer size={14} strokeWidth={1.5} />} color="text-primary">
+        {data.temperature}°C
+      </Pill>,
+    );
+  }
+
+  // Humidity
+  if (data.humidity !== null) {
+    pills.push(
+      <Pill key="hum" icon={<Droplets size={14} strokeWidth={1.5} />} color="text-primary">
+        {data.humidity}%
+      </Pill>,
+    );
+  }
+
+  // Motion (only shown when active)
+  if (data.motion) {
+    pills.push(
+      <Pill key="motion" icon={<PersonStanding size={14} strokeWidth={1.5} />} color="text-amber-500" active>
+        Mouvement
+      </Pill>,
+    );
+  }
+
+  // Lights
+  if (data.lightsTotal > 0) {
+    const isOn = data.lightsOn > 0;
+    pills.push(
+      <Pill
+        key="lights"
+        icon={<Lightbulb size={14} strokeWidth={1.5} />}
+        color={isOn ? "text-amber-500" : "text-text-tertiary"}
+        active={isOn}
+      >
+        {data.lightsOn}/{data.lightsTotal}
+      </Pill>,
+    );
+  }
+
+  // Open doors
+  if (data.openDoors > 0) {
+    pills.push(
+      <Pill key="doors" icon={<DoorOpen size={14} strokeWidth={1.5} />} color="text-amber-500" active>
+        {data.openDoors} ouverte{data.openDoors > 1 ? "s" : ""}
+      </Pill>,
+    );
+  }
+
+  // Open windows
+  if (data.openWindows > 0) {
+    pills.push(
+      <Pill key="windows" icon={<SquareStack size={14} strokeWidth={1.5} />} color="text-amber-500" active>
+        {data.openWindows} ouverte{data.openWindows > 1 ? "s" : ""}
+      </Pill>,
+    );
+  }
+
+  // Water leak alert
+  if (data.waterLeak) {
+    pills.push(
+      <Pill key="water" icon={<Droplet size={14} strokeWidth={1.5} />} color="text-error" alert>
+        Fuite eau
+      </Pill>,
+    );
+  }
+
+  // Smoke alert
+  if (data.smoke) {
+    pills.push(
+      <Pill key="smoke" icon={<Flame size={14} strokeWidth={1.5} />} color="text-error" alert>
+        Fumée
+      </Pill>,
+    );
+  }
+
+  if (pills.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 mb-6">
+      {pills}
+    </div>
+  );
+}
+
+interface PillProps {
+  icon: React.ReactNode;
+  color: string;
+  active?: boolean;
+  alert?: boolean;
+  children: React.ReactNode;
+}
+
+function Pill({ icon, color, active, alert, children }: PillProps) {
+  const bg = alert
+    ? "bg-error/10"
+    : active
+      ? "bg-amber-400/10"
+      : "bg-border-light/60";
+
+  return (
+    <span
+      className={`
+        inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full
+        text-[13px] font-medium tabular-nums
+        ${bg} ${color}
+      `}
+    >
+      {icon}
+      {children}
+    </span>
+  );
+}

--- a/ui/src/components/maison/ZoneAggregationHeader.tsx
+++ b/ui/src/components/maison/ZoneAggregationHeader.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import {
   Thermometer,
   Droplets,
@@ -17,6 +18,7 @@ interface ZoneAggregationHeaderProps {
 
 export function ZoneAggregationHeader({ data }: ZoneAggregationHeaderProps) {
   const pills: React.ReactNode[] = [];
+  const duration = useRelativeTime(data.motionSince);
 
   // Temperature
   if (data.temperature !== null) {
@@ -38,14 +40,16 @@ export function ZoneAggregationHeader({ data }: ZoneAggregationHeaderProps) {
 
   // Motion (shown when zone has motion sensors)
   if (data.motionSensors > 0) {
+    const label = data.motion ? "Mouvement" : "Calme";
+    const suffix = duration ? ` · ${duration}` : "";
     pills.push(
       data.motion ? (
         <Pill key="motion" icon={<PersonStanding size={14} strokeWidth={1.5} />} color="text-amber-500" active>
-          Mouvement
+          {label}{suffix}
         </Pill>
       ) : (
         <Pill key="motion" icon={<PersonStanding size={14} strokeWidth={1.5} />} color="text-text-tertiary">
-          Calme
+          {label}{suffix}
         </Pill>
       ),
     );
@@ -118,6 +122,42 @@ export function ZoneAggregationHeader({ data }: ZoneAggregationHeaderProps) {
     </div>
   );
 }
+
+// ============================================================
+// Relative time hook — refreshes every 30s, zero CPU when no timestamp
+// ============================================================
+
+function useRelativeTime(since: string | null): string | null {
+  const [, tick] = useState(0);
+
+  useEffect(() => {
+    if (!since) return;
+    const id = setInterval(() => tick((n) => n + 1), 30_000);
+    return () => clearInterval(id);
+  }, [since]);
+
+  if (!since) return null;
+  return formatDuration(since);
+}
+
+function formatDuration(since: string): string {
+  const ms = Date.now() - new Date(since).getTime();
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return "< 1 min";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const remainMinutes = minutes % 60;
+  if (hours < 24) {
+    return remainMinutes > 0 ? `${hours}h${String(remainMinutes).padStart(2, "0")}` : `${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days}j`;
+}
+
+// ============================================================
+// Pill component
+// ============================================================
 
 interface PillProps {
   icon: React.ReactNode;

--- a/ui/src/components/maison/ZoneAggregationHeader.tsx
+++ b/ui/src/components/maison/ZoneAggregationHeader.tsx
@@ -7,6 +7,7 @@ import {
   SquareStack,
   Droplet,
   Flame,
+  Activity,
 } from "lucide-react";
 import type { ZoneAggregatedData } from "../../types";
 
@@ -98,8 +99,16 @@ export function ZoneAggregationHeader({ data }: ZoneAggregationHeaderProps) {
   if (pills.length === 0) return null;
 
   return (
-    <div className="flex flex-wrap items-center gap-2 mb-6">
-      {pills}
+    <div className="mb-6 rounded-[10px] border border-border bg-surface px-4 py-3">
+      <div className="flex items-center gap-1.5 mb-2">
+        <Activity size={14} strokeWidth={1.5} className="text-text-tertiary" />
+        <span className="text-[12px] font-semibold text-text-tertiary uppercase tracking-wider">
+          Statut
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        {pills}
+      </div>
     </div>
   );
 }

--- a/ui/src/components/maison/ZoneAggregationHeader.tsx
+++ b/ui/src/components/maison/ZoneAggregationHeader.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import {
   Thermometer,
   Droplets,
+  Sun,
   PersonStanding,
   Lightbulb,
   DoorOpen,
@@ -34,6 +35,15 @@ export function ZoneAggregationHeader({ data }: ZoneAggregationHeaderProps) {
     pills.push(
       <Pill key="hum" icon={<Droplets size={14} strokeWidth={1.5} />} color="text-primary">
         {data.humidity}%
+      </Pill>,
+    );
+  }
+
+  // Luminosity
+  if (data.luminosity !== null) {
+    pills.push(
+      <Pill key="lux" icon={<Sun size={14} strokeWidth={1.5} />} color="text-primary">
+        {data.luminosity} lx
       </Pill>,
     );
   }

--- a/ui/src/components/maison/ZoneAggregationHeader.tsx
+++ b/ui/src/components/maison/ZoneAggregationHeader.tsx
@@ -36,12 +36,18 @@ export function ZoneAggregationHeader({ data }: ZoneAggregationHeaderProps) {
     );
   }
 
-  // Motion (only shown when active)
-  if (data.motion) {
+  // Motion (shown when zone has motion sensors)
+  if (data.motionSensors > 0) {
     pills.push(
-      <Pill key="motion" icon={<PersonStanding size={14} strokeWidth={1.5} />} color="text-amber-500" active>
-        Mouvement
-      </Pill>,
+      data.motion ? (
+        <Pill key="motion" icon={<PersonStanding size={14} strokeWidth={1.5} />} color="text-amber-500" active>
+          Mouvement
+        </Pill>
+      ) : (
+        <Pill key="motion" icon={<PersonStanding size={14} strokeWidth={1.5} />} color="text-text-tertiary">
+          Calme
+        </Pill>
+      ),
     );
   }
 

--- a/ui/src/components/maison/ZoneEquipmentsView.tsx
+++ b/ui/src/components/maison/ZoneEquipmentsView.tsx
@@ -61,7 +61,7 @@ export function ZoneEquipmentsView({
               {group.equipments.length}
             </span>
           </div>
-          <div className="p-2 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2">
+          <div className="divide-y divide-border-light">
             {group.equipments.map((eq) => (
               <CompactEquipmentCard
                 key={eq.id}

--- a/ui/src/components/maison/ZoneEquipmentsView.tsx
+++ b/ui/src/components/maison/ZoneEquipmentsView.tsx
@@ -1,20 +1,30 @@
-import { Box } from "lucide-react";
+import {
+  Box,
+  Lightbulb,
+  ArrowUpDown,
+  Gauge,
+  ThermometerSun,
+  Shield,
+  MonitorSpeaker,
+  ToggleRight,
+} from "lucide-react";
 import type { EquipmentType, EquipmentWithDetails } from "../../types";
 import { CompactEquipmentCard } from "./CompactEquipmentCard";
 
 interface EquipmentGroup {
   label: string;
   types: EquipmentType[];
+  icon: React.ReactNode;
 }
 
 const EQUIPMENT_GROUPS: EquipmentGroup[] = [
-  { label: "Eclairages", types: ["light_onoff", "light_dimmable", "light_color"] },
-  { label: "Volets", types: ["shutter"] },
-  { label: "Capteurs", types: ["sensor", "motion_sensor", "contact_sensor"] },
-  { label: "Climat", types: ["thermostat"] },
-  { label: "Securite", types: ["lock", "alarm"] },
-  { label: "Multimedia", types: ["media_player", "camera"] },
-  { label: "Autres", types: ["switch", "generic"] },
+  { label: "Eclairages", types: ["light_onoff", "light_dimmable", "light_color"], icon: <Lightbulb size={14} strokeWidth={1.5} /> },
+  { label: "Volets", types: ["shutter"], icon: <ArrowUpDown size={14} strokeWidth={1.5} /> },
+  { label: "Capteurs", types: ["sensor", "motion_sensor", "contact_sensor"], icon: <Gauge size={14} strokeWidth={1.5} /> },
+  { label: "Climat", types: ["thermostat"], icon: <ThermometerSun size={14} strokeWidth={1.5} /> },
+  { label: "Securite", types: ["lock", "alarm"], icon: <Shield size={14} strokeWidth={1.5} /> },
+  { label: "Multimedia", types: ["media_player", "camera"], icon: <MonitorSpeaker size={14} strokeWidth={1.5} /> },
+  { label: "Autres", types: ["switch", "generic"], icon: <ToggleRight size={14} strokeWidth={1.5} /> },
 ];
 
 interface ZoneEquipmentsViewProps {
@@ -39,13 +49,19 @@ export function ZoneEquipmentsView({
   })).filter((g) => g.equipments.length > 0);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {grouped.map((group) => (
-        <div key={group.label}>
-          <h3 className="text-[12px] font-semibold text-text-tertiary uppercase tracking-wider mb-2 px-1">
-            {group.label}
-          </h3>
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2">
+        <div key={group.label} className="rounded-[10px] border border-border bg-surface overflow-hidden">
+          <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border-light">
+            <span className="text-text-tertiary">{group.icon}</span>
+            <span className="text-[12px] font-semibold text-text-tertiary uppercase tracking-wider">
+              {group.label}
+            </span>
+            <span className="text-[11px] text-text-tertiary ml-auto tabular-nums">
+              {group.equipments.length}
+            </span>
+          </div>
+          <div className="p-2 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2">
             {group.equipments.map((eq) => (
               <CompactEquipmentCard
                 key={eq.id}

--- a/ui/src/pages/MaisonPage.tsx
+++ b/ui/src/pages/MaisonPage.tsx
@@ -3,7 +3,9 @@ import { useParams, useNavigate } from "react-router-dom";
 import { Loader2, Home } from "lucide-react";
 import { useZones } from "../store/useZones";
 import { useEquipments } from "../store/useEquipments";
+import { useZoneAggregation } from "../store/useZoneAggregation";
 import { ZoneEquipmentsView } from "../components/maison/ZoneEquipmentsView";
+import { ZoneAggregationHeader } from "../components/maison/ZoneAggregationHeader";
 import type { ZoneWithChildren } from "../types";
 
 export function MaisonPage() {
@@ -16,11 +18,14 @@ export function MaisonPage() {
   const equipmentsLoading = useEquipments((s) => s.loading);
   const fetchEquipments = useEquipments((s) => s.fetchEquipments);
   const executeOrder = useEquipments((s) => s.executeOrder);
+  const aggregationData = useZoneAggregation((s) => s.data);
+  const fetchAggregation = useZoneAggregation((s) => s.fetchAggregation);
 
   useEffect(() => {
     fetchZones();
     fetchEquipments();
-  }, [fetchZones, fetchEquipments]);
+    fetchAggregation();
+  }, [fetchZones, fetchEquipments, fetchAggregation]);
 
   // If no zoneId in URL, redirect to first zone
   useEffect(() => {
@@ -85,6 +90,11 @@ export function MaisonPage() {
             : `${zoneEquipments.length} equipment${zoneEquipments.length !== 1 ? "s" : ""}`}
         </p>
       </div>
+
+      {/* Aggregated zone data */}
+      {zoneId && aggregationData[zoneId] && (
+        <ZoneAggregationHeader data={aggregationData[zoneId]} />
+      )}
 
       {/* Equipments grouped by type */}
       <ZoneEquipmentsView

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -3,6 +3,7 @@ import type { EngineEvent } from "../types";
 import { useDevices } from "./useDevices";
 import { useZones } from "./useZones";
 import { useEquipments } from "./useEquipments";
+import { useZoneAggregation } from "./useZoneAggregation";
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected";
 
@@ -58,6 +59,9 @@ function handleEvent(event: EngineEvent): void {
       break;
     case "zone.removed":
       useZones.getState().handleZoneRemoved(event.zoneId);
+      break;
+    case "zone.data.changed":
+      useZoneAggregation.getState().handleZoneDataChanged(event.zoneId, event.aggregatedData);
       break;
     case "equipment.created":
       useEquipments.getState().handleEquipmentCreated();

--- a/ui/src/store/useZoneAggregation.ts
+++ b/ui/src/store/useZoneAggregation.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import type { ZoneAggregatedData } from "../types";
+import { getZoneAggregation } from "../api";
+
+interface ZoneAggregationState {
+  data: Record<string, ZoneAggregatedData>;
+  loading: boolean;
+
+  fetchAggregation: () => Promise<void>;
+  handleZoneDataChanged: (zoneId: string, aggregatedData: ZoneAggregatedData) => void;
+}
+
+export const useZoneAggregation = create<ZoneAggregationState>((set) => ({
+  data: {},
+  loading: false,
+
+  fetchAggregation: async () => {
+    set({ loading: true });
+    try {
+      const data = await getZoneAggregation();
+      set({ data, loading: false });
+    } catch {
+      set({ loading: false });
+    }
+  },
+
+  handleZoneDataChanged: (zoneId, aggregatedData) => {
+    set((state) => ({
+      data: { ...state.data, [zoneId]: aggregatedData },
+    }));
+  },
+}));

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -112,6 +112,7 @@ export interface ZoneAggregatedData {
   humidity: number | null;
   motion: boolean;
   motionSensors: number;
+  motionSince: string | null;
   openDoors: number;
   openWindows: number;
   waterLeak: boolean;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -110,6 +110,7 @@ export interface ZoneWithChildren extends Zone {
 export interface ZoneAggregatedData {
   temperature: number | null;
   humidity: number | null;
+  luminosity: number | null;
   motion: boolean;
   motionSensors: number;
   motionSince: string | null;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -111,6 +111,7 @@ export interface ZoneAggregatedData {
   temperature: number | null;
   humidity: number | null;
   motion: boolean;
+  motionSensors: number;
   openDoors: number;
   openWindows: number;
   waterLeak: boolean;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -107,6 +107,18 @@ export interface ZoneWithChildren extends Zone {
   children: ZoneWithChildren[];
 }
 
+export interface ZoneAggregatedData {
+  temperature: number | null;
+  humidity: number | null;
+  motion: boolean;
+  openDoors: number;
+  openWindows: number;
+  waterLeak: boolean;
+  smoke: boolean;
+  lightsOn: number;
+  lightsTotal: number;
+}
+
 // ============================================================
 // Equipment
 // ============================================================
@@ -208,6 +220,7 @@ export type EngineEvent =
   | { type: "zone.created"; zone: Zone }
   | { type: "zone.updated"; zone: Zone }
   | { type: "zone.removed"; zoneId: string; zoneName: string }
+  | { type: "zone.data.changed"; zoneId: string; aggregatedData: ZoneAggregatedData }
   | { type: "equipment.created"; equipment: Equipment }
   | { type: "equipment.updated"; equipment: Equipment }
   | { type: "equipment.removed"; equipmentId: string; equipmentName: string }


### PR DESCRIPTION
## Summary
- Backend zone aggregation engine that automatically computes consolidated data from equipment bindings per zone
- Recursive aggregation: parent zones include data from all child zones
- Real-time UI header with pill badges showing zone status at a glance

## Aggregation rules
| Key | Strategy | Source |
|-----|----------|--------|
| `temperature` | AVG | temperature sensors |
| `humidity` | AVG | humidity sensors |
| `motion` | OR | PIR sensors |
| `openDoors` | COUNT (open) | door contacts |
| `openWindows` | COUNT (open) | window contacts |
| `waterLeak` | OR | water leak sensors |
| `smoke` | OR | smoke detectors |
| `lightsOn` / `lightsTotal` | COUNT | lights |

## Changes
- **Backend**: New `zone-aggregator.ts` — event-driven, in-memory cache, listens to `equipment.data.changed`
- **Backend**: New `zone.data.changed` event type in `EngineEvent`
- **API**: `GET /api/v1/zones/aggregation` endpoint
- **UI**: `ZoneAggregationHeader` component — pill badges (temperature, humidity, motion, lights, contacts, alerts)
- **UI**: `useZoneAggregation` Zustand store with WebSocket real-time updates
- **Specs**: `specs/007-V0.7-zone-aggregation/`

## Test plan
- [x] TypeScript compiles with zero errors (backend + frontend)
- [x] All 134 tests pass (20 new for zone-aggregator)
- [x] AVG aggregation for temperature/humidity
- [x] OR aggregation for motion/water_leak/smoke
- [x] COUNT aggregation for lights and contacts
- [x] Recursive parent-child aggregation
- [x] Real-time updates via equipment.data.changed → zone.data.changed
- [x] No spurious events when aggregation unchanged

## Roadmap
- Implements zone aggregation from corbel-spec.md §Zone auto-aggregation

🤖 Generated with [Claude Code](https://claude.com/claude-code)