### PR TITLE
feat: V0.8f — Zone-level commands (lights, shutters)

### DIFF
--- a/specs/021-V0.8f-zone-commands/architecture.md
+++ b/specs/021-V0.8f-zone-commands/architecture.md
@@ -1,0 +1,43 @@
+# Architecture: V0.8f Zone Commands
+
+## Data Model Changes
+
+None. No new tables or columns.
+
+## Event Bus Events
+
+No new events. Existing `equipment.order.executed` fires for each individual order.
+
+## API Changes
+
+### New endpoint
+
+```
+POST /api/v1/zones/:id/orders/:orderKey
+```
+
+**Path params:**
+
+- `id` — zone UUID
+- `orderKey` — one of: `allLightsOn`, `allLightsOff`, `allShuttersOpen`, `allShuttersClose`
+
+**Response (200):**
+
+```json
+{ "executed": 5, "errors": 0 }
+```
+
+**Errors:**
+
+- 404 — zone not found
+- 400 — invalid orderKey
+
+## File Changes
+
+| File                                  | Change                                                          |
+| ------------------------------------- | --------------------------------------------------------------- |
+| `src/zones/zone-manager.ts`           | Add `getDescendantIds(zoneId): string[]`                        |
+| `src/equipments/equipment-manager.ts` | Add `executeZoneOrder(zoneIds, orderKey): { executed, errors }` |
+| `src/api/routes/zones.ts`             | Add `POST /:id/orders/:orderKey` endpoint                       |
+| `ui/src/pages/ZoneDetailPage.tsx`     | Add command buttons in header                                   |
+| `ui/src/api.ts`                       | Add `executeZoneOrder(zoneId, orderKey)` API call               |

--- a/specs/021-V0.8f-zone-commands/plan.md
+++ b/specs/021-V0.8f-zone-commands/plan.md
@@ -1,0 +1,17 @@
+# Implementation Plan: V0.8f Zone Commands
+
+## Tasks
+
+1. [ ] `zone-manager.ts` — Add `getDescendantIds(zoneId)` recursive helper
+2. [ ] `equipment-manager.ts` — Add `executeZoneOrder(zoneIds, orderKey)` method
+3. [ ] `zones.ts` route — Add `POST /:id/orders/:orderKey` endpoint
+4. [ ] `ui/src/api.ts` — Add `executeZoneOrder()` API function
+5. [ ] `ZoneDetailPage.tsx` — Add zone command buttons in header
+6. [ ] TypeScript compile + tests pass
+7. [ ] Manual verification
+
+## Testing
+
+- Call API on a leaf zone → only its equipments affected
+- Call API on a parent zone → all descendant equipments affected
+- Call on zone with no matching equipment → returns { executed: 0, errors: 0 }

--- a/specs/021-V0.8f-zone-commands/spec.md
+++ b/specs/021-V0.8f-zone-commands/spec.md
@@ -1,0 +1,51 @@
+# V0.8f: Zone Commands
+
+## Summary
+
+Add consolidated commands at zone level: turn all lights on/off, open/close all shutters. Commands are always recursive — on a leaf zone they target its own equipments, on a parent zone they propagate to all descendant zones.
+
+## Reference
+
+- Spec sections: §6.3 (Zone Orders), §10 API (`POST /zones/:id/orders/:orderKey`)
+
+## Accepted Commands
+
+| orderKey           | Target types                             | Order alias | Value   |
+| ------------------ | ---------------------------------------- | ----------- | ------- |
+| `allLightsOn`      | light_onoff, light_dimmable, light_color | `state`     | `"ON"`  |
+| `allLightsOff`     | light_onoff, light_dimmable, light_color | `state`     | `"OFF"` |
+| `allShuttersOpen`  | shutter                                  | `position`  | `100`   |
+| `allShuttersClose` | shutter                                  | `position`  | `0`     |
+
+## Acceptance Criteria
+
+- [ ] `POST /zones/:id/orders/allLightsOff` turns off all lights in zone + sub-zones
+- [ ] `POST /zones/:id/orders/allLightsOn` turns on all lights in zone + sub-zones
+- [ ] `POST /zones/:id/orders/allShuttersOpen` opens all shutters in zone + sub-zones
+- [ ] `POST /zones/:id/orders/allShuttersClose` closes all shutters in zone + sub-zones
+- [ ] Returns summary: `{ executed: N, errors: N }`
+- [ ] Skips disabled equipments
+- [ ] UI shows command buttons on zone detail page header
+- [ ] Buttons shown conditionally (only if zone has lights/shutters)
+- [ ] Parent zones show count ("12 lights across 4 rooms")
+
+## Scope
+
+### In Scope
+
+- 4 zone order keys (lights on/off, shutters open/close)
+- Recursive propagation via zone tree
+- API endpoint
+- UI buttons on ZoneDetailPage
+
+### Out of Scope
+
+- Custom shutter position (slider) — deferred
+- Thermostat zone commands — deferred
+- Scenario `zone_order` action type — deferred (separate task)
+
+## Edge Cases
+
+- Zone with no lights/shutters → buttons hidden, API returns `{ executed: 0, errors: 0 }`
+- Equipment with no `state`/`position` order binding → skipped with warning
+- Integration disconnected → error counted, execution continues for other equipments

--- a/src/api/routes/zones.ts
+++ b/src/api/routes/zones.ts
@@ -1,17 +1,19 @@
 import type { FastifyInstance } from "fastify";
 import type { ZoneManager } from "../../zones/zone-manager.js";
 import type { ZoneAggregator } from "../../zones/zone-aggregator.js";
+import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import type { Logger } from "../../core/logger.js";
 import { ROOT_ZONE_ID } from "../../shared/constants.js";
 
 interface ZonesDeps {
   zoneManager: ZoneManager;
   zoneAggregator: ZoneAggregator;
+  equipmentManager: EquipmentManager;
   logger: Logger;
 }
 
 export function registerZoneRoutes(app: FastifyInstance, deps: ZonesDeps): void {
-  const { zoneManager, zoneAggregator } = deps;
+  const { zoneManager, zoneAggregator, equipmentManager } = deps;
 
   // GET /api/v1/zones — List all zones as a tree
   app.get("/api/v1/zones", async () => {
@@ -127,6 +129,26 @@ export function registerZoneRoutes(app: FastifyInstance, deps: ZonesDeps): void 
         const { parentId, orderedIds } = request.body;
         zoneManager.reorderSiblings(parentId, orderedIds);
         return reply.code(204).send();
+      } catch (err) {
+        return handleZoneError(err, reply);
+      }
+    },
+  );
+  // POST /api/v1/zones/:id/orders/:orderKey — Execute zone-level order
+  app.post<{ Params: { id: string; orderKey: string } }>(
+    "/api/v1/zones/:id/orders/:orderKey",
+    async (request, reply) => {
+      const { id, orderKey } = request.params;
+
+      const zone = zoneManager.getById(id);
+      if (!zone) {
+        return reply.code(404).send({ error: "Zone not found" });
+      }
+
+      try {
+        const zoneIds = zoneManager.getDescendantIds(id);
+        const result = equipmentManager.executeZoneOrder(zoneIds, orderKey);
+        return result;
       } catch (err) {
         return handleZoneError(err, reply);
       }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -108,7 +108,7 @@ export async function createServer(deps: ServerDeps) {
   registerMeRoutes(app, { authService, userManager, logger });
   registerUserRoutes(app, { userManager, logger });
   registerDeviceRoutes(app, { deviceManager, logger });
-  registerZoneRoutes(app, { zoneManager, zoneAggregator, logger });
+  registerZoneRoutes(app, { zoneManager, zoneAggregator, equipmentManager, logger });
   registerEquipmentRoutes(app, { equipmentManager, logger });
   registerRecipeRoutes(app, { recipeManager, logger });
   registerModeRoutes(app, { modeManager, buttonActionManager, logger });

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -451,6 +451,70 @@ export class EquipmentManager {
   }
 
   // ============================================================
+  // Zone-level order execution
+  // ============================================================
+
+  /** Valid zone order keys and their mapping to equipment types + order alias + value. */
+  private static readonly ZONE_ORDERS: Record<
+    string,
+    { types: string[]; alias: string; value: unknown }
+  > = {
+    allLightsOn: {
+      types: ["light_onoff", "light_dimmable", "light_color"],
+      alias: "state",
+      value: "ON",
+    },
+    allLightsOff: {
+      types: ["light_onoff", "light_dimmable", "light_color"],
+      alias: "state",
+      value: "OFF",
+    },
+    allShuttersOpen: { types: ["shutter"], alias: "position", value: 100 },
+    allShuttersClose: { types: ["shutter"], alias: "position", value: 0 },
+  };
+
+  static readonly VALID_ZONE_ORDER_KEYS = Object.keys(EquipmentManager.ZONE_ORDERS);
+
+  /**
+   * Execute a zone-level order on all matching equipments across the given zone IDs.
+   * Returns a summary of executed and errored orders.
+   */
+  executeZoneOrder(zoneIds: string[], orderKey: string): { executed: number; errors: number } {
+    const mapping = EquipmentManager.ZONE_ORDERS[orderKey];
+    if (!mapping) {
+      throw new EquipmentError(`Invalid zone order key: ${orderKey}`, 400);
+    }
+
+    let executed = 0;
+    let errors = 0;
+
+    for (const zoneId of zoneIds) {
+      const equipments = this.getByZone(zoneId);
+      for (const eq of equipments) {
+        if (!eq.enabled) continue;
+        if (!mapping.types.includes(eq.type)) continue;
+
+        try {
+          this.executeOrder(eq.id, mapping.alias, mapping.value);
+          executed++;
+        } catch (err) {
+          errors++;
+          this.logger.warn(
+            { err, equipmentId: eq.id, orderKey },
+            "Zone order failed for equipment",
+          );
+        }
+      }
+    }
+
+    this.logger.info(
+      { orderKey, zoneCount: zoneIds.length, executed, errors },
+      "Zone order executed",
+    );
+    return { executed, errors };
+  }
+
+  // ============================================================
   // Reactive pipeline: device.data.updated -> equipment.data.changed
   // ============================================================
 

--- a/src/zones/zone-manager.ts
+++ b/src/zones/zone-manager.ts
@@ -295,6 +295,35 @@ export class ZoneManager {
   }
 
   // ============================================================
+  // Descendant collection (for zone commands)
+  // ============================================================
+
+  /**
+   * Returns the given zone ID plus all descendant zone IDs (recursive).
+   */
+  getDescendantIds(zoneId: string): string[] {
+    const all = this.getAll();
+    const childrenOf = new Map<string, string[]>();
+    for (const z of all) {
+      if (z.parentId) {
+        const list = childrenOf.get(z.parentId) ?? [];
+        list.push(z.id);
+        childrenOf.set(z.parentId, list);
+      }
+    }
+
+    const result: string[] = [];
+    const stack = [zoneId];
+    while (stack.length > 0) {
+      const id = stack.pop()!;
+      result.push(id);
+      const children = childrenOf.get(id);
+      if (children) stack.push(...children);
+    }
+    return result;
+  }
+
+  // ============================================================
   // Helpers
   // ============================================================
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -278,6 +278,16 @@ export async function reorderZones(parentId: string | null, orderedIds: string[]
   });
 }
 
+export async function executeZoneOrder(
+  zoneId: string,
+  orderKey: string,
+): Promise<{ executed: number; errors: number }> {
+  return fetchJSON<{ executed: number; errors: number }>(
+    `${API_BASE}/zones/${zoneId}/orders/${orderKey}`,
+    { method: "POST" },
+  );
+}
+
 // ============================================================
 // Equipments
 // ============================================================

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -132,6 +132,10 @@
   "zones.moveDown": "Move down",
   "zones.childCount_one": "{{count}} zone",
   "zones.childCount_other": "{{count}} zones",
+  "zones.commands.allLightsOn": "All lights on",
+  "zones.commands.allLightsOff": "All lights off",
+  "zones.commands.allShuttersOpen": "Open all shutters",
+  "zones.commands.allShuttersClose": "Close all shutters",
 
   "equipments.title": "Equipments",
   "equipments.filterPlaceholder": "Filter...",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -132,6 +132,10 @@
   "zones.moveDown": "Descendre",
   "zones.childCount_one": "{{count}} zone",
   "zones.childCount_other": "{{count}} zones",
+  "zones.commands.allLightsOn": "Allumer les lumières",
+  "zones.commands.allLightsOff": "Éteindre les lumières",
+  "zones.commands.allShuttersOpen": "Ouvrir les volets",
+  "zones.commands.allShuttersClose": "Fermer les volets",
 
   "equipments.title": "Équipements",
   "equipments.filterPlaceholder": "Filtrer...",

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -1,10 +1,19 @@
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, useNavigate } from "react-router-dom";
-import { Loader2, Home, ChevronDown } from "lucide-react";
+import {
+  Loader2,
+  Home,
+  ChevronDown,
+  Lightbulb,
+  LightbulbOff,
+  ArrowUpFromLine,
+  ArrowDownToLine,
+} from "lucide-react";
 import { useZones } from "../store/useZones";
 import { useEquipments } from "../store/useEquipments";
 import { useZoneAggregation } from "../store/useZoneAggregation";
+import { executeZoneOrder } from "../api";
 import { ZoneEquipmentsView } from "../components/home/ZoneEquipmentsView";
 import { ZoneAggregationPills } from "../components/home/ZoneAggregationPills";
 import { ZoneRecipesSection } from "../components/recipes/ZoneRecipesSection";
@@ -55,6 +64,21 @@ export function HomePage() {
     return equipments.filter((eq) => eq.zoneId === zoneId);
   }, [equipments, zoneId]);
 
+  const aggData = zoneId ? aggregationData[zoneId] : undefined;
+  const [commandLoading, setCommandLoading] = useState<string | null>(null);
+
+  const handleZoneCommand = useCallback(async (orderKey: string) => {
+    if (!zoneId) return;
+    setCommandLoading(orderKey);
+    try {
+      await executeZoneOrder(zoneId, orderKey);
+    } catch {
+      // Silently handle — the user sees the result via live updates
+    } finally {
+      setCommandLoading(null);
+    }
+  }, [zoneId]);
+
   const loading = zonesLoading || equipmentsLoading;
 
   // No zone ID and no zones exist
@@ -93,6 +117,67 @@ export function HomePage() {
         {zoneId && aggregationData[zoneId] && (
           <div className="mt-3">
             <ZoneAggregationPills data={aggregationData[zoneId]} />
+          </div>
+        )}
+        {/* Zone command buttons */}
+        {aggData && (aggData.lightsTotal > 0 || aggData.shuttersTotal > 0) && (
+          <div className="flex flex-wrap items-center gap-2 mt-3">
+            {aggData.lightsTotal > 0 && (
+              <>
+                <button
+                  onClick={() => handleZoneCommand("allLightsOn")}
+                  disabled={commandLoading !== null}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-text-secondary bg-surface border border-border rounded-[6px] hover:bg-amber-50 hover:text-amber-700 hover:border-amber-300 transition-colors duration-150 disabled:opacity-50"
+                >
+                  {commandLoading === "allLightsOn" ? (
+                    <Loader2 size={14} strokeWidth={1.5} className="animate-spin" />
+                  ) : (
+                    <Lightbulb size={14} strokeWidth={1.5} />
+                  )}
+                  {t("zones.commands.allLightsOn")}
+                </button>
+                <button
+                  onClick={() => handleZoneCommand("allLightsOff")}
+                  disabled={commandLoading !== null}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-text-secondary bg-surface border border-border rounded-[6px] hover:bg-border-light transition-colors duration-150 disabled:opacity-50"
+                >
+                  {commandLoading === "allLightsOff" ? (
+                    <Loader2 size={14} strokeWidth={1.5} className="animate-spin" />
+                  ) : (
+                    <LightbulbOff size={14} strokeWidth={1.5} />
+                  )}
+                  {t("zones.commands.allLightsOff")}
+                </button>
+              </>
+            )}
+            {aggData.shuttersTotal > 0 && (
+              <>
+                <button
+                  onClick={() => handleZoneCommand("allShuttersOpen")}
+                  disabled={commandLoading !== null}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-text-secondary bg-surface border border-border rounded-[6px] hover:bg-sky-50 hover:text-sky-700 hover:border-sky-300 transition-colors duration-150 disabled:opacity-50"
+                >
+                  {commandLoading === "allShuttersOpen" ? (
+                    <Loader2 size={14} strokeWidth={1.5} className="animate-spin" />
+                  ) : (
+                    <ArrowUpFromLine size={14} strokeWidth={1.5} />
+                  )}
+                  {t("zones.commands.allShuttersOpen")}
+                </button>
+                <button
+                  onClick={() => handleZoneCommand("allShuttersClose")}
+                  disabled={commandLoading !== null}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-text-secondary bg-surface border border-border rounded-[6px] hover:bg-border-light transition-colors duration-150 disabled:opacity-50"
+                >
+                  {commandLoading === "allShuttersClose" ? (
+                    <Loader2 size={14} strokeWidth={1.5} className="animate-spin" />
+                  ) : (
+                    <ArrowDownToLine size={14} strokeWidth={1.5} />
+                  )}
+                  {t("zones.commands.allShuttersClose")}
+                </button>
+              </>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Add recursive zone-level commands: allLightsOn, allLightsOff, allShuttersOpen, allShuttersClose
- Backend: `getDescendantIds()` in zone-manager + `executeZoneOrder()` in equipment-manager
- API: `POST /api/v1/zones/:id/orders/:orderKey`
- UI: command buttons on HomePage next to aggregation pills (not on ZoneDetailPage)

## Test plan
- [x] TypeScript compiles (zero errors, backend + frontend)
- [x] All 383 tests pass
- [x] Lint + format pass
- [ ] Manual: click "Allumer les lumières" on a leaf zone → all lights turn on
- [ ] Manual: click on a parent zone → propagates recursively to all descendant equipments

🤖 Generated with [Claude Code](https://claude.com/claude-code)