### PR TITLE
fix: device heartbeat event to keep lastSeen fresh

### DIFF
--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -57,6 +57,8 @@ function getDedupKey(event: EngineEvent): string | null {
       return `d:${event.deviceId}:${event.key}`;
     case "device.status_changed":
       return `ds:${event.deviceId}`;
+    case "device.heartbeat":
+      return `dh:${event.deviceId}`;
     case "equipment.data.changed":
       return `e:${event.equipmentId}:${event.alias}`;
     case "zone.data.changed":

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -327,6 +327,11 @@ export class DeviceManager {
 
     // A device sending data is online — update status and last_seen
     this.stmts.updateDeviceLastSeen.run(device.id);
+    this.eventBus.emit({
+      type: "device.heartbeat",
+      deviceId: device.id,
+      timestamp: new Date().toISOString(),
+    });
     if (device.status !== "online") {
       this.stmts.updateDeviceStatus.run("online", device.id);
       this.eventBus.emit({

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -372,6 +372,11 @@ export type EngineEvent =
       previous: unknown;
       timestamp: string;
     }
+  | {
+      type: "device.heartbeat";
+      deviceId: string;
+      timestamp: string;
+    }
   // Zone events
   | { type: "zone.created"; zone: Zone }
   | { type: "zone.updated"; zone: Zone }

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, useNavigate, Link } from "react-router-dom";
+import { useDevices } from "../store/useDevices";
 import { useEquipments } from "../store/useEquipments";
 import { useZones } from "../store/useZones";
 import { getEquipment } from "../api";
@@ -36,7 +37,7 @@ import type { EquipmentWithDetails } from "../types";
 import { useWsSubscription } from "../hooks/useWsSubscription";
 
 export function EquipmentDetailPage() {
-  useWsSubscription(["equipments"]);
+  useWsSubscription(["equipments", "devices"]);
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -398,6 +399,7 @@ export function EquipmentDetailPage() {
 /** Group bindings by device and show a summary card per device. */
 function DevicesSection({ equipment, onChangeDevice }: { equipment: EquipmentWithDetails; onChangeDevice: () => void }) {
   const { t } = useTranslation();
+  const devicesStore = useDevices((s) => s.devices);
   // Collect unique devices from all bindings
   const deviceMap = new Map<string, { deviceId: string; deviceName: string; dataKeys: string[]; orderKeys: string[] }>();
 
@@ -457,19 +459,27 @@ function DevicesSection({ equipment, onChangeDevice }: { equipment: EquipmentWit
         </button>
       </div>
       <div className="space-y-2">
-        {devices.map((dev) => (
-          <div key={dev.deviceId} className="flex items-center gap-3 px-3 py-2.5 rounded-[6px] bg-border-light/50">
-            <Cpu size={14} strokeWidth={1.5} className="text-text-tertiary flex-shrink-0" />
-            <div className="flex-1 min-w-0">
-              <div className="text-[13px] font-medium text-text">{dev.deviceName}</div>
+        {devices.map((dev) => {
+          const storeDevice = devicesStore[dev.deviceId];
+          const lastSeen = storeDevice?.lastSeen ?? null;
+          return (
+            <div key={dev.deviceId} className="flex items-center gap-3 px-3 py-2.5 rounded-[6px] bg-border-light/50">
+              <Cpu size={14} strokeWidth={1.5} className="text-text-tertiary flex-shrink-0" />
+              <div className="flex-1 min-w-0">
+                <div className="text-[13px] font-medium text-text">{dev.deviceName}</div>
+                <div className="flex items-center gap-1 text-[11px] text-text-tertiary mt-0.5">
+                  <Clock size={10} strokeWidth={1.5} />
+                  <span>{formatRelativeTime(lastSeen)}</span>
+                </div>
+              </div>
+              <span className="text-[11px] text-text-tertiary flex-shrink-0">
+                {dev.dataKeys.length > 0 && t("equipments.dataCount", { count: dev.dataKeys.length })}
+                {dev.dataKeys.length > 0 && dev.orderKeys.length > 0 && " · "}
+                {dev.orderKeys.length > 0 && t("equipments.orderCount", { count: dev.orderKeys.length })}
+              </span>
             </div>
-            <span className="text-[11px] text-text-tertiary flex-shrink-0">
-              {dev.dataKeys.length > 0 && t("equipments.dataCount", { count: dev.dataKeys.length })}
-              {dev.dataKeys.length > 0 && dev.orderKeys.length > 0 && " · "}
-              {dev.orderKeys.length > 0 && t("equipments.orderCount", { count: dev.orderKeys.length })}
-            </span>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/ui/src/store/useDevices.ts
+++ b/ui/src/store/useDevices.ts
@@ -23,6 +23,7 @@ interface DevicesState {
     value: unknown,
     timestamp: string
   ) => void;
+  updateDeviceHeartbeat: (deviceId: string, timestamp: string) => void;
   updateDeviceName: (deviceId: string, name: string) => Promise<void>;
 }
 
@@ -101,6 +102,16 @@ export const useDevices = create<DevicesState>((set, get) => ({
         : state.devices;
 
       return { devices, deviceData: { ...state.deviceData, [deviceId]: updated } };
+    });
+  },
+
+  updateDeviceHeartbeat: (deviceId, timestamp) => {
+    set((state) => {
+      const device = state.devices[deviceId];
+      if (!device) return state;
+      return {
+        devices: { ...state.devices, [deviceId]: { ...device, lastSeen: timestamp } },
+      };
     });
   },
 

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -67,6 +67,9 @@ function handleEvent(event: EngineEvent): void {
         event.timestamp
       );
       break;
+    case "device.heartbeat":
+      devices.updateDeviceHeartbeat(event.deviceId, event.timestamp);
+      break;
     case "zone.created":
       useZones.getState().handleZoneCreated(event.zone);
       break;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -217,6 +217,7 @@ export type EngineEvent =
       previous: unknown;
       timestamp: string;
     }
+  | { type: "device.heartbeat"; deviceId: string; timestamp: string }
   | { type: "zone.created"; zone: Zone }
   | { type: "zone.updated"; zone: Zone }
   | { type: "zone.removed"; zoneId: string; zoneName: string }


### PR DESCRIPTION
## Summary
- Adds a new `device.heartbeat` event emitted on every `updateDeviceData()` call, even when data values haven't changed
- Fixes stale `lastSeen` display for MCZ and Panasonic devices that poll periodically but may return unchanged data

## Changes
- **Backend**: New `device.heartbeat` EngineEvent type, emitted in `device-manager.ts`
- **WebSocket**: Dedup key for heartbeat events to avoid flooding
- **Frontend store**: `updateDeviceHeartbeat` action in `useDevices`, routed from `useWebSocket`
- **Frontend types**: Added `device.heartbeat` to UI EngineEvent union

## Test plan
- [x] TypeScript compiles (zero errors backend + frontend)
- [x] All 273 tests pass
- [x] Lint passes
- [ ] Manually verify: MCZ/Panasonic lastSeen updates every ~5min even when data is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)