### PR TITLE
chore(docs): update documentation for multi-integration architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Winch** is a home automation engine that uses MQTT as its sole data source (zigbee2mqtt, Tasmota, ESPHome). It separates physical **Devices** (auto-discovered from MQTT) from user-facing **Equipments** (functional units like "Spots Salon"), provides automatic **Zone** aggregation, a **Scenario** engine with reusable **Recipe** templates, and exposes a reactive web UI.
+**Winch** is a home automation engine with a plugin-based integration architecture. It supports multiple device sources (Zigbee2MQTT, Panasonic Comfort Cloud, MCZ Maestro, and more via the IntegrationPlugin interface). It separates physical **Devices** (auto-discovered from integrations) from user-facing **Equipments** (functional units like "Spots Salon"), provides automatic **Zone** aggregation, a **Scenario** engine with reusable **Recipe** templates, and exposes a reactive web UI.
 
 The full specification is in [winch-spec.md](winch-spec.md) — it is the single source of truth. It is a living document that evolves alongside feature development; always re-read the relevant sections before implementing a milestone.
 
@@ -13,22 +13,24 @@ The full specification is in [winch-spec.md](winch-spec.md) — it is the single
 ### Reactive Pipeline (core data flow)
 
 ```
-MQTT message → MQTT Connector → Device Manager (updates DeviceData)
-  → Event Bus: "device.data.updated"
-    → Equipment Manager (re-evaluates bindings + computed Data)
-      → Event Bus: "equipment.data.changed"
-        → Zone Manager (re-evaluates aggregations)
-          → Event Bus: "zone.data.changed"
-            → Scenario Engine (evaluates triggers → conditions → actions)
-              → Actions may emit Orders → MQTT publish
-        → WebSocket pushes to UI clients
+Integration message (MQTT, cloud API poll, etc.)
+  → Integration Plugin (receives + parses)
+    → Device Manager (updates DeviceData)
+      → Event Bus: "device.data.updated"
+        → Equipment Manager (re-evaluates bindings + computed Data)
+          → Event Bus: "equipment.data.changed"
+            → Zone Manager (re-evaluates aggregations)
+              → Event Bus: "zone.data.changed"
+                → Scenario Engine (evaluates triggers → conditions → actions)
+                  → Actions may emit Orders → Integration Plugin → device
+            → WebSocket pushes to UI clients
 ```
 
 ### Key Domain Concepts
 
 | Term          | Role                                                                                                            |
 | ------------- | --------------------------------------------------------------------------------------------------------------- |
-| **Device**    | Physical MQTT hardware, auto-discovered. Exposes raw Data and Orders.                                           |
+| **Device**    | Physical hardware, auto-discovered from integrations. Exposes raw Data and Orders.                              |
 | **Equipment** | User-facing functional unit. Binds to one or more Devices. Can have computed Data and dispatched Orders.        |
 | **Zone**      | Spatial grouping (nestable). Auto-aggregates Equipment Data (motion=OR, temperature=AVG, lightsOn=COUNT, etc.). |
 | **Scenario**  | Automation rule: trigger(s) → condition(s) → action(s).                                                         |
@@ -36,11 +38,11 @@ MQTT message → MQTT Connector → Device Manager (updates DeviceData)
 
 ### Tech Stack
 
-**Backend:** Node.js 20+ / TypeScript (strict) / Fastify / mqtt.js / SQLite (better-sqlite3) / InfluxDB 2.x / ws (WebSocket)
+**Backend:** Node.js 20+ / TypeScript (strict) / Fastify / SQLite (better-sqlite3) / InfluxDB 2.x / ws (WebSocket) / mqtt.js (for MQTT integrations)
 
 **Frontend:** React 18+ / TypeScript / Vite / Tailwind CSS / Zustand / Lucide React
 
-**Infrastructure:** Docker + docker-compose / Mosquitto MQTT broker (external) / PM2
+**Infrastructure:** Docker + docker-compose / PM2
 
 ### Project Structure
 
@@ -50,7 +52,7 @@ winch/
 │   ├── index.ts                 # Entry point
 │   ├── config.ts                # Env config loading
 │   ├── core/                    # event-bus, database (SQLite), influx, logger
-│   ├── mqtt/                    # MQTT connector + parsers (zigbee2mqtt, tasmota, generic)
+│   ├── integrations/            # Integration plugins (zigbee2mqtt, panasonic-cc, mcz-maestro, ...)
 │   ├── devices/                 # Device manager, auto-discovery, category inference
 │   ├── equipments/              # Equipment manager, bindings, computed engine, order dispatcher
 │   ├── zones/                   # Zone manager, auto-aggregation engine
@@ -108,12 +110,14 @@ npm test -- --grep "pattern"  # Run specific tests
 - Run migrations on startup
 - Use transactions for batch operations
 
-### MQTT
+### Integrations
 
-- `mqtt.js` with `connectAsync` for async/await
-- Always handle reconnection gracefully
-- Parse payloads as JSON with try/catch fallback to raw string
-- Message handlers must never throw — wrap in try/catch with logging
+- Plugin-based architecture: each device source implements `IntegrationPlugin`
+- Plugins register with `IntegrationRegistry` which manages lifecycle (start/stop/reconnect)
+- MQTT-based integrations use `mqtt.js` with `connectAsync` for async/await
+- Cloud-based integrations use polling with configurable intervals
+- All message/event handlers must never throw — wrap in try/catch with logging
+- Settings stored in SQLite `settings` table, configurable from UI
 
 ### Event Bus
 
@@ -202,7 +206,7 @@ Structured JSON logging via pino (Fastify default) with multistream: ring buffer
 
 ## Development Roadmap
 
-V0.1 MQTT+Devices → V0.2 Equipments+Bindings → V0.3 Zones+Aggregation → V0.4 UI+Realtime → V0.5 Computed Data → V0.6 History (InfluxDB) → V0.7 Scenario Engine → V0.8 Recipes → V0.9 Polish → V1.0+ AI Assistant
+V0.1 Devices → V0.2 Zones → V0.3 Equipments+Bindings → V0.4 UI Home → V0.5 Sensors → V0.6 Zone Aggregation → V0.7 Shutters → V0.8 Recipes → V0.9 Modes+Calendar → V0.10 Integration Plugins (Z2M, Panasonic CC, MCZ Maestro, Netatmo HC) → V0.11 Logging → V0.12 Computed Data → V0.13 History (InfluxDB) → V1.0+ AI Assistant
 
 ## Environment Variables
 
@@ -219,4 +223,4 @@ All settings are optional with sensible defaults — Winch runs zero-config out 
 | `LOG_LEVEL`       | `info`            | Pino log level                                  |
 | `CORS_ORIGINS`    | `*`               | Comma-separated allowed origins                 |
 
-MQTT and Zigbee2MQTT settings are configured from the UI (Administration > Integrations), not from `.env`.
+Integration settings (MQTT, cloud credentials, polling intervals) are configured from the UI (Administration > Integrations), not from `.env`.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -23,7 +23,7 @@ Winch separates concerns into three distinct layers:
 │  Binds to one or more physical Devices                       │
 ├─────────────────────────────────────────────────────────────┤
 │  LAYER 3 — PHYSICAL (Devices)                                │
-│  Hardware on the MQTT network                                │
+│  Hardware discovered from integrations                       │
 │  Auto-discovered, raw data and commands                      │
 │  Never directly manipulated by the end user                  │
 └─────────────────────────────────────────────────────────────┘
@@ -260,14 +260,14 @@ interface Equipment {
 
 ### 5.2 Equipment vs Device
 
-|                      | Device                           | Equipment                        |
-| -------------------- | -------------------------------- | -------------------------------- |
-| **Nature**           | Physical hardware                | Functional abstraction           |
-| **Discovery**        | Auto-discovered from MQTT        | Manually created by user         |
-| **Identity**         | IEEE address, MQTT topic         | User-chosen name                 |
-| **Location**         | Where physically installed       | Where functionally used          |
-| **Cardinality**      | 1 Device → N Equipments possible | 1 Equipment → N Devices possible |
-| **User interaction** | Never (technical layer)          | Always (primary interface)       |
+|                      | Device                            | Equipment                        |
+| -------------------- | --------------------------------- | -------------------------------- |
+| **Nature**           | Physical hardware                 | Functional abstraction           |
+| **Discovery**        | Auto-discovered from integrations | Manually created by user         |
+| **Identity**         | Integration-specific ID           | User-chosen name                 |
+| **Location**         | Where physically installed        | Where functionally used          |
+| **Cardinality**      | 1 Device → N Equipments possible  | 1 Equipment → N Devices possible |
+| **User interaction** | Never (technical layer)           | Always (primary interface)       |
 
 **Examples:**
 
@@ -295,7 +295,7 @@ interface DataBinding {
 ### 6.2 How It Works
 
 ```
-Device "Variateur Z2M #1"
+Device "Variateur #1"
 ├── DeviceData: key="state", value="ON"        ←─┐
 ├── DeviceData: key="brightness", value=180    ←──┼── DataBinding
 └── DeviceData: key="linkquality", value=85       │
@@ -349,8 +349,8 @@ When an Equipment Order is executed:
 User clicks "Turn On" on Equipment "Spots Salon"
   → API: POST /equipments/:id/orders/turn_on { value: true }
     → Equipment Manager finds OrderBinding alias="turn_on"
-      → Resolves to DeviceOrder (mqttSetTopic, payloadKey)
-        → MQTT publish: zigbee2mqtt/variateur_1/set {"state": "ON"}
+      → Resolves to DeviceOrder
+        → Integration Plugin dispatches command to device
 ```
 
 ### 7.3 Multi-Device Dispatch
@@ -383,23 +383,23 @@ CREATE TABLE order_bindings (
 
 ## 8. Device (Layer 3 — Physical)
 
-Devices are auto-discovered from MQTT. They are documented here for completeness — see V0.1 implementation for details.
+Devices are auto-discovered from configured integrations (Zigbee2MQTT, Panasonic CC, MCZ Maestro, Netatmo HC, etc.). They are documented here for completeness.
 
 ### 8.1 Interface
 
 ```typescript
 interface Device {
   id: string; // UUID v4
-  mqttBaseTopic: string; // "zigbee2mqtt/0x00158d0001a2b3c4"
-  mqttName: string; // "0x00158d0001a2b3c4" or friendly_name
+  mqttBaseTopic: string; // Integration-specific topic or identifier
+  mqttName: string; // Integration-specific name or ID
   name: string; // User-editable display name
-  manufacturer?: string; // "Aqara", "IKEA", "Sonoff"
-  model?: string; // "MCCGQ11LM"
-  ieeeAddress?: string; // Zigbee IEEE address
-  source: DeviceSource; // "zigbee2mqtt" | "tasmota" | "esphome" | ...
+  manufacturer?: string; // "Aqara", "IKEA", "Panasonic", "MCZ"
+  model?: string; // "MCCGQ11LM", "CS-Z25VKEW", etc.
+  ieeeAddress?: string; // Hardware address (Zigbee IEEE, serial, etc.)
+  source: DeviceSource; // "zigbee2mqtt" | "panasonic_cc" | "mcz_maestro" | "netatmo_hc" | ...
   status: DeviceStatus; // "online" | "offline" | "unknown"
   lastSeen: string | null; // ISO 8601
-  rawExpose?: unknown; // Raw zigbee2mqtt expose definition
+  rawExpose?: unknown; // Raw integration-specific metadata
   createdAt: string;
   updatedAt: string;
 }
@@ -490,13 +490,10 @@ zone.<zoneId>.<key>                    → Zone aggregated Data
 The complete event-driven pipeline:
 
 ```
-MQTT message arrives
+Integration event (MQTT message, cloud API poll, etc.)
   │
   ▼
-MQTT Connector (receives raw message)
-  │
-  ▼
-Parser (zigbee2mqtt / tasmota / esphome)
+Integration Plugin (receives + parses)
   │
   ▼
 Device Manager (updates DeviceData)
@@ -524,7 +521,7 @@ Scenario Engine (V0.7)
   ├── Checks conditions
   ├── Executes actions
   │
-  ├──▶ Actions may dispatch Equipment/Zone Orders → MQTT publish
+  ├──▶ Actions may dispatch Equipment/Zone Orders → Integration Plugin → device
   │
   ▼
 WebSocket Server
@@ -612,7 +609,7 @@ CREATE TABLE devices (
   manufacturer TEXT,
   model TEXT,
   ieee_address TEXT,
-  source TEXT NOT NULL DEFAULT 'zigbee2mqtt',
+  source TEXT NOT NULL,  -- integration source: 'zigbee2mqtt', 'panasonic_cc', 'mcz_maestro', 'netatmo_hc', ...
   status TEXT NOT NULL DEFAULT 'unknown',
   last_seen DATETIME,
   raw_expose JSON,

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -1,6 +1,6 @@
 # Winch — Implementation Status
 
-> Updated: 2026-02-22 — V0.1 through V0.10c done, Auth + i18n, Backup/Restore + Integrations
+> Updated: 2026-02-24 — V0.1 through V0.11 done, Auth + i18n, Backup/Restore + Integrations
 
 ## Roadmap Changes
 
@@ -27,24 +27,26 @@
 | **V0.10a** | Integration Plugin Architecture (multi-source device management)    | ✅ Done |
 | **V0.10b** | Panasonic Comfort Cloud Integration (AC units)                      | ✅ Done |
 | **V0.10c** | MCZ Maestro Integration (pellet stoves)                             | ✅ Done |
-| V0.11      | Computed Data                                                       | —       |
-| V0.12      | History (InfluxDB)                                                  | —       |
-| V0.13      | Polish                                                              | —       |
+| **V0.10d** | Netatmo Home Control Integration (weather, thermostat, cameras)     | ✅ Done |
+| **V0.11**  | Structured Logging (pino multistream, ring buffer, UI LogsPage)     | ✅ Done |
+| **V0.8b**  | Motion-Light Enhancements (multi-light, lux, impulse, failsafe)     | ✅ Done |
+| V0.12      | Computed Data                                                       | —       |
+| V0.13      | History (InfluxDB)                                                  | —       |
 | V1.0+      | AI Assistant                                                        | —       |
 
 ---
 
 ## V0.1 — MQTT + Devices + UI
 
-**Objective**: Connect to zigbee2mqtt, auto-discover all Zigbee devices, track their state in real-time, persist in SQLite. Provide a web UI to browse devices.
+**Objective**: Connect to device integrations, auto-discover devices, track their state in real-time, persist in SQLite. Provide a web UI to browse devices.
 
 ### What it does
 
-- Connects to an MQTT broker and subscribes to zigbee2mqtt topics
-- Auto-discovers devices from `zigbee2mqtt/bridge/devices` (parses exposes)
+- Connects to configured integrations (initially Zigbee2MQTT, later expanded to cloud APIs)
+- Auto-discovers devices and parses their capabilities
 - Creates DeviceData (readable properties) and DeviceOrders (writable properties) for each device
 - Infers DataCategory from property names (occupancy→motion, temperature→temperature, brightness→light_brightness, etc.)
-- Tracks device state in real-time via MQTT state messages
+- Tracks device state in real-time via integration events
 - Marks devices online when they send data
 - Persists everything in SQLite (WAL mode)
 - Broadcasts all events via WebSocket
@@ -71,20 +73,20 @@
 | GET    | `/api/v1/devices/:id`     | Device detail with Data + Orders           |
 | PUT    | `/api/v1/devices/:id`     | Update device name or zoneId               |
 | DELETE | `/api/v1/devices/:id`     | Remove device                              |
-| GET    | `/api/v1/devices/:id/raw` | Raw zigbee2mqtt expose data                |
+| GET    | `/api/v1/devices/:id/raw` | Raw integration-specific expose data       |
 | WS     | `/ws`                     | WebSocket — broadcasts all engine events   |
 
 ### Event Bus Events
 
-| Event                      | When                            |
-| -------------------------- | ------------------------------- |
-| `device.discovered`        | New device found in zigbee2mqtt |
-| `device.removed`           | Device disappeared or deleted   |
-| `device.status_changed`    | Device goes online/offline      |
-| `device.data.updated`      | A device property value changes |
-| `system.started`           | Engine boot complete            |
-| `system.mqtt.connected`    | MQTT broker connected           |
-| `system.mqtt.disconnected` | MQTT broker disconnected        |
+| Event                      | When                             |
+| -------------------------- | -------------------------------- |
+| `device.discovered`        | New device found via integration |
+| `device.removed`           | Device disappeared or deleted    |
+| `device.status_changed`    | Device goes online/offline       |
+| `device.data.updated`      | A device property value changes  |
+| `system.started`           | Engine boot complete             |
+| `system.mqtt.connected`    | MQTT broker connected            |
+| `system.mqtt.disconnected` | MQTT broker disconnected         |
 
 ### Files
 
@@ -355,7 +357,7 @@
 | Recipes     | `src/recipes/recipe.ts`, `recipe-manager.ts`, `recipe-state-store.ts`, `motion-light.ts`         |
 | API         | `src/api/routes/recipes.ts`                                                                      |
 | Integration | `src/api/server.ts`, `src/index.ts`                                                              |
-| Tests       | `src/recipes/recipe-manager.test.ts` (9), `src/recipes/motion-light.test.ts` (12)                |
+| Tests       | `src/recipes/engine/recipe-manager.test.ts` (9), `src/recipes/motion-light.test.ts` (26)         |
 
 ---
 
@@ -411,15 +413,15 @@
 
 ### What it does
 
-- **Settings table**: SQLite key-value store (`settings`) for integration configuration (replaces `.env` for MQTT/Z2M)
-- **Integrations page**: Admin UI to configure Zigbee2MQTT connection (MQTT URL, credentials, client ID, Z2M base topic), with connection status and reconnect button
-- **MQTT reconnect**: Change integration settings from UI and reconnect without engine restart
-- **Conditional MQTT startup**: Engine starts without MQTT if integration not yet configured (`isMqttConfigured()` check)
+- **Settings table**: SQLite key-value store (`settings`) for integration configuration
+- **Integrations page**: Admin UI to configure integrations (connection settings, credentials, polling intervals), with status and connect/disconnect buttons
+- **Dynamic reconnect**: Change integration settings from UI and reconnect without engine restart
+- **Conditional startup**: Engine starts without integrations if none are yet configured
 - **Backup/restore**: Export/import full Winch configuration as JSON (all config tables in dependency order)
 - **Backup UI**: Export/Import buttons in Settings page (admin only)
-- **Device auto-cleanup**: Offline devices are automatically deleted from DB when z2m sends availability "offline"
-- **Stale device cleanup**: On every `bridge/devices` message, devices in DB not in the bridge list are deleted
-- **Manual device delete**: Delete button on device detail page (Winch DB only, does not touch z2m)
+- **Device auto-cleanup**: Offline devices are automatically cleaned up based on integration events
+- **Stale device cleanup**: Devices in DB not seen by the integration are removed
+- **Manual device delete**: Delete button on device detail page (Winch DB only)
 
 ### API Endpoints
 
@@ -635,6 +637,78 @@
 
 ---
 
+## V0.10d — Netatmo Home Control Integration
+
+**Objective**: Control Netatmo devices (weather station, thermostat, cameras) via the Netatmo Connect API.
+
+### What it does
+
+- **NetatmoHCIntegration** implements IntegrationPlugin
+- **OAuth2 authentication**: token-based auth with automatic refresh
+- **Polling**: periodic state refresh (configurable interval, default 300s)
+- **Device discovery**: Netatmo devices appear as Winch Devices with source `netatmo_hc`
+- **DeviceData**: temperature, humidity, CO2, noise, pressure, rain, wind, battery, WiFi signal
+- **DeviceOrders**: thermostat setpoint, mode changes
+
+### Files
+
+| Module | Files                                           |
+| ------ | ----------------------------------------------- |
+| Plugin | `src/integrations/netatmo-hc/index.ts`          |
+| Bridge | `src/integrations/netatmo-hc/netatmo-bridge.ts` |
+| Poller | `src/integrations/netatmo-hc/netatmo-poller.ts` |
+| Types  | `src/integrations/netatmo-hc/netatmo-types.ts`  |
+
+---
+
+## V0.11 — Structured Logging
+
+**Objective**: Production-grade structured logging with pino multistream, ring buffer for UI access, and a real-time LogsPage.
+
+### What it does
+
+- **Pino multistream**: ring buffer (in-memory for UI), pino-pretty (dev), JSON stdout + pino-roll file rotation (prod)
+- **Ring buffer API**: `GET /api/v1/logs` with query params (level, module, search, limit, offset)
+- **WebSocket streaming**: real-time log push to connected UI clients
+- **LogsPage**: filterable log viewer with level badges, module chips, auto-scroll, live/pause toggle
+- **Log level strategy**: fatal/error/warn/info for production, debug/trace for dev/UI
+
+### Files
+
+| Module | Files                                           |
+| ------ | ----------------------------------------------- |
+| Core   | `src/core/logger.ts` (multistream, ring buffer) |
+| API    | `src/api/routes/logs.ts`                        |
+| WS     | `src/api/websocket.ts` (log streaming)          |
+| UI     | `ui/src/pages/LogsPage.tsx`                     |
+
+---
+
+## V0.8b — Motion-Light Recipe Enhancements
+
+**Objective**: Improve motion-light recipe with multi-light support, lux threshold, motion impulse reset, and failsafe max-on duration.
+
+### What it does
+
+- **Multi-light support**: `lights` slot accepts a list of equipment IDs (replaces single `light`)
+- **Lux threshold**: optional — blocks light-on when zone luminosity exceeds threshold
+- **Impulse timer reset**: every motion=true event restarts the off-timer (handles PIR impulse sensors)
+- **Failsafe max-on duration**: optional — forces lights off after max duration regardless of motion
+- **Backward compatibility**: existing instances with `light` param auto-migrated to `lights` array
+- **RecipeSlotDef updated**: `list?: boolean` flag, `EquipmentType[]` constraint support
+
+### Files
+
+| Module | Files                                                             |
+| ------ | ----------------------------------------------------------------- |
+| Types  | `src/shared/types.ts` (RecipeSlotDef: list, array constraint)     |
+| Recipe | `src/recipes/motion-light.ts` (full rewrite)                      |
+| Tests  | `src/recipes/motion-light.test.ts` (26 tests, 14 new)             |
+| UI     | `ui/src/components/recipes/ZoneRecipesSection.tsx` (multi-select) |
+| UI     | `ui/src/types.ts` (RecipeSlotDef update)                          |
+
+---
+
 ## Test Summary
 
 | Module              | File                                        | Tests         |
@@ -646,12 +720,12 @@
 | Zone Aggregator     | `src/zones/zone-aggregator.test.ts`         | 25            |
 | Equipment Manager   | `src/equipments/equipment-manager.test.ts`  | 38            |
 | Recipe Manager      | `src/recipes/engine/recipe-manager.test.ts` | 9             |
-| Motion-Light Recipe | `src/recipes/motion-light.test.ts`          | 12            |
+| Motion-Light Recipe | `src/recipes/motion-light.test.ts`          | 26            |
 | Mode Manager        | `src/modes/mode-manager.test.ts`            | 39            |
 | Calendar Manager    | `src/modes/calendar-manager.test.ts`        | 25            |
 | Modes API           | `src/api/routes/modes.test.ts`              | 27            |
 | Calendar API        | `src/api/routes/calendar.test.ts`           | 18            |
-| **Total**           | **12 test files**                           | **273 tests** |
+| **Total**           | **12 test files**                           | **290 tests** |
 
 ---
 
@@ -666,5 +740,5 @@ cd ui && npm install && npm run dev
 
 # Open http://localhost:5173
 # First run: create admin account
-# Then configure MQTT integration in Administration > Integrations
+# Then configure your integrations in Administration > Integrations
 ```

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,6 +1,6 @@
 # Winch — User Manual
 
-> Updated: 2026-02-21 — V0.9 Modes & Calendar
+> Updated: 2026-02-24 — V0.11 Logging
 
 ---
 
@@ -13,7 +13,7 @@ Winch takes the opposite approach: **structure first, simplicity always**.
 |                     | Home Assistant                                                    | Jeedom                               | **Winch**                                                                            |
 | ------------------- | ----------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------ |
 | **Architecture**    | Flat entity list (thousands of `sensor.`, `light.`, `switch.`...) | Nested objects & commands            | **3 clear layers**: Device → Equipment → Zone                                        |
-| **Device setup**    | Integration + entity config per device                            | Plugin per protocol (often paid)     | **Zero config** — auto-discovery from zigbee2mqtt                                    |
+| **Device setup**    | Integration + entity config per device                            | Plugin per protocol (often paid)     | **Zero config** — auto-discovery from configured integrations                        |
 | **Room status**     | Create template sensors manually for each aggregation             | Write virtual devices + scenarios    | **Automatic** — motion, temperature, lights count, all computed in real-time         |
 | **Automations**     | YAML automations or Node-RED (extra component)                    | Block-based scenario editor          | **Recipes** — pre-built templates, just pick the zone and the light                  |
 | **Operating modes** | Manual: create `input_boolean` + automation per mode per room     | Manual: virtual switches + scenarios | **Built-in Modes** — define once, configure per zone, activate by button or calendar |
@@ -32,7 +32,7 @@ Winch separates the physical (Device) from the functional (Equipment), then orga
 
 ### 1. Devices — auto-discovered, never configured
 
-Devices are physical hardware on the MQTT network. Winch subscribes to zigbee2mqtt and discovers everything automatically: sensors, lights, switches, shutters, buttons. Each device exposes **Data** (readable properties like temperature, state, brightness) and **Orders** (writable commands).
+Devices are physical hardware discovered from configured integrations (Zigbee2MQTT, Panasonic Comfort Cloud, MCZ Maestro, Netatmo Home Control, etc.). Winch discovers everything automatically: sensors, lights, switches, shutters, buttons, thermostats. Each device exposes **Data** (readable properties like temperature, state, brightness) and **Orders** (writable commands).
 
 You never configure a Device. You just look at the list, and they're there.
 
@@ -174,11 +174,12 @@ Browse auto-discovered hardware:
 
 ### Administration > Integrations
 
-Configure zigbee2mqtt connection:
+Configure device source connections:
 
-- MQTT broker URL, credentials, Z2M base topic
-- Connection status indicator
-- Save + reconnect without restarting
+- Each integration has its own settings (MQTT URL, cloud credentials, polling intervals, etc.)
+- Connection status indicator per integration
+- Connect / disconnect without restarting the engine
+- Supported: Zigbee2MQTT, Panasonic Comfort Cloud, MCZ Maestro, Netatmo Home Control
 
 ### Settings
 
@@ -196,7 +197,7 @@ Configure zigbee2mqtt connection:
 ### Prerequisites
 
 - Node.js 20+
-- An MQTT broker with zigbee2mqtt running
+- At least one supported integration (e.g. Zigbee2MQTT with an MQTT broker, Panasonic CC account, etc.)
 
 ### Installation
 
@@ -218,7 +219,7 @@ LOG_LEVEL=info
 CORS_ORIGINS=http://localhost:5173
 ```
 
-> **Note**: MQTT and Zigbee2MQTT settings are configured from the UI (Administration > Integrations), not from `.env`.
+> **Note**: Integration settings (MQTT, cloud credentials, polling intervals) are configured from the UI (Administration > Integrations), not from `.env`.
 
 ### Start
 
@@ -235,8 +236,8 @@ Open **http://localhost:5173**.
 ### First run
 
 1. **Setup page** appears — create your admin account
-2. Go to **Administration > Integrations** — configure your MQTT broker
-3. Devices appear automatically
+2. Go to **Administration > Integrations** — configure your device sources (Zigbee2MQTT, cloud accounts, etc.)
+3. Devices appear automatically from connected integrations
 4. Go to **Administration > Zones** — create your home topology (Maison → Étage → Pièces)
 5. Go to **Administration > Equipments** — create equipments and bind them to devices
 6. Go to **Home** — enjoy your real-time dashboard
@@ -351,7 +352,7 @@ curl -X POST http://localhost:3000/api/v1/calendar/profiles/<id>/slots \
 curl http://localhost:3000/api/v1/recipes           # Available recipes
 curl -X POST http://localhost:3000/api/v1/recipe-instances \
   -H "Content-Type: application/json" \
-  -d '{"recipeId": "motion-light", "params": {"zone": "<zone-id>", "light": "<eq-id>", "timeout": "10m"}}'
+  -d '{"recipeId": "motion-light", "params": {"zone": "<zone-id>", "lights": ["<eq-id-1>", "<eq-id-2>"], "timeout": "10m"}}'
 ```
 
 ### Backup / Restore
@@ -376,6 +377,6 @@ Events: `device.data.updated`, `device.discovered`, `equipment.data.changed`, `e
 
 | Version | Feature                                                               |
 | ------- | --------------------------------------------------------------------- |
-| V0.10   | Computed Data — virtual data expressions (formulas across equipments) |
-| V0.11   | History — InfluxDB time-series with charts in UI                      |
+| V0.12   | Computed Data — virtual data expressions (formulas across equipments) |
+| V0.13   | History — InfluxDB time-series with charts in UI                      |
 | V1.0+   | AI Assistant — natural language scenario creation                     |

--- a/ui/src/components/equipments/LightControl.tsx
+++ b/ui/src/components/equipments/LightControl.tsx
@@ -98,7 +98,7 @@ export function LightControl({ equipment, onExecuteOrder, compact }: LightContro
               onChange={(e) => handleBrightnessChange(Number(e.target.value))}
               onMouseUp={handleBrightnessCommit}
               onTouchEnd={handleBrightnessCommit}
-              className="w-[80px] accent-primary h-1"
+              className="w-[80px] accent-active h-1"
             />
             <span className="text-[11px] text-text-tertiary w-7 text-right tabular-nums">
               {Math.round((brightness / 254) * 100)}%
@@ -112,7 +112,7 @@ export function LightControl({ equipment, onExecuteOrder, compact }: LightContro
           className={`
             p-2 rounded-[6px] transition-colors duration-150 cursor-pointer
             ${isOn
-              ? "bg-primary text-white hover:bg-primary-hover"
+              ? "bg-active text-white hover:bg-active/80"
               : "bg-border-light text-text-tertiary hover:bg-border hover:text-text-secondary"
             }
             disabled:opacity-50 disabled:cursor-not-allowed
@@ -136,7 +136,7 @@ export function LightControl({ equipment, onExecuteOrder, compact }: LightContro
             flex items-center gap-2 px-4 py-2 rounded-[6px] text-[13px] font-medium
             transition-colors duration-150
             ${isOn
-              ? "bg-primary text-white hover:bg-primary-hover"
+              ? "bg-active text-white hover:bg-active/80"
               : "bg-border-light text-text-secondary hover:bg-border hover:text-text"
             }
             disabled:opacity-50
@@ -159,7 +159,7 @@ export function LightControl({ equipment, onExecuteOrder, compact }: LightContro
             onChange={(e) => handleBrightnessChange(Number(e.target.value))}
             onMouseUp={handleBrightnessCommit}
             onTouchEnd={handleBrightnessCommit}
-            className="flex-1 accent-primary h-1.5"
+            className="flex-1 accent-active h-1.5"
           />
           <span className="text-[12px] text-text-secondary w-10 text-right">
             {Math.round((brightness / 254) * 100)}%

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -177,7 +177,7 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
                 onMouseUp={handleBrightnessCommit}
                 onTouchEnd={handleBrightnessCommit}
                 onClick={(e) => e.stopPropagation()}
-                className="w-[60px] accent-primary h-1"
+                className="w-[60px] accent-active h-1"
               />
               <span className="text-[11px] text-text-tertiary w-6 text-right tabular-nums">
                 {Math.round((brightness / 254) * 100)}%
@@ -192,7 +192,7 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
               className={`
                 p-1.5 rounded-[5px] transition-colors duration-150 cursor-pointer
                 ${isOn
-                  ? "bg-primary text-white hover:bg-primary-hover"
+                  ? "bg-active text-white hover:bg-active/80"
                   : "bg-border-light text-text-tertiary hover:bg-border hover:text-text-secondary"
                 }
                 disabled:opacity-50 disabled:cursor-not-allowed

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -241,7 +241,7 @@ function RecipeInstanceRow({
     for (const slot of recipe.slots) {
       if (slot.id === "zone") continue;
       const val = instance.params[slot.id];
-      if (val === undefined || val === null) continue;
+      if (val === undefined || val === null || val === "") continue;
       if (slot.type === "equipment" && Array.isArray(val)) {
         const names = val
           .map((id: string) => equipments.find((e) => e.id === id)?.name ?? id)
@@ -251,7 +251,7 @@ function RecipeInstanceRow({
         const eq = equipments.find((e) => e.id === val);
         parts.push(eq?.name ?? String(val));
       } else {
-        parts.push(String(val));
+        parts.push(`${slot.name}: ${String(val)}`);
       }
     }
     return parts.join(" · ");


### PR DESCRIPTION
## Summary
- Update all documentation files to reflect multi-integration architecture (no longer MQTT-only)
- Add missing V0.10d (Netatmo HC), V0.11 (Logging), V0.8b (Motion-Light Enhancements) sections to implementation-status
- Fix recipe API example to use `lights` array instead of single `light`
- Fix recipe summary display to show slot names for non-equipment params
- Fix light controls accent color (primary → active)

## Changes
- **CLAUDE.md**: generic pipeline, integration plugins section, updated roadmap
- **docs/user-manual.md**: generic device sources, updated prerequisites, recipe API fix
- **docs/data-model.md**: integration-agnostic device model and reactive pipeline
- **docs/implementation-status.md**: add V0.10d/V0.11/V0.8b, fix test counts (273→290)
- **ui/ZoneRecipesSection.tsx**: label non-equipment params in recipe summary
- **ui/LightControl.tsx + CompactEquipmentCard.tsx**: accent-primary → accent-active

## Test plan
- [x] All 290 tests pass
- [x] TypeScript compiles (backend + UI)
- [x] ESLint + Prettier pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)