### PR TITLE
chore(ui): Ocean palette + logo + favicon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,8 @@ npm test -- --grep "pattern"  # Run specific tests
 ## Design System
 
 - **Font:** Inter (body), JetBrains Mono (values/logs)
-- **Primary color:** `#1B6B5A` (light) / `#3DBDA0` (dark)
-- **Accent color:** `#D4873F` (light) / `#E9A55C` (dark)
+- **Primary color:** `#1A4F6E` (ocean blue) — hover: `#13405A`, light: `#E6F0F6`
+- **Accent color:** `#D4963F` (amber) — hover: `#BB8232`
 - **Spacing base unit:** 4px
 - **Border radius:** 6px (buttons), 10px (cards), 14px (modals)
 - **Body font size:** 14px (dense dashboard), Data values: 28px (readable at a glance)

--- a/docs/design-system-preview.html
+++ b/docs/design-system-preview.html
@@ -1,0 +1,410 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Winch Design System</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --primary: #1A4F6E;
+    --primary-hover: #13405A;
+    --primary-light: #E6F0F6;
+    --accent: #D4963F;
+    --accent-hover: #BB8232;
+    --active: #EAB308;
+    --active-text: #A16207;
+    --success: #3D8B6E;
+    --warning: #C88B3A;
+    --error: #C0453A;
+    --bg: #F8FAFB;
+    --surface: #FFFFFF;
+    --text: #1A1A1A;
+    --text-secondary: #6B7280;
+    --text-tertiary: #9CA3AF;
+    --border: #E1E6EA;
+    --border-light: #EDF0F3;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: 'Inter', system-ui, sans-serif; font-size: 14px; color: var(--text); background: var(--bg); padding: 32px; line-height: 1.5; }
+  h1 { font-size: 28px; font-weight: 700; margin-bottom: 8px; }
+  h2 { font-size: 18px; font-weight: 600; margin: 32px 0 16px; color: var(--text); }
+  h3 { font-size: 14px; font-weight: 600; margin-bottom: 12px; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; }
+  .subtitle { color: var(--text-secondary); font-size: 14px; margin-bottom: 32px; }
+  .grid { display: grid; gap: 24px; }
+  .grid-2 { grid-template-columns: 1fr 1fr; }
+  .grid-3 { grid-template-columns: 1fr 1fr 1fr; }
+  .card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 20px; }
+
+  /* Color swatches */
+  .swatch-row { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 16px; }
+  .swatch { width: 120px; }
+  .swatch-color { width: 100%; height: 48px; border-radius: 8px; border: 1px solid var(--border); margin-bottom: 6px; }
+  .swatch-label { font-size: 12px; font-weight: 600; color: var(--text); }
+  .swatch-hex { font-size: 11px; color: var(--text-tertiary); font-family: 'JetBrains Mono', monospace; }
+
+  /* Section headers */
+  .section-header { display: flex; align-items: center; gap: 6px; padding: 4px 12px; border-radius: 10px 10px 0 0; font-size: 11px; font-weight: 500; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-tertiary); }
+  .section-body { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; margin-bottom: 8px; }
+  .section-row { padding: 10px 16px; font-size: 13px; border-top: 1px solid var(--border-light); color: var(--text-secondary); }
+  .section-row:first-child { border-top: none; }
+
+  /* Pills */
+  .pill { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 5px; font-size: 13px; font-weight: 500; }
+  .pill-bar { display: flex; align-items: center; gap: 0; padding: 4px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; }
+  .pill-sep { width: 1px; height: 16px; background: var(--border); margin: 0 4px; }
+
+  /* Badges */
+  .badge { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; }
+
+  /* Buttons */
+  .btn { display: inline-flex; align-items: center; gap: 6px; padding: 8px 16px; border-radius: 6px; font-size: 13px; font-weight: 500; border: none; cursor: pointer; }
+  .btn-primary { background: var(--primary); color: white; }
+  .btn-primary:hover { background: var(--primary-hover); }
+  .btn-outline { background: transparent; border: 1px solid var(--border); color: var(--text-secondary); }
+
+  /* Toggle */
+  .toggle { width: 36px; height: 20px; border-radius: 10px; position: relative; cursor: pointer; transition: background 0.2s; }
+  .toggle-knob { width: 16px; height: 16px; border-radius: 50%; background: white; position: absolute; top: 2px; transition: left 0.2s; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+
+  /* Slider */
+  .slider-track { width: 200px; height: 4px; border-radius: 2px; background: var(--border); position: relative; }
+  .slider-fill { height: 100%; border-radius: 2px; }
+  .slider-thumb { width: 16px; height: 16px; border-radius: 50%; position: absolute; top: -6px; border: 2px solid white; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+
+  /* Logo */
+  .logo-row { display: flex; align-items: center; gap: 16px; margin-bottom: 16px; }
+  .logo-label { font-size: 11px; color: var(--text-tertiary); }
+
+  /* Alerts */
+  .alert { padding: 12px 16px; border-radius: 6px; font-size: 13px; margin-bottom: 8px; border-left: 3px solid; }
+
+  /* Mono values */
+  .mono { font-family: 'JetBrains Mono', monospace; }
+</style>
+</head>
+<body>
+
+<div style="display: flex; align-items: center; gap: 12px; margin-bottom: 4px;">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="40" height="40" fill="none">
+    <rect width="32" height="32" rx="7" fill="#1A4F6E"/>
+    <circle cx="16" cy="16" r="6.5" stroke="white" stroke-width="2" fill="none"/>
+    <circle cx="16" cy="16" r="2" fill="white"/>
+    <line x1="16" y1="16" x2="23.5" y2="10.5" stroke="white" stroke-width="2" stroke-linecap="round"/>
+    <circle cx="23.5" cy="10.5" r="2" fill="white"/>
+  </svg>
+  <h1>Winch Design System</h1>
+</div>
+<p class="subtitle">One turn. Full control. &mdash; Home automation engine</p>
+
+<!-- ============================== COLORS ============================== -->
+<h2>Colors</h2>
+
+<h3>Core Palette</h3>
+<div class="swatch-row">
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--primary);"></div>
+    <div class="swatch-label">Primary</div>
+    <div class="swatch-hex">#1A4F6E</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--primary-hover);"></div>
+    <div class="swatch-label">Primary Hover</div>
+    <div class="swatch-hex">#13405A</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--primary-light);"></div>
+    <div class="swatch-label">Primary Light</div>
+    <div class="swatch-hex">#E6F0F6</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--accent);"></div>
+    <div class="swatch-label">Accent</div>
+    <div class="swatch-hex">#D4963F</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--accent-hover);"></div>
+    <div class="swatch-label">Accent Hover</div>
+    <div class="swatch-hex">#BB8232</div>
+  </div>
+</div>
+
+<h3>Semantic Colors</h3>
+<div class="swatch-row">
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--active);"></div>
+    <div class="swatch-label">Active / ON</div>
+    <div class="swatch-hex">#EAB308</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--active-text);"></div>
+    <div class="swatch-label">Active Text</div>
+    <div class="swatch-hex">#A16207</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--success);"></div>
+    <div class="swatch-label">Success</div>
+    <div class="swatch-hex">#3D8B6E</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--warning);"></div>
+    <div class="swatch-label">Warning</div>
+    <div class="swatch-hex">#C88B3A</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--error);"></div>
+    <div class="swatch-label">Error</div>
+    <div class="swatch-hex">#C0453A</div>
+  </div>
+</div>
+
+<h3>Neutrals</h3>
+<div class="swatch-row">
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--bg); border: 1px solid var(--border);"></div>
+    <div class="swatch-label">Background</div>
+    <div class="swatch-hex">#F8FAFB</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--surface); border: 1px solid var(--border);"></div>
+    <div class="swatch-label">Surface</div>
+    <div class="swatch-hex">#FFFFFF</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--text);"></div>
+    <div class="swatch-label">Text</div>
+    <div class="swatch-hex">#1A1A1A</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--text-secondary);"></div>
+    <div class="swatch-label">Text Secondary</div>
+    <div class="swatch-hex">#6B7280</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--text-tertiary);"></div>
+    <div class="swatch-label">Text Tertiary</div>
+    <div class="swatch-hex">#9CA3AF</div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color" style="background: var(--border);"></div>
+    <div class="swatch-label">Border</div>
+    <div class="swatch-hex">#E1E6EA</div>
+  </div>
+</div>
+
+<!-- ============================== TYPOGRAPHY ============================== -->
+<h2>Typography</h2>
+<div class="card" style="margin-bottom: 24px;">
+  <div style="margin-bottom: 16px;">
+    <span style="font-size: 28px; font-weight: 600;" class="mono">21.5<span style="font-size: 14px; color: var(--text-tertiary); font-weight: 400;">°C</span></span>
+    <span style="font-size: 11px; color: var(--text-tertiary); margin-left: 12px;">Data value (28px, JetBrains Mono)</span>
+  </div>
+  <div style="margin-bottom: 16px;">
+    <span style="font-size: 20px; font-weight: 600;" class="mono">65<span style="font-size: 13px; color: var(--text-tertiary); font-weight: 400;">%</span></span>
+    <span style="font-size: 11px; color: var(--text-tertiary); margin-left: 12px;">Data medium (20px)</span>
+  </div>
+  <div style="margin-bottom: 8px; font-size: 14px;">Body text at 14px using Inter font family.</div>
+  <div style="font-size: 11px; color: var(--text-tertiary); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 500;">Label &mdash; 11px uppercase tracking</div>
+</div>
+
+<!-- ============================== SECTION HEADERS ============================== -->
+<h2>Section Headers (Zone Cards)</h2>
+<div class="grid grid-2">
+  <div>
+    <div class="section-body">
+      <div class="section-header" style="background: rgba(234,179,8,0.08);">
+        <span style="color: var(--active-text);">&#9728;</span> Lights <span style="margin-left: auto;">3</span>
+      </div>
+      <div class="section-row">Spots Salon &mdash; ON</div>
+      <div class="section-row">Lampe Bureau &mdash; OFF</div>
+    </div>
+    <div class="section-body">
+      <div class="section-header" style="background: rgba(26,79,110,0.06);">
+        <span style="color: var(--primary);">&#9632;</span> Shutters <span style="margin-left: auto;">2</span>
+      </div>
+      <div class="section-row">Volet Salon &mdash; 75%</div>
+    </div>
+    <div class="section-body">
+      <div class="section-header" style="background: rgba(192,69,58,0.06);">
+        <span style="color: var(--error);">&#9832;</span> Climate <span style="margin-left: auto;">1</span>
+      </div>
+      <div class="section-row">Pompe chaleur &mdash; 21.5°C</div>
+    </div>
+  </div>
+  <div>
+    <div class="section-body">
+      <div class="section-header" style="background: rgba(26,79,110,0.06);">
+        <span style="color: var(--primary);">&#9673;</span> Sensors <span style="margin-left: auto;">4</span>
+      </div>
+      <div class="section-row">Capteur Salon &mdash; 22.1°C / 45%</div>
+    </div>
+    <div class="section-body">
+      <div class="section-header" style="background: rgba(61,139,110,0.08);">
+        <span style="color: var(--success);">&#9881;</span> Modes <span style="margin-left: auto;">2 active</span>
+      </div>
+      <div class="section-row">Mode Nuit &mdash; Active</div>
+    </div>
+    <div class="section-body">
+      <div class="section-header" style="background: rgba(212,150,63,0.08);">
+        <span style="color: var(--accent);">&#9733;</span> Recipes <span style="margin-left: auto;">1</span>
+      </div>
+      <div class="section-row">Auto-off &mdash; Spots Salon</div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================== AGGREGATION PILLS ============================== -->
+<h2>Aggregation Pills</h2>
+<div class="card">
+  <div class="pill-bar">
+    <div class="pill" style="color: var(--primary);">&#9832; 21.5°C</div>
+    <div class="pill-sep"></div>
+    <div class="pill" style="color: var(--primary);">&#128167; 45%</div>
+    <div class="pill-sep"></div>
+    <div class="pill" style="color: var(--active-text);">&#9899; Motion &middot; 5min</div>
+    <div class="pill-sep"></div>
+    <div class="pill" style="color: var(--active-text);">&#128161; 2/3</div>
+    <div class="pill-sep"></div>
+    <div class="pill" style="color: var(--primary);">&#9632; 1/2</div>
+    <div class="pill-sep"></div>
+    <div class="pill" style="color: var(--active-text);">&#128682; 1 open</div>
+  </div>
+</div>
+
+<!-- ============================== CONTROLS ============================== -->
+<h2>Controls</h2>
+<div class="grid grid-3">
+  <div class="card">
+    <h3>Buttons</h3>
+    <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+      <button class="btn btn-primary">Save</button>
+      <button class="btn btn-outline">Cancel</button>
+      <button class="btn" style="background: var(--error); color: white;">Delete</button>
+    </div>
+  </div>
+  <div class="card">
+    <h3>Toggles</h3>
+    <div style="display: flex; gap: 16px; align-items: center;">
+      <div>
+        <div class="toggle" style="background: var(--primary);"><div class="toggle-knob" style="left: 18px;"></div></div>
+        <div style="font-size: 11px; color: var(--text-tertiary); margin-top: 4px;">Primary ON</div>
+      </div>
+      <div>
+        <div class="toggle" style="background: var(--border);"><div class="toggle-knob" style="left: 2px;"></div></div>
+        <div style="font-size: 11px; color: var(--text-tertiary); margin-top: 4px;">OFF</div>
+      </div>
+    </div>
+  </div>
+  <div class="card">
+    <h3>Sliders</h3>
+    <div style="display: flex; flex-direction: column; gap: 12px;">
+      <div>
+        <div class="slider-track">
+          <div class="slider-fill" style="width: 65%; background: var(--primary);"></div>
+          <div class="slider-thumb" style="left: calc(65% - 8px); background: var(--primary);"></div>
+        </div>
+        <div style="font-size: 11px; color: var(--text-tertiary); margin-top: 4px;">Primary slider</div>
+      </div>
+      <div>
+        <div class="slider-track">
+          <div class="slider-fill" style="width: 80%; background: var(--active);"></div>
+          <div class="slider-thumb" style="left: calc(80% - 8px); background: var(--active);"></div>
+        </div>
+        <div style="font-size: 11px; color: var(--text-tertiary); margin-top: 4px;">Active slider (brightness)</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================== BADGES ============================== -->
+<h2>Status Badges</h2>
+<div class="card">
+  <div style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;">
+    <span class="badge" style="background: rgba(61,139,110,0.1); color: var(--success);">&#10003; Connected</span>
+    <span class="badge" style="background: rgba(192,69,58,0.1); color: var(--error);">&#9888; Error</span>
+    <span class="badge" style="background: rgba(200,139,58,0.1); color: var(--warning);">&#9888; Ignition</span>
+    <span class="badge" style="background: rgba(234,179,8,0.14); color: var(--active-text);">&#128161; ON</span>
+    <span class="badge" style="background: rgba(26,79,110,0.1); color: var(--primary);">&#10148; Running</span>
+    <span class="badge" style="background: var(--border-light); color: var(--text-tertiary);">Inactive</span>
+  </div>
+</div>
+
+<!-- ============================== ALERTS ============================== -->
+<h2>Alerts</h2>
+<div style="max-width: 500px;">
+  <div class="alert" style="background: rgba(61,139,110,0.08); border-color: var(--success); color: var(--success);">
+    Token created successfully. Copy it now.
+  </div>
+  <div class="alert" style="background: rgba(200,139,58,0.08); border-color: var(--warning); color: var(--warning);">
+    Integration restarted with new settings.
+  </div>
+  <div class="alert" style="background: rgba(192,69,58,0.08); border-color: var(--error); color: var(--error);">
+    Connection failed. Check your credentials.
+  </div>
+</div>
+
+<!-- ============================== THERMOSTAT MODES ============================== -->
+<h2>Thermostat Modes</h2>
+<div class="card">
+  <div style="display: flex; gap: 6px; flex-wrap: wrap;">
+    <span class="badge" style="background: rgba(26,79,110,0.1); color: var(--primary); border: 1px solid rgba(26,79,110,0.3);">&#9889; Auto</span>
+    <span class="badge" style="background: rgba(26,79,110,0.1); color: var(--primary); border: 1px solid rgba(26,79,110,0.3);">&#10052; Cool</span>
+    <span class="badge" style="background: rgba(192,69,58,0.1); color: var(--error); border: 1px solid rgba(192,69,58,0.3);">&#9728; Heat</span>
+    <span class="badge" style="background: rgba(61,139,110,0.1); color: var(--success); border: 1px solid rgba(61,139,110,0.3);">&#128167; Dry</span>
+    <span class="badge" style="background: rgba(156,163,175,0.1); color: var(--text-secondary); border: 1px solid rgba(156,163,175,0.3);">&#127744; Fan</span>
+    <span class="badge" style="background: rgba(200,139,58,0.1); color: var(--warning); border: 1px solid rgba(200,139,58,0.3);">&#128715; Comfort</span>
+  </div>
+</div>
+
+<!-- ============================== LOGO ============================== -->
+<h2>Logo</h2>
+<div class="card">
+  <div class="logo-row">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none">
+      <rect width="32" height="32" rx="7" fill="#1A4F6E"/>
+      <circle cx="16" cy="16" r="6.5" stroke="white" stroke-width="2" fill="none"/>
+      <circle cx="16" cy="16" r="2" fill="white"/>
+      <line x1="16" y1="16" x2="23.5" y2="10.5" stroke="white" stroke-width="2" stroke-linecap="round"/>
+      <circle cx="23.5" cy="10.5" r="2" fill="white"/>
+    </svg>
+    <span class="logo-label">32px (sidebar)</span>
+
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="48" height="48" fill="none">
+      <rect width="32" height="32" rx="7" fill="#1A4F6E"/>
+      <circle cx="16" cy="16" r="6.5" stroke="white" stroke-width="2" fill="none"/>
+      <circle cx="16" cy="16" r="2" fill="white"/>
+      <line x1="16" y1="16" x2="23.5" y2="10.5" stroke="white" stroke-width="2" stroke-linecap="round"/>
+      <circle cx="23.5" cy="10.5" r="2" fill="white"/>
+    </svg>
+    <span class="logo-label">48px (login)</span>
+
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="64" height="64" fill="none">
+      <rect width="32" height="32" rx="7" fill="#1A4F6E"/>
+      <circle cx="16" cy="16" r="6.5" stroke="white" stroke-width="2" fill="none"/>
+      <circle cx="16" cy="16" r="2" fill="white"/>
+      <line x1="16" y1="16" x2="23.5" y2="10.5" stroke="white" stroke-width="2" stroke-linecap="round"/>
+      <circle cx="23.5" cy="10.5" r="2" fill="white"/>
+    </svg>
+    <span class="logo-label">64px (large)</span>
+  </div>
+</div>
+
+<!-- ============================== RADIUS ============================== -->
+<h2>Border Radius</h2>
+<div style="display: flex; gap: 16px; align-items: end;">
+  <div style="text-align: center;">
+    <div style="width: 60px; height: 36px; background: var(--primary); border-radius: 6px;"></div>
+    <div style="font-size: 11px; color: var(--text-tertiary); margin-top: 4px;">6px (btn)</div>
+  </div>
+  <div style="text-align: center;">
+    <div style="width: 80px; height: 60px; background: var(--surface); border: 1px solid var(--border); border-radius: 10px;"></div>
+    <div style="font-size: 11px; color: var(--text-tertiary); margin-top: 4px;">10px (card)</div>
+  </div>
+  <div style="text-align: center;">
+    <div style="width: 100px; height: 70px; background: var(--surface); border: 1px solid var(--border); border-radius: 14px;"></div>
+    <div style="font-size: 11px; color: var(--text-tertiary); margin-top: 4px;">14px (modal)</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,82 @@
+# Winch Design System
+
+## Typography
+
+| Usage       | Font           | Size                 |
+| ----------- | -------------- | -------------------- |
+| Body        | Inter          | 14px                 |
+| Data values | JetBrains Mono | 28px (lg), 20px (md) |
+
+## Colors
+
+### Core Palette
+
+| Token           | Hex       | Usage                                       |
+| --------------- | --------- | ------------------------------------------- |
+| `primary`       | `#1A4F6E` | Buttons, links, shutters, sensors           |
+| `primary-hover` | `#13405A` | Interactive hover state                     |
+| `primary-light` | `#E6F0F6` | Light primary backgrounds                   |
+| `accent`        | `#D4963F` | Recipes, weather outdoor, integration icons |
+| `accent-hover`  | `#BB8232` | Accent hover state                          |
+
+### Semantic Colors
+
+| Token         | Hex       | Usage                                                   |
+| ------------- | --------- | ------------------------------------------------------- |
+| `active`      | `#EAB308` | Light ON state (dot indicator, slider thumb)            |
+| `active-text` | `#A16207` | Light ON text, motion detected, doors/windows open      |
+| `success`     | `#3D8B6E` | Connected status, modes header, enabled badge           |
+| `warning`     | `#C88B3A` | Ignition/stabilizing, comfort mode, log warnings        |
+| `error`       | `#C0453A` | Errors, thermostat/climate header, disconnected, alarms |
+
+### Neutral Colors
+
+| Token            | Hex       | Usage                          |
+| ---------------- | --------- | ------------------------------ |
+| `background`     | `#F8FAFB` | Page background                |
+| `surface`        | `#FFFFFF` | Cards, panels                  |
+| `text`           | `#1A1A1A` | Primary text                   |
+| `text-secondary` | `#6B7280` | Secondary text                 |
+| `text-tertiary`  | `#9CA3AF` | Tertiary text, inactive states |
+| `border`         | `#E1E6EA` | Card borders                   |
+| `border-light`   | `#EDF0F3` | Dividers, subtle borders       |
+
+## Section Headers (Zone Cards)
+
+| Section  | Background           | Icon Color            |
+| -------- | -------------------- | --------------------- |
+| Lights   | `bg-active/8`        | `text-active-text`    |
+| Shutters | `bg-primary/6`       | `text-primary`        |
+| Climate  | `bg-error/6`         | `text-error`          |
+| Sensors  | `bg-primary/6`       | `text-primary`        |
+| Weather  | `bg-primary/6`       | `text-primary`        |
+| Other    | `bg-text-tertiary/6` | `text-text-secondary` |
+| Modes    | `bg-success/8`       | `text-success`        |
+| Recipes  | `bg-accent/8`        | `text-accent`         |
+
+## Spacing & Radius
+
+| Token       | Value         |
+| ----------- | ------------- |
+| Base unit   | 4px           |
+| `radius-sm` | 6px (buttons) |
+| `radius-md` | 10px (cards)  |
+| `radius-lg` | 14px (modals) |
+
+## Icons
+
+- Library: **Lucide React**
+- Stroke width: **1.5px**
+- Sizes: 14px (inline), 16-18px (card icons), 22px (page headers)
+
+## Logo
+
+Winch logo: white drum + crank on `primary` rounded square. Drum centered at (16,16) in a 32x32 viewBox.
+
+## Shadows
+
+| Token       | Value                         |
+| ----------- | ----------------------------- |
+| `shadow-sm` | `0 1px 2px rgba(0,0,0,0.05)`  |
+| `shadow-md` | `0 2px 8px rgba(0,0,0,0.08)`  |
+| `shadow-lg` | `0 8px 24px rgba(0,0,0,0.12)` |

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Winch</title>
   </head>
   <body>

--- a/ui/public/favicon.svg
+++ b/ui/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="7" fill="#1A4F6E"/>
+  <!-- Winch drum — centered in square -->
+  <circle cx="16" cy="16" r="6.5" stroke="white" stroke-width="2" fill="none"/>
+  <circle cx="16" cy="16" r="2" fill="white"/>
+  <!-- Handle/crank -->
+  <line x1="16" y1="16" x2="23.5" y2="10.5" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="23.5" cy="10.5" r="2" fill="white"/>
+</svg>

--- a/ui/src/components/equipments/SensorDataPanel.tsx
+++ b/ui/src/components/equipments/SensorDataPanel.tsx
@@ -140,7 +140,7 @@ function BooleanSensorValue({
       <span
         className={`
           text-[14px] font-semibold font-mono
-          ${displayActive ? "text-amber-500" : "text-text-tertiary"}
+          ${displayActive ? "text-active-text" : "text-text-tertiary"}
         `}
       >
         {text}
@@ -148,7 +148,7 @@ function BooleanSensorValue({
       <div
         className={`
           w-2.5 h-2.5 rounded-full
-          ${displayActive ? "bg-amber-500" : "bg-border"}
+          ${displayActive ? "bg-active" : "bg-border"}
         `}
       />
     </div>
@@ -200,11 +200,11 @@ function BatteryRow({ level, deviceName }: { level: number | null; deviceName?: 
 function getRowIconColor(category: DataCategory, bindings: DataBindingWithValue[]): string {
   if (category === "motion") {
     const active = bindings.some((b) => b.value === true || b.value === "ON");
-    return active ? "bg-amber-400/15 text-amber-500" : "bg-border-light text-text-tertiary";
+    return active ? "bg-active/15 text-active-text" : "bg-border-light text-text-tertiary";
   }
   if (category === "contact_door" || category === "contact_window") {
     const open = bindings.some((b) => b.value === false || b.value === "OFF");
-    return open ? "bg-amber-400/15 text-amber-500" : "bg-border-light text-text-tertiary";
+    return open ? "bg-active/15 text-active-text" : "bg-border-light text-text-tertiary";
   }
   if (category === "water_leak" || category === "smoke") {
     const active = bindings.some((b) => b.value === true || b.value === "ON");

--- a/ui/src/components/equipments/SensorValues.tsx
+++ b/ui/src/components/equipments/SensorValues.tsx
@@ -45,7 +45,7 @@ export function SensorValues({
           {sensorBindings.map((b) => (
             <span key={b.id} className="text-[13px] tabular-nums flex-shrink-0">
               {b.category === "motion" && isBooleanActive(b.category, b.value) ? (
-                <span className="font-medium px-2 py-0.5 rounded-full text-[11px] bg-amber-400/15 text-amber-500 inline-flex items-center gap-1">
+                <span className="font-medium px-2 py-0.5 rounded-full text-[11px] bg-active/15 text-active-text inline-flex items-center gap-1">
                   {formatBooleanSensor(b.category, b.value, t)}
                   <ElapsedCounter lastUpdated={b.lastUpdated} lockOrigin />
                 </span>
@@ -59,7 +59,7 @@ export function SensorValues({
                   className={`
                     font-medium px-2 py-0.5 rounded-full text-[11px]
                     ${isBooleanActive(b.category, b.value)
-                      ? "bg-amber-400/15 text-amber-500"
+                      ? "bg-active/15 text-active-text"
                       : "bg-border-light text-text-tertiary"
                     }
                   `}

--- a/ui/src/components/equipments/ThermostatCard.tsx
+++ b/ui/src/components/equipments/ThermostatCard.tsx
@@ -42,22 +42,22 @@ const MODE_ICONS: Record<string, React.ReactNode> = {
 const MODE_COLORS: Record<string, string> = {
   // HVAC modes
   auto: "bg-primary/10 text-primary border-primary/30",
-  cool: "bg-blue-500/10 text-blue-500 border-blue-500/30",
-  heat: "bg-orange-500/10 text-orange-500 border-orange-500/30",
-  dry: "bg-teal-500/10 text-teal-500 border-teal-500/30",
-  fan: "bg-gray-500/10 text-gray-500 border-gray-500/30",
+  cool: "bg-primary/10 text-primary border-primary/30",
+  heat: "bg-error/10 text-error border-error/30",
+  dry: "bg-success/10 text-success border-success/30",
+  fan: "bg-text-tertiary/10 text-text-secondary border-text-tertiary/30",
   // Stove profiles
   dynamic: "bg-primary/10 text-primary border-primary/30",
-  overnight: "bg-indigo-500/10 text-indigo-500 border-indigo-500/30",
-  comfort: "bg-orange-500/10 text-orange-500 border-orange-500/30",
+  overnight: "bg-primary/10 text-primary border-primary/30",
+  comfort: "bg-warning/10 text-warning border-warning/30",
 };
 
 /** Color classes for stove state badge */
 function stoveStateColor(state: string): string {
   if (state === "off" || state === "standby") return "text-text-tertiary bg-border-light";
   if (state.startsWith("running") || state === "auto_eco") return "text-success bg-success/10";
-  if (state.startsWith("ignition") || state === "checking" || state === "stabilizing") return "text-orange-500 bg-orange-500/10";
-  if (state === "extinguishing" || state === "cooling" || state.startsWith("cleaning")) return "text-blue-500 bg-blue-500/10";
+  if (state.startsWith("ignition") || state === "checking" || state === "stabilizing") return "text-warning bg-warning/10";
+  if (state === "extinguishing" || state === "cooling" || state.startsWith("cleaning")) return "text-primary bg-primary/10";
   if (state.startsWith("error")) return "text-error bg-error/10";
   return "text-text-tertiary bg-border-light";
 }

--- a/ui/src/components/equipments/WeatherPanel.tsx
+++ b/ui/src/components/equipments/WeatherPanel.tsx
@@ -59,11 +59,11 @@ function getKindIcon(kind: DeviceKind) {
 function getKindColor(kind: DeviceKind): string {
   switch (kind) {
     case "wind":
-      return "text-sky-500 bg-sky-500/10";
+      return "text-primary bg-primary/10";
     case "rain":
-      return "text-blue-500 bg-blue-500/10";
+      return "text-primary bg-primary/10";
     default:
-      return "text-orange-500 bg-orange-500/10";
+      return "text-accent bg-accent/10";
   }
 }
 

--- a/ui/src/components/equipments/sensorUtils.tsx
+++ b/ui/src/components/equipments/sensorUtils.tsx
@@ -185,7 +185,7 @@ export function isContactOpen(bindings: DataBindingWithValue[]): boolean {
 export function getSensorIconColor(bindings: DataBindingWithValue[]): string {
   const primaryCat = getPrimarySensorCategory(bindings);
   if (primaryCat === "motion" && isMotionDetected(bindings)) {
-    return "bg-amber-400/15 text-amber-500";
+    return "bg-active/15 text-active-text";
   }
   if (primaryCat === "action") {
     return "bg-primary/10 text-primary";
@@ -194,7 +194,7 @@ export function getSensorIconColor(bindings: DataBindingWithValue[]): string {
     (primaryCat === "contact_door" || primaryCat === "contact_window") &&
     isContactOpen(bindings)
   ) {
-    return "bg-amber-400/15 text-amber-500";
+    return "bg-active/15 text-active-text";
   }
   return "bg-border-light text-text-tertiary";
 }

--- a/ui/src/components/equipments/useEquipmentState.ts
+++ b/ui/src/components/equipments/useEquipmentState.ts
@@ -71,14 +71,14 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
     ? getSensorIconColor(equipment.dataBindings)
     : isThermostat
       ? isOn
-        ? "bg-blue-500/10 text-blue-500"
+        ? "bg-error/10 text-error"
         : "bg-border-light text-text-tertiary"
       : isShutter
         ? shutterIsOpen
           ? "bg-primary/10 text-primary"
           : "bg-border-light text-text-tertiary"
         : isLight && isOn
-          ? "bg-amber-400/15 text-amber-500"
+          ? "bg-active/15 text-active-text"
           : isOn
             ? "bg-primary/10 text-primary"
             : "bg-border-light text-text-tertiary";

--- a/ui/src/components/home/ZoneAggregationPills.tsx
+++ b/ui/src/components/home/ZoneAggregationPills.tsx
@@ -69,7 +69,7 @@ export function ZoneAggregationPills({ data }: ZoneAggregationPillsProps) {
       key: "motion",
       icon: <PersonStanding size={14} strokeWidth={1.5} />,
       label: `${label}${suffix}`,
-      color: data.motion ? "text-amber-500" : "text-text-tertiary",
+      color: data.motion ? "text-active-text" : "text-text-tertiary",
     });
   }
 
@@ -80,7 +80,7 @@ export function ZoneAggregationPills({ data }: ZoneAggregationPillsProps) {
       key: "lights",
       icon: <Lightbulb size={14} strokeWidth={1.5} />,
       label: `${data.lightsOn}/${data.lightsTotal}`,
-      color: isOn ? "text-amber-500" : "text-text-tertiary",
+      color: isOn ? "text-active-text" : "text-text-tertiary",
     });
   }
 
@@ -105,7 +105,7 @@ export function ZoneAggregationPills({ data }: ZoneAggregationPillsProps) {
       key: "doors",
       icon: <DoorOpen size={14} strokeWidth={1.5} />,
       label: t("aggregation.open", { count: data.openDoors }),
-      color: "text-amber-500",
+      color: "text-active-text",
     });
   }
 
@@ -115,7 +115,7 @@ export function ZoneAggregationPills({ data }: ZoneAggregationPillsProps) {
       key: "windows",
       icon: <SquareStack size={14} strokeWidth={1.5} />,
       label: t("aggregation.open", { count: data.openWindows }),
-      color: "text-amber-500",
+      color: "text-active-text",
     });
   }
 

--- a/ui/src/components/home/ZoneEquipmentsView.tsx
+++ b/ui/src/components/home/ZoneEquipmentsView.tsx
@@ -20,11 +20,11 @@ interface EquipmentGroup {
 }
 
 const EQUIPMENT_GROUPS: EquipmentGroup[] = [
-  { labelKey: "equipments.group.lights", types: ["light_onoff", "light_dimmable", "light_color"], icon: <Lightbulb size={14} strokeWidth={1.5} />, headerBg: "bg-amber-400/8", iconColor: "text-amber-500" },
+  { labelKey: "equipments.group.lights", types: ["light_onoff", "light_dimmable", "light_color"], icon: <Lightbulb size={14} strokeWidth={1.5} />, headerBg: "bg-active/8", iconColor: "text-active-text" },
   { labelKey: "equipments.group.shutters", types: ["shutter"], icon: <ShutterClosedIcon size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
-  { labelKey: "equipments.group.climate", types: ["thermostat"], icon: <Thermometer size={14} strokeWidth={1.5} />, headerBg: "bg-blue-500/6", iconColor: "text-blue-500" },
-  { labelKey: "equipments.group.sensors", types: ["sensor"], icon: <Gauge size={14} strokeWidth={1.5} />, headerBg: "bg-info/6", iconColor: "text-info" },
-  { labelKey: "equipments.group.weather", types: ["weather"], icon: <CloudSun size={14} strokeWidth={1.5} />, headerBg: "bg-orange-400/8", iconColor: "text-orange-500" },
+  { labelKey: "equipments.group.climate", types: ["thermostat"], icon: <Thermometer size={14} strokeWidth={1.5} />, headerBg: "bg-error/6", iconColor: "text-error" },
+  { labelKey: "equipments.group.sensors", types: ["sensor"], icon: <Gauge size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
+  { labelKey: "equipments.group.weather", types: ["weather"], icon: <CloudSun size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
   { labelKey: "equipments.group.other", types: ["switch", "button"], icon: <ToggleRight size={14} strokeWidth={1.5} />, headerBg: "bg-text-tertiary/6", iconColor: "text-text-secondary" },
 ];
 

--- a/ui/src/components/home/ZoneModesSection.tsx
+++ b/ui/src/components/home/ZoneModesSection.tsx
@@ -33,8 +33,8 @@ export function ZoneModesSection({ zoneId }: ZoneModesSectionProps) {
 
   return (
     <div className="rounded-[10px] border border-border bg-surface overflow-hidden">
-      <div className="flex items-center gap-1.5 px-3 py-1 bg-primary/8">
-        <span className="text-primary">
+      <div className="flex items-center gap-1.5 px-3 py-1 bg-success/8">
+        <span className="text-success">
           <ToggleRight size={14} strokeWidth={1.5} />
         </span>
         <span className="text-[11px] font-medium text-text-tertiary uppercase tracking-wider">

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -9,6 +9,7 @@ import { useZones } from "../../store/useZones";
 import { useEquipments } from "../../store/useEquipments";
 import { useAuth } from "../../store/useAuth";
 import { LogOut, User } from "lucide-react";
+import { WinchLogo } from "./WinchLogo";
 
 export function AppLayout() {
   const { t } = useTranslation();
@@ -42,9 +43,7 @@ export function AppLayout() {
           <div className="flex items-center gap-4">
             {/* Mobile logo */}
             <div className="flex md:hidden items-center gap-2">
-              <div className="w-7 h-7 bg-primary rounded-[5px] flex items-center justify-center">
-                <span className="text-white font-semibold text-xs">C</span>
-              </div>
+              <WinchLogo size={28} />
               <span className="font-semibold text-[15px] text-text">{t("app.name")}</span>
             </div>
           </div>

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { SidebarZoneTree } from "./SidebarZoneTree";
 import { SidebarModeList } from "./SidebarModeList";
+import { WinchLogo } from "./WinchLogo";
 import { useAuth } from "../../store/useAuth";
 
 interface NavItem {
@@ -49,9 +50,7 @@ export function Sidebar() {
       {/* Logo area */}
       <div className="flex items-center h-[60px] px-4 border-b border-border-light">
         <div className="flex items-center gap-3 min-w-0">
-          <div className="flex-shrink-0 w-8 h-8 bg-primary rounded-[6px] flex items-center justify-center">
-            <span className="text-white font-semibold text-sm">C</span>
-          </div>
+          <WinchLogo size={32} className="flex-shrink-0" />
           {!collapsed && (
             <span className="font-semibold text-[16px] tracking-[-0.01em] text-text truncate">
               {t("app.name")}

--- a/ui/src/components/layout/WinchLogo.tsx
+++ b/ui/src/components/layout/WinchLogo.tsx
@@ -1,0 +1,25 @@
+interface WinchLogoProps {
+  size?: number;
+  className?: string;
+}
+
+export function WinchLogo({ size = 32, className = "" }: WinchLogoProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 32 32"
+      width={size}
+      height={size}
+      fill="none"
+      className={className}
+    >
+      <rect width="32" height="32" rx="7" className="fill-primary" />
+      {/* Winch drum — centered in square */}
+      <circle cx="16" cy="16" r="6.5" stroke="white" strokeWidth="2" fill="none" />
+      <circle cx="16" cy="16" r="2" fill="white" />
+      {/* Handle/crank */}
+      <line x1="16" y1="16" x2="23.5" y2="10.5" stroke="white" strokeWidth="2" strokeLinecap="round" />
+      <circle cx="23.5" cy="10.5" r="2" fill="white" />
+    </svg>
+  );
+}

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -367,7 +367,7 @@ function RecipeInstanceRow({
                         log.level === "error"
                           ? "text-error"
                           : log.level === "warn"
-                            ? "text-amber-500"
+                            ? "text-warning"
                             : "text-text-secondary"
                       }
                     >

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -9,25 +9,25 @@
    ============================================================ */
 
 @theme {
-  /* Colors — Light mode */
-  --color-primary: #1B6B5A;
-  --color-primary-light: #E8F4F0;
-  --color-primary-hover: #155A4A;
-  --color-accent: #D4873F;
-  --color-accent-hover: #BE7535;
-  --color-background: #FAFAF8;
+  /* Colors — Light mode (Ocean palette) */
+  --color-primary: #1A4F6E;
+  --color-primary-light: #E6F0F6;
+  --color-primary-hover: #13405A;
+  --color-accent: #D4963F;
+  --color-accent-hover: #BB8232;
+  --color-background: #F8FAFB;
   --color-surface: #FFFFFF;
   --color-surface-raised: #FFFFFF;
   --color-text: #1A1A1A;
   --color-text-secondary: #6B7280;
   --color-text-tertiary: #9CA3AF;
-  --color-border: #E5E5E3;
-  --color-border-light: #F0F0EE;
-  --color-success: #22A06B;
-  --color-warning: #D4873F;
-  --color-error: #C9372C;
-  --color-info: #2563EB;
-  --color-motion: #2563EB;
+  --color-border: #E1E6EA;
+  --color-border-light: #EDF0F3;
+  --color-active: #EAB308;
+  --color-active-text: #A16207;
+  --color-success: #3D8B6E;
+  --color-warning: #C88B3A;
+  --color-error: #C0453A;
 
   /* Typography */
   --font-sans: "Inter", system-ui, -apple-system, sans-serif;

--- a/ui/src/pages/IntegrationsPage.tsx
+++ b/ui/src/pages/IntegrationsPage.tsx
@@ -148,8 +148,8 @@ function IntegrationCard({ integration, onRefresh }: { integration: IntegrationI
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2.5">
-          <div className="w-8 h-8 bg-yellow-100 dark:bg-yellow-900/30 rounded-[6px] flex items-center justify-center">
-            <IconComponent size={16} className="text-yellow-600 dark:text-yellow-400" />
+          <div className="w-8 h-8 bg-accent/10 rounded-[6px] flex items-center justify-center">
+            <IconComponent size={16} className="text-accent" />
           </div>
           <div>
             <h2 className="text-[14px] font-semibold text-text">{integration.name}</h2>
@@ -159,17 +159,17 @@ function IntegrationCard({ integration, onRefresh }: { integration: IntegrationI
         <div className="flex flex-col items-end gap-1">
           <div className="flex items-center gap-1.5">
             {isConnected ? (
-              <Wifi size={14} className="text-green-500" />
+              <Wifi size={14} className="text-success" />
             ) : isError ? (
-              <AlertTriangle size={14} className="text-red-500" />
+              <AlertTriangle size={14} className="text-error" />
             ) : (
               <WifiOff size={14} className="text-text-tertiary" />
             )}
             <span className={`text-[11px] font-medium ${
               isConnected
-                ? "text-green-600 dark:text-green-400"
+                ? "text-success"
                 : isError
-                  ? "text-red-600 dark:text-red-400"
+                  ? "text-error"
                   : "text-text-tertiary"
             }`}>
               {t(`status.${integration.status === "not_configured" ? "disconnected" : integration.status}`)}
@@ -195,7 +195,7 @@ function IntegrationCard({ integration, onRefresh }: { integration: IntegrationI
 
       {/* Error / Success */}
       {error && <p className="mt-3 text-[13px] text-error">{error}</p>}
-      {success && <p className="mt-3 text-[13px] text-green-600 dark:text-green-400">{success}</p>}
+      {success && <p className="mt-3 text-[13px] text-success">{success}</p>}
 
       {/* Actions */}
       <div className="flex items-center gap-2 mt-4">

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -277,7 +277,7 @@ function ChangePasswordSection() {
             />
           </div>
           {error && <p className="text-[13px] text-error">{error}</p>}
-          {success && <p className="text-[13px] text-green-600">{t("settings.passwordChanged")}</p>}
+          {success && <p className="text-[13px] text-success">{t("settings.passwordChanged")}</p>}
           <div className="flex gap-2">
             <button
               onClick={handleSubmit}
@@ -354,8 +354,8 @@ function ApiTokensSection() {
       <h2 className="text-[14px] font-semibold text-text mb-4">{t("settings.apiTokens")}</h2>
 
       {newTokenValue && (
-        <div className="mb-4 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-[6px]">
-          <p className="text-[12px] text-green-800 dark:text-green-300 mb-2">{t("settings.tokenCreated")}</p>
+        <div className="mb-4 p-3 bg-success/10 border border-success/30 rounded-[6px]">
+          <p className="text-[12px] text-success mb-2">{t("settings.tokenCreated")}</p>
           <div className="flex items-center gap-2">
             <code className="flex-1 text-[12px] font-mono bg-background px-2 py-1 rounded border border-border break-all">
               {newTokenValue}
@@ -405,7 +405,7 @@ function ApiTokensSection() {
               </div>
               <button
                 onClick={() => handleRevoke(token.id)}
-                className="text-[12px] text-error hover:text-red-700 font-medium cursor-pointer"
+                className="text-[12px] text-error hover:text-error/80 font-medium cursor-pointer"
               >
                 {t("settings.revokeToken")}
               </button>
@@ -589,8 +589,8 @@ function UserManagementSection({ currentUserId }: { currentUserId: string }) {
                   disabled={u.id === currentUserId}
                   className={`text-[11px] px-2 py-0.5 rounded font-medium cursor-pointer ${
                     u.enabled
-                      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                      : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                      ? "bg-success/10 text-success"
+                      : "bg-error/10 text-error"
                   } ${u.id === currentUserId ? "opacity-50 cursor-not-allowed" : ""}`}
                 >
                   {u.enabled ? t("settings.enabled") : t("common.disabled")}
@@ -670,7 +670,7 @@ function BackupSection() {
       <p className="text-[12px] text-text-tertiary mb-4">{t("settings.backupDescription")}</p>
 
       {error && <p className="mb-3 text-[13px] text-error">{error}</p>}
-      {success && <p className="mb-3 text-[13px] text-green-600 dark:text-green-400">{success}</p>}
+      {success && <p className="mb-3 text-[13px] text-success">{success}</p>}
 
       <div className="flex items-center gap-2">
         <button


### PR DESCRIPTION
## Summary
- Apply "Ocean" color palette: primary `#1A4F6E` (bleu pétrole) + accent `#D4963F` (ambre)
- Create WinchLogo SVG component (winch drum + cable + crank handle)
- Add `favicon.svg` and link in `index.html`
- Replace hardcoded "C" text badge with the new logo in Sidebar and mobile header

## Changes
- `ui/src/index.css` — color tokens updated
- `ui/src/components/layout/WinchLogo.tsx` — new component
- `ui/public/favicon.svg` — new favicon
- `ui/src/components/layout/Sidebar.tsx` — uses WinchLogo
- `ui/src/components/layout/AppLayout.tsx` — uses WinchLogo
- `ui/index.html` — favicon link
- `CLAUDE.md` — design system colors updated

## Test plan
- [x] TypeScript compiles (backend + frontend, zero errors)
- [x] All 276 tests pass
- [x] Pre-push validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)