### PR TITLE
feat: V0.11b — Backup/Restore hardening + dedicated admin page

### DIFF
--- a/specs/017-V0.11b-backup-hardening/architecture.md
+++ b/specs/017-V0.11b-backup-hardening/architecture.md
@@ -1,0 +1,64 @@
+# Architecture: V0.11b Backup/Restore Hardening
+
+## Data Model Changes
+
+None — no schema changes.
+
+## Event Bus Events
+
+None — no new events.
+
+## API Changes
+
+### Modified: POST `/api/v1/backup` (restore)
+
+After re-enabling foreign keys, run `PRAGMA foreign_key_check`. If violations are found, roll back the transaction and return 400 with violation details.
+
+```typescript
+// Inside the transaction, after re-enabling FK:
+db.pragma("foreign_keys = ON");
+const violations = db.pragma("foreign_key_check") as FKViolation[];
+if (violations.length > 0) {
+  throw new Error(`FK integrity violations: ${violations.length} found`);
+}
+```
+
+Note: `PRAGMA foreign_key_check` returns rows with `(table, rowid, parent, fkid)` for each violation.
+
+## UI Changes
+
+### New: `ui/src/pages/BackupPage.tsx`
+
+Dedicated admin page for backup/restore. Content extracted from `SettingsPage.tsx` BackupSection (lines 620-702), adapted to full-page layout.
+
+### Modified: `ui/src/pages/SettingsPage.tsx`
+
+Remove `BackupSection` component and its import/usage. Settings page keeps: Profile, Preferences, Password, API Tokens, User Management.
+
+### Modified: `ui/src/App.tsx`
+
+Add route: `<Route path="/backup" element={<BackupPage />} />`
+
+### Modified: `ui/src/components/layout/Sidebar.tsx`
+
+Add nav item to `ADMIN_ITEMS` array:
+
+```typescript
+{ to: "/backup", label: "nav.backup", icon: <DatabaseBackup /> }
+```
+
+### Modified: `ui/src/i18n/locales/fr.json` + `en.json`
+
+Add translation key: `nav.backup` → "Sauvegarde" / "Backup"
+
+## File Changes
+
+| File                                   | Change                               |
+| -------------------------------------- | ------------------------------------ |
+| `src/api/routes/backup.ts`             | Add FK integrity check after restore |
+| `ui/src/pages/BackupPage.tsx`          | New dedicated backup page            |
+| `ui/src/pages/SettingsPage.tsx`        | Remove BackupSection                 |
+| `ui/src/App.tsx`                       | Add `/backup` route                  |
+| `ui/src/components/layout/Sidebar.tsx` | Add backup nav item                  |
+| `ui/src/i18n/locales/fr.json`          | Add `nav.backup` key                 |
+| `ui/src/i18n/locales/en.json`          | Add `nav.backup` key                 |

--- a/specs/017-V0.11b-backup-hardening/plan.md
+++ b/specs/017-V0.11b-backup-hardening/plan.md
@@ -1,0 +1,25 @@
+# Implementation Plan: V0.11b Backup/Restore Hardening
+
+## Tasks
+
+1. [ ] Backend: Add FK integrity check in restore route (`backup.ts`)
+2. [ ] Frontend: Create `BackupPage.tsx` (extract from SettingsPage)
+3. [ ] Frontend: Add page reload after successful restore
+4. [ ] Frontend: Add `/backup` route in `App.tsx`
+5. [ ] Frontend: Add sidebar nav item in `Sidebar.tsx`
+6. [ ] Frontend: Add i18n keys (`nav.backup`)
+7. [ ] Frontend: Remove BackupSection from `SettingsPage.tsx`
+8. [ ] Validate: `npx tsc --noEmit` (backend + frontend)
+9. [ ] Validate: `npm test`
+
+## Dependencies
+
+- None — builds on existing backup/restore implementation
+
+## Testing
+
+- Export backup, verify JSON file downloads
+- Import backup, verify page reloads and data is correct
+- Import corrupted backup (bad FK references), verify 400 error with details
+- Verify `/backup` page accessible from sidebar
+- Verify backup no longer appears in Settings page

--- a/specs/017-V0.11b-backup-hardening/spec.md
+++ b/specs/017-V0.11b-backup-hardening/spec.md
@@ -1,0 +1,44 @@
+# V0.11b: Backup/Restore Hardening
+
+## Summary
+
+Harden the existing backup/restore feature with FK integrity validation and post-restore page reload. Move the backup UI from the Settings page into a dedicated `/backup` page accessible from the Administration sidebar section.
+
+## Reference
+
+- Existing implementation: `src/api/routes/backup.ts`, `ui/src/pages/SettingsPage.tsx` (BackupSection)
+- Audit findings: missing `PRAGMA foreign_key_check`, no post-restore reload, UI buried in Settings
+
+## Acceptance Criteria
+
+- [ ] Backend runs `PRAGMA foreign_key_check` after restore and reports violations
+- [ ] Frontend reloads the page after a successful restore
+- [ ] New `/backup` route with dedicated `BackupPage`
+- [ ] Sidebar Administration section includes a "Backup" nav item
+- [ ] `BackupSection` removed from `SettingsPage`
+- [ ] TypeScript compiles with zero errors (backend + frontend)
+- [ ] All tests pass
+
+## Scope
+
+### In Scope
+
+- FK integrity check after restore (backend)
+- Page reload after successful restore (frontend)
+- Dedicated BackupPage at `/backup`
+- Sidebar nav item in Administration section
+- Remove backup from Settings page
+
+### Out of Scope
+
+- Schema version migration during restore (deferred)
+- Pre-restore automatic backup (deferred)
+- Credential redaction in backup files (deferred)
+- Selective table backup (deferred)
+- Backend re-initialization after restore (page reload is sufficient)
+
+## Edge Cases
+
+- FK violations after restore: return 400 with details, rollback the transaction
+- Empty backup file: handled by existing validation (`version !== 1`)
+- Backup from older schema (missing columns): INSERT will fail, transaction rolls back

--- a/src/api/routes/backup.ts
+++ b/src/api/routes/backup.ts
@@ -120,8 +120,24 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupDeps): vo
           }
         }
 
-        // Re-enable foreign keys
+        // Re-enable foreign keys and verify integrity
         db.pragma("foreign_keys = ON");
+
+        const violations = db.pragma("foreign_key_check") as {
+          table: string;
+          rowid: number;
+          parent: string;
+          fkid: number;
+        }[];
+
+        if (violations.length > 0) {
+          const details = violations
+            .slice(0, 10)
+            .map((v) => `${v.table} row ${v.rowid} → ${v.parent}`);
+          throw new Error(
+            `FK integrity check failed: ${violations.length} violation(s). ${details.join("; ")}`,
+          );
+        }
       });
 
       restore();

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -17,6 +17,7 @@ import { ModesPage } from "./pages/ModesPage";
 import { ModeDetailPage } from "./pages/ModeDetailPage";
 import { CalendarPage } from "./pages/CalendarPage";
 import { LogsPage } from "./pages/LogsPage";
+import { BackupPage } from "./pages/BackupPage";
 
 export default function App() {
   return (
@@ -52,6 +53,7 @@ export default function App() {
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/integrations" element={<IntegrationsPage />} />
           <Route path="/logs" element={<LogsPage />} />
+          <Route path="/backup" element={<BackupPage />} />
 
           {/* Default redirect to Maison */}
           <Route path="*" element={<Navigate to="/home" replace />} />

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Layers,
   Calendar,
   ScrollText,
+  DatabaseBackup,
 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -33,6 +34,7 @@ const ADMIN_ITEMS: NavItem[] = [
   { to: "/calendar", label: "nav.calendar", icon: <Calendar size={18} strokeWidth={1.5} /> },
   { to: "/integrations", label: "nav.integrations", icon: <Plug size={18} strokeWidth={1.5} /> },
   { to: "/logs", label: "nav.logs", icon: <ScrollText size={18} strokeWidth={1.5} /> },
+  { to: "/backup", label: "nav.backup", icon: <DatabaseBackup size={18} strokeWidth={1.5} /> },
 ];
 
 export function Sidebar() {

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -378,15 +378,16 @@
   "settings.deleteUserConfirm": "Delete user \"{{name}}\"?",
   "settings.cannotDeleteSelf": "Cannot delete your own account",
 
-  "settings.backup": "Backup / Restore",
-  "settings.backupDescription": "Export or import the full Winch configuration (zones, devices, equipments, users, recipes, integrations).",
-  "settings.exportBackup": "Export",
-  "settings.importBackup": "Import",
-  "settings.backupExported": "Backup exported successfully",
-  "settings.backupImported": "Backup imported successfully. Restart Winch to apply changes.",
+  "backup.title": "Backup / Restore",
+  "backup.description": "Export or import the full Winch configuration (zones, devices, equipments, users, recipes, integrations).",
+  "backup.export": "Export",
+  "backup.import": "Import",
+  "backup.exported": "Backup exported successfully",
+  "backup.imported": "Backup imported successfully. Reloading...",
 
   "nav.integrations": "Integrations",
   "nav.logs": "Logs",
+  "nav.backup": "Backup",
 
   "integrations.title": "Integrations",
   "integrations.subtitle": "Configure connections with your home automation systems.",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -378,15 +378,16 @@
   "settings.deleteUserConfirm": "Supprimer l'utilisateur « {{name}} » ?",
   "settings.cannotDeleteSelf": "Vous ne pouvez pas supprimer votre propre compte",
 
-  "settings.backup": "Sauvegarde / Restauration",
-  "settings.backupDescription": "Exportez ou importez la configuration complète de Winch (zones, appareils, équipements, utilisateurs, recettes, intégrations).",
-  "settings.exportBackup": "Exporter",
-  "settings.importBackup": "Importer",
-  "settings.backupExported": "Sauvegarde exportée avec succès",
-  "settings.backupImported": "Sauvegarde importée avec succès. Redémarrez Winch pour appliquer les changements.",
+  "backup.title": "Sauvegarde / Restauration",
+  "backup.description": "Exportez ou importez la configuration complète de Winch (zones, appareils, équipements, utilisateurs, recettes, intégrations).",
+  "backup.export": "Exporter",
+  "backup.import": "Importer",
+  "backup.exported": "Sauvegarde exportée avec succès",
+  "backup.imported": "Sauvegarde importée avec succès. Rechargement...",
 
   "nav.integrations": "Intégrations",
   "nav.logs": "Logs",
+  "nav.backup": "Sauvegarde",
 
   "integrations.title": "Intégrations",
   "integrations.subtitle": "Configurez les connexions avec vos systèmes domotiques.",

--- a/ui/src/pages/BackupPage.tsx
+++ b/ui/src/pages/BackupPage.tsx
@@ -1,0 +1,124 @@
+import { useState, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { DatabaseBackup, Download, Upload, Loader2 } from "lucide-react";
+import { exportBackup, importBackup } from "../api";
+
+export function BackupPage() {
+  const { t } = useTranslation();
+  const [exporting, setExporting] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleExport = async () => {
+    setError("");
+    setSuccess("");
+    setExporting(true);
+    try {
+      const blob = await exportBackup();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `winch-backup-${new Date().toISOString().slice(0, 10)}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      setSuccess(t("backup.exported"));
+      setTimeout(() => setSuccess(""), 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("common.error"));
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setError("");
+    setSuccess("");
+    setImporting(true);
+    try {
+      await importBackup(file);
+      setSuccess(t("backup.imported"));
+      // Reload the page after a short delay to let the user see the success message
+      setTimeout(() => window.location.reload(), 1500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("common.error"));
+    } finally {
+      setImporting(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  return (
+    <div className="p-6">
+      {/* Page header */}
+      <div className="mb-6">
+        <div className="flex items-center gap-2.5 mb-1">
+          <DatabaseBackup size={22} strokeWidth={1.5} className="text-text-secondary" />
+          <h1 className="text-[24px] font-semibold text-text leading-[32px]">
+            {t("backup.title")}
+          </h1>
+        </div>
+        <p className="text-[13px] text-text-tertiary mt-1">
+          {t("backup.description")}
+        </p>
+      </div>
+
+      {/* Backup card */}
+      <div className="max-w-xl">
+        <section className="bg-surface rounded-[10px] border border-border p-5">
+          <h2 className="text-[14px] font-semibold text-text mb-4">
+            {t("backup.title")}
+          </h2>
+
+          {error && (
+            <div className="mb-4 p-3 bg-error/10 border border-error/30 rounded-[6px]">
+              <p className="text-[13px] text-error">{error}</p>
+            </div>
+          )}
+          {success && (
+            <div className="mb-4 p-3 bg-success/10 border border-success/30 rounded-[6px]">
+              <p className="text-[13px] text-success">{success}</p>
+            </div>
+          )}
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleExport}
+              disabled={exporting}
+              className="flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium bg-primary text-white rounded-[6px] hover:bg-primary-hover transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-default"
+            >
+              {exporting ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Download size={14} />
+              )}
+              {t("backup.export")}
+            </button>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={importing}
+              className="flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-default"
+            >
+              {importing ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Upload size={14} />
+              )}
+              {t("backup.import")}
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json"
+              onChange={handleImport}
+              className="hidden"
+            />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2, Plus, Trash2, Copy, Check, Eye, EyeOff, Settings, Download, Upload } from "lucide-react";
+import { Loader2, Plus, Trash2, Copy, Check, Eye, EyeOff, Settings } from "lucide-react";
 import { useAuth } from "../store/useAuth";
 import {
   updateMe,
@@ -12,8 +12,6 @@ import {
   createUser,
   updateUser,
   deleteUser,
-  exportBackup,
-  importBackup,
 } from "../api";
 import type { ApiToken, User, UserRole } from "../types";
 
@@ -63,7 +61,6 @@ export function SettingsPage() {
         <div className="space-y-6">
           <ApiTokensSection />
           {isAdmin && <UserManagementSection currentUserId={user?.id ?? ""} />}
-          {isAdmin && <BackupSection />}
         </div>
       </div>
     </div>
@@ -613,90 +610,3 @@ function UserManagementSection({ currentUserId }: { currentUserId: string }) {
   );
 }
 
-// ============================================================
-// Backup / Restore (admin only)
-// ============================================================
-
-function BackupSection() {
-  const { t } = useTranslation();
-  const [exporting, setExporting] = useState(false);
-  const [importing, setImporting] = useState(false);
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const handleExport = async () => {
-    setError("");
-    setSuccess("");
-    setExporting(true);
-    try {
-      const blob = await exportBackup();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `winch-backup-${new Date().toISOString().slice(0, 10)}.json`;
-      a.click();
-      URL.revokeObjectURL(url);
-      setSuccess(t("settings.backupExported"));
-      setTimeout(() => setSuccess(""), 3000);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t("common.error"));
-    } finally {
-      setExporting(false);
-    }
-  };
-
-  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setError("");
-    setSuccess("");
-    setImporting(true);
-    try {
-      await importBackup(file);
-      setSuccess(t("settings.backupImported"));
-      setTimeout(() => setSuccess(""), 3000);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t("common.error"));
-    } finally {
-      setImporting(false);
-      if (fileInputRef.current) fileInputRef.current.value = "";
-    }
-  };
-
-  return (
-    <section className="bg-surface rounded-[10px] border border-border p-5">
-      <h2 className="text-[14px] font-semibold text-text mb-2">{t("settings.backup")}</h2>
-      <p className="text-[12px] text-text-tertiary mb-4">{t("settings.backupDescription")}</p>
-
-      {error && <p className="mb-3 text-[13px] text-error">{error}</p>}
-      {success && <p className="mb-3 text-[13px] text-success">{success}</p>}
-
-      <div className="flex items-center gap-2">
-        <button
-          onClick={handleExport}
-          disabled={exporting}
-          className="flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium bg-primary text-white rounded-[6px] hover:bg-primary-hover transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-default"
-        >
-          <Download size={14} />
-          {exporting ? t("common.loading") : t("settings.exportBackup")}
-        </button>
-        <button
-          onClick={() => fileInputRef.current?.click()}
-          disabled={importing}
-          className="flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-default"
-        >
-          <Upload size={14} />
-          {importing ? t("common.loading") : t("settings.importBackup")}
-        </button>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".json"
-          onChange={handleImport}
-          className="hidden"
-        />
-      </div>
-    </section>
-  );
-}


### PR DESCRIPTION
## Summary
- Add `PRAGMA foreign_key_check` after restore — rollback on FK violations with detailed error
- Create dedicated `/backup` page with auto page-reload after successful restore
- Add "Sauvegarde" nav item in sidebar Administration section
- Remove BackupSection from Settings page

## Changes
- **Backend**: `src/api/routes/backup.ts` — FK integrity check in restore transaction
- **Frontend**: New `BackupPage.tsx`, route in `App.tsx`, sidebar nav in `Sidebar.tsx`
- **i18n**: New `nav.backup` + `backup.*` keys (fr + en), removed old `settings.backup*` keys
- **Spec**: `specs/017-V0.11b-backup-hardening/`

## Test plan
- [x] TypeScript compiles (zero errors, backend + frontend)
- [x] All 290 tests pass
- [x] ESLint + Prettier pass
- [ ] Manual: export backup → JSON file downloads
- [ ] Manual: import backup → page reloads automatically
- [ ] Manual: verify `/backup` page accessible from sidebar
- [ ] Manual: verify backup no longer in Settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)