### PR TITLE
feat: V0.8 — Recipe Engine + Motion-Light

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -1,6 +1,6 @@
 # Corbel — Implementation Status
 
-> Updated: 2026-02-20 — V0.1 through V0.7 done
+> Updated: 2026-02-20 — V0.1 through V0.8 done
 
 ## Roadmap Changes
 
@@ -20,9 +20,9 @@
 | **V0.5** | Sensor Equipment Support (adaptive UI) | ✅ Done |
 | **V0.6** | Zone Aggregation Engine (real-time status) | ✅ Done |
 | **V0.7** | Shutter Equipment Support (controls + aggregation) | ✅ Done |
-| V0.8 | Computed Data + Internal Rules | — |
+| **V0.8** | Recipe Engine + Motion-Light Recipe | ✅ Done |
 | V0.9 | Scenario Engine | — |
-| V0.10 | Recipes | — |
+| V0.10 | Computed Data | — |
 | V0.11 | History (InfluxDB) | — |
 | V0.12 | Polish | — |
 | V1.0+ | AI Assistant | — |
@@ -295,6 +295,65 @@
 
 ---
 
+## V0.8 — Recipe Engine + Motion-Light Recipe
+
+**Objective**: Introduce a code-driven Recipe engine for pre-built behavior patterns with user-supplied parameters. First recipe: motion-light (auto-light on motion detection).
+
+### What it does
+
+- Abstract `Recipe` base class with lifecycle (`validate` / `start` / `stop`)
+- `RecipeManager` manages recipe registration, instance creation/deletion, DB persistence, execution logging
+- `RecipeStateStore` provides key-value persistence per instance (SQLite)
+- `RecipeContext` injected into recipes: eventBus, equipmentManager, zoneAggregator, logger, stateStore, log
+- Recipe instances restored on engine restart (all enabled instances re-started)
+- Execution log per instance (structured messages stored in SQLite)
+- EventBus enhanced with unsubscribe support (on/onType return cleanup functions)
+- **motion-light** recipe: auto-light on motion + timeout extinction + manual override support
+
+### Motion-Light Recipe Logic
+
+- Motion detected + light OFF → turn ON
+- Motion detected + light ON → reset timer
+- Motion stops + light ON → start extinction timer
+- Timer expires → turn OFF
+- Light turned ON externally (manual) → start timer if no motion
+- Light turned OFF externally → cancel timer
+
+### API Endpoints
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| GET | `/api/v1/recipes` | List available recipe definitions |
+| GET | `/api/v1/recipes/:recipeId` | Get recipe definition with slots |
+| GET | `/api/v1/recipe-instances` | List all active instances |
+| POST | `/api/v1/recipe-instances` | Create instance `{ recipeId, params }` |
+| DELETE | `/api/v1/recipe-instances/:id` | Stop and delete instance |
+| GET | `/api/v1/recipe-instances/:id/log` | Get execution log (`?limit=50`) |
+
+### Event Bus Events
+
+| Event | When |
+|-------|------|
+| `recipe.instance.created` | Instance created |
+| `recipe.instance.started` | Instance started |
+| `recipe.instance.stopped` | Instance stopped |
+| `recipe.instance.removed` | Instance deleted |
+| `recipe.instance.error` | Instance error |
+
+### Files
+
+| Module | Files |
+|--------|-------|
+| Types | `src/shared/types.ts` (RecipeSlotDef, RecipeInfo, RecipeInstance, RecipeLogEntry, recipe events) |
+| DB | `migrations/005_recipes.sql` |
+| Core | `src/core/event-bus.ts` (unsubscribe support) |
+| Recipes | `src/recipes/recipe.ts`, `recipe-manager.ts`, `recipe-state-store.ts`, `motion-light.ts` |
+| API | `src/api/routes/recipes.ts` |
+| Integration | `src/api/server.ts`, `src/index.ts` |
+| Tests | `src/recipes/recipe-manager.test.ts` (9), `src/recipes/motion-light.test.ts` (12) |
+
+---
+
 ## Test Summary
 
 | Module | File | Tests |
@@ -305,7 +364,9 @@
 | Zone Manager | `src/zones/zone-manager.test.ts` | 23 |
 | Zone Aggregator | `src/zones/zone-aggregator.test.ts` | 25 |
 | Equipment Manager | `src/equipments/equipment-manager.test.ts` | 38 |
-| **Total** | **6 test files** | **139 tests** |
+| Recipe Manager | `src/recipes/recipe-manager.test.ts` | 9 |
+| Motion-Light Recipe | `src/recipes/motion-light.test.ts` | 12 |
+| **Total** | **8 test files** | **160 tests** |
 
 ---
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,6 +1,6 @@
 # Corbel — User Manual
 
-> Updated: 2026-02-20 — V0.7 (MQTT + Devices + Zones + Equipments + Sensors + Shutters + Zone Aggregation)
+> Updated: 2026-02-20 — V0.8 (MQTT + Devices + Zones + Equipments + Sensors + Shutters + Zone Aggregation + Recipes)
 
 ## What is Corbel?
 
@@ -209,13 +209,50 @@ curl http://localhost:3000/api/v1/zones/aggregation
 curl http://localhost:3000/api/v1/zones/<id>/aggregation
 ```
 
+### Recipes
+
+```bash
+# List available recipes
+curl http://localhost:3000/api/v1/recipes
+
+# Get recipe details (slots, description)
+curl http://localhost:3000/api/v1/recipes/motion-light
+
+# Create a motion-light instance
+curl -X POST http://localhost:3000/api/v1/recipe-instances \
+  -H "Content-Type: application/json" \
+  -d '{"recipeId": "motion-light", "params": {"zone": "<zone-id>", "light": "<equipment-id>", "timeout": "10m"}}'
+
+# List active instances
+curl http://localhost:3000/api/v1/recipe-instances
+
+# Get instance execution log
+curl http://localhost:3000/api/v1/recipe-instances/<id>/log
+
+# Delete an instance (stops it)
+curl -X DELETE http://localhost:3000/api/v1/recipe-instances/<id>
+```
+
+#### Available Recipes
+
+| Recipe | Description | Slots |
+|--------|-------------|-------|
+| **motion-light** | Auto-light on motion, off after timeout | zone, light, timeout (default 10m) |
+
+The motion-light recipe:
+- Turns light ON when motion is detected in the zone
+- Starts an extinction timer when motion stops
+- Turns light OFF when the timer expires
+- Handles manual turn-on: starts the timer if no motion is active
+- Handles manual turn-off: cancels any running timer
+
 ### WebSocket — Live Events
 
 ```bash
 websocat ws://localhost:3000/ws
 ```
 
-Events: `device.data.updated`, `device.status_changed`, `device.discovered`, `equipment.data.changed`, `equipment.order.executed`, `zone.aggregation.changed`
+Events: `device.data.updated`, `device.status_changed`, `device.discovered`, `equipment.data.changed`, `equipment.order.executed`, `zone.aggregation.changed`, `recipe.instance.created`, `recipe.instance.started`, `recipe.instance.stopped`, `recipe.instance.removed`, `recipe.instance.error`
 
 ---
 
@@ -223,8 +260,7 @@ Events: `device.data.updated`, `device.status_changed`, `device.discovered`, `eq
 
 | Version | Feature |
 |---------|---------|
-| **V0.8** | Computed Data — virtual Equipments that aggregate multiple Devices |
 | **V0.9** | Scenario Engine — trigger/condition/action automation |
-| **V0.10** | Recipes — reusable scenario templates |
+| **V0.10** | Computed Data — virtual Equipments that aggregate multiple Devices |
 | **V0.11** | History — InfluxDB time-series charts |
 | **V1.0+** | AI Assistant — natural language scenarios |

--- a/migrations/005_recipes.sql
+++ b/migrations/005_recipes.sql
@@ -1,0 +1,24 @@
+CREATE TABLE recipe_instances (
+  id TEXT PRIMARY KEY,
+  recipe_id TEXT NOT NULL,
+  params JSON NOT NULL,
+  enabled INTEGER DEFAULT 1,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE recipe_state (
+  instance_id TEXT NOT NULL REFERENCES recipe_instances(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  value TEXT,
+  PRIMARY KEY (instance_id, key)
+);
+
+CREATE TABLE recipe_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  instance_id TEXT NOT NULL REFERENCES recipe_instances(id) ON DELETE CASCADE,
+  timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+  message TEXT NOT NULL,
+  level TEXT DEFAULT 'info'
+);
+
+CREATE INDEX idx_recipe_log_instance ON recipe_log(instance_id, timestamp DESC);

--- a/specs/009-V0.8-recipes/architecture.md
+++ b/specs/009-V0.8-recipes/architecture.md
@@ -1,0 +1,302 @@
+# Architecture: V0.8 Recipe Engine + Motion-Light Recipe
+
+## Data Model
+
+### New Types (src/shared/types.ts)
+
+```typescript
+// Recipe slot definition (metadata for UI/API)
+interface RecipeSlotDef {
+  id: string;                    // "zone", "light", "timeout"
+  name: string;                  // Display name
+  description: string;           // Help text
+  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean";
+  required: boolean;
+  defaultValue?: unknown;
+  constraints?: {
+    equipmentType?: EquipmentType;
+    min?: number;
+    max?: number;
+  };
+}
+
+// Recipe metadata (returned by API)
+interface RecipeInfo {
+  id: string;                    // "motion-light"
+  name: string;
+  description: string;
+  slots: RecipeSlotDef[];
+}
+
+// Persisted recipe instance
+interface RecipeInstance {
+  id: string;                    // UUID
+  recipeId: string;              // "motion-light"
+  params: Record<string, unknown>;
+  enabled: boolean;
+  createdAt: string;
+}
+
+// Log entry
+interface RecipeLogEntry {
+  id: number;
+  instanceId: string;
+  timestamp: string;
+  message: string;
+  level: "info" | "warn" | "error";
+}
+```
+
+### New Event Bus Events
+
+```typescript
+| { type: "recipe.instance.created"; instanceId: string; recipeId: string }
+| { type: "recipe.instance.removed"; instanceId: string; recipeId: string }
+| { type: "recipe.instance.started"; instanceId: string; recipeId: string }
+| { type: "recipe.instance.stopped"; instanceId: string; recipeId: string }
+| { type: "recipe.instance.error"; instanceId: string; recipeId: string; error: string }
+```
+
+## SQLite Schema (migration 005_recipes.sql)
+
+```sql
+CREATE TABLE recipe_instances (
+  id TEXT PRIMARY KEY,
+  recipe_id TEXT NOT NULL,
+  params JSON NOT NULL,
+  enabled INTEGER DEFAULT 1,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE recipe_state (
+  instance_id TEXT NOT NULL REFERENCES recipe_instances(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  value TEXT,
+  PRIMARY KEY (instance_id, key)
+);
+
+CREATE TABLE recipe_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  instance_id TEXT NOT NULL REFERENCES recipe_instances(id) ON DELETE CASCADE,
+  timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+  message TEXT NOT NULL,
+  level TEXT DEFAULT 'info'
+);
+
+CREATE INDEX idx_recipe_log_instance ON recipe_log(instance_id, timestamp DESC);
+```
+
+## Architecture
+
+### Recipe Base Class
+
+```typescript
+// src/recipes/recipe.ts
+
+interface RecipeContext {
+  eventBus: TypedEventEmitter;
+  equipmentManager: EquipmentManager;
+  zoneAggregator: ZoneAggregator;
+  logger: Logger;
+  state: RecipeStateStore;           // Scoped to this instance
+  log: (message: string, level?: "info" | "warn" | "error") => void;  // Write to recipe_log
+}
+
+abstract class Recipe {
+  abstract readonly id: string;
+  abstract readonly name: string;
+  abstract readonly description: string;
+  abstract readonly slots: RecipeSlotDef[];
+
+  // Validate params before starting. Throw if invalid.
+  abstract validate(params: Record<string, unknown>, ctx: RecipeContext): void;
+
+  // Start the recipe instance. Subscribe to events, set up timers.
+  abstract start(params: Record<string, unknown>, ctx: RecipeContext): void;
+
+  // Stop the recipe instance. Unsubscribe events, clear timers. Must be idempotent.
+  abstract stop(): void;
+}
+```
+
+### RecipeManager
+
+```typescript
+// src/recipes/recipe-manager.ts
+
+class RecipeManager {
+  private registry: Map<string, Recipe>;          // recipe id → Recipe class instance
+  private running: Map<string, RunningInstance>;   // instance id → { recipe, unsubs, timers }
+
+  constructor(db, eventBus, equipmentManager, zoneAggregator, logger) {}
+
+  // Called on engine startup
+  init(): void {
+    // Register all built-in recipes
+    this.register(new MotionLightRecipe());
+    // Restore enabled instances from DB
+    // Call start() on each
+  }
+
+  // API: list available recipes
+  getRecipes(): RecipeInfo[] {}
+
+  // API: list active instances
+  getInstances(): RecipeInstance[] {}
+
+  // API: create and start a new instance
+  createInstance(recipeId: string, params: Record<string, unknown>): RecipeInstance {}
+
+  // API: stop and delete an instance
+  deleteInstance(instanceId: string): void {}
+
+  // API: get instance execution log
+  getLog(instanceId: string, limit?: number): RecipeLogEntry[] {}
+
+  // Engine shutdown
+  stopAll(): void {}
+}
+```
+
+### RecipeStateStore
+
+```typescript
+// src/recipes/recipe-state-store.ts
+
+class RecipeStateStore {
+  constructor(private db: Database, private instanceId: string) {}
+
+  get(key: string): unknown | null {}      // Read from recipe_state
+  set(key: string, value: unknown): void {} // Write to recipe_state
+  delete(key: string): void {}
+  clear(): void {}                          // Delete all state for this instance
+}
+```
+
+## Motion-Light Recipe
+
+### File: src/recipes/motion-light.ts
+
+```typescript
+class MotionLightRecipe extends Recipe {
+  readonly id = "motion-light";
+  readonly name = "Éclairage auto sur mouvement";
+  readonly description = "Allume la lumière sur détection de mouvement, éteint après un délai sans mouvement. Gère aussi l'allumage manuel.";
+  readonly slots = [
+    { id: "zone",    name: "Zone",    type: "zone",     required: true, description: "Zone à surveiller" },
+    { id: "light",   name: "Lumière", type: "equipment", required: true, description: "Lumière à contrôler",
+      constraints: { equipmentType: "light_onoff" } },
+    { id: "timeout", name: "Timeout", type: "duration",  required: true, description: "Délai sans mouvement avant extinction",
+      defaultValue: "10m" },
+  ];
+
+  private timer: NodeJS.Timeout | null = null;
+  private unsubs: (() => void)[] = [];
+  private ctx!: RecipeContext;
+  private params!: { zoneId: string; lightId: string; timeoutMs: number };
+
+  validate(params, ctx) {
+    // Check zone exists and has motion sensors
+    // Check light equipment exists and has "state" order
+  }
+
+  start(params, ctx) {
+    this.ctx = ctx;
+    this.params = parseParams(params);
+
+    // Listen to zone aggregation changes (for motion)
+    this.unsubs.push(
+      ctx.eventBus.on("zone.aggregation.changed", this.onZoneChanged)
+    );
+
+    // Listen to light state changes (for manual on/off)
+    this.unsubs.push(
+      ctx.eventBus.on("equipment.data.changed", this.onLightChanged)
+    );
+
+    ctx.log("Recipe démarrée");
+  }
+
+  stop() {
+    if (this.timer) clearTimeout(this.timer);
+    this.unsubs.forEach(fn => fn());
+    this.unsubs = [];
+    this.timer = null;
+  }
+
+  private onZoneChanged = (event) => {
+    if (event.zoneId !== this.params.zoneId) return;
+    const motion = event.data.motion;
+    const lightOn = this.isLightOn();
+
+    if (motion && !lightOn) {
+      this.turnOn();
+    } else if (motion && lightOn) {
+      this.resetTimer();
+    } else if (!motion && lightOn) {
+      this.startTimer();
+    }
+  };
+
+  private onLightChanged = (event) => {
+    if (event.equipmentId !== this.params.lightId) return;
+    if (event.category !== "light_state") return;
+
+    const lightOn = event.value === true || event.value === "ON";
+    const motion = this.hasMotion();
+
+    if (lightOn && !motion) {
+      this.startTimer();
+      this.ctx.log("Lumière allumée (externe) → extinction dans " + this.formatTimeout());
+    } else if (lightOn && motion) {
+      this.resetTimer();
+    } else if (!lightOn) {
+      this.cancelTimer();
+      this.ctx.log("Lumière éteinte (externe) → timer annulé");
+    }
+  };
+}
+```
+
+## Event Flow
+
+```
+MQTT (PIR occupancy=true)
+  → device.data.updated
+  → equipment.data.changed (motion sensor)
+  → zone-aggregator recomputes → zone.aggregation.changed (motion=true)
+  → MotionLightRecipe.onZoneChanged()
+  → isLightOn() ? resetTimer() : turnOn()
+
+MQTT (wall switch state=ON)
+  → device.data.updated
+  → equipment.data.changed (light, category=light_state)
+  → MotionLightRecipe.onLightChanged()
+  → hasMotion() ? resetTimer() : startTimer()
+```
+
+## API Endpoints
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| GET | `/api/v1/recipes` | List available recipe definitions |
+| GET | `/api/v1/recipes/:recipeId` | Get recipe definition with slots |
+| GET | `/api/v1/recipe-instances` | List all active instances |
+| POST | `/api/v1/recipe-instances` | Create instance `{ recipeId, params }` |
+| DELETE | `/api/v1/recipe-instances/:id` | Stop and delete instance |
+| GET | `/api/v1/recipe-instances/:id/log` | Get execution log (query: `?limit=50`) |
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `src/shared/types.ts` | Add RecipeSlotDef, RecipeInfo, RecipeInstance, RecipeLogEntry, recipe events |
+| `migrations/005_recipes.sql` | New tables: recipe_instances, recipe_state, recipe_log |
+| `src/recipes/recipe.ts` | NEW — Abstract base class, RecipeContext interface |
+| `src/recipes/recipe-manager.ts` | NEW — Registry, instance lifecycle, DB persistence |
+| `src/recipes/recipe-state-store.ts` | NEW — Key-value state per instance |
+| `src/recipes/motion-light.ts` | NEW — First recipe implementation |
+| `src/api/routes/recipes.ts` | NEW — REST endpoints |
+| `src/api/server.ts` | Register recipe routes |
+| `src/api/websocket.ts` | Broadcast recipe events |
+| `src/index.ts` | Initialize RecipeManager after ZoneAggregator |

--- a/specs/009-V0.8-recipes/plan.md
+++ b/specs/009-V0.8-recipes/plan.md
@@ -1,0 +1,58 @@
+# Implementation Plan: V0.8 Recipe Engine + Motion-Light Recipe
+
+## Tasks
+
+1. [x] Types: add RecipeSlotDef, RecipeInfo, RecipeInstance, RecipeLogEntry, recipe events to types.ts
+2. [x] Migration: create 005_recipes.sql (recipe_instances, recipe_state, recipe_log)
+3. [x] Recipe base class: src/recipes/recipe.ts (abstract class + RecipeContext interface)
+4. [x] RecipeStateStore: src/recipes/recipe-state-store.ts (SQLite key-value per instance)
+5. [x] RecipeManager: src/recipes/recipe-manager.ts (registry, lifecycle, DB persistence, log)
+6. [x] Motion-Light recipe: src/recipes/motion-light.ts
+7. [x] API routes: src/api/routes/recipes.ts (CRUD + log)
+8. [x] Wire up: server.ts (routes), websocket.ts (events), index.ts (init RecipeManager)
+9. [x] Tests: recipe-manager.test.ts (9 tests), motion-light.test.ts (12 tests)
+10. [x] TypeScript compile check (backend) — zero errors
+
+## Dependencies
+
+- Requires V0.6 (zone aggregation) — zone.aggregation.changed events
+- Requires V0.3 (equipment manager) — executeOrder, equipment.data.changed events
+
+## Additional Changes
+
+- EventBus.on() and onType() now return unsubscribe functions (needed for recipe cleanup)
+- RecipeManager uses constructor registration (each running instance gets its own Recipe object)
+
+## Testing
+
+### Unit tests (recipe-manager.test.ts) — 9 tests ✅
+- Register a recipe, list recipes
+- Get recipe by id
+- Create instance with valid params → persisted in DB
+- Create instance with invalid params → rejected
+- Create instance for unknown recipe → rejected
+- Delete instance → stopped and removed from DB
+- Delete nonexistent instance → error
+- Restore instances on init → all enabled instances started
+- Log entries written and retrievable
+
+### Unit tests (motion-light.test.ts) — 12 tests ✅
+- Validates required params
+- Validates zone exists
+- Validates light has state order
+- Motion true + light off → turn on
+- Motion true + light on → reset timer (no action)
+- Motion false + light on → start timer → turn off on expiry
+- Motion re-detected before timer → timer cancelled
+- Light turned on externally + no motion → start timer
+- Light turned off externally → timer cancelled
+- Zone has no motion sensors → warning logged
+- Light equipment missing state order → error
+- Stop cleans up (delete instance cancels timers)
+
+### Manual verification
+- Create a motion-light instance via API for a real zone/light
+- Walk in front of PIR → light turns on
+- Leave the room → light turns off after timeout
+- Turn on light manually → light turns off after timeout if no motion
+- Check execution log via API

--- a/specs/009-V0.8-recipes/spec.md
+++ b/specs/009-V0.8-recipes/spec.md
@@ -1,0 +1,74 @@
+# V0.8: Recipe Engine + Motion-Light Recipe
+
+## Summary
+
+Introduce a code-driven Recipe engine that runs pre-built behavior patterns with user-supplied parameters. Recipes are TypeScript classes that subscribe to the Event Bus, manage internal state, and execute orders. They coexist with a future data-driven Scenario engine (V0.9).
+
+The first recipe — **motion-light** — automatically turns a light on when motion is detected in a zone and off after a configurable timeout with no motion.
+
+## Reference
+
+- Spec sections: §5.5 (Recipe), §11 (Roadmap V0.8/V0.10)
+- Jeedom scenario analysis (session 2026-02-20): complex kitchen light automation
+
+## Design Decision: Code-driven vs Data-driven
+
+Recipes are **code-driven** (TypeScript classes), not data-driven (JSON templates). Rationale:
+
+- Complex behaviors (state machines, hysteresis, rolling averages) are trivial in code, nearly impossible in a JSON trigger/condition/action model
+- Each recipe is a single isolated file — easy to test, easy to maintain
+- Users don't edit recipe logic, they fill in typed parameters (slots)
+- A separate data-driven Scenario engine (V0.9) handles simple user-created automations
+
+## Acceptance Criteria
+
+### Recipe Engine Framework
+
+- [ ] Abstract `Recipe` base class with lifecycle (`start` / `stop`)
+- [ ] `RecipeManager` loads all recipes, manages instances (create / start / stop / delete)
+- [ ] `RecipeStateStore` provides key-value persistence per instance (SQLite)
+- [ ] `RecipeContext` injected into recipes: eventBus, equipmentManager, zoneAggregator, logger, stateStore
+- [ ] Recipe instances restored on engine restart (re-start all enabled instances)
+- [ ] Execution log per instance (structured messages stored in SQLite)
+- [ ] API endpoints: list recipes, list instances, create instance, delete instance, get instance log
+- [ ] WebSocket events for recipe instance state changes
+
+### Motion-Light Recipe
+
+- [ ] Recipe ID: `motion-light`
+- [ ] Slots: zone (zone), light (equipment, any light type), timeout (duration, default 10m)
+- [ ] Motion detected in zone + light OFF → turn light ON
+- [ ] Motion detected in zone + light ON → reset extinction timer
+- [ ] Motion stops in zone + light ON → start extinction timer
+- [ ] Timer expires → turn light OFF
+- [ ] Light turned ON externally (manual, UI, API) → start monitoring, timer managed same as auto
+- [ ] Light turned OFF externally → cancel timer, stop monitoring
+- [ ] All decisions logged to execution log
+
+## Scope
+
+### In Scope
+
+- Recipe engine framework (base class, manager, state store, context)
+- SQLite tables: recipe_instances, recipe_state, recipe_log
+- REST API for recipe management
+- WebSocket events
+- motion-light recipe implementation
+- Unit tests for recipe engine and motion-light recipe
+
+### Out of Scope
+
+- UI for recipe management (deferred — API-only for now)
+- Data-driven Scenario engine (V0.9)
+- Advanced recipes (dimming, lux threshold, time-based brightness)
+- InfluxDB / rolling average dependencies
+
+## Edge Cases
+
+- Zone has no motion sensors → recipe starts but never triggers (log warning on start)
+- Light equipment deleted while recipe running → recipe detects missing equipment, logs error, auto-disables
+- Zone deleted while recipe running → recipe detects missing zone, logs error, auto-disables
+- Multiple recipe instances on same light → allowed (user responsibility), each manages its own timer
+- Engine restart → all enabled instances re-started, timers lost (acceptable for V1 — timer is short-lived)
+- MQTT disconnect → no events flow, recipe idle. On reconnect, state re-syncs naturally
+- Light has no "state" order binding → recipe logs error on start, refuses to activate

--- a/src/api/routes/recipes.ts
+++ b/src/api/routes/recipes.ts
@@ -1,0 +1,101 @@
+import type { FastifyInstance } from "fastify";
+import type { RecipeManager } from "../../recipes/engine/recipe-manager.js";
+import { RecipeError } from "../../recipes/engine/recipe-manager.js";
+import type { Logger } from "../../core/logger.js";
+
+interface RecipesDeps {
+  recipeManager: RecipeManager;
+  logger: Logger;
+}
+
+export function registerRecipeRoutes(app: FastifyInstance, deps: RecipesDeps): void {
+  const { recipeManager } = deps;
+
+  // GET /api/v1/recipes — List available recipe definitions
+  app.get("/api/v1/recipes", async () => {
+    return recipeManager.getRecipes();
+  });
+
+  // GET /api/v1/recipes/:recipeId — Get recipe definition with slots
+  app.get<{ Params: { recipeId: string } }>("/api/v1/recipes/:recipeId", async (request, reply) => {
+    const recipe = recipeManager.getRecipeById(request.params.recipeId);
+    if (!recipe) {
+      return reply.code(404).send({ error: "Recipe not found" });
+    }
+    return recipe;
+  });
+
+  // GET /api/v1/recipe-instances — List all active instances
+  app.get("/api/v1/recipe-instances", async () => {
+    return recipeManager.getInstances();
+  });
+
+  // POST /api/v1/recipe-instances — Create instance { recipeId, params }
+  app.post<{
+    Body: {
+      recipeId: string;
+      params: Record<string, unknown>;
+    };
+  }>("/api/v1/recipe-instances", async (request, reply) => {
+    const { recipeId, params } = request.body ?? {};
+
+    if (!recipeId) {
+      return reply.code(400).send({ error: "recipeId is required" });
+    }
+    if (!params || typeof params !== "object") {
+      return reply.code(400).send({ error: "params object is required" });
+    }
+
+    try {
+      const instance = recipeManager.createInstance(recipeId, params);
+      return reply.code(201).send(instance);
+    } catch (err) {
+      if (err instanceof RecipeError) {
+        return reply.code(err.status).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  // PUT /api/v1/recipe-instances/:id — Update instance params
+  app.put<{
+    Params: { id: string };
+    Body: { params: Record<string, unknown> };
+  }>("/api/v1/recipe-instances/:id", async (request, reply) => {
+    const { params } = request.body ?? {};
+    if (!params || typeof params !== "object") {
+      return reply.code(400).send({ error: "params object is required" });
+    }
+    try {
+      const instance = recipeManager.updateInstance(request.params.id, params);
+      return instance;
+    } catch (err) {
+      if (err instanceof RecipeError) {
+        return reply.code(err.status).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  // DELETE /api/v1/recipe-instances/:id — Stop and delete instance
+  app.delete<{ Params: { id: string } }>("/api/v1/recipe-instances/:id", async (request, reply) => {
+    try {
+      recipeManager.deleteInstance(request.params.id);
+      return reply.code(204).send();
+    } catch (err) {
+      if (err instanceof RecipeError) {
+        return reply.code(err.status).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  // GET /api/v1/recipe-instances/:id/log — Get execution log
+  app.get<{
+    Params: { id: string };
+    Querystring: { limit?: string };
+  }>("/api/v1/recipe-instances/:id/log", async (request) => {
+    const limit = request.query.limit ? parseInt(request.query.limit, 10) : 50;
+    return recipeManager.getLog(request.params.id, limit);
+  });
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -8,10 +8,12 @@ import type { ZoneAggregator } from "../zones/zone-aggregator.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { MqttConnector } from "../mqtt/mqtt-connector.js";
+import type { RecipeManager } from "../recipes/engine/recipe-manager.js";
 import { registerDeviceRoutes } from "./routes/devices.js";
 import { registerHealthRoutes } from "./routes/health.js";
 import { registerZoneRoutes } from "./routes/zones.js";
 import { registerEquipmentRoutes } from "./routes/equipments.js";
+import { registerRecipeRoutes } from "./routes/recipes.js";
 import { registerWebSocket } from "./websocket.js";
 
 interface ServerDeps {
@@ -19,6 +21,7 @@ interface ServerDeps {
   zoneManager: ZoneManager;
   zoneAggregator: ZoneAggregator;
   equipmentManager: EquipmentManager;
+  recipeManager: RecipeManager;
   eventBus: EventBus;
   mqttConnector: MqttConnector;
   logger: Logger;
@@ -26,7 +29,7 @@ interface ServerDeps {
 }
 
 export async function createServer(deps: ServerDeps) {
-  const { deviceManager, zoneManager, zoneAggregator, equipmentManager, eventBus, mqttConnector, logger, corsOrigins } = deps;
+  const { deviceManager, zoneManager, zoneAggregator, equipmentManager, recipeManager, eventBus, mqttConnector, logger, corsOrigins } = deps;
 
   const app = Fastify({
     logger: false, // We use our own pino logger
@@ -46,6 +49,7 @@ export async function createServer(deps: ServerDeps) {
   registerDeviceRoutes(app, { deviceManager, logger });
   registerZoneRoutes(app, { zoneManager, zoneAggregator, logger });
   registerEquipmentRoutes(app, { equipmentManager, logger });
+  registerRecipeRoutes(app, { recipeManager, logger });
   registerWebSocket(app, { eventBus, logger });
 
   return app;

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -24,6 +24,18 @@ export function openDatabase(dbPath: string, logger: Logger): Database.Database 
   return db;
 }
 
+/**
+ * SQLite CURRENT_TIMESTAMP stores UTC without timezone marker (e.g. "2026-02-20 14:30:00").
+ * JavaScript parses that as local time, causing offset errors.
+ * This helper appends 'Z' so Date correctly interprets it as UTC.
+ */
+export function toISOUtc(sqliteTimestamp: string): string;
+export function toISOUtc(sqliteTimestamp: string | null): string | null;
+export function toISOUtc(sqliteTimestamp: string | null): string | null {
+  if (!sqliteTimestamp) return null;
+  return sqliteTimestamp.endsWith("Z") ? sqliteTimestamp : `${sqliteTimestamp}Z`;
+}
+
 export function runMigrations(db: Database.Database, migrationsDir: string, logger: Logger): void {
   const log = logger.child({ module: "migrations" });
 

--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -16,21 +16,25 @@ export class EventBus {
     this.emitter.emit("event", event);
   }
 
-  on(handler: (event: EngineEvent) => void): void {
-    this.emitter.on("event", (event: EngineEvent) => {
+  on(handler: (event: EngineEvent) => void): () => void {
+    const wrapped = (event: EngineEvent) => {
       try {
         handler(event);
       } catch (err) {
         this.logger.error({ err, eventType: event.type }, "Event handler error");
       }
-    });
+    };
+    this.emitter.on("event", wrapped);
+    return () => {
+      this.emitter.off("event", wrapped);
+    };
   }
 
   onType<T extends EngineEvent["type"]>(
     type: T,
     handler: (event: Extract<EngineEvent, { type: T }>) => void,
-  ): void {
-    this.on((event) => {
+  ): () => void {
+    return this.on((event) => {
       if (event.type === type) {
         handler(event as Extract<EngineEvent, { type: T }>);
       }

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -1,4 +1,5 @@
 import { randomUUID, createHash } from "node:crypto";
+import { toISOUtc } from "../core/database.js";
 
 /**
  * Generate a deterministic UUID-shaped ID from input parts.
@@ -519,9 +520,9 @@ function rowToDevice(row: DeviceRow): Device {
     zoneId: row.zone_id,
     source: row.source as Device["source"],
     status: row.status as Device["status"],
-    lastSeen: row.last_seen,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
+    lastSeen: toISOUtc(row.last_seen),
+    createdAt: toISOUtc(row.created_at),
+    updatedAt: toISOUtc(row.updated_at),
   };
 }
 
@@ -542,7 +543,7 @@ function rowToDeviceData(row: DeviceDataRow): DeviceData {
     category: row.category as DataCategory,
     value,
     unit: row.unit ?? undefined,
-    lastUpdated: row.last_updated,
+    lastUpdated: toISOUtc(row.last_updated),
   };
 }
 

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -3,6 +3,7 @@ import type Database from "better-sqlite3";
 import type { Logger } from "../core/logger.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { MqttConnector } from "../mqtt/mqtt-connector.js";
+import { toISOUtc } from "../core/database.js";
 import type {
   Equipment,
   EquipmentType,
@@ -503,8 +504,8 @@ function rowToEquipment(row: EquipmentRow): Equipment {
     icon: row.icon ?? undefined,
     description: row.description ?? undefined,
     enabled: row.enabled === 1,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
+    createdAt: toISOUtc(row.created_at),
+    updatedAt: toISOUtc(row.updated_at),
   };
 }
 
@@ -529,7 +530,7 @@ function rowToDataBindingWithValue(row: DataBindingJoinRow): DataBindingWithValu
     category: row.category as DataCategory,
     value,
     unit: row.unit ?? undefined,
-    lastUpdated: row.last_updated,
+    lastUpdated: toISOUtc(row.last_updated),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import { ZoneManager } from "./zones/zone-manager.js";
 import { EquipmentManager } from "./equipments/equipment-manager.js";
 import { Zigbee2MqttParser } from "./mqtt/parsers/zigbee2mqtt.js";
 import { ZoneAggregator } from "./zones/zone-aggregator.js";
+import { RecipeManager } from "./recipes/engine/recipe-manager.js";
+import { MotionLightRecipe } from "./recipes/motion-light.js";
 import { createServer } from "./api/server.js";
 
 async function main() {
@@ -54,6 +56,10 @@ async function main() {
   // 6d. Create Zone Aggregator
   const zoneAggregator = new ZoneAggregator(zoneManager, equipmentManager, eventBus, logger);
 
+  // 6e. Create Recipe Manager
+  const recipeManager = new RecipeManager(db, eventBus, equipmentManager, zoneManager, zoneAggregator, logger);
+  recipeManager.register(MotionLightRecipe);
+
   // 7. Create zigbee2mqtt parser
   const z2mParser = new Zigbee2MqttParser(
     config.z2m.baseTopic,
@@ -72,6 +78,7 @@ async function main() {
     zoneManager,
     zoneAggregator,
     equipmentManager,
+    recipeManager,
     eventBus,
     mqttConnector,
     logger,
@@ -84,13 +91,17 @@ async function main() {
     `Corbel API listening on http://${config.api.host}:${config.api.port}`,
   );
 
-  // 10. Emit system started event
+  // 10. Emit system started event (triggers zone aggregation compute)
   eventBus.emit({ type: "system.started" });
+
+  // 11. Initialize recipe manager (restore persisted instances — after aggregation is ready)
+  recipeManager.init();
   logger.info("Corbel engine started successfully");
 
   // Graceful shutdown
   const shutdown = async () => {
     logger.info("Shutting down...");
+    recipeManager.stopAll();
     await server.close();
     await mqttConnector.disconnect();
     db.close();

--- a/src/recipes/engine/recipe-manager.test.ts
+++ b/src/recipes/engine/recipe-manager.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { ZoneManager } from "../../zones/zone-manager.js";
+import { ZoneAggregator } from "../../zones/zone-aggregator.js";
+import { EquipmentManager } from "../../equipments/equipment-manager.js";
+import { EventBus } from "../../core/event-bus.js";
+import { createLogger } from "../../core/logger.js";
+import { RecipeManager, RecipeError } from "./recipe-manager.js";
+import { Recipe, type RecipeContext } from "./recipe.js";
+import type { RecipeSlotDef, EngineEvent } from "../../shared/types.js";
+
+// ============================================================
+// Test helpers
+// ============================================================
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  const migrations = ["001_devices.sql", "002_zones.sql", "003_equipments.sql", "005_recipes.sql"];
+  for (const file of migrations) {
+    const sql = readFileSync(
+      resolve(import.meta.dirname ?? ".", "../../../migrations", file),
+      "utf-8",
+    );
+    db.exec(sql);
+  }
+  return db;
+}
+
+const logger = createLogger("silent");
+const mockMqtt = {
+  publish: () => {},
+  isConnected: () => true,
+};
+
+function seedDevice(
+  db: Database.Database,
+  opts: {
+    name?: string;
+    dataKeys?: { id?: string; key: string; type?: string; category?: string; value?: string }[];
+    orderKeys?: { id?: string; key: string; type?: string; payloadKey?: string }[];
+  } = {},
+) {
+  const deviceId = crypto.randomUUID();
+  const name = opts.name ?? "Test Device";
+  db.prepare(
+    `INSERT INTO devices (id, mqtt_base_topic, mqtt_name, name, source, status)
+     VALUES (?, ?, ?, ?, 'zigbee2mqtt', 'online')`,
+  ).run(deviceId, `z2m/${name}`, name, name);
+
+  const dataIds: string[] = [];
+  for (const d of opts.dataKeys ?? []) {
+    const id = d.id ?? crypto.randomUUID();
+    db.prepare(
+      `INSERT INTO device_data (id, device_id, key, type, category, value)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(id, deviceId, d.key, d.type ?? "boolean", d.category ?? "generic", d.value ?? null);
+    dataIds.push(id);
+  }
+
+  const orderIds: string[] = [];
+  for (const o of opts.orderKeys ?? []) {
+    const id = o.id ?? crypto.randomUUID();
+    db.prepare(
+      `INSERT INTO device_orders (id, device_id, key, type, mqtt_set_topic, payload_key)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(id, deviceId, o.key, o.type ?? "boolean", `z2m/${name}/set`, o.payloadKey ?? o.key);
+    orderIds.push(id);
+  }
+
+  return { deviceId, dataIds, orderIds };
+}
+
+// ============================================================
+// Test recipe — minimal implementation
+// ============================================================
+
+class TestRecipe extends Recipe {
+  readonly id = "test-recipe";
+  readonly name = "Test Recipe";
+  readonly description = "A test recipe";
+  readonly slots: RecipeSlotDef[] = [
+    { id: "value", name: "Value", description: "A test value", type: "number", required: true },
+  ];
+
+  started = false;
+  stopped = false;
+  validateCalled = false;
+  lastParams: Record<string, unknown> = {};
+
+  validate(params: Record<string, unknown>): void {
+    this.validateCalled = true;
+    if (params.value === undefined) {
+      throw new Error("value is required");
+    }
+  }
+
+  start(params: Record<string, unknown>): void {
+    this.started = true;
+    this.lastParams = params;
+  }
+
+  stop(): void {
+    this.stopped = true;
+  }
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("RecipeManager", () => {
+  let db: Database.Database;
+  let eventBus: EventBus;
+  let zoneManager: ZoneManager;
+  let equipmentManager: EquipmentManager;
+  let aggregator: ZoneAggregator;
+  let manager: RecipeManager;
+  let events: EngineEvent[];
+
+  beforeEach(() => {
+    db = createTestDb();
+    eventBus = new EventBus(logger);
+    zoneManager = new ZoneManager(db, eventBus, logger);
+    equipmentManager = new EquipmentManager(db, eventBus, mockMqtt as never, logger);
+    aggregator = new ZoneAggregator(zoneManager, equipmentManager, eventBus, logger);
+    manager = new RecipeManager(db, eventBus, equipmentManager, zoneManager, aggregator, logger);
+    events = [];
+    eventBus.on((event) => events.push(event));
+  });
+
+  afterEach(() => {
+    manager.stopAll();
+    db.close();
+  });
+
+  // ============================================================
+  // Registration
+  // ============================================================
+
+  it("registers a recipe and lists it", () => {
+    manager.register(TestRecipe);
+
+    const recipes = manager.getRecipes();
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0].id).toBe("test-recipe");
+    expect(recipes[0].name).toBe("Test Recipe");
+    expect(recipes[0].slots).toHaveLength(1);
+  });
+
+  it("gets a recipe by id", () => {
+    manager.register(TestRecipe);
+
+    const recipe = manager.getRecipeById("test-recipe");
+    expect(recipe).not.toBeNull();
+    expect(recipe!.id).toBe("test-recipe");
+
+    const missing = manager.getRecipeById("nonexistent");
+    expect(missing).toBeNull();
+  });
+
+  // ============================================================
+  // Instance lifecycle
+  // ============================================================
+
+  it("creates an instance with valid params", () => {
+    manager.register(TestRecipe);
+
+    const instance = manager.createInstance("test-recipe", { value: 42 });
+    expect(instance.recipeId).toBe("test-recipe");
+    expect(instance.params).toEqual({ value: 42 });
+    expect(instance.enabled).toBe(true);
+
+    // Check persisted
+    const instances = manager.getInstances();
+    expect(instances).toHaveLength(1);
+    expect(instances[0].id).toBe(instance.id);
+
+    // Check events
+    const createEvent = events.find((e) => e.type === "recipe.instance.created");
+    expect(createEvent).toBeDefined();
+    const startEvent = events.find((e) => e.type === "recipe.instance.started");
+    expect(startEvent).toBeDefined();
+  });
+
+  it("rejects instance with invalid params", () => {
+    manager.register(TestRecipe);
+
+    expect(() => manager.createInstance("test-recipe", {})).toThrow(RecipeError);
+    expect(() => manager.createInstance("test-recipe", {})).toThrow("Invalid params");
+  });
+
+  it("rejects instance for unknown recipe", () => {
+    expect(() => manager.createInstance("nonexistent", {})).toThrow(RecipeError);
+    expect(() => manager.createInstance("nonexistent", {})).toThrow("Recipe not found");
+  });
+
+  it("deletes an instance — stops and removes from DB", () => {
+    manager.register(TestRecipe);
+    const instance = manager.createInstance("test-recipe", { value: 42 });
+
+    manager.deleteInstance(instance.id);
+
+    expect(manager.getInstances()).toHaveLength(0);
+
+    const removeEvent = events.find((e) => e.type === "recipe.instance.removed");
+    expect(removeEvent).toBeDefined();
+  });
+
+  it("throws when deleting nonexistent instance", () => {
+    expect(() => manager.deleteInstance("nonexistent")).toThrow(RecipeError);
+  });
+
+  // ============================================================
+  // Restore on init
+  // ============================================================
+
+  it("restores enabled instances on init", () => {
+    manager.register(TestRecipe);
+    manager.createInstance("test-recipe", { value: 1 });
+    manager.createInstance("test-recipe", { value: 2 });
+
+    // Create a new manager to simulate restart
+    manager.stopAll();
+    const newManager = new RecipeManager(db, eventBus, equipmentManager, zoneManager, aggregator, logger);
+    newManager.register(TestRecipe);
+    newManager.init();
+
+    // Instances should be in DB
+    expect(newManager.getInstances()).toHaveLength(2);
+
+    newManager.stopAll();
+  });
+
+  // ============================================================
+  // Logging
+  // ============================================================
+
+  it("writes and retrieves log entries", () => {
+    manager.register(TestRecipe);
+    const instance = manager.createInstance("test-recipe", { value: 42 });
+
+    const logs = manager.getLog(instance.id);
+    // Should have at least "Instance created" log
+    expect(logs.length).toBeGreaterThanOrEqual(1);
+    expect(logs.some((l) => l.message === "Instance created")).toBe(true);
+  });
+});

--- a/src/recipes/engine/recipe-manager.ts
+++ b/src/recipes/engine/recipe-manager.ts
@@ -1,0 +1,412 @@
+import { randomUUID } from "node:crypto";
+import type Database from "better-sqlite3";
+import type { Logger } from "../../core/logger.js";
+import type { EventBus } from "../../core/event-bus.js";
+import type { EquipmentManager } from "../../equipments/equipment-manager.js";
+import type { ZoneAggregator } from "../../zones/zone-aggregator.js";
+import type { ZoneManager } from "../../zones/zone-manager.js";
+import type { RecipeInfo, RecipeInstance, RecipeLogEntry } from "../../shared/types.js";
+import type { Recipe, RecipeContext } from "./recipe.js";
+import { toISOUtc } from "../../core/database.js";
+import { RecipeStateStore } from "./recipe-state-store.js";
+
+// ============================================================
+// Types
+// ============================================================
+
+export type RecipeConstructor = new () => Recipe;
+
+interface RegisteredRecipe {
+  info: RecipeInfo;
+  create: () => Recipe;
+}
+
+interface RunningInstance {
+  recipe: Recipe;
+  instance: RecipeInstance;
+}
+
+// ============================================================
+// RecipeManager — registry, lifecycle, DB persistence
+// ============================================================
+
+export class RecipeManager {
+  private registry = new Map<string, RegisteredRecipe>();
+  private running = new Map<string, RunningInstance>();
+  private db: Database.Database;
+  private eventBus: EventBus;
+  private equipmentManager: EquipmentManager;
+  private zoneManager: ZoneManager;
+  private zoneAggregator: ZoneAggregator;
+  private logger: Logger;
+  private stmts: ReturnType<typeof this.prepareStatements>;
+
+  constructor(
+    db: Database.Database,
+    eventBus: EventBus,
+    equipmentManager: EquipmentManager,
+    zoneManager: ZoneManager,
+    zoneAggregator: ZoneAggregator,
+    logger: Logger,
+  ) {
+    this.db = db;
+    this.eventBus = eventBus;
+    this.equipmentManager = equipmentManager;
+    this.zoneManager = zoneManager;
+    this.zoneAggregator = zoneAggregator;
+    this.logger = logger.child({ module: "recipe-manager" });
+    this.stmts = this.prepareStatements();
+  }
+
+  private prepareStatements() {
+    return {
+      insertInstance: this.db.prepare(
+        `INSERT INTO recipe_instances (id, recipe_id, params, enabled)
+         VALUES (@id, @recipeId, @params, @enabled)`,
+      ),
+      getAllInstances: this.db.prepare(
+        "SELECT * FROM recipe_instances ORDER BY created_at",
+      ),
+      getInstanceById: this.db.prepare(
+        "SELECT * FROM recipe_instances WHERE id = ?",
+      ),
+      deleteInstance: this.db.prepare(
+        "DELETE FROM recipe_instances WHERE id = ?",
+      ),
+      insertLog: this.db.prepare(
+        `INSERT INTO recipe_log (instance_id, message, level)
+         VALUES (?, ?, ?)`,
+      ),
+      getLog: this.db.prepare(
+        `SELECT * FROM recipe_log WHERE instance_id = ?
+         ORDER BY timestamp DESC LIMIT ?`,
+      ),
+      updateInstanceParams: this.db.prepare(
+        "UPDATE recipe_instances SET params = ? WHERE id = ?",
+      ),
+      getState: this.db.prepare(
+        "SELECT key, value FROM recipe_state WHERE instance_id = ?",
+      ),
+    };
+  }
+
+  // ============================================================
+  // Registration
+  // ============================================================
+
+  register(RecipeClass: RecipeConstructor): void {
+    const sample = new RecipeClass();
+    this.registry.set(sample.id, {
+      info: {
+        id: sample.id,
+        name: sample.name,
+        description: sample.description,
+        slots: sample.slots,
+      },
+      create: () => new RecipeClass(),
+    });
+    this.logger.info({ recipeId: sample.id }, "Recipe registered");
+  }
+
+  // ============================================================
+  // Init — restore instances from DB
+  // ============================================================
+
+  init(): void {
+    const rows = this.stmts.getAllInstances.all() as InstanceRow[];
+    let restored = 0;
+
+    for (const row of rows) {
+      if (row.enabled !== 1) continue;
+
+      const registered = this.registry.get(row.recipe_id);
+      if (!registered) {
+        this.logger.warn({ instanceId: row.id, recipeId: row.recipe_id }, "Recipe not found for instance, skipping");
+        continue;
+      }
+
+      const instance = rowToInstance(row);
+      try {
+        const recipe = registered.create();
+        this.startInstance(recipe, instance);
+        restored++;
+      } catch (err) {
+        this.logger.error({ err, instanceId: row.id }, "Failed to restore recipe instance");
+        this.writeLog(row.id, `Failed to restore: ${err instanceof Error ? err.message : String(err)}`, "error");
+      }
+    }
+
+    this.logger.info({ restored, total: rows.length }, "Recipe instances restored");
+  }
+
+  // ============================================================
+  // Public API
+  // ============================================================
+
+  getRecipes(): RecipeInfo[] {
+    return Array.from(this.registry.values()).map((r) => r.info);
+  }
+
+  getRecipeById(recipeId: string): RecipeInfo | null {
+    return this.registry.get(recipeId)?.info ?? null;
+  }
+
+  getInstances(): (RecipeInstance & { state: Record<string, unknown> })[] {
+    const rows = this.stmts.getAllInstances.all() as InstanceRow[];
+    return rows.map((row) => ({
+      ...rowToInstance(row),
+      state: this.getInstanceState(row.id),
+    }));
+  }
+
+  getInstanceState(instanceId: string): Record<string, unknown> {
+    const rows = this.stmts.getState.all(instanceId) as { key: string; value: string | null }[];
+    const state: Record<string, unknown> = {};
+    for (const row of rows) {
+      try {
+        state[row.key] = row.value !== null ? JSON.parse(row.value) : null;
+      } catch {
+        state[row.key] = row.value;
+      }
+    }
+    return state;
+  }
+
+  createInstance(recipeId: string, params: Record<string, unknown>): RecipeInstance {
+    const registered = this.registry.get(recipeId);
+    if (!registered) {
+      throw new RecipeError(`Recipe not found: ${recipeId}`, 404);
+    }
+
+    // Create a recipe instance for validation
+    const recipe = registered.create();
+    const tempCtx = this.buildContext("temp", recipeId);
+
+    try {
+      recipe.validate(params, tempCtx);
+    } catch (err) {
+      throw new RecipeError(
+        `Invalid params: ${err instanceof Error ? err.message : String(err)}`,
+        400,
+      );
+    }
+
+    const id = randomUUID();
+    this.stmts.insertInstance.run({
+      id,
+      recipeId,
+      params: JSON.stringify(params),
+      enabled: 1,
+    });
+
+    const row = this.stmts.getInstanceById.get(id) as InstanceRow;
+    const instance = rowToInstance(row);
+
+    this.eventBus.emit({ type: "recipe.instance.created", instanceId: id, recipeId });
+    this.writeLog(id, "Instance created");
+
+    // Start with a fresh recipe instance
+    try {
+      const runRecipe = registered.create();
+      this.startInstance(runRecipe, instance);
+    } catch (err) {
+      this.logger.error({ err, instanceId: id }, "Failed to start recipe instance");
+      this.writeLog(id, `Failed to start: ${err instanceof Error ? err.message : String(err)}`, "error");
+      this.eventBus.emit({
+        type: "recipe.instance.error",
+        instanceId: id,
+        recipeId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    return instance;
+  }
+
+  deleteInstance(instanceId: string): void {
+    const row = this.stmts.getInstanceById.get(instanceId) as InstanceRow | undefined;
+    if (!row) {
+      throw new RecipeError("Instance not found", 404);
+    }
+
+    // Stop if running
+    this.stopInstance(instanceId);
+
+    // Delete from DB (cascades to recipe_state and recipe_log)
+    this.stmts.deleteInstance.run(instanceId);
+
+    this.logger.info({ instanceId, recipeId: row.recipe_id }, "Recipe instance deleted");
+    this.eventBus.emit({ type: "recipe.instance.removed", instanceId, recipeId: row.recipe_id });
+  }
+
+  updateInstance(instanceId: string, params: Record<string, unknown>): RecipeInstance {
+    const row = this.stmts.getInstanceById.get(instanceId) as InstanceRow | undefined;
+    if (!row) {
+      throw new RecipeError("Instance not found", 404);
+    }
+
+    const registered = this.registry.get(row.recipe_id);
+    if (!registered) {
+      throw new RecipeError(`Recipe not found: ${row.recipe_id}`, 404);
+    }
+
+    // Validate new params
+    const recipe = registered.create();
+    const tempCtx = this.buildContext("temp", row.recipe_id);
+    try {
+      recipe.validate(params, tempCtx);
+    } catch (err) {
+      throw new RecipeError(
+        `Invalid params: ${err instanceof Error ? err.message : String(err)}`,
+        400,
+      );
+    }
+
+    // Stop running instance
+    this.stopInstance(instanceId);
+
+    // Update params in DB
+    this.stmts.updateInstanceParams.run(JSON.stringify(params), instanceId);
+
+    // Reload and restart
+    const updatedRow = this.stmts.getInstanceById.get(instanceId) as InstanceRow;
+    const instance = rowToInstance(updatedRow);
+
+    try {
+      const runRecipe = registered.create();
+      this.startInstance(runRecipe, instance);
+    } catch (err) {
+      this.logger.error({ err, instanceId }, "Failed to restart recipe instance after update");
+      this.writeLog(instanceId, `Failed to restart: ${err instanceof Error ? err.message : String(err)}`, "error");
+    }
+
+    this.logger.info({ instanceId, recipeId: row.recipe_id }, "Recipe instance updated");
+    return instance;
+  }
+
+  getLog(instanceId: string, limit = 50): RecipeLogEntry[] {
+    const rows = this.stmts.getLog.all(instanceId, limit) as LogRow[];
+    return rows.map(rowToLogEntry);
+  }
+
+  stopAll(): void {
+    for (const [instanceId] of this.running) {
+      this.stopInstance(instanceId);
+    }
+  }
+
+  // ============================================================
+  // Internal lifecycle
+  // ============================================================
+
+  private startInstance(recipe: Recipe, instance: RecipeInstance): void {
+    const ctx = this.buildContext(instance.id, instance.recipeId);
+
+    recipe.validate(instance.params, ctx);
+    recipe.start(instance.params, ctx);
+
+    this.running.set(instance.id, { recipe, instance });
+    this.logger.info({ instanceId: instance.id, recipeId: instance.recipeId }, "Recipe instance started");
+    this.eventBus.emit({ type: "recipe.instance.started", instanceId: instance.id, recipeId: instance.recipeId });
+  }
+
+  private stopInstance(instanceId: string): void {
+    const running = this.running.get(instanceId);
+    if (!running) return;
+
+    try {
+      running.recipe.stop();
+    } catch (err) {
+      this.logger.error({ err, instanceId }, "Error stopping recipe instance");
+    }
+
+    this.running.delete(instanceId);
+    this.logger.info({ instanceId, recipeId: running.instance.recipeId }, "Recipe instance stopped");
+    this.eventBus.emit({ type: "recipe.instance.stopped", instanceId, recipeId: running.instance.recipeId });
+  }
+
+  private buildContext(instanceId: string, recipeId: string): RecipeContext {
+    const stateStore = new RecipeStateStore(this.db, instanceId);
+    return {
+      eventBus: this.eventBus,
+      equipmentManager: this.equipmentManager,
+      zoneManager: this.zoneManager,
+      zoneAggregator: this.zoneAggregator,
+      logger: this.logger.child({ instanceId }),
+      state: stateStore,
+      log: (message: string, level: "info" | "warn" | "error" = "info") => {
+        this.writeLog(instanceId, message, level);
+      },
+      notifyStateChanged: () => {
+        this.eventBus.emit({ type: "recipe.instance.state.changed", instanceId, recipeId });
+      },
+    };
+  }
+
+  private writeLog(instanceId: string, message: string, level: "info" | "warn" | "error" = "info"): void {
+    try {
+      this.stmts.insertLog.run(instanceId, message, level);
+    } catch (err) {
+      this.logger.error({ err, instanceId }, "Failed to write recipe log");
+    }
+  }
+}
+
+// ============================================================
+// Custom error
+// ============================================================
+
+export class RecipeError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "RecipeError";
+    this.status = status;
+  }
+}
+
+// ============================================================
+// SQLite row types and mappers
+// ============================================================
+
+interface InstanceRow {
+  id: string;
+  recipe_id: string;
+  params: string;
+  enabled: number;
+  created_at: string;
+}
+
+interface LogRow {
+  id: number;
+  instance_id: string;
+  timestamp: string;
+  message: string;
+  level: string;
+}
+
+function rowToInstance(row: InstanceRow): RecipeInstance {
+  let params: Record<string, unknown>;
+  try {
+    params = JSON.parse(row.params);
+  } catch {
+    params = {};
+  }
+  return {
+    id: row.id,
+    recipeId: row.recipe_id,
+    params,
+    enabled: row.enabled === 1,
+    createdAt: toISOUtc(row.created_at),
+  };
+}
+
+function rowToLogEntry(row: LogRow): RecipeLogEntry {
+  return {
+    id: row.id,
+    instanceId: row.instance_id,
+    timestamp: toISOUtc(row.timestamp)!,
+    message: row.message,
+    level: row.level as "info" | "warn" | "error",
+  };
+}

--- a/src/recipes/engine/recipe-state-store.ts
+++ b/src/recipes/engine/recipe-state-store.ts
@@ -1,0 +1,57 @@
+import type Database from "better-sqlite3";
+
+// ============================================================
+// RecipeStateStore — key-value persistence per recipe instance
+// ============================================================
+
+export class RecipeStateStore {
+  private stmts: ReturnType<typeof this.prepareStatements>;
+
+  constructor(
+    private db: Database.Database,
+    private instanceId: string,
+  ) {
+    this.stmts = this.prepareStatements();
+  }
+
+  private prepareStatements() {
+    return {
+      get: this.db.prepare(
+        "SELECT value FROM recipe_state WHERE instance_id = ? AND key = ?",
+      ),
+      set: this.db.prepare(
+        `INSERT INTO recipe_state (instance_id, key, value) VALUES (?, ?, ?)
+         ON CONFLICT(instance_id, key) DO UPDATE SET value = excluded.value`,
+      ),
+      delete: this.db.prepare(
+        "DELETE FROM recipe_state WHERE instance_id = ? AND key = ?",
+      ),
+      clear: this.db.prepare(
+        "DELETE FROM recipe_state WHERE instance_id = ?",
+      ),
+    };
+  }
+
+  get(key: string): unknown | null {
+    const row = this.stmts.get.get(this.instanceId, key) as { value: string | null } | undefined;
+    if (!row || row.value === null) return null;
+    try {
+      return JSON.parse(row.value);
+    } catch {
+      return row.value;
+    }
+  }
+
+  set(key: string, value: unknown): void {
+    const serialized = value === undefined ? null : JSON.stringify(value);
+    this.stmts.set.run(this.instanceId, key, serialized);
+  }
+
+  delete(key: string): void {
+    this.stmts.delete.run(this.instanceId, key);
+  }
+
+  clear(): void {
+    this.stmts.clear.run(this.instanceId);
+  }
+}

--- a/src/recipes/engine/recipe.ts
+++ b/src/recipes/engine/recipe.ts
@@ -1,0 +1,50 @@
+import type { EventBus } from "../../core/event-bus.js";
+import type { Logger } from "../../core/logger.js";
+import type { EquipmentManager } from "../../equipments/equipment-manager.js";
+import type { ZoneManager } from "../../zones/zone-manager.js";
+import type { ZoneAggregator } from "../../zones/zone-aggregator.js";
+import type { RecipeSlotDef } from "../../shared/types.js";
+import type { RecipeStateStore } from "./recipe-state-store.js";
+
+// ============================================================
+// RecipeContext — injected into each recipe instance
+// ============================================================
+
+export interface RecipeContext {
+  eventBus: EventBus;
+  equipmentManager: EquipmentManager;
+  zoneManager: ZoneManager;
+  zoneAggregator: ZoneAggregator;
+  logger: Logger;
+  state: RecipeStateStore;
+  log: (message: string, level?: "info" | "warn" | "error") => void;
+  /** Notify UI that recipe state has changed (e.g. timer started/cancelled). */
+  notifyStateChanged: () => void;
+}
+
+// ============================================================
+// Recipe — abstract base class for all recipes
+// ============================================================
+
+export abstract class Recipe {
+  abstract readonly id: string;
+  abstract readonly name: string;
+  abstract readonly description: string;
+  abstract readonly slots: RecipeSlotDef[];
+
+  /**
+   * Validate params before starting. Throw if invalid.
+   */
+  abstract validate(params: Record<string, unknown>, ctx: RecipeContext): void;
+
+  /**
+   * Start the recipe instance. Subscribe to events, set up timers.
+   */
+  abstract start(params: Record<string, unknown>, ctx: RecipeContext): void;
+
+  /**
+   * Stop the recipe instance. Unsubscribe events, clear timers.
+   * Must be idempotent.
+   */
+  abstract stop(): void;
+}

--- a/src/recipes/motion-light.test.ts
+++ b/src/recipes/motion-light.test.ts
@@ -1,0 +1,453 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { ZoneManager } from "../zones/zone-manager.js";
+import { ZoneAggregator } from "../zones/zone-aggregator.js";
+import { EquipmentManager } from "../equipments/equipment-manager.js";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+import { RecipeManager } from "./engine/recipe-manager.js";
+import { MotionLightRecipe } from "./motion-light.js";
+import type { EngineEvent } from "../shared/types.js";
+
+// ============================================================
+// Test helpers
+// ============================================================
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  const migrations = ["001_devices.sql", "002_zones.sql", "003_equipments.sql", "005_recipes.sql"];
+  for (const file of migrations) {
+    const sql = readFileSync(
+      resolve(import.meta.dirname ?? ".", "../../migrations", file),
+      "utf-8",
+    );
+    db.exec(sql);
+  }
+  return db;
+}
+
+const logger = createLogger("silent");
+
+function seedDevice(
+  db: Database.Database,
+  opts: {
+    name?: string;
+    dataKeys?: { id?: string; key: string; type?: string; category?: string; value?: string }[];
+    orderKeys?: { id?: string; key: string; type?: string; payloadKey?: string }[];
+  } = {},
+) {
+  const deviceId = crypto.randomUUID();
+  const name = opts.name ?? "Test Device";
+  db.prepare(
+    `INSERT INTO devices (id, mqtt_base_topic, mqtt_name, name, source, status)
+     VALUES (?, ?, ?, ?, 'zigbee2mqtt', 'online')`,
+  ).run(deviceId, `z2m/${name}`, name, name);
+
+  const dataIds: string[] = [];
+  for (const d of opts.dataKeys ?? []) {
+    const id = d.id ?? crypto.randomUUID();
+    db.prepare(
+      `INSERT INTO device_data (id, device_id, key, type, category, value)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(id, deviceId, d.key, d.type ?? "boolean", d.category ?? "generic", d.value ?? null);
+    dataIds.push(id);
+  }
+
+  const orderIds: string[] = [];
+  for (const o of opts.orderKeys ?? []) {
+    const id = o.id ?? crypto.randomUUID();
+    db.prepare(
+      `INSERT INTO device_orders (id, device_id, key, type, mqtt_set_topic, payload_key)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(id, deviceId, o.key, o.type ?? "boolean", `z2m/${name}/set`, o.payloadKey ?? o.key);
+    orderIds.push(id);
+  }
+
+  return { deviceId, dataIds, orderIds };
+}
+
+// ============================================================
+// Setup helpers
+// ============================================================
+
+interface TestSetup {
+  db: Database.Database;
+  eventBus: EventBus;
+  zoneManager: ZoneManager;
+  equipmentManager: EquipmentManager;
+  aggregator: ZoneAggregator;
+  manager: RecipeManager;
+  events: EngineEvent[];
+  published: Array<{ topic: string; payload: string }>;
+  zoneId: string;
+  lightId: string;
+  pirDataId: string;
+  lightDataId: string;
+}
+
+function createTestSetup(): TestSetup {
+  const db = createTestDb();
+  const eventBus = new EventBus(logger);
+  const published: Array<{ topic: string; payload: string }> = [];
+  const mockMqtt = {
+    publish: (topic: string, payload: string) => published.push({ topic, payload }),
+    isConnected: () => true,
+  };
+
+  const zoneManager = new ZoneManager(db, eventBus, logger);
+  const equipmentManager = new EquipmentManager(db, eventBus, mockMqtt as never, logger);
+  const aggregator = new ZoneAggregator(zoneManager, equipmentManager, eventBus, logger);
+  const manager = new RecipeManager(db, eventBus, equipmentManager, zoneManager, aggregator, logger);
+  manager.register(MotionLightRecipe);
+
+  // Create zone
+  const zone = zoneManager.create({ name: "Salon" });
+
+  // Create PIR sensor device + equipment
+  const pirDevice = seedDevice(db, {
+    name: "PIR Salon",
+    dataKeys: [{ key: "occupancy", type: "boolean", category: "motion", value: "false" }],
+  });
+  const pirEq = equipmentManager.create({ name: "PIR Salon", type: "motion_sensor", zoneId: zone.id });
+  equipmentManager.addDataBinding(pirEq.id, pirDevice.dataIds[0], "occupancy");
+
+  // Create light device + equipment with both data and order bindings
+  const lightDevice = seedDevice(db, {
+    name: "Spots Salon",
+    dataKeys: [{ key: "state", type: "boolean", category: "light_state", value: JSON.stringify("OFF") }],
+    orderKeys: [{ key: "state", type: "boolean", payloadKey: "state" }],
+  });
+  const lightEq = equipmentManager.create({ name: "Spots Salon", type: "light_onoff", zoneId: zone.id });
+  equipmentManager.addDataBinding(lightEq.id, lightDevice.dataIds[0], "state");
+  equipmentManager.addOrderBinding(lightEq.id, lightDevice.orderIds[0], "state");
+
+  // Compute initial aggregation
+  aggregator.computeAll();
+
+  const events: EngineEvent[] = [];
+  eventBus.on((event) => events.push(event));
+
+  return {
+    db,
+    eventBus,
+    zoneManager,
+    equipmentManager,
+    aggregator,
+    manager,
+    events,
+    published,
+    zoneId: zone.id,
+    lightId: lightEq.id,
+    pirDataId: pirDevice.dataIds[0],
+    lightDataId: lightDevice.dataIds[0],
+  };
+}
+
+function simulateMotion(setup: TestSetup, active: boolean): void {
+  // Update DB
+  setup.db.prepare("UPDATE device_data SET value = ? WHERE id = ?").run(
+    JSON.stringify(active),
+    setup.pirDataId,
+  );
+  // Trigger reactive pipeline
+  setup.eventBus.emit({
+    type: "device.data.updated",
+    deviceId: "pir-device",
+    deviceName: "PIR Salon",
+    dataId: setup.pirDataId,
+    key: "occupancy",
+    value: active,
+    previous: !active,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+function simulateLightState(setup: TestSetup, state: "ON" | "OFF"): void {
+  setup.db.prepare("UPDATE device_data SET value = ? WHERE id = ?").run(
+    JSON.stringify(state),
+    setup.lightDataId,
+  );
+  setup.eventBus.emit({
+    type: "device.data.updated",
+    deviceId: "light-device",
+    deviceName: "Spots Salon",
+    dataId: setup.lightDataId,
+    key: "state",
+    value: state,
+    previous: state === "ON" ? "OFF" : "ON",
+    timestamp: new Date().toISOString(),
+  });
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("MotionLightRecipe", () => {
+  let setup: TestSetup;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setup = createTestSetup();
+  });
+
+  afterEach(() => {
+    setup.manager.stopAll();
+    setup.db.close();
+    vi.useRealTimers();
+  });
+
+  // ============================================================
+  // Validation
+  // ============================================================
+
+  it("validates required params", () => {
+    expect(() => setup.manager.createInstance("motion-light", {})).toThrow("Invalid params");
+  });
+
+  it("validates zone exists", () => {
+    expect(() =>
+      setup.manager.createInstance("motion-light", { zone: "nonexistent", light: setup.lightId, timeout: "10m" }),
+    ).toThrow("Invalid params");
+  });
+
+  it("validates light exists and has state order", () => {
+    expect(() =>
+      setup.manager.createInstance("motion-light", { zone: setup.zoneId, light: "nonexistent", timeout: "10m" }),
+    ).toThrow("Invalid params");
+  });
+
+  // ============================================================
+  // Motion → turn on
+  // ============================================================
+
+  it("turns light on when motion detected and light is off", () => {
+    setup.manager.createInstance("motion-light", {
+      zone: setup.zoneId,
+      light: setup.lightId,
+      timeout: "5m",
+    });
+
+    setup.published.length = 0;
+
+    // Simulate motion detected
+    simulateMotion(setup, true);
+
+    // Should have published ON command
+    expect(setup.published.length).toBeGreaterThanOrEqual(1);
+    const onCommand = setup.published.find((p) => {
+      const payload = JSON.parse(p.payload);
+      return payload.state === "ON";
+    });
+    expect(onCommand).toBeDefined();
+  });
+
+  // ============================================================
+  // Motion true + light already on → reset timer (no action)
+  // ============================================================
+
+  it("resets timer when motion detected and light is already on", () => {
+    setup.manager.createInstance("motion-light", {
+      zone: setup.zoneId,
+      light: setup.lightId,
+      timeout: "5m",
+    });
+
+    // Light is already on
+    simulateLightState(setup, "ON");
+    setup.published.length = 0;
+
+    // Simulate motion — should NOT turn on (already on)
+    simulateMotion(setup, true);
+
+    // No new ON command published
+    const onCommand = setup.published.find((p) => {
+      const payload = JSON.parse(p.payload);
+      return payload.state === "ON";
+    });
+    expect(onCommand).toBeUndefined();
+  });
+
+  // ============================================================
+  // No motion + light on → start timer → turn off
+  // ============================================================
+
+  it("starts timer when no motion and light is on, turns off on expiry", () => {
+    setup.manager.createInstance("motion-light", {
+      zone: setup.zoneId,
+      light: setup.lightId,
+      timeout: "5m",
+    });
+
+    // Light on + motion on
+    simulateLightState(setup, "ON");
+    simulateMotion(setup, true);
+    setup.published.length = 0;
+
+    // Motion stops
+    simulateMotion(setup, false);
+
+    // Timer not yet expired
+    vi.advanceTimersByTime(4 * 60 * 1000);
+    expect(setup.published.find((p) => JSON.parse(p.payload).state === "OFF")).toBeUndefined();
+
+    // Timer expires
+    vi.advanceTimersByTime(2 * 60 * 1000);
+    const offCommand = setup.published.find((p) => JSON.parse(p.payload).state === "OFF");
+    expect(offCommand).toBeDefined();
+  });
+
+  // ============================================================
+  // Motion re-detected before timer → timer cancelled
+  // ============================================================
+
+  it("cancels timer when motion re-detected before expiry", () => {
+    setup.manager.createInstance("motion-light", {
+      zone: setup.zoneId,
+      light: setup.lightId,
+      timeout: "5m",
+    });
+
+    // Light on, motion on, then motion off (starts timer)
+    simulateLightState(setup, "ON");
+    simulateMotion(setup, true);
+    simulateMotion(setup, false);
+
+    // Advance 3 minutes
+    vi.advanceTimersByTime(3 * 60 * 1000);
+    setup.published.length = 0;
+
+    // Motion re-detected
+    simulateMotion(setup, true);
+
+    // Wait full timeout — should NOT turn off because motion was re-detected
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    const offCommand = setup.published.find((p) => JSON.parse(p.payload).state === "OFF");
+    expect(offCommand).toBeUndefined();
+  });
+
+  // ============================================================
+  // Light turned on externally + no motion → start timer
+  // ============================================================
+
+  it("starts timer when light turned on externally without motion", () => {
+    setup.manager.createInstance("motion-light", {
+      zone: setup.zoneId,
+      light: setup.lightId,
+      timeout: "5m",
+    });
+    setup.published.length = 0;
+
+    // External turn on (no motion)
+    simulateLightState(setup, "ON");
+
+    // Timer should expire and turn off
+    vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+    const offCommand = setup.published.find((p) => JSON.parse(p.payload).state === "OFF");
+    expect(offCommand).toBeDefined();
+  });
+
+  // ============================================================
+  // Light turned off externally → timer cancelled
+  // ============================================================
+
+  it("cancels timer when light turned off externally", () => {
+    setup.manager.createInstance("motion-light", {
+      zone: setup.zoneId,
+      light: setup.lightId,
+      timeout: "5m",
+    });
+
+    // Light on externally (starts timer)
+    simulateLightState(setup, "ON");
+    setup.published.length = 0;
+
+    // Light turned off externally
+    simulateLightState(setup, "OFF");
+
+    // Timer should be cancelled — nothing happens after timeout
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    const offCommand = setup.published.find((p) => JSON.parse(p.payload).state === "OFF");
+    expect(offCommand).toBeUndefined();
+  });
+
+  // ============================================================
+  // Zone with no motion sensors → warning logged
+  // ============================================================
+
+  it("logs warning when zone has no motion sensors", () => {
+    // Create a zone without PIR
+    const emptyZone = setup.zoneManager.create({ name: "Empty Zone" });
+    setup.aggregator.computeAll();
+
+    // Create a light in the empty zone
+    const lightDevice = seedDevice(setup.db, {
+      name: "Light2",
+      dataKeys: [{ key: "state", type: "boolean", category: "light_state", value: JSON.stringify("OFF") }],
+      orderKeys: [{ key: "state", type: "boolean", payloadKey: "state" }],
+    });
+    const lightEq = setup.equipmentManager.create({ name: "Light2", type: "light_onoff", zoneId: emptyZone.id });
+    setup.equipmentManager.addDataBinding(lightEq.id, lightDevice.dataIds[0], "state");
+    setup.equipmentManager.addOrderBinding(lightEq.id, lightDevice.orderIds[0], "state");
+    setup.aggregator.computeAll();
+
+    const instance = setup.manager.createInstance("motion-light", {
+      zone: emptyZone.id,
+      light: lightEq.id,
+      timeout: "5m",
+    });
+
+    // Check logs contain the warning
+    const logs = setup.manager.getLog(instance.id);
+    expect(logs.some((l) => l.level === "warn")).toBe(true);
+  });
+
+  // ============================================================
+  // Light equipment missing → error
+  // ============================================================
+
+  it("throws error when light equipment has no state order", () => {
+    // Create a light without order binding
+    const lightDevice = seedDevice(setup.db, {
+      name: "Light No Order",
+      dataKeys: [{ key: "state", type: "boolean", category: "light_state", value: JSON.stringify("OFF") }],
+    });
+    const lightEq = setup.equipmentManager.create({ name: "Light No Order", type: "light_onoff", zoneId: setup.zoneId });
+    setup.equipmentManager.addDataBinding(lightEq.id, lightDevice.dataIds[0], "state");
+
+    expect(() =>
+      setup.manager.createInstance("motion-light", {
+        zone: setup.zoneId,
+        light: lightEq.id,
+        timeout: "5m",
+      }),
+    ).toThrow("Invalid params");
+  });
+
+  // ============================================================
+  // Stop cleans up
+  // ============================================================
+
+  it("stops recipe cleanly on delete", () => {
+    const instance = setup.manager.createInstance("motion-light", {
+      zone: setup.zoneId,
+      light: setup.lightId,
+      timeout: "5m",
+    });
+
+    // Light on + motion → then motion off (timer started)
+    simulateLightState(setup, "ON");
+    simulateMotion(setup, true);
+    simulateMotion(setup, false);
+
+    setup.manager.deleteInstance(instance.id);
+    setup.published.length = 0;
+
+    // Advance past timeout — should NOT turn off (recipe stopped)
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    expect(setup.published).toHaveLength(0);
+  });
+});

--- a/src/recipes/motion-light.ts
+++ b/src/recipes/motion-light.ts
@@ -1,0 +1,245 @@
+import type { RecipeSlotDef } from "../shared/types.js";
+import { Recipe, type RecipeContext } from "./engine/recipe.js";
+
+// ============================================================
+// Duration parsing helper
+// ============================================================
+
+function parseDuration(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value !== "string") throw new Error(`Invalid duration: ${value}`);
+
+  const match = value.match(/^(\d+)\s*(s|m|h)$/);
+  if (!match) throw new Error(`Invalid duration format: ${value}. Use e.g. "10m", "30s", "1h"`);
+
+  const num = parseInt(match[1], 10);
+  switch (match[2]) {
+    case "s": return num * 1000;
+    case "m": return num * 60 * 1000;
+    case "h": return num * 60 * 60 * 1000;
+    default: throw new Error(`Invalid duration unit: ${match[2]}`);
+  }
+}
+
+function formatDuration(ms: number): string {
+  if (ms >= 60 * 60 * 1000) return `${Math.round(ms / (60 * 60 * 1000))}h`;
+  if (ms >= 60 * 1000) return `${Math.round(ms / (60 * 1000))}min`;
+  return `${Math.round(ms / 1000)}s`;
+}
+
+// ============================================================
+// Motion-Light Recipe
+// ============================================================
+
+export class MotionLightRecipe extends Recipe {
+  readonly id = "motion-light";
+  readonly name = "Motion Light";
+  readonly description = "Turns on the light when motion is detected, turns off after a timeout with no motion. Also handles manual on/off.";
+  readonly slots: RecipeSlotDef[] = [
+    {
+      id: "zone",
+      name: "Zone",
+      description: "Zone to monitor",
+      type: "zone",
+      required: true,
+    },
+    {
+      id: "light",
+      name: "Light",
+      description: "Light to control",
+      type: "equipment",
+      required: true,
+      constraints: { equipmentType: "light_onoff" },
+    },
+    {
+      id: "timeout",
+      name: "Timeout",
+      description: "Delay with no motion before turning off",
+      type: "duration",
+      required: true,
+      defaultValue: "10m",
+    },
+  ];
+
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private unsubs: (() => void)[] = [];
+  private ctx!: RecipeContext;
+  private zoneId!: string;
+  private lightId!: string;
+  private timeoutMs!: number;
+
+  validate(params: Record<string, unknown>, ctx: RecipeContext): void {
+    const { zone, light, timeout } = params;
+
+    // Validate zone exists (use zoneManager, not aggregator — aggregator cache may be empty at startup)
+    if (!zone || typeof zone !== "string") {
+      throw new Error("Zone parameter is required");
+    }
+    const zoneObj = ctx.zoneManager.getById(zone);
+    if (!zoneObj) {
+      throw new Error(`Zone not found: ${zone}`);
+    }
+    const zoneData = ctx.zoneAggregator.getByZoneId(zone);
+    if (zoneData && zoneData.motionSensors === 0) {
+      ctx.log(`Zone has no motion sensors — recipe will never trigger`, "warn");
+    }
+
+    // Validate light exists and has state order
+    if (!light || typeof light !== "string") {
+      throw new Error("Light parameter is required");
+    }
+    const equipment = ctx.equipmentManager.getByIdWithDetails(light);
+    if (!equipment) {
+      throw new Error(`Light equipment not found: ${light}`);
+    }
+    const hasStateOrder = equipment.orderBindings.some((ob) => ob.alias === "state");
+    if (!hasStateOrder) {
+      throw new Error(`Light equipment "${equipment.name}" has no "state" order binding`);
+    }
+
+    // Validate timeout
+    const timeoutValue = timeout ?? "10m";
+    parseDuration(timeoutValue);
+  }
+
+  start(params: Record<string, unknown>, ctx: RecipeContext): void {
+    this.ctx = ctx;
+    this.zoneId = params.zone as string;
+    this.lightId = params.light as string;
+    this.timeoutMs = parseDuration(params.timeout ?? "10m");
+
+    // Listen to zone aggregation changes (for motion)
+    const unsubZone = ctx.eventBus.onType("zone.data.changed", (event) => {
+      if (event.zoneId !== this.zoneId) return;
+      this.onZoneChanged(event.aggregatedData.motion);
+    });
+    this.unsubs.push(unsubZone);
+
+    // Listen to light state changes (for manual on/off)
+    const unsubLight = ctx.eventBus.onType("equipment.data.changed", (event) => {
+      if (event.equipmentId !== this.lightId) return;
+      if (event.alias !== "state") return;
+      this.onLightChanged(event.value);
+    });
+    this.unsubs.push(unsubLight);
+
+  }
+
+  stop(): void {
+    this.cancelTimer();
+    for (const unsub of this.unsubs) {
+      unsub();
+    }
+    this.unsubs = [];
+  }
+
+  // ============================================================
+  // Event handlers
+  // ============================================================
+
+  private onZoneChanged(motion: boolean): void {
+    const lightOn = this.isLightOn();
+
+    if (motion && !lightOn) {
+      this.turnOn();
+    } else if (motion && lightOn) {
+      this.resetTimer();
+    } else if (!motion && lightOn) {
+      this.startTimer();
+    }
+    // !motion && !lightOn → nothing to do
+  }
+
+  private onLightChanged(value: unknown): void {
+    const lightOn = value === true || value === "ON";
+    const motion = this.hasMotion();
+
+    if (lightOn && !motion) {
+      this.startTimer();
+      this.ctx.log(`Light turned on externally — turning off in ${formatDuration(this.timeoutMs)}`);
+    } else if (lightOn && motion) {
+      this.resetTimer();
+    } else if (!lightOn) {
+      this.cancelTimer();
+      this.ctx.log("Light turned off externally — timer cancelled");
+    }
+  }
+
+  // ============================================================
+  // Light state helpers
+  // ============================================================
+
+  private isLightOn(): boolean {
+    const bindings = this.ctx.equipmentManager.getDataBindingsWithValues(this.lightId);
+    const stateBinding = bindings.find((b) => b.alias === "state" || b.category === "light_state");
+    if (!stateBinding) return false;
+    return stateBinding.value === true || stateBinding.value === "ON";
+  }
+
+  private hasMotion(): boolean {
+    const zoneData = this.ctx.zoneAggregator.getByZoneId(this.zoneId);
+    return zoneData?.motion ?? false;
+  }
+
+  // ============================================================
+  // Actions
+  // ============================================================
+
+  private turnOn(): void {
+    try {
+      this.ctx.equipmentManager.executeOrder(this.lightId, "state", "ON");
+      this.ctx.log("Motion detected — light turned on");
+    } catch (err) {
+      this.ctx.log(`Error turning on light: ${err instanceof Error ? err.message : String(err)}`, "error");
+    }
+  }
+
+  private turnOff(): void {
+    try {
+      this.ctx.equipmentManager.executeOrder(this.lightId, "state", "OFF");
+      this.ctx.log(`No motion for ${formatDuration(this.timeoutMs)} — light turned off`);
+    } catch (err) {
+      this.ctx.log(`Error turning off light: ${err instanceof Error ? err.message : String(err)}`, "error");
+    }
+  }
+
+  // ============================================================
+  // Timer management
+  // ============================================================
+
+  private startTimer(): void {
+    this.cancelTimer();
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.clearTimerState();
+      this.turnOff();
+    }, this.timeoutMs);
+    this.persistTimerState();
+  }
+
+  private resetTimer(): void {
+    if (this.timer) {
+      this.cancelTimer();
+    }
+    // No new timer — motion is active, wait for it to stop
+  }
+
+  private cancelTimer(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+      this.clearTimerState();
+    }
+  }
+
+  private persistTimerState(): void {
+    const expiresAt = new Date(Date.now() + this.timeoutMs).toISOString();
+    this.ctx.state.set("timerExpiresAt", expiresAt);
+    this.ctx.notifyStateChanged();
+  }
+
+  private clearTimerState(): void {
+    this.ctx.state.delete("timerExpiresAt");
+    this.ctx.notifyStateChanged();
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -205,6 +205,47 @@ export interface EquipmentWithDetails extends Equipment {
 }
 
 // ============================================================
+// Recipe
+// ============================================================
+
+export interface RecipeSlotDef {
+  id: string;
+  name: string;
+  description: string;
+  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean";
+  required: boolean;
+  defaultValue?: unknown;
+  constraints?: {
+    equipmentType?: EquipmentType;
+    min?: number;
+    max?: number;
+  };
+}
+
+export interface RecipeInfo {
+  id: string;
+  name: string;
+  description: string;
+  slots: RecipeSlotDef[];
+}
+
+export interface RecipeInstance {
+  id: string;
+  recipeId: string;
+  params: Record<string, unknown>;
+  enabled: boolean;
+  createdAt: string;
+}
+
+export interface RecipeLogEntry {
+  id: number;
+  instanceId: string;
+  timestamp: string;
+  message: string;
+  level: "info" | "warn" | "error";
+}
+
+// ============================================================
 // Event Bus
 // ============================================================
 
@@ -257,6 +298,13 @@ export type EngineEvent =
       orderAlias: string;
       value: unknown;
     }
+  // Recipe events
+  | { type: "recipe.instance.created"; instanceId: string; recipeId: string }
+  | { type: "recipe.instance.removed"; instanceId: string; recipeId: string }
+  | { type: "recipe.instance.started"; instanceId: string; recipeId: string }
+  | { type: "recipe.instance.stopped"; instanceId: string; recipeId: string }
+  | { type: "recipe.instance.error"; instanceId: string; recipeId: string; error: string }
+  | { type: "recipe.instance.state.changed"; instanceId: string; recipeId: string }
   // System events
   | { type: "system.started" }
   | { type: "system.mqtt.connected" }

--- a/src/zones/zone-manager.ts
+++ b/src/zones/zone-manager.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type Database from "better-sqlite3";
 import type { Logger } from "../core/logger.js";
 import type { EventBus } from "../core/event-bus.js";
+import { toISOUtc } from "../core/database.js";
 import type { Zone, ZoneWithChildren } from "../shared/types.js";
 
 interface CreateZoneInput {
@@ -312,8 +313,8 @@ function rowToZone(row: ZoneRow): Zone {
     icon: row.icon ?? undefined,
     description: row.description ?? undefined,
     displayOrder: row.display_order,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
+    createdAt: toISOUtc(row.created_at),
+    updatedAt: toISOUtc(row.updated_at),
   };
 }
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -3,6 +3,7 @@ import type {
   ZoneWithChildren, Zone, ZoneAggregatedData,
   Equipment, EquipmentType, EquipmentWithDetails,
   DataBinding, OrderBinding,
+  RecipeInfo, RecipeInstance, RecipeLogEntry,
 } from "./types";
 
 const API_BASE = "/api/v1";
@@ -202,4 +203,49 @@ export async function removeOrderBinding(equipmentId: string, bindingId: string)
   return fetchJSON<void>(`${API_BASE}/equipments/${equipmentId}/order-bindings/${bindingId}`, {
     method: "DELETE",
   });
+}
+
+// ============================================================
+// Recipes
+// ============================================================
+
+export async function getRecipes(): Promise<RecipeInfo[]> {
+  return fetchJSON<RecipeInfo[]>(`${API_BASE}/recipes`);
+}
+
+export async function getRecipeInstances(): Promise<RecipeInstance[]> {
+  return fetchJSON<RecipeInstance[]>(`${API_BASE}/recipe-instances`);
+}
+
+export async function createRecipeInstance(
+  recipeId: string,
+  params: Record<string, unknown>,
+): Promise<RecipeInstance> {
+  return fetchJSON<RecipeInstance>(`${API_BASE}/recipe-instances`, {
+    method: "POST",
+    body: JSON.stringify({ recipeId, params }),
+  });
+}
+
+export async function updateRecipeInstance(
+  instanceId: string,
+  params: Record<string, unknown>,
+): Promise<RecipeInstance> {
+  return fetchJSON<RecipeInstance>(`${API_BASE}/recipe-instances/${instanceId}`, {
+    method: "PUT",
+    body: JSON.stringify({ params }),
+  });
+}
+
+export async function deleteRecipeInstance(instanceId: string): Promise<void> {
+  return fetchJSON<void>(`${API_BASE}/recipe-instances/${instanceId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function getRecipeInstanceLog(
+  instanceId: string,
+  limit = 50,
+): Promise<RecipeLogEntry[]> {
+  return fetchJSON<RecipeLogEntry[]>(`${API_BASE}/recipe-instances/${instanceId}/log?limit=${limit}`);
 }

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Power, ChevronUp, Square, ChevronDown } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
@@ -188,7 +188,12 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder }: CompactEquip
         <div className="flex items-center gap-2 flex-shrink-0">
           {sensorBindings.map((b) => (
             <span key={b.id} className="text-[13px] tabular-nums flex-shrink-0">
-              {isBooleanSensorCategory(b.category) ? (
+              {b.category === "motion" && isBooleanActive(b.category, b.value) ? (
+                <span className="font-medium px-2 py-0.5 rounded-full text-[11px] bg-amber-400/15 text-amber-500 inline-flex items-center gap-1">
+                  {formatBooleanSensor(b.category, b.value)}
+                  <ElapsedCounter lastUpdated={b.lastUpdated} />
+                </span>
+              ) : isBooleanSensorCategory(b.category) ? (
                 <span
                   className={`
                     font-medium px-2 py-0.5 rounded-full text-[11px]
@@ -231,6 +236,11 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder }: CompactEquip
           className="flex items-center gap-2 flex-shrink-0"
           onClick={(e) => e.preventDefault()}
         >
+          {isOn && stateBinding?.lastUpdated && (
+            <span className="text-[11px] text-text-tertiary tabular-nums">
+              <ElapsedCounter lastUpdated={stateBinding.lastUpdated} />
+            </span>
+          )}
           {hasBrightness && brightness !== null && (
             <div className="flex items-center gap-1.5">
               <input
@@ -336,6 +346,33 @@ function isBooleanActive(category: string, value: unknown): boolean {
     return value === false || value === "OFF"; // contact=false means open
   }
   return value === true || value === "ON";
+}
+
+/** Live elapsed counter for active motion sensors — ticks every second. */
+function ElapsedCounter({ lastUpdated }: { lastUpdated: string | null }) {
+  const [elapsed, setElapsed] = useState(() => computeElapsed(lastUpdated));
+
+  useEffect(() => {
+    setElapsed(computeElapsed(lastUpdated));
+    const id = setInterval(() => setElapsed(computeElapsed(lastUpdated)), 1000);
+    return () => clearInterval(id);
+  }, [lastUpdated]);
+
+  return <span className="tabular-nums opacity-80">{formatElapsed(elapsed)}</span>;
+}
+
+function computeElapsed(iso: string | null): number {
+  if (!iso) return 0;
+  const ts = iso.endsWith("Z") ? iso : `${iso}Z`;
+  return Math.max(0, Math.floor((Date.now() - new Date(ts).getTime()) / 1000));
+}
+
+function formatElapsed(s: number): string {
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m${String(s % 60).padStart(2, "0")}s`;
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  return `${h}h${String(m).padStart(2, "0")}`;
 }
 
 function formatValue(value: unknown, unit?: string): string {

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -1,0 +1,675 @@
+import { useState, useEffect, useMemo } from "react";
+import { ChefHat, Plus, Trash2, ScrollText, X, Loader2, ChevronLeft, ChevronRight, Timer, Pencil, Check } from "lucide-react";
+import { useRecipes } from "../../store/useRecipes";
+import { useEquipments } from "../../store/useEquipments";
+import type { RecipeInfo, RecipeInstance, RecipeLogEntry, EquipmentWithDetails } from "../../types";
+import { formatTime } from "../../lib/format";
+
+interface ZoneRecipesSectionProps {
+  zoneId: string;
+  zoneName: string;
+}
+
+export function ZoneRecipesSection({ zoneId, zoneName }: ZoneRecipesSectionProps) {
+  const recipes = useRecipes((s) => s.recipes);
+  const instances = useRecipes((s) => s.instances);
+  const fetchRecipes = useRecipes((s) => s.fetchRecipes);
+  const fetchInstances = useRecipes((s) => s.fetchInstances);
+  const [showForm, setShowForm] = useState(false);
+
+  useEffect(() => {
+    fetchRecipes();
+    fetchInstances();
+  }, [fetchRecipes, fetchInstances]);
+
+  // Filter instances that belong to this zone
+  const zoneInstances = useMemo(() => {
+    return instances.filter((inst) => inst.params.zone === zoneId);
+  }, [instances, zoneId]);
+
+  if (recipes.length === 0 && zoneInstances.length === 0) return null;
+
+  return (
+    <div className="rounded-[10px] border border-border bg-surface overflow-hidden">
+      <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border-light">
+        <span className="text-text-tertiary">
+          <ChefHat size={14} strokeWidth={1.5} />
+        </span>
+        <span className="text-[12px] font-semibold text-text-tertiary uppercase tracking-wider">
+          Recipes
+        </span>
+        <span className="text-[11px] text-text-tertiary ml-auto tabular-nums">
+          {zoneInstances.length}
+        </span>
+        <button
+          onClick={() => setShowForm(true)}
+          className="ml-2 p-1 rounded-[4px] text-text-tertiary hover:text-primary hover:bg-primary/5 transition-colors duration-150"
+          title="Add a recipe"
+        >
+          <Plus size={14} strokeWidth={1.5} />
+        </button>
+      </div>
+
+      {zoneInstances.length > 0 && (
+        <div className="divide-y divide-border-light">
+          {zoneInstances.map((inst) => (
+            <RecipeInstanceRow key={inst.id} instance={inst} recipes={recipes} zoneId={zoneId} />
+          ))}
+        </div>
+      )}
+
+      {zoneInstances.length === 0 && !showForm && (
+        <div className="px-4 py-6 text-center">
+          <p className="text-[13px] text-text-tertiary">
+            No active recipes for {zoneName}
+          </p>
+          <button
+            onClick={() => setShowForm(true)}
+            className="mt-2 text-[13px] text-primary hover:text-primary-hover transition-colors duration-150"
+          >
+            Add a recipe
+          </button>
+        </div>
+      )}
+
+      {showForm && (
+        <AddRecipeForm
+          zoneId={zoneId}
+          recipes={recipes}
+          onClose={() => setShowForm(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ============================================================
+// Instance row
+// ============================================================
+
+function RecipeInstanceRow({
+  instance,
+  recipes,
+  zoneId,
+}: {
+  instance: RecipeInstance;
+  recipes: RecipeInfo[];
+  zoneId: string;
+}) {
+  const deleteInstance = useRecipes((s) => s.deleteInstance);
+  const updateInstance = useRecipes((s) => s.updateInstance);
+  const getLog = useRecipes((s) => s.getLog);
+  const allInstances = useRecipes((s) => s.instances);
+  const equipments = useEquipments((s) => s.equipments);
+  const [showLog, setShowLog] = useState(false);
+  const [logs, setLogs] = useState<RecipeLogEntry[]>([]);
+  const [deleting, setDeleting] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [editParams, setEditParams] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [editError, setEditError] = useState("");
+
+  const recipe = recipes.find((r) => r.id === instance.recipeId);
+  const recipeName = recipe?.name ?? instance.recipeId;
+
+  const handleDelete = async () => {
+    if (!confirm(`Delete this recipe?`)) return;
+    setDeleting(true);
+    try {
+      await deleteInstance(instance.id);
+    } catch {
+      setDeleting(false);
+    }
+  };
+
+  const handleShowLog = async () => {
+    if (showLog) {
+      setShowLog(false);
+      return;
+    }
+    const entries = await getLog(instance.id);
+    setLogs(entries);
+    setShowLog(true);
+  };
+
+  const handleStartEdit = () => {
+    const params: Record<string, string> = {};
+    for (const [key, val] of Object.entries(instance.params)) {
+      params[key] = String(val ?? "");
+    }
+    setEditParams(params);
+    setEditError("");
+    setEditing(true);
+  };
+
+  const handleCancelEdit = () => {
+    setEditing(false);
+    setEditError("");
+  };
+
+  const handleSave = async () => {
+    if (!recipe) return;
+    setEditError("");
+    setSaving(true);
+
+    const finalParams: Record<string, unknown> = {};
+    for (const slot of recipe.slots) {
+      const value = editParams[slot.id];
+      if (slot.required && !value) {
+        setEditError(`${slot.name} is required`);
+        setSaving(false);
+        return;
+      }
+      finalParams[slot.id] = value;
+    }
+
+    try {
+      await updateInstance(instance.id, finalParams);
+      setEditing(false);
+    } catch (err) {
+      setEditError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Light IDs used by other recipe instances in this zone (exclude current instance)
+  const usedLightIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const inst of allInstances) {
+      if (inst.id === instance.id) continue;
+      if (inst.params.zone === zoneId && typeof inst.params.light === "string") {
+        ids.add(inst.params.light);
+      }
+    }
+    return ids;
+  }, [allInstances, zoneId, instance.id]);
+
+  const getEquipmentOptions = (slotId: string): EquipmentWithDetails[] => {
+    const slot = recipe?.slots.find((s) => s.id === slotId);
+    if (!slot) return [];
+    return equipments.filter((eq) => {
+      if (eq.zoneId !== zoneId) return false;
+      if (slot.type === "equipment" && usedLightIds.has(eq.id)) return false;
+      if (slot.constraints?.equipmentType) {
+        const constraintType = slot.constraints.equipmentType;
+        if (constraintType === "light_onoff") {
+          return eq.type === "light_onoff" || eq.type === "light_dimmable" || eq.type === "light_color";
+        }
+        return eq.type === constraintType;
+      }
+      return true;
+    });
+  };
+
+  // Build a human-readable summary of params
+  const paramsSummary = useMemo(() => {
+    if (!recipe) return "";
+    const parts: string[] = [];
+    for (const slot of recipe.slots) {
+      if (slot.id === "zone") continue;
+      const val = instance.params[slot.id];
+      if (val === undefined || val === null) continue;
+      if (slot.type === "equipment") {
+        const eq = equipments.find((e) => e.id === val);
+        parts.push(eq?.name ?? String(val));
+      } else {
+        parts.push(String(val));
+      }
+    }
+    return parts.join(" · ");
+  }, [instance.params, recipe, equipments]);
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 px-4 py-2.5">
+        <div className="w-7 h-7 rounded-[6px] bg-accent/10 flex items-center justify-center flex-shrink-0">
+          <ChefHat size={14} strokeWidth={1.5} className="text-accent" />
+        </div>
+        <button
+          onClick={handleStartEdit}
+          className="flex-1 min-w-0 text-left hover:opacity-70 transition-opacity duration-150"
+          title="Edit"
+        >
+          <div className="text-[13px] font-medium text-text truncate">
+            {recipeName}
+          </div>
+          {paramsSummary && (
+            <div className="text-[11px] text-text-tertiary truncate">
+              {paramsSummary}
+            </div>
+          )}
+        </button>
+        {instance.state?.timerExpiresAt && (
+          <CountdownTimer expiresAt={instance.state.timerExpiresAt as string} />
+        )}
+        <button
+          onClick={handleShowLog}
+          className="p-1.5 rounded-[4px] text-text-tertiary hover:text-text hover:bg-border-light/60 transition-colors duration-150"
+          title="View log"
+        >
+          <ScrollText size={14} strokeWidth={1.5} />
+        </button>
+        <button
+          onClick={handleDelete}
+          disabled={deleting}
+          className="p-1.5 rounded-[4px] text-text-tertiary hover:text-error hover:bg-error/5 transition-colors duration-150 disabled:opacity-50"
+          title="Delete"
+        >
+          <Trash2 size={14} strokeWidth={1.5} />
+        </button>
+      </div>
+
+      {/* Edit form */}
+      {editing && recipe && (
+        <div className="px-4 pb-3">
+          <div className="bg-border-light/20 border border-border-light rounded-[6px] p-3">
+            {recipe.slots
+              .filter((slot) => slot.id !== "zone")
+              .map((slot) => (
+                <div key={slot.id} className="mb-2.5">
+                  <label className="block text-[11px] text-text-tertiary uppercase tracking-wider mb-1">
+                    {slot.name}
+                  </label>
+                  {slot.type === "equipment" ? (
+                    <select
+                      value={editParams[slot.id] ?? ""}
+                      onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
+                      className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                    >
+                      <option value="">Select...</option>
+                      {getEquipmentOptions(slot.id).map((eq) => (
+                        <option key={eq.id} value={eq.id}>{eq.name}</option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      type="text"
+                      value={editParams[slot.id] ?? ""}
+                      onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
+                      placeholder={slot.defaultValue ? String(slot.defaultValue) : slot.description}
+                      className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text placeholder:text-text-tertiary"
+                    />
+                  )}
+                </div>
+              ))}
+            {editError && (
+              <p className="text-[12px] text-error mb-2">{editError}</p>
+            )}
+            <div className="flex gap-2">
+              <button
+                onClick={handleSave}
+                disabled={saving}
+                className="flex items-center gap-1.5 px-3 py-1.5 bg-primary text-white text-[12px] font-medium rounded-[6px] hover:bg-primary-hover transition-colors duration-150 disabled:opacity-50"
+              >
+                {saving ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} strokeWidth={1.5} />}
+                Save
+              </button>
+              <button
+                onClick={handleCancelEdit}
+                className="px-3 py-1.5 bg-border-light text-text-secondary text-[12px] font-medium rounded-[6px] hover:bg-border transition-colors duration-150"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Log panel */}
+      {showLog && (
+        <div className="px-4 pb-3">
+          <div className="bg-border-light/40 rounded-[6px] p-2 max-h-[200px] overflow-y-auto">
+            {logs.length === 0 ? (
+              <p className="text-[11px] text-text-tertiary text-center py-2">No logs</p>
+            ) : (
+              <div className="space-y-0.5">
+                {logs.map((log) => (
+                  <div key={log.id} className="flex gap-2 text-[11px] font-mono">
+                    <span className="text-text-tertiary whitespace-nowrap">
+                      {formatTime(log.timestamp)}
+                    </span>
+                    <span
+                      className={
+                        log.level === "error"
+                          ? "text-error"
+                          : log.level === "warn"
+                            ? "text-amber-500"
+                            : "text-text-secondary"
+                      }
+                    >
+                      {log.message}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================
+// Countdown timer — shows remaining time before auto-off
+// ============================================================
+
+function CountdownTimer({ expiresAt }: { expiresAt: string }) {
+  const [remaining, setRemaining] = useState(() => computeRemaining(expiresAt));
+
+  useEffect(() => {
+    setRemaining(computeRemaining(expiresAt));
+    const id = setInterval(() => setRemaining(computeRemaining(expiresAt)), 1000);
+    return () => clearInterval(id);
+  }, [expiresAt]);
+
+  if (remaining <= 0) return null;
+
+  return (
+    <span className="flex items-center gap-1 text-[11px] font-medium text-accent tabular-nums flex-shrink-0">
+      <Timer size={12} strokeWidth={1.5} />
+      {formatCountdown(remaining)}
+    </span>
+  );
+}
+
+function computeRemaining(iso: string): number {
+  return Math.max(0, Math.floor((new Date(iso).getTime() - Date.now()) / 1000));
+}
+
+function formatCountdown(s: number): string {
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const sec = s % 60;
+  if (m < 60) return `${m}m${sec > 0 ? String(sec).padStart(2, "0") + "s" : ""}`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return `${h}h${String(rm).padStart(2, "0")}`;
+}
+
+// ============================================================
+// Add recipe wizard (step 1: choose recipe, step 2: configure)
+// ============================================================
+
+type WizardStep = "choose" | "configure";
+
+function AddRecipeForm({
+  zoneId,
+  recipes,
+  onClose,
+}: {
+  zoneId: string;
+  recipes: RecipeInfo[];
+  onClose: () => void;
+}) {
+  const createInstance = useRecipes((s) => s.createInstance);
+  const instances = useRecipes((s) => s.instances);
+  const equipments = useEquipments((s) => s.equipments);
+  const [step, setStep] = useState<WizardStep>("choose");
+  const [selectedRecipeId, setSelectedRecipeId] = useState("");
+  const [params, setParams] = useState<Record<string, string>>({});
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const selectedRecipe = recipes.find((r) => r.id === selectedRecipeId);
+
+  // Light IDs already managed by a recipe instance in this zone
+  const usedLightIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const inst of instances) {
+      if (inst.params.zone === zoneId && typeof inst.params.light === "string") {
+        ids.add(inst.params.light);
+      }
+    }
+    return ids;
+  }, [instances, zoneId]);
+
+  // Filter equipments for current zone matching slot constraints, excluding already-used lights
+  const getEquipmentOptions = (slotId: string): EquipmentWithDetails[] => {
+    const slot = selectedRecipe?.slots.find((s) => s.id === slotId);
+    if (!slot) return [];
+    return equipments.filter((eq) => {
+      if (eq.zoneId !== zoneId) return false;
+      if (slot.type === "equipment" && usedLightIds.has(eq.id)) return false;
+      if (slot.constraints?.equipmentType) {
+        const eqType = eq.type;
+        const constraintType = slot.constraints.equipmentType;
+        if (constraintType === "light_onoff") {
+          return eqType === "light_onoff" || eqType === "light_dimmable" || eqType === "light_color";
+        }
+        return eqType === constraintType;
+      }
+      return true;
+    });
+  };
+
+  // Check if a recipe has available equipment slots (to disable recipes with no free lights)
+  const hasAvailableEquipments = (recipe: RecipeInfo): boolean => {
+    for (const slot of recipe.slots) {
+      if (slot.type !== "equipment") continue;
+      const available = equipments.filter((eq) => {
+        if (eq.zoneId !== zoneId) return false;
+        if (usedLightIds.has(eq.id)) return false;
+        if (slot.constraints?.equipmentType) {
+          const constraintType = slot.constraints.equipmentType;
+          if (constraintType === "light_onoff") {
+            return eq.type === "light_onoff" || eq.type === "light_dimmable" || eq.type === "light_color";
+          }
+          return eq.type === constraintType;
+        }
+        return true;
+      });
+      if (available.length === 0) return false;
+    }
+    return true;
+  };
+
+  // Initialize default params when recipe is selected
+  useEffect(() => {
+    if (!selectedRecipe) return;
+    const defaults: Record<string, string> = {};
+    for (const slot of selectedRecipe.slots) {
+      if (slot.id === "zone") {
+        defaults[slot.id] = zoneId;
+      } else if (slot.defaultValue !== undefined) {
+        defaults[slot.id] = String(slot.defaultValue);
+      } else {
+        defaults[slot.id] = "";
+      }
+    }
+    setParams(defaults);
+    setError("");
+  }, [selectedRecipeId, selectedRecipe, zoneId]);
+
+  const handleSelectRecipe = (recipeId: string) => {
+    setSelectedRecipeId(recipeId);
+    setStep("configure");
+  };
+
+  const handleBack = () => {
+    setStep("choose");
+    setSelectedRecipeId("");
+    setError("");
+  };
+
+  const handleSubmit = async () => {
+    if (!selectedRecipe) return;
+    setError("");
+    setSubmitting(true);
+
+    const finalParams: Record<string, unknown> = {};
+    for (const slot of selectedRecipe.slots) {
+      const value = params[slot.id];
+      if (slot.required && !value) {
+        setError(`${slot.name} is required`);
+        setSubmitting(false);
+        return;
+      }
+      finalParams[slot.id] = value;
+    }
+
+    try {
+      await createInstance(selectedRecipeId, finalParams);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="border-t border-border-light px-4 py-3 bg-border-light/20">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          {step === "configure" && (
+            <button
+              onClick={handleBack}
+              className="p-1 rounded-[4px] text-text-tertiary hover:text-text hover:bg-border-light/60 transition-colors duration-150"
+            >
+              <ChevronLeft size={14} strokeWidth={1.5} />
+            </button>
+          )}
+          <span className="text-[13px] font-medium text-text">
+            {step === "choose" ? "Choose a recipe" : selectedRecipe?.name}
+          </span>
+        </div>
+        <button onClick={onClose} className="p-1 text-text-tertiary hover:text-text transition-colors duration-150">
+          <X size={14} strokeWidth={1.5} />
+        </button>
+      </div>
+
+      {/* Step indicator */}
+      <div className="flex items-center gap-2 mb-3">
+        <div className={`h-1 flex-1 rounded-full ${step === "choose" ? "bg-primary" : "bg-primary/30"}`} />
+        <div className={`h-1 flex-1 rounded-full ${step === "configure" ? "bg-primary" : "bg-border-light"}`} />
+      </div>
+
+      {/* Step 1: Choose recipe */}
+      {step === "choose" && (() => {
+        const allUnavailable = recipes.length > 0 && recipes.every((r) => !hasAvailableEquipments(r));
+
+        if (allUnavailable) {
+          return (
+            <div className="text-center py-4">
+              <p className="text-[13px] text-text-secondary">
+                All lights in this zone are already managed by recipes.
+              </p>
+              <p className="text-[11px] text-text-tertiary mt-1">
+                Delete an existing recipe to free up a light.
+              </p>
+              <button
+                onClick={onClose}
+                className="mt-3 px-4 py-1.5 bg-border-light text-text-secondary text-[12px] font-medium rounded-[6px] hover:bg-border transition-colors duration-150"
+              >
+                Close
+              </button>
+            </div>
+          );
+        }
+
+        return (
+          <div className="space-y-2">
+            {recipes.map((recipe) => {
+              const available = hasAvailableEquipments(recipe);
+              return (
+                <button
+                  key={recipe.id}
+                  onClick={() => available && handleSelectRecipe(recipe.id)}
+                  disabled={!available}
+                  className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-[8px] border transition-all duration-150 text-left group ${
+                    available
+                      ? "border-border hover:border-primary/40 hover:bg-primary/5"
+                      : "border-border-light opacity-50 cursor-not-allowed"
+                  }`}
+                >
+                  <div className={`w-8 h-8 rounded-[6px] flex items-center justify-center flex-shrink-0 transition-colors duration-150 ${
+                    available ? "bg-accent/10 group-hover:bg-accent/15" : "bg-border-light"
+                  }`}>
+                    <ChefHat size={16} strokeWidth={1.5} className={available ? "text-accent" : "text-text-tertiary"} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-[13px] font-medium text-text">
+                      {recipe.name}
+                    </div>
+                    <div className="text-[11px] text-text-tertiary line-clamp-1">
+                      {available ? recipe.description : "All lights in this zone are already managed"}
+                    </div>
+                  </div>
+                  {available && (
+                    <ChevronRight size={14} strokeWidth={1.5} className="text-text-tertiary group-hover:text-primary flex-shrink-0 transition-colors duration-150" />
+                  )}
+                </button>
+              );
+            })}
+            {recipes.length === 0 && (
+              <p className="text-[13px] text-text-tertiary text-center py-4">
+                No recipes available
+              </p>
+            )}
+          </div>
+        );
+      })()}
+
+      {/* Step 2: Configure parameters */}
+      {step === "configure" && selectedRecipe && (
+        <>
+          <p className="text-[11px] text-text-tertiary mb-3">{selectedRecipe.description}</p>
+
+          {selectedRecipe.slots
+            .filter((slot) => slot.id !== "zone")
+            .map((slot) => (
+              <div key={slot.id} className="mb-3">
+                <label className="block text-[11px] text-text-tertiary uppercase tracking-wider mb-1">
+                  {slot.name}
+                </label>
+                {slot.type === "equipment" ? (
+                  <select
+                    value={params[slot.id] ?? ""}
+                    onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
+                    className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                  >
+                    <option value="">Select...</option>
+                    {getEquipmentOptions(slot.id).map((eq) => (
+                      <option key={eq.id} value={eq.id}>{eq.name}</option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    type="text"
+                    value={params[slot.id] ?? ""}
+                    onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
+                    placeholder={slot.defaultValue ? String(slot.defaultValue) : slot.description}
+                    className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text placeholder:text-text-tertiary"
+                  />
+                )}
+                <p className="text-[11px] text-text-tertiary mt-0.5">{slot.description}</p>
+              </div>
+            ))}
+
+          {error && (
+            <p className="text-[12px] text-error mb-3">{error}</p>
+          )}
+
+          <div className="flex gap-2">
+            <button
+              onClick={handleSubmit}
+              disabled={submitting}
+              className="flex-1 px-4 py-2 bg-primary text-white text-[13px] font-medium rounded-[6px] hover:bg-primary-hover transition-colors duration-150 disabled:opacity-50 flex items-center justify-center gap-2"
+            >
+              {submitting && <Loader2 size={14} className="animate-spin" />}
+              Create
+            </button>
+            <button
+              onClick={onClose}
+              className="px-4 py-2 bg-border-light text-text-secondary text-[13px] font-medium rounded-[6px] hover:bg-border transition-colors duration-150"
+            >
+              Cancel
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -1,4 +1,18 @@
 /**
+ * Format a timestamp as hh:mm:ss (24h local time).
+ */
+export function formatTime(iso: string | null): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  return date.toLocaleTimeString("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}
+
+/**
  * Format a timestamp as relative time ("2 min ago") or absolute ("Feb 16, 14:30").
  * Uses relative for timestamps less than 24h old, absolute otherwise.
  */

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -6,6 +6,7 @@ import { useEquipments } from "../store/useEquipments";
 import { useZoneAggregation } from "../store/useZoneAggregation";
 import { ZoneEquipmentsView } from "../components/home/ZoneEquipmentsView";
 import { ZoneAggregationHeader } from "../components/home/ZoneAggregationHeader";
+import { ZoneRecipesSection } from "../components/recipes/ZoneRecipesSection";
 import type { ZoneWithChildren } from "../types";
 
 export function HomePage() {
@@ -102,6 +103,13 @@ export function HomePage() {
         equipments={zoneEquipments}
         onExecuteOrder={executeOrder}
       />
+
+      {/* Recipes for this zone */}
+      {zoneId && (
+        <div className="mt-4">
+          <ZoneRecipesSection zoneId={zoneId} zoneName={currentZone.name} />
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/store/useEquipments.ts
+++ b/ui/src/store/useEquipments.ts
@@ -114,13 +114,14 @@ export const useEquipments = create<EquipmentsState>((set, get) => ({
   handleEquipmentUpdated: () => { get().fetchEquipments(); },
   handleEquipmentRemoved: () => { get().fetchEquipments(); },
   handleEquipmentDataChanged: (equipmentId, alias, value) => {
+    const now = new Date().toISOString();
     set((state) => ({
       equipments: state.equipments.map((eq) => {
         if (eq.id !== equipmentId) return eq;
         return {
           ...eq,
           dataBindings: eq.dataBindings.map((db) =>
-            db.alias === alias ? { ...db, value } : db
+            db.alias === alias ? { ...db, value, lastUpdated: now } : db
           ),
         };
       }),

--- a/ui/src/store/useRecipes.ts
+++ b/ui/src/store/useRecipes.ts
@@ -1,0 +1,72 @@
+import { create } from "zustand";
+import type { RecipeInfo, RecipeInstance, RecipeLogEntry } from "../types";
+import {
+  getRecipes,
+  getRecipeInstances,
+  createRecipeInstance,
+  updateRecipeInstance,
+  deleteRecipeInstance,
+  getRecipeInstanceLog,
+} from "../api";
+
+interface RecipesState {
+  recipes: RecipeInfo[];
+  instances: RecipeInstance[];
+  loading: boolean;
+  fetchRecipes: () => Promise<void>;
+  fetchInstances: () => Promise<void>;
+  createInstance: (recipeId: string, params: Record<string, unknown>) => Promise<RecipeInstance>;
+  updateInstance: (instanceId: string, params: Record<string, unknown>) => Promise<void>;
+  deleteInstance: (instanceId: string) => Promise<void>;
+  getLog: (instanceId: string) => Promise<RecipeLogEntry[]>;
+  handleInstanceChanged: () => void;
+}
+
+export const useRecipes = create<RecipesState>((set, get) => ({
+  recipes: [],
+  instances: [],
+  loading: false,
+
+  fetchRecipes: async () => {
+    try {
+      const recipes = await getRecipes();
+      set({ recipes });
+    } catch {
+      // Ignore — API may not be ready yet
+    }
+  },
+
+  fetchInstances: async () => {
+    set({ loading: true });
+    try {
+      const instances = await getRecipeInstances();
+      set({ instances, loading: false });
+    } catch {
+      set({ loading: false });
+    }
+  },
+
+  createInstance: async (recipeId, params) => {
+    const instance = await createRecipeInstance(recipeId, params);
+    await get().fetchInstances();
+    return instance;
+  },
+
+  updateInstance: async (instanceId, params) => {
+    await updateRecipeInstance(instanceId, params);
+    await get().fetchInstances();
+  },
+
+  deleteInstance: async (instanceId) => {
+    await deleteRecipeInstance(instanceId);
+    await get().fetchInstances();
+  },
+
+  getLog: async (instanceId) => {
+    return getRecipeInstanceLog(instanceId);
+  },
+
+  handleInstanceChanged: () => {
+    get().fetchInstances();
+  },
+}));

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -4,6 +4,7 @@ import { useDevices } from "./useDevices";
 import { useZones } from "./useZones";
 import { useEquipments } from "./useEquipments";
 import { useZoneAggregation } from "./useZoneAggregation";
+import { useRecipes } from "./useRecipes";
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected";
 
@@ -78,6 +79,14 @@ function handleEvent(event: EngineEvent): void {
         event.alias,
         event.value
       );
+      break;
+    case "recipe.instance.created":
+    case "recipe.instance.removed":
+    case "recipe.instance.started":
+    case "recipe.instance.stopped":
+    case "recipe.instance.error":
+    case "recipe.instance.state.changed":
+      useRecipes.getState().handleInstanceChanged();
       break;
     case "system.mqtt.connected":
       useWebSocket.setState({ mqttConnected: true });

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -243,8 +243,57 @@ export type EngineEvent =
       orderAlias: string;
       value: unknown;
     }
+  // Recipe events
+  | { type: "recipe.instance.created"; instanceId: string; recipeId: string }
+  | { type: "recipe.instance.removed"; instanceId: string; recipeId: string }
+  | { type: "recipe.instance.started"; instanceId: string; recipeId: string }
+  | { type: "recipe.instance.stopped"; instanceId: string; recipeId: string }
+  | { type: "recipe.instance.error"; instanceId: string; recipeId: string; error: string }
+  | { type: "recipe.instance.state.changed"; instanceId: string; recipeId: string }
   | { type: "system.started" }
   | { type: "system.mqtt.connected" }
   | { type: "system.mqtt.disconnected" }
   | { type: "system.error"; error: string }
   | { type: "connected"; message: string; version: string };
+
+// ============================================================
+// Recipe
+// ============================================================
+
+export interface RecipeSlotDef {
+  id: string;
+  name: string;
+  description: string;
+  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean";
+  required: boolean;
+  defaultValue?: unknown;
+  constraints?: {
+    equipmentType?: EquipmentType;
+    min?: number;
+    max?: number;
+  };
+}
+
+export interface RecipeInfo {
+  id: string;
+  name: string;
+  description: string;
+  slots: RecipeSlotDef[];
+}
+
+export interface RecipeInstance {
+  id: string;
+  recipeId: string;
+  params: Record<string, unknown>;
+  enabled: boolean;
+  createdAt: string;
+  state: Record<string, unknown>;
+}
+
+export interface RecipeLogEntry {
+  id: number;
+  instanceId: string;
+  timestamp: string;
+  message: string;
+  level: "info" | "warn" | "error";
+}


### PR DESCRIPTION
## Summary
- Recipe engine with abstract `Recipe` base class and full lifecycle management
- `RecipeManager` with instance CRUD, DB persistence, execution logging, state store
- **motion-light** recipe: auto-light on motion detection with configurable timeout
- Recipe instance editing (PUT endpoint), light filtering (no duplicates), countdown timer UI
- EventBus enhanced with unsubscribe support

## Changes
- **Backend**: Recipe engine (`src/recipes/`), API routes, migration, EventBus unsubscribe, `toISOUtc` helper
- **Frontend**: `ZoneRecipesSection` (wizard, edit, log, countdown), Zustand store, WS handler, elapsed counters
- **Docs**: implementation-status.md and user-manual.md updated for V0.8
- **Specs**: `specs/009-V0.8-recipes/`
- **Tests**: 21 new tests (recipe-manager: 9, motion-light: 12)

## Test plan
- [x] TypeScript compiles (zero errors backend + frontend)
- [x] All 160 tests pass
- [x] Manually verified with real MQTT/zigbee2mqtt
- [x] Recipe creation, editing, deletion
- [x] Motion-light: auto-on, countdown, auto-off, manual override
- [x] Light filtering: already-managed lights excluded from wizard
- [x] Recipe instances restored on engine restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)