### PR TITLE
feat: V0.10b — Panasonic Comfort Cloud integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ data/
 *.db-shm
 .DS_Store
 coverage/
+.venv/

--- a/migrations/012_fix_nullable_mqtt_columns.sql
+++ b/migrations/012_fix_nullable_mqtt_columns.sql
@@ -1,0 +1,100 @@
+-- Fix: migration 011 table recreation failed (foreign_keys=ON blocks DROP with FK refs).
+-- Recreate devices, device_data, device_orders with nullable MQTT columns.
+-- Must also handle data_bindings and order_bindings which reference these tables.
+
+-- 1. Backup all affected tables into temp tables
+
+CREATE TABLE IF NOT EXISTS _bak_devices AS SELECT * FROM devices;
+CREATE TABLE IF NOT EXISTS _bak_device_data AS SELECT * FROM device_data;
+CREATE TABLE IF NOT EXISTS _bak_device_orders AS SELECT * FROM device_orders;
+CREATE TABLE IF NOT EXISTS _bak_data_bindings AS SELECT * FROM data_bindings;
+CREATE TABLE IF NOT EXISTS _bak_order_bindings AS SELECT * FROM order_bindings;
+
+-- 2. Drop tables in reverse dependency order
+DROP TABLE IF EXISTS order_bindings;
+DROP TABLE IF EXISTS data_bindings;
+DROP TABLE IF EXISTS device_orders;
+DROP TABLE IF EXISTS device_data;
+DROP TABLE IF EXISTS devices;
+
+-- 3. Recreate with correct schema (mqtt columns nullable)
+
+CREATE TABLE devices (
+  id TEXT PRIMARY KEY,
+  mqtt_base_topic TEXT,
+  mqtt_name TEXT,
+  name TEXT NOT NULL,
+  manufacturer TEXT,
+  model TEXT,
+  ieee_address TEXT,
+  zone_id TEXT,
+  source TEXT NOT NULL DEFAULT 'zigbee2mqtt',
+  status TEXT NOT NULL DEFAULT 'unknown',
+  last_seen DATETIME,
+  raw_expose JSON,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  integration_id TEXT NOT NULL DEFAULT '',
+  source_device_id TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE device_data (
+  id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  type TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'generic',
+  unit TEXT,
+  value TEXT,
+  last_updated DATETIME,
+  UNIQUE(device_id, key)
+);
+
+CREATE TABLE device_orders (
+  id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  type TEXT NOT NULL,
+  mqtt_set_topic TEXT,
+  payload_key TEXT,
+  min_value REAL,
+  max_value REAL,
+  enum_values JSON,
+  unit TEXT,
+  dispatch_config JSON NOT NULL DEFAULT '{}',
+  UNIQUE(device_id, key)
+);
+
+CREATE TABLE data_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  device_data_id TEXT NOT NULL REFERENCES device_data(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL,
+  UNIQUE(equipment_id, alias)
+);
+
+CREATE TABLE order_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  device_order_id TEXT NOT NULL REFERENCES device_orders(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL,
+  UNIQUE(equipment_id, alias)
+);
+
+-- 4. Restore data
+INSERT INTO devices SELECT * FROM _bak_devices;
+INSERT INTO device_data SELECT * FROM _bak_device_data;
+INSERT INTO device_orders SELECT * FROM _bak_device_orders;
+INSERT INTO data_bindings SELECT * FROM _bak_data_bindings;
+INSERT INTO order_bindings SELECT * FROM _bak_order_bindings;
+
+-- 5. Cleanup backup tables
+DROP TABLE _bak_devices;
+DROP TABLE _bak_device_data;
+DROP TABLE _bak_device_orders;
+DROP TABLE _bak_data_bindings;
+DROP TABLE _bak_order_bindings;
+
+-- 6. Recreate indexes
+CREATE UNIQUE INDEX IF NOT EXISTS idx_devices_integration_source
+  ON devices(integration_id, source_device_id);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+aio-panasonic-comfort-cloud

--- a/scripts/run
+++ b/scripts/run
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Corbel — start/stop/restart helper
+# Usage: scripts/run [start|stop|restart|status]
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+BACKEND_PORT=3000
+UI_PORT=5173
+
+pid_on_port() {
+  lsof -ti :"$1" 2>/dev/null || true
+}
+
+stop_all() {
+  echo "Stopping Corbel processes..."
+
+  # Kill tsx watch (backend)
+  pids=$(pgrep -f "tsx watch src/index" 2>/dev/null || true)
+  if [ -n "$pids" ]; then
+    echo "$pids" | xargs kill 2>/dev/null || true
+  fi
+
+  # Kill backend on port
+  pid=$(pid_on_port $BACKEND_PORT)
+  if [ -n "$pid" ]; then
+    echo "$pid" | xargs kill 2>/dev/null || true
+  fi
+
+  # Kill vite dev server (UI)
+  pids=$(pgrep -f "node.*ui/node_modules/.bin/vite" 2>/dev/null || true)
+  if [ -n "$pids" ]; then
+    echo "$pids" | xargs kill 2>/dev/null || true
+  fi
+
+  # Kill esbuild (spawned by vite)
+  pids=$(pgrep -f "esbuild.*ui/node_modules" 2>/dev/null || true)
+  if [ -n "$pids" ]; then
+    echo "$pids" | xargs kill 2>/dev/null || true
+  fi
+
+  sleep 1
+  echo "All Corbel processes stopped."
+}
+
+start_backend() {
+  echo "Starting backend (port $BACKEND_PORT)..."
+  npm run dev &
+}
+
+start_ui() {
+  echo "Starting UI (port $UI_PORT)..."
+  (cd ui && npm run dev) &
+}
+
+show_status() {
+  echo "=== Corbel Status ==="
+  pid=$(pid_on_port $BACKEND_PORT)
+  if [ -n "$pid" ]; then
+    echo "Backend:  running (PID $pid, port $BACKEND_PORT)"
+  else
+    echo "Backend:  stopped"
+  fi
+
+  pid=$(pid_on_port $UI_PORT)
+  if [ -n "$pid" ]; then
+    echo "UI:       running (PID $pid, port $UI_PORT)"
+  else
+    echo "UI:       stopped"
+  fi
+}
+
+case "${1:-status}" in
+  start)
+    start_backend
+    start_ui
+    sleep 3
+    show_status
+    ;;
+  stop)
+    stop_all
+    ;;
+  restart)
+    stop_all
+    start_backend
+    start_ui
+    sleep 3
+    show_status
+    ;;
+  status)
+    show_status
+    ;;
+  *)
+    echo "Usage: scripts/run [start|stop|restart|status]"
+    exit 1
+    ;;
+esac

--- a/specs/012-V0.10b-panasonic-comfort-cloud/architecture.md
+++ b/specs/012-V0.10b-panasonic-comfort-cloud/architecture.md
@@ -1,156 +1,232 @@
 # Architecture: V0.10b Panasonic Comfort Cloud Integration
 
-## Panasonic CC Integration Plugin
+## Design Decision: Python Bridge
+
+Instead of porting the Panasonic auth/API logic to TypeScript, we use the community-maintained Python library `aio-panasonic-comfort-cloud` (used by Home Assistant) via a CLI bridge script. This gives us:
+
+- **Community maintenance** — Auth flow, API headers, app version updates are handled by the HA community
+- **Zero auth complexity** — No OAuth2/PKCE, no HTML parsing, no cookie management in TypeScript
+- **Simple upgrade path** — `pip install --upgrade aio-panasonic-comfort-cloud` follows HA updates
+- **Trade-off** — Requires Python 3.10+ runtime on the host
+
+## File Structure
 
 ```
 src/integrations/panasonic-cc/
-├── index.ts                  # PanasonicCCIntegration implements IntegrationPlugin
-├── panasonic-client.ts       # HTTP client: auth, token management, API calls
-├── panasonic-discovery.ts    # Device group parsing, device model mapping
-├── panasonic-poller.ts       # Polling scheduler (regular + on-demand)
-└── panasonic-types.ts        # Panasonic API response types, enums
+├── index.ts              # PanasonicCCIntegration implements IntegrationPlugin
+├── panasonic-bridge.ts   # Spawns Python bridge, parses JSON output
+├── panasonic-poller.ts   # Polling scheduler (regular + on-demand)
+├── panasonic-types.ts    # TypeScript types for bridge JSON responses + enum mappings
+└── bridge.py             # Python CLI wrapper around aio-panasonic-comfort-cloud
 ```
 
-## Authentication Flow
+## Python Bridge (`bridge.py`)
 
-TypeScript port of the Auth0 PKCE flow from `aio-panasonic-comfort-cloud`:
+A thin CLI script that wraps `aio-panasonic-comfort-cloud`. Called via `child_process.execFile('python3', ['bridge.py', ...])`. All output is JSON to stdout.
 
-1. Generate PKCE params (code_verifier, code_challenge, state)
-2. GET `/authorize` → follow redirect chain
-3. POST `/usernamepassword/login` with credentials
-4. Parse HTML response for hidden form fields (wa, wresult, wctx)
-5. POST `/login/callback` → follow redirect → extract `code`
-6. POST `/oauth/token` → get `access_token` + `refresh_token`
-7. POST `accsmart.panasonic.com/auth/v2/login` → get ACC `clientId`
+### Commands
 
-### Token Storage
+```bash
+# Login + verify credentials (also discovers devices)
+python3 bridge.py login --email X --password Y --token-file /path/tokens.json
 
-Stored in SettingsManager:
+# Get all devices (groups + status)
+python3 bridge.py get_devices --email X --password Y --token-file /path/tokens.json
 
-- `integration.panasonic-cc.access_token`
-- `integration.panasonic-cc.refresh_token`
-- `integration.panasonic-cc.token_expires` (ISO timestamp)
-- `integration.panasonic-cc.acc_client_id`
-- `integration.panasonic-cc.scope`
+# Get single device status
+python3 bridge.py get_device --id GUID --email X --password Y --token-file /path/tokens.json
 
-### Token Refresh
-
-Before each API call, check if `access_token` is expired (decode JWT payload, compare `exp` field). If expired, call `POST /oauth/token` with `grant_type=refresh_token`. If refresh fails, re-authenticate with stored email/password.
-
-### API Key Computation
-
-Each request to `accsmart.panasonic.com` requires a computed `x-cfc-api-key` header:
-
-```
-timestamp = "YYYY-MM-DD HH:MM:SS"
-timestamp_ms = Date.parse(timestamp + " UTC").toString()
-input = "Comfort Cloud" + "521325fb2dd486bf4831b47644317fca" + timestamp_ms + "Bearer " + access_token
-api_key = SHA256(input).hex()
-result = api_key[0:9] + "cfc" + api_key[9:]
+# Send control command
+python3 bridge.py control --id GUID --param power --value 1 --email X --password Y --token-file /path/tokens.json
 ```
 
-## Data Model
+### Token Persistence
 
-### Panasonic Device → Corbel Device Mapping
+The Python `Session` class handles token storage natively via `--token-file`. Tokens are persisted between calls, avoiding re-authentication on every command. The file is stored in `data/panasonic-tokens.json`.
 
-Each AC unit in `/device/group` becomes a Corbel Device:
+### JSON Output Format
 
-| Corbel field     | Panasonic source                      |
-| ---------------- | ------------------------------------- |
-| `integrationId`  | `"panasonic_cc"`                      |
-| `sourceDeviceId` | `deviceHashGuid` or `MD5(deviceGuid)` |
-| `name`           | `deviceName`                          |
-| `manufacturer`   | `"Panasonic"`                         |
-| `model`          | `deviceModuleNumber`                  |
-| `source`         | `"panasonic_cc"`                      |
-| `ieeeAddress`    | _not applicable_                      |
+```json
+// get_devices response
+{
+  "ok": true,
+  "devices": [
+    {
+      "id": "CS-Z50VKEW_ABCDEF123",
+      "guid": "actual-device-guid",
+      "name": "Salon",
+      "group": "Maison",
+      "model": "CS-Z50VKEW",
+      "parameters": {
+        "power": true,
+        "mode": "cool",
+        "targetTemperature": 22.5,
+        "insideTemperature": 24,
+        "outsideTemperature": 32,
+        "fanSpeed": "auto",
+        "airSwingUD": "mid",
+        "airSwingLR": "mid",
+        "ecoMode": "auto",
+        "nanoe": "on"
+      },
+      "features": {
+        "nanoe": true,
+        "autoMode": true,
+        "heatMode": true,
+        "dryMode": true,
+        "coolMode": true,
+        "fanMode": true,
+        "airSwingLR": true
+      }
+    }
+  ]
+}
 
-### DeviceData exposed per AC unit
+// control response
+{
+  "ok": true
+}
 
-| key                  | type    | category    | unit | Panasonic source                                                       |
-| -------------------- | ------- | ----------- | ---- | ---------------------------------------------------------------------- |
-| `power`              | boolean | generic     | —    | `parameters.operate` (0→false, 1→true)                                 |
-| `operationMode`      | enum    | generic     | —    | `parameters.operationMode` → "auto"/"dry"/"cool"/"heat"/"fan"          |
-| `targetTemperature`  | number  | temperature | °C   | `parameters.temperatureSet` (126 → null)                               |
-| `insideTemperature`  | number  | temperature | °C   | `parameters.insideTemperature` (126 → null)                            |
-| `outsideTemperature` | number  | temperature | °C   | `parameters.outTemperature` (126 → null)                               |
-| `fanSpeed`           | enum    | generic     | —    | `parameters.fanSpeed` → "auto"/"low"/"low_mid"/"mid"/"high_mid"/"high" |
-| `airSwingUD`         | enum    | generic     | —    | `parameters.airSwingUD` → "auto"/"up"/"down"/"mid"/...                 |
-| `airSwingLR`         | enum    | generic     | —    | `parameters.airSwingLR` → "auto"/"right"/"left"/"mid"/...              |
-| `ecoMode`            | enum    | generic     | —    | `parameters.ecoMode` → "auto"/"powerful"/"quiet"                       |
-| `nanoe`              | enum    | generic     | —    | `parameters.nanoe` → "unavailable"/"off"/"on"/"modeG"/"all"            |
+// error response
+{
+  "ok": false,
+  "error": "Invalid credentials"
+}
+```
 
-### DeviceOrders exposed per AC unit
+The bridge script handles all enum conversions (numeric → string for output, string → numeric for control).
 
-| key                 | type    | dispatchConfig                                                                                    |
-| ------------------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `power`             | boolean | `{ "param": "operate" }`                                                                          |
-| `operationMode`     | enum    | `{ "param": "operationMode", "enumValues": ["auto","dry","cool","heat","fan"] }`                  |
-| `targetTemperature` | number  | `{ "param": "temperatureSet", "min": 16, "max": 30, "step": 0.5 }`                                |
-| `fanSpeed`          | enum    | `{ "param": "fanSpeed", "enumValues": ["auto","low","low_mid","mid","high_mid","high"] }`         |
-| `airSwingUD`        | enum    | `{ "param": "airSwingUD", "enumValues": ["auto","up","down","mid","up_mid","down_mid","swing"] }` |
-| `airSwingLR`        | enum    | `{ "param": "airSwingLR", "enumValues": ["auto","right","left","mid","right_mid","left_mid"] }`   |
-| `ecoMode`           | enum    | `{ "param": "ecoMode", "enumValues": ["auto","powerful","quiet"] }`                               |
-| `nanoe`             | enum    | `{ "param": "nanoe", "enumValues": ["off","on","modeG","all"] }`                                  |
+### Error Handling
 
-### Order Dispatch
+- Wrong credentials → `{"ok": false, "error": "Login failed: ..."}`
+- Network error → `{"ok": false, "error": "Connection error: ..."}`
+- Invalid temperature (126) → exposed as `null`
+- Script exits with code 0 even on errors (error in JSON), non-zero only for crashes
 
-`PanasonicCCIntegration.executeOrder(device, dispatchConfig, value)`:
+## TypeScript Integration
 
-1. Map string enum values back to Panasonic numeric codes
-2. Handle swing mode coordination (fanAutoMode)
-3. POST to `/deviceStatus/control` with `{ deviceGuid, parameters: { [param]: numericValue } }`
-4. Schedule on-demand poll after delay (10s default)
+### PanasonicBridge (`panasonic-bridge.ts`)
 
-## Polling Strategy
+Thin wrapper that spawns the Python script and parses JSON:
 
-### Regular Polling
+```ts
+class PanasonicBridge {
+  constructor(
+    private pythonPath: string, // default: "python3"
+    private bridgePath: string, // path to bridge.py
+    private tokenFile: string, // data/panasonic-tokens.json
+  ) {}
+
+  async getDevices(email: string, password: string): Promise<BridgeDevicesResponse>;
+  async getDevice(id: string, email: string, password: string): Promise<BridgeDeviceResponse>;
+  async control(
+    id: string,
+    param: string,
+    value: unknown,
+    email: string,
+    password: string,
+  ): Promise<void>;
+}
+```
+
+Each call spawns `python3 bridge.py <command> --args...`, reads stdout, parses JSON. Timeout: 30s per command.
+
+### PanasonicPoller (`panasonic-poller.ts`)
+
+Manages polling on the Node.js side:
 
 ```ts
 class PanasonicPoller {
   private interval: NodeJS.Timeout | null = null;
   private pollIntervalMs: number; // default 300_000 (5 min)
 
-  start(): void {
-    this.poll(); // Immediate first poll
-    this.interval = setInterval(() => this.poll(), this.pollIntervalMs);
-  }
-
-  stop(): void {
-    if (this.interval) clearInterval(this.interval);
-  }
-
-  async poll(): Promise<void> {
-    for (const device of devices) {
-      await this.pollDevice(device);
-      // Small delay between devices to avoid burst
-    }
-  }
-
-  // Called after an order is executed
-  scheduleOnDemandPoll(deviceGuid: string, delayMs: number = 10_000): void {
-    setTimeout(() => this.pollDevice(deviceGuid), delayMs);
-  }
+  start(): void; // Immediate first poll + setInterval
+  stop(): void; // clearInterval
+  scheduleOnDemandPoll(deviceGuid: string, delayMs?: number): void; // setTimeout after order
 }
 ```
 
-### Request Serialization
+On each poll cycle:
 
-A simple mutex (queue) ensures only one API request is in flight:
+1. Call `bridge.getDevices()` (single Python invocation returns all devices + status)
+2. For each device, map to Corbel `DiscoveredDevice` format
+3. Call `deviceManager.upsertFromDiscovery()` to update/create devices + data
+
+### PanasonicCCIntegration (`index.ts`)
 
 ```ts
-class RequestMutex {
-  private queue: Array<() => void> = [];
-  private locked = false;
+class PanasonicCCIntegration implements IntegrationPlugin {
+  readonly id = "panasonic_cc";
+  readonly name = "Panasonic Comfort Cloud";
+  readonly icon = "AirVent";
 
-  async acquire(): Promise<void> { ... }
-  release(): void { ... }
+  // Settings schema (UI form)
+  getSettingsSchema(): IntegrationSettingDef[] → email, password, polling_interval
+
+  // Start: validate credentials, discover devices, start polling
+  start(): Promise<void>
+
+  // Stop: stop polling
+  stop(): Promise<void>
+
+  // Execute order: call bridge.control(), schedule on-demand poll
+  executeOrder(device, dispatchConfig, value): Promise<void>
 }
 ```
 
-### Cached vs Live Fallback
+### Order Dispatch
 
-On poll, use cached endpoint (`/deviceStatus/now/{guid}`). If it fails, log warning and retry on next cycle. Live endpoint (`/deviceStatus/{guid}`) is not used by default (slower, more rate-limit prone).
+`executeOrder(device, dispatchConfig, value)`:
+
+1. Read `dispatchConfig.param` (e.g. `"operationMode"`)
+2. Read `dispatchConfig.guid` (the Panasonic device GUID)
+3. Call `bridge.control(guid, param, value, email, password)`
+4. Schedule on-demand poll after 10s delay
+
+## Data Model
+
+### Panasonic Device → Corbel Device Mapping
+
+Each AC unit becomes a Corbel Device:
+
+| Corbel field     | Source                         |
+| ---------------- | ------------------------------ |
+| `integrationId`  | `"panasonic_cc"`               |
+| `sourceDeviceId` | `device.id` from bridge output |
+| `name`           | `device.name`                  |
+| `manufacturer`   | `"Panasonic"`                  |
+| `model`          | `device.model`                 |
+| `source`         | `"panasonic_cc"`               |
+
+### DeviceData exposed per AC unit
+
+| key                  | type    | category    | unit | Bridge source                                     |
+| -------------------- | ------- | ----------- | ---- | ------------------------------------------------- |
+| `power`              | boolean | generic     | —    | `parameters.power`                                |
+| `operationMode`      | enum    | generic     | —    | `parameters.mode`                                 |
+| `targetTemperature`  | number  | temperature | °C   | `parameters.targetTemperature` (null if invalid)  |
+| `insideTemperature`  | number  | temperature | °C   | `parameters.insideTemperature` (null if invalid)  |
+| `outsideTemperature` | number  | temperature | °C   | `parameters.outsideTemperature` (null if invalid) |
+| `fanSpeed`           | enum    | generic     | —    | `parameters.fanSpeed`                             |
+| `airSwingUD`         | enum    | generic     | —    | `parameters.airSwingUD`                           |
+| `airSwingLR`         | enum    | generic     | —    | `parameters.airSwingLR`                           |
+| `ecoMode`            | enum    | generic     | —    | `parameters.ecoMode`                              |
+| `nanoe`              | enum    | generic     | —    | `parameters.nanoe`                                |
+
+### DeviceOrders exposed per AC unit
+
+| key                 | type    | dispatchConfig                                                                                |
+| ------------------- | ------- | --------------------------------------------------------------------------------------------- |
+| `power`             | boolean | `{ "param": "power", "guid": "<deviceGuid>" }`                                                |
+| `operationMode`     | enum    | `{ "param": "mode", "guid": "<deviceGuid>", "enumValues": [...] }`                            |
+| `targetTemperature` | number  | `{ "param": "targetTemperature", "guid": "<deviceGuid>", "min": 16, "max": 30, "step": 0.5 }` |
+| `fanSpeed`          | enum    | `{ "param": "fanSpeed", "guid": "<deviceGuid>", "enumValues": [...] }`                        |
+| `airSwingUD`        | enum    | `{ "param": "airSwingUD", "guid": "<deviceGuid>", "enumValues": [...] }`                      |
+| `airSwingLR`        | enum    | `{ "param": "airSwingLR", "guid": "<deviceGuid>", "enumValues": [...] }`                      |
+| `ecoMode`           | enum    | `{ "param": "ecoMode", "guid": "<deviceGuid>", "enumValues": [...] }`                         |
+| `nanoe`             | enum    | `{ "param": "nanoe", "guid": "<deviceGuid>", "enumValues": [...] }`                           |
+
+Available enum values are filtered per device based on `features` flags from the bridge.
 
 ## New EquipmentType: thermostat
 
@@ -192,13 +268,12 @@ New component `ThermostatCard` in `ui/src/components/equipments/`:
 
 ### IntegrationsPage
 
-Add `PanasonicCCCard` (rendered dynamically from integration registry):
+Rendered dynamically from integration registry (already working from V0.10a):
 
-- Email/password fields
+- Email/password fields (from settings schema)
 - Polling interval (number input, seconds)
 - Status indicator (connected/disconnected/error)
-- Device count after connection
-- Save / Connect / Disconnect buttons
+- Save / Start / Stop buttons
 
 ### EquipmentDetailPage
 
@@ -210,48 +285,50 @@ When `equipment.type === "thermostat"`, show a thermostat-specific detail view w
 
 ## API Changes
 
-No new REST endpoints beyond V0.10a's integration endpoints. The Panasonic integration uses the existing:
+No new REST endpoints beyond V0.10a's integration endpoints.
 
-- `GET /api/v1/integrations` → includes panasonic-cc status
-- `POST /api/v1/integrations/panasonic-cc/start`
-- `POST /api/v1/integrations/panasonic-cc/stop`
-- `PUT /api/v1/settings` → save panasonic-cc credentials + polling interval
+## Dependencies
 
-## Dependencies (npm)
+### Python (runtime)
 
-- `node-html-parser` — parse Auth0 HTML response for hidden form fields (lightweight, zero-dependency)
-- No need for cookie jar library — manual cookie extraction from response headers
+- `aio-panasonic-comfort-cloud` — Community-maintained Panasonic CC client (HA ecosystem)
+- Python 3.10+ on the host
+
+### npm
+
+- No new npm dependencies (removed `node-html-parser`)
 
 ## File Changes
 
-| File                                                   | Change                                                                |
-| ------------------------------------------------------ | --------------------------------------------------------------------- |
-| `src/integrations/panasonic-cc/index.ts`               | **New** — PanasonicCCIntegration                                      |
-| `src/integrations/panasonic-cc/panasonic-client.ts`    | **New** — Auth + API client                                           |
-| `src/integrations/panasonic-cc/panasonic-discovery.ts` | **New** — Device mapping                                              |
-| `src/integrations/panasonic-cc/panasonic-poller.ts`    | **New** — Polling scheduler                                           |
-| `src/integrations/panasonic-cc/panasonic-types.ts`     | **New** — API types + enums                                           |
-| `src/shared/types.ts`                                  | Add `"panasonic_cc"` to DeviceSource, `"thermostat"` to EquipmentType |
-| `src/equipments/equipment-manager.ts`                  | Add `"thermostat"` to VALID_EQUIPMENT_TYPES                           |
-| `src/index.ts`                                         | Register PanasonicCCIntegration in IntegrationRegistry                |
-| `ui/src/components/equipments/ThermostatCard.tsx`      | **New** — Thermostat widget                                           |
-| `ui/src/components/equipments/ThermostatControl.tsx`   | **New** — Temperature/mode/fan controls                               |
-| `ui/src/pages/EquipmentDetailPage.tsx`                 | Add thermostat-specific detail view                                   |
-| `ui/src/i18n/locales/fr.json`                          | Thermostat + Panasonic translations                                   |
-| `ui/src/i18n/locales/en.json`                          | Thermostat + Panasonic translations                                   |
-| `package.json`                                         | Add `node-html-parser` dependency                                     |
+| File                                                | Change                                          |
+| --------------------------------------------------- | ----------------------------------------------- |
+| `src/integrations/panasonic-cc/bridge.py`           | **New** — Python CLI bridge                     |
+| `src/integrations/panasonic-cc/index.ts`            | **New** — PanasonicCCIntegration                |
+| `src/integrations/panasonic-cc/panasonic-bridge.ts` | **New** — TS wrapper for Python bridge          |
+| `src/integrations/panasonic-cc/panasonic-poller.ts` | **New** — Polling scheduler                     |
+| `src/integrations/panasonic-cc/panasonic-types.ts`  | **New** — Bridge response types + enum mappings |
+| `src/shared/types.ts`                               | Add `"thermostat"` to EquipmentType             |
+| `src/equipments/equipment-manager.ts`               | Add `"thermostat"` to VALID_EQUIPMENT_TYPES     |
+| `src/index.ts`                                      | Register PanasonicCCIntegration                 |
+| `ui/src/components/equipments/ThermostatCard.tsx`   | **New** — Thermostat widget                     |
+| `ui/src/pages/EquipmentDetailPage.tsx`              | Add thermostat-specific detail view             |
+| `ui/src/i18n/locales/fr.json`                       | Thermostat translations                         |
+| `ui/src/i18n/locales/en.json`                       | Thermostat translations                         |
+| `requirements.txt`                                  | **New** — `aio-panasonic-comfort-cloud`         |
 
 ## Pipeline
 
 ```
-PanasonicCCIntegration
-  ├── PanasonicClient (auth + HTTP)
-  ├── PanasonicPoller (scheduled polling)
-  │    └── GET /deviceStatus/now/{guid}
-  │         └── DeviceManager.updateDeviceData(integrationId, sourceDeviceId, payload)
+PanasonicCCIntegration (TypeScript)
+  ├── PanasonicBridge (spawns Python bridge.py)
+  │    └── aio-panasonic-comfort-cloud (Python, community-maintained)
+  │         └── Panasonic Cloud API (OAuth2 + REST)
+  ├── PanasonicPoller (Node.js setInterval)
+  │    └── bridge.getDevices()
+  │         └── DeviceManager.upsertFromDiscovery()
   │              └── EventBus: "device.data.updated"
   │                   └── EquipmentManager → ZoneAggregator → Scenarios → WebSocket
   └── executeOrder(device, dispatchConfig, value)
-       ├── POST /deviceStatus/control
+       ├── bridge.control(guid, param, value)
        └── scheduleOnDemandPoll(device, 10s)
 ```

--- a/specs/012-V0.10b-panasonic-comfort-cloud/plan.md
+++ b/specs/012-V0.10b-panasonic-comfort-cloud/plan.md
@@ -1,31 +1,35 @@
 # Implementation Plan: V0.10b Panasonic Comfort Cloud Integration
 
+## Architecture: Python Bridge
+
+Uses `aio-panasonic-comfort-cloud` (Python, community-maintained by HA) via a CLI bridge script, instead of a TypeScript port. Node.js spawns `python3 bridge.py <command>` and parses JSON output.
+
 ## Tasks
 
-1. [ ] **Types** — Add `"panasonic_cc"` to DeviceSource, `"thermostat"` to EquipmentType
-2. [ ] **Panasonic types** — Create `src/integrations/panasonic-cc/panasonic-types.ts` (API types, enums, constants)
-3. [ ] **Panasonic client** — Create `src/integrations/panasonic-cc/panasonic-client.ts` (OAuth2 PKCE auth, token management, ACC API calls)
-4. [ ] **Panasonic discovery** — Create `src/integrations/panasonic-cc/panasonic-discovery.ts` (map API response to Corbel Device/Data/Orders)
-5. [ ] **Panasonic poller** — Create `src/integrations/panasonic-cc/panasonic-poller.ts` (regular + on-demand polling, request mutex)
-6. [ ] **Panasonic integration** — Create `src/integrations/panasonic-cc/index.ts` (IntegrationPlugin, wire everything)
-7. [ ] **Register integration** — Update `src/index.ts` to register PanasonicCCIntegration
+1. [ ] **Python bridge** — Create `src/integrations/panasonic-cc/bridge.py` (CLI wrapper around `aio-panasonic-comfort-cloud`: login, get_devices, get_device, control)
+2. [ ] **requirements.txt** — Create `requirements.txt` with `aio-panasonic-comfort-cloud`
+3. [ ] **Bridge types** — Create `src/integrations/panasonic-cc/panasonic-types.ts` (TS types for bridge JSON responses, enum value lists)
+4. [ ] **Bridge wrapper** — Create `src/integrations/panasonic-cc/panasonic-bridge.ts` (child_process spawn, JSON parse, timeout handling)
+5. [ ] **Poller** — Create `src/integrations/panasonic-cc/panasonic-poller.ts` (regular + on-demand polling via Node.js timers)
+6. [ ] **Integration plugin** — Create `src/integrations/panasonic-cc/index.ts` (IntegrationPlugin: settings schema, start/stop, executeOrder, device mapping)
+7. [ ] **Types** — Add `"thermostat"` to EquipmentType in `src/shared/types.ts`
 8. [ ] **EquipmentManager** — Add `"thermostat"` to VALID_EQUIPMENT_TYPES
-9. [ ] **UI ThermostatCard** — Create thermostat dashboard widget (temperature, mode, fan, power)
-10. [ ] **UI ThermostatControl** — Create control components (temp up/down, mode selector, fan selector)
+9. [ ] **Register** — Update `src/index.ts` to register PanasonicCCIntegration
+10. [ ] **UI ThermostatCard** — Create thermostat dashboard widget (temperature, mode, fan, power)
 11. [ ] **UI EquipmentDetailPage** — Add thermostat-specific detail view
-12. [ ] **UI Translations** — Add FR/EN translations for thermostat + Panasonic
-13. [ ] **Install dependency** — Add `node-html-parser` to package.json
-14. [ ] **Tests** — Unit tests for PanasonicClient (auth flow mock), discovery mapping, poller scheduling
-15. [ ] **Type-check + lint** — Verify zero errors on backend and frontend
+12. [ ] **Translations** — Add FR/EN translations for thermostat + Panasonic
+13. [ ] **Tests** — Unit tests for bridge wrapper (mocked child_process), device mapping, poller scheduling
+14. [ ] **Validation** — `npx tsc --noEmit` backend + frontend, `npm test`, lint
 
 ## Dependencies
 
-- Requires V0.10a (Integration Plugin Architecture) to be completed first
-- npm: `node-html-parser` (HTML parsing for Auth0 login flow)
+- **Python 3.10+** on the host
+- **pip**: `aio-panasonic-comfort-cloud`
+- **npm**: no new dependencies
 
 ## Testing
 
-- Unit tests: PanasonicClient auth flow (mocked HTTP), device discovery mapping, enum conversions
-- Unit tests: Poller scheduling (timer mocks), request mutex
+- Unit tests: PanasonicBridge (mock child_process.execFile), device discovery mapping, enum conversions
+- Unit tests: PanasonicPoller (timer mocks)
 - Integration test: requires real Panasonic account (manual only)
-- Manual: configure credentials in UI, verify devices appear, control AC, check polling updates
+- Manual: configure credentials in UI → verify devices appear → control AC → check polling updates

--- a/specs/012-V0.10b-panasonic-comfort-cloud/spec.md
+++ b/specs/012-V0.10b-panasonic-comfort-cloud/spec.md
@@ -2,66 +2,68 @@
 
 ## Summary
 
-Add a Panasonic Comfort Cloud integration plugin that discovers AC units from the Panasonic cloud API, exposes them as Devices with Data and Orders, and allows controlling them from the Corbel UI. Introduces the `thermostat` EquipmentType with a dedicated dashboard widget. Uses polling-based data updates with configurable interval (default 5 min) and on-demand polling after order execution.
+Add a Panasonic Comfort Cloud integration plugin that discovers AC units from the Panasonic cloud API, exposes them as Devices with Data and Orders, and allows controlling them from the Corbel UI. Uses a **Python bridge** wrapping the community-maintained `aio-panasonic-comfort-cloud` library (Home Assistant ecosystem) for authentication and API calls. Introduces the `thermostat` EquipmentType with a dedicated dashboard widget. Uses polling-based data updates with configurable interval (default 5 min) and on-demand polling after order execution.
 
 ## Reference
 
 - Spec sections: §4 (Devices), §6 (Equipments), §15 (UI Design System)
 - Depends on: V0.10a (Integration Plugin Architecture)
-- API reference: `aio-panasonic-comfort-cloud` Python library (TypeScript port)
+- Python library: [aio-panasonic-comfort-cloud](https://pypi.org/project/aio-panasonic-comfort-cloud/) (HA community)
+
+## Design Decision
+
+**Python bridge instead of TypeScript port.** The Panasonic API auth flow (OAuth2/PKCE via Auth0) is complex and changes frequently. The Home Assistant community maintains `aio-panasonic-comfort-cloud` which handles auth, token refresh, app version detection, and API headers. We wrap it via a CLI bridge script called from Node.js (`child_process.execFile`), avoiding the need to port and maintain the auth logic ourselves. A `pip install --upgrade` follows HA community updates.
 
 ## Acceptance Criteria
 
 - [ ] `PanasonicCCIntegration implements IntegrationPlugin` is registered in the IntegrationRegistry
+- [ ] Python bridge script (`bridge.py`) wraps `aio-panasonic-comfort-cloud` with JSON CLI interface
 - [ ] User can enter Panasonic email/password in the IntegrationsPage UI
-- [ ] OAuth2/Auth0 PKCE authentication flow works (login, token refresh, session recovery)
 - [ ] AC units are discovered as Devices with source `panasonic_cc`
 - [ ] Each AC unit exposes Data: power, operationMode, targetTemperature, insideTemperature, outsideTemperature, fanSpeed, airSwingUD, airSwingLR, ecoMode, nanoe
-- [ ] Each AC unit exposes Orders: setPower, setMode, setTargetTemperature, setFanSpeed, setSwingUD, setSwingLR, setEcoMode, setNanoe
-- [ ] Orders are executed via the Panasonic cloud API (`/deviceStatus/control`)
+- [ ] Each AC unit exposes Orders: power, operationMode, targetTemperature, fanSpeed, airSwingUD, airSwingLR, ecoMode, nanoe
+- [ ] Orders are executed via the Python bridge → Panasonic cloud API
 - [ ] Polling interval is configurable (default 300s / 5 min)
 - [ ] After order execution, a confirmation poll runs after a configurable delay (default 10s)
-- [ ] Requests are serialized (single concurrency) to avoid rate limiting
-- [ ] Token refresh is automatic when access token expires
+- [ ] Token persistence via file (handled by Python library)
 - [ ] `thermostat` EquipmentType is added to the system
 - [ ] A thermostat widget in the dashboard shows temperature + controls
 - [ ] Feature flags from device capabilities are respected (e.g., nanoe available or not)
 - [ ] TypeScript compiles with zero errors (backend + frontend)
+- [ ] Python 3.10+ is documented as a runtime dependency
 
 ## Scope
 
 ### In Scope
 
-- Panasonic CC integration plugin (auth, discovery, polling, orders)
-- OAuth2/Auth0 PKCE authentication flow (TypeScript implementation)
-- Token persistence in SettingsManager (encrypted in DB)
-- Device discovery from `/device/group` API
-- Device status polling from `/deviceStatus/now/{guid}` (cached endpoint)
-- Order execution via `/deviceStatus/control`
-- Configurable polling interval (settings)
-- On-demand poll after order execution (with delay)
-- Request serialization (mutex)
+- Panasonic CC integration plugin (Python bridge + TypeScript wrapper)
+- Python bridge script (`bridge.py`) with commands: login, get_devices, get_device, control
+- Token persistence via `aio-panasonic-comfort-cloud` native file storage
+- Device discovery from Python bridge output
+- Device status polling (configurable interval, on-demand after orders)
+- Order execution via Python bridge
 - `thermostat` EquipmentType
 - Thermostat dashboard widget (temperature display, mode selector, target temp control)
-- IntegrationsPage: Panasonic CC card with email/password form + status
+- IntegrationsPage: Panasonic CC card with email/password form + status (dynamic from V0.10a)
 - Translations (FR/EN)
+- `requirements.txt` for Python dependencies
 
 ### Out of Scope
 
 - Aquarea heat pump devices (different protocol, deferred)
-- Energy/history data from Panasonic API (deferred to V0.11 History)
+- Energy/history data from Panasonic API (deferred)
 - Zone parameters for ducted systems (multi-zone AC, rare)
-- App version auto-update from Play Store scraping (use hardcoded version)
 - Multi-account support (one Panasonic account per Corbel instance)
+- Docker configuration for Python runtime (deferred)
 
 ## Edge Cases
 
-- What if Panasonic credentials are wrong? → LoginError, integration status "error", UI shows error message.
-- What if access token expires during polling? → Auto-refresh via refresh_token. If refresh fails, re-authenticate with stored credentials.
-- What if the Panasonic API is unreachable? → Integration status "disconnected", devices keep last known values, retry on next poll cycle.
-- What if rate limited? → Respect serialization, log warning, back off polling interval temporarily.
-- What if a device is offline (AC unit unplugged)? → Device status "offline", Data values stale, orders return error.
-- What if API returns 401 with code 4106? → App version mismatch. Log error, retry with updated version header.
-- What if live status request fails? → Fall back to cached endpoint (`/deviceStatus/now/{guid}`) for next N requests.
-- What if insideTemperature = 126? → Invalid sensor reading, expose as `null`.
+- What if Python 3.10+ is not installed? → Integration status "error", log clear message about missing dependency.
+- What if Panasonic credentials are wrong? → Bridge returns `{"ok": false, "error": "..."}`, integration status "error", UI shows message.
+- What if token expires? → Python library handles refresh automatically; if refresh fails, re-authenticates with stored credentials.
+- What if Panasonic API is unreachable? → Bridge returns error JSON, integration status "disconnected", devices keep last known values, retry on next poll.
+- What if rate limited? → Polling serializes requests (one Python invocation at a time), log warning.
+- What if a device is offline? → Device status "offline", Data values stale, orders return error.
+- What if insideTemperature = 126? → Bridge maps to `null` (invalid sensor reading).
 - What if user has no AC units? → Integration connected, zero devices discovered, UI shows "no devices found".
+- What if Python bridge process hangs? → 30s timeout on child_process, kill and return error.

--- a/src/api/routes/integrations.ts
+++ b/src/api/routes/integrations.ts
@@ -58,6 +58,40 @@ export function registerIntegrationRoutes(app: FastifyInstance, deps: Integratio
     }
   });
 
+  // POST /api/v1/integrations/:id/refresh — Force a data refresh
+  app.post<{ Params: { id: string } }>(
+    "/api/v1/integrations/:id/refresh",
+    async (request, reply) => {
+      if (!request.auth || request.auth.role !== "admin") {
+        return reply.code(403).send({ error: "Admin access required" });
+      }
+
+      const integration = integrationRegistry.getById(request.params.id);
+      if (!integration) {
+        return reply.code(404).send({ error: "Integration not found" });
+      }
+
+      if (!integration.refresh) {
+        return reply.code(400).send({ error: "Integration does not support refresh" });
+      }
+
+      if (integration.getStatus() !== "connected") {
+        return reply.code(400).send({ error: "Integration not connected" });
+      }
+
+      try {
+        await integration.refresh();
+        logger.info({ integrationId: integration.id }, "Integration refreshed via API");
+        return { success: true };
+      } catch (err) {
+        logger.error({ err, integrationId: integration.id }, "Failed to refresh integration");
+        return reply.code(500).send({
+          error: err instanceof Error ? err.message : "Refresh failed",
+        });
+      }
+    },
+  );
+
   // POST /api/v1/integrations/:id/stop — Stop an integration
   app.post<{ Params: { id: string } }>("/api/v1/integrations/:id/stop", async (request, reply) => {
     if (!request.auth || request.auth.role !== "admin") {

--- a/src/api/routes/zones.ts
+++ b/src/api/routes/zones.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { ZoneManager } from "../../zones/zone-manager.js";
 import type { ZoneAggregator } from "../../zones/zone-aggregator.js";
 import type { Logger } from "../../core/logger.js";
+import { ROOT_ZONE_ID } from "../../shared/constants.js";
 
 interface ZonesDeps {
   zoneManager: ZoneManager;
@@ -56,7 +57,7 @@ export function registerZoneRoutes(app: FastifyInstance, deps: ZonesDeps): void 
     try {
       const zone = zoneManager.create({
         name: name.trim(),
-        parentId,
+        parentId: parentId || ROOT_ZONE_ID,
         icon,
         description,
         displayOrder,

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -29,6 +29,7 @@ const VALID_EQUIPMENT_TYPES: Set<string> = new Set([
   "switch",
   "sensor",
   "button",
+  "thermostat",
 ]);
 
 // ============================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { ModeManager } from "./modes/mode-manager.js";
 import { CalendarManager } from "./modes/calendar-manager.js";
 import { IntegrationRegistry } from "./integrations/integration-registry.js";
 import { Zigbee2MqttIntegration } from "./integrations/zigbee2mqtt/index.js";
+import { PanasonicCCIntegration } from "./integrations/panasonic-cc/index.js";
 import { createServer } from "./api/server.js";
 
 async function main() {
@@ -53,6 +54,14 @@ async function main() {
     logger,
   );
   integrationRegistry.register(zigbee2mqttIntegration);
+
+  const panasonicCCIntegration = new PanasonicCCIntegration(
+    settingsManager,
+    deviceManager,
+    eventBus,
+    logger,
+  );
+  integrationRegistry.register(panasonicCCIntegration);
 
   // 8. Create Zone Manager
   const zoneManager = new ZoneManager(db, eventBus, logger);

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,8 +63,9 @@ async function main() {
   );
   integrationRegistry.register(panasonicCCIntegration);
 
-  // 8. Create Zone Manager
+  // 8. Create Zone Manager & ensure root zone exists
   const zoneManager = new ZoneManager(db, eventBus, logger);
+  zoneManager.ensureRootZone();
 
   // 9. Create Equipment Manager (uses IntegrationRegistry for order dispatch)
   const equipmentManager = new EquipmentManager(

--- a/src/integrations/integration-registry.ts
+++ b/src/integrations/integration-registry.ts
@@ -46,6 +46,12 @@ export interface IntegrationPlugin {
     dispatchConfig: Record<string, unknown>,
     value: unknown,
   ): Promise<void>;
+
+  /**
+   * Force a data refresh (e.g. re-poll cloud API).
+   * Optional — integrations that don't support it should return immediately.
+   */
+  refresh?(): Promise<void>;
 }
 
 // ============================================================

--- a/src/integrations/panasonic-cc/bridge.py
+++ b/src/integrations/panasonic-cc/bridge.py
@@ -96,19 +96,22 @@ async def open_session(email, password, token_file):
 async def cmd_login(args):
     """Login and verify credentials."""
     async with open_session(args.email, args.password, args.token_file) as client:
-        devices = await client.get_devices()
+        # get_devices() is sync — returns cached PanasonicDeviceInfo list
+        device_infos = client.get_devices()
         return {
             "ok": True,
-            "deviceCount": len(devices) if devices else 0,
+            "deviceCount": len(device_infos) if device_infos else 0,
         }
 
 
 async def cmd_get_devices(args):
     """Get all devices with current status."""
     async with open_session(args.email, args.password, args.token_file) as client:
-        devices = await client.get_devices()
+        device_infos = client.get_devices()
         result_devices = []
-        for dev in (devices or []):
+        for info in (device_infos or []):
+            # get_device() is async — fetches live parameters from cloud
+            dev = await client.get_device(info)
             device_data = format_device(dev)
             result_devices.append(device_data)
         return {"ok": True, "devices": result_devices}
@@ -117,27 +120,26 @@ async def cmd_get_devices(args):
 async def cmd_get_device(args):
     """Get single device status by guid."""
     async with open_session(args.email, args.password, args.token_file) as client:
-        devices = await client.get_devices()
-        target = None
-        for dev in (devices or []):
-            if dev.id == args.id or getattr(dev.info, 'guid', None) == args.id:
-                target = dev
+        device_infos = client.get_devices()
+        target_info = None
+        for info in (device_infos or []):
+            if info.id == args.id or info.guid == args.id:
+                target_info = info
                 break
-        if not target:
+        if not target_info:
             return {"ok": False, "error": f"Device {args.id} not found"}
-        refreshed = await client.get_device(target.info)
-        return {"ok": True, "device": format_device(refreshed)}
+        dev = await client.get_device(target_info)
+        return {"ok": True, "device": format_device(dev)}
 
 
 async def cmd_control(args):
     """Send a control command to a device."""
     async with open_session(args.email, args.password, args.token_file) as client:
-        # Find device by id/guid
-        devices = await client.get_devices()
+        device_infos = client.get_devices()
         target_info = None
-        for dev in (devices or []):
-            if dev.id == args.id or getattr(dev.info, 'guid', None) == args.id:
-                target_info = dev.info
+        for info in (device_infos or []):
+            if info.id == args.id or info.guid == args.id:
+                target_info = info
                 break
         if not target_info:
             return {"ok": False, "error": f"Device {args.id} not found"}

--- a/src/integrations/panasonic-cc/bridge.py
+++ b/src/integrations/panasonic-cc/bridge.py
@@ -10,12 +10,17 @@ import argparse
 import asyncio
 import json
 import sys
-import traceback
 
 try:
-    import pcomfortcloud
+    import aiohttp
+    import aio_panasonic_comfort_cloud as pcc
+    from aio_panasonic_comfort_cloud import constants
 except ImportError:
-    print(json.dumps({"ok": False, "error": "Python package 'pcomfortcloud' not installed. Run: pip install aio-panasonic-comfort-cloud"}))
+    print(json.dumps({
+        "ok": False,
+        "error": "Python package 'aio-panasonic-comfort-cloud' not installed. "
+                 "Activate the venv and run: pip install aio-panasonic-comfort-cloud"
+    }))
     sys.exit(0)
 
 
@@ -32,10 +37,10 @@ MODE_MAP_REV = {v: k for k, v in MODE_MAP.items()}
 FAN_SPEED_MAP = {0: "auto", 1: "low", 2: "lowMid", 3: "mid", 4: "highMid", 5: "high"}
 FAN_SPEED_MAP_REV = {v: k for k, v in FAN_SPEED_MAP.items()}
 
-SWING_UD_MAP = {0: "up", 1: "down", 2: "mid", 3: "upMid", 4: "downMid"}
+SWING_UD_MAP = {-1: "auto", 0: "up", 1: "down", 2: "mid", 3: "upMid", 4: "downMid", 5: "swing"}
 SWING_UD_MAP_REV = {v: k for k, v in SWING_UD_MAP.items()}
 
-SWING_LR_MAP = {0: "left", 1: "right", 2: "mid", 3: "rightMid", 4: "leftMid"}
+SWING_LR_MAP = {-1: "auto", 0: "right", 1: "left", 2: "mid", 4: "rightMid", 5: "leftMid", 6: "unavailable"}
 SWING_LR_MAP_REV = {v: k for k, v in SWING_LR_MAP.items()}
 
 ECO_MODE_MAP = {0: "auto", 1: "powerful", 2: "quiet"}
@@ -55,27 +60,33 @@ def safe_temp(val):
 
 
 def enum_to_str(mapping, val):
-    """Convert numeric enum to string, or return str(val) as fallback."""
+    """Convert enum to string using its .value attribute."""
     if val is None:
         return None
-    if isinstance(val, int):
-        return mapping.get(val, str(val))
-    # Already a string or enum object — try .value
     try:
         return mapping.get(val.value, str(val.value))
     except AttributeError:
+        if isinstance(val, int):
+            return mapping.get(val, str(val))
         return str(val)
 
 
 # ============================================================
-# Session helper
+# Session context manager
 # ============================================================
 
-async def create_session(email, password, token_file):
-    """Create and authenticate a pcomfortcloud session."""
-    session = pcomfortcloud.ApiClient(email, password, token_file)
-    await session.start_session()
-    return session
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def open_session(email, password, token_file):
+    """Create, authenticate, and yield a Panasonic CC client. Always closes the HTTP session."""
+    http_session = aiohttp.ClientSession()
+    try:
+        client = pcc.ApiClient(email, password, http_session, token_file_name=token_file)
+        await client.start_session()
+        yield client
+    finally:
+        await http_session.close()
 
 
 # ============================================================
@@ -84,120 +95,115 @@ async def create_session(email, password, token_file):
 
 async def cmd_login(args):
     """Login and verify credentials."""
-    session = await create_session(args.email, args.password, args.token_file)
-    devices = await session.get_devices()
-    result = {
-        "ok": True,
-        "deviceCount": len(devices) if devices else 0,
-    }
-    return result
+    async with open_session(args.email, args.password, args.token_file) as client:
+        devices = await client.get_devices()
+        return {
+            "ok": True,
+            "deviceCount": len(devices) if devices else 0,
+        }
 
 
 async def cmd_get_devices(args):
     """Get all devices with current status."""
-    session = await create_session(args.email, args.password, args.token_file)
-    devices = await session.get_devices()
-
-    result_devices = []
-    for dev in (devices or []):
-        device_data = format_device(dev)
-        result_devices.append(device_data)
-
-    return {"ok": True, "devices": result_devices}
+    async with open_session(args.email, args.password, args.token_file) as client:
+        devices = await client.get_devices()
+        result_devices = []
+        for dev in (devices or []):
+            device_data = format_device(dev)
+            result_devices.append(device_data)
+        return {"ok": True, "devices": result_devices}
 
 
 async def cmd_get_device(args):
-    """Get single device status."""
-    session = await create_session(args.email, args.password, args.token_file)
-    dev = await session.get_device(args.id)
-    if not dev:
-        return {"ok": False, "error": f"Device {args.id} not found"}
-    return {"ok": True, "device": format_device(dev)}
+    """Get single device status by guid."""
+    async with open_session(args.email, args.password, args.token_file) as client:
+        devices = await client.get_devices()
+        target = None
+        for dev in (devices or []):
+            if dev.id == args.id or getattr(dev.info, 'guid', None) == args.id:
+                target = dev
+                break
+        if not target:
+            return {"ok": False, "error": f"Device {args.id} not found"}
+        refreshed = await client.get_device(target.info)
+        return {"ok": True, "device": format_device(refreshed)}
 
 
 async def cmd_control(args):
     """Send a control command to a device."""
-    session = await create_session(args.email, args.password, args.token_file)
+    async with open_session(args.email, args.password, args.token_file) as client:
+        # Find device by id/guid
+        devices = await client.get_devices()
+        target_info = None
+        for dev in (devices or []):
+            if dev.id == args.id or getattr(dev.info, 'guid', None) == args.id:
+                target_info = dev.info
+                break
+        if not target_info:
+            return {"ok": False, "error": f"Device {args.id} not found"}
 
-    kwargs = {}
-    param = args.param
-    value = args.value
+        kwargs = {}
+        param = args.param
+        value = args.value
 
-    if param == "power":
-        kwargs["power"] = pcomfortcloud.constants.Power(POWER_MAP_REV.get(value, int(value)))
-    elif param == "mode":
-        kwargs["operationMode"] = pcomfortcloud.constants.OperationMode(MODE_MAP_REV.get(value, int(value)))
-    elif param == "targetTemperature":
-        kwargs["temperature"] = float(value)
-    elif param == "fanSpeed":
-        kwargs["fanSpeed"] = pcomfortcloud.constants.FanSpeed(FAN_SPEED_MAP_REV.get(value, int(value)))
-    elif param == "airSwingUD":
-        kwargs["airSwingVertical"] = pcomfortcloud.constants.AirSwingUD(SWING_UD_MAP_REV.get(value, int(value)))
-    elif param == "airSwingLR":
-        kwargs["airSwingHorizontal"] = pcomfortcloud.constants.AirSwingLR(SWING_LR_MAP_REV.get(value, int(value)))
-    elif param == "ecoMode":
-        kwargs["eco"] = pcomfortcloud.constants.EcoMode(ECO_MODE_MAP_REV.get(value, int(value)))
-    elif param == "nanoe":
-        kwargs["nanoe"] = pcomfortcloud.constants.NanoeMode(NANOE_MAP_REV.get(value, int(value)))
-    else:
-        return {"ok": False, "error": f"Unknown parameter: {param}"}
+        if param == "power":
+            if value in ("true", "on"):
+                kwargs["power"] = constants.Power.On
+            else:
+                kwargs["power"] = constants.Power.Off
+        elif param == "mode":
+            kwargs["mode"] = constants.OperationMode(MODE_MAP_REV.get(value, int(value)))
+        elif param == "targetTemperature":
+            kwargs["temperature"] = float(value)
+        elif param == "fanSpeed":
+            kwargs["fanSpeed"] = constants.FanSpeed(FAN_SPEED_MAP_REV.get(value, int(value)))
+        elif param == "airSwingUD":
+            kwargs["airSwingVertical"] = constants.AirSwingUD(SWING_UD_MAP_REV.get(value, int(value)))
+        elif param == "airSwingLR":
+            kwargs["airSwingHorizontal"] = constants.AirSwingLR(SWING_LR_MAP_REV.get(value, int(value)))
+        elif param == "ecoMode":
+            kwargs["eco"] = constants.EcoMode(ECO_MODE_MAP_REV.get(value, int(value)))
+        elif param == "nanoe":
+            kwargs["nanoe"] = constants.NanoeMode(NANOE_MAP_REV.get(value, int(value)))
+        else:
+            return {"ok": False, "error": f"Unknown parameter: {param}"}
 
-    await session.set_device(args.id, **kwargs)
-    return {"ok": True}
+        await client.set_device(target_info, **kwargs)
+        return {"ok": True}
 
 
 def format_device(dev):
-    """Format a device object into our JSON structure."""
-    params = dev.get("parameters", {}) if isinstance(dev, dict) else {}
+    """Format a PanasonicDevice object into our JSON structure."""
+    info = dev.info
+    dev_id = info.id or ""
+    name = info.name or ""
+    group = info.group or ""
+    model = info.model or ""
 
-    # Handle both dict and object-style access
-    if not isinstance(dev, dict):
-        # Object with attributes
-        dev_id = getattr(dev, "id", None) or ""
-        name = getattr(dev, "name", None) or ""
-        group = getattr(dev, "group", None) or ""
-        model = getattr(dev, "model", None) or ""
+    p = dev.parameters
+    params = {
+        "power": enum_to_str(POWER_MAP, p.power),
+        "mode": enum_to_str(MODE_MAP, p.mode),
+        "targetTemperature": safe_temp(p.target_temperature),
+        "insideTemperature": safe_temp(p.inside_temperature),
+        "outsideTemperature": safe_temp(p.outside_temperature),
+        "fanSpeed": enum_to_str(FAN_SPEED_MAP, p.fan_speed),
+        "airSwingUD": enum_to_str(SWING_UD_MAP, p.vertical_swing_mode),
+        "airSwingLR": enum_to_str(SWING_LR_MAP, p.horizontal_swing_mode),
+        "ecoMode": enum_to_str(ECO_MODE_MAP, p.eco_mode),
+        "nanoe": enum_to_str(NANOE_MAP, p.nanoe_mode),
+    }
 
-        p = getattr(dev, "parameters", None)
-        if p is not None and not isinstance(p, dict):
-            # Parameters object
-            params = {
-                "power": enum_to_str(POWER_MAP, getattr(p, "power", None)),
-                "mode": enum_to_str(MODE_MAP, getattr(p, "operationMode", None)),
-                "targetTemperature": safe_temp(getattr(p, "temperatureSet", None)),
-                "insideTemperature": safe_temp(getattr(p, "insideTemperature", None)),
-                "outsideTemperature": safe_temp(getattr(p, "outsideTemperature", None)),
-                "fanSpeed": enum_to_str(FAN_SPEED_MAP, getattr(p, "fanSpeed", None)),
-                "airSwingUD": enum_to_str(SWING_UD_MAP, getattr(p, "airSwingUD", None)),
-                "airSwingLR": enum_to_str(SWING_LR_MAP, getattr(p, "airSwingLR", None)),
-                "ecoMode": enum_to_str(ECO_MODE_MAP, getattr(p, "eco", None)),
-                "nanoe": enum_to_str(NANOE_MAP, getattr(p, "nanoe", None)),
-            }
-        elif isinstance(p, dict):
-            params = p
-
-        features_obj = getattr(dev, "features", None)
-        if features_obj is not None and not isinstance(features_obj, dict):
-            features = {
-                "nanoe": getattr(features_obj, "nanoe", False),
-                "autoMode": getattr(features_obj, "autoMode", False),
-                "heatMode": getattr(features_obj, "heatMode", False),
-                "dryMode": getattr(features_obj, "dryMode", False),
-                "coolMode": getattr(features_obj, "coolMode", False),
-                "fanMode": getattr(features_obj, "fanMode", False),
-                "airSwingLR": getattr(features_obj, "airSwingLR", False),
-            }
-        elif isinstance(features_obj, dict):
-            features = features_obj
-        else:
-            features = {}
-    else:
-        # Dict style
-        dev_id = dev.get("id", "")
-        name = dev.get("name", "")
-        group = dev.get("group", "")
-        model = dev.get("model", "")
-        features = dev.get("features", {})
+    f = dev.features
+    features = {
+        "nanoe": f.nanoe,
+        "autoMode": f.auto_mode,
+        "heatMode": f.heat_mode,
+        "dryMode": f.dry_mode,
+        "coolMode": f.cool_mode,
+        "fanMode": f.fan_mode,
+        "airSwingLR": f.air_swing_lr,
+    }
 
     return {
         "id": str(dev_id),
@@ -226,30 +232,27 @@ def main():
     args = parser.parse_args()
 
     try:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-        if args.command == "login":
-            result = loop.run_until_complete(cmd_login(args))
-        elif args.command == "get_devices":
-            result = loop.run_until_complete(cmd_get_devices(args))
-        elif args.command == "get_device":
-            if not args.id:
-                result = {"ok": False, "error": "--id is required for get_device"}
-            else:
-                result = loop.run_until_complete(cmd_get_device(args))
-        elif args.command == "control":
-            if not args.id or not args.param or args.value is None:
-                result = {"ok": False, "error": "--id, --param, and --value are required for control"}
-            else:
-                result = loop.run_until_complete(cmd_control(args))
-        else:
-            result = {"ok": False, "error": f"Unknown command: {args.command}"}
-
+        result = asyncio.run(dispatch(args))
         print(json.dumps(result))
-
     except Exception as e:
         print(json.dumps({"ok": False, "error": str(e)}))
+
+
+async def dispatch(args):
+    if args.command == "login":
+        return await cmd_login(args)
+    elif args.command == "get_devices":
+        return await cmd_get_devices(args)
+    elif args.command == "get_device":
+        if not args.id:
+            return {"ok": False, "error": "--id is required for get_device"}
+        return await cmd_get_device(args)
+    elif args.command == "control":
+        if not args.id or not args.param or args.value is None:
+            return {"ok": False, "error": "--id, --param, and --value are required for control"}
+        return await cmd_control(args)
+    else:
+        return {"ok": False, "error": f"Unknown command: {args.command}"}
 
 
 if __name__ == "__main__":

--- a/src/integrations/panasonic-cc/bridge.py
+++ b/src/integrations/panasonic-cc/bridge.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+Corbel — Panasonic Comfort Cloud bridge.
+Thin CLI wrapper around aio-panasonic-comfort-cloud.
+Called by Node.js via child_process.execFile.
+All output is JSON to stdout.
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+import traceback
+
+try:
+    import pcomfortcloud
+except ImportError:
+    print(json.dumps({"ok": False, "error": "Python package 'pcomfortcloud' not installed. Run: pip install aio-panasonic-comfort-cloud"}))
+    sys.exit(0)
+
+
+# ============================================================
+# Enum conversions (numeric → string, string → numeric)
+# ============================================================
+
+POWER_MAP = {0: "off", 1: "on"}
+POWER_MAP_REV = {v: k for k, v in POWER_MAP.items()}
+
+MODE_MAP = {0: "auto", 1: "dry", 2: "cool", 3: "heat", 4: "fan"}
+MODE_MAP_REV = {v: k for k, v in MODE_MAP.items()}
+
+FAN_SPEED_MAP = {0: "auto", 1: "low", 2: "lowMid", 3: "mid", 4: "highMid", 5: "high"}
+FAN_SPEED_MAP_REV = {v: k for k, v in FAN_SPEED_MAP.items()}
+
+SWING_UD_MAP = {0: "up", 1: "down", 2: "mid", 3: "upMid", 4: "downMid"}
+SWING_UD_MAP_REV = {v: k for k, v in SWING_UD_MAP.items()}
+
+SWING_LR_MAP = {0: "left", 1: "right", 2: "mid", 3: "rightMid", 4: "leftMid"}
+SWING_LR_MAP_REV = {v: k for k, v in SWING_LR_MAP.items()}
+
+ECO_MODE_MAP = {0: "auto", 1: "powerful", 2: "quiet"}
+ECO_MODE_MAP_REV = {v: k for k, v in ECO_MODE_MAP.items()}
+
+NANOE_MAP = {0: "unavailable", 1: "off", 2: "on", 3: "modeG", 4: "all"}
+NANOE_MAP_REV = {v: k for k, v in NANOE_MAP.items()}
+
+INVALID_TEMPERATURE = 126
+
+
+def safe_temp(val):
+    """Return temperature or None if invalid."""
+    if val is None or val == INVALID_TEMPERATURE:
+        return None
+    return val
+
+
+def enum_to_str(mapping, val):
+    """Convert numeric enum to string, or return str(val) as fallback."""
+    if val is None:
+        return None
+    if isinstance(val, int):
+        return mapping.get(val, str(val))
+    # Already a string or enum object — try .value
+    try:
+        return mapping.get(val.value, str(val.value))
+    except AttributeError:
+        return str(val)
+
+
+# ============================================================
+# Session helper
+# ============================================================
+
+async def create_session(email, password, token_file):
+    """Create and authenticate a pcomfortcloud session."""
+    session = pcomfortcloud.ApiClient(email, password, token_file)
+    await session.start_session()
+    return session
+
+
+# ============================================================
+# Commands
+# ============================================================
+
+async def cmd_login(args):
+    """Login and verify credentials."""
+    session = await create_session(args.email, args.password, args.token_file)
+    devices = await session.get_devices()
+    result = {
+        "ok": True,
+        "deviceCount": len(devices) if devices else 0,
+    }
+    return result
+
+
+async def cmd_get_devices(args):
+    """Get all devices with current status."""
+    session = await create_session(args.email, args.password, args.token_file)
+    devices = await session.get_devices()
+
+    result_devices = []
+    for dev in (devices or []):
+        device_data = format_device(dev)
+        result_devices.append(device_data)
+
+    return {"ok": True, "devices": result_devices}
+
+
+async def cmd_get_device(args):
+    """Get single device status."""
+    session = await create_session(args.email, args.password, args.token_file)
+    dev = await session.get_device(args.id)
+    if not dev:
+        return {"ok": False, "error": f"Device {args.id} not found"}
+    return {"ok": True, "device": format_device(dev)}
+
+
+async def cmd_control(args):
+    """Send a control command to a device."""
+    session = await create_session(args.email, args.password, args.token_file)
+
+    kwargs = {}
+    param = args.param
+    value = args.value
+
+    if param == "power":
+        kwargs["power"] = pcomfortcloud.constants.Power(POWER_MAP_REV.get(value, int(value)))
+    elif param == "mode":
+        kwargs["operationMode"] = pcomfortcloud.constants.OperationMode(MODE_MAP_REV.get(value, int(value)))
+    elif param == "targetTemperature":
+        kwargs["temperature"] = float(value)
+    elif param == "fanSpeed":
+        kwargs["fanSpeed"] = pcomfortcloud.constants.FanSpeed(FAN_SPEED_MAP_REV.get(value, int(value)))
+    elif param == "airSwingUD":
+        kwargs["airSwingVertical"] = pcomfortcloud.constants.AirSwingUD(SWING_UD_MAP_REV.get(value, int(value)))
+    elif param == "airSwingLR":
+        kwargs["airSwingHorizontal"] = pcomfortcloud.constants.AirSwingLR(SWING_LR_MAP_REV.get(value, int(value)))
+    elif param == "ecoMode":
+        kwargs["eco"] = pcomfortcloud.constants.EcoMode(ECO_MODE_MAP_REV.get(value, int(value)))
+    elif param == "nanoe":
+        kwargs["nanoe"] = pcomfortcloud.constants.NanoeMode(NANOE_MAP_REV.get(value, int(value)))
+    else:
+        return {"ok": False, "error": f"Unknown parameter: {param}"}
+
+    await session.set_device(args.id, **kwargs)
+    return {"ok": True}
+
+
+def format_device(dev):
+    """Format a device object into our JSON structure."""
+    params = dev.get("parameters", {}) if isinstance(dev, dict) else {}
+
+    # Handle both dict and object-style access
+    if not isinstance(dev, dict):
+        # Object with attributes
+        dev_id = getattr(dev, "id", None) or ""
+        name = getattr(dev, "name", None) or ""
+        group = getattr(dev, "group", None) or ""
+        model = getattr(dev, "model", None) or ""
+
+        p = getattr(dev, "parameters", None)
+        if p is not None and not isinstance(p, dict):
+            # Parameters object
+            params = {
+                "power": enum_to_str(POWER_MAP, getattr(p, "power", None)),
+                "mode": enum_to_str(MODE_MAP, getattr(p, "operationMode", None)),
+                "targetTemperature": safe_temp(getattr(p, "temperatureSet", None)),
+                "insideTemperature": safe_temp(getattr(p, "insideTemperature", None)),
+                "outsideTemperature": safe_temp(getattr(p, "outsideTemperature", None)),
+                "fanSpeed": enum_to_str(FAN_SPEED_MAP, getattr(p, "fanSpeed", None)),
+                "airSwingUD": enum_to_str(SWING_UD_MAP, getattr(p, "airSwingUD", None)),
+                "airSwingLR": enum_to_str(SWING_LR_MAP, getattr(p, "airSwingLR", None)),
+                "ecoMode": enum_to_str(ECO_MODE_MAP, getattr(p, "eco", None)),
+                "nanoe": enum_to_str(NANOE_MAP, getattr(p, "nanoe", None)),
+            }
+        elif isinstance(p, dict):
+            params = p
+
+        features_obj = getattr(dev, "features", None)
+        if features_obj is not None and not isinstance(features_obj, dict):
+            features = {
+                "nanoe": getattr(features_obj, "nanoe", False),
+                "autoMode": getattr(features_obj, "autoMode", False),
+                "heatMode": getattr(features_obj, "heatMode", False),
+                "dryMode": getattr(features_obj, "dryMode", False),
+                "coolMode": getattr(features_obj, "coolMode", False),
+                "fanMode": getattr(features_obj, "fanMode", False),
+                "airSwingLR": getattr(features_obj, "airSwingLR", False),
+            }
+        elif isinstance(features_obj, dict):
+            features = features_obj
+        else:
+            features = {}
+    else:
+        # Dict style
+        dev_id = dev.get("id", "")
+        name = dev.get("name", "")
+        group = dev.get("group", "")
+        model = dev.get("model", "")
+        features = dev.get("features", {})
+
+    return {
+        "id": str(dev_id),
+        "name": name,
+        "group": group,
+        "model": model,
+        "parameters": params,
+        "features": features,
+    }
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def main():
+    parser = argparse.ArgumentParser(description="Panasonic Comfort Cloud bridge for Corbel")
+    parser.add_argument("command", choices=["login", "get_devices", "get_device", "control"])
+    parser.add_argument("--email", required=True)
+    parser.add_argument("--password", required=True)
+    parser.add_argument("--token-file", required=True)
+    parser.add_argument("--id", help="Device ID/GUID (for get_device and control)")
+    parser.add_argument("--param", help="Parameter name (for control)")
+    parser.add_argument("--value", help="Value to set (for control)")
+
+    args = parser.parse_args()
+
+    try:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        if args.command == "login":
+            result = loop.run_until_complete(cmd_login(args))
+        elif args.command == "get_devices":
+            result = loop.run_until_complete(cmd_get_devices(args))
+        elif args.command == "get_device":
+            if not args.id:
+                result = {"ok": False, "error": "--id is required for get_device"}
+            else:
+                result = loop.run_until_complete(cmd_get_device(args))
+        elif args.command == "control":
+            if not args.id or not args.param or args.value is None:
+                result = {"ok": False, "error": "--id, --param, and --value are required for control"}
+            else:
+                result = loop.run_until_complete(cmd_control(args))
+        else:
+            result = {"ok": False, "error": f"Unknown command: {args.command}"}
+
+        print(json.dumps(result))
+
+    except Exception as e:
+        print(json.dumps({"ok": False, "error": str(e)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/integrations/panasonic-cc/index.ts
+++ b/src/integrations/panasonic-cc/index.ts
@@ -73,6 +73,13 @@ export class PanasonicCCIntegration implements IntegrationPlugin {
   }
 
   async start(): Promise<void> {
+    // Clean up previous state before (re)starting
+    if (this.poller) {
+      this.poller.stop();
+      this.poller = null;
+    }
+    this.bridge = null;
+
     if (!this.isConfigured()) {
       this.status = "not_configured";
       return;

--- a/src/integrations/panasonic-cc/index.ts
+++ b/src/integrations/panasonic-cc/index.ts
@@ -1,0 +1,155 @@
+import { resolve } from "node:path";
+import type { IntegrationPlugin } from "../integration-registry.js";
+import type { IntegrationStatus, IntegrationSettingDef, Device } from "../../shared/types.js";
+import type { Logger } from "../../core/logger.js";
+import type { EventBus } from "../../core/event-bus.js";
+import type { SettingsManager } from "../../core/settings-manager.js";
+import type { DeviceManager } from "../../devices/device-manager.js";
+import { PanasonicBridge } from "./panasonic-bridge.js";
+import { PanasonicPoller } from "./panasonic-poller.js";
+
+const SETTINGS_PREFIX = "integration.panasonic_cc.";
+const DEFAULT_DATA_DIR = resolve(process.cwd(), "data");
+
+export class PanasonicCCIntegration implements IntegrationPlugin {
+  readonly id = "panasonic_cc";
+  readonly name = "Panasonic Comfort Cloud";
+  readonly description = "Panasonic AC units via Comfort Cloud API";
+  readonly icon = "AirVent";
+
+  private logger: Logger;
+  private eventBus: EventBus;
+  private settingsManager: SettingsManager;
+  private deviceManager: DeviceManager;
+  private bridge: PanasonicBridge | null = null;
+  private poller: PanasonicPoller | null = null;
+  private status: IntegrationStatus = "disconnected";
+
+  constructor(
+    settingsManager: SettingsManager,
+    deviceManager: DeviceManager,
+    eventBus: EventBus,
+    logger: Logger,
+  ) {
+    this.settingsManager = settingsManager;
+    this.deviceManager = deviceManager;
+    this.eventBus = eventBus;
+    this.logger = logger.child({ module: "integration-panasonic-cc" });
+  }
+
+  getStatus(): IntegrationStatus {
+    if (!this.isConfigured()) return "not_configured";
+    return this.status;
+  }
+
+  isConfigured(): boolean {
+    return this.getSetting("email") !== undefined && this.getSetting("password") !== undefined;
+  }
+
+  getSettingsSchema(): IntegrationSettingDef[] {
+    return [
+      {
+        key: "email",
+        label: "Panasonic ID (email)",
+        type: "text",
+        required: true,
+        placeholder: "user@example.com",
+      },
+      {
+        key: "password",
+        label: "Password",
+        type: "password",
+        required: true,
+      },
+      {
+        key: "polling_interval",
+        label: "Polling interval (seconds)",
+        type: "number",
+        required: false,
+        defaultValue: "300",
+        placeholder: "300",
+      },
+    ];
+  }
+
+  async start(): Promise<void> {
+    if (!this.isConfigured()) {
+      this.status = "not_configured";
+      return;
+    }
+
+    const email = this.getSetting("email")!;
+    const password = this.getSetting("password")!;
+    const pollingIntervalSec = parseInt(this.getSetting("polling_interval") ?? "300", 10);
+    const pollingIntervalMs = (isNaN(pollingIntervalSec) ? 300 : pollingIntervalSec) * 1000;
+    const tokenFile = resolve(DEFAULT_DATA_DIR, "panasonic-tokens.json");
+
+    try {
+      this.bridge = new PanasonicBridge(tokenFile, this.logger);
+
+      // Verify credentials
+      await this.bridge.login(email, password);
+      this.logger.info("Panasonic CC credentials verified");
+
+      // Start polling
+      this.poller = new PanasonicPoller(
+        this.bridge,
+        this.deviceManager,
+        this.logger,
+        email,
+        password,
+        pollingIntervalMs,
+      );
+      this.poller.start();
+
+      this.status = "connected";
+      this.eventBus.emit({ type: "system.integration.connected", integrationId: this.id });
+      this.logger.info({ pollingIntervalMs }, "Panasonic CC integration started");
+    } catch (err) {
+      this.status = "error";
+      this.logger.error({ err }, "Failed to start Panasonic CC integration");
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.poller) {
+      this.poller.stop();
+      this.poller = null;
+    }
+    this.bridge = null;
+    this.status = "disconnected";
+    this.eventBus.emit({ type: "system.integration.disconnected", integrationId: this.id });
+    this.logger.info("Panasonic CC integration stopped");
+  }
+
+  async executeOrder(
+    _device: Device,
+    dispatchConfig: Record<string, unknown>,
+    value: unknown,
+  ): Promise<void> {
+    if (!this.bridge || this.status !== "connected") {
+      throw new Error("Panasonic CC integration not connected");
+    }
+
+    const email = this.getSetting("email")!;
+    const password = this.getSetting("password")!;
+    const param = dispatchConfig.param as string;
+    const guid = dispatchConfig.guid as string;
+
+    if (!param || !guid) {
+      throw new Error("Invalid dispatch config: missing param or guid");
+    }
+
+    await this.bridge.control(guid, param, value, email, password);
+    this.logger.info({ guid, param, value }, "Panasonic order executed");
+
+    // Schedule on-demand poll to confirm the change
+    if (this.poller) {
+      this.poller.scheduleOnDemandPoll();
+    }
+  }
+
+  private getSetting(key: string): string | undefined {
+    return this.settingsManager.get(`${SETTINGS_PREFIX}${key}`);
+  }
+}

--- a/src/integrations/panasonic-cc/index.ts
+++ b/src/integrations/panasonic-cc/index.ts
@@ -107,7 +107,7 @@ export class PanasonicCCIntegration implements IntegrationPlugin {
         password,
         pollingIntervalMs,
       );
-      this.poller.start();
+      await this.poller.start();
 
       this.status = "connected";
       this.eventBus.emit({ type: "system.integration.connected", integrationId: this.id });
@@ -154,6 +154,14 @@ export class PanasonicCCIntegration implements IntegrationPlugin {
     if (this.poller) {
       this.poller.scheduleOnDemandPoll();
     }
+  }
+
+  async refresh(): Promise<void> {
+    if (!this.poller || this.status !== "connected") {
+      throw new Error("Panasonic CC integration not connected");
+    }
+    await this.poller.refresh();
+    this.logger.info("Panasonic CC manual refresh completed");
   }
 
   private getSetting(key: string): string | undefined {

--- a/src/integrations/panasonic-cc/panasonic-bridge.ts
+++ b/src/integrations/panasonic-cc/panasonic-bridge.ts
@@ -1,0 +1,130 @@
+import { execFile } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Logger } from "../../core/logger.js";
+import type {
+  BridgeDevicesResponse,
+  BridgeDeviceResponse,
+  BridgeLoginResponse,
+  BridgeResponse,
+} from "./panasonic-types.js";
+
+const BRIDGE_TIMEOUT_MS = 30_000;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_BRIDGE_PATH = resolve(__dirname, "bridge.py");
+
+export class PanasonicBridge {
+  private pythonPath: string;
+  private bridgePath: string;
+  private tokenFile: string;
+  private logger: Logger;
+
+  constructor(
+    tokenFile: string,
+    logger: Logger,
+    pythonPath = "python3",
+    bridgePath = DEFAULT_BRIDGE_PATH,
+  ) {
+    this.pythonPath = pythonPath;
+    this.bridgePath = bridgePath;
+    this.tokenFile = tokenFile;
+    this.logger = logger.child({ module: "panasonic-bridge" });
+  }
+
+  async login(email: string, password: string): Promise<BridgeLoginResponse> {
+    const result = await this.exec("login", email, password);
+    if (!result.ok) {
+      throw new Error(`Panasonic login failed: ${(result as { error: string }).error}`);
+    }
+    return result as BridgeLoginResponse;
+  }
+
+  async getDevices(email: string, password: string): Promise<BridgeDevicesResponse> {
+    const result = await this.exec("get_devices", email, password);
+    if (!result.ok) {
+      throw new Error(`Failed to get devices: ${(result as { error: string }).error}`);
+    }
+    return result as BridgeDevicesResponse;
+  }
+
+  async getDevice(
+    deviceId: string,
+    email: string,
+    password: string,
+  ): Promise<BridgeDeviceResponse> {
+    const result = await this.exec("get_device", email, password, ["--id", deviceId]);
+    if (!result.ok) {
+      throw new Error(`Failed to get device: ${(result as { error: string }).error}`);
+    }
+    return result as BridgeDeviceResponse;
+  }
+
+  async control(
+    deviceId: string,
+    param: string,
+    value: unknown,
+    email: string,
+    password: string,
+  ): Promise<void> {
+    const result = await this.exec("control", email, password, [
+      "--id",
+      deviceId,
+      "--param",
+      param,
+      "--value",
+      String(value),
+    ]);
+    if (!result.ok) {
+      throw new Error(`Control failed: ${(result as { error: string }).error}`);
+    }
+  }
+
+  private exec(
+    command: string,
+    email: string,
+    password: string,
+    extraArgs: string[] = [],
+  ): Promise<BridgeResponse> {
+    const args = [
+      this.bridgePath,
+      command,
+      "--email",
+      email,
+      "--password",
+      password,
+      "--token-file",
+      this.tokenFile,
+      ...extraArgs,
+    ];
+
+    this.logger.debug({ command, extraArgs }, "Executing Python bridge");
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        this.pythonPath,
+        args,
+        { timeout: BRIDGE_TIMEOUT_MS, maxBuffer: 1024 * 1024 },
+        (error, stdout, stderr) => {
+          if (error) {
+            this.logger.error({ err: error, stderr }, "Python bridge execution failed");
+            reject(new Error(`Bridge process failed: ${error.message}`));
+            return;
+          }
+
+          if (stderr) {
+            this.logger.warn({ stderr: stderr.trim() }, "Python bridge stderr");
+          }
+
+          try {
+            const result = JSON.parse(stdout) as BridgeResponse;
+            resolve(result);
+          } catch {
+            this.logger.error({ stdout: stdout.substring(0, 500) }, "Failed to parse bridge JSON");
+            reject(new Error("Bridge returned invalid JSON"));
+          }
+        },
+      );
+    });
+  }
+}

--- a/src/integrations/panasonic-cc/panasonic-bridge.ts
+++ b/src/integrations/panasonic-cc/panasonic-bridge.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Logger } from "../../core/logger.js";
@@ -14,6 +15,17 @@ const BRIDGE_TIMEOUT_MS = 30_000;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_BRIDGE_PATH = resolve(__dirname, "bridge.py");
 
+/** Resolve the Python path: prefer .venv in project root, fall back to system python3. */
+function resolveDefaultPython(): string {
+  // __dirname is src/integrations/panasonic-cc (or dist equivalent)
+  const projectRoot = resolve(__dirname, "..", "..", "..");
+  const venvPython = resolve(projectRoot, ".venv", "bin", "python3");
+  if (existsSync(venvPython)) {
+    return venvPython;
+  }
+  return "python3";
+}
+
 export class PanasonicBridge {
   private pythonPath: string;
   private bridgePath: string;
@@ -23,7 +35,7 @@ export class PanasonicBridge {
   constructor(
     tokenFile: string,
     logger: Logger,
-    pythonPath = "python3",
+    pythonPath = resolveDefaultPython(),
     bridgePath = DEFAULT_BRIDGE_PATH,
   ) {
     this.pythonPath = pythonPath;

--- a/src/integrations/panasonic-cc/panasonic-poller.ts
+++ b/src/integrations/panasonic-cc/panasonic-poller.ts
@@ -1,0 +1,230 @@
+import type { Logger } from "../../core/logger.js";
+import type { DeviceManager } from "../../devices/device-manager.js";
+import type { PanasonicBridge } from "./panasonic-bridge.js";
+import type { BridgeDevice } from "./panasonic-types.js";
+import type { DiscoveredDevice } from "../../devices/device-manager.js";
+import type { DataType, DataCategory } from "../../shared/types.js";
+import {
+  FAN_SPEED_VALUES,
+  AIR_SWING_UD_VALUES,
+  AIR_SWING_LR_VALUES,
+  ECO_MODE_VALUES,
+  NANOE_VALUES,
+  getAvailableModes,
+} from "./panasonic-types.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 300_000; // 5 minutes
+const DEFAULT_ON_DEMAND_DELAY_MS = 10_000; // 10 seconds
+
+export class PanasonicPoller {
+  private bridge: PanasonicBridge;
+  private deviceManager: DeviceManager;
+  private logger: Logger;
+  private email: string;
+  private password: string;
+  private pollIntervalMs: number;
+  private onDemandDelayMs: number;
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private pendingTimers: Set<ReturnType<typeof setTimeout>> = new Set();
+  private polling = false;
+
+  constructor(
+    bridge: PanasonicBridge,
+    deviceManager: DeviceManager,
+    logger: Logger,
+    email: string,
+    password: string,
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    onDemandDelayMs = DEFAULT_ON_DEMAND_DELAY_MS,
+  ) {
+    this.bridge = bridge;
+    this.deviceManager = deviceManager;
+    this.logger = logger.child({ module: "panasonic-poller" });
+    this.email = email;
+    this.password = password;
+    this.pollIntervalMs = pollIntervalMs;
+    this.onDemandDelayMs = onDemandDelayMs;
+  }
+
+  start(): void {
+    this.logger.info({ intervalMs: this.pollIntervalMs }, "Starting Panasonic poller");
+    // Immediate first poll
+    this.poll();
+    // Regular polling
+    this.interval = setInterval(() => this.poll(), this.pollIntervalMs);
+  }
+
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    for (const timer of this.pendingTimers) {
+      clearTimeout(timer);
+    }
+    this.pendingTimers.clear();
+    this.logger.info("Panasonic poller stopped");
+  }
+
+  scheduleOnDemandPoll(delayMs?: number): void {
+    const delay = delayMs ?? this.onDemandDelayMs;
+    this.logger.debug({ delayMs: delay }, "Scheduling on-demand poll");
+    const timer = setTimeout(() => {
+      this.pendingTimers.delete(timer);
+      this.poll();
+    }, delay);
+    this.pendingTimers.add(timer);
+  }
+
+  private async poll(): Promise<void> {
+    if (this.polling) {
+      this.logger.debug("Poll already in progress, skipping");
+      return;
+    }
+    this.polling = true;
+
+    try {
+      this.logger.debug("Polling Panasonic devices...");
+      const response = await this.bridge.getDevices(this.email, this.password);
+
+      for (const device of response.devices) {
+        const discovered = mapBridgeDeviceToDiscovered(device);
+        this.deviceManager.upsertFromDiscovery("panasonic_cc", "panasonic_cc", discovered);
+
+        // Update data values
+        this.updateDeviceData(device);
+      }
+
+      this.logger.debug({ deviceCount: response.devices.length }, "Panasonic poll complete");
+    } catch (err) {
+      this.logger.error({ err }, "Panasonic poll failed");
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  private updateDeviceData(bridgeDevice: BridgeDevice): void {
+    const sourceDeviceId = bridgeDevice.id;
+    const p = bridgeDevice.parameters;
+
+    const payload: Record<string, unknown> = {};
+    if (p.power !== null) payload.power = p.power === "on";
+    if (p.mode !== null) payload.operationMode = p.mode;
+    if (p.targetTemperature !== null) payload.targetTemperature = p.targetTemperature;
+    if (p.insideTemperature !== null) payload.insideTemperature = p.insideTemperature;
+    if (p.outsideTemperature !== null) payload.outsideTemperature = p.outsideTemperature;
+    if (p.fanSpeed !== null) payload.fanSpeed = p.fanSpeed;
+    if (p.airSwingUD !== null) payload.airSwingUD = p.airSwingUD;
+    if (p.airSwingLR !== null) payload.airSwingLR = p.airSwingLR;
+    if (p.ecoMode !== null) payload.ecoMode = p.ecoMode;
+    if (p.nanoe !== null) payload.nanoe = p.nanoe;
+
+    // updateDeviceData also sets status to "online"
+    this.deviceManager.updateDeviceData("panasonic_cc", sourceDeviceId, payload);
+  }
+}
+
+/**
+ * Map a bridge device to a Corbel DiscoveredDevice for upsert.
+ */
+function mapBridgeDeviceToDiscovered(bridgeDevice: BridgeDevice): DiscoveredDevice {
+  const features = bridgeDevice.features;
+
+  const data: DiscoveredDevice["data"] = [
+    { key: "power", type: "boolean" as DataType, category: "generic" as DataCategory },
+    { key: "operationMode", type: "enum" as DataType, category: "generic" as DataCategory },
+    {
+      key: "targetTemperature",
+      type: "number" as DataType,
+      category: "temperature" as DataCategory,
+      unit: "°C",
+    },
+    {
+      key: "insideTemperature",
+      type: "number" as DataType,
+      category: "temperature" as DataCategory,
+      unit: "°C",
+    },
+    {
+      key: "outsideTemperature",
+      type: "number" as DataType,
+      category: "temperature" as DataCategory,
+      unit: "°C",
+    },
+    { key: "fanSpeed", type: "enum" as DataType, category: "generic" as DataCategory },
+    { key: "airSwingUD", type: "enum" as DataType, category: "generic" as DataCategory },
+    { key: "airSwingLR", type: "enum" as DataType, category: "generic" as DataCategory },
+    { key: "ecoMode", type: "enum" as DataType, category: "generic" as DataCategory },
+  ];
+
+  if (features.nanoe) {
+    data.push({ key: "nanoe", type: "enum" as DataType, category: "generic" as DataCategory });
+  }
+
+  const orders: DiscoveredDevice["orders"] = [
+    {
+      key: "power",
+      type: "boolean" as DataType,
+      dispatchConfig: { param: "power", guid: bridgeDevice.id },
+    },
+    {
+      key: "operationMode",
+      type: "enum" as DataType,
+      dispatchConfig: { param: "mode", guid: bridgeDevice.id },
+      enumValues: getAvailableModes(features),
+    },
+    {
+      key: "targetTemperature",
+      type: "number" as DataType,
+      dispatchConfig: { param: "targetTemperature", guid: bridgeDevice.id },
+      min: 16,
+      max: 30,
+      unit: "°C",
+    },
+    {
+      key: "fanSpeed",
+      type: "enum" as DataType,
+      dispatchConfig: { param: "fanSpeed", guid: bridgeDevice.id },
+      enumValues: [...FAN_SPEED_VALUES],
+    },
+    {
+      key: "airSwingUD",
+      type: "enum" as DataType,
+      dispatchConfig: { param: "airSwingUD", guid: bridgeDevice.id },
+      enumValues: [...AIR_SWING_UD_VALUES],
+    },
+  ];
+
+  if (features.airSwingLR) {
+    orders.push({
+      key: "airSwingLR",
+      type: "enum" as DataType,
+      dispatchConfig: { param: "airSwingLR", guid: bridgeDevice.id },
+      enumValues: [...AIR_SWING_LR_VALUES],
+    });
+  }
+
+  orders.push({
+    key: "ecoMode",
+    type: "enum" as DataType,
+    dispatchConfig: { param: "ecoMode", guid: bridgeDevice.id },
+    enumValues: [...ECO_MODE_VALUES],
+  });
+
+  if (features.nanoe) {
+    orders.push({
+      key: "nanoe",
+      type: "enum" as DataType,
+      dispatchConfig: { param: "nanoe", guid: bridgeDevice.id },
+      enumValues: [...NANOE_VALUES],
+    });
+  }
+
+  return {
+    friendlyName: bridgeDevice.id,
+    manufacturer: "Panasonic",
+    model: bridgeDevice.model || undefined,
+    data,
+    orders,
+  };
+}

--- a/src/integrations/panasonic-cc/panasonic-poller.ts
+++ b/src/integrations/panasonic-cc/panasonic-poller.ts
@@ -46,10 +46,10 @@ export class PanasonicPoller {
     this.onDemandDelayMs = onDemandDelayMs;
   }
 
-  start(): void {
+  async start(): Promise<void> {
     this.logger.info({ intervalMs: this.pollIntervalMs }, "Starting Panasonic poller");
-    // Immediate first poll
-    this.poll();
+    // Immediate first poll — awaited so data is available at startup
+    await this.poll();
     // Regular polling
     this.interval = setInterval(() => this.poll(), this.pollIntervalMs);
   }
@@ -64,6 +64,11 @@ export class PanasonicPoller {
     }
     this.pendingTimers.clear();
     this.logger.info("Panasonic poller stopped");
+  }
+
+  /** Force an immediate poll (for manual refresh). */
+  async refresh(): Promise<void> {
+    await this.poll();
   }
 
   scheduleOnDemandPoll(delayMs?: number): void {
@@ -104,7 +109,7 @@ export class PanasonicPoller {
   }
 
   private updateDeviceData(bridgeDevice: BridgeDevice): void {
-    const sourceDeviceId = bridgeDevice.id;
+    const sourceDeviceId = bridgeDevice.name || bridgeDevice.id;
     const p = bridgeDevice.parameters;
 
     const payload: Record<string, unknown> = {};
@@ -221,7 +226,7 @@ function mapBridgeDeviceToDiscovered(bridgeDevice: BridgeDevice): DiscoveredDevi
   }
 
   return {
-    friendlyName: bridgeDevice.id,
+    friendlyName: bridgeDevice.name || bridgeDevice.id,
     manufacturer: "Panasonic",
     model: bridgeDevice.model || undefined,
     data,

--- a/src/integrations/panasonic-cc/panasonic-types.ts
+++ b/src/integrations/panasonic-cc/panasonic-types.ts
@@ -1,0 +1,106 @@
+// ============================================================
+// Panasonic Comfort Cloud — Bridge response types + enum values
+// ============================================================
+
+/** Successful bridge response for get_devices */
+export interface BridgeDevicesResponse {
+  ok: true;
+  devices: BridgeDevice[];
+}
+
+/** Successful bridge response for get_device */
+export interface BridgeDeviceResponse {
+  ok: true;
+  device: BridgeDevice;
+}
+
+/** Successful bridge response for login */
+export interface BridgeLoginResponse {
+  ok: true;
+  deviceCount: number;
+}
+
+/** Successful bridge response for control */
+export interface BridgeControlResponse {
+  ok: true;
+}
+
+/** Error response from bridge */
+export interface BridgeErrorResponse {
+  ok: false;
+  error: string;
+}
+
+/** Union of all bridge responses */
+export type BridgeResponse =
+  | BridgeDevicesResponse
+  | BridgeDeviceResponse
+  | BridgeLoginResponse
+  | BridgeControlResponse
+  | BridgeErrorResponse;
+
+/** A device as returned by the Python bridge */
+export interface BridgeDevice {
+  id: string;
+  name: string;
+  group: string;
+  model: string;
+  parameters: BridgeDeviceParameters;
+  features: BridgeDeviceFeatures;
+}
+
+/** Device parameters from bridge */
+export interface BridgeDeviceParameters {
+  power: string | null;
+  mode: string | null;
+  targetTemperature: number | null;
+  insideTemperature: number | null;
+  outsideTemperature: number | null;
+  fanSpeed: string | null;
+  airSwingUD: string | null;
+  airSwingLR: string | null;
+  ecoMode: string | null;
+  nanoe: string | null;
+}
+
+/** Device feature flags from bridge */
+export interface BridgeDeviceFeatures {
+  nanoe?: boolean;
+  autoMode?: boolean;
+  heatMode?: boolean;
+  dryMode?: boolean;
+  coolMode?: boolean;
+  fanMode?: boolean;
+  airSwingLR?: boolean;
+}
+
+// ============================================================
+// Enum value lists (for DeviceOrder enumValues)
+// ============================================================
+
+export const POWER_VALUES = ["off", "on"] as const;
+
+export const OPERATION_MODE_VALUES = ["auto", "dry", "cool", "heat", "fan"] as const;
+
+export const FAN_SPEED_VALUES = ["auto", "low", "lowMid", "mid", "highMid", "high"] as const;
+
+export const AIR_SWING_UD_VALUES = ["up", "down", "mid", "upMid", "downMid"] as const;
+
+export const AIR_SWING_LR_VALUES = ["left", "right", "mid", "rightMid", "leftMid"] as const;
+
+export const ECO_MODE_VALUES = ["auto", "powerful", "quiet"] as const;
+
+export const NANOE_VALUES = ["unavailable", "off", "on", "modeG", "all"] as const;
+
+/**
+ * Filter operation mode values based on device features.
+ */
+export function getAvailableModes(features: BridgeDeviceFeatures): string[] {
+  const modes: string[] = [];
+  if (features.autoMode !== false) modes.push("auto");
+  if (features.dryMode !== false) modes.push("dry");
+  if (features.coolMode !== false) modes.push("cool");
+  if (features.heatMode !== false) modes.push("heat");
+  if (features.fanMode !== false) modes.push("fan");
+  return modes;
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,6 +1,13 @@
 import type { DataCategory, DataType } from "./types.js";
 
 // ============================================================
+// Root Zone — "Maison" is the root of the zone hierarchy
+// ============================================================
+
+/** Well-known ID for the root zone "Maison". */
+export const ROOT_ZONE_ID = "00000000-0000-0000-0000-000000000001";
+
+// ============================================================
 // DataCategory inference from zigbee2mqtt expose property names
 // ============================================================
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -141,7 +141,8 @@ export type EquipmentType =
   | "shutter"
   | "switch"
   | "sensor"
-  | "button";
+  | "button"
+  | "thermostat";
 
 export interface Equipment {
   id: string;

--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -465,8 +465,8 @@ export class ZoneAggregator {
           break;
 
         case "shutter_position":
+          acc.shuttersTotal += 1;
           if (typeof value === "number") {
-            acc.shuttersTotal += 1;
             acc.shutterPositionSum += value;
             acc.shutterPositionCount += 1;
             if (value > 0) {

--- a/src/zones/zone-manager.ts
+++ b/src/zones/zone-manager.ts
@@ -4,6 +4,7 @@ import type { Logger } from "../core/logger.js";
 import type { EventBus } from "../core/event-bus.js";
 import { toISOUtc } from "../core/database.js";
 import type { Zone, ZoneWithChildren } from "../shared/types.js";
+import { ROOT_ZONE_ID } from "../shared/constants.js";
 
 interface CreateZoneInput {
   name: string;
@@ -61,7 +62,43 @@ export class ZoneManager {
       updateDisplayOrder: this.db.prepare(
         "UPDATE zones SET display_order = ?, updated_at = datetime('now') WHERE id = ?",
       ),
+      reparentOrphanZones: this.db.prepare(
+        "UPDATE zones SET parent_id = ? WHERE parent_id IS NULL AND id != ?",
+      ),
     };
+  }
+
+  // ============================================================
+  // Root zone bootstrap
+  // ============================================================
+
+  /**
+   * Ensures the root zone "Maison" exists.
+   * If it doesn't, creates it and reparents existing top-level zones under it.
+   */
+  ensureRootZone(): Zone {
+    const existing = this.stmts.getZoneById.get(ROOT_ZONE_ID) as ZoneRow | undefined;
+    if (existing) {
+      // Reparent any orphan top-level zones under root (safety net)
+      this.stmts.reparentOrphanZones.run(ROOT_ZONE_ID, ROOT_ZONE_ID);
+      return rowToZone(existing);
+    }
+
+    this.stmts.insertZone.run({
+      id: ROOT_ZONE_ID,
+      name: "Maison",
+      parentId: null,
+      icon: "home",
+      description: null,
+      displayOrder: 0,
+    });
+
+    // Reparent existing top-level zones under the new root
+    this.stmts.reparentOrphanZones.run(ROOT_ZONE_ID, ROOT_ZONE_ID);
+
+    const zone = this.getById(ROOT_ZONE_ID)!;
+    this.logger.info("Root zone 'Maison' created");
+    return zone;
   }
 
   // ============================================================
@@ -71,18 +108,20 @@ export class ZoneManager {
   create(input: CreateZoneInput): Zone {
     const id = randomUUID();
 
+    const parentId = input.parentId ?? null;
+
     // Validate parent exists if provided
-    if (input.parentId) {
-      const parent = this.stmts.getZoneById.get(input.parentId) as ZoneRow | undefined;
+    if (parentId) {
+      const parent = this.stmts.getZoneById.get(parentId) as ZoneRow | undefined;
       if (!parent) {
-        throw new ZoneError(`Parent zone not found: ${input.parentId}`, 404);
+        throw new ZoneError(`Parent zone not found: ${parentId}`, 404);
       }
     }
 
     this.stmts.insertZone.run({
       id,
       name: input.name,
-      parentId: input.parentId ?? null,
+      parentId,
       icon: input.icon ?? null,
       description: input.description ?? null,
       displayOrder: input.displayOrder ?? 0,
@@ -197,6 +236,10 @@ export class ZoneManager {
   }
 
   delete(id: string): void {
+    if (id === ROOT_ZONE_ID) {
+      throw new ZoneError("Cannot delete the root zone", 400);
+    }
+
     const existing = this.getById(id);
     if (!existing) {
       throw new ZoneError("Zone not found", 404);

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -457,6 +457,10 @@ export async function stopIntegration(id: string): Promise<{ success: boolean; s
   return fetchJSON(`${API_BASE}/integrations/${id}/stop`, { method: "POST" });
 }
 
+export async function refreshIntegration(id: string): Promise<{ success: boolean }> {
+  return fetchJSON(`${API_BASE}/integrations/${id}/refresh`, { method: "POST" });
+}
+
 // ============================================================
 // Backup (admin)
 // ============================================================

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -15,6 +15,11 @@ const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> 
   button: ["action"],
 };
 
+/** Maps EquipmentType to required data keys for filtering (when category alone is too broad). */
+const EQUIPMENT_TYPE_DATA_KEYS: Partial<Record<EquipmentType, string[]>> = {
+  thermostat: ["targetTemperature"],
+};
+
 interface DeviceSelectorProps {
   equipmentType: EquipmentType;
   selectedDeviceIds: string[];
@@ -54,11 +59,16 @@ export function DeviceSelector({
     : allDevices;
 
   const categories = EQUIPMENT_TYPE_CATEGORIES[equipmentType];
-  const compatible = categories && categories.length > 0
+  const requiredKeys = EQUIPMENT_TYPE_DATA_KEYS[equipmentType];
+  const compatible = requiredKeys
     ? availableDevices.filter((device) =>
-        device.data.some((d) => categories.includes(d.category))
+        device.data.some((d) => requiredKeys.includes(d.key))
       )
-    : availableDevices;
+    : categories && categories.length > 0
+      ? availableDevices.filter((device) =>
+          device.data.some((d) => categories.includes(d.category))
+        )
+      : availableDevices;
 
   const baseDevices = showAll ? availableDevices : compatible;
   const filterLower = filter.toLowerCase();

--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -8,7 +8,7 @@ import {
   Gauge,
   ToggleLeft,
   CircleDot,
-  AirVent,
+  Thermometer,
 } from "lucide-react";
 import type { EquipmentType, EquipmentWithDetails } from "../../types";
 import { LightControl } from "./LightControl";
@@ -25,7 +25,7 @@ const TYPE_ICONS: Record<EquipmentType, React.ReactNode> = {
   switch: <ToggleLeft size={18} strokeWidth={1.5} />,
   sensor: <Gauge size={18} strokeWidth={1.5} />,
   button: <CircleDot size={18} strokeWidth={1.5} />,
-  thermostat: <AirVent size={18} strokeWidth={1.5} />,
+  thermostat: <Thermometer size={18} strokeWidth={1.5} />,
 };
 
 const TYPE_LABELS: Record<EquipmentType, string> = {

--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -8,11 +8,13 @@ import {
   Gauge,
   ToggleLeft,
   CircleDot,
+  AirVent,
 } from "lucide-react";
 import type { EquipmentType, EquipmentWithDetails } from "../../types";
 import { LightControl } from "./LightControl";
 import { SensorValues } from "./SensorValues";
 import { ShutterControls } from "./ShutterControls";
+import { ThermostatCard } from "./ThermostatCard";
 import { useEquipmentState } from "./useEquipmentState";
 
 const TYPE_ICONS: Record<EquipmentType, React.ReactNode> = {
@@ -23,6 +25,7 @@ const TYPE_ICONS: Record<EquipmentType, React.ReactNode> = {
   switch: <ToggleLeft size={18} strokeWidth={1.5} />,
   sensor: <Gauge size={18} strokeWidth={1.5} />,
   button: <CircleDot size={18} strokeWidth={1.5} />,
+  thermostat: <AirVent size={18} strokeWidth={1.5} />,
 };
 
 const TYPE_LABELS: Record<EquipmentType, string> = {
@@ -33,6 +36,7 @@ const TYPE_LABELS: Record<EquipmentType, string> = {
   switch: "equipments.type.switch",
   sensor: "equipments.type.sensor",
   button: "equipments.type.button",
+  thermostat: "equipments.type.thermostat",
 };
 
 interface EquipmentCardProps {
@@ -46,6 +50,7 @@ export function EquipmentCard({ equipment, onExecuteOrder }: EquipmentCardProps)
     isLight,
     isShutter,
     isSensor,
+    isThermostat,
     iconElement,
     iconColor,
     shutterPosition,
@@ -108,6 +113,15 @@ export function EquipmentCard({ equipment, onExecuteOrder }: EquipmentCardProps)
           hasShutterState={hasShutterState}
           hasPositionOrder={equipment.orderBindings.some((ob) => ob.alias === "position")}
           onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
+        />
+      )}
+
+      {/* Thermostat quick control */}
+      {isThermostat && equipment.enabled && (
+        <ThermostatCard
+          equipment={equipment}
+          onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
+          compact
         />
       )}
     </div>

--- a/ui/src/components/equipments/EquipmentForm.tsx
+++ b/ui/src/components/equipments/EquipmentForm.tsx
@@ -12,6 +12,7 @@ const EQUIPMENT_TYPE_KEYS: { value: EquipmentType; labelKey: string }[] = [
   { value: "switch", labelKey: "equipments.type.switch" },
   { value: "sensor", labelKey: "equipments.type.sensor" },
   { value: "button", labelKey: "equipments.type.button" },
+  { value: "thermostat", labelKey: "equipments.type.thermostat" },
 ];
 
 interface EquipmentFormProps {

--- a/ui/src/components/equipments/ThermostatCard.tsx
+++ b/ui/src/components/equipments/ThermostatCard.tsx
@@ -1,0 +1,286 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Power,
+  ChevronUp,
+  ChevronDown,
+  Wind,
+  Snowflake,
+  Sun,
+  Droplets,
+  Fan,
+  Zap,
+  Leaf,
+} from "lucide-react";
+import type { EquipmentWithDetails } from "../../types";
+
+interface ThermostatCardProps {
+  equipment: EquipmentWithDetails;
+  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+  compact?: boolean;
+}
+
+const MODE_ICONS: Record<string, React.ReactNode> = {
+  auto: <Zap size={14} strokeWidth={1.5} />,
+  cool: <Snowflake size={14} strokeWidth={1.5} />,
+  heat: <Sun size={14} strokeWidth={1.5} />,
+  dry: <Droplets size={14} strokeWidth={1.5} />,
+  fan: <Fan size={14} strokeWidth={1.5} />,
+};
+
+const MODE_COLORS: Record<string, string> = {
+  auto: "bg-primary/10 text-primary border-primary/30",
+  cool: "bg-blue-500/10 text-blue-500 border-blue-500/30",
+  heat: "bg-orange-500/10 text-orange-500 border-orange-500/30",
+  dry: "bg-teal-500/10 text-teal-500 border-teal-500/30",
+  fan: "bg-gray-500/10 text-gray-500 border-gray-500/30",
+};
+
+export function ThermostatCard({ equipment, onExecuteOrder, compact }: ThermostatCardProps) {
+  const { t } = useTranslation();
+  const [executing, setExecuting] = useState<string | null>(null);
+
+  // Read data bindings
+  const powerBinding = equipment.dataBindings.find((b) => b.alias === "power");
+  const modeBinding = equipment.dataBindings.find((b) => b.alias === "operationMode");
+  const targetTempBinding = equipment.dataBindings.find((b) => b.alias === "targetTemperature");
+  const insideTempBinding = equipment.dataBindings.find((b) => b.alias === "insideTemperature");
+  const outsideTempBinding = equipment.dataBindings.find((b) => b.alias === "outsideTemperature");
+  const fanSpeedBinding = equipment.dataBindings.find((b) => b.alias === "fanSpeed");
+  const ecoModeBinding = equipment.dataBindings.find((b) => b.alias === "ecoMode");
+
+  const isOn = powerBinding?.value === true;
+  const currentMode = typeof modeBinding?.value === "string" ? modeBinding.value : null;
+  const targetTemp = typeof targetTempBinding?.value === "number" ? targetTempBinding.value : null;
+  const insideTemp = typeof insideTempBinding?.value === "number" ? insideTempBinding.value : null;
+  const outsideTemp = typeof outsideTempBinding?.value === "number" ? outsideTempBinding.value : null;
+  const fanSpeed = typeof fanSpeedBinding?.value === "string" ? fanSpeedBinding.value : null;
+  const ecoMode = typeof ecoModeBinding?.value === "string" ? ecoModeBinding.value : null;
+
+  // Order bindings (available controls)
+  const hasPowerOrder = equipment.orderBindings.some((o) => o.alias === "power");
+  const modeOrder = equipment.orderBindings.find((o) => o.alias === "operationMode");
+  const targetTempOrder = equipment.orderBindings.find((o) => o.alias === "targetTemperature");
+  const fanSpeedOrder = equipment.orderBindings.find((o) => o.alias === "fanSpeed");
+
+  const availableModes = modeOrder?.enumValues ?? [];
+  const availableFanSpeeds = fanSpeedOrder?.enumValues ?? [];
+
+  const exec = async (alias: string, value: unknown) => {
+    if (executing) return;
+    setExecuting(alias);
+    try {
+      await onExecuteOrder(alias, value);
+    } finally {
+      setExecuting(null);
+    }
+  };
+
+  if (compact) {
+    return (
+      <CompactThermostat
+        isOn={isOn}
+        currentMode={currentMode}
+        insideTemp={insideTemp}
+        targetTemp={targetTemp}
+        hasPowerOrder={hasPowerOrder}
+        executing={executing}
+        onTogglePower={() => exec("power", !isOn)}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Temperature display + Power */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-end gap-3">
+          <div className="text-[36px] font-semibold text-text leading-none tabular-nums font-mono">
+            {insideTemp !== null ? insideTemp.toFixed(1) : "—"}
+            <span className="text-[16px] text-text-tertiary font-normal">°C</span>
+          </div>
+          {outsideTemp !== null && (
+            <div className="text-[13px] text-text-tertiary mb-1">
+              {t("thermostat.outside")}: {outsideTemp.toFixed(1)}°C
+            </div>
+          )}
+        </div>
+        {hasPowerOrder && (
+          <button
+            onClick={() => exec("power", !isOn)}
+            disabled={executing === "power"}
+            className={`
+              p-2.5 rounded-[8px] transition-colors duration-150 cursor-pointer
+              ${isOn
+                ? "bg-primary text-white hover:bg-primary-hover"
+                : "bg-border-light text-text-tertiary hover:bg-border hover:text-text-secondary"
+              }
+              disabled:opacity-50 disabled:cursor-not-allowed
+            `}
+            title={isOn ? t("controls.turnOff") : t("controls.turnOn")}
+          >
+            <Power size={18} strokeWidth={1.5} />
+          </button>
+        )}
+      </div>
+
+      {/* Target temperature control */}
+      {targetTempOrder && isOn && (
+        <div className="flex items-center gap-3">
+          <span className="text-[12px] text-text-tertiary">{t("thermostat.target")}</span>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => targetTemp !== null && exec("targetTemperature", targetTemp - 0.5)}
+              disabled={executing === "targetTemperature" || targetTemp === null || targetTemp <= (targetTempOrder.min ?? 16)}
+              className="p-1 rounded-[4px] bg-border-light text-text-secondary hover:bg-border hover:text-text transition-colors disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+            >
+              <ChevronDown size={14} strokeWidth={2} />
+            </button>
+            <span className="text-[20px] font-semibold text-text tabular-nums font-mono min-w-[60px] text-center">
+              {targetTemp !== null ? targetTemp.toFixed(1) : "—"}
+              <span className="text-[12px] text-text-tertiary font-normal">°C</span>
+            </span>
+            <button
+              onClick={() => targetTemp !== null && exec("targetTemperature", targetTemp + 0.5)}
+              disabled={executing === "targetTemperature" || targetTemp === null || targetTemp >= (targetTempOrder.max ?? 30)}
+              className="p-1 rounded-[4px] bg-border-light text-text-secondary hover:bg-border hover:text-text transition-colors disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+            >
+              <ChevronUp size={14} strokeWidth={2} />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Mode selector */}
+      {availableModes.length > 0 && isOn && (
+        <div className="space-y-1.5">
+          <span className="text-[12px] text-text-tertiary">{t("thermostat.mode")}</span>
+          <div className="flex gap-1.5 flex-wrap">
+            {availableModes.map((mode) => (
+              <button
+                key={mode}
+                onClick={() => exec("operationMode", mode)}
+                disabled={executing === "operationMode"}
+                className={`
+                  flex items-center gap-1 px-2.5 py-1.5 rounded-[6px] text-[12px] font-medium border
+                  transition-colors duration-150 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed
+                  ${currentMode === mode
+                    ? MODE_COLORS[mode] ?? "bg-primary/10 text-primary border-primary/30"
+                    : "bg-surface text-text-tertiary border-border hover:border-border hover:text-text-secondary"
+                  }
+                `}
+              >
+                {MODE_ICONS[mode]}
+                {t(`thermostat.modes.${mode}`)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Fan speed */}
+      {availableFanSpeeds.length > 0 && isOn && (
+        <div className="space-y-1.5">
+          <span className="text-[12px] text-text-tertiary flex items-center gap-1">
+            <Wind size={12} strokeWidth={1.5} />
+            {t("thermostat.fanSpeed")}
+          </span>
+          <div className="flex gap-1.5 flex-wrap">
+            {availableFanSpeeds.map((speed) => (
+              <button
+                key={speed}
+                onClick={() => exec("fanSpeed", speed)}
+                disabled={executing === "fanSpeed"}
+                className={`
+                  px-2.5 py-1 rounded-[6px] text-[11px] font-medium border
+                  transition-colors duration-150 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed
+                  ${fanSpeed === speed
+                    ? "bg-primary/10 text-primary border-primary/30"
+                    : "bg-surface text-text-tertiary border-border hover:text-text-secondary"
+                  }
+                `}
+              >
+                {t(`thermostat.fanSpeeds.${speed}`)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Eco mode indicator */}
+      {ecoMode && ecoMode !== "auto" && isOn && (
+        <div className="flex items-center gap-1.5 text-[12px] text-success">
+          <Leaf size={12} strokeWidth={1.5} />
+          {t(`thermostat.ecoModes.${ecoMode}`)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Compact inline thermostat for dashboard lists */
+function CompactThermostat({
+  isOn,
+  currentMode,
+  insideTemp,
+  targetTemp,
+  hasPowerOrder,
+  executing,
+  onTogglePower,
+}: {
+  isOn: boolean;
+  currentMode: string | null;
+  insideTemp: number | null;
+  targetTemp: number | null;
+  hasPowerOrder: boolean;
+  executing: string | null;
+  onTogglePower: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex items-center gap-2 flex-shrink-0" onClick={(e) => e.preventDefault()}>
+      {/* Current temp */}
+      <span className="text-[14px] font-semibold text-text tabular-nums font-mono">
+        {insideTemp !== null ? `${insideTemp.toFixed(1)}°` : "—"}
+      </span>
+
+      {/* Target temp */}
+      {isOn && targetTemp !== null && (
+        <span className="text-[11px] text-text-tertiary tabular-nums">
+          → {targetTemp.toFixed(1)}°
+        </span>
+      )}
+
+      {/* Mode badge */}
+      {isOn && currentMode && (
+        <span className={`flex items-center gap-0.5 px-1.5 py-0.5 rounded-[4px] text-[10px] font-medium ${MODE_COLORS[currentMode] ?? "bg-border-light text-text-tertiary"}`}>
+          {MODE_ICONS[currentMode]}
+          {t(`thermostat.modes.${currentMode}`)}
+        </span>
+      )}
+
+      {/* Power toggle */}
+      {hasPowerOrder && (
+        <>
+          <div className="w-px h-5 bg-border" />
+          <button
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onTogglePower(); }}
+            disabled={executing === "power"}
+            className={`
+              p-1.5 rounded-[5px] transition-colors duration-150 cursor-pointer
+              ${isOn
+                ? "bg-primary text-white hover:bg-primary-hover"
+                : "bg-border-light text-text-tertiary hover:bg-border hover:text-text-secondary"
+              }
+              disabled:opacity-50 disabled:cursor-not-allowed
+            `}
+            title={isOn ? t("controls.turnOff") : t("controls.turnOn")}
+          >
+            <Power size={14} strokeWidth={1.5} />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/equipments/ThermostatCard.tsx
+++ b/ui/src/components/equipments/ThermostatCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Power,
@@ -11,6 +11,8 @@ import {
   Fan,
   Zap,
   Leaf,
+  Thermometer,
+  Crosshair,
 } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
 
@@ -40,7 +42,24 @@ export function ThermostatCard({ equipment, onExecuteOrder, compact }: Thermosta
   const { t } = useTranslation();
   const [executing, setExecuting] = useState<string | null>(null);
 
-  // Read data bindings
+  // Optimistic overrides — applied immediately, cleared when real data arrives
+  const [optimistic, setOptimistic] = useState<Record<string, unknown>>({});
+  const prevBindingsRef = useRef(equipment.dataBindings);
+
+  // Clear optimistic values when real data changes (WebSocket update)
+  useEffect(() => {
+    const prev = prevBindingsRef.current;
+    const changed = equipment.dataBindings.some((b) => {
+      const old = prev.find((p) => p.alias === b.alias);
+      return old && old.value !== b.value;
+    });
+    if (changed) {
+      setOptimistic({});
+    }
+    prevBindingsRef.current = equipment.dataBindings;
+  }, [equipment.dataBindings]);
+
+  // Read data bindings (with optimistic overlay)
   const powerBinding = equipment.dataBindings.find((b) => b.alias === "power");
   const modeBinding = equipment.dataBindings.find((b) => b.alias === "operationMode");
   const targetTempBinding = equipment.dataBindings.find((b) => b.alias === "targetTemperature");
@@ -49,12 +68,18 @@ export function ThermostatCard({ equipment, onExecuteOrder, compact }: Thermosta
   const fanSpeedBinding = equipment.dataBindings.find((b) => b.alias === "fanSpeed");
   const ecoModeBinding = equipment.dataBindings.find((b) => b.alias === "ecoMode");
 
-  const isOn = powerBinding?.value === true;
-  const currentMode = typeof modeBinding?.value === "string" ? modeBinding.value : null;
-  const targetTemp = typeof targetTempBinding?.value === "number" ? targetTempBinding.value : null;
+  const isOn = "power" in optimistic ? optimistic.power === true : powerBinding?.value === true;
+  const currentMode = "operationMode" in optimistic
+    ? (optimistic.operationMode as string | null)
+    : typeof modeBinding?.value === "string" ? modeBinding.value : null;
+  const targetTemp = "targetTemperature" in optimistic
+    ? (optimistic.targetTemperature as number | null)
+    : typeof targetTempBinding?.value === "number" ? targetTempBinding.value : null;
   const insideTemp = typeof insideTempBinding?.value === "number" ? insideTempBinding.value : null;
   const outsideTemp = typeof outsideTempBinding?.value === "number" ? outsideTempBinding.value : null;
-  const fanSpeed = typeof fanSpeedBinding?.value === "string" ? fanSpeedBinding.value : null;
+  const fanSpeed = "fanSpeed" in optimistic
+    ? (optimistic.fanSpeed as string | null)
+    : typeof fanSpeedBinding?.value === "string" ? fanSpeedBinding.value : null;
   const ecoMode = typeof ecoModeBinding?.value === "string" ? ecoModeBinding.value : null;
 
   // Order bindings (available controls)
@@ -68,9 +93,18 @@ export function ThermostatCard({ equipment, onExecuteOrder, compact }: Thermosta
 
   const exec = async (alias: string, value: unknown) => {
     if (executing) return;
+    // Apply optimistic update immediately
+    setOptimistic((prev) => ({ ...prev, [alias]: value }));
     setExecuting(alias);
     try {
       await onExecuteOrder(alias, value);
+    } catch {
+      // Revert optimistic on error
+      setOptimistic((prev) => {
+        const next = { ...prev };
+        delete next[alias];
+        return next;
+      });
     } finally {
       setExecuting(null);
     }
@@ -80,12 +114,15 @@ export function ThermostatCard({ equipment, onExecuteOrder, compact }: Thermosta
     return (
       <CompactThermostat
         isOn={isOn}
-        currentMode={currentMode}
         insideTemp={insideTemp}
         targetTemp={targetTemp}
         hasPowerOrder={hasPowerOrder}
+        hasTargetTempOrder={!!targetTempOrder}
+        targetMin={targetTempOrder?.min ?? 16}
+        targetMax={targetTempOrder?.max ?? 30}
         executing={executing}
         onTogglePower={() => exec("power", !isOn)}
+        onSetTarget={(v) => exec("targetTemperature", v)}
       />
     );
   }
@@ -221,43 +258,66 @@ export function ThermostatCard({ equipment, onExecuteOrder, compact }: Thermosta
 /** Compact inline thermostat for dashboard lists */
 function CompactThermostat({
   isOn,
-  currentMode,
   insideTemp,
   targetTemp,
   hasPowerOrder,
+  hasTargetTempOrder,
+  targetMin,
+  targetMax,
   executing,
   onTogglePower,
+  onSetTarget,
 }: {
   isOn: boolean;
-  currentMode: string | null;
   insideTemp: number | null;
   targetTemp: number | null;
   hasPowerOrder: boolean;
+  hasTargetTempOrder: boolean;
+  targetMin: number;
+  targetMax: number;
   executing: string | null;
   onTogglePower: () => void;
+  onSetTarget: (value: number) => void;
 }) {
   const { t } = useTranslation();
 
   return (
     <div className="flex items-center gap-2 flex-shrink-0" onClick={(e) => e.preventDefault()}>
       {/* Current temp */}
-      <span className="text-[14px] font-semibold text-text tabular-nums font-mono">
-        {insideTemp !== null ? `${insideTemp.toFixed(1)}°` : "—"}
-      </span>
-
-      {/* Target temp */}
-      {isOn && targetTemp !== null && (
-        <span className="text-[11px] text-text-tertiary tabular-nums">
-          → {targetTemp.toFixed(1)}°
+      {insideTemp !== null && (
+        <span className="flex items-center gap-0.5 text-[12px] text-text-tertiary tabular-nums">
+          <Thermometer size={11} strokeWidth={1.5} />
+          {insideTemp.toFixed(1)}°
         </span>
       )}
 
-      {/* Mode badge */}
-      {isOn && currentMode && (
-        <span className={`flex items-center gap-0.5 px-1.5 py-0.5 rounded-[4px] text-[10px] font-medium ${MODE_COLORS[currentMode] ?? "bg-border-light text-text-tertiary"}`}>
-          {MODE_ICONS[currentMode]}
-          {t(`thermostat.modes.${currentMode}`)}
-        </span>
+      {/* Separator */}
+      {isOn && hasTargetTempOrder && targetTemp !== null && insideTemp !== null && (
+        <div className="w-px h-4 bg-border" />
+      )}
+
+      {/* Target temp with +/- controls */}
+      {isOn && hasTargetTempOrder && targetTemp !== null && (
+        <div className="flex items-center gap-0.5">
+          <button
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onSetTarget(targetTemp - 0.5); }}
+            disabled={executing === "targetTemperature" || targetTemp <= targetMin}
+            className="p-0.5 rounded-[3px] text-text-tertiary hover:bg-border-light hover:text-text transition-colors disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+          >
+            <ChevronDown size={12} strokeWidth={2} />
+          </button>
+          <span className="flex items-center gap-0.5 text-[14px] font-semibold text-text tabular-nums font-mono">
+            <Crosshair size={11} strokeWidth={1.5} className="text-text-secondary" />
+            {targetTemp.toFixed(1)}°
+          </span>
+          <button
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onSetTarget(targetTemp + 0.5); }}
+            disabled={executing === "targetTemperature" || targetTemp >= targetMax}
+            className="p-0.5 rounded-[3px] text-text-tertiary hover:bg-border-light hover:text-text transition-colors disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+          >
+            <ChevronUp size={12} strokeWidth={2} />
+          </button>
+        </div>
       )}
 
       {/* Power toggle */}

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -16,6 +16,7 @@ const RELEVANT_DATA: Record<string, string[]> = {
   switch: ["light_state"],
   sensor: ["temperature", "humidity", "pressure", "luminosity", "co2", "voc", "motion", "contact_door", "contact_window", "water_leak", "smoke", "battery"],
   button: ["action", "battery"],
+  thermostat: ["temperature", "generic"],
 };
 
 /** Maps equipment types to relevant order keys for auto-binding. */
@@ -26,6 +27,7 @@ const RELEVANT_ORDERS: Record<string, string[]> = {
   shutter: ["position", "state"],
   switch: ["state"],
   button: [],
+  thermostat: ["power", "operationMode", "targetTemperature", "fanSpeed", "airSwingUD", "airSwingLR", "ecoMode", "nanoe"],
 };
 
 export function isRelevantData(category: string, equipmentType: string): boolean {

--- a/ui/src/components/equipments/useEquipmentState.ts
+++ b/ui/src/components/equipments/useEquipmentState.ts
@@ -15,14 +15,20 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
     equipment.type === "light_color";
   const isShutter = equipment.type === "shutter";
   const isSensor = equipment.type === "sensor" || equipment.type === "button";
+  const isThermostat = equipment.type === "thermostat";
 
   // State binding
   const stateBinding = equipment.dataBindings.find(
     (db) => db.alias === "state" || db.category === "light_state",
   );
-  const isOn = stateBinding
-    ? stateBinding.value === true || stateBinding.value === "ON"
-    : false;
+  const powerBinding = isThermostat
+    ? equipment.dataBindings.find((db) => db.alias === "power")
+    : null;
+  const isOn = isThermostat
+    ? powerBinding?.value === true
+    : stateBinding
+      ? stateBinding.value === true || stateBinding.value === "ON"
+      : false;
 
   // Shutter
   const shutterPositionBinding = isShutter
@@ -59,20 +65,25 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
 
   const iconColor = isSensor
     ? getSensorIconColor(equipment.dataBindings)
-    : isShutter
-      ? shutterIsOpen
-        ? "bg-primary/10 text-primary"
+    : isThermostat
+      ? isOn
+        ? "bg-blue-500/10 text-blue-500"
         : "bg-border-light text-text-tertiary"
-      : isLight && isOn
-        ? "bg-amber-400/15 text-amber-500"
-        : isOn
+      : isShutter
+        ? shutterIsOpen
           ? "bg-primary/10 text-primary"
-          : "bg-border-light text-text-tertiary";
+          : "bg-border-light text-text-tertiary"
+        : isLight && isOn
+          ? "bg-amber-400/15 text-amber-500"
+          : isOn
+            ? "bg-primary/10 text-primary"
+            : "bg-border-light text-text-tertiary";
 
   return {
     isLight,
     isShutter,
     isSensor,
+    isThermostat,
     stateBinding,
     isOn,
     shutterPosition,

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -6,6 +6,7 @@ import type { EquipmentWithDetails } from "../../types";
 import { useEquipmentState, formatValue } from "../equipments/useEquipmentState";
 import { SensorValues } from "../equipments/SensorValues";
 import { ShutterControls } from "../equipments/ShutterControls";
+import { ThermostatCard } from "../equipments/ThermostatCard";
 
 const SETTLE_DELAY_MS = 2000;
 
@@ -25,6 +26,7 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder }: CompactEquip
     isLight,
     isShutter,
     isSensor,
+    isThermostat,
     stateBinding,
     isOn,
     shutterPosition,
@@ -56,8 +58,8 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder }: CompactEquip
     (ob) => ob.alias === "brightness",
   );
 
-  // Find primary data value for non-light, non-sensor, non-shutter equipments
-  const primaryBinding = !isLight && !isSensor && !isShutter
+  // Find primary data value for non-light, non-sensor, non-shutter, non-thermostat equipments
+  const primaryBinding = !isLight && !isSensor && !isShutter && !isThermostat
     ? equipment.dataBindings[0] ?? null
     : null;
 
@@ -136,8 +138,8 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder }: CompactEquip
         />
       )}
 
-      {/* Primary value for non-light, non-sensor, non-shutter equipments */}
-      {primaryBinding && !isLight && !isSensor && !isShutter && (
+      {/* Primary value for other equipments */}
+      {primaryBinding && !isLight && !isSensor && !isShutter && !isThermostat && (
         <span className="text-[13px] text-text-secondary tabular-nums flex-shrink-0">
           {formatValue(primaryBinding.value, primaryBinding.unit)}
         </span>
@@ -203,8 +205,17 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder }: CompactEquip
         />
       )}
 
+      {/* Thermostat controls */}
+      {isThermostat && equipment.enabled && (
+        <ThermostatCard
+          equipment={equipment}
+          onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
+          compact
+        />
+      )}
+
       {/* Boolean state badge for non-light, non-sensor, non-shutter equipments */}
-      {!isLight && !isSensor && !isShutter && stateBinding && (
+      {!isLight && !isSensor && !isShutter && !isThermostat && stateBinding && (
         <span
           className={`
             text-[11px] font-medium px-2 py-0.5 rounded-full flex-shrink-0

--- a/ui/src/components/home/ZoneEquipmentsView.tsx
+++ b/ui/src/components/home/ZoneEquipmentsView.tsx
@@ -4,7 +4,7 @@ import {
   ArrowUpDown,
   Gauge,
   ToggleRight,
-  AirVent,
+  Thermometer,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { EquipmentType, EquipmentWithDetails } from "../../types";
@@ -21,7 +21,7 @@ interface EquipmentGroup {
 const EQUIPMENT_GROUPS: EquipmentGroup[] = [
   { labelKey: "equipments.group.lights", types: ["light_onoff", "light_dimmable", "light_color"], icon: <Lightbulb size={14} strokeWidth={1.5} />, headerBg: "bg-amber-400/8", iconColor: "text-amber-500" },
   { labelKey: "equipments.group.shutters", types: ["shutter"], icon: <ArrowUpDown size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
-  { labelKey: "equipments.group.climate", types: ["thermostat"], icon: <AirVent size={14} strokeWidth={1.5} />, headerBg: "bg-blue-500/6", iconColor: "text-blue-500" },
+  { labelKey: "equipments.group.climate", types: ["thermostat"], icon: <Thermometer size={14} strokeWidth={1.5} />, headerBg: "bg-blue-500/6", iconColor: "text-blue-500" },
   { labelKey: "equipments.group.sensors", types: ["sensor"], icon: <Gauge size={14} strokeWidth={1.5} />, headerBg: "bg-info/6", iconColor: "text-info" },
   { labelKey: "equipments.group.other", types: ["switch", "button"], icon: <ToggleRight size={14} strokeWidth={1.5} />, headerBg: "bg-text-tertiary/6", iconColor: "text-text-secondary" },
 ];

--- a/ui/src/components/home/ZoneEquipmentsView.tsx
+++ b/ui/src/components/home/ZoneEquipmentsView.tsx
@@ -4,6 +4,7 @@ import {
   ArrowUpDown,
   Gauge,
   ToggleRight,
+  AirVent,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { EquipmentType, EquipmentWithDetails } from "../../types";
@@ -20,6 +21,7 @@ interface EquipmentGroup {
 const EQUIPMENT_GROUPS: EquipmentGroup[] = [
   { labelKey: "equipments.group.lights", types: ["light_onoff", "light_dimmable", "light_color"], icon: <Lightbulb size={14} strokeWidth={1.5} />, headerBg: "bg-amber-400/8", iconColor: "text-amber-500" },
   { labelKey: "equipments.group.shutters", types: ["shutter"], icon: <ArrowUpDown size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
+  { labelKey: "equipments.group.climate", types: ["thermostat"], icon: <AirVent size={14} strokeWidth={1.5} />, headerBg: "bg-blue-500/6", iconColor: "text-blue-500" },
   { labelKey: "equipments.group.sensors", types: ["sensor"], icon: <Gauge size={14} strokeWidth={1.5} />, headerBg: "bg-info/6", iconColor: "text-info" },
   { labelKey: "equipments.group.other", types: ["switch", "button"], icon: <ToggleRight size={14} strokeWidth={1.5} />, headerBg: "bg-text-tertiary/6", iconColor: "text-text-secondary" },
 ];

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -62,14 +62,6 @@ export function Sidebar() {
 
       {/* Maison section — scrollable */}
       <div className="flex-1 overflow-y-auto py-3 px-2">
-        {!collapsed && (
-          <div className="flex items-center gap-2 px-3 mb-2">
-            <Home size={14} strokeWidth={1.5} className="text-text-tertiary" />
-            <span className="text-[11px] font-semibold text-text-tertiary uppercase tracking-wider">
-              {t("nav.maison")}
-            </span>
-          </div>
-        )}
         {collapsed ? (
           <NavLink
             to="/home"

--- a/ui/src/components/layout/SidebarZoneTree.tsx
+++ b/ui/src/components/layout/SidebarZoneTree.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { NavLink, useParams } from "react-router-dom";
-import { ChevronRight, ChevronDown, Building2, Layers, DoorOpen } from "lucide-react";
+import { ChevronRight, ChevronDown, Home, Layers, DoorOpen } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { ZoneWithChildren } from "../../types";
 import { useZones } from "../../store/useZones";
@@ -49,7 +49,7 @@ function SidebarZoneNode({ zone, depth }: { zone: ZoneWithChildren; depth: numbe
   }, [zoneId, zone]);
 
   const icon = depth === 0
-    ? <Building2 size={15} strokeWidth={1.5} />
+    ? <Home size={15} strokeWidth={1.5} />
     : hasChildren
       ? <Layers size={15} strokeWidth={1.5} />
       : <DoorOpen size={15} strokeWidth={1.5} />;

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -171,9 +171,11 @@
   "equipments.type.sensor": "Sensor",
   "equipments.type.switch": "Switch / Plug",
   "equipments.type.button": "Button / Remote",
+  "equipments.type.thermostat": "Thermostat / AC",
 
   "equipments.group.lights": "Lights",
   "equipments.group.shutters": "Shutters",
+  "equipments.group.climate": "Climate",
   "equipments.group.sensors": "Sensors",
   "equipments.group.other": "Other",
 
@@ -404,5 +406,23 @@
   "calendar.days.wed": "Wed",
   "calendar.days.thu": "Thu",
   "calendar.days.fri": "Fri",
-  "calendar.days.sat": "Sat"
+  "calendar.days.sat": "Sat",
+
+  "thermostat.outside": "Outside",
+  "thermostat.target": "Target",
+  "thermostat.mode": "Mode",
+  "thermostat.fanSpeed": "Fan speed",
+  "thermostat.modes.auto": "Auto",
+  "thermostat.modes.cool": "Cool",
+  "thermostat.modes.heat": "Heat",
+  "thermostat.modes.dry": "Dry",
+  "thermostat.modes.fan": "Fan",
+  "thermostat.fanSpeeds.auto": "Auto",
+  "thermostat.fanSpeeds.low": "Low",
+  "thermostat.fanSpeeds.lowMid": "Low-Mid",
+  "thermostat.fanSpeeds.mid": "Mid",
+  "thermostat.fanSpeeds.highMid": "High-Mid",
+  "thermostat.fanSpeeds.high": "High",
+  "thermostat.ecoModes.powerful": "Powerful",
+  "thermostat.ecoModes.quiet": "Quiet"
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -56,6 +56,7 @@
   "common.noLogs": "No logs",
   "common.select": "Select...",
   "common.disabled": "Disabled",
+  "common.all": "All",
 
   "status.online": "Online",
   "status.offline": "Offline",

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -172,7 +172,7 @@
   "equipments.type.sensor": "Sensor",
   "equipments.type.switch": "Switch / Plug",
   "equipments.type.button": "Button / Remote",
-  "equipments.type.thermostat": "Thermostat / AC",
+  "equipments.type.thermostat": "Thermostat",
 
   "equipments.group.lights": "Lights",
   "equipments.group.shutters": "Shutters",
@@ -205,6 +205,8 @@
   "controls.position": "Position",
   "controls.opened": "Open",
   "controls.closed": "Closed",
+  "controls.on": "On",
+  "controls.off": "Off",
 
   "sensors.title": "Sensors",
   "sensors.noData": "No sensor data.",
@@ -380,6 +382,8 @@
   "integrations.saved": "Configuration saved",
   "integrations.started": "Integration started",
   "integrations.stopped": "Integration stopped",
+  "integrations.refresh": "Refresh",
+  "integrations.refreshed": "Data refreshed",
 
   "calendar.title": "Calendar",
   "calendar.subtitle": "Schedule automatic mode activation throughout the week",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -172,11 +172,11 @@
   "equipments.type.sensor": "Capteur",
   "equipments.type.switch": "Interrupteur / Prise",
   "equipments.type.button": "Bouton / Télécommande",
-  "equipments.type.thermostat": "Thermostat / Climatisation",
+  "equipments.type.thermostat": "Thermostat",
 
   "equipments.group.lights": "Éclairages",
   "equipments.group.shutters": "Volets",
-  "equipments.group.climate": "Climatisation",
+  "equipments.group.climate": "Thermostat",
   "equipments.group.sensors": "Capteurs",
   "equipments.group.other": "Autres",
 
@@ -205,6 +205,8 @@
   "controls.position": "Position",
   "controls.opened": "Ouvert",
   "controls.closed": "Fermé",
+  "controls.on": "Marche",
+  "controls.off": "Arrêt",
 
   "sensors.title": "Capteurs",
   "sensors.noData": "Aucune donnée capteur.",
@@ -380,6 +382,8 @@
   "integrations.saved": "Configuration enregistrée",
   "integrations.started": "Intégration démarrée",
   "integrations.stopped": "Intégration arrêtée",
+  "integrations.refresh": "Rafraîchir",
+  "integrations.refreshed": "Données actualisées",
 
   "calendar.title": "Calendrier",
   "calendar.subtitle": "Planifiez l'activation automatique des modes selon la semaine",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -56,6 +56,7 @@
   "common.noLogs": "Aucun log",
   "common.select": "Sélectionner...",
   "common.disabled": "Désactivé",
+  "common.all": "Tous",
 
   "status.online": "En ligne",
   "status.offline": "Hors ligne",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -171,9 +171,11 @@
   "equipments.type.sensor": "Capteur",
   "equipments.type.switch": "Interrupteur / Prise",
   "equipments.type.button": "Bouton / Télécommande",
+  "equipments.type.thermostat": "Thermostat / Climatisation",
 
   "equipments.group.lights": "Éclairages",
   "equipments.group.shutters": "Volets",
+  "equipments.group.climate": "Climatisation",
   "equipments.group.sensors": "Capteurs",
   "equipments.group.other": "Autres",
 
@@ -404,5 +406,23 @@
   "calendar.days.wed": "Mer",
   "calendar.days.thu": "Jeu",
   "calendar.days.fri": "Ven",
-  "calendar.days.sat": "Sam"
+  "calendar.days.sat": "Sam",
+
+  "thermostat.outside": "Extérieur",
+  "thermostat.target": "Consigne",
+  "thermostat.mode": "Mode",
+  "thermostat.fanSpeed": "Ventilation",
+  "thermostat.modes.auto": "Auto",
+  "thermostat.modes.cool": "Froid",
+  "thermostat.modes.heat": "Chaud",
+  "thermostat.modes.dry": "Déshumid.",
+  "thermostat.modes.fan": "Ventil.",
+  "thermostat.fanSpeeds.auto": "Auto",
+  "thermostat.fanSpeeds.low": "Min",
+  "thermostat.fanSpeeds.lowMid": "Faible",
+  "thermostat.fanSpeeds.mid": "Moyen",
+  "thermostat.fanSpeeds.highMid": "Fort",
+  "thermostat.fanSpeeds.high": "Max",
+  "thermostat.ecoModes.powerful": "Puissant",
+  "thermostat.ecoModes.quiet": "Silence"
 }

--- a/ui/src/pages/DevicesPage.tsx
+++ b/ui/src/pages/DevicesPage.tsx
@@ -1,9 +1,21 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useDevices } from "../store/useDevices";
 import { DeviceList } from "../components/devices/DeviceList";
 import { Radio, Loader2, Search, X } from "lucide-react";
 import { useWsSubscription } from "../hooks/useWsSubscription";
+
+/** Labels for integration tabs. */
+const INTEGRATION_LABELS: Record<string, string> = {
+  zigbee2mqtt: "Zigbee2MQTT",
+  panasonic_cc: "Panasonic CC",
+  tasmota: "Tasmota",
+  esphome: "ESPHome",
+  shelly: "Shelly",
+  custom_mqtt: "MQTT",
+};
+
+const ALL_TAB = "__all__";
 
 export function DevicesPage() {
   useWsSubscription(["devices"]);
@@ -13,28 +25,46 @@ export function DevicesPage() {
   const loading = useDevices((s) => s.loading);
   const error = useDevices((s) => s.error);
   const [filter, setFilter] = useState("");
+  const [activeTab, setActiveTab] = useState(ALL_TAB);
 
   const deviceList = Object.values(devices);
-  const onlineCount = deviceList.filter((d) => d.status === "online").length;
+
+  // Build tabs from actual integrations present in device list
+  const tabs = useMemo(() => {
+    const integrationIds = new Set(deviceList.map((d) => d.integrationId));
+    return Array.from(integrationIds)
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b));
+  }, [deviceList]);
+
+  // If active tab no longer exists (e.g. integration removed), fall back to all
+  const resolvedTab = activeTab === ALL_TAB || tabs.includes(activeTab) ? activeTab : ALL_TAB;
+
+  // Filter by tab then by search
+  const tabFiltered = resolvedTab === ALL_TAB
+    ? deviceList
+    : deviceList.filter((d) => d.integrationId === resolvedTab);
 
   const filtered = filter
-    ? deviceList.filter((d) =>
+    ? tabFiltered.filter((d) =>
         d.name.toLowerCase().includes(filter.toLowerCase())
       )
-    : deviceList;
+    : tabFiltered;
+
+  const onlineCount = tabFiltered.filter((d) => d.status === "online").length;
 
   return (
     <div className="p-6">
       {/* Page header */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between mb-4">
         <div>
           <h1 className="text-[24px] font-semibold text-text leading-[32px]">
             {t("devices.title")}
           </h1>
           <p className="text-[13px] text-text-secondary mt-0.5">
-            {deviceList.length === 0
+            {tabFiltered.length === 0
               ? t("devices.waitingDiscovery")
-              : t("devices.subtitle", { count: deviceList.length, online: onlineCount })}
+              : t("devices.subtitle", { count: tabFiltered.length, online: onlineCount })}
           </p>
         </div>
 
@@ -66,11 +96,35 @@ export function DevicesPage() {
           <div className="flex items-center gap-2 px-3 py-1.5 rounded-[6px] bg-primary-light text-primary">
             <Radio size={16} strokeWidth={1.5} />
             <span className="text-[13px] font-medium">
-              {filter ? `${filtered.length}/${deviceList.length}` : deviceList.length}
+              {filter ? `${filtered.length}/${tabFiltered.length}` : tabFiltered.length}
             </span>
           </div>
         </div>
       </div>
+
+      {/* Integration tabs */}
+      {tabs.length > 1 && (
+        <div className="flex items-center gap-1 mb-4 border-b border-border">
+          <TabButton
+            label={t("common.all")}
+            count={deviceList.length}
+            active={resolvedTab === ALL_TAB}
+            onClick={() => setActiveTab(ALL_TAB)}
+          />
+          {tabs.map((integrationId) => {
+            const count = deviceList.filter((d) => d.integrationId === integrationId).length;
+            return (
+              <TabButton
+                key={integrationId}
+                label={INTEGRATION_LABELS[integrationId] ?? integrationId}
+                count={count}
+                active={resolvedTab === integrationId}
+                onClick={() => setActiveTab(integrationId)}
+              />
+            );
+          })}
+        </div>
+      )}
 
       {/* Content */}
       {loading ? (
@@ -83,6 +137,37 @@ export function DevicesPage() {
         <DeviceList devices={filtered} deviceData={deviceData} />
       )}
     </div>
+  );
+}
+
+function TabButton({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`
+        px-3 py-2 text-[13px] font-medium transition-colors duration-150
+        border-b-2 -mb-px cursor-pointer
+        ${active
+          ? "border-primary text-primary"
+          : "border-transparent text-text-tertiary hover:text-text-secondary hover:border-border"
+        }
+      `}
+    >
+      {label}
+      <span className={`ml-1.5 text-[11px] tabular-nums ${active ? "text-primary/70" : "text-text-tertiary"}`}>
+        {count}
+      </span>
+    </button>
   );
 }
 

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -7,6 +7,7 @@ import { getEquipment } from "../api";
 import { EquipmentForm } from "../components/equipments/EquipmentForm";
 import { LightControl } from "../components/equipments/LightControl";
 import { ShutterControl } from "../components/equipments/ShutterControl";
+import { ThermostatCard } from "../components/equipments/ThermostatCard";
 import { SensorDataPanel } from "../components/equipments/SensorDataPanel";
 import { AddBindingModal } from "../components/equipments/AddBindingModal";
 import { DeviceSelector } from "../components/equipments/DeviceSelector";
@@ -135,7 +136,7 @@ export function EquipmentDetailPage() {
     }
   };
 
-  const { isLight, isShutter, isSensor, actionBinding } = equipmentState;
+  const { isLight, isShutter, isSensor, isThermostat, actionBinding } = equipmentState;
 
   return (
     <div className="p-6">
@@ -208,6 +209,17 @@ export function EquipmentDetailPage() {
         <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
           <h3 className="text-[14px] font-semibold text-text mb-3">{t("equipments.controls")}</h3>
           <ShutterControl
+            equipment={equipment}
+            onExecuteOrder={(alias, value) => executeOrder(equipment.id, alias, value)}
+          />
+        </div>
+      )}
+
+      {/* Thermostat controls */}
+      {isThermostat && equipment.enabled && (
+        <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
+          <h3 className="text-[14px] font-semibold text-text mb-3">{t("equipments.controls")}</h3>
+          <ThermostatCard
             equipment={equipment}
             onExecuteOrder={(alias, value) => executeOrder(equipment.id, alias, value)}
           />

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -67,7 +67,8 @@ export function EquipmentDetailPage() {
   }, [fetchZones]);
 
   // Must call hooks before any early returns
-  const equipmentState = useEquipmentState(equipment ?? ({} as EquipmentWithDetails));
+  const EMPTY: EquipmentWithDetails = { id: "", name: "", type: "sensor", zoneId: "", enabled: true, createdAt: "", updatedAt: "", dataBindings: [], orderBindings: [] };
+  const equipmentState = useEquipmentState(equipment ?? EMPTY);
 
   useEffect(() => {
     if (!id) return;

--- a/ui/src/pages/IntegrationsPage.tsx
+++ b/ui/src/pages/IntegrationsPage.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2, Plug, Wifi, WifiOff, Play, Square, AlertTriangle } from "lucide-react";
+import { Loader2, Plug, Wifi, WifiOff, Play, Square, AlertTriangle, RefreshCw } from "lucide-react";
 import * as LucideIcons from "lucide-react";
-import { getIntegrations, updateSettings, startIntegration, stopIntegration } from "../api";
+import { getIntegrations, updateSettings, startIntegration, stopIntegration, refreshIntegration } from "../api";
 import type { IntegrationInfo, IntegrationSettingDef } from "../types";
 
 export function IntegrationsPage() {
@@ -56,6 +56,7 @@ function IntegrationCard({ integration, onRefresh }: { integration: IntegrationI
   const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
   const [starting, setStarting] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
   const [dirty, setDirty] = useState(false);
@@ -112,6 +113,21 @@ function IntegrationCard({ integration, onRefresh }: { integration: IntegrationI
       setError(err instanceof Error ? err.message : t("common.error"));
     } finally {
       setStarting(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    setError("");
+    setRefreshing(true);
+    try {
+      await refreshIntegration(integration.id);
+      setSuccess(t("integrations.refreshed"));
+      setTimeout(() => setSuccess(""), 3000);
+      onRefresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("common.error"));
+    } finally {
+      setRefreshing(false);
     }
   };
 
@@ -185,6 +201,16 @@ function IntegrationCard({ integration, onRefresh }: { integration: IntegrationI
           )}
           {isConnected ? t("integrations.stop") : t("integrations.start")}
         </button>
+        {isConnected && (
+          <button
+            onClick={handleRefresh}
+            disabled={refreshing}
+            className="flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-default"
+          >
+            <RefreshCw size={14} className={refreshing ? "animate-spin" : ""} />
+            {t("integrations.refresh")}
+          </button>
+        )}
       </div>
     </section>
   );

--- a/ui/src/pages/ZoneDetailPage.tsx
+++ b/ui/src/pages/ZoneDetailPage.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import type { ZoneWithChildren } from "../types";
 import { useWsSubscription } from "../hooks/useWsSubscription";
+import { ROOT_ZONE_ID } from "../lib/constants";
 
 export function ZoneDetailPage() {
   useWsSubscription(["zones", "equipments"]);
@@ -132,14 +133,16 @@ export function ZoneDetailPage() {
             <Pencil size={14} strokeWidth={1.5} />
             {t("common.edit")}
           </button>
-          <button
-            onClick={handleDelete}
-            disabled={deleting}
-            className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-error border border-error/30 rounded-[6px] hover:bg-error/10 transition-colors duration-150 disabled:opacity-50"
-          >
-            <Trash2 size={14} strokeWidth={1.5} />
-            {deleting ? t("common.deleting") : t("common.delete")}
-          </button>
+          {zone.id !== ROOT_ZONE_ID && (
+            <button
+              onClick={handleDelete}
+              disabled={deleting}
+              className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-error border border-error/30 rounded-[6px] hover:bg-error/10 transition-colors duration-150 disabled:opacity-50"
+            >
+              <Trash2 size={14} strokeWidth={1.5} />
+              {deleting ? t("common.deleting") : t("common.delete")}
+            </button>
+          )}
         </div>
       </div>
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -137,7 +137,8 @@ export type EquipmentType =
   | "shutter"
   | "switch"
   | "sensor"
-  | "button";
+  | "button"
+  | "thermostat";
 
 export interface Equipment {
   id: string;


### PR DESCRIPTION
## Summary
- Add Panasonic Comfort Cloud integration plugin using Python bridge (`aio-panasonic-comfort-cloud` from HA community)
- Python CLI bridge script (`bridge.py`) wraps auth + device discovery + control, called via `child_process.execFile`
- TypeScript wrapper (`PanasonicBridge`) + polling scheduler (`PanasonicPoller`) with configurable interval (default 5min) and on-demand poll after orders
- New `thermostat` EquipmentType with dedicated dashboard widget (temperature display, mode selector, fan speed, power toggle)
- Thermostat controls in EquipmentCard (compact), CompactEquipmentCard (inline), and EquipmentDetailPage (full)
- "Climate" equipment group in dashboard zone view
- FR/EN translations for thermostat modes, fan speeds, eco modes

## New files
- `src/integrations/panasonic-cc/bridge.py` — Python CLI bridge
- `src/integrations/panasonic-cc/index.ts` — PanasonicCCIntegration plugin
- `src/integrations/panasonic-cc/panasonic-bridge.ts` — TS wrapper (child_process)
- `src/integrations/panasonic-cc/panasonic-poller.ts` — Polling scheduler
- `src/integrations/panasonic-cc/panasonic-types.ts` — Bridge response types + enums
- `ui/src/components/equipments/ThermostatCard.tsx` — Thermostat widget
- `requirements.txt` — Python dependencies

## Test plan
- [x] TypeScript compiles (zero errors backend + frontend)
- [x] ESLint passes
- [x] Prettier passes
- [x] All 273 tests pass
- [ ] Manual: configure Panasonic credentials in UI → verify devices appear → control AC → check polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)