### PR TITLE
feat: backup/restore, integrations page, device cleanup

### DIFF
--- a/migrations/007_settings.sql
+++ b/migrations/007_settings.sql
@@ -1,0 +1,6 @@
+-- Settings key-value table for integration configurations
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/api/routes/backup.ts
+++ b/src/api/routes/backup.ts
@@ -1,0 +1,136 @@
+import type { FastifyInstance } from "fastify";
+import type Database from "better-sqlite3";
+import type { Logger } from "../../core/logger.js";
+
+interface BackupDeps {
+  db: Database.Database;
+  logger: Logger;
+}
+
+// Tables to export, in dependency order (parents first)
+const BACKUP_TABLES = [
+  "settings",
+  "zones",
+  "devices",
+  "device_data",
+  "device_orders",
+  "equipments",
+  "data_bindings",
+  "order_bindings",
+  "users",
+  "api_tokens",
+  "recipe_instances",
+  "recipe_state",
+] as const;
+
+// Reverse order for deletion (children first)
+const DELETE_ORDER = [...BACKUP_TABLES].reverse();
+
+interface BackupPayload {
+  version: 1;
+  exportedAt: string;
+  tables: Record<string, unknown[]>;
+}
+
+export function registerBackupRoutes(app: FastifyInstance, deps: BackupDeps): void {
+  const { db, logger: parentLogger } = deps;
+  const logger = parentLogger.child({ module: "backup" });
+
+  // GET /api/v1/backup — Export full configuration as JSON
+  app.get("/api/v1/backup", async (request, reply) => {
+    if (!request.auth || request.auth.role !== "admin") {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+
+    const tables: Record<string, unknown[]> = {};
+    for (const table of BACKUP_TABLES) {
+      tables[table] = db.prepare(`SELECT * FROM ${table}`).all();
+    }
+
+    const payload: BackupPayload = {
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      tables,
+    };
+
+    logger.info("Configuration exported");
+
+    return reply
+      .header("Content-Disposition", `attachment; filename="corbel-backup-${new Date().toISOString().slice(0, 10)}.json"`)
+      .send(payload);
+  });
+
+  // POST /api/v1/backup — Restore configuration from JSON
+  app.post<{ Body: BackupPayload }>("/api/v1/backup", async (request, reply) => {
+    if (!request.auth || request.auth.role !== "admin") {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+
+    const payload = request.body;
+
+    // Validate structure
+    if (!payload || payload.version !== 1 || !payload.tables) {
+      return reply.code(400).send({ error: "Invalid backup format" });
+    }
+
+    // Validate that all tables in the payload are known
+    for (const tableName of Object.keys(payload.tables)) {
+      if (!(BACKUP_TABLES as readonly string[]).includes(tableName)) {
+        return reply.code(400).send({ error: `Unknown table: ${tableName}` });
+      }
+      if (!Array.isArray(payload.tables[tableName])) {
+        return reply.code(400).send({ error: `Table ${tableName} must be an array` });
+      }
+    }
+
+    try {
+      const restore = db.transaction(() => {
+        // Disable foreign keys during restore
+        db.pragma("foreign_keys = OFF");
+
+        // Delete all data in reverse dependency order
+        for (const table of DELETE_ORDER) {
+          db.prepare(`DELETE FROM ${table}`).run();
+        }
+
+        // Insert data in dependency order
+        for (const table of BACKUP_TABLES) {
+          const rows = payload.tables[table];
+          if (!rows || rows.length === 0) continue;
+
+          // Get column names from the first row
+          const firstRow = rows[0] as Record<string, unknown>;
+          const columns = Object.keys(firstRow);
+          const placeholders = columns.map(() => "?").join(", ");
+          const stmt = db.prepare(
+            `INSERT INTO ${table} (${columns.join(", ")}) VALUES (${placeholders})`,
+          );
+
+          for (const row of rows) {
+            const r = row as Record<string, unknown>;
+            stmt.run(...columns.map((col) => r[col] ?? null));
+          }
+        }
+
+        // Re-enable foreign keys
+        db.pragma("foreign_keys = ON");
+      });
+
+      restore();
+
+      logger.info(
+        { tables: Object.keys(payload.tables).length, exportedAt: payload.exportedAt },
+        "Configuration restored from backup",
+      );
+
+      return { success: true, restoredAt: new Date().toISOString() };
+    } catch (err) {
+      logger.error({ err }, "Backup restore failed");
+      // Re-enable foreign keys even on error
+      db.pragma("foreign_keys = ON");
+      return reply.code(500).send({
+        error: err instanceof Error ? err.message : "Restore failed",
+      });
+    }
+  });
+}

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -1,0 +1,85 @@
+import type { FastifyInstance } from "fastify";
+import type { Logger } from "../../core/logger.js";
+import type { SettingsManager } from "../../core/settings-manager.js";
+import type { MqttConnector } from "../../mqtt/mqtt-connector.js";
+
+interface SettingsDeps {
+  settingsManager: SettingsManager;
+  mqttConnector: MqttConnector;
+  logger: Logger;
+}
+
+export function registerSettingsRoutes(app: FastifyInstance, deps: SettingsDeps): void {
+  const { settingsManager, mqttConnector, logger: parentLogger } = deps;
+  const logger = parentLogger.child({ module: "settings-routes" });
+
+  // GET /api/v1/settings — Get all settings (admin only)
+  app.get("/api/v1/settings", async (request, reply) => {
+    if (!request.auth || request.auth.role !== "admin") {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+
+    return settingsManager.getAll();
+  });
+
+  // PUT /api/v1/settings — Update settings (admin only)
+  app.put<{ Body: Record<string, string> }>("/api/v1/settings", async (request, reply) => {
+    if (!request.auth || request.auth.role !== "admin") {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+
+    const entries = request.body;
+    if (!entries || typeof entries !== "object") {
+      return reply.code(400).send({ error: "Body must be a key-value object" });
+    }
+
+    // Validate all values are strings
+    for (const [key, value] of Object.entries(entries)) {
+      if (typeof key !== "string" || typeof value !== "string") {
+        return reply.code(400).send({ error: `Invalid entry: ${key}` });
+      }
+    }
+
+    settingsManager.setMany(entries);
+    logger.info({ keys: Object.keys(entries) }, "Settings updated");
+
+    return { success: true };
+  });
+
+  // POST /api/v1/settings/mqtt/reconnect — Apply MQTT settings and reconnect (admin only)
+  app.post("/api/v1/settings/mqtt/reconnect", async (request, reply) => {
+    if (!request.auth || request.auth.role !== "admin") {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+
+    try {
+      const mqttConfig = settingsManager.getMqttConfig();
+      await mqttConnector.reconnect(mqttConfig.url, {
+        username: mqttConfig.username,
+        password: mqttConfig.password,
+        clientId: mqttConfig.clientId,
+      });
+
+      return {
+        success: true,
+        connected: mqttConnector.isConnected(),
+      };
+    } catch (err) {
+      logger.error({ err }, "MQTT reconnect failed");
+      return reply.code(500).send({
+        error: err instanceof Error ? err.message : "Reconnect failed",
+      });
+    }
+  });
+
+  // GET /api/v1/settings/mqtt/status — Get MQTT connection status
+  app.get("/api/v1/settings/mqtt/status", async (request, reply) => {
+    if (!request.auth || request.auth.role !== "admin") {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+
+    return {
+      connected: mqttConnector.isConnected(),
+    };
+  });
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -8,9 +8,11 @@ import type { ZoneAggregator } from "../zones/zone-aggregator.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { MqttConnector } from "../mqtt/mqtt-connector.js";
+import type Database from "better-sqlite3";
 import type { RecipeManager } from "../recipes/engine/recipe-manager.js";
 import type { UserManager } from "../auth/user-manager.js";
 import type { AuthService } from "../auth/auth-service.js";
+import type { SettingsManager } from "../core/settings-manager.js";
 import { registerAuthMiddleware } from "../auth/auth-middleware.js";
 import { registerDeviceRoutes } from "./routes/devices.js";
 import { registerHealthRoutes } from "./routes/health.js";
@@ -20,9 +22,12 @@ import { registerRecipeRoutes } from "./routes/recipes.js";
 import { registerAuthRoutes } from "./routes/auth.js";
 import { registerMeRoutes } from "./routes/me.js";
 import { registerUserRoutes } from "./routes/users.js";
+import { registerBackupRoutes } from "./routes/backup.js";
+import { registerSettingsRoutes } from "./routes/settings.js";
 import { registerWebSocket } from "./websocket.js";
 
 interface ServerDeps {
+  db: Database.Database;
   deviceManager: DeviceManager;
   zoneManager: ZoneManager;
   zoneAggregator: ZoneAggregator;
@@ -30,6 +35,7 @@ interface ServerDeps {
   recipeManager: RecipeManager;
   userManager: UserManager;
   authService: AuthService;
+  settingsManager: SettingsManager;
   eventBus: EventBus;
   mqttConnector: MqttConnector;
   logger: Logger;
@@ -38,8 +44,8 @@ interface ServerDeps {
 
 export async function createServer(deps: ServerDeps) {
   const {
-    deviceManager, zoneManager, zoneAggregator, equipmentManager, recipeManager,
-    userManager, authService, eventBus, mqttConnector, logger, corsOrigins,
+    db, deviceManager, zoneManager, zoneAggregator, equipmentManager, recipeManager,
+    userManager, authService, settingsManager, eventBus, mqttConnector, logger, corsOrigins,
   } = deps;
 
   const app = Fastify({
@@ -67,6 +73,8 @@ export async function createServer(deps: ServerDeps) {
   registerZoneRoutes(app, { zoneManager, zoneAggregator, logger });
   registerEquipmentRoutes(app, { equipmentManager, logger });
   registerRecipeRoutes(app, { recipeManager, logger });
+  registerBackupRoutes(app, { db, logger });
+  registerSettingsRoutes(app, { settingsManager, mqttConnector, logger });
   registerWebSocket(app, { eventBus, authService, logger });
 
   return app;

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,15 +23,6 @@ function envInt(key: string, fallback: number): number {
 
 export function loadConfig(): AppConfig {
   return {
-    mqtt: {
-      url: env("MQTT_URL", "mqtt://localhost:1883"),
-      username: process.env["MQTT_USERNAME"] || undefined,
-      password: process.env["MQTT_PASSWORD"] || undefined,
-      clientId: env("MQTT_CLIENT_ID", "corbel"),
-    },
-    z2m: {
-      baseTopic: env("Z2M_BASE_TOPIC", "zigbee2mqtt"),
-    },
     sqlite: {
       path: env("SQLITE_PATH", "./data/corbel.db"),
     },

--- a/src/core/settings-manager.ts
+++ b/src/core/settings-manager.ts
@@ -1,0 +1,105 @@
+import type Database from "better-sqlite3";
+
+export interface SettingRow {
+  key: string;
+  value: string;
+  updated_at: string;
+}
+
+/**
+ * Manages key-value settings stored in SQLite.
+ * Integration settings (MQTT, Z2M) are configured from the UI.
+ */
+export class SettingsManager {
+  private db: Database.Database;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+  }
+
+  /** Get a single setting value, or undefined if not set. */
+  get(key: string): string | undefined {
+    const row = this.db
+      .prepare("SELECT value FROM settings WHERE key = ?")
+      .get(key) as { value: string } | undefined;
+    return row?.value;
+  }
+
+  /** Get all settings as a key-value record. */
+  getAll(): Record<string, string> {
+    const rows = this.db
+      .prepare("SELECT key, value FROM settings")
+      .all() as SettingRow[];
+    const result: Record<string, string> = {};
+    for (const row of rows) {
+      result[row.key] = row.value;
+    }
+    return result;
+  }
+
+  /** Get all settings that start with a given prefix. */
+  getByPrefix(prefix: string): Record<string, string> {
+    const rows = this.db
+      .prepare("SELECT key, value FROM settings WHERE key LIKE ?")
+      .all(`${prefix}%`) as SettingRow[];
+    const result: Record<string, string> = {};
+    for (const row of rows) {
+      result[row.key] = row.value;
+    }
+    return result;
+  }
+
+  /** Set a single setting. */
+  set(key: string, value: string): void {
+    this.db
+      .prepare(
+        `INSERT INTO settings (key, value, updated_at)
+         VALUES (?, ?, datetime('now'))
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+      )
+      .run(key, value);
+  }
+
+  /** Set multiple settings at once. */
+  setMany(entries: Record<string, string>): void {
+    const stmt = this.db.prepare(
+      `INSERT INTO settings (key, value, updated_at)
+       VALUES (?, ?, datetime('now'))
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    );
+    const tx = this.db.transaction(() => {
+      for (const [key, value] of Object.entries(entries)) {
+        stmt.run(key, value);
+      }
+    });
+    tx();
+  }
+
+  /** Returns true if MQTT integration has been configured from the UI. */
+  isMqttConfigured(): boolean {
+    return this.get("mqtt.url") !== undefined;
+  }
+
+  /** Get MQTT connection config from settings. */
+  getMqttConfig(): {
+    url: string;
+    username?: string;
+    password?: string;
+    clientId: string;
+  } {
+    const settings = this.getByPrefix("mqtt.");
+    return {
+      url: settings["mqtt.url"] ?? "mqtt://localhost:1883",
+      username: settings["mqtt.username"] || undefined,
+      password: settings["mqtt.password"] || undefined,
+      clientId: settings["mqtt.clientId"] ?? "corbel",
+    };
+  }
+
+  /** Get Zigbee2mqtt config from settings. */
+  getZ2mConfig(): { baseTopic: string } {
+    return {
+      baseTopic: this.get("z2m.baseTopic") ?? "zigbee2mqtt",
+    };
+  }
+}

--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -200,7 +200,7 @@ describe("DeviceManager", () => {
   });
 
   describe("updateDeviceStatus", () => {
-    it("updates status and emits event", () => {
+    it("updates status to online and emits event", () => {
       manager.upsertFromDiscovery("zigbee2mqtt", sampleDevice);
       events.length = 0;
 
@@ -214,6 +214,16 @@ describe("DeviceManager", () => {
         expect(statusEvent.status).toBe("online");
         expect(statusEvent.deviceName).toBe("salon_pir");
       }
+    });
+
+    it("deletes device on offline status", () => {
+      manager.upsertFromDiscovery("zigbee2mqtt", sampleDevice);
+      events.length = 0;
+
+      manager.updateDeviceStatus("zigbee2mqtt", "salon_pir", "offline");
+
+      expect(manager.getAll()).toHaveLength(0);
+      expect(events.find((e) => e.type === "device.removed")).toBeDefined();
     });
 
     it("does not emit event if status unchanged", () => {
@@ -285,15 +295,52 @@ describe("DeviceManager", () => {
   });
 
   describe("markRemoved", () => {
-    it("sets device offline and emits event", () => {
+    it("deletes device from DB and emits event", () => {
       manager.upsertFromDiscovery("zigbee2mqtt", sampleDevice);
       events.length = 0;
 
       manager.markRemoved("zigbee2mqtt", "salon_pir");
 
-      const device = manager.getAll()[0];
-      expect(device.status).toBe("offline");
+      expect(manager.getAll()).toHaveLength(0);
       expect(events.find((e) => e.type === "device.removed")).toBeDefined();
+    });
+  });
+
+  describe("removeStaleDevices", () => {
+    it("deletes devices not in active set", () => {
+      manager.upsertFromDiscovery("zigbee2mqtt", sampleDevice);
+      manager.upsertFromDiscovery("zigbee2mqtt", sampleLight);
+      events.length = 0;
+
+      // Only salon_lampe is active — salon_pir should be removed
+      manager.removeStaleDevices("zigbee2mqtt", new Set(["salon_lampe"]));
+
+      const devices = manager.getAll();
+      expect(devices).toHaveLength(1);
+      expect(devices[0].name).toBe("salon_lampe");
+      expect(events.filter((e) => e.type === "device.removed")).toHaveLength(1);
+    });
+
+    it("does nothing when all devices are active", () => {
+      manager.upsertFromDiscovery("zigbee2mqtt", sampleDevice);
+      manager.upsertFromDiscovery("zigbee2mqtt", sampleLight);
+      events.length = 0;
+
+      manager.removeStaleDevices("zigbee2mqtt", new Set(["salon_pir", "salon_lampe"]));
+
+      expect(manager.getAll()).toHaveLength(2);
+      expect(events.filter((e) => e.type === "device.removed")).toHaveLength(0);
+    });
+
+    it("only affects devices with matching baseTopic", () => {
+      manager.upsertFromDiscovery("zigbee2mqtt", sampleDevice);
+      events.length = 0;
+
+      // Different baseTopic — should not touch zigbee2mqtt devices
+      manager.removeStaleDevices("other_topic", new Set());
+
+      expect(manager.getAll()).toHaveLength(1);
+      expect(events.filter((e) => e.type === "device.removed")).toHaveLength(0);
     });
   });
 

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -255,17 +255,34 @@ export class DeviceManager {
   }
 
   /**
-   * Mark a device as removed (offline) when it disappears from bridge/devices.
-   * Does NOT delete from DB — user can delete via API.
+   * Remove a device from DB when it disappears from bridge/devices.
    */
   markRemoved(baseTopic: string, mqttName: string): void {
     const existing = this.stmts.findDeviceByMqtt.get(baseTopic, mqttName) as
       | DeviceRow
       | undefined;
     if (existing) {
-      this.stmts.updateDeviceStatus.run("offline", existing.id);
-      this.logger.warn({ deviceId: existing.id, name: mqttName }, "Device removed from bridge");
+      this.stmts.deleteDevice.run(existing.id);
+      this.logger.warn({ deviceId: existing.id, name: mqttName }, "Device removed from bridge — deleted from DB");
       this.eventBus.emit({ type: "device.removed", deviceId: existing.id, deviceName: existing.name });
+    }
+  }
+
+  /**
+   * Remove all devices for a baseTopic that are NOT in the active set.
+   * Called after processing bridge/devices to clean up stale DB entries.
+   */
+  removeStaleDevices(baseTopic: string, activeNames: Set<string>): void {
+    const allDevices = this.db
+      .prepare("SELECT id, mqtt_name, name FROM devices WHERE mqtt_base_topic = ?")
+      .all(baseTopic) as { id: string; mqtt_name: string; name: string }[];
+
+    for (const device of allDevices) {
+      if (!activeNames.has(device.mqtt_name)) {
+        this.stmts.deleteDevice.run(device.id);
+        this.logger.warn({ deviceId: device.id, name: device.mqtt_name }, "Stale device cleaned up — not in bridge device list");
+        this.eventBus.emit({ type: "device.removed", deviceId: device.id, deviceName: device.name });
+      }
     }
   }
 
@@ -334,7 +351,9 @@ export class DeviceManager {
   }
 
   /**
-   * Update device online/offline status.
+   * Update device status.
+   * "online" → update status in DB.
+   * "offline" → delete device from DB (will be re-created on next bridge/devices if still present).
    */
   updateDeviceStatus(
     baseTopic: string,
@@ -345,6 +364,13 @@ export class DeviceManager {
       | DeviceRow
       | undefined;
     if (!device) return;
+
+    if (status === "offline") {
+      this.stmts.deleteDevice.run(device.id);
+      this.logger.info({ deviceId: device.id, name: mqttName }, "Device offline — deleted from DB");
+      this.eventBus.emit({ type: "device.removed", deviceId: device.id, deviceName: device.name });
+      return;
+    }
 
     if (device.status !== status) {
       this.stmts.updateDeviceStatus.run(status, device.id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { RecipeManager } from "./recipes/engine/recipe-manager.js";
 import { MotionLightRecipe } from "./recipes/motion-light.js";
 import { UserManager } from "./auth/user-manager.js";
 import { AuthService } from "./auth/auth-service.js";
+import { SettingsManager } from "./core/settings-manager.js";
 import { createServer } from "./api/server.js";
 
 async function main() {
@@ -31,16 +32,20 @@ async function main() {
   );
   runMigrations(db, migrationsDir, logger);
 
-  // 4. Create Event Bus
+  // 4. Create Settings Manager
+  const settingsManager = new SettingsManager(db);
+
+  // 5. Create Event Bus
   const eventBus = new EventBus(logger);
 
-  // 5. Create MQTT Connector
+  // 6. Create MQTT Connector (settings come from DB, configured via UI)
+  const mqttConfig = settingsManager.getMqttConfig();
   const mqttConnector = new MqttConnector(
-    config.mqtt.url,
+    mqttConfig.url,
     {
-      username: config.mqtt.username,
-      password: config.mqtt.password,
-      clientId: config.mqtt.clientId,
+      username: mqttConfig.username,
+      password: mqttConfig.password,
+      clientId: mqttConfig.clientId,
     },
     eventBus,
     logger,
@@ -67,19 +72,25 @@ async function main() {
   const authService = new AuthService(db, userManager, config.jwt, logger);
 
   // 7. Create zigbee2mqtt parser
+  const z2mConfig = settingsManager.getZ2mConfig();
   const z2mParser = new Zigbee2MqttParser(
-    config.z2m.baseTopic,
+    z2mConfig.baseTopic,
     mqttConnector,
     deviceManager,
     logger,
   );
 
-  // 8. Connect to MQTT and start parser
-  await mqttConnector.connect();
-  z2mParser.start();
+  // 8. Connect to MQTT and start parser (only if integration is configured)
+  if (settingsManager.isMqttConfigured()) {
+    await mqttConnector.connect();
+    z2mParser.start();
+  } else {
+    logger.info("MQTT integration not configured — configure it from Administration > Intégrations");
+  }
 
   // 9. Start Fastify server
   const server = await createServer({
+    db,
     deviceManager,
     zoneManager,
     zoneAggregator,
@@ -87,6 +98,7 @@ async function main() {
     recipeManager,
     userManager,
     authService,
+    settingsManager,
     eventBus,
     mqttConnector,
     logger,

--- a/src/mqtt/mqtt-connector.ts
+++ b/src/mqtt/mqtt-connector.ts
@@ -118,10 +118,56 @@ export class MqttConnector {
     return this.client?.connected ?? false;
   }
 
+  /**
+   * Reconnect with new broker settings.
+   * Disconnects, updates URL/options, reconnects, and re-subscribes all handlers.
+   */
+  async reconnect(
+    url: string,
+    options: { username?: string; password?: string; clientId: string },
+  ): Promise<void> {
+    this.logger.info({ url }, "Reconnecting MQTT with new settings");
+
+    // Disconnect existing client
+    if (this.client) {
+      try {
+        await this.client.endAsync(true);
+      } catch {
+        // Ignore disconnect errors
+      }
+      this.client = null;
+    }
+
+    // Update connection settings
+    this.url = url;
+    this.options = {
+      clientId: options.clientId,
+      username: options.username,
+      password: options.password,
+      clean: true,
+      reconnectPeriod: 5000,
+    };
+
+    // Reconnect (preserves all registered handlers)
+    await this.connect();
+    this.resubscribeAll();
+  }
+
   async disconnect(): Promise<void> {
     if (this.client) {
       await this.client.endAsync();
       this.logger.info("MQTT disconnected");
+    }
+  }
+
+  private resubscribeAll(): void {
+    if (!this.client) return;
+    for (const pattern of this.handlers.keys()) {
+      this.client.subscribe(pattern, (err) => {
+        if (err) {
+          this.logger.error({ err, topic: pattern }, "MQTT re-subscribe error");
+        }
+      });
     }
   }
 

--- a/src/mqtt/parsers/zigbee2mqtt.ts
+++ b/src/mqtt/parsers/zigbee2mqtt.ts
@@ -38,7 +38,6 @@ export class Zigbee2MqttParser {
   private mqttConnector: MqttConnector;
   private deviceManager: DeviceManager;
   private baseTopic: string;
-  private knownDeviceNames = new Set<string>();
 
   constructor(
     baseTopic: string,
@@ -105,14 +104,8 @@ export class Zigbee2MqttParser {
         }
       }
 
-      // Detect removed devices
-      for (const name of this.knownDeviceNames) {
-        if (!currentNames.has(name)) {
-          this.deviceManager.markRemoved(this.baseTopic, name);
-        }
-      }
-
-      this.knownDeviceNames = currentNames;
+      // Clean up devices in DB that are no longer in the bridge device list
+      this.deviceManager.removeStaleDevices(this.baseTopic, currentNames);
       this.deviceManager.logSummary();
     } catch (err) {
       this.logger.error({ err }, "Failed to parse bridge/devices");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -386,15 +386,6 @@ export interface Z2MBridgeEvent {
 // ============================================================
 
 export interface AppConfig {
-  mqtt: {
-    url: string;
-    username?: string;
-    password?: string;
-    clientId: string;
-  };
-  z2m: {
-    baseTopic: string;
-  };
   sqlite: {
     path: string;
   };

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -11,6 +11,7 @@ import { EquipmentsPage } from "./pages/EquipmentsPage";
 import { EquipmentDetailPage } from "./pages/EquipmentDetailPage";
 import { HomePage } from "./pages/HomePage";
 import { SettingsPage } from "./pages/SettingsPage";
+import { IntegrationsPage } from "./pages/IntegrationsPage";
 
 export default function App() {
   return (
@@ -40,6 +41,7 @@ export default function App() {
           <Route path="/zones" element={<ZonesPage />} />
           <Route path="/zones/:id" element={<ZoneDetailPage />} />
           <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/integrations" element={<IntegrationsPage />} />
 
           {/* Default redirect to Maison */}
           <Route path="*" element={<Navigate to="/home" replace />} />

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -213,6 +213,10 @@ export async function updateDevice(
   });
 }
 
+export async function deleteDevice(id: string): Promise<void> {
+  return fetchJSON<void>(`${API_BASE}/devices/${id}`, { method: "DELETE" });
+}
+
 export async function getDeviceRawExpose(
   id: string
 ): Promise<{ deviceId: string; name: string; mqttName: string; expose: unknown }> {
@@ -408,4 +412,54 @@ export async function getRecipeInstanceLog(
   limit = 50,
 ): Promise<RecipeLogEntry[]> {
   return fetchJSON<RecipeLogEntry[]>(`${API_BASE}/recipe-instances/${instanceId}/log?limit=${limit}`);
+}
+
+// ============================================================
+// Settings (admin)
+// ============================================================
+
+export async function getSettings(): Promise<Record<string, string>> {
+  return fetchJSON<Record<string, string>>(`${API_BASE}/settings`);
+}
+
+export async function updateSettings(entries: Record<string, string>): Promise<{ success: boolean }> {
+  return fetchJSON(`${API_BASE}/settings`, {
+    method: "PUT",
+    body: JSON.stringify(entries),
+  });
+}
+
+export async function reconnectMqtt(): Promise<{ success: boolean; connected: boolean }> {
+  return fetchJSON(`${API_BASE}/settings/mqtt/reconnect`, {
+    method: "POST",
+  });
+}
+
+export async function getMqttStatus(): Promise<{ connected: boolean }> {
+  return fetchJSON(`${API_BASE}/settings/mqtt/status`);
+}
+
+// ============================================================
+// Backup (admin)
+// ============================================================
+
+export async function exportBackup(): Promise<Blob> {
+  const headers: Record<string, string> = {};
+  if (_accessToken) {
+    headers["Authorization"] = `Bearer ${_accessToken}`;
+  }
+  const response = await fetch(`${API_BASE}/backup`, { headers });
+  if (!response.ok) {
+    throw new Error(`Export failed: ${response.statusText}`);
+  }
+  return response.blob();
+}
+
+export async function importBackup(file: File): Promise<{ success: boolean }> {
+  const text = await file.text();
+  const payload = JSON.parse(text);
+  return fetchJSON(`${API_BASE}/backup`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
 }

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -3,6 +3,7 @@ import {
   Radio,
   Box,
   Map,
+  Plug,
   Settings,
   Shield,
   Home,
@@ -24,6 +25,7 @@ const ADMIN_ITEMS: NavItem[] = [
   { to: "/devices", label: "nav.devices", icon: <Radio size={18} strokeWidth={1.5} /> },
   { to: "/equipments", label: "nav.equipments", icon: <Box size={18} strokeWidth={1.5} /> },
   { to: "/zones", label: "nav.zones", icon: <Map size={18} strokeWidth={1.5} /> },
+  { to: "/integrations", label: "nav.integrations", icon: <Plug size={18} strokeWidth={1.5} /> },
 ];
 
 export function Sidebar() {

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -97,6 +97,7 @@
   "devices.col.updated": "Updated",
   "devices.col.range": "Range / Values",
   "devices.col.topic": "Topic",
+  "devices.deleteConfirm": "Delete this device from Corbel? It will be re-discovered automatically if still active on the bridge.",
 
   "zones.title": "Home Topology",
   "zones.subtitle": "Define the topology of your home",
@@ -297,5 +298,27 @@
   "settings.role": "Role",
   "settings.enabled": "Enabled",
   "settings.deleteUserConfirm": "Delete user \"{{name}}\"?",
-  "settings.cannotDeleteSelf": "Cannot delete your own account"
+  "settings.cannotDeleteSelf": "Cannot delete your own account",
+
+  "settings.backup": "Backup / Restore",
+  "settings.backupDescription": "Export or import the full Corbel configuration (zones, devices, equipments, users, recipes, integrations).",
+  "settings.exportBackup": "Export",
+  "settings.importBackup": "Import",
+  "settings.backupExported": "Backup exported successfully",
+  "settings.backupImported": "Backup imported successfully. Restart Corbel to apply changes.",
+
+  "nav.integrations": "Integrations",
+
+  "integrations.title": "Integrations",
+  "integrations.subtitle": "Configure connections with your home automation systems.",
+  "integrations.z2mDescription": "Zigbee to MQTT gateway",
+  "integrations.mqttUrl": "MQTT broker URL",
+  "integrations.mqttUsername": "Username",
+  "integrations.mqttPassword": "Password",
+  "integrations.mqttClientId": "Client ID",
+  "integrations.z2mBaseTopic": "Z2M base topic",
+  "integrations.reconnect": "Reconnect",
+  "integrations.saved": "Configuration saved",
+  "integrations.reconnectSuccess": "MQTT reconnection successful",
+  "integrations.reconnectFailed": "MQTT reconnection failed — check settings"
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -97,6 +97,7 @@
   "devices.col.updated": "Mis à jour",
   "devices.col.range": "Plage / Valeurs",
   "devices.col.topic": "Topic",
+  "devices.deleteConfirm": "Supprimer cet appareil de Corbel ? Il sera redécouvert automatiquement s'il est toujours actif sur le bridge.",
 
   "zones.title": "Topologie",
   "zones.subtitle": "Définissez la topologie de votre maison",
@@ -297,5 +298,27 @@
   "settings.role": "Rôle",
   "settings.enabled": "Actif",
   "settings.deleteUserConfirm": "Supprimer l'utilisateur « {{name}} » ?",
-  "settings.cannotDeleteSelf": "Vous ne pouvez pas supprimer votre propre compte"
+  "settings.cannotDeleteSelf": "Vous ne pouvez pas supprimer votre propre compte",
+
+  "settings.backup": "Sauvegarde / Restauration",
+  "settings.backupDescription": "Exportez ou importez la configuration complète de Corbel (zones, appareils, équipements, utilisateurs, recettes, intégrations).",
+  "settings.exportBackup": "Exporter",
+  "settings.importBackup": "Importer",
+  "settings.backupExported": "Sauvegarde exportée avec succès",
+  "settings.backupImported": "Sauvegarde importée avec succès. Redémarrez Corbel pour appliquer les changements.",
+
+  "nav.integrations": "Intégrations",
+
+  "integrations.title": "Intégrations",
+  "integrations.subtitle": "Configurez les connexions avec vos systèmes domotiques.",
+  "integrations.z2mDescription": "Passerelle Zigbee vers MQTT",
+  "integrations.mqttUrl": "URL du broker MQTT",
+  "integrations.mqttUsername": "Identifiant",
+  "integrations.mqttPassword": "Mot de passe",
+  "integrations.mqttClientId": "Client ID",
+  "integrations.z2mBaseTopic": "Topic de base Z2M",
+  "integrations.reconnect": "Reconnecter",
+  "integrations.saved": "Configuration enregistrée",
+  "integrations.reconnectSuccess": "Reconnexion MQTT réussie",
+  "integrations.reconnectFailed": "Reconnexion MQTT échouée — vérifiez les paramètres"
 }

--- a/ui/src/pages/DeviceDetailPage.tsx
+++ b/ui/src/pages/DeviceDetailPage.tsx
@@ -8,9 +8,10 @@ import {
   ChevronDown,
   ChevronRight,
   Zap,
+  Trash2,
 } from "lucide-react";
 import type { DeviceOrder, DeviceWithDetails } from "../types";
-import { getDevice, getDeviceRawExpose } from "../api";
+import { getDevice, getDeviceRawExpose, deleteDevice } from "../api";
 import { useDevices } from "../store/useDevices";
 import { DeviceNameEditor } from "../components/devices/DeviceNameEditor";
 import { DeviceDataTable } from "../components/devices/DeviceDataTable";
@@ -32,6 +33,19 @@ export function DeviceDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showRaw, setShowRaw] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    if (!id) return;
+    if (!confirm(t("devices.deleteConfirm"))) return;
+    setDeleting(true);
+    try {
+      await deleteDevice(id);
+      navigate("/devices");
+    } catch {
+      setDeleting(false);
+    }
+  };
 
   useEffect(() => {
     if (!id) return;
@@ -122,6 +136,14 @@ export function DeviceDetailPage() {
             </div>
           </div>
         </div>
+        <button
+          onClick={handleDelete}
+          disabled={deleting}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-[6px] text-[12px] font-medium text-error hover:bg-error/10 transition-colors duration-150 cursor-pointer disabled:opacity-50"
+        >
+          <Trash2 size={14} strokeWidth={1.5} />
+          {deleting ? t("common.deleting") : t("common.delete")}
+        </button>
       </div>
 
       {/* Info bar */}

--- a/ui/src/pages/IntegrationsPage.tsx
+++ b/ui/src/pages/IntegrationsPage.tsx
@@ -1,0 +1,244 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Loader2, Plug, Wifi, WifiOff, RefreshCw } from "lucide-react";
+import { getSettings, updateSettings, reconnectMqtt, getMqttStatus } from "../api";
+
+export function IntegrationsPage() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="p-6">
+      <div className="mb-6">
+        <div className="flex items-center gap-2.5 mb-1">
+          <Plug size={22} strokeWidth={1.5} className="text-text-secondary" />
+          <h1 className="text-[24px] font-semibold text-text leading-[32px]">
+            {t("integrations.title")}
+          </h1>
+        </div>
+        <p className="text-[13px] text-text-secondary mt-1">{t("integrations.subtitle")}</p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Zigbee2mqttCard />
+      </div>
+    </div>
+  );
+}
+
+function Zigbee2mqttCard() {
+  const { t } = useTranslation();
+  const [settings, setSettings] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [dirty, setDirty] = useState(false);
+
+  // Editable fields
+  const [mqttUrl, setMqttUrl] = useState("");
+  const [mqttUsername, setMqttUsername] = useState("");
+  const [mqttPassword, setMqttPassword] = useState("");
+  const [mqttClientId, setMqttClientId] = useState("");
+  const [z2mBaseTopic, setZ2mBaseTopic] = useState("");
+
+  const load = async () => {
+    try {
+      const [data, status] = await Promise.all([getSettings(), getMqttStatus()]);
+      setSettings(data);
+      setConnected(status.connected);
+      setMqttUrl(data["mqtt.url"] ?? "");
+      setMqttUsername(data["mqtt.username"] ?? "");
+      setMqttPassword(data["mqtt.password"] ?? "");
+      setMqttClientId(data["mqtt.clientId"] ?? "");
+      setZ2mBaseTopic(data["z2m.baseTopic"] ?? "");
+      setDirty(false);
+    } catch {
+      setError(t("common.error"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  // Check if any field has changed
+  const checkDirty = (field: string, value: string) => {
+    const next = { ...settings, [field]: value };
+    const changed = Object.keys(next).some((k) => next[k] !== settings[k]);
+    setDirty(changed);
+  };
+
+  const handleSave = async () => {
+    setError("");
+    setSuccess("");
+    setSaving(true);
+    try {
+      await updateSettings({
+        "mqtt.url": mqttUrl,
+        "mqtt.username": mqttUsername,
+        "mqtt.password": mqttPassword,
+        "mqtt.clientId": mqttClientId,
+        "z2m.baseTopic": z2mBaseTopic,
+      });
+      // Reload settings from server
+      const data = await getSettings();
+      setSettings(data);
+      setDirty(false);
+      setSuccess(t("integrations.saved"));
+      setTimeout(() => setSuccess(""), 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("common.error"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReconnect = async () => {
+    setError("");
+    setSuccess("");
+    setReconnecting(true);
+    try {
+      const result = await reconnectMqtt();
+      setConnected(result.connected);
+      setSuccess(
+        result.connected
+          ? t("integrations.reconnectSuccess")
+          : t("integrations.reconnectFailed"),
+      );
+      setTimeout(() => setSuccess(""), 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("common.error"));
+    } finally {
+      setReconnecting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-surface rounded-[10px] border border-border p-5 flex items-center justify-center py-12">
+        <Loader2 size={20} className="animate-spin text-text-tertiary" />
+      </div>
+    );
+  }
+
+  return (
+    <section className="bg-surface rounded-[10px] border border-border p-5">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2.5">
+          <div className="w-8 h-8 bg-yellow-100 dark:bg-yellow-900/30 rounded-[6px] flex items-center justify-center">
+            <Plug size={16} className="text-yellow-600 dark:text-yellow-400" />
+          </div>
+          <div>
+            <h2 className="text-[14px] font-semibold text-text">Zigbee2MQTT</h2>
+            <p className="text-[11px] text-text-tertiary">{t("integrations.z2mDescription")}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5">
+          {connected ? (
+            <Wifi size={14} className="text-green-500" />
+          ) : (
+            <WifiOff size={14} className="text-red-500" />
+          )}
+          <span className={`text-[11px] font-medium ${connected ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}>
+            {connected ? t("status.connected") : t("status.disconnected")}
+          </span>
+        </div>
+      </div>
+
+      {/* Form */}
+      <div className="space-y-3">
+        <div>
+          <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+            {t("integrations.mqttUrl")}
+          </label>
+          <input
+            type="text"
+            value={mqttUrl}
+            onChange={(e) => { setMqttUrl(e.target.value); checkDirty("mqtt.url", e.target.value); }}
+            placeholder="mqtt://localhost:1883"
+            className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text placeholder:text-text-tertiary focus:outline-none focus:border-primary"
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+              {t("integrations.mqttUsername")}
+              <span className="text-text-tertiary ml-1">({t("common.optional")})</span>
+            </label>
+            <input
+              type="text"
+              value={mqttUsername}
+              onChange={(e) => { setMqttUsername(e.target.value); checkDirty("mqtt.username", e.target.value); }}
+              className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text focus:outline-none focus:border-primary"
+            />
+          </div>
+          <div>
+            <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+              {t("integrations.mqttPassword")}
+              <span className="text-text-tertiary ml-1">({t("common.optional")})</span>
+            </label>
+            <input
+              type="password"
+              value={mqttPassword}
+              onChange={(e) => { setMqttPassword(e.target.value); checkDirty("mqtt.password", e.target.value); }}
+              className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text focus:outline-none focus:border-primary"
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+              {t("integrations.mqttClientId")}
+            </label>
+            <input
+              type="text"
+              value={mqttClientId}
+              onChange={(e) => { setMqttClientId(e.target.value); checkDirty("mqtt.clientId", e.target.value); }}
+              className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text focus:outline-none focus:border-primary"
+            />
+          </div>
+          <div>
+            <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+              {t("integrations.z2mBaseTopic")}
+            </label>
+            <input
+              type="text"
+              value={z2mBaseTopic}
+              onChange={(e) => { setZ2mBaseTopic(e.target.value); checkDirty("z2m.baseTopic", e.target.value); }}
+              placeholder="zigbee2mqtt"
+              className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text placeholder:text-text-tertiary focus:outline-none focus:border-primary"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Error / Success */}
+      {error && <p className="mt-3 text-[13px] text-error">{error}</p>}
+      {success && <p className="mt-3 text-[13px] text-green-600 dark:text-green-400">{success}</p>}
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 mt-4">
+        <button
+          onClick={handleSave}
+          disabled={saving || !dirty}
+          className="px-4 py-2 text-[13px] font-medium bg-primary text-white rounded-[6px] hover:bg-primary-hover transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-default"
+        >
+          {saving ? t("common.saving") : t("common.save")}
+        </button>
+        <button
+          onClick={handleReconnect}
+          disabled={reconnecting}
+          className="flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-default"
+        >
+          <RefreshCw size={14} className={reconnecting ? "animate-spin" : ""} />
+          {t("integrations.reconnect")}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2, Plus, Trash2, Copy, Check, Eye, EyeOff, Settings } from "lucide-react";
+import { Loader2, Plus, Trash2, Copy, Check, Eye, EyeOff, Settings, Download, Upload } from "lucide-react";
 import { useAuth } from "../store/useAuth";
 import {
   updateMe,
@@ -12,6 +12,8 @@ import {
   createUser,
   updateUser,
   deleteUser,
+  exportBackup,
+  importBackup,
 } from "../api";
 import type { ApiToken, User, UserRole } from "../types";
 
@@ -57,10 +59,11 @@ export function SettingsPage() {
           <ChangePasswordSection />
         </div>
 
-        {/* Right column: API Tokens + User Management */}
+        {/* Right column: API Tokens + User Management + Backup */}
         <div className="space-y-6">
           <ApiTokensSection />
           {isAdmin && <UserManagementSection currentUserId={user?.id ?? ""} />}
+          {isAdmin && <BackupSection />}
         </div>
       </div>
     </div>
@@ -606,6 +609,94 @@ function UserManagementSection({ currentUserId }: { currentUserId: string }) {
           ))}
         </div>
       )}
+    </section>
+  );
+}
+
+// ============================================================
+// Backup / Restore (admin only)
+// ============================================================
+
+function BackupSection() {
+  const { t } = useTranslation();
+  const [exporting, setExporting] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleExport = async () => {
+    setError("");
+    setSuccess("");
+    setExporting(true);
+    try {
+      const blob = await exportBackup();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `corbel-backup-${new Date().toISOString().slice(0, 10)}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      setSuccess(t("settings.backupExported"));
+      setTimeout(() => setSuccess(""), 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("common.error"));
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setError("");
+    setSuccess("");
+    setImporting(true);
+    try {
+      await importBackup(file);
+      setSuccess(t("settings.backupImported"));
+      setTimeout(() => setSuccess(""), 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("common.error"));
+    } finally {
+      setImporting(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  return (
+    <section className="bg-surface rounded-[10px] border border-border p-5">
+      <h2 className="text-[14px] font-semibold text-text mb-2">{t("settings.backup")}</h2>
+      <p className="text-[12px] text-text-tertiary mb-4">{t("settings.backupDescription")}</p>
+
+      {error && <p className="mb-3 text-[13px] text-error">{error}</p>}
+      {success && <p className="mb-3 text-[13px] text-green-600 dark:text-green-400">{success}</p>}
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleExport}
+          disabled={exporting}
+          className="flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium bg-primary text-white rounded-[6px] hover:bg-primary-hover transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-default"
+        >
+          <Download size={14} />
+          {exporting ? t("common.loading") : t("settings.exportBackup")}
+        </button>
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={importing}
+          className="flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-default"
+        >
+          <Upload size={14} />
+          {importing ? t("common.loading") : t("settings.importBackup")}
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json"
+          onChange={handleImport}
+          className="hidden"
+        />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- **Settings in SQLite**: New `settings` key-value table replaces `.env` for MQTT/Z2M config — configurable from UI
- **Integrations page**: Admin page to configure Zigbee2MQTT connection (URL, credentials, base topic) with reconnect
- **Backup/restore**: Export/import full Corbel configuration as JSON via API + UI buttons in Settings
- **Device cleanup**: Offline devices are automatically deleted from DB; stale devices cleaned on every bridge/devices message; delete button on device detail page (Corbel DB only, does not touch z2m)

## Test plan
- [x] TypeScript compiles (zero errors backend + frontend)
- [x] All 164 tests pass
- [x] Manual: configure integration from UI, reconnect MQTT
- [x] Manual: export backup, import backup
- [x] Manual: delete device from detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)