### PR TITLE
feat: add action DataCategory for button/remote devices

### DIFF
--- a/migrations/009_action_category.sql
+++ b/migrations/009_action_category.sql
@@ -1,0 +1,2 @@
+-- Reclassify action properties from generic to action category
+UPDATE device_data SET category = 'action' WHERE key = 'action' AND category = 'generic';

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -75,6 +75,9 @@ export const PROPERTY_TO_CATEGORY: Record<string, DataCategory> = {
   // Air quality
   co2: "co2",
   voc: "voc",
+
+  // Button / remote action
+  action: "action",
 };
 
 // ============================================================

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -27,6 +27,7 @@ export type DataCategory =
   | "smoke"
   | "co2"
   | "voc"
+  | "action"
   | "generic";
 
 // ============================================================

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -11,7 +11,7 @@ const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> 
   light_color: ["light_state", "light_brightness", "light_color"],
   shutter: ["shutter_position"],
   switch: ["light_state"],
-  sensor: ["temperature", "humidity", "pressure", "luminosity", "co2", "voc", "motion", "contact_door", "contact_window", "water_leak", "smoke"],
+  sensor: ["temperature", "humidity", "pressure", "luminosity", "co2", "voc", "motion", "contact_door", "contact_window", "water_leak", "smoke", "action"],
 };
 
 interface DeviceSelectorProps {

--- a/ui/src/components/equipments/sensorUtils.tsx
+++ b/ui/src/components/equipments/sensorUtils.tsx
@@ -13,6 +13,7 @@ import {
   BatteryFull,
   BatteryMedium,
   BatteryLow,
+  CircleDot,
 } from "lucide-react";
 import type { DataBindingWithValue, DataCategory } from "../../types";
 
@@ -29,6 +30,7 @@ export const SENSOR_DATA_CATEGORIES: DataCategory[] = [
   "voc",
   "water_leak",
   "smoke",
+  "action",
   "battery",
 ];
 
@@ -37,6 +39,7 @@ const CATEGORY_PRIORITY: DataCategory[] = [
   "motion",
   "contact_door",
   "contact_window",
+  "action",
   "temperature",
   "humidity",
   "luminosity",
@@ -59,6 +62,7 @@ const CATEGORY_KEYS: Partial<Record<DataCategory, string>> = {
   voc: "category.voc",
   water_leak: "category.water_leak",
   smoke: "category.smoke",
+  action: "category.action",
   battery: "category.battery",
 };
 
@@ -89,6 +93,8 @@ function iconForCategory(category: DataCategory, value?: unknown): React.ReactNo
       return <Droplet size={ICON_SIZE} strokeWidth={ICON_STROKE} />;
     case "smoke":
       return <Flame size={ICON_SIZE} strokeWidth={ICON_STROKE} />;
+    case "action":
+      return <CircleDot size={ICON_SIZE} strokeWidth={ICON_STROKE} />;
     case "battery":
       return getBatteryIcon(typeof value === "number" ? value : null, ICON_SIZE, ICON_STROKE);
     default:
@@ -154,6 +160,9 @@ export function getSensorIconColor(bindings: DataBindingWithValue[]): string {
   const primaryCat = getPrimarySensorCategory(bindings);
   if (primaryCat === "motion" && isMotionDetected(bindings)) {
     return "bg-amber-400/15 text-amber-500";
+  }
+  if (primaryCat === "action") {
+    return "bg-primary/10 text-primary";
   }
   if (
     (primaryCat === "contact_door" || primaryCat === "contact_window") &&

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -211,6 +211,7 @@
   "category.voc": "VOC",
   "category.water_leak": "Water leak",
   "category.smoke": "Smoke",
+  "category.action": "Action",
   "category.battery": "Battery",
 
   "category.value.motion.detected": "Detected",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -211,6 +211,7 @@
   "category.voc": "COV",
   "category.water_leak": "Fuite d'eau",
   "category.smoke": "Fumée",
+  "category.action": "Action",
   "category.battery": "Batterie",
 
   "category.value.motion.detected": "Détecté",

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -27,6 +27,7 @@ export type DataCategory =
   | "smoke"
   | "co2"
   | "voc"
+  | "action"
   | "generic";
 
 // ============================================================


### PR DESCRIPTION
## Summary
- Add `action` DataCategory for button/remote devices (Xiaomi WXKG01LM, Tuya IH-K663, etc.)
- Property `action` mapped from `generic` → `action` category
- Buttons work as `sensor` equipment type with auto-adaptive UI showing last action value
- Migration 009 reclassifies existing action data in DB

## Test plan
- [x] TypeScript compiles (zero errors backend + frontend)
- [x] All 164 tests pass
- [x] Verified: Xiaomi_switch and Tuya_switch devices already have `action` data in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)