### PR TITLE
feat: V0.11 — Logging system with UI viewer and live streaming

### DIFF
--- a/.claude/skills/winch-feature/SKILL.md
+++ b/.claude/skills/winch-feature/SKILL.md
@@ -293,10 +293,70 @@ Follow this strict order to avoid broken dependencies:
 | MQTT never throws  | All MQTT handlers wrapped in try/catch with logging      |
 | Events never throw | All event handlers wrapped in try/catch with logging     |
 | SQLite synchronous | Use `better-sqlite3` sync API, WAL mode                  |
-| Pino logging       | Use Fastify's pino logger, structured JSON               |
+| Pino logging       | Use structured pino logger, follow log level strategy    |
+| No console.\*      | Never use `console.log/error/warn` — always pino logger  |
 | Tailwind only      | No custom CSS files in UI, utility classes only          |
 | CSS variables      | Use design system tokens from tailwind.config.js         |
 | Lucide icons       | Use lucide-react for all icons                           |
+
+### 3.4 Logging Rules (MANDATORY)
+
+Every new module or feature MUST follow the logging strategy defined in `CLAUDE.md § Logging`.
+
+#### Logger Setup
+
+```typescript
+// In a class — create child logger with module context
+constructor(deps: { logger: Logger }) {
+  this.logger = deps.logger.child({ module: "my-module" });
+}
+
+// In a standalone function
+const logger = parentLogger.child({ module: "my-module" });
+```
+
+- Property name: `this.logger` in classes, `logger` in functions. Never `this.log` or `log`.
+
+#### Level Assignment Checklist
+
+When adding log calls, verify each one against this table:
+
+| Level     | Use for                                            | NOT for                                       |
+| --------- | -------------------------------------------------- | --------------------------------------------- |
+| **fatal** | Process crash, unrecoverable state                 | Recoverable errors                            |
+| **error** | Operation failed, needs attention                  | Expected failures (e.g., 404, invalid input)  |
+| **warn**  | Self-recovered issue, degradation signal           | Normal operations, business events            |
+| **info**  | One log per business operation (CRUD, connect)     | Per-item details, per-message, per-data-point |
+| **debug** | Troubleshooting details, step-by-step trace        | Hot-path data that fires every second         |
+| **trace** | Every event emission, every MQTT msg, every update | Anything that should be visible in production |
+
+#### Structured Context
+
+```typescript
+// GOOD — structured context as first arg, message as second
+logger.info({ deviceId, status }, "Device status changed");
+logger.error({ err, integrationId }, "Poll failed");
+
+// BAD — string interpolation
+logger.info(`Device ${deviceId} changed to ${status}`);
+logger.error(`Poll failed: ${err.message}`);
+```
+
+#### Domain-Specific Guidelines
+
+| Domain       | info                                   | debug                                | trace                     |
+| ------------ | -------------------------------------- | ------------------------------------ | ------------------------- |
+| MQTT         | Connected/disconnected/reconnecting    | Topic subscribed, publish result     | Every message received    |
+| Devices      | Discovered, removed, status changed    | Data auto-created, category inferred | Every data point update   |
+| Equipments   | CRUD, order dispatched                 | Binding evaluation, computed result  | Every binding re-eval     |
+| Zones        | CRUD, aggregation summary              | Individual fields computed           | Every aggregation trigger |
+| Modes        | Activated/deactivated, CRUD            | Each impact action executed          | —                         |
+| Recipes      | Instance CRUD, enabled/disabled        | Execution steps, trigger evaluation  | —                         |
+| Integrations | Started/stopped, poll completed        | Poll cycle details, API call results | Raw API responses         |
+| Auth         | Login, token created, password changed | JWT validation, middleware decisions | —                         |
+| API          | Server listening                       | Request handling details             | Every request/response    |
+| WebSocket    | Client connected/disconnected          | Topic subscription                   | Every frame               |
+| Event Bus    | —                                      | —                                    | Every event emitted       |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,52 @@ npm test -- --grep "pattern"  # Run specific tests
 
 ### Logging
 
-- Structured JSON logging via pino (Fastify default)
+Structured JSON logging via pino (Fastify default) with multistream: ring buffer (UI), pino-pretty (dev), JSON stdout + pino-roll files (prod).
+
+#### Log Level Strategy
+
+| Level     | Purpose                                             | Production visible | Examples                                                                     |
+| --------- | --------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------- |
+| **fatal** | Process about to crash, unrecoverable               | Yes                | Uncaught exception, database corruption                                      |
+| **error** | Operation failed, engine continues. Needs attention | Yes                | Integration poll failed, order dispatch error, recipe execution error        |
+| **warn**  | Unexpected situation, handled gracefully            | Yes                | MQTT reconnecting, device offline, token refresh retry, stale device cleanup |
+| **info**  | Significant business events — one per operation     | Yes                | Engine start/stop, device discovered/removed, equipment CRUD, mode activated |
+| **debug** | Operational detail for troubleshooting              | No (dev/UI only)   | Binding evaluation, aggregation steps, migration applied, config loaded      |
+| **trace** | High-volume hot-path data, deep debugging only      | No (dev/UI only)   | Every event bus emission, every MQTT message, every data point update        |
+
+#### Level Assignment Rules
+
+- **info = admin dashboard**: an operator reading info logs should understand _what happened_ without drowning. One log per business operation, not per item processed.
+- **debug = developer session**: detailed enough to trace a specific problem. One human can read these for a module during a debug session.
+- **trace = replay mode**: enables reproducing exact state transitions. High volume, never on in production.
+- **error always includes `{ err }`**: pass the Error object as structured context, e.g. `logger.error({ err }, "Poll failed")`.
+- **warn = self-recovering**: the system handled it, but repeated warnings signal degradation.
+- **Never use `console.log/error/warn`**: always use the structured pino logger. Console calls bypass the ring buffer, file rotation, and redaction.
+
+#### What Goes Where (by domain)
+
+| Domain           | info                                        | debug                                    | trace                       |
+| ---------------- | ------------------------------------------- | ---------------------------------------- | --------------------------- |
+| **MQTT**         | Connected, disconnected, reconnecting       | Subscribed to topic, publish result      | Every message received      |
+| **Devices**      | Discovered, removed, status changed         | Data auto-created, category inferred     | Every data point update     |
+| **Equipments**   | CRUD, order dispatched                      | Binding evaluation, computed data result | Every binding re-evaluation |
+| **Zones**        | CRUD, aggregation summary                   | Individual aggregation fields computed   | Every aggregation trigger   |
+| **Modes**        | Activated, deactivated, CRUD                | Each impact action executed              | —                           |
+| **Recipes**      | Instance created/deleted, enabled/disabled  | Execution steps, trigger evaluation      | —                           |
+| **Integrations** | Started, stopped, connected, poll completed | Poll cycle details, API call results     | Raw API responses           |
+| **Auth**         | User login, token created, password changed | JWT validation, middleware decisions     | —                           |
+| **API**          | Server listening, route registered          | Request handling details                 | Every request/response      |
+| **WebSocket**    | Client connected/disconnected               | Topic subscription, message sent         | Every frame                 |
+| **Event Bus**    | —                                           | —                                        | Every event emitted         |
+| **Database**     | DB opened, migration applied                | Query execution, schema changes          | —                           |
+
+#### Logger Conventions
+
+- **Property name**: use `this.logger` in classes, `logger` in standalone functions. Never `this.log`, `log`, or `console`.
+- **Child loggers**: every module creates a child logger with `{ module: "module-name" }` for filtering.
+- **Structured context**: pass data as first argument object, message as second: `logger.info({ deviceId, status }, "Device status changed")`.
+- **Sensitive data**: automatically redacted by pino config (passwords, tokens, secrets, API keys). Never log credentials manually.
+- **No string interpolation in messages**: use `logger.info({ count }, "Devices discovered")` not `logger.info("Discovered ${count} devices")`.
 
 ## Design System
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "mqtt": "^5.10.4",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
+        "pino-roll": "^4.0.0",
         "socket.io-client": "^4.8.3"
       },
       "devDependencies": {
@@ -2442,6 +2443,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -4469,6 +4480,16 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-roll": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-roll/-/pino-roll-4.0.0.tgz",
+      "integrity": "sha512-axI1aQaIxXdw1F4OFFli1EDxIrdYNGLowkw/ZoZogX8oCSLHUghzwVVXUS8U+xD/Savwa5IXpiXmsSGKFX/7Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "date-fns": "^4.1.0",
+        "sonic-boom": "^4.0.1"
       }
     },
     "node_modules/pino-std-serializers": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mqtt": "^5.10.4",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
+    "pino-roll": "^4.0.0",
     "socket.io-client": "^4.8.3"
   },
   "devDependencies": {

--- a/specs/015-V0.11-logging-system/architecture.md
+++ b/specs/015-V0.11-logging-system/architecture.md
@@ -1,0 +1,216 @@
+# Architecture: V0.11 Logging System
+
+## Overview
+
+Single pino root logger → 3 simultaneous outputs via `pino.multistream()`:
+
+```
+pino root logger (formatters, redaction, ISO timestamps)
+        |
+        +-- stdout (pino-pretty in dev, JSON in prod)
+        +-- pino-roll file transport (data/logs/winch.log, daily rotation)
+        +-- Writable stream → LogRingBuffer (in-memory, 2000 entries)
+                                    |
+                                    +-- WebSocket "logs" topic (live tail)
+                                    +-- REST GET /api/v1/logs (query)
+```
+
+## Data Model Changes
+
+### No SQLite changes
+
+Logs are NOT persisted in the database. The ring buffer is in-memory only, and file logs are handled by pino-roll. This keeps the system simple and avoids database bloat.
+
+### New types in types.ts
+
+```typescript
+/** Log entry as stored in ring buffer and sent to UI */
+export interface LogEntry {
+  level: string; // "debug" | "info" | "warn" | "error" | "fatal"
+  time: string; // ISO 8601
+  module?: string; // e.g. "mqtt", "device-manager", "equipment-manager"
+  msg: string; // Human-readable message
+  [key: string]: unknown; // Additional context (deviceId, equipmentId, etc.)
+}
+
+/** Log level type for runtime level changes */
+export type LogLevel = "debug" | "info" | "warn" | "error" | "fatal" | "silent";
+```
+
+## Event Bus Events
+
+No new event bus events. Logs use a dedicated ring buffer subscription mechanism, not the EngineEvent pipeline. This keeps log streaming decoupled from the domain event system and avoids noise.
+
+## MQTT Topics
+
+No changes.
+
+## API Changes
+
+### New endpoints
+
+| Method | Path                 | Auth  | Description                    |
+| ------ | -------------------- | ----- | ------------------------------ |
+| `GET`  | `/api/v1/logs`       | admin | Query ring buffer with filters |
+| `PUT`  | `/api/v1/logs/level` | admin | Change runtime log level       |
+| `GET`  | `/api/v1/logs/level` | admin | Get current log level          |
+
+#### GET /api/v1/logs
+
+Query params:
+
+- `limit` (number, default 100, max 2000) — max entries to return
+- `level` (string) — filter by minimum level (e.g. "warn" returns warn + error + fatal)
+- `module` (string) — filter by module name (exact match)
+- `search` (string) — substring search in `msg` field
+- `since` (ISO date string) — only entries after this timestamp
+
+Response:
+
+```json
+{
+  "entries": [
+    {
+      "level": "info",
+      "time": "2026-02-24T10:30:00.000Z",
+      "module": "device-manager",
+      "msg": "Device discovered",
+      "deviceId": "0x00158d..."
+    }
+  ],
+  "total": 42,
+  "capacity": 2000,
+  "currentLevel": "info"
+}
+```
+
+#### PUT /api/v1/logs/level
+
+Body: `{ "level": "debug" }`
+
+Changes the runtime log level of the root pino logger (affects all child loggers). Takes effect immediately, no restart needed.
+
+Response: `{ "level": "debug", "previous": "info" }`
+
+#### GET /api/v1/logs/level
+
+Response: `{ "level": "info" }`
+
+### WebSocket changes
+
+New topic `"logs"` added to `VALID_TOPICS`. When a client subscribes to the `logs` topic, it receives log entries in real time from the ring buffer subscription.
+
+Log entries are sent **immediately** (not batched like engine events) for true live-tail behavior. They are sent as individual messages, not arrays:
+
+```json
+{
+  "type": "log.entry",
+  "level": "info",
+  "time": "2026-02-24T10:30:00.000Z",
+  "module": "mqtt",
+  "msg": "Message received"
+}
+```
+
+Clients can optionally specify a minimum level when subscribing:
+
+```json
+{ "type": "subscribe", "topics": ["logs"], "logLevel": "warn" }
+```
+
+## UI Changes
+
+### New page: LogsPage
+
+Route: `/logs` (added under admin section in sidebar + router)
+
+### New component: LogViewer
+
+Located at `ui/src/pages/LogsPage.tsx` (self-contained page component).
+
+Features:
+
+- **Header bar**: level filter dropdown, module filter dropdown, text search input, live/pause toggle, clear button
+- **Log list**: virtualized scrollable list with auto-scroll in live mode
+- **Entry format**: `[HH:mm:ss.SSS] [LEVEL] [module] message`
+- **Colors**: error=red (`text-error`), warn=amber (`text-accent`), info=default (`text-text-secondary`), debug=muted (`text-text-tertiary`)
+- **Font**: JetBrains Mono (`font-mono` in Tailwind config)
+- **Expandable rows**: click to see full JSON context (deviceId, equipmentId, etc.)
+- **Module dropdown**: populated dynamically from modules seen in current entries
+
+### New store: useLogStore
+
+Zustand store managing:
+
+- `entries: LogEntry[]` — current displayed entries
+- `live: boolean` — whether auto-scroll is active
+- `filters: { level, module, search }` — active filters
+- WebSocket subscription lifecycle
+
+### Sidebar change
+
+Add "Logs" nav item to `ADMIN_ITEMS` in `Sidebar.tsx`:
+
+```typescript
+{ to: "/logs", label: "nav.logs", icon: <ScrollText size={18} strokeWidth={1.5} /> }
+```
+
+### i18n keys
+
+Add `nav.logs`, `logs.title`, `logs.live`, `logs.paused`, `logs.clear`, `logs.noEntries`, `logs.level`, `logs.module`, `logs.search`, `logs.allLevels`, `logs.allModules` to both `en.json` and `fr.json`.
+
+## File Changes
+
+| File                                   | Change                                                                |
+| -------------------------------------- | --------------------------------------------------------------------- |
+| `package.json`                         | Add `pino-roll` dependency                                            |
+| `src/core/log-buffer.ts`               | **NEW** — LogRingBuffer class (~60 lines)                             |
+| `src/core/logger.ts`                   | Rewrite: multistream, formatters, redaction, ring buffer integration  |
+| `src/shared/types.ts`                  | Add `LogEntry` and `LogLevel` types                                   |
+| `src/index.ts`                         | Create LogRingBuffer, pass to createLogger and createServer           |
+| `src/api/server.ts`                    | Add `logBuffer` to ServerDeps, register log routes, pass to WebSocket |
+| `src/api/routes/logs.ts`               | **NEW** — GET /api/v1/logs, PUT/GET /api/v1/logs/level                |
+| `src/api/websocket.ts`                 | Add "logs" topic, ring buffer subscriber per client                   |
+| `ui/src/pages/LogsPage.tsx`            | **NEW** — Log viewer page                                             |
+| `ui/src/store/useLogStore.ts`          | **NEW** — Zustand store for logs                                      |
+| `ui/src/api.ts`                        | Add `fetchLogs()`, `getLogLevel()`, `setLogLevel()` API functions     |
+| `ui/src/types.ts`                      | Add `LogEntry` type                                                   |
+| `ui/src/App.tsx`                       | Add `/logs` route                                                     |
+| `ui/src/components/layout/Sidebar.tsx` | Add "Logs" to ADMIN_ITEMS                                             |
+| `ui/src/i18n/en.json`                  | Add log-related translation keys                                      |
+| `ui/src/i18n/fr.json`                  | Add log-related translation keys                                      |
+
+## Security
+
+### Redaction
+
+Configure at root logger level:
+
+```typescript
+redact: {
+  paths: [
+    "password", "*.password",
+    "token", "*.token",
+    "accessToken", "*.accessToken",
+    "refreshToken", "*.refreshToken",
+    "secret", "*.secret",
+    "apiKey", "*.apiKey",
+    "authorization", "req.headers.authorization",
+    "mqttPassword", "*.mqttPassword",
+  ],
+  censor: "[REDACTED]",
+}
+```
+
+### Access control
+
+- All log endpoints require `admin` role
+- WebSocket log subscription requires authentication (existing WS auth applies)
+- Ring buffer is only accessible through the API layer
+
+## Performance Considerations
+
+- Ring buffer operations are O(1) push, O(n) query (n = buffer size, max 2000). Negligible.
+- pino-roll runs file I/O in a worker thread — zero impact on main event loop.
+- WebSocket log streaming is direct (not batched), but pino serialization is the bottleneck, not sending.
+- Memory: 2000 entries × ~500 bytes average = ~1 MB. Trivial for a home automation box.

--- a/specs/015-V0.11-logging-system/plan.md
+++ b/specs/015-V0.11-logging-system/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: V0.11 Logging System
+
+## Dependencies
+
+- No dependency on other unimplemented features
+- Builds on existing Pino logger infrastructure
+
+## Tasks
+
+### Backend
+
+1. [ ] Install `pino-roll` dependency
+2. [ ] Add `LogEntry` and `LogLevel` types to `src/shared/types.ts`
+3. [ ] Create `src/core/log-buffer.ts` — LogRingBuffer class
+   - Circular buffer with configurable capacity (default 2000)
+   - `push(entry)` — O(1) insert
+   - `query({ limit, level, module, search, since })` — filtered retrieval
+   - `subscribe(listener)` / unsubscribe — for WebSocket streaming
+   - `getModules()` — unique module names seen
+4. [ ] Rewrite `src/core/logger.ts`
+   - `createLogger(level, logBuffer?)` returns pino Logger
+   - Production: `pino.multistream` with stdout + pino-roll + ring buffer stream
+   - Development: `pino.multistream` with pino-pretty stdout + ring buffer stream
+   - Formatters: level labels (string not number), ISO timestamps
+   - Redaction: passwords, tokens, secrets, API keys
+   - Export `setLogLevel(logger, level)` helper for runtime changes
+5. [ ] Update `src/index.ts`
+   - Create LogRingBuffer instance
+   - Pass it to `createLogger()` and to `createServer()` deps
+6. [ ] Update `src/api/server.ts`
+   - Add `logBuffer` and `rootLogger` to ServerDeps
+   - Register log routes
+   - Pass logBuffer to WebSocket handler
+7. [ ] Create `src/api/routes/logs.ts`
+   - `GET /api/v1/logs` — query ring buffer, admin only
+   - `GET /api/v1/logs/level` — return current level, admin only
+   - `PUT /api/v1/logs/level` — change runtime level, admin only
+8. [ ] Update `src/api/websocket.ts`
+   - Add `"logs"` to `WsTopic` and `VALID_TOPICS`
+   - On client subscribe to "logs": register ring buffer listener
+   - On client disconnect: unsubscribe listener
+   - Send log entries immediately (not batched)
+
+### Frontend
+
+9. [ ] Add `LogEntry` type to `ui/src/types.ts`
+10. [ ] Add API functions to `ui/src/api.ts`: `fetchLogs()`, `getLogLevel()`, `setLogLevel()`
+11. [ ] Create `ui/src/store/useLogStore.ts` — Zustand store
+    - State: entries, live mode, filters, connected
+    - Actions: connect (WS), disconnect, setFilter, toggleLive, clear
+12. [ ] Create `ui/src/pages/LogsPage.tsx` — Log viewer page
+    - Filter bar: level, module, search, live/pause toggle
+    - Scrollable log list with color-coded entries
+    - Auto-scroll in live mode, freeze in pause mode
+    - Expandable entries for full context
+13. [ ] Update `ui/src/App.tsx` — Add `/logs` route
+14. [ ] Update `ui/src/components/layout/Sidebar.tsx` — Add "Logs" to ADMIN_ITEMS
+15. [ ] Add i18n keys to `ui/src/i18n/en.json` and `ui/src/i18n/fr.json`
+
+### Validation
+
+16. [ ] Backend TypeScript compiles (`npx tsc --noEmit`)
+17. [ ] Frontend TypeScript compiles (`cd ui && npx tsc --noEmit`)
+18. [ ] Manual test: start engine, verify logs in console + file + ring buffer
+19. [ ] Manual test: open UI log viewer, verify live streaming and filters
+20. [ ] Manual test: change log level via API, verify it takes effect
+
+## Testing
+
+### Manual verification steps
+
+1. Start engine with `npm run dev`
+2. Verify pino-pretty logs appear in console with module context
+3. Check `data/logs/` directory is created and `winch.log` exists (production mode)
+4. Call `GET /api/v1/logs` — verify entries returned
+5. Call `GET /api/v1/logs?level=warn` — verify filtering works
+6. Call `GET /api/v1/logs?module=mqtt` — verify module filter works
+7. Call `PUT /api/v1/logs/level` with `{"level":"debug"}` — verify more logs appear
+8. Open UI `/logs` page — verify entries load
+9. Trigger MQTT activity — verify new entries appear in real time
+10. Toggle pause — verify auto-scroll stops
+11. Filter by level/module — verify list updates

--- a/specs/015-V0.11-logging-system/spec.md
+++ b/specs/015-V0.11-logging-system/spec.md
@@ -1,0 +1,84 @@
+# V0.11: Logging System
+
+## Summary
+
+Implement a unified logging system that serves three audiences simultaneously:
+
+1. **Linux sysadmin** — structured JSON log files with rotation, compatible with `grep`, `jq`, `journalctl`
+2. **Platform admin** — real-time log viewer in the UI with filtering by level, module, and text search
+3. **Developer / AI debug** — rich structured context (module, deviceId, correlationId) accessible via console, files, and API
+
+The system builds on the existing Pino logger with minimal changes to current logging call sites.
+
+## Reference
+
+- CLAUDE.md: "Structured JSON logging via pino (Fastify default)"
+- Spec §4.1: Logging conventions
+- Current implementation: `src/core/logger.ts` (14 lines, stdout only)
+
+## Acceptance Criteria
+
+### Backend — Logger Enhancement
+
+- [ ] Pino logger outputs to 3 destinations simultaneously: stdout, file (pino-roll), in-memory ring buffer
+- [ ] File transport rotates daily + at 10 MB, keeps 14 days of history
+- [ ] Log files written to `data/logs/winch.log` with auto-created directory
+- [ ] Ring buffer holds last 2000 entries in memory (configurable)
+- [ ] Ring buffer captures at `debug` level; file transport at `info` level
+- [ ] Sensitive fields (password, token, secret, apiKey) are redacted with `[REDACTED]`
+- [ ] Log entries use human-readable level names (`info` not `30`)
+- [ ] ISO 8601 timestamps on all entries
+
+### Backend — API
+
+- [ ] `GET /api/v1/logs` returns recent log entries from ring buffer
+  - Query params: `limit` (default 100), `level`, `module`, `search`, `since`
+  - Requires admin role
+- [ ] `PUT /api/v1/settings/log-level` changes runtime log level without restart
+  - Body: `{ "level": "debug" | "info" | "warn" | "error" }`
+  - Requires admin role
+- [ ] WebSocket topic `"logs"` streams log entries in real time
+  - Clients can subscribe with optional level filter
+  - Entries sent immediately (not batched like engine events)
+
+### Frontend — Log Viewer
+
+- [ ] New page accessible at Administration > Logs
+- [ ] Displays log entries in a scrollable, monospace-font list
+- [ ] Filter controls: level dropdown, module dropdown (populated from seen modules), text search
+- [ ] Live mode: auto-scrolls as new entries arrive via WebSocket
+- [ ] Pause mode: freezes display for consultation, resumes on click
+- [ ] Color-coded levels: red = error, amber = warn, default = info, muted = debug
+- [ ] Shows timestamp, level, module, message for each entry
+- [ ] Expandable entries to see full structured data (deviceId, etc.)
+
+## Scope
+
+### In Scope
+
+- Enhanced Pino logger with multistream (stdout + file + ring buffer)
+- `pino-roll` for file rotation
+- `LogRingBuffer` class (in-memory circular buffer)
+- REST endpoint to query logs
+- REST endpoint to change log level at runtime
+- WebSocket topic for live log streaming
+- UI log viewer page with filters and live/pause toggle
+- Redaction of sensitive fields
+
+### Out of Scope
+
+- Log shipping to external systems (ELK, Loki, Datadog) — not needed for home automation
+- Log persistence in SQLite or InfluxDB — ring buffer + files is sufficient
+- Per-user log access control (admin-only is fine)
+- Log alerts/notifications — scenarios handle this
+- Audit log (who changed what) — separate concern for later
+- Changing existing `logger.child()` call sites — they continue to work as-is
+
+## Edge Cases
+
+- **Ring buffer overflow**: Oldest entries are silently dropped (circular buffer behavior). No error, no warning.
+- **Log file disk full**: pino-roll handles this gracefully; logs still go to stdout and ring buffer.
+- **Many WebSocket log subscribers**: Each subscriber gets its own listener. Cap at ~10 concurrent log subscribers to prevent memory issues.
+- **High-frequency debug logs**: Ring buffer at debug level may fill fast under heavy MQTT traffic. 2000 entries covers ~2-5 min of debug, ~15-30 min of info. This is acceptable for real-time monitoring.
+- **Server restart**: Ring buffer is lost (by design). File logs persist. UI shows "no entries" until new logs arrive.
+- **No auth configured (first-run)**: Log endpoints still require admin role. During first-run setup, logs are only available via console/files.

--- a/src/api/routes/calendar.test.ts
+++ b/src/api/routes/calendar.test.ts
@@ -23,7 +23,7 @@ function createTestDb(): Database.Database {
   return db;
 }
 
-const logger = createLogger("silent");
+const logger = createLogger("silent").logger;
 
 function createMockEquipmentManager() {
   return { executeOrder: vi.fn() } as any;

--- a/src/api/routes/logs.ts
+++ b/src/api/routes/logs.ts
@@ -1,0 +1,73 @@
+import type { FastifyInstance } from "fastify";
+import type { Logger } from "../../core/logger.js";
+import type { LogRingBuffer } from "../../core/log-buffer.js";
+import type { LogLevel } from "../../shared/types.js";
+
+const VALID_LEVELS: LogLevel[] = ["debug", "info", "warn", "error", "fatal", "silent"];
+
+interface LogsDeps {
+  logBuffer: LogRingBuffer;
+  logger: Logger;
+}
+
+export function registerLogRoutes(app: FastifyInstance, deps: LogsDeps): void {
+  const { logBuffer, logger: rootLogger } = deps;
+  const logger = rootLogger.child({ module: "logs-routes" });
+
+  // GET /api/v1/logs — Query ring buffer
+  app.get<{
+    Querystring: {
+      limit?: string;
+      level?: string;
+      module?: string;
+      search?: string;
+      since?: string;
+    };
+  }>("/api/v1/logs", async (request, reply) => {
+    if (!request.auth || request.auth.role !== "admin") {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+
+    const limit = Math.min(Math.max(Number(request.query.limit) || 100, 1), 2000);
+    const { level, module, search, since } = request.query;
+
+    const entries = logBuffer.query({ limit, level, module, search, since });
+
+    return {
+      entries,
+      total: entries.length,
+      capacity: logBuffer.getCapacity(),
+      currentLevel: rootLogger.level,
+      modules: logBuffer.getModules(),
+    };
+  });
+
+  // GET /api/v1/logs/level — Get current log level
+  app.get("/api/v1/logs/level", async (request, reply) => {
+    if (!request.auth || request.auth.role !== "admin") {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+
+    return { level: rootLogger.level };
+  });
+
+  // PUT /api/v1/logs/level — Change runtime log level
+  app.put<{ Body: { level: string } }>("/api/v1/logs/level", async (request, reply) => {
+    if (!request.auth || request.auth.role !== "admin") {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+
+    const { level } = request.body ?? {};
+    if (!level || !VALID_LEVELS.includes(level as LogLevel)) {
+      return reply.code(400).send({
+        error: `Invalid level. Must be one of: ${VALID_LEVELS.join(", ")}`,
+      });
+    }
+
+    const previous = rootLogger.level;
+    rootLogger.level = level;
+    logger.info({ level, previous }, "Log level changed");
+
+    return { level, previous };
+  });
+}

--- a/src/api/routes/modes.test.ts
+++ b/src/api/routes/modes.test.ts
@@ -27,7 +27,7 @@ function createTestDb(): Database.Database {
   return db;
 }
 
-const logger = createLogger("silent");
+const logger = createLogger("silent").logger;
 
 function createMockEquipmentManager() {
   return { executeOrder: vi.fn() } as any;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -5,6 +5,7 @@ import cors from "@fastify/cors";
 import fastifyStatic from "@fastify/static";
 import websocket from "@fastify/websocket";
 import type { Logger } from "../core/logger.js";
+import type { LogRingBuffer } from "../core/log-buffer.js";
 import type { DeviceManager } from "../devices/device-manager.js";
 import type { ZoneManager } from "../zones/zone-manager.js";
 import type { ZoneAggregator } from "../zones/zone-aggregator.js";
@@ -34,6 +35,7 @@ import { registerModeRoutes } from "./routes/modes.js";
 import { registerCalendarRoutes } from "./routes/calendar.js";
 import { registerIntegrationRoutes } from "./routes/integrations.js";
 import { registerButtonActionRoutes } from "./routes/button-actions.js";
+import { registerLogRoutes } from "./routes/logs.js";
 import { registerWebSocket } from "./websocket.js";
 
 interface ServerDeps {
@@ -51,6 +53,7 @@ interface ServerDeps {
   buttonActionManager: ButtonActionManager;
   eventBus: EventBus;
   integrationRegistry: IntegrationRegistry;
+  logBuffer: LogRingBuffer;
   logger: Logger;
   corsOrigins: string[];
 }
@@ -71,12 +74,13 @@ export async function createServer(deps: ServerDeps) {
     buttonActionManager,
     eventBus,
     integrationRegistry,
+    logBuffer,
     logger,
     corsOrigins,
   } = deps;
 
   const app = Fastify({
-    logger: false, // We use our own pino logger
+    logger: false,
   });
 
   // CORS
@@ -106,7 +110,8 @@ export async function createServer(deps: ServerDeps) {
   registerSettingsRoutes(app, { settingsManager, logger });
   registerIntegrationRoutes(app, { integrationRegistry, settingsManager, logger });
   registerButtonActionRoutes(app, { buttonActionManager, logger });
-  registerWebSocket(app, { eventBus, authService, logger });
+  registerLogRoutes(app, { logBuffer, logger });
+  registerWebSocket(app, { eventBus, authService, logBuffer, logger });
 
   // Serve UI static files (production: ui/dist is copied alongside dist/)
   const uiDir = resolve(import.meta.dirname ?? ".", "../ui-dist");

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -2,16 +2,26 @@ import type { FastifyInstance } from "fastify";
 import type { WebSocket } from "ws";
 import type { EventBus } from "../core/event-bus.js";
 import type { AuthService } from "../auth/auth-service.js";
+import type { LogRingBuffer } from "../core/log-buffer.js";
 import type { Logger } from "../core/logger.js";
 import type { EngineEvent } from "../shared/types.js";
 
 interface WebSocketDeps {
   eventBus: EventBus;
   authService: AuthService;
+  logBuffer: LogRingBuffer;
   logger: Logger;
 }
 
-type WsTopic = "devices" | "equipments" | "zones" | "modes" | "recipes" | "calendar" | "system";
+type WsTopic =
+  | "devices"
+  | "equipments"
+  | "zones"
+  | "modes"
+  | "recipes"
+  | "calendar"
+  | "system"
+  | "logs";
 
 const VALID_TOPICS = new Set<WsTopic>([
   "devices",
@@ -21,6 +31,7 @@ const VALID_TOPICS = new Set<WsTopic>([
   "recipes",
   "calendar",
   "system",
+  "logs",
 ]);
 const BATCH_INTERVAL_MS = 200;
 
@@ -28,6 +39,7 @@ interface ClientState {
   socket: WebSocket;
   topics: Set<WsTopic>;
   pending: EngineEvent[];
+  logUnsubscribe?: () => void;
 }
 
 function getEventTopic(event: EngineEvent): WsTopic {
@@ -85,7 +97,7 @@ function deduplicateEvents(events: EngineEvent[]): EngineEvent[] {
 }
 
 export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): void {
-  const { eventBus, authService, logger: baseLogger } = deps;
+  const { eventBus, authService, logBuffer, logger: baseLogger } = deps;
   const logger = baseLogger.child({ module: "websocket" });
   const clients = new Map<WebSocket, ClientState>();
 
@@ -121,6 +133,32 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
       }
     }
   });
+
+  /** Subscribe a client to log streaming via ring buffer */
+  function subscribeToLogs(state: ClientState): void {
+    // Unsubscribe previous if any
+    if (state.logUnsubscribe) {
+      state.logUnsubscribe();
+      state.logUnsubscribe = undefined;
+    }
+
+    state.logUnsubscribe = logBuffer.subscribe((entry) => {
+      if (state.socket.readyState !== 1) return;
+      try {
+        state.socket.send(JSON.stringify({ type: "log.entry", ...entry }));
+      } catch {
+        // Socket may have closed
+      }
+    });
+  }
+
+  /** Unsubscribe a client from log streaming */
+  function unsubscribeFromLogs(state: ClientState): void {
+    if (state.logUnsubscribe) {
+      state.logUnsubscribe();
+      state.logUnsubscribe = undefined;
+    }
+  }
 
   app.get("/ws", { websocket: true }, (socket, request) => {
     // Auth via query param: ws://host/ws?token=xxx
@@ -160,6 +198,16 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
               newTopics.add(t as WsTopic);
             }
           }
+
+          // Handle logs topic subscription/unsubscription
+          const hadLogs = state.topics.has("logs");
+          const wantsLogs = newTopics.has("logs");
+          if (!hadLogs && wantsLogs) {
+            subscribeToLogs(state);
+          } else if (hadLogs && !wantsLogs) {
+            unsubscribeFromLogs(state);
+          }
+
           state.topics = newTopics;
           logger.debug({ topics: [...newTopics] }, "Client subscribed");
         }
@@ -169,12 +217,14 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
     });
 
     socket.on("close", () => {
+      unsubscribeFromLogs(state);
       clients.delete(socket);
       logger.info({ clients: clients.size }, "WebSocket client disconnected");
     });
 
     socket.on("error", (err) => {
       logger.error({ err }, "WebSocket error");
+      unsubscribeFromLogs(state);
       clients.delete(socket);
     });
 

--- a/src/buttons/button-action-manager.test.ts
+++ b/src/buttons/button-action-manager.test.ts
@@ -25,7 +25,7 @@ function createTestDb(): Database.Database {
   return db;
 }
 
-const logger = createLogger("silent");
+const logger = createLogger("silent").logger;
 
 function createMockEquipmentManager() {
   return { executeOrder: vi.fn() } as any;

--- a/src/buttons/button-action-manager.ts
+++ b/src/buttons/button-action-manager.ts
@@ -9,7 +9,7 @@ import { toISOUtc } from "../core/database.js";
 import type { ButtonActionBinding, ButtonEffectType } from "../shared/types.js";
 
 export class ButtonActionManager {
-  private readonly log;
+  private readonly logger;
   private readonly stmts;
 
   constructor(
@@ -20,7 +20,7 @@ export class ButtonActionManager {
     private readonly recipeManager: RecipeManager,
     logger: Logger,
   ) {
-    this.log = logger.child({ module: "button-action-manager" });
+    this.logger = logger.child({ module: "button-action-manager" });
     this.stmts = this.prepareStatements();
   }
 
@@ -49,14 +49,17 @@ export class ButtonActionManager {
         try {
           this.handleActionEvent(event.equipmentId, event.value);
         } catch (err) {
-          this.log.error({ err, equipmentId: event.equipmentId }, "Error handling button action");
+          this.logger.error(
+            { err, equipmentId: event.equipmentId },
+            "Error handling button action",
+          );
         }
       }
     });
 
     const bindings = this.stmts.listAll.all() as ButtonActionBindingRow[];
     if (bindings.length > 0) {
-      this.log.info({ count: bindings.length }, "Button action bindings loaded");
+      this.logger.info({ count: bindings.length }, "Button action bindings loaded");
     }
   }
 
@@ -70,7 +73,7 @@ export class ButtonActionManager {
   ): ButtonActionBinding {
     const id = randomUUID();
     this.stmts.insert.run(id, equipmentId, actionValue, effectType, JSON.stringify(config));
-    this.log.info(
+    this.logger.info(
       { bindingId: id, equipmentId, actionValue, effectType },
       "Button action binding added",
     );
@@ -88,7 +91,7 @@ export class ButtonActionManager {
     config: Record<string, unknown>,
   ): ButtonActionBinding {
     this.stmts.update.run(actionValue, effectType, JSON.stringify(config), bindingId);
-    this.log.info({ bindingId, actionValue, effectType }, "Button action binding updated");
+    this.logger.info({ bindingId, actionValue, effectType }, "Button action binding updated");
 
     const row = this.db
       .prepare(`SELECT * FROM button_action_bindings WHERE id = ?`)
@@ -99,7 +102,7 @@ export class ButtonActionManager {
 
   removeBinding(bindingId: string): void {
     this.stmts.delete.run(bindingId);
-    this.log.info({ bindingId }, "Button action binding removed");
+    this.logger.info({ bindingId }, "Button action binding removed");
   }
 
   getBindingsByEquipment(equipmentId: string): ButtonActionBinding[] {
@@ -117,7 +120,7 @@ export class ButtonActionManager {
       if (row.action_value !== actionValue) continue;
 
       const config = JSON.parse(row.config) as Record<string, unknown>;
-      this.log.info(
+      this.logger.info(
         { bindingId: row.id, equipmentId, actionValue, effectType: row.effect_type },
         "Button action binding matched",
       );
@@ -125,7 +128,7 @@ export class ButtonActionManager {
       try {
         this.executeEffect(row.effect_type as ButtonEffectType, config);
       } catch (err) {
-        this.log.warn(
+        this.logger.warn(
           { err, bindingId: row.id, effectType: row.effect_type },
           "Failed to execute button action effect",
         );

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -3,14 +3,14 @@ import { readFileSync, readdirSync, mkdirSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { Logger } from "./logger.js";
 
-export function openDatabase(dbPath: string, logger: Logger): Database.Database {
-  const log = logger.child({ module: "database" });
+export function openDatabase(dbPath: string, parentLogger: Logger): Database.Database {
+  const logger = parentLogger.child({ module: "database" });
 
   // Ensure data directory exists
   const dir = dirname(dbPath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
-    log.info({ dir }, "Created data directory");
+    logger.info({ dir }, "Created data directory");
   }
 
   const db = new Database(dbPath);
@@ -19,7 +19,7 @@ export function openDatabase(dbPath: string, logger: Logger): Database.Database 
   db.pragma("journal_mode = WAL");
   db.pragma("foreign_keys = ON");
 
-  log.info({ path: dbPath }, "SQLite database opened");
+  logger.info({ path: dbPath }, "SQLite database opened");
 
   return db;
 }
@@ -36,8 +36,12 @@ export function toISOUtc(sqliteTimestamp: string | null): string | null {
   return sqliteTimestamp.endsWith("Z") ? sqliteTimestamp : `${sqliteTimestamp}Z`;
 }
 
-export function runMigrations(db: Database.Database, migrationsDir: string, logger: Logger): void {
-  const log = logger.child({ module: "migrations" });
+export function runMigrations(
+  db: Database.Database,
+  migrationsDir: string,
+  parentLogger: Logger,
+): void {
+  const logger = parentLogger.child({ module: "migrations" });
 
   // Create migrations tracking table
   db.exec(`
@@ -57,7 +61,7 @@ export function runMigrations(db: Database.Database, migrationsDir: string, logg
 
   // Read migration files, sorted alphabetically
   if (!existsSync(migrationsDir)) {
-    log.warn({ dir: migrationsDir }, "Migrations directory does not exist");
+    logger.warn({ dir: migrationsDir }, "Migrations directory does not exist");
     return;
   }
 
@@ -67,7 +71,7 @@ export function runMigrations(db: Database.Database, migrationsDir: string, logg
 
   for (const file of files) {
     if (applied.has(file)) {
-      log.debug({ migration: file }, "Already applied, skipping");
+      logger.debug({ migration: file }, "Already applied, skipping");
       continue;
     }
 
@@ -79,6 +83,6 @@ export function runMigrations(db: Database.Database, migrationsDir: string, logg
     });
 
     runMigration();
-    log.info({ migration: file }, "Migration applied");
+    logger.info({ migration: file }, "Migration applied");
   }
 }

--- a/src/core/event-bus.test.ts
+++ b/src/core/event-bus.test.ts
@@ -3,7 +3,7 @@ import { EventBus } from "./event-bus.js";
 import { createLogger } from "./logger.js";
 import type { EngineEvent } from "../shared/types.js";
 
-const logger = createLogger("silent");
+const logger = createLogger("silent").logger;
 
 describe("EventBus", () => {
   it("emits events to handlers", () => {

--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -12,7 +12,7 @@ export class EventBus {
   }
 
   emit(event: EngineEvent): void {
-    this.logger.debug({ eventType: event.type }, "Event emitted");
+    this.logger.trace({ eventType: event.type }, "Event emitted");
     this.emitter.emit("event", event);
   }
 

--- a/src/core/log-buffer.ts
+++ b/src/core/log-buffer.ts
@@ -1,0 +1,89 @@
+import type { LogEntry } from "../shared/types.js";
+
+const LEVEL_ORDER: Record<string, number> = {
+  trace: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+  fatal: 5,
+};
+
+export class LogRingBuffer {
+  private buffer: (LogEntry | undefined)[];
+  private head = 0;
+  private count = 0;
+  private listeners = new Set<(entry: LogEntry) => void>();
+  private modules = new Set<string>();
+
+  constructor(private capacity: number = 2000) {
+    this.buffer = new Array(capacity);
+  }
+
+  push(entry: LogEntry): void {
+    this.buffer[this.head] = entry;
+    this.head = (this.head + 1) % this.capacity;
+    if (this.count < this.capacity) this.count++;
+
+    if (entry.module) this.modules.add(entry.module);
+
+    for (const listener of this.listeners) {
+      try {
+        listener(entry);
+      } catch {
+        // Never let a listener error break the logger
+      }
+    }
+  }
+
+  query(options?: {
+    limit?: number;
+    level?: string;
+    module?: string;
+    search?: string;
+    since?: string;
+  }): LogEntry[] {
+    const { limit = 100, level, module, search, since } = options ?? {};
+    const minLevel = level ? (LEVEL_ORDER[level] ?? 0) : 0;
+    const sinceTime = since ? new Date(since).getTime() : 0;
+
+    // Walk from oldest to newest, collect matching entries
+    const result: LogEntry[] = [];
+    const start = (this.head - this.count + this.capacity) % this.capacity;
+
+    for (let i = 0; i < this.count; i++) {
+      const idx = (start + i) % this.capacity;
+      const entry = this.buffer[idx];
+      if (!entry) continue;
+
+      if (minLevel > 0 && (LEVEL_ORDER[entry.level] ?? 0) < minLevel) continue;
+      if (module && entry.module !== module) continue;
+      if (search && !entry.msg.toLowerCase().includes(search.toLowerCase())) continue;
+      if (sinceTime && new Date(entry.time).getTime() < sinceTime) continue;
+
+      result.push(entry);
+    }
+
+    // Return the last `limit` entries (most recent)
+    return result.slice(-limit);
+  }
+
+  subscribe(listener: (entry: LogEntry) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getModules(): string[] {
+    return [...this.modules].sort();
+  }
+
+  getCount(): number {
+    return this.count;
+  }
+
+  getCapacity(): number {
+    return this.capacity;
+  }
+}

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,13 +1,129 @@
 import pino from "pino";
+import { Writable } from "node:stream";
+import type { LogRingBuffer } from "./log-buffer.js";
 
 export type Logger = pino.Logger;
 
-export function createLogger(level: string): Logger {
-  return pino({
-    level,
-    transport:
-      process.env["NODE_ENV"] !== "production"
-        ? { target: "pino-pretty", options: { colorize: true } }
-        : undefined,
-  });
+const REDACT_PATHS = [
+  "password",
+  "*.password",
+  "token",
+  "*.token",
+  "accessToken",
+  "*.accessToken",
+  "refreshToken",
+  "*.refreshToken",
+  "secret",
+  "*.secret",
+  "apiKey",
+  "*.apiKey",
+  "mqttPassword",
+  "*.mqttPassword",
+];
+
+export interface LoggerHandle {
+  logger: Logger;
+  /** Flush buffers and close worker-thread transports. Call on shutdown. */
+  close: () => Promise<void>;
+}
+
+/**
+ * Creates the pino logger with multistream output:
+ * - stdout (pino-pretty in dev, raw JSON in prod)
+ * - ring buffer (in-memory, always at debug level)
+ * - file transport via pino-roll (production only, daily rotation)
+ *
+ * Returns a handle with the logger and a close() for graceful shutdown.
+ */
+export function createLogger(level: string, logBuffer?: LogRingBuffer): LoggerHandle {
+  const isDev = process.env["NODE_ENV"] !== "production";
+
+  // Build stream entries for multistream
+  const streams: pino.StreamEntry[] = [];
+  // Track transports (worker threads) that need closing
+  const transports: NodeJS.WritableStream[] = [];
+
+  // 1. Ring buffer stream — always captures at debug level
+  if (logBuffer) {
+    streams.push({
+      stream: new Writable({
+        write(chunk, _, cb) {
+          try {
+            logBuffer.push(JSON.parse(chunk.toString()));
+          } catch {
+            // Ignore non-JSON or parse errors
+          }
+          cb();
+        },
+      }),
+      level: "debug",
+    });
+  }
+
+  // 2. Console output
+  if (isDev) {
+    // Development: use pino-pretty via transport-like stream
+    const transport = pino.transport({
+      target: "pino-pretty",
+      options: { colorize: true },
+    });
+    streams.push({
+      stream: transport,
+      level: level as pino.Level,
+    });
+    transports.push(transport);
+  } else {
+    // Production: raw JSON to stdout (captured by journald/Docker)
+    streams.push({
+      stream: process.stdout,
+      level: level as pino.Level,
+    });
+
+    // 3. File transport via pino-roll (production only)
+    const fileTransport = pino.transport({
+      target: "pino-roll",
+      options: {
+        file: "data/logs/winch",
+        frequency: "daily",
+        limit: { count: 14 },
+        mkdir: true,
+      },
+    });
+    streams.push({
+      stream: fileTransport,
+      level: level as pino.Level,
+    });
+    transports.push(fileTransport);
+  }
+
+  // Root level = "debug" when ring buffer is present (so debug entries reach it)
+  const rootLevel = logBuffer ? "debug" : level;
+
+  const logger = pino(
+    {
+      level: rootLevel,
+      formatters: {
+        level(label) {
+          return { level: label };
+        },
+      },
+      timestamp: pino.stdTimeFunctions.isoTime,
+      redact: {
+        paths: REDACT_PATHS,
+        censor: "[REDACTED]",
+      },
+    },
+    pino.multistream(streams),
+  );
+
+  const close = async () => {
+    logger.flush();
+    for (const t of transports) {
+      t.end();
+    }
+    // Give worker threads a moment to flush
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  };
+
+  return { logger, close };
 }

--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -20,7 +20,7 @@ function createTestDb(): Database.Database {
   return db;
 }
 
-const logger = createLogger("silent");
+const logger = createLogger("silent").logger;
 
 describe("DeviceManager", () => {
   let db: Database.Database;

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -40,7 +40,7 @@ function createTestDb(): Database.Database {
   return db;
 }
 
-const logger = createLogger("silent");
+const logger = createLogger("silent").logger;
 
 // Helper to seed a device with data and orders
 function seedDevice(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 import { loadConfig } from "./config.js";
 import { createLogger } from "./core/logger.js";
+import { LogRingBuffer } from "./core/log-buffer.js";
 import { openDatabase, runMigrations } from "./core/database.js";
 import { EventBus } from "./core/event-bus.js";
 import { DeviceManager } from "./devices/device-manager.js";
@@ -26,8 +27,10 @@ async function main() {
   // 1. Load configuration
   const config = loadConfig();
 
-  // 2. Initialize logger
-  const logger = createLogger(config.log.level);
+  // 2. Initialize logger with ring buffer for UI log viewer
+  const logBuffer = new LogRingBuffer();
+  const logHandle = createLogger(config.log.level, logBuffer);
+  const logger = logHandle.logger;
   logger.info("Winch engine starting...");
 
   // 3. Open SQLite database and run migrations
@@ -146,6 +149,7 @@ async function main() {
     buttonActionManager,
     eventBus,
     integrationRegistry,
+    logBuffer,
     logger,
     corsOrigins: config.cors.origins,
   });
@@ -176,11 +180,13 @@ async function main() {
   // Graceful shutdown
   const shutdown = async () => {
     logger.info("Shutting down...");
+    calendarManager.stopAll();
     recipeManager.stopAll();
     await server.close();
     await integrationRegistry.stopAll();
     db.close();
     logger.info("Shutdown complete");
+    await logHandle.close();
     process.exit(0);
   };
 
@@ -189,6 +195,13 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error("Fatal error:", err);
+  // Use stderr JSON as last resort — logger may not be initialized yet
+  const entry = {
+    level: "fatal",
+    time: new Date().toISOString(),
+    msg: "Fatal error",
+    err: String(err),
+  };
+  process.stderr.write(JSON.stringify(entry) + "\n");
   process.exit(1);
 });

--- a/src/modes/calendar-manager.test.ts
+++ b/src/modes/calendar-manager.test.ts
@@ -22,7 +22,7 @@ function createTestDb(): Database.Database {
   return db;
 }
 
-const logger = createLogger("silent");
+const logger = createLogger("silent").logger;
 
 function createMockEquipmentManager() {
   return { executeOrder: vi.fn() } as any;

--- a/src/modes/calendar-manager.ts
+++ b/src/modes/calendar-manager.ts
@@ -12,7 +12,7 @@ const ACTIVE_PROFILE_KEY = "calendar.activeProfileId";
 const DEFAULT_PROFILE_ID = "travail";
 
 export class CalendarManager {
-  private readonly log;
+  private readonly logger;
   private readonly stmts;
   private cronJobs: Cron[] = [];
 
@@ -23,7 +23,7 @@ export class CalendarManager {
     private readonly modeManager: ModeManager,
     logger: Logger,
   ) {
-    this.log = logger.child({ module: "calendar-manager" });
+    this.logger = logger.child({ module: "calendar-manager" });
     this.stmts = this.prepareStatements();
   }
 
@@ -49,7 +49,7 @@ export class CalendarManager {
   init(): void {
     const profile = this.getActiveProfile();
     this.scheduleProfile(profile.id);
-    this.log.info(
+    this.logger.info(
       { profileId: profile.id, profileName: profile.name },
       "Calendar initialized with active profile",
     );
@@ -85,7 +85,7 @@ export class CalendarManager {
       profileId: profile.id,
       profileName: profile.name,
     });
-    this.log.info({ profileId, profileName: profile.name }, "Active calendar profile changed");
+    this.logger.info({ profileId, profileName: profile.name }, "Active calendar profile changed");
   }
 
   // ── Slots ─────────────────────────────────────────────────
@@ -102,7 +102,7 @@ export class CalendarManager {
     const id = randomUUID();
     this.stmts.insertSlot.run(id, profileId, JSON.stringify(days), time, JSON.stringify(modeIds));
 
-    this.log.info({ slotId: id, profileId, days, time, modeIds }, "Calendar slot added");
+    this.logger.info({ slotId: id, profileId, days, time, modeIds }, "Calendar slot added");
 
     // Reschedule if this is the active profile
     const activeProfile = this.getActiveProfile();
@@ -126,7 +126,7 @@ export class CalendarManager {
 
     this.stmts.updateSlot.run(JSON.stringify(days), time, JSON.stringify(modeIds), slotId);
 
-    this.log.info({ slotId, days, time, modeIds }, "Calendar slot updated");
+    this.logger.info({ slotId, days, time, modeIds }, "Calendar slot updated");
 
     // Reschedule if this is the active profile
     const activeProfile = this.getActiveProfile();
@@ -142,13 +142,21 @@ export class CalendarManager {
     if (!existing) throw new CalendarError(`Slot not found: ${slotId}`, 404);
 
     this.stmts.deleteSlot.run(slotId);
-    this.log.info({ slotId }, "Calendar slot removed");
+    this.logger.info({ slotId }, "Calendar slot removed");
 
     // Reschedule if this is the active profile
     const activeProfile = this.getActiveProfile();
     if (activeProfile.id === existing.profile_id) {
       this.scheduleProfile(existing.profile_id);
     }
+  }
+
+  /** Stop all cron jobs (used during graceful shutdown). */
+  stopAll(): void {
+    for (const job of this.cronJobs) {
+      job.stop();
+    }
+    this.cronJobs = [];
   }
 
   // ── Scheduling ────────────────────────────────────────────
@@ -167,7 +175,7 @@ export class CalendarManager {
       const cronExpr = buildCronExpression(slot.time, slot.days);
       try {
         const job = new Cron(cronExpr, () => {
-          this.log.info(
+          this.logger.info(
             { slotId: slot.id, time: slot.time, modeIds: slot.modeIds },
             "Calendar slot fired",
           );
@@ -175,7 +183,7 @@ export class CalendarManager {
             try {
               this.modeManager.activateMode(modeId);
             } catch (err) {
-              this.log.warn(
+              this.logger.warn(
                 { err, modeId, slotId: slot.id },
                 "Failed to activate mode from calendar",
               );
@@ -184,11 +192,11 @@ export class CalendarManager {
         });
         this.cronJobs.push(job);
       } catch (err) {
-        this.log.error({ err, slotId: slot.id, cronExpr }, "Failed to schedule calendar slot");
+        this.logger.error({ err, slotId: slot.id, cronExpr }, "Failed to schedule calendar slot");
       }
     }
 
-    this.log.info({ profileId, jobCount: this.cronJobs.length }, "Calendar cron jobs scheduled");
+    this.logger.info({ profileId, jobCount: this.cronJobs.length }, "Calendar cron jobs scheduled");
   }
 }
 

--- a/src/modes/mode-manager.test.ts
+++ b/src/modes/mode-manager.test.ts
@@ -27,7 +27,7 @@ function createTestDb(): Database.Database {
   return db;
 }
 
-const logger = createLogger("silent");
+const logger = createLogger("silent").logger;
 
 // Minimal mocks for EquipmentManager and RecipeManager
 function createMockEquipmentManager() {

--- a/src/modes/mode-manager.ts
+++ b/src/modes/mode-manager.ts
@@ -13,7 +13,7 @@ import type {
 } from "../shared/types.js";
 
 export class ModeManager {
-  private readonly log;
+  private readonly logger;
   private readonly stmts;
 
   constructor(
@@ -23,7 +23,7 @@ export class ModeManager {
     private readonly recipeManager: RecipeManager,
     logger: Logger,
   ) {
-    this.log = logger.child({ module: "mode-manager" });
+    this.logger = logger.child({ module: "mode-manager" });
     this.stmts = this.prepareStatements();
   }
 
@@ -62,7 +62,7 @@ export class ModeManager {
     const modes = this.listModes();
     const activeModes = modes.filter((m) => m.active);
     if (activeModes.length > 0) {
-      this.log.info({ count: activeModes.length }, "Active modes restored from DB");
+      this.logger.info({ count: activeModes.length }, "Active modes restored from DB");
     }
   }
 
@@ -73,7 +73,7 @@ export class ModeManager {
     this.stmts.insertMode.run(id, name, icon ?? null, description ?? null);
     const mode = this.getMode(id)!;
     this.eventBus.emit({ type: "mode.created", mode });
-    this.log.info({ modeId: id, name }, "Mode created");
+    this.logger.info({ modeId: id, name }, "Mode created");
     return mode;
   }
 
@@ -90,7 +90,7 @@ export class ModeManager {
 
     const mode = this.getMode(id)!;
     this.eventBus.emit({ type: "mode.updated", mode });
-    this.log.info({ modeId: id }, "Mode updated");
+    this.logger.info({ modeId: id }, "Mode updated");
     return mode;
   }
 
@@ -100,7 +100,7 @@ export class ModeManager {
 
     this.stmts.deleteMode.run(id);
     this.eventBus.emit({ type: "mode.removed", modeId: id, modeName: existing.name });
-    this.log.info({ modeId: id, name: existing.name }, "Mode deleted");
+    this.logger.info({ modeId: id, name: existing.name }, "Mode deleted");
   }
 
   getMode(id: string): Mode | null {
@@ -136,7 +136,7 @@ export class ModeManager {
     if (!mode) throw new ModeError(`Mode not found: ${id}`, 404);
 
     if (mode.active) {
-      this.log.info({ modeId: id, name: mode.name }, "Mode already active, skipping");
+      this.logger.info({ modeId: id, name: mode.name }, "Mode already active, skipping");
       return;
     }
 
@@ -150,7 +150,10 @@ export class ModeManager {
     }
 
     this.eventBus.emit({ type: "mode.activated", modeId: id, modeName: mode.name });
-    this.log.info({ modeId: id, name: mode.name, impactCount: impacts.length }, "Mode activated");
+    this.logger.info(
+      { modeId: id, name: mode.name, impactCount: impacts.length },
+      "Mode activated",
+    );
   }
 
   applyModeToZone(modeId: string, zoneId: string): void {
@@ -164,7 +167,7 @@ export class ModeManager {
     }
 
     this.executeImpact(zoneImpact, mode.name);
-    this.log.info(
+    this.logger.info(
       { modeId, zoneId, actionCount: zoneImpact.actions.length, modeName: mode.name },
       "Mode applied to zone (local)",
     );
@@ -175,13 +178,13 @@ export class ModeManager {
     if (!mode) throw new ModeError(`Mode not found: ${id}`, 404);
 
     if (!mode.active) {
-      this.log.info({ modeId: id, name: mode.name }, "Mode already inactive, skipping");
+      this.logger.info({ modeId: id, name: mode.name }, "Mode already inactive, skipping");
       return;
     }
 
     this.stmts.setActive.run(0, id);
     this.eventBus.emit({ type: "mode.deactivated", modeId: id, modeName: mode.name });
-    this.log.info({ modeId: id, name: mode.name }, "Mode deactivated");
+    this.logger.info({ modeId: id, name: mode.name }, "Mode deactivated");
   }
 
   private executeImpact(impact: ZoneModeImpact, modeName: string): void {
@@ -189,7 +192,7 @@ export class ModeManager {
       try {
         this.executeAction(action, modeName);
       } catch (err) {
-        this.log.warn(
+        this.logger.warn(
           { err, action, zoneId: impact.zoneId, modeName },
           "Failed to execute mode impact action",
         );
@@ -201,7 +204,7 @@ export class ModeManager {
     switch (action.type) {
       case "order":
         this.equipmentManager.executeOrder(action.equipmentId, action.orderAlias, action.value);
-        this.log.debug(
+        this.logger.debug(
           {
             equipmentId: action.equipmentId,
             alias: action.orderAlias,
@@ -218,7 +221,7 @@ export class ModeManager {
         } else {
           this.recipeManager.disableInstance(action.instanceId);
         }
-        this.log.debug(
+        this.logger.debug(
           { instanceId: action.instanceId, enabled: action.enabled, modeName },
           "Mode recipe toggle executed",
         );
@@ -226,7 +229,7 @@ export class ModeManager {
 
       case "recipe_params":
         this.recipeManager.updateInstanceParams(action.instanceId, action.params);
-        this.log.debug(
+        this.logger.debug(
           { instanceId: action.instanceId, params: action.params, modeName },
           "Mode recipe params updated",
         );
@@ -242,14 +245,14 @@ export class ModeManager {
 
     const id = randomUUID();
     this.stmts.upsertImpact.run(id, modeId, zoneId, JSON.stringify(actions));
-    this.log.info({ modeId, zoneId, actionCount: actions.length }, "Zone impact set");
+    this.logger.info({ modeId, zoneId, actionCount: actions.length }, "Zone impact set");
 
     return { id, modeId, zoneId, actions };
   }
 
   removeZoneImpact(modeId: string, zoneId: string): void {
     this.stmts.deleteImpactByModeZone.run(modeId, zoneId);
-    this.log.info({ modeId, zoneId }, "Zone impact removed");
+    this.logger.info({ modeId, zoneId }, "Zone impact removed");
   }
 
   getImpactsByMode(modeId: string): ZoneModeImpact[] {

--- a/src/recipes/engine/recipe-manager.test.ts
+++ b/src/recipes/engine/recipe-manager.test.ts
@@ -37,7 +37,7 @@ function createTestDb(): Database.Database {
   return db;
 }
 
-const logger = createLogger("silent");
+const logger = createLogger("silent").logger;
 
 // ============================================================
 // Test recipe — minimal implementation

--- a/src/recipes/motion-light.test.ts
+++ b/src/recipes/motion-light.test.ts
@@ -37,7 +37,7 @@ function createTestDb(): Database.Database {
   return db;
 }
 
-const logger = createLogger("silent");
+const logger = createLogger("silent").logger;
 
 function seedDevice(
   db: Database.Database,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -502,6 +502,20 @@ export interface IntegrationInfo {
 }
 
 // ============================================================
+// Logging
+// ============================================================
+
+export type LogLevel = "debug" | "info" | "warn" | "error" | "fatal" | "silent";
+
+export interface LogEntry {
+  level: string;
+  time: string;
+  module?: string;
+  msg: string;
+  [key: string]: unknown;
+}
+
+// ============================================================
 // Config
 // ============================================================
 

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -41,7 +41,7 @@ function createTestDb(): Database.Database {
   return db;
 }
 
-const logger = createLogger("silent");
+const logger = createLogger("silent").logger;
 
 function seedDevice(
   db: Database.Database,

--- a/src/zones/zone-manager.test.ts
+++ b/src/zones/zone-manager.test.ts
@@ -28,7 +28,7 @@ function createTestDb(): Database.Database {
   return db;
 }
 
-const logger = createLogger("silent");
+const logger = createLogger("silent").logger;
 
 describe("ZoneManager", () => {
   let db: Database.Database;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -15,6 +15,7 @@ import { IntegrationsPage } from "./pages/IntegrationsPage";
 import { ModesPage } from "./pages/ModesPage";
 import { ModeDetailPage } from "./pages/ModeDetailPage";
 import { CalendarPage } from "./pages/CalendarPage";
+import { LogsPage } from "./pages/LogsPage";
 
 export default function App() {
   return (
@@ -48,6 +49,7 @@ export default function App() {
           <Route path="/calendar" element={<CalendarPage />} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/integrations" element={<IntegrationsPage />} />
+          <Route path="/logs" element={<LogsPage />} />
 
           {/* Default redirect to Maison */}
           <Route path="*" element={<Navigate to="/home" replace />} />

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -10,6 +10,7 @@ import type {
   ButtonActionBinding, ButtonEffectType,
   CalendarProfile, CalendarSlot,
   IntegrationInfo,
+  LogsResponse, LogLevel,
 } from "./types";
 
 const API_BASE = "/api/v1";
@@ -638,5 +639,37 @@ export async function updateButtonActionBinding(
 export async function removeButtonActionBinding(equipmentId: string, bindingId: string): Promise<void> {
   return fetchJSON<void>(`${API_BASE}/equipments/${equipmentId}/action-bindings/${bindingId}`, {
     method: "DELETE",
+  });
+}
+
+// ============================================================
+// Logs (admin)
+// ============================================================
+
+export async function fetchLogs(params?: {
+  limit?: number;
+  level?: string;
+  module?: string;
+  search?: string;
+  since?: string;
+}): Promise<LogsResponse> {
+  const query = new URLSearchParams();
+  if (params?.limit) query.set("limit", String(params.limit));
+  if (params?.level) query.set("level", params.level);
+  if (params?.module) query.set("module", params.module);
+  if (params?.search) query.set("search", params.search);
+  if (params?.since) query.set("since", params.since);
+  const qs = query.toString();
+  return fetchJSON<LogsResponse>(`${API_BASE}/logs${qs ? `?${qs}` : ""}`);
+}
+
+export async function getLogLevel(): Promise<{ level: string }> {
+  return fetchJSON<{ level: string }>(`${API_BASE}/logs/level`);
+}
+
+export async function setLogLevel(level: LogLevel): Promise<{ level: string; previous: string }> {
+  return fetchJSON(`${API_BASE}/logs/level`, {
+    method: "PUT",
+    body: JSON.stringify({ level }),
   });
 }

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   ChevronRight,
   Layers,
   Calendar,
+  ScrollText,
 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -31,6 +32,7 @@ const ADMIN_ITEMS: NavItem[] = [
   { to: "/zones", label: "nav.zones", icon: <Map size={18} strokeWidth={1.5} /> },
   { to: "/calendar", label: "nav.calendar", icon: <Calendar size={18} strokeWidth={1.5} /> },
   { to: "/integrations", label: "nav.integrations", icon: <Plug size={18} strokeWidth={1.5} /> },
+  { to: "/logs", label: "nav.logs", icon: <ScrollText size={18} strokeWidth={1.5} /> },
 ];
 
 export function Sidebar() {

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -386,6 +386,7 @@
   "settings.backupImported": "Backup imported successfully. Restart Winch to apply changes.",
 
   "nav.integrations": "Integrations",
+  "nav.logs": "Logs",
 
   "integrations.title": "Integrations",
   "integrations.subtitle": "Configure connections with your home automation systems.",
@@ -505,5 +506,20 @@
   "stove.pellet.sufficient": "Sufficient",
   "stove.pellet.almost_empty": "Almost empty",
   "stove.sparkPlug.ok": "OK",
-  "stove.sparkPlug.worn": "Worn"
+  "stove.sparkPlug.worn": "Worn",
+
+  "logs.title": "Engine Logs",
+  "logs.subtitle": "Real-time engine log viewer",
+  "logs.live": "Live",
+  "logs.paused": "Paused",
+  "logs.clear": "Clear",
+  "logs.noEntries": "No log entries",
+  "logs.level": "Level",
+  "logs.module": "Module",
+  "logs.search": "Search...",
+  "logs.allLevels": "All levels",
+  "logs.allModules": "All modules",
+  "logs.entries": "{{count}} entries",
+  "logs.engineLevel": "Engine level",
+  "logs.levelChanged": "Log level changed to {{level}}"
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -386,6 +386,7 @@
   "settings.backupImported": "Sauvegarde importée avec succès. Redémarrez Winch pour appliquer les changements.",
 
   "nav.integrations": "Intégrations",
+  "nav.logs": "Logs",
 
   "integrations.title": "Intégrations",
   "integrations.subtitle": "Configurez les connexions avec vos systèmes domotiques.",
@@ -505,5 +506,20 @@
   "stove.pellet.sufficient": "Suffisant",
   "stove.pellet.almost_empty": "Presque vide",
   "stove.sparkPlug.ok": "OK",
-  "stove.sparkPlug.worn": "Usée"
+  "stove.sparkPlug.worn": "Usée",
+
+  "logs.title": "Logs moteur",
+  "logs.subtitle": "Visualisation des logs moteur en temps réel",
+  "logs.live": "Direct",
+  "logs.paused": "Pause",
+  "logs.clear": "Vider",
+  "logs.noEntries": "Aucune entrée de log",
+  "logs.level": "Niveau",
+  "logs.module": "Module",
+  "logs.search": "Rechercher...",
+  "logs.allLevels": "Tous les niveaux",
+  "logs.allModules": "Tous les modules",
+  "logs.entries": "{{count}} entrées",
+  "logs.engineLevel": "Niveau moteur",
+  "logs.levelChanged": "Niveau de log changé à {{level}}"
 }

--- a/ui/src/pages/LogsPage.tsx
+++ b/ui/src/pages/LogsPage.tsx
@@ -1,0 +1,326 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  ScrollText,
+  Play,
+  Pause,
+  Trash2,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+import { fetchLogs, setLogLevel } from "../api";
+import { useAuth } from "../store/useAuth";
+import type { LogEntry, LogLevel } from "../types";
+
+const LOG_LEVELS: LogLevel[] = ["debug", "info", "warn", "error", "fatal"];
+
+const LEVEL_COLORS: Record<string, string> = {
+  fatal: "text-error font-semibold",
+  error: "text-error",
+  warn: "text-accent",
+  info: "text-text-secondary",
+  debug: "text-text-tertiary",
+  trace: "text-text-tertiary",
+};
+
+function formatTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString("en-GB", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      fractionalSecondDigits: 3,
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatLevel(level: string): string {
+  return level.toUpperCase().padEnd(5);
+}
+
+export function LogsPage() {
+  const { t } = useTranslation();
+  const accessToken = useAuth((s) => s.accessToken);
+  const isAuthenticated = useAuth((s) => s.isAuthenticated);
+
+  // State
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [modules, setModules] = useState<string[]>([]);
+  const [currentLevel, setCurrentLevel] = useState<string>("info");
+  const [live, setLive] = useState(true);
+  const [filterLevel, setFilterLevel] = useState<string>("");
+  const [filterModule, setFilterModule] = useState<string>("");
+  const [filterSearch, setFilterSearch] = useState<string>("");
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const liveRef = useRef(live);
+  useEffect(() => {
+    liveRef.current = live;
+  }, [live]);
+
+  // Auto-scroll to top when live and new entries arrive
+  useEffect(() => {
+    if (live && scrollRef.current) {
+      scrollRef.current.scrollTop = 0;
+    }
+  }, [entries, live]);
+
+  // Fetch initial entries
+  useEffect(() => {
+    fetchLogs({ limit: 500 })
+      .then((res) => {
+        setEntries(res.entries.reverse());
+        setModules(res.modules);
+        setCurrentLevel(res.currentLevel);
+      })
+      .catch(() => {
+        // Ignore fetch errors
+      });
+  }, []);
+
+  // WebSocket connection for live logs (wait for session to be verified)
+  useEffect(() => {
+    if (!accessToken || !isAuthenticated) return;
+
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    // In dev mode, connect directly to backend to avoid Vite proxy EPIPE issues
+    const wsHost = import.meta.env.DEV ? `${window.location.hostname}:3000` : window.location.host;
+    const ws = new WebSocket(`${protocol}//${wsHost}/ws?token=${encodeURIComponent(accessToken)}`);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: "subscribe", topics: ["logs"] }));
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        // Log entries come as { type: "log.entry", level, time, msg, ... }
+        if (data.type === "log.entry") {
+          if (!liveRef.current) return;
+          const entry: LogEntry = data;
+          setEntries((prev) => {
+            const next = [entry, ...prev];
+            // Keep most recent 2000 entries in UI
+            return next.length > 2000 ? next.slice(0, 2000) : next;
+          });
+          if (entry.module) {
+            setModules((prev) =>
+              prev.includes(entry.module!) ? prev : [...prev, entry.module!].sort(),
+            );
+          }
+        }
+      } catch {
+        // Ignore non-JSON
+      }
+    };
+
+    ws.onclose = () => {
+      wsRef.current = null;
+    };
+
+    return () => {
+      ws.close();
+      wsRef.current = null;
+    };
+  }, [accessToken, isAuthenticated]);
+
+  // Filter entries client-side
+  const filtered = entries.filter((e) => {
+    if (filterLevel && e.level !== filterLevel) return false;
+    if (filterModule && e.module !== filterModule) return false;
+    if (filterSearch && !e.msg.toLowerCase().includes(filterSearch.toLowerCase()))
+      return false;
+    return true;
+  });
+
+  const handleClear = useCallback(() => {
+    setEntries([]);
+    setExpandedIdx(null);
+  }, []);
+
+  const handleLevelChange = useCallback(
+    async (newLevel: LogLevel) => {
+      try {
+        await setLogLevel(newLevel);
+        setCurrentLevel(newLevel);
+      } catch {
+        // Ignore errors
+      }
+    },
+    [],
+  );
+
+  const toggleExpand = useCallback((idx: number) => {
+    setExpandedIdx((prev) => (prev === idx ? null : idx));
+  }, []);
+
+  return (
+    <div className="p-6 h-full flex flex-col">
+      {/* Header */}
+      <div className="mb-4">
+        <div className="flex items-center gap-2.5 mb-1">
+          <ScrollText size={22} strokeWidth={1.5} className="text-text-secondary" />
+          <h1 className="text-[24px] font-semibold text-text leading-[32px]">
+            {t("logs.title")}
+          </h1>
+        </div>
+        <p className="text-[13px] text-text-tertiary">{t("logs.subtitle")}</p>
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-3 mb-3">
+        {/* Level filter */}
+        <select
+          value={filterLevel}
+          onChange={(e) => setFilterLevel(e.target.value)}
+          className="px-3 py-1.5 text-[13px] bg-background border border-border rounded-[6px] text-text focus:outline-none focus:border-primary"
+        >
+          <option value="">{t("logs.allLevels")}</option>
+          {LOG_LEVELS.map((l) => (
+            <option key={l} value={l}>
+              {l.toUpperCase()}
+            </option>
+          ))}
+        </select>
+
+        {/* Module filter */}
+        <select
+          value={filterModule}
+          onChange={(e) => setFilterModule(e.target.value)}
+          className="px-3 py-1.5 text-[13px] bg-background border border-border rounded-[6px] text-text focus:outline-none focus:border-primary"
+        >
+          <option value="">{t("logs.allModules")}</option>
+          {modules.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+
+        {/* Text search */}
+        <input
+          type="text"
+          value={filterSearch}
+          onChange={(e) => setFilterSearch(e.target.value)}
+          placeholder={t("logs.search")}
+          className="px-3 py-1.5 text-[13px] bg-background border border-border rounded-[6px] text-text placeholder:text-text-tertiary focus:outline-none focus:border-primary w-48"
+        />
+
+        <div className="flex-1" />
+
+        {/* Entry count */}
+        <span className="text-[12px] text-text-tertiary">
+          {t("logs.entries", { count: filtered.length })}
+        </span>
+
+        {/* Engine level control */}
+        <div className="flex items-center gap-1.5">
+          <span className="text-[12px] text-text-tertiary">{t("logs.engineLevel")}:</span>
+          <select
+            value={currentLevel}
+            onChange={(e) => handleLevelChange(e.target.value as LogLevel)}
+            className="px-2 py-1 text-[12px] bg-background border border-border rounded-[6px] text-text focus:outline-none focus:border-primary"
+          >
+            {LOG_LEVELS.map((l) => (
+              <option key={l} value={l}>
+                {l}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Live / Pause toggle */}
+        <button
+          onClick={() => setLive(!live)}
+          className={`flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium rounded-[6px] border transition-colors cursor-pointer ${
+            live
+              ? "bg-success/10 text-success border-success/30"
+              : "bg-accent/10 text-accent border-accent/30"
+          }`}
+        >
+          {live ? <Play size={14} /> : <Pause size={14} />}
+          {live ? t("logs.live") : t("logs.paused")}
+        </button>
+
+        {/* Clear */}
+        <button
+          onClick={handleClear}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors cursor-pointer"
+        >
+          <Trash2 size={14} />
+          {t("logs.clear")}
+        </button>
+      </div>
+
+      {/* Log entries */}
+      <div
+        ref={scrollRef}
+        className="flex-1 min-h-0 overflow-y-auto bg-background border border-border rounded-[10px] font-mono text-[12px] leading-[18px]"
+      >
+        {filtered.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-text-tertiary text-[13px]">
+            {t("logs.noEntries")}
+          </div>
+        ) : (
+          <div className="p-2">
+            {filtered.map((entry, idx) => {
+              const isExpanded = expandedIdx === idx;
+              const levelClass = LEVEL_COLORS[entry.level] ?? "text-text-secondary";
+              // Build extra context keys (exclude standard fields)
+              const extraKeys = Object.keys(entry).filter(
+                (k) => !["level", "time", "module", "msg", "type", "pid", "hostname"].includes(k),
+              );
+
+              return (
+                <div key={idx}>
+                  <div
+                    className={`flex items-start gap-2 px-2 py-0.5 rounded hover:bg-border-light/50 cursor-pointer ${levelClass}`}
+                    onClick={() => extraKeys.length > 0 && toggleExpand(idx)}
+                  >
+                    {extraKeys.length > 0 ? (
+                      isExpanded ? (
+                        <ChevronDown size={12} className="mt-[3px] flex-shrink-0 opacity-50" />
+                      ) : (
+                        <ChevronRight size={12} className="mt-[3px] flex-shrink-0 opacity-50" />
+                      )
+                    ) : (
+                      <span className="w-3 flex-shrink-0" />
+                    )}
+                    <span className="text-text-tertiary flex-shrink-0">
+                      {formatTime(entry.time)}
+                    </span>
+                    <span className={`flex-shrink-0 w-[44px] ${levelClass}`}>
+                      {formatLevel(entry.level)}
+                    </span>
+                    <span className="text-primary/70 flex-shrink-0 w-[140px] truncate">
+                      {entry.module ?? ""}
+                    </span>
+                    <span className="text-text break-all">{entry.msg}</span>
+                  </div>
+                  {isExpanded && extraKeys.length > 0 && (
+                    <div className="ml-[22px] pl-4 py-1 mb-1 border-l border-border-light text-[11px] text-text-tertiary">
+                      {extraKeys.map((k) => (
+                        <div key={k}>
+                          <span className="text-text-secondary">{k}</span>:{" "}
+                          {typeof entry[k] === "object"
+                            ? JSON.stringify(entry[k])
+                            : String(entry[k])}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/store/useAuth.ts
+++ b/ui/src/store/useAuth.ts
@@ -17,6 +17,7 @@ interface AuthState {
   isAuthenticated: boolean;
   setupRequired: boolean | null; // null = loading
   loading: boolean;
+  accessToken: string | null;
 
   // Actions
   checkStatus: () => Promise<void>;
@@ -35,12 +36,14 @@ function saveTokens(accessToken: string, refreshToken: string): void {
   localStorage.setItem(STORAGE_KEY_ACCESS, accessToken);
   localStorage.setItem(STORAGE_KEY_REFRESH, refreshToken);
   setAccessToken(accessToken);
+  useAuth.setState({ accessToken });
 }
 
 function clearTokens(): void {
   localStorage.removeItem(STORAGE_KEY_ACCESS);
   localStorage.removeItem(STORAGE_KEY_REFRESH);
   setAccessToken(null);
+  useAuth.setState({ accessToken: null });
 }
 
 function getStoredRefreshToken(): string | null {
@@ -67,6 +70,7 @@ export const useAuth = create<AuthState>((set, get) => {
     isAuthenticated: false,
     setupRequired: null,
     loading: true,
+    accessToken: storedToken,
 
     checkStatus: async () => {
       set({ loading: true });

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -410,6 +410,28 @@ export interface CalendarSlot {
 }
 
 // ============================================================
+// Logging
+// ============================================================
+
+export type LogLevel = "debug" | "info" | "warn" | "error" | "fatal" | "silent";
+
+export interface LogEntry {
+  level: string;
+  time: string;
+  module?: string;
+  msg: string;
+  [key: string]: unknown;
+}
+
+export interface LogsResponse {
+  entries: LogEntry[];
+  total: number;
+  capacity: number;
+  currentLevel: string;
+  modules: string[];
+}
+
+// ============================================================
 // Integration
 // ============================================================
 


### PR DESCRIPTION
## Summary
- Pino multistream logging: console (pino-pretty in dev), file rotation (pino-roll in prod), in-memory ring buffer
- New LogsPage UI with real-time WebSocket streaming, level/module/search filters, expandable log entries
- REST API for log queries (`GET /api/v1/logs`) and runtime log level changes (`PUT /api/v1/logs/level`)
- LoggerHandle pattern for graceful transport shutdown
- Ring buffer (2000 entries) with listener subscriptions for WebSocket broadcast

## Changes
- **Backend**: `src/core/logger.ts` rewritten with multistream + LoggerHandle, new `src/core/log-buffer.ts`, new `src/api/routes/logs.ts`
- **WebSocket**: Added "logs" topic subscription in `src/api/websocket.ts`
- **UI**: New `ui/src/pages/LogsPage.tsx` with live log viewer, direct WS connection to backend in dev mode
- **Auth store**: Exposed `accessToken` in Zustand state for WebSocket authentication
- **Tests**: Updated 12 test files for `createLogger("silent").logger` pattern
- **Specs**: Added `specs/015-V0.11-logging-system/`

## Test plan
- [x] TypeScript compiles (zero errors backend + UI)
- [x] All 276 tests pass
- [x] ESLint passes (backend + UI)
- [x] Manually verified: logs appear in terminal, UI shows live entries, level/module filters work, "Direct" toggle pauses/resumes stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)