### PR TITLE
feat(zones): sunrise/sunset computation and sunlight banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "winch",
       "version": "0.1.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cors": "^10.0.2",
         "@fastify/rate-limit": "^10.3.0",
@@ -22,7 +23,8 @@
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
         "pino-roll": "^4.0.0",
-        "socket.io-client": "^4.8.3"
+        "socket.io-client": "^4.8.3",
+        "suncalc": "^1.9.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -30,6 +32,7 @@
         "@types/better-sqlite3": "^7.6.12",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.12.0",
+        "@types/suncalc": "^1.9.2",
         "@vitest/coverage-v8": "^2.1.9",
         "eslint": "^10.0.1",
         "globals": "^17.3.0",
@@ -1551,6 +1554,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/suncalc": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@types/suncalc/-/suncalc-1.9.2.tgz",
+      "integrity": "sha512-ATAGBHHfA1TlE2tjfidLyTcysjoT2JHHEAmWRULh73SU9UTn++j5fqHEW16X6Y/2Li87jEQXzgu4R/OOdlDqzw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -5249,6 +5259,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/suncalc": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
+      "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "pino-roll": "^4.0.0",
-    "socket.io-client": "^4.8.3"
+    "socket.io-client": "^4.8.3",
+    "suncalc": "^1.9.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -45,6 +46,7 @@
     "@types/better-sqlite3": "^7.6.12",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^22.12.0",
+    "@types/suncalc": "^1.9.2",
     "@vitest/coverage-v8": "^2.1.9",
     "eslint": "^10.0.1",
     "globals": "^17.3.0",

--- a/specs/023-sunrise-sunset/architecture.md
+++ b/specs/023-sunrise-sunset/architecture.md
@@ -1,0 +1,155 @@
+# Architecture: Sunrise/Sunset
+
+## Dependency
+
+- npm package: `suncalc` (MIT, zero deps, well-maintained)
+
+## Data Model Changes
+
+### ZoneAggregatedData (src/shared/types.ts + ui/src/types.ts)
+
+Add three new optional fields:
+
+```typescript
+export interface ZoneAggregatedData {
+  // ... existing fields ...
+  sunrise: string | null; // "HH:mm" format, e.g. "07:23"
+  sunset: string | null; // "HH:mm" format, e.g. "20:45"
+  isDaylight: boolean | null; // true between sunrise+offset and sunset-offset
+}
+```
+
+These fields are **only populated on the root zone** — child zones inherit them from the root via the existing aggregation chain.
+
+### Settings (SQLite settings table)
+
+New keys (stored as strings in existing `settings` table):
+
+| Key                  | Example value |
+| -------------------- | ------------- |
+| `home.latitude`      | `"48.8566"`   |
+| `home.longitude`     | `"2.3522"`    |
+| `home.sunriseOffset` | `"30"`        |
+| `home.sunsetOffset`  | `"45"`        |
+
+No migration needed — settings table is key-value.
+
+## New Module: SunlightManager
+
+**File:** `src/zones/sunlight-manager.ts`
+
+Responsibilities:
+
+- Read location settings from SettingsManager
+- Compute sunrise/sunset using `suncalc`
+- Maintain current `isDaylight` state
+- Check for transitions every 60 seconds
+- Emit `zone.data.changed` on the root zone when `isDaylight` transitions
+
+### Lifecycle
+
+```
+Engine startup
+  → SunlightManager.start()
+    → Read settings (lat, lon, offsets)
+    → Compute today's sunrise/sunset
+    → Compute current isDaylight
+    → Start 60-second interval timer
+
+Every 60 seconds:
+  → Recompute isDaylight
+  → If changed → emit zone.data.changed for root zone
+
+Midnight (detected by date change in interval):
+  → Recompute sunrise/sunset for new day
+
+Settings changed:
+  → eventBus "settings.changed" → recompute everything
+```
+
+### Public API
+
+```typescript
+class SunlightManager {
+  start(): void;
+  stop(): void;
+  getSunlightData(): { sunrise: string | null; sunset: string | null; isDaylight: boolean | null };
+}
+```
+
+## Integration with Zone Aggregator
+
+**File:** `src/zones/zone-aggregator.ts`
+
+The aggregator already computes `ZoneAggregatedData` for each zone. For the root zone, it will call `sunlightManager.getSunlightData()` and merge the result.
+
+**Change:** In `accumulatorToPublic()` (or equivalent), when building root zone data:
+
+```typescript
+if (zoneId === ROOT_ZONE_ID) {
+  const sunlight = this.sunlightManager.getSunlightData();
+  data.sunrise = sunlight.sunrise;
+  data.sunset = sunlight.sunset;
+  data.isDaylight = sunlight.isDaylight;
+}
+```
+
+## Event Flow
+
+```
+SunlightManager (isDaylight transitions)
+  → eventBus: "zone.data.changed" { zoneId: ROOT_ZONE_ID, data: { ...existing, sunrise, sunset, isDaylight } }
+    → WebSocket broadcast to UI clients
+    → Recipe engine evaluates conditions (isDaylight changed)
+```
+
+## API Changes
+
+No new endpoints. Data flows through existing:
+
+- `GET /api/v1/zones/aggregation` — root zone entry now includes sunrise/sunset/isDaylight
+- WebSocket `zone.data.changed` events include the new fields
+
+## UI Changes
+
+### ZoneAggregationPills (ui/src/components/home/ZoneAggregationPills.tsx)
+
+Add a sunrise/sunset pill (only shown for root zone or when data exists):
+
+```
+☀ 07:23 — 20:45  (Jour)
+```
+
+or
+
+```
+☾ 07:23 — 20:45  (Nuit)
+```
+
+- Icon: `Sunrise` / `Moon` from Lucide
+- Color: warm yellow for day, blue-grey for night
+- Format: sunrise — sunset with day/night label
+
+### Settings Page
+
+Add a "Home" section in Administration > Settings with:
+
+- Latitude (number input)
+- Longitude (number input)
+- Sunrise offset in minutes (number input, default 30)
+- Sunset offset in minutes (number input, default 45)
+
+## File Changes
+
+| File                                              | Change                                                  |
+| ------------------------------------------------- | ------------------------------------------------------- |
+| `package.json`                                    | Add `suncalc` dependency                                |
+| `src/shared/types.ts`                             | Add sunrise/sunset/isDaylight to ZoneAggregatedData     |
+| `ui/src/types.ts`                                 | Mirror ZoneAggregatedData changes                       |
+| `src/zones/sunlight-manager.ts`                   | **NEW** — sunrise/sunset computation + isDaylight timer |
+| `src/zones/zone-aggregator.ts`                    | Inject sunlight data into root zone aggregation         |
+| `src/index.ts`                                    | Create and start SunlightManager                        |
+| `ui/src/components/home/ZoneAggregationPills.tsx` | Add sunrise/sunset pill                                 |
+| `ui/src/pages/SettingsPage.tsx` (or equivalent)   | Add home location settings                              |
+| `ui/src/i18n/locales/fr.json`                     | Labels for new settings + aggregation pill              |
+| `ui/src/i18n/locales/en.json`                     | Labels for new settings + aggregation pill              |

--- a/specs/023-sunrise-sunset/plan.md
+++ b/specs/023-sunrise-sunset/plan.md
@@ -1,0 +1,21 @@
+# Implementation Plan: Sunrise/Sunset
+
+## Tasks
+
+1. [ ] Install `suncalc` dependency
+2. [ ] Add `sunrise`, `sunset`, `isDaylight` to `ZoneAggregatedData` in `src/shared/types.ts` + `ui/src/types.ts`
+3. [ ] Create `src/zones/sunlight-manager.ts` — compute sunrise/sunset, manage isDaylight transitions
+4. [ ] Wire SunlightManager into `src/index.ts` (create, start, pass to zone-aggregator)
+5. [ ] Modify `src/zones/zone-aggregator.ts` — inject sunlight data into root zone aggregation output
+6. [ ] Add home settings section in UI Settings page (lat, lon, sunriseOffset, sunsetOffset)
+7. [ ] Add sunrise/sunset pill in `ZoneAggregationPills.tsx`
+8. [ ] Add i18n keys (fr + en)
+9. [ ] Build + test
+
+## Testing
+
+- Configure location (Paris: 48.8566, 2.3522)
+- Verify `GET /api/v1/zones/aggregation` returns sunrise/sunset/isDaylight for root zone
+- Verify WebSocket emits `zone.data.changed` when isDaylight transitions
+- Verify UI shows sunrise/sunset pill on home page
+- Verify null values when no location configured

--- a/specs/023-sunrise-sunset/spec.md
+++ b/specs/023-sunrise-sunset/spec.md
@@ -1,0 +1,57 @@
+# Sunrise/Sunset — Home Daylight Awareness
+
+## Summary
+
+Compute sunrise and sunset times based on the home's geographic location. Expose these values (plus a configurable `isDaylight` boolean) in the root zone's aggregated data. This enables recipes to use daylight as a condition without requiring a lux sensor.
+
+## Why
+
+- Many rooms don't have a luminosity sensor
+- Recipes like "turn on lights at dusk" or "close shutters at night" need a daylight signal
+- The `isDaylight` flag with configurable offsets is more practical than raw sunrise/sunset times: it accounts for the fact that it's already dark well before sunset and still dark after sunrise
+
+## Acceptance Criteria
+
+- [ ] Home location (latitude, longitude) configurable via Administration > Settings UI
+- [ ] Sunrise offset and sunset offset (minutes) configurable via Settings UI
+- [ ] `sunrise`, `sunset` (HH:mm format), and `isDaylight` (boolean) available in root zone aggregated data
+- [ ] `isDaylight` transitions emit `zone.data.changed` events (enabling recipe conditions)
+- [ ] `isDaylight = true` when `now > sunrise + sunriseOffset AND now < sunset - sunsetOffset`
+- [ ] Values recomputed daily at midnight and on settings change
+- [ ] `isDaylight` checked every minute for transitions
+- [ ] UI displays sunrise/sunset in ZoneAggregationPills for root zone
+- [ ] Works without location configured (fields are null, no errors)
+
+## Scope
+
+### In Scope
+
+- Location settings (lat, lon, sunrise offset, sunset offset)
+- Daily sunrise/sunset computation (library: `suncalc`)
+- `isDaylight` boolean with configurable offsets
+- Root zone aggregated data enrichment
+- ZoneAggregationPills UI display
+- Recipe conditions can reference `isDaylight`
+
+### Out of Scope
+
+- Temporal triggers ("at sunrise", "30 min before sunset") — deferred
+- Dawn/dusk/solar noon/golden hour — future enhancement
+- Weather-based cloud cover adjustment
+- Per-zone location (single home location only)
+
+## Edge Cases
+
+- No location configured → `sunrise`, `sunset`, `isDaylight` all null
+- Polar regions (midnight sun / polar night) → `suncalc` handles this correctly
+- Settings changed mid-day → immediate recomputation
+- Engine restart → immediate computation on startup
+
+## Settings
+
+| Key                  | Label                | Type   | Default | Description                                  |
+| -------------------- | -------------------- | ------ | ------- | -------------------------------------------- |
+| `home.latitude`      | Latitude             | number | —       | Geographic latitude (e.g. 48.8566)           |
+| `home.longitude`     | Longitude            | number | —       | Geographic longitude (e.g. 2.3522)           |
+| `home.sunriseOffset` | Sunrise offset (min) | number | 30      | Minutes after sunrise before isDaylight=true |
+| `home.sunsetOffset`  | Sunset offset (min)  | number | 45      | Minutes before sunset when isDaylight=false  |

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -1,14 +1,16 @@
 import type { FastifyInstance } from "fastify";
 import type { Logger } from "../../core/logger.js";
+import type { EventBus } from "../../core/event-bus.js";
 import type { SettingsManager } from "../../core/settings-manager.js";
 
 interface SettingsDeps {
   settingsManager: SettingsManager;
+  eventBus: EventBus;
   logger: Logger;
 }
 
 export function registerSettingsRoutes(app: FastifyInstance, deps: SettingsDeps): void {
-  const { settingsManager, logger: parentLogger } = deps;
+  const { settingsManager, eventBus, logger: parentLogger } = deps;
   const logger = parentLogger.child({ module: "settings-routes" });
 
   // GET /api/v1/settings — Get all settings (admin only)
@@ -39,7 +41,9 @@ export function registerSettingsRoutes(app: FastifyInstance, deps: SettingsDeps)
     }
 
     settingsManager.setMany(entries);
-    logger.info({ keys: Object.keys(entries) }, "Settings updated");
+    const keys = Object.keys(entries);
+    logger.info({ keys }, "Settings updated");
+    eventBus.emit({ type: "settings.changed", keys });
 
     return { success: true };
   });

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -114,7 +114,7 @@ export async function createServer(deps: ServerDeps) {
   registerModeRoutes(app, { modeManager, buttonActionManager, logger });
   registerCalendarRoutes(app, { calendarManager, logger });
   registerBackupRoutes(app, { db, logger });
-  registerSettingsRoutes(app, { settingsManager, logger });
+  registerSettingsRoutes(app, { settingsManager, eventBus, logger });
   registerIntegrationRoutes(app, { integrationRegistry, settingsManager, logger });
   registerButtonActionRoutes(app, { buttonActionManager, logger });
   registerLogRoutes(app, { logBuffer, logger });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { DeviceManager } from "./devices/device-manager.js";
 import { ZoneManager } from "./zones/zone-manager.js";
 import { EquipmentManager } from "./equipments/equipment-manager.js";
 import { ZoneAggregator } from "./zones/zone-aggregator.js";
+import { SunlightManager } from "./zones/sunlight-manager.js";
 import { RecipeManager } from "./recipes/engine/recipe-manager.js";
 import { MotionLightRecipe } from "./recipes/motion-light.js";
 import { SwitchLightRecipe } from "./recipes/switch-light.js";
@@ -109,8 +110,10 @@ async function main() {
     logger,
   );
 
-  // 10. Create Zone Aggregator
+  // 10. Create Zone Aggregator + Sunlight Manager
   const zoneAggregator = new ZoneAggregator(zoneManager, equipmentManager, eventBus, logger);
+  const sunlightManager = new SunlightManager(settingsManager, eventBus, logger);
+  zoneAggregator.setSunlightManager(sunlightManager);
 
   // 11. Create Recipe Manager
   const recipeManager = new RecipeManager(
@@ -173,7 +176,10 @@ async function main() {
     `Winch API listening on http://${config.api.host}:${config.api.port}`,
   );
 
-  // 16. Emit system started event (triggers zone aggregation compute)
+  // 16. Start Sunlight Manager (before system.started so aggregation has sunlight data)
+  sunlightManager.start();
+
+  // 17. Emit system started event (triggers zone aggregation compute)
   eventBus.emit({ type: "system.started" });
 
   // 17. Initialize recipe manager (restore persisted instances — after aggregation is ready)
@@ -193,6 +199,11 @@ async function main() {
   // Graceful shutdown — each step is isolated so one failure doesn't block the rest
   const shutdown = async () => {
     logger.info("Shutting down...");
+    try {
+      sunlightManager.stop();
+    } catch (err) {
+      logger.error({ err }, "Error stopping sunlight manager");
+    }
     try {
       calendarManager.stopAll();
     } catch (err) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -135,6 +135,9 @@ export interface ZoneAggregatedData {
   shuttersOpen: number;
   shuttersTotal: number;
   averageShutterPosition: number | null;
+  sunrise: string | null;
+  sunset: string | null;
+  isDaylight: boolean | null;
 }
 
 // ============================================================
@@ -451,6 +454,10 @@ export type EngineEvent =
   | { type: "mode.deactivated"; modeId: string; modeName: string }
   // Calendar events
   | { type: "calendar.profile.changed"; profileId: string; profileName: string }
+  // Settings events
+  | { type: "settings.changed"; keys: string[] }
+  // Sunlight events
+  | { type: "sunlight.changed" }
   // System events
   | { type: "system.started" }
   | { type: "system.integration.connected"; integrationId: string }

--- a/src/zones/sunlight-manager.ts
+++ b/src/zones/sunlight-manager.ts
@@ -1,0 +1,169 @@
+import SunCalc from "suncalc";
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { SettingsManager } from "../core/settings-manager.js";
+
+export interface SunlightData {
+  sunrise: string | null;
+  sunset: string | null;
+  isDaylight: boolean | null;
+}
+
+export class SunlightManager {
+  private logger: Logger;
+  private eventBus: EventBus;
+  private settingsManager: SettingsManager;
+
+  private currentData: SunlightData = { sunrise: null, sunset: null, isDaylight: null };
+  private lastComputedDate: string | null = null;
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(settingsManager: SettingsManager, eventBus: EventBus, logger: Logger) {
+    this.settingsManager = settingsManager;
+    this.eventBus = eventBus;
+    this.logger = logger.child({ module: "sunlight-manager" });
+  }
+
+  start(): void {
+    this.compute();
+
+    // Check isDaylight every 60 seconds and detect date changes
+    this.intervalId = setInterval(() => {
+      this.tick();
+    }, 60_000);
+
+    // React to settings changes
+    this.unsubscribe = this.eventBus.onType("settings.changed", (event) => {
+      const relevant = event.keys.some((k) => k.startsWith("home."));
+      if (relevant) {
+        this.logger.info("Home settings changed, recomputing sunlight");
+        this.compute();
+      }
+    });
+
+    this.logger.info(
+      {
+        sunrise: this.currentData.sunrise,
+        sunset: this.currentData.sunset,
+        isDaylight: this.currentData.isDaylight,
+      },
+      "Sunlight manager started",
+    );
+  }
+
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+  }
+
+  getSunlightData(): SunlightData {
+    return this.currentData;
+  }
+
+  private getSettings(): {
+    latitude: number;
+    longitude: number;
+    sunriseOffset: number;
+    sunsetOffset: number;
+  } | null {
+    const lat = this.settingsManager.get("home.latitude");
+    const lon = this.settingsManager.get("home.longitude");
+    if (!lat || !lon) return null;
+
+    const latitude = parseFloat(lat);
+    const longitude = parseFloat(lon);
+    if (isNaN(latitude) || isNaN(longitude)) return null;
+
+    const sunriseOffsetRaw = this.settingsManager.get("home.sunriseOffset");
+    const sunsetOffsetRaw = this.settingsManager.get("home.sunsetOffset");
+    const sunriseOffset = sunriseOffsetRaw ? parseInt(sunriseOffsetRaw, 10) : 30;
+    const sunsetOffset = sunsetOffsetRaw ? parseInt(sunsetOffsetRaw, 10) : 45;
+
+    return {
+      latitude,
+      longitude,
+      sunriseOffset: isNaN(sunriseOffset) ? 30 : sunriseOffset,
+      sunsetOffset: isNaN(sunsetOffset) ? 45 : sunsetOffset,
+    };
+  }
+
+  private compute(): void {
+    const settings = this.getSettings();
+    if (!settings) {
+      const changed =
+        this.currentData.sunrise !== null ||
+        this.currentData.sunset !== null ||
+        this.currentData.isDaylight !== null;
+      this.currentData = { sunrise: null, sunset: null, isDaylight: null };
+      this.lastComputedDate = null;
+      if (changed) {
+        this.eventBus.emit({ type: "sunlight.changed" });
+      }
+      return;
+    }
+
+    const now = new Date();
+    const times = SunCalc.getTimes(now, settings.latitude, settings.longitude);
+
+    const sunrise = this.formatTime(times.sunrise);
+    const sunset = this.formatTime(times.sunset);
+
+    // isDaylight: true when now > sunrise + sunriseOffset AND now < sunset - sunsetOffset
+    const sunriseWithOffset = new Date(times.sunrise.getTime() + settings.sunriseOffset * 60_000);
+    const sunsetWithOffset = new Date(times.sunset.getTime() - settings.sunsetOffset * 60_000);
+    const isDaylight = now >= sunriseWithOffset && now < sunsetWithOffset;
+
+    const prev = this.currentData;
+    this.currentData = { sunrise, sunset, isDaylight };
+    this.lastComputedDate = this.dateKey(now);
+
+    if (prev.sunrise !== sunrise || prev.sunset !== sunset || prev.isDaylight !== isDaylight) {
+      this.eventBus.emit({ type: "sunlight.changed" });
+    }
+  }
+
+  private tick(): void {
+    const now = new Date();
+    const todayKey = this.dateKey(now);
+
+    // Date changed — recompute sunrise/sunset for new day
+    if (this.lastComputedDate && this.lastComputedDate !== todayKey) {
+      this.logger.debug("New day detected, recomputing sunrise/sunset");
+      this.compute();
+      return;
+    }
+
+    // Check isDaylight transition
+    const settings = this.getSettings();
+    if (!settings || !this.currentData.sunrise || !this.currentData.sunset) return;
+
+    const times = SunCalc.getTimes(now, settings.latitude, settings.longitude);
+    const sunriseWithOffset = new Date(times.sunrise.getTime() + settings.sunriseOffset * 60_000);
+    const sunsetWithOffset = new Date(times.sunset.getTime() - settings.sunsetOffset * 60_000);
+    const isDaylight = now >= sunriseWithOffset && now < sunsetWithOffset;
+
+    if (isDaylight !== this.currentData.isDaylight) {
+      this.logger.info(
+        { isDaylight, previous: this.currentData.isDaylight },
+        "Daylight state changed",
+      );
+      this.currentData = { ...this.currentData, isDaylight };
+      this.eventBus.emit({ type: "sunlight.changed" });
+    }
+  }
+
+  private formatTime(date: Date): string {
+    const h = String(date.getHours()).padStart(2, "0");
+    const m = String(date.getMinutes()).padStart(2, "0");
+    return `${h}:${m}`;
+  }
+
+  private dateKey(date: Date): string {
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+  }
+}

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -145,6 +145,9 @@ describe("ZoneAggregator", () => {
         shuttersOpen: 0,
         shuttersTotal: 0,
         averageShutterPosition: null,
+        sunrise: null,
+        sunset: null,
+        isDaylight: null,
       });
     });
 

--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -2,12 +2,14 @@ import type { Logger } from "../core/logger.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { ZoneManager } from "./zone-manager.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import type { SunlightManager } from "./sunlight-manager.js";
 import type {
   DataCategory,
   ZoneAggregatedData,
   DataBindingWithValue,
   Zone,
 } from "../shared/types.js";
+import { ROOT_ZONE_ID } from "../shared/constants.js";
 
 // ============================================================
 // Internal accumulator for aggregation (tracks sums + counts)
@@ -105,6 +107,9 @@ function accumulatorToPublic(acc: Accumulator): ZoneAggregatedData {
       acc.shutterPositionCount > 0
         ? Math.round(acc.shutterPositionSum / acc.shutterPositionCount)
         : null,
+    sunrise: null,
+    sunset: null,
+    isDaylight: null,
   };
 }
 
@@ -126,7 +131,10 @@ function aggregatedDataEqual(a: ZoneAggregatedData, b: ZoneAggregatedData): bool
     a.lightsTotal === b.lightsTotal &&
     a.shuttersOpen === b.shuttersOpen &&
     a.shuttersTotal === b.shuttersTotal &&
-    a.averageShutterPosition === b.averageShutterPosition
+    a.averageShutterPosition === b.averageShutterPosition &&
+    a.sunrise === b.sunrise &&
+    a.sunset === b.sunset &&
+    a.isDaylight === b.isDaylight
   );
 }
 
@@ -169,6 +177,7 @@ export class ZoneAggregator {
   private eventBus: EventBus;
   private zoneManager: ZoneManager;
   private equipmentManager: EquipmentManager;
+  private sunlightManager: SunlightManager | null = null;
   private unsubscribe: (() => void) | null = null;
 
   // Cache: per-zone accumulators and public data
@@ -188,6 +197,10 @@ export class ZoneAggregator {
     this.logger = logger.child({ module: "zone-aggregator" });
 
     this.setupEventListeners();
+  }
+
+  setSunlightManager(sunlightManager: SunlightManager): void {
+    this.sunlightManager = sunlightManager;
   }
 
   destroy(): void {
@@ -260,6 +273,7 @@ export class ZoneAggregator {
       const pub = accumulatorToPublic(merged);
       const oldPub = this.publicCache.get(zoneId);
       pub.motionSince = resolveMotionSince(pub, oldPub, now);
+      this.injectSunlightData(zoneId, pub);
       this.publicCache.set(zoneId, pub);
       computed.add(zoneId);
     };
@@ -294,6 +308,9 @@ export class ZoneAggregator {
           case "zone.updated":
           case "zone.removed":
             this.computeAll();
+            break;
+          case "sunlight.changed":
+            this.recomputeZoneChain(ROOT_ZONE_ID);
             break;
           case "system.started":
             this.computeAll();
@@ -365,6 +382,7 @@ export class ZoneAggregator {
 
       // Resolve motionSince before equality check
       newPublic.motionSince = resolveMotionSince(newPublic, oldPublic, now);
+      this.injectSunlightData(currentId, newPublic);
 
       if (!oldPublic || !aggregatedDataEqual(oldPublic, newPublic)) {
         this.publicCache.set(currentId, newPublic);
@@ -384,6 +402,17 @@ export class ZoneAggregator {
 
       currentId = zone.parentId;
     }
+  }
+
+  /**
+   * Inject sunlight data into root zone aggregation.
+   */
+  private injectSunlightData(zoneId: string, data: ZoneAggregatedData): void {
+    if (zoneId !== ROOT_ZONE_ID || !this.sunlightManager) return;
+    const sunlight = this.sunlightManager.getSunlightData();
+    data.sunrise = sunlight.sunrise;
+    data.sunset = sunlight.sunset;
+    data.isDaylight = sunlight.isDaylight;
   }
 
   /**

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -3,13 +3,16 @@ import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Sidebar } from "./Sidebar";
 import { ConnectionStatus } from "./ConnectionStatus";
+import { SunlightBanner } from "./SunlightBanner";
 import { useWebSocket } from "../../store/useWebSocket";
 import { useDevices } from "../../store/useDevices";
 import { useZones } from "../../store/useZones";
 import { useEquipments } from "../../store/useEquipments";
+import { useZoneAggregation } from "../../store/useZoneAggregation";
 import { useAuth } from "../../store/useAuth";
 import { LogOut, User } from "lucide-react";
 import { WinchLogo } from "./WinchLogo";
+import { ROOT_ZONE_ID } from "../../lib/constants";
 
 export function AppLayout() {
   const { t } = useTranslation();
@@ -20,14 +23,17 @@ export function AppLayout() {
   const fetchEquipments = useEquipments((s) => s.fetchEquipments);
   const user = useAuth((s) => s.user);
   const logout = useAuth((s) => s.logout);
+  const fetchAggregation = useZoneAggregation((s) => s.fetchAggregation);
+  const rootAgg = useZoneAggregation((s) => s.data[ROOT_ZONE_ID]);
 
   useEffect(() => {
     fetchDevices();
     fetchZones();
     fetchEquipments();
+    fetchAggregation();
     connect();
     return () => disconnect();
-  }, [fetchDevices, fetchZones, fetchEquipments, connect, disconnect]);
+  }, [fetchDevices, fetchZones, fetchEquipments, fetchAggregation, connect, disconnect]);
 
   return (
     <div className="flex h-screen overflow-hidden">
@@ -45,6 +51,10 @@ export function AppLayout() {
             <div className="flex md:hidden items-center gap-2">
               <WinchLogo size={28} />
               <span className="font-semibold text-[15px] text-text">{t("app.name")}</span>
+            </div>
+            {/* Sunlight banner — visible on desktop */}
+            <div className="hidden md:block">
+              <SunlightBanner data={rootAgg} />
             </div>
           </div>
 

--- a/ui/src/components/layout/SunlightBanner.tsx
+++ b/ui/src/components/layout/SunlightBanner.tsx
@@ -1,0 +1,35 @@
+import { useTranslation } from "react-i18next";
+import { Sunrise, Moon } from "lucide-react";
+import type { ZoneAggregatedData } from "../../types";
+
+interface SunlightBannerProps {
+  data: ZoneAggregatedData | undefined;
+}
+
+export function SunlightBanner({ data }: SunlightBannerProps) {
+  const { t } = useTranslation();
+
+  if (!data || data.sunrise === null || data.sunset === null) return null;
+
+  const isDay = data.isDaylight === true;
+
+  return (
+    <div
+      className={`
+        flex items-center gap-2 px-3 py-1.5 rounded-[8px]
+        text-[13px] font-medium tabular-nums
+        ${isDay
+          ? "bg-accent/10 text-accent"
+          : "bg-primary/10 text-primary"
+        }
+      `}
+    >
+      {isDay
+        ? <Sunrise size={15} strokeWidth={1.5} />
+        : <Moon size={15} strokeWidth={1.5} />
+      }
+      <span>{data.sunrise} — {data.sunset}</span>
+      <span className="text-[11px] opacity-70">{isDay ? t("aggregation.daylight") : t("aggregation.night")}</span>
+    </div>
+  );
+}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -272,6 +272,8 @@
   "aggregation.smoke": "Smoke",
   "aggregation.open_one": "{{count}} open",
   "aggregation.open_other": "{{count}} open",
+  "aggregation.daylight": "Day",
+  "aggregation.night": "Night",
 
   "time.min": "min",
   "time.hour": "h",
@@ -399,6 +401,14 @@
   "settings.enabled": "Enabled",
   "settings.deleteUserConfirm": "Delete user \"{{name}}\"?",
   "settings.cannotDeleteSelf": "Cannot delete your own account",
+  "settings.home": "Home",
+  "settings.homeDescription": "Geographic location for sunrise/sunset calculation",
+  "settings.latitude": "Latitude",
+  "settings.longitude": "Longitude",
+  "settings.sunriseOffset": "Sunrise offset (min)",
+  "settings.sunsetOffset": "Sunset offset (min)",
+  "settings.sunriseOffsetHelp": "Minutes after sunrise before considering it daylight",
+  "settings.sunsetOffsetHelp": "Minutes before sunset to anticipate night",
 
   "backup.title": "Backup / Restore",
   "backup.description": "Export or import the full Winch configuration (zones, devices, equipments, users, recipes, integrations).",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -272,6 +272,8 @@
   "aggregation.smoke": "Fumée",
   "aggregation.open_one": "{{count}} ouvert(e)",
   "aggregation.open_other": "{{count}} ouvert(e)s",
+  "aggregation.daylight": "Jour",
+  "aggregation.night": "Nuit",
 
   "time.min": "min",
   "time.hour": "h",
@@ -399,6 +401,14 @@
   "settings.enabled": "Actif",
   "settings.deleteUserConfirm": "Supprimer l'utilisateur « {{name}} » ?",
   "settings.cannotDeleteSelf": "Vous ne pouvez pas supprimer votre propre compte",
+  "settings.home": "Maison",
+  "settings.homeDescription": "Localisation géographique pour le calcul lever/coucher du soleil",
+  "settings.latitude": "Latitude",
+  "settings.longitude": "Longitude",
+  "settings.sunriseOffset": "Décalage lever (min)",
+  "settings.sunsetOffset": "Décalage coucher (min)",
+  "settings.sunriseOffsetHelp": "Minutes après le lever avant de considérer qu'il fait jour",
+  "settings.sunsetOffsetHelp": "Minutes avant le coucher pour anticiper la nuit",
 
   "backup.title": "Sauvegarde / Restauration",
   "backup.description": "Exportez ou importez la configuration complète de Winch (zones, appareils, équipements, utilisateurs, recettes, intégrations).",

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -12,6 +12,8 @@ import {
   createUser,
   updateUser,
   deleteUser,
+  getSettings,
+  updateSettings,
 } from "../api";
 import { setTheme } from "../theme";
 import type { ThemeSetting } from "../theme";
@@ -38,8 +40,9 @@ export function SettingsPage() {
 
       {/* Two-column grid on desktop, single column on mobile */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Left column: Profile + Preferences + Password */}
+        {/* Left column: Home + Profile + Preferences + Password */}
         <div className="space-y-6">
+          {isAdmin && <HomeSettingsSection />}
           <ProfileSection user={user} onSave={async (displayName) => {
             await updateMe({ displayName });
             await fetchMe();
@@ -73,6 +76,134 @@ export function SettingsPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+// ============================================================
+// Home Settings (location + sunlight offsets)
+// ============================================================
+
+function HomeSettingsSection() {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [latitude, setLatitude] = useState("");
+  const [longitude, setLongitude] = useState("");
+  const [sunriseOffset, setSunriseOffset] = useState("30");
+  const [sunsetOffset, setSunsetOffset] = useState("45");
+  const [initial, setInitial] = useState({ latitude: "", longitude: "", sunriseOffset: "30", sunsetOffset: "45" });
+
+  useEffect(() => {
+    getSettings().then((all) => {
+      const lat = all["home.latitude"] ?? "";
+      const lon = all["home.longitude"] ?? "";
+      const sr = all["home.sunriseOffset"] ?? "30";
+      const ss = all["home.sunsetOffset"] ?? "45";
+      setLatitude(lat);
+      setLongitude(lon);
+      setSunriseOffset(sr);
+      setSunsetOffset(ss);
+      setInitial({ latitude: lat, longitude: lon, sunriseOffset: sr, sunsetOffset: ss });
+    }).finally(() => setLoading(false));
+  }, []);
+
+  const dirty = latitude !== initial.latitude || longitude !== initial.longitude
+    || sunriseOffset !== initial.sunriseOffset || sunsetOffset !== initial.sunsetOffset;
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await updateSettings({
+        "home.latitude": latitude,
+        "home.longitude": longitude,
+        "home.sunriseOffset": sunriseOffset,
+        "home.sunsetOffset": sunsetOffset,
+      });
+      setInitial({ latitude, longitude, sunriseOffset, sunsetOffset });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <section className="bg-surface rounded-[10px] border border-border p-5">
+        <h2 className="text-[14px] font-semibold text-text mb-4">{t("settings.home")}</h2>
+        <Loader2 size={16} className="animate-spin text-text-tertiary" />
+      </section>
+    );
+  }
+
+  return (
+    <section className="bg-surface rounded-[10px] border border-border p-5">
+      <h2 className="text-[14px] font-semibold text-text mb-1">{t("settings.home")}</h2>
+      <p className="text-[12px] text-text-tertiary mb-4">{t("settings.homeDescription")}</p>
+      <div className="space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+              {t("settings.latitude")}
+            </label>
+            <input
+              type="number"
+              step="any"
+              value={latitude}
+              onChange={(e) => setLatitude(e.target.value)}
+              placeholder="48.8566"
+              className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text placeholder:text-text-tertiary focus:outline-none focus:border-primary"
+            />
+          </div>
+          <div>
+            <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+              {t("settings.longitude")}
+            </label>
+            <input
+              type="number"
+              step="any"
+              value={longitude}
+              onChange={(e) => setLongitude(e.target.value)}
+              placeholder="2.3522"
+              className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text placeholder:text-text-tertiary focus:outline-none focus:border-primary"
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+              {t("settings.sunriseOffset")}
+            </label>
+            <input
+              type="number"
+              value={sunriseOffset}
+              onChange={(e) => setSunriseOffset(e.target.value)}
+              className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text focus:outline-none focus:border-primary"
+            />
+            <p className="text-[11px] text-text-tertiary mt-1">{t("settings.sunriseOffsetHelp")}</p>
+          </div>
+          <div>
+            <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+              {t("settings.sunsetOffset")}
+            </label>
+            <input
+              type="number"
+              value={sunsetOffset}
+              onChange={(e) => setSunsetOffset(e.target.value)}
+              className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text focus:outline-none focus:border-primary"
+            />
+            <p className="text-[11px] text-text-tertiary mt-1">{t("settings.sunsetOffsetHelp")}</p>
+          </div>
+        </div>
+        {dirty && (
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="px-4 py-2 text-[13px] font-medium bg-primary text-white rounded-[6px] hover:bg-primary-hover transition-colors disabled:opacity-50"
+          >
+            {saving ? t("common.saving") : t("common.save")}
+          </button>
+        )}
+      </div>
+    </section>
   );
 }
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -130,6 +130,9 @@ export interface ZoneAggregatedData {
   shuttersOpen: number;
   shuttersTotal: number;
   averageShutterPosition: number | null;
+  sunrise: string | null;
+  sunset: string | null;
+  isDaylight: boolean | null;
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
- Compute sunrise/sunset times from home geographic coordinates using `suncalc`
- Expose `sunrise` (HH:mm), `sunset` (HH:mm), and `isDaylight` (boolean with configurable offsets) in root zone aggregated data
- Display a sunlight banner in the top bar header, visible across all zones

## Changes
- **Backend**: `SunlightManager` — computes via suncalc, 60s interval, reacts to `settings.changed` events
- **Events**: new `settings.changed` and `sunlight.changed` event types in `EngineEvent`
- **ZoneAggregator**: injects sunlight data into root zone aggregation
- **Settings API**: emits `settings.changed` event on save
- **UI**: `SunlightBanner` component in AppLayout header (sunrise icon for day, moon icon for night)
- **UI**: `HomeSettingsSection` in settings page (latitude, longitude, sunrise/sunset offsets)
- **i18n**: daylight/night labels and settings labels (fr + en)
- **Spec**: `specs/023-sunrise-sunset/`

## Test plan
- [x] TypeScript compiles (zero errors backend + frontend)
- [x] All 383 tests pass
- [x] ESLint + Prettier pass
- [x] UI typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)