### PR TITLE
feat: V0.13 — InfluxDB historization foundation (IT1)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,5 +13,24 @@ services:
     #   API_PORT: 3000
     #   LOG_LEVEL: info
 
+  # InfluxDB 2.x — optional time-series backend for data history (V0.13)
+  # Configure connection in Winch Settings > InfluxDB after first start.
+  influxdb:
+    image: influxdb:2.7
+    container_name: winch-influxdb
+    restart: unless-stopped
+    ports:
+      - "8086:8086"
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=winch
+      - DOCKER_INFLUXDB_INIT_PASSWORD=winch-secret
+      - DOCKER_INFLUXDB_INIT_ORG=winch
+      - DOCKER_INFLUXDB_INIT_BUCKET=winch
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=winch-dev-token
+
 volumes:
   winch-data:
+  influxdb-data:

--- a/docs/equipment-types.md
+++ b/docs/equipment-types.md
@@ -455,30 +455,66 @@ This allows simplified UX: a gate toggle with `enumValues: ["latch"]` doesn't re
 
 ## Data Category Reference
 
-Categories drive zone aggregation and UI icon/color selection.
+Categories drive zone aggregation, UI icon/color selection, and history defaults.
 
-| Category           | Type      | Aggregation      | Unit   | Icon            |
-| ------------------ | --------- | ---------------- | ------ | --------------- |
-| `temperature`      | `number`  | AVG              | °C     | Thermometer     |
-| `humidity`         | `number`  | AVG              | %      | Droplets        |
-| `pressure`         | `number`  | —                | hPa    | —               |
-| `luminosity`       | `number`  | AVG              | lux    | Sun             |
-| `motion`           | `boolean` | OR + COUNT       | —      | PersonStanding  |
-| `contact_door`     | `boolean` | COUNT open       | —      | DoorOpen/Closed |
-| `contact_window`   | `boolean` | COUNT open       | —      | DoorOpen/Closed |
-| `light_state`      | `boolean` | COUNT on/total   | —      | Lightbulb       |
-| `light_brightness` | `number`  | —                | 0–254  | SunDim          |
-| `light_color_temp` | `number`  | —                | mireds | —               |
-| `shutter_position` | `number`  | AVG + COUNT open | %      | Blinds          |
-| `battery`          | `number`  | —                | %      | Battery         |
-| `voltage`          | `number`  | —                | V      | —               |
-| `power`            | `number`  | —                | W      | —               |
-| `energy`           | `number`  | —                | kWh    | —               |
-| `water_leak`       | `boolean` | OR               | —      | Droplet         |
-| `smoke`            | `boolean` | OR               | —      | Flame           |
-| `co2`              | `number`  | —                | ppm    | —               |
-| `voc`              | `number`  | —                | —      | —               |
-| `wind`             | `number`  | —                | km/h   | Wind            |
-| `rain`             | `number`  | —                | mm     | CloudRain       |
-| `action`           | `text`    | —                | —      | CircleDot       |
-| `generic`          | any       | —                | —      | —               |
+| Category           | Type      | Aggregation      | Unit   | Icon            | History |
+| ------------------ | --------- | ---------------- | ------ | --------------- | ------- |
+| `temperature`      | `number`  | AVG              | °C     | Thermometer     | ON      |
+| `humidity`         | `number`  | AVG              | %      | Droplets        | ON      |
+| `pressure`         | `number`  | —                | hPa    | —               | ON      |
+| `luminosity`       | `number`  | AVG              | lux    | Sun             | ON      |
+| `motion`           | `boolean` | OR + COUNT       | —      | PersonStanding  | OFF     |
+| `contact_door`     | `boolean` | COUNT open       | —      | DoorOpen/Closed | OFF     |
+| `contact_window`   | `boolean` | COUNT open       | —      | DoorOpen/Closed | OFF     |
+| `light_state`      | `boolean` | COUNT on/total   | —      | Lightbulb       | OFF     |
+| `light_brightness` | `number`  | —                | 0–254  | SunDim          | OFF     |
+| `light_color_temp` | `number`  | —                | mireds | —               | OFF     |
+| `shutter_position` | `number`  | AVG + COUNT open | %      | Blinds          | ON      |
+| `battery`          | `number`  | —                | %      | Battery         | ON      |
+| `voltage`          | `number`  | —                | V      | —               | ON      |
+| `power`            | `number`  | —                | W      | —               | ON      |
+| `energy`           | `number`  | —                | kWh    | —               | ON      |
+| `water_leak`       | `boolean` | OR               | —      | Droplet         | OFF     |
+| `smoke`            | `boolean` | OR               | —      | Flame           | OFF     |
+| `co2`              | `number`  | —                | ppm    | —               | ON      |
+| `voc`              | `number`  | —                | —      | —               | ON      |
+| `wind`             | `number`  | —                | km/h   | Wind            | ON      |
+| `rain`             | `number`  | —                | mm     | CloudRain       | ON      |
+| `action`           | `text`    | —                | —      | CircleDot       | OFF     |
+| `generic`          | any       | —                | —      | —               | OFF     |
+
+---
+
+## History Defaults (V0.13)
+
+When InfluxDB is configured, Winch historizes data bindings using **convention over configuration**. Each binding's effective historize state is resolved in priority order:
+
+1. **Explicit override** (`data_bindings.historize = 1` or `0`) → force ON or OFF
+2. **Alias default** (see below) → handles semantically important bindings in `generic` category
+3. **Category default** (see History column in Data Category Reference above)
+
+If no override and no alias/category match → OFF (manual opt-in required).
+
+### Alias Defaults
+
+Some bindings have category `generic` but are semantically important. These are historized by default based on their alias:
+
+| Alias      | Default | Rationale                                                                                           |
+| ---------- | ------- | --------------------------------------------------------------------------------------------------- |
+| `setpoint` | ON      | Thermostat setpoint — essential for target vs actual temperature analysis                           |
+| `power`    | ON      | HVAC ON/OFF state on thermostats — category is `generic` boolean, but essential for energy analysis |
+
+### Per Equipment Type Summary
+
+| Equipment Type   | Historized by default                              | Not historized (opt-in)                        |
+| ---------------- | -------------------------------------------------- | ---------------------------------------------- |
+| `thermostat`     | temperature, setpoint, outsideTemperature, power   | mode, fanSpeed, ecoMode, deviceState (generic) |
+| `sensor`         | temperature, humidity, pressure, co2, voc, battery | motion, contact, water_leak, smoke             |
+| `weather`        | temperature, humidity, pressure, wind*\*, rain*\*  | —                                              |
+| `shutter`        | position                                           | —                                              |
+| `light_onoff`    | —                                                  | state (light_state)                            |
+| `light_dimmable` | —                                                  | state, brightness                              |
+| `light_color`    | —                                                  | state, brightness, color_temp                  |
+| `gate`           | —                                                  | state (gate_state)                             |
+| `button`         | —                                                  | action                                         |
+| `switch`         | —                                                  | state (light_state)                            |

--- a/migrations/020_history.sql
+++ b/migrations/020_history.sql
@@ -1,0 +1,4 @@
+-- V0.13: InfluxDB History — add historize flag to data_bindings
+-- NULL = use category/alias default, 1 = force ON, 0 = force OFF
+
+ALTER TABLE data_bindings ADD COLUMN historize INTEGER DEFAULT NULL;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fastify/rate-limit": "^10.3.0",
         "@fastify/static": "^9.0.0",
         "@fastify/websocket": "^11.0.1",
+        "@influxdata/influxdb-client": "^1.35.0",
         "bcrypt": "^6.0.0",
         "better-sqlite3": "^11.7.0",
         "croner": "^10.0.1",
@@ -985,6 +986,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@influxdata/influxdb-client": {
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@influxdata/influxdb-client/-/influxdb-client-1.35.0.tgz",
+      "integrity": "sha512-woWMi8PDpPQpvTsRaUw4Ig+nOGS/CWwAwS66Fa1Vr/EkW+NEwxI8YfPBsdBMn33jK2Y86/qMiiuX/ROHIkJLTw==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",
     "@fastify/websocket": "^11.0.1",
+    "@influxdata/influxdb-client": "^1.35.0",
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^11.7.0",
     "croner": "^10.0.1",

--- a/specs/025-V0.13-history/architecture.md
+++ b/specs/025-V0.13-history/architecture.md
@@ -1,0 +1,385 @@
+# Architecture: V0.13 Data History
+
+## Design Principles
+
+1. **Zero performance impact** — The history writer is a passive observer. It subscribes to events, buffers, and writes asynchronously. It never blocks the event loop or slows down the reactive pipeline.
+2. **Optional dependency** — Winch boots and operates fully without InfluxDB. History features are hidden when not configured.
+3. **Per-binding granularity** — Users opt-in per equipment data binding. No unnecessary storage.
+4. **Iterative UI** — Charts appear progressively: first inline in equipment detail, then sparklines everywhere, then a full analyse page.
+
+## InfluxDB Data Model
+
+### Measurement: `equipment_data`
+
+| Type  | Name         | Description                                    |
+| ----- | ------------ | ---------------------------------------------- |
+| Tag   | equipmentId  | Equipment UUID                                 |
+| Tag   | alias        | Binding alias (e.g. "temperature", "power")    |
+| Tag   | category     | DataCategory (e.g. "temperature", "power")     |
+| Tag   | zoneId       | Zone UUID (for zone-level queries)             |
+| Tag   | type         | DataType ("number", "boolean", "enum", "text") |
+| Field | value_number | Float value (for numeric categories)           |
+| Field | value_string | String value (for boolean/enum/text)           |
+
+### Retention Policies
+
+| Policy | Duration | Resolution  | Created by     |
+| ------ | -------- | ----------- | -------------- |
+| raw    | 7 days   | As received | Default bucket |
+| hourly | 90 days  | 1 hour      | InfluxDB task  |
+| daily  | 5 years  | 1 day       | InfluxDB task  |
+
+Downsampling tasks compute `mean`, `min`, `max`, `count` per window and write to dedicated buckets (`winch-hourly`, `winch-daily`).
+
+## SQLite Changes
+
+### Migration 020: `data_bindings` + `history_settings`
+
+```sql
+-- Add historize flag to existing data_bindings.
+-- NULL = use category default, 1 = force ON, 0 = force OFF.
+ALTER TABLE data_bindings ADD COLUMN historize INTEGER DEFAULT NULL;
+```
+
+**Historize resolution logic** (in HistoryWriter):
+
+1. If `data_bindings.historize` is `1` → always historize
+2. If `data_bindings.historize` is `0` → never historize
+3. If `data_bindings.historize` is `NULL` → use category default
+
+**Default resolution** (convention over configuration):
+
+The HistoryWriter determines the effective historize state in order:
+
+1. `data_bindings.historize = 1` → force ON
+2. `data_bindings.historize = 0` → force OFF
+3. `data_bindings.historize = NULL` → check alias defaults, then category defaults
+
+**Alias defaults** (takes precedence over category — handles cases where category is `generic` but the data is semantically important):
+
+| Alias    | Default | Rationale                                                                                                                                                                                              |
+| -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| setpoint | ON      | Thermostat setpoint — essential for consigne vs actual temperature analysis. Category is `temperature` in practice, but alias default is a safety net.                                                 |
+| power    | ON      | HVAC ON/OFF state on thermostats (PAC, Poêle) — category is `generic` boolean, but knowing when heating ran is essential for energy analysis. Only writes on state transitions (deadband: any change). |
+
+**Category defaults** (based on production audit of 88 bindings across 32 equipments):
+
+| Category                      | Default | Rationale                   | Production examples                                                                                                                     |
+| ----------------------------- | ------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| temperature                   | ON      | Key trend                   | THR temperature, PAC temperature/setpoint/outsideTemperature                                                                            |
+| humidity                      | ON      | Key trend                   | THR humidity, Station Météo humidity                                                                                                    |
+| pressure                      | ON      | Weather trend               | —                                                                                                                                       |
+| luminosity                    | ON      | Day/night cycle             | PIRL illuminance                                                                                                                        |
+| power                         | ON      | Consumption monitoring      | Power meters (number, W)                                                                                                                |
+| energy                        | ON      | Cumulative, essential       | Energy meters (kWh)                                                                                                                     |
+| rain                          | ON      | Weather trend               | Station Météo rain, sum_rain_1, sum_rain_24                                                                                             |
+| wind                          | ON      | Weather trend               | Station Météo wind_strength, gust_strength, wind_angle, gust_angle                                                                      |
+| co2, voc, noise               | ON      | Air quality, health         | —                                                                                                                                       |
+| voltage, current              | ON      | Electrical diagnostic       | —                                                                                                                                       |
+| shutter_position              | ON      | Opening tracking            | Volets position (×10 in production)                                                                                                     |
+| battery                       | ON      | Anticipate replacements     | All sensors battery level (number, %). Note: `battery_low` (boolean) also matches but produces minimal data (2-4 points per lifecycle). |
+| light_state                   | OFF     | Too frequent, recipe-driven | Spots state, Lumière state                                                                                                              |
+| light_brightness              | OFF     | Noisy, recipe-driven        | Spots brightness, Appliques brightness                                                                                                  |
+| light_color_temp, light_color | OFF     | Noisy, recipe-driven        | —                                                                                                                                       |
+| motion                        | OFF     | Ultra-frequent binary       | PIR occupancy (×8 sensors in production)                                                                                                |
+| contact_door, contact_window  | OFF     | Frequent, better as alerts  | —                                                                                                                                       |
+| water_leak, smoke             | OFF     | Rare events, alert-driven   | —                                                                                                                                       |
+| action                        | OFF     | Punctual events (buttons)   | Switch action (×3 in production)                                                                                                        |
+| gate_state                    | OFF     | Rare, alert-driven          | —                                                                                                                                       |
+| generic                       | OFF     | Unknown, manual opt-in      | Thermostat operationMode, fanSpeed, stoveState, etc. — can be enabled per-binding if desired                                            |
+
+InfluxDB connection stored in `settings` table with prefix `history.`:
+
+| Key                   | Example               |
+| --------------------- | --------------------- |
+| history.influx.url    | http://localhost:8086 |
+| history.influx.token  | my-super-secret-token |
+| history.influx.org    | winch                 |
+| history.influx.bucket | winch                 |
+| history.enabled       | true                  |
+
+## Backend Architecture
+
+### New Module: `src/history/`
+
+```
+src/history/
+├── influx-client.ts      # InfluxDB 2.x client wrapper (connect, write, query, health)
+├── history-writer.ts     # Event listener → batch write (fire-and-forget)
+└── history-query.ts      # Query builder (time range, aggregation, multi-series)
+```
+
+### `InfluxClient` (influx-client.ts)
+
+Wraps `@influxdata/influxdb-client` with:
+
+- **connect(settings)** — Initialize client from settings
+- **disconnect()** — Flush pending writes and close
+- **isConnected()** — Health check (ping)
+- **writePoint(point)** — Buffer a single data point
+- **flush()** — Force flush buffered writes
+- **query(flux)** — Execute a Flux query and return rows
+
+Configuration:
+
+- Batch size: 100 points (flush when buffer full)
+- Flush interval: 5 seconds (flush even if buffer not full)
+- Retry: 3 attempts with exponential backoff (1s, 2s, 4s)
+- On persistent failure: log error, drop batch, continue
+
+### `HistoryWriter` (history-writer.ts)
+
+Subscribes to `equipment.data.changed` events:
+
+```
+equipment.data.changed
+  → Is binding historized? (check in-memory cache)
+  → Is InfluxDB configured & connected?
+  → Deduplication: has value changed significantly? (deadband + min interval)
+  → Build InfluxDB point (tags + fields)
+  → Write to InfluxClient buffer (non-blocking)
+```
+
+**Caching**: Keeps an in-memory Set of historized binding IDs (refreshed on equipment changes) to avoid DB lookups on every event.
+
+**Deduplication / Disk Protection**:
+
+The writer maintains a `lastWritten` map per binding: `{ value, timestamp }`. A new point is written only if BOTH conditions are met:
+
+1. **Minimum interval elapsed** (default: 30s, configurable globally via `history.minWriteInterval`)
+   - Prevents high-frequency sensors from flooding the DB
+   - A power meter reporting every second → max 2 points/minute instead of 60
+
+2. **Value changed significantly** (deadband by category):
+   | Category | Deadband | Example |
+   |----------|----------|---------|
+   | temperature | ±0.2 | 21.5→21.6 = skip, 21.5→21.8 = write |
+   | humidity | ±1.0 | 52→53 = skip, 52→54 = write |
+   | luminosity | ±5% | 500→520 = skip, 500→530 = write |
+   | power | ±5W | 100→103 = skip, 100→108 = write |
+   | energy | ±0.01 | Always write (cumulative) |
+   | boolean/enum | any change | ON→ON = skip, ON→OFF = write |
+   | shutter_position | ±2 | 50→51 = skip, 50→53 = write |
+   | default | any change | Write on any value change |
+
+   Deadband values are sensible defaults. Can be overridden per category in settings (`history.deadband.temperature`, etc.).
+
+3. **Force write on state transitions**: regardless of deadband/interval, always write when:
+   - Boolean changes (ON↔OFF, true↔false)
+   - Enum changes (any state transition)
+   - This ensures no state transitions are lost even with aggressive deduplication
+
+**Disk usage estimation** (typical home, 50 historized bindings):
+
+- With deduplication: ~14,400 points/day (~200 KB/day compressed)
+- Raw 7 days: ~1.4 MB
+- Hourly 90 days: ~1.6 MB
+- Daily 5 years: ~1.4 MB
+- **Total steady-state: ~5 MB** — negligible
+
+**Value mapping**:
+
+- `number` → `value_number` field (float)
+- `boolean` → `value_string` field ("true"/"false") + `value_number` (1/0)
+- `enum`/`text` → `value_string` field
+- `null`/`undefined` → skip (don't write null points)
+
+### `HistoryQuery` (history-query.ts)
+
+Builds Flux queries for the API layer:
+
+```typescript
+interface HistoryQueryParams {
+  equipmentId: string;
+  alias: string;
+  from: string; // ISO 8601 or relative (-24h, -7d)
+  to?: string; // ISO 8601, defaults to now()
+  aggregation?: "raw" | "1h" | "1d" | "auto"; // auto picks based on range
+}
+
+interface HistoryPoint {
+  time: string; // ISO 8601
+  value: number;
+  min?: number; // Only for aggregated
+  max?: number; // Only for aggregated
+}
+```
+
+**Auto-aggregation logic**:
+
+- Range ≤ 6h → raw data
+- Range ≤ 7d → 1h aggregation (from hourly bucket)
+- Range > 7d → 1d aggregation (from daily bucket)
+
+## API Endpoints
+
+### History Data
+
+```
+GET /api/v1/history/:equipmentId/:alias
+  Query: from, to, aggregation
+  Response: { points: HistoryPoint[], resolution: "raw"|"1h"|"1d" }
+
+GET /api/v1/history/:equipmentId
+  Response: { aliases: string[] }   // List historized aliases for an equipment
+```
+
+### History Status
+
+```
+GET /api/v1/history/status
+  Response: {
+    configured: boolean,
+    connected: boolean,
+    historizedBindings: number,
+    stats: { pointsWritten24h: number, errors24h: number }
+  }
+```
+
+### History Settings (admin only)
+
+Settings are managed via existing `PUT /api/v1/settings` with `history.*` prefix keys. No new routes needed.
+
+## Event Bus
+
+No new event types needed. The history writer passively consumes:
+
+- `equipment.data.changed` — write data point
+- `equipment.created` / `equipment.updated` / `equipment.removed` — refresh historize cache
+- `settings.changed` — reconnect InfluxDB if config changed
+
+## UI Architecture
+
+### Dependencies
+
+Add to `ui/package.json`:
+
+- `recharts` — React-native charting library (~200KB)
+
+### New Components
+
+```
+ui/src/components/history/
+├── TimeSeriesChart.tsx      # Full chart (Recharts LineChart + tooltip + legend)
+├── Sparkline.tsx            # Tiny inline chart (no axes, no tooltip, 60×24px)
+├── TimeRangeSelector.tsx    # Preset buttons (6h, 24h, 7d, 30d) + custom range
+├── HistoryPanel.tsx         # Expandable chart panel for equipment detail
+├── HistorySection.tsx       # Dedicated collapsible section in equipment detail
+└── AnalyseView.tsx          # Full analyse page content
+```
+
+### New Store
+
+```
+ui/src/store/useHistory.ts
+  - fetchHistory(equipmentId, alias, from, to) → HistoryPoint[]
+  - fetchHistoryStatus() → status object
+  - fetchHistorizeConfig(equipmentId) → binding historize states
+  - setHistorize(equipmentId, bindingId, enabled | null) → toggle
+  - cache: Map<cacheKey, { points, fetchedAt }> with 60s TTL
+```
+
+### Equipment Detail: "Historique" Section
+
+A dedicated collapsible section in equipment detail (between controls and Devices section). Only visible when InfluxDB is configured.
+
+```
+┌─ Historique ──────────────────────────────┐
+│                                            │
+│  Température      [██ ON ]  (défaut)       │
+│  Humidité         [██ ON ]  (défaut)       │
+│  Luminosité       [██ ON ]  (modifié)      │
+│  Mouvement        [  OFF ]  (défaut)       │
+│  Batterie         [██ ON ]  (défaut)       │
+│                                            │
+└────────────────────────────────────────────┘
+```
+
+- Lists all data bindings of the equipment
+- Each binding shows: alias name, toggle ON/OFF, "(défaut)" or "(modifié)" label
+- Toggle has 3 states internally: NULL (use category default), 1 (force ON), 0 (force OFF)
+- UI simplifies to ON/OFF toggle — shows "(défaut)" when matching category default, "(modifié)" when overridden
+- Bindings currently historized (effective ON) are highlighted
+- Section hidden entirely when InfluxDB not configured
+
+### Integration Points
+
+| Location                  | Component        | What                                                   |
+| ------------------------- | ---------------- | ------------------------------------------------------ |
+| Equipment detail page     | HistorySection   | Dedicated collapsible section with per-binding toggles |
+| Equipment detail page     | HistoryPanel     | Expandable chart per historized binding (IT2)          |
+| Home page: zone pills     | Sparkline        | 24h mini-chart for temperature, humidity (IT3)         |
+| Home page: equipment card | Sparkline        | 24h mini-chart for primary metric (IT3)                |
+| Settings page             | InfluxDB section | URL, token, org, bucket + test button                  |
+| Sidebar                   | "Analyse" link   | New page /analyse (IT4)                                |
+| Analyse page              | AnalyseView      | Multi-metric selector + full charts (IT4)              |
+
+### Chart Design
+
+**Sparkline** (inline, no interaction):
+
+- Size: 60×24px
+- Color: primary color, 1px stroke
+- No axes, no labels, no tooltip
+- Fill: primary-light with 20% opacity
+- Data: last 24h, auto-aggregated
+
+**Full chart** (in HistoryPanel and Analyse):
+
+- Recharts ResponsiveContainer + LineChart
+- X axis: time (auto-formatted by range)
+- Y axis: value with unit
+- Tooltip: value + timestamp
+- Dark mode support via CSS variables
+- Min/max range shown as light fill area (for aggregated data)
+
+## Docker Compose
+
+Add InfluxDB service:
+
+```yaml
+services:
+  influxdb:
+    image: influxdb:2.7
+    container_name: winch-influxdb
+    restart: unless-stopped
+    ports:
+      - "8086:8086"
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=winch
+      - DOCKER_INFLUXDB_INIT_PASSWORD=winch-secret
+      - DOCKER_INFLUXDB_INIT_ORG=winch
+      - DOCKER_INFLUXDB_INIT_BUCKET=winch
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=winch-dev-token
+
+volumes:
+  influxdb-data:
+```
+
+## File Changes Summary
+
+| File                                   | Change                                          |
+| -------------------------------------- | ----------------------------------------------- |
+| `src/history/influx-client.ts`         | NEW — InfluxDB wrapper                          |
+| `src/history/history-writer.ts`        | NEW — Event-driven batch writer                 |
+| `src/history/history-query.ts`         | NEW — Flux query builder                        |
+| `src/api/routes/history.ts`            | NEW — History REST endpoints                    |
+| `src/api/server.ts`                    | Register history routes + pass deps             |
+| `src/index.ts`                         | Instantiate HistoryWriter, pass to server       |
+| `src/shared/types.ts`                  | Add HistoryPoint, HistoryQueryParams interfaces |
+| `src/equipments/equipment-manager.ts`  | Expose historize flag in bindings               |
+| `migrations/020_history.sql`           | Add historize column to data_bindings           |
+| `docker-compose.yml`                   | Add InfluxDB service                            |
+| `package.json`                         | Add `@influxdata/influxdb-client` dependency    |
+| `ui/package.json`                      | Add `recharts` dependency                       |
+| `ui/src/components/history/`           | NEW — All chart components                      |
+| `ui/src/store/useHistory.ts`           | NEW — History data store                        |
+| `ui/src/pages/AnalysePage.tsx`         | NEW — Analyse page                              |
+| `ui/src/App.tsx`                       | Add /analyse route                              |
+| `ui/src/components/layout/`            | Add Analyse to sidebar                          |
+| `ui/src/pages/EquipmentDetailPage.tsx` | Add HistoryPanel + historize toggles            |
+| `ui/src/components/home/`              | Add sparklines to cards and pills               |
+| `ui/src/pages/SettingsPage.tsx`        | Add InfluxDB config section                     |

--- a/specs/025-V0.13-history/plan.md
+++ b/specs/025-V0.13-history/plan.md
@@ -1,0 +1,202 @@
+# Implementation Plan: V0.13 Data History
+
+## Iterative Delivery
+
+Each iteration is independently deployable and delivers visible value to the user. No iteration depends on a later one. The user can stop at any iteration and have a fully functional system.
+
+---
+
+## Iteration 1: InfluxDB Foundation + Settings UI
+
+**Goal**: Wire up InfluxDB client, store config, test connection from UI.
+
+**Backend**:
+
+- [ ] Add `@influxdata/influxdb-client` to package.json
+- [ ] Create `src/history/influx-client.ts` — connect, disconnect, health check, writePoint, flush, query
+- [ ] Create `src/history/history-writer.ts` — subscribe to `equipment.data.changed`, buffer writes, fire-and-forget flush
+- [ ] Migration `020_history.sql` — add `historize` column to `data_bindings`
+- [ ] Update `EquipmentManager.addDataBinding()` to accept optional `historize` flag
+- [ ] Add `setHistorize(equipmentId, bindingId, enabled)` method to EquipmentManager
+- [ ] Expose historize status in `getDataBindingsWithValues()`
+- [ ] Create `src/api/routes/history.ts` — `GET /api/v1/history/status`, `POST /api/v1/history/test-connection`
+- [ ] Register history routes in `server.ts`
+- [ ] Wire HistoryWriter in `index.ts` (instantiate after EquipmentManager, before server)
+
+**Deployment / InfluxDB Setup**:
+
+- [ ] Update `docker-compose.yml` with InfluxDB 2.7 service (auto-init: org, bucket, admin token)
+- [ ] Auto-setup on first connect: InfluxClient verifies/creates required buckets (winch, winch-hourly, winch-daily) with correct retention policies
+- [ ] Test connection endpoint validates: ping OK + bucket exists + write permission
+- [ ] Graceful startup: if InfluxDB is in docker-compose but slow to start, HistoryWriter retries connection silently (no crash)
+- [ ] Add `history.enabled` setting — master switch (default: false until configured)
+
+**Frontend**:
+
+- [ ] Settings page: InfluxDB configuration section (URL, token, org, bucket)
+- [ ] "Test Connection" button with success/error feedback (shows: ping, bucket check, write test)
+- [ ] Equipment detail: dedicated collapsible "Historique" section with per-binding ON/OFF toggles (shows category default vs overridden)
+- [ ] Connection status indicator (health dot) in settings
+- [ ] When not configured: history UI sections hidden (no empty states cluttering the UI)
+
+**Testing**:
+
+- [ ] Unit test: HistoryWriter correctly filters by historize flag
+- [ ] Unit test: HistoryWriter batch buffering (flush on size + interval)
+- [ ] Unit test: HistoryWriter graceful degradation when InfluxDB down
+- [ ] Unit test: Deduplication (deadband + min interval + force on state transition)
+- [ ] Manual: `docker-compose up` → configure in Settings → test connection → enable historize on a binding → verify points in InfluxDB UI (localhost:8086)
+
+**Deliverable**: Admin can deploy InfluxDB via docker-compose, configure the connection in Settings, enable per-binding historization, and verify data is being recorded.
+
+---
+
+## Iteration 2: History API + Equipment Charts
+
+**Goal**: Query historical data and display charts in equipment detail.
+
+**Backend**:
+
+- [ ] Create `src/history/history-query.ts` — Flux query builder with time range + aggregation
+- [ ] Add `GET /api/v1/history/:equipmentId/:alias` endpoint
+- [ ] Add `GET /api/v1/history/:equipmentId` endpoint (list historized aliases)
+- [ ] Auto-aggregation logic (raw ≤6h, hourly ≤7d, daily >7d)
+
+**Frontend**:
+
+- [ ] Add `recharts` to ui/package.json
+- [ ] Create `ui/src/store/useHistory.ts` — fetch + cache with 60s TTL
+- [ ] Create `ui/src/components/history/TimeSeriesChart.tsx` — LineChart with tooltip, responsive
+- [ ] Create `ui/src/components/history/TimeRangeSelector.tsx` — 6h/24h/7d/30d presets
+- [ ] Create `ui/src/components/history/HistoryPanel.tsx` — expandable panel per binding
+- [ ] Integrate HistoryPanel in EquipmentDetailPage (below sensor data, for historized bindings)
+- [ ] Dark mode support for charts (use CSS variables)
+
+**Testing**:
+
+- [ ] Unit test: query builder generates correct Flux for each aggregation level
+- [ ] Manual: open equipment detail → see 24h chart for temperature → switch to 7d → data loads
+
+**Deliverable**: Users see time-series charts in equipment detail for each historized binding.
+
+---
+
+## Iteration 3: Sparklines + Home Integration
+
+**Goal**: Mini-charts appear inline in home page cards and zone pills.
+
+**Frontend**:
+
+- [ ] Create `ui/src/components/history/Sparkline.tsx` — 60×24px, no axes, primary color fill
+- [ ] Home page: zone aggregation pills — sparkline next to temperature/humidity values
+- [ ] Home page: equipment cards — sparkline for primary numeric metric
+- [ ] Sparkline data: 24h auto-aggregated, fetched on mount, cached per session
+- [ ] Lazy loading: sparklines fetch only when visible (IntersectionObserver or scroll into view)
+- [ ] Loading state: skeleton animation (no spinner)
+
+**Backend**:
+
+- [ ] Add `GET /api/v1/history/sparkline/:equipmentId/:alias` — optimized endpoint returning last 24h as ~48 points (30min aggregation)
+
+**Testing**:
+
+- [ ] Manual: home page loads → sparklines appear next to temperature values
+- [ ] Performance: page load time unaffected when InfluxDB has no data
+
+**Deliverable**: At-a-glance trends visible everywhere without clicking into equipment detail.
+
+---
+
+## Iteration 4: Analyse Page
+
+**Goal**: Dedicated analysis page for deep data exploration.
+
+**Frontend**:
+
+- [ ] Create `ui/src/pages/AnalysePage.tsx`
+- [ ] Add `/analyse` route in App.tsx
+- [ ] Add "Analyse" entry in sidebar (BarChart3 icon from Lucide, between Calendar and Admin section)
+- [ ] Create `ui/src/components/history/AnalyseView.tsx`:
+  - Zone selector (tree dropdown)
+  - Equipment selector (filtered by zone)
+  - Metric/alias multi-selector (checkboxes)
+  - TimeRangeSelector (reuse from iteration 2)
+  - Multi-series overlay chart (different colors per series)
+  - Legend with color + equipment name + alias
+- [ ] Compare mode: overlay metrics from different zones on same chart
+- [ ] Chart interaction: zoom (drag to select range), pan
+- [ ] Responsive layout: full width on all screen sizes
+
+**Testing**:
+
+- [ ] Manual: select 2 zones → compare temperature → zoom into spike
+
+**Deliverable**: Power users can explore and compare metrics across zones and time ranges.
+
+---
+
+## Iteration 5: Retention & Downsampling
+
+**Goal**: Automatic data lifecycle management.
+
+**Backend**:
+
+- [ ] Create InfluxDB downsampling tasks on first connection (or via setup endpoint):
+  - Task `downsample-hourly`: aggregate raw → `winch-hourly` bucket (mean, min, max per 1h)
+  - Task `downsample-daily`: aggregate hourly → `winch-daily` bucket (mean, min, max per 1d)
+- [ ] Bucket retention: raw=7d, hourly=90d, daily=5y (configurable in settings)
+- [ ] `GET /api/v1/history/status` returns storage stats (bucket sizes, oldest/newest points)
+- [ ] HistoryQuery auto-selects bucket based on time range
+
+**Frontend**:
+
+- [ ] Settings: retention policy display (read-only for now, shows current config)
+- [ ] Settings: storage usage indicator (total points, approximate disk usage)
+
+**Testing**:
+
+- [ ] Manual: wait for downsampling task to run → query daily bucket → verify data
+
+**Deliverable**: Data is automatically managed — old raw data pruned, aggregated data kept long-term.
+
+---
+
+## Iteration 6 (Future): Data Export + Advanced
+
+**Goal**: Export capabilities and advanced features.
+
+- [ ] CSV export from Analyse page (button → download)
+- [ ] Pinnable charts on home dashboard
+- [ ] Threshold lines on charts (e.g. lux threshold from recipe config)
+- [ ] Event markers on timeline (mode changes, recipe overrides)
+
+---
+
+## Dependencies
+
+- Winch V0.12 (Computed Data) is NOT a prerequisite — history can be built independently
+- InfluxDB 2.7+ (Docker image: `influxdb:2.7`)
+- npm: `@influxdata/influxdb-client` (backend)
+- npm: `recharts` (frontend)
+
+## Risk Mitigation
+
+| Risk                                  | Mitigation                                                   |
+| ------------------------------------- | ------------------------------------------------------------ |
+| InfluxDB adds deployment complexity   | Docker-compose preconfigured, zero-config init               |
+| High write volume impacts performance | Batch writer with configurable buffer, fire-and-forget       |
+| InfluxDB downtime loses data          | Acceptable for home automation — warning log, auto-reconnect |
+| Large query results slow UI           | Auto-aggregation, max 500 points per response, pagination    |
+| Recharts bundle size                  | Tree-shakeable, only import LineChart + Tooltip              |
+
+## Manual Testing Checklist
+
+- [ ] Start Winch without InfluxDB → no errors, history features hidden
+- [ ] Configure InfluxDB in Settings → test connection succeeds
+- [ ] Enable historize on a temperature binding → data appears in InfluxDB
+- [ ] Open equipment detail → chart shows last 24h of temperature
+- [ ] Switch to 7d range → hourly aggregation loads
+- [ ] Home page sparklines show trends
+- [ ] Analyse page: overlay temperature from 2 zones
+- [ ] Kill InfluxDB → Winch continues running, warning in logs
+- [ ] Restart InfluxDB → writes resume automatically

--- a/specs/025-V0.13-history/spec.md
+++ b/specs/025-V0.13-history/spec.md
@@ -1,0 +1,56 @@
+# V0.13: Data History (InfluxDB)
+
+## Summary
+
+Add time-series data historization to Winch using InfluxDB 2.x as an **optional** backend. Users configure which equipment data bindings to historize. Mini-charts appear inline in equipment/zone views, and a dedicated "Analyse" page enables deep exploration. The system has zero impact on Winch core performance — writes are async, batched, and fire-and-forget.
+
+## Reference
+
+- Spec sections: winch-spec.md §9 (InfluxDB Schema), §7.6 (History API), §10 (influx.ts), §12 (env vars)
+
+## Acceptance Criteria
+
+- [ ] Winch starts and runs normally without InfluxDB configured
+- [ ] Admin can configure InfluxDB connection in Settings (URL, token, org, bucket) with a "Test" button
+- [ ] Admin can toggle historization per equipment data binding (checkbox in equipment detail)
+- [ ] Historized data points are written to InfluxDB asynchronously with batch buffering
+- [ ] API endpoint returns historical data with time range and aggregation support
+- [ ] Equipment detail shows expandable time-series charts for historized bindings
+- [ ] Zone/home cards show mini sparkline charts for key metrics (temperature, humidity, etc.)
+- [ ] Dedicated "Analyse" page allows multi-metric overlay with time range selector
+- [ ] InfluxDB downsampling tasks auto-created (raw→hourly→daily)
+- [ ] If InfluxDB goes down, Winch continues operating — data points are silently dropped with warning logs
+
+## Scope
+
+### In Scope
+
+- InfluxDB 2.x client wrapper with health check
+- Async batch writer subscribing to `equipment.data.changed` events
+- Per-binding historize toggle (stored in SQLite)
+- History query API with time range + aggregation
+- Recharts-based charting (sparklines + full charts)
+- Mini-charts in equipment/zone cards
+- Dedicated "Analyse" page with metric selector + time range picker
+- InfluxDB connection settings in admin UI
+- Docker-compose InfluxDB service
+- Retention policies + downsampling configuration
+
+### Out of Scope (deferred)
+
+- AI-powered anomaly detection (V1.3)
+- Customizable dashboard widgets (drag-and-drop)
+- Data export to CSV/Excel (can be added later)
+- Zone-level aggregated history writes (only equipment-level for now)
+- InfluxDB alerting/thresholds
+
+## Edge Cases
+
+- InfluxDB not configured → all history features hidden in UI, no errors
+- InfluxDB goes offline after config → warning logs, data points dropped, UI shows "history unavailable"
+- Equipment deleted → InfluxDB data remains (no cascade delete — retention handles cleanup)
+- Binding alias renamed → new series in InfluxDB, old data still queryable under old alias
+- Very high data rate (e.g. power meter every second) → batch writer absorbs bursts, configurable flush interval
+- No data points for a time range → empty chart with "No data" message
+- Device offline → no data points written (no synthetic gaps)
+- String/boolean values → stored as string field, charted as step/event markers

--- a/src/api/routes/history.ts
+++ b/src/api/routes/history.ts
@@ -1,0 +1,128 @@
+import type { FastifyInstance } from "fastify";
+import type { Logger } from "../../core/logger.js";
+import { HistoryWriter } from "../../history/history-writer.js";
+import type { EquipmentManager } from "../../equipments/equipment-manager.js";
+import type { SettingsManager } from "../../core/settings-manager.js";
+import type { EventBus } from "../../core/event-bus.js";
+import type { DataCategory } from "../../shared/types.js";
+
+export function registerHistoryRoutes(
+  app: FastifyInstance,
+  deps: {
+    historyWriter: HistoryWriter;
+    equipmentManager: EquipmentManager;
+    settingsManager: SettingsManager;
+    eventBus: EventBus;
+    logger: Logger;
+  },
+) {
+  const { historyWriter, equipmentManager, settingsManager, eventBus, logger: parentLogger } = deps;
+  const logger = parentLogger.child({ module: "history-routes" });
+
+  // ============================================================
+  // GET /api/v1/history/status
+  // ============================================================
+
+  app.get("/api/v1/history/status", async () => {
+    const influx = historyWriter.getInfluxClient();
+    const configured =
+      !!settingsManager.get("history.influx.url") &&
+      !!settingsManager.get("history.influx.token") &&
+      !!settingsManager.get("history.influx.org") &&
+      !!settingsManager.get("history.influx.bucket");
+
+    return {
+      configured,
+      connected: influx.isConnected(),
+      enabled: settingsManager.get("history.enabled") === "true",
+      historizedBindings: historyWriter.getHistorizedCount(),
+      stats: influx.getStats(),
+    };
+  });
+
+  // ============================================================
+  // POST /api/v1/history/test-connection
+  // ============================================================
+
+  app.post("/api/v1/history/test-connection", async (_req, reply) => {
+    const influx = historyWriter.getInfluxClient();
+    if (!influx.isConnected()) {
+      return reply.status(400).send({ error: "InfluxDB not configured or not connected" });
+    }
+
+    const ok = await influx.ping();
+    if (ok) {
+      return { success: true, message: "InfluxDB connection successful" };
+    } else {
+      return reply.status(503).send({ error: "InfluxDB ping failed" });
+    }
+  });
+
+  // ============================================================
+  // GET /api/v1/history/bindings/:equipmentId
+  // ============================================================
+
+  app.get<{ Params: { equipmentId: string } }>(
+    "/api/v1/history/bindings/:equipmentId",
+    async (req, reply) => {
+      const { equipmentId } = req.params;
+      const equipment = equipmentManager.getById(equipmentId);
+      if (!equipment) {
+        return reply.status(404).send({ error: "Equipment not found" });
+      }
+
+      const bindings = equipmentManager.getDataBindingsWithValues(equipmentId);
+      const result = bindings
+        .filter((b) => !b.id.startsWith("virtual:"))
+        .map((b) => ({
+          bindingId: b.id,
+          alias: b.alias,
+          category: b.category,
+          historize: b.historize ?? null,
+          effectiveOn: HistoryWriter.resolveHistorize(
+            b.historize ?? null,
+            b.alias,
+            b.category as DataCategory,
+          ),
+        }));
+
+      return result;
+    },
+  );
+
+  // ============================================================
+  // PUT /api/v1/history/bindings/:equipmentId/:bindingId
+  // ============================================================
+
+  app.put<{
+    Params: { equipmentId: string; bindingId: string };
+    Body: { historize: number | null };
+  }>("/api/v1/history/bindings/:equipmentId/:bindingId", async (req, reply) => {
+    const { equipmentId, bindingId } = req.params;
+    const { historize } = req.body as { historize: number | null };
+
+    const equipment = equipmentManager.getById(equipmentId);
+    if (!equipment) {
+      return reply.status(404).send({ error: "Equipment not found" });
+    }
+
+    // Validate historize value
+    if (historize !== null && historize !== 0 && historize !== 1) {
+      return reply.status(400).send({ error: "historize must be null, 0, or 1" });
+    }
+
+    try {
+      equipmentManager.setHistorize(bindingId, historize);
+    } catch (err) {
+      logger.error({ err, bindingId }, "Failed to update historize flag");
+      return reply.status(500).send({ error: "Failed to update historize flag" });
+    }
+
+    // Notify system so history writer refreshes its cache
+    eventBus.emit({ type: "equipment.updated", equipment });
+
+    return { success: true };
+  });
+
+  logger.debug("History routes registered");
+}

--- a/src/api/routes/modes.test.ts
+++ b/src/api/routes/modes.test.ts
@@ -17,6 +17,7 @@ function createTestDb(): Database.Database {
     "003_equipments.sql",
     "010_modes.sql",
     "013_button_action_bindings.sql",
+    "020_history.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../../migrations/${file}`),

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -21,6 +21,7 @@ import type { UserManager } from "../auth/user-manager.js";
 import type { AuthService } from "../auth/auth-service.js";
 import type { SettingsManager } from "../core/settings-manager.js";
 import type { ButtonActionManager } from "../buttons/button-action-manager.js";
+import type { HistoryWriter } from "../history/history-writer.js";
 import { registerAuthMiddleware } from "../auth/auth-middleware.js";
 import { registerDeviceRoutes } from "./routes/devices.js";
 import { registerHealthRoutes } from "./routes/health.js";
@@ -37,6 +38,7 @@ import { registerCalendarRoutes } from "./routes/calendar.js";
 import { registerIntegrationRoutes } from "./routes/integrations.js";
 import { registerButtonActionRoutes } from "./routes/button-actions.js";
 import { registerLogRoutes } from "./routes/logs.js";
+import { registerHistoryRoutes } from "./routes/history.js";
 import { registerWebSocket } from "./websocket.js";
 
 interface ServerDeps {
@@ -52,6 +54,7 @@ interface ServerDeps {
   authService: AuthService;
   settingsManager: SettingsManager;
   buttonActionManager: ButtonActionManager;
+  historyWriter: HistoryWriter;
   eventBus: EventBus;
   integrationRegistry: IntegrationRegistry;
   logBuffer: LogRingBuffer;
@@ -73,6 +76,7 @@ export async function createServer(deps: ServerDeps) {
     authService,
     settingsManager,
     buttonActionManager,
+    historyWriter,
     eventBus,
     integrationRegistry,
     logBuffer,
@@ -117,6 +121,13 @@ export async function createServer(deps: ServerDeps) {
   registerSettingsRoutes(app, { settingsManager, eventBus, logger });
   registerIntegrationRoutes(app, { integrationRegistry, settingsManager, logger });
   registerButtonActionRoutes(app, { buttonActionManager, logger });
+  registerHistoryRoutes(app, {
+    historyWriter,
+    equipmentManager,
+    settingsManager,
+    eventBus,
+    logger,
+  });
   registerLogRoutes(app, { logBuffer, logger });
   registerWebSocket(app, { eventBus, authService, logBuffer, logger });
 

--- a/src/buttons/button-action-manager.test.ts
+++ b/src/buttons/button-action-manager.test.ts
@@ -15,6 +15,7 @@ function createTestDb(): Database.Database {
     "003_equipments.sql",
     "010_modes.sql",
     "013_button_action_bindings.sql",
+    "020_history.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -32,11 +32,16 @@ function createTestDb(): Database.Database {
     resolve(import.meta.dirname ?? ".", "../../migrations/011_integration_architecture.sql"),
     "utf-8",
   );
+  const migration20 = readFileSync(
+    resolve(import.meta.dirname ?? ".", "../../migrations/020_history.sql"),
+    "utf-8",
+  );
   db.exec(migration1);
   db.exec(migration2);
   db.exec(migration3);
   db.exec(migration7);
   db.exec(migration11);
+  db.exec(migration20);
   return db;
 }
 

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -138,7 +138,7 @@ export class EquipmentManager {
         "SELECT * FROM data_bindings WHERE device_data_id = ?",
       ),
       getDataBindingsWithValues: this.db.prepare(
-        `SELECT db.id, db.equipment_id, db.device_data_id, db.alias,
+        `SELECT db.id, db.equipment_id, db.device_data_id, db.alias, db.historize,
                 dd.device_id, d.name as device_name, dd.key, dd.type, dd.category,
                 dd.value, dd.unit, dd.last_updated
          FROM data_bindings db
@@ -146,6 +146,7 @@ export class EquipmentManager {
          JOIN devices d ON dd.device_id = d.id
          WHERE db.equipment_id = ?`,
       ),
+      setHistorize: this.db.prepare("UPDATE data_bindings SET historize = ? WHERE id = ?"),
 
       // OrderBinding
       insertOrderBinding: this.db.prepare(
@@ -397,6 +398,12 @@ export class EquipmentManager {
     }
 
     return bindings;
+  }
+
+  /** Set the historize flag on a data binding. NULL = category default, 1 = force ON, 0 = force OFF. */
+  setHistorize(bindingId: string, historize: number | null): void {
+    this.stmts.setHistorize.run(historize, bindingId);
+    this.logger.info({ bindingId, historize }, "DataBinding historize flag updated");
   }
 
   // ============================================================
@@ -780,6 +787,7 @@ interface DataBindingJoinRow {
   equipment_id: string;
   device_data_id: string;
   alias: string;
+  historize: number | null;
   device_id: string;
   device_name: string;
   key: string;
@@ -834,6 +842,7 @@ function rowToDataBindingWithValue(row: DataBindingJoinRow): DataBindingWithValu
     equipmentId: row.equipment_id,
     deviceDataId: row.device_data_id,
     alias: row.alias,
+    historize: row.historize ?? undefined,
     deviceId: row.device_id,
     deviceName: row.device_name,
     key: row.key,

--- a/src/history/history-writer.ts
+++ b/src/history/history-writer.ts
@@ -1,0 +1,353 @@
+import type Database from "better-sqlite3";
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { SettingsManager } from "../core/settings-manager.js";
+import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import type { DataCategory } from "../shared/types.js";
+import { InfluxClient, Point } from "./influx-client.js";
+
+// ============================================================
+// History defaults — convention over configuration
+// ============================================================
+
+/** Categories historized ON by default. */
+const CATEGORY_DEFAULTS_ON: ReadonlySet<string> = new Set([
+  "temperature",
+  "humidity",
+  "pressure",
+  "luminosity",
+  "power",
+  "energy",
+  "rain",
+  "wind",
+  "co2",
+  "voc",
+  "noise",
+  "voltage",
+  "current",
+  "shutter_position",
+  "battery",
+]);
+
+/** Aliases historized ON regardless of category (handles generic bindings). */
+const ALIAS_DEFAULTS_ON: ReadonlySet<string> = new Set(["setpoint", "power"]);
+
+/** Deadband thresholds by category — skip writes if delta is below this. */
+const DEADBAND: Record<string, number> = {
+  temperature: 0.2,
+  humidity: 1.0,
+  luminosity: 0.05, // 5% relative
+  power: 5,
+  energy: 0.01,
+  shutter_position: 2,
+  pressure: 0.5,
+  voltage: 0.1,
+  current: 0.05,
+  battery: 1,
+};
+
+/** Minimum write interval in ms (default 30s). */
+const DEFAULT_MIN_WRITE_INTERVAL = 30_000;
+
+interface LastWritten {
+  value: unknown;
+  timestamp: number;
+}
+
+// ============================================================
+// HistoryWriter
+// ============================================================
+
+export class HistoryWriter {
+  private logger: Logger;
+  private eventBus: EventBus;
+  private settingsManager: SettingsManager;
+  private equipmentManager: EquipmentManager;
+  private influxClient: InfluxClient;
+  private unsubscribe: (() => void) | null = null;
+
+  /** Cache of historized binding IDs for fast lookup. */
+  private historizedBindings: Set<string> = new Set();
+
+  /** Binding metadata cache: bindingId → { alias, category, type, equipmentId, zoneId } */
+  private bindingMeta: Map<string, BindingMeta> = new Map();
+
+  /** Last written value per binding for deduplication. */
+  private lastWritten: Map<string, LastWritten> = new Map();
+
+  /** Resolved min write interval. */
+  private minWriteInterval = DEFAULT_MIN_WRITE_INTERVAL;
+
+  constructor(
+    _db: Database.Database,
+    eventBus: EventBus,
+    settingsManager: SettingsManager,
+    equipmentManager: EquipmentManager,
+    logger: Logger,
+  ) {
+    this.eventBus = eventBus;
+    this.settingsManager = settingsManager;
+    this.equipmentManager = equipmentManager;
+    this.logger = logger.child({ module: "history-writer" });
+    this.influxClient = new InfluxClient(logger);
+  }
+
+  /** Initialize: connect to InfluxDB if configured, subscribe to events. */
+  init(): void {
+    this.tryConnect();
+    this.refreshCache();
+
+    // Read configurable min interval
+    const intervalSetting = this.settingsManager.get("history.minWriteInterval");
+    if (intervalSetting) {
+      const parsed = parseInt(intervalSetting, 10);
+      if (!isNaN(parsed) && parsed > 0) this.minWriteInterval = parsed;
+    }
+
+    // Subscribe to events
+    this.unsubscribe = this.eventBus.on((event) => {
+      try {
+        switch (event.type) {
+          case "equipment.data.changed":
+            this.handleEquipmentDataChanged(
+              event.equipmentId,
+              event.alias,
+              event.value,
+              event.previous,
+            );
+            break;
+          case "equipment.created":
+          case "equipment.updated":
+          case "equipment.removed":
+            this.refreshCache();
+            break;
+          case "settings.changed":
+            if (event.keys.some((k) => k.startsWith("history."))) {
+              this.tryConnect();
+            }
+            break;
+        }
+      } catch (err) {
+        this.logger.error({ err }, "Error in history writer event handler");
+      }
+    });
+
+    this.logger.info(
+      { historizedBindings: this.historizedBindings.size },
+      "History writer initialized",
+    );
+  }
+
+  /** Graceful shutdown. */
+  async destroy(): Promise<void> {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    await this.influxClient.disconnect();
+  }
+
+  /** Get the InfluxClient instance (for API routes). */
+  getInfluxClient(): InfluxClient {
+    return this.influxClient;
+  }
+
+  /** Check if history is enabled and InfluxDB connected. */
+  isEnabled(): boolean {
+    return (
+      this.settingsManager.get("history.enabled") === "true" && this.influxClient.isConnected()
+    );
+  }
+
+  /** Get the count of effectively historized bindings. */
+  getHistorizedCount(): number {
+    return this.historizedBindings.size;
+  }
+
+  // ============================================================
+  // Historize resolution
+  // ============================================================
+
+  /**
+   * Resolve effective historize state for a binding.
+   * Priority: explicit override → alias default → category default → OFF.
+   */
+  static resolveHistorize(
+    historize: number | null | undefined,
+    alias: string,
+    category: DataCategory,
+  ): boolean {
+    // 1. Explicit override
+    if (historize === 1) return true;
+    if (historize === 0) return false;
+    // 2. Alias default
+    if (ALIAS_DEFAULTS_ON.has(alias)) return true;
+    // 3. Category default
+    if (CATEGORY_DEFAULTS_ON.has(category)) return true;
+    return false;
+  }
+
+  // ============================================================
+  // Private: connection
+  // ============================================================
+
+  private tryConnect(): void {
+    const url = this.settingsManager.get("history.influx.url");
+    const token = this.settingsManager.get("history.influx.token");
+    const org = this.settingsManager.get("history.influx.org");
+    const bucket = this.settingsManager.get("history.influx.bucket");
+    const enabled = this.settingsManager.get("history.enabled");
+
+    if (!url || !token || !org || !bucket || enabled !== "true") {
+      if (this.influxClient.isConnected()) {
+        this.influxClient.disconnect().catch((err) => {
+          this.logger.warn({ err }, "Error disconnecting InfluxDB");
+        });
+      }
+      return;
+    }
+
+    this.influxClient.connect({ url, token, org, bucket });
+  }
+
+  // ============================================================
+  // Private: cache
+  // ============================================================
+
+  private refreshCache(): void {
+    this.historizedBindings.clear();
+    this.bindingMeta.clear();
+
+    const equipments = this.equipmentManager.getAll();
+    for (const eq of equipments) {
+      if (!eq.enabled) continue;
+      const bindings = this.equipmentManager.getDataBindingsWithValues(eq.id);
+      for (const b of bindings) {
+        if (b.id.startsWith("virtual:")) continue; // Skip virtual bindings (gate state)
+        const effectiveOn = HistoryWriter.resolveHistorize(
+          b.historize ?? null,
+          b.alias,
+          b.category,
+        );
+        if (effectiveOn) {
+          this.historizedBindings.add(b.id);
+        }
+        this.bindingMeta.set(b.id, {
+          alias: b.alias,
+          category: b.category,
+          type: b.type,
+          equipmentId: eq.id,
+          zoneId: eq.zoneId,
+        });
+      }
+    }
+
+    this.logger.debug(
+      { total: this.bindingMeta.size, historized: this.historizedBindings.size },
+      "History cache refreshed",
+    );
+  }
+
+  // ============================================================
+  // Private: event handling
+  // ============================================================
+
+  private handleEquipmentDataChanged(
+    equipmentId: string,
+    alias: string,
+    value: unknown,
+    previous: unknown,
+  ): void {
+    if (!this.influxClient.isConnected()) return;
+    if (value === null || value === undefined) return;
+
+    // Find binding by equipmentId + alias
+    let bindingId: string | null = null;
+    let meta: BindingMeta | null = null;
+    for (const [id, m] of this.bindingMeta) {
+      if (m.equipmentId === equipmentId && m.alias === alias) {
+        bindingId = id;
+        meta = m;
+        break;
+      }
+    }
+
+    if (!bindingId || !meta) return;
+    if (!this.historizedBindings.has(bindingId)) return;
+
+    // Deduplication check
+    if (!this.shouldWrite(bindingId, meta, value, previous)) return;
+
+    // Build and write point
+    const point = new Point("equipment_data")
+      .tag("equipmentId", equipmentId)
+      .tag("alias", alias)
+      .tag("category", meta.category)
+      .tag("zoneId", meta.zoneId)
+      .tag("type", meta.type);
+
+    if (meta.type === "number" && typeof value === "number") {
+      point.floatField("value_number", value);
+    } else if (meta.type === "boolean") {
+      const boolVal = value === true || value === "ON" || value === "true";
+      point.stringField("value_string", String(boolVal));
+      point.floatField("value_number", boolVal ? 1 : 0);
+    } else {
+      point.stringField("value_string", String(value));
+    }
+
+    this.influxClient.writePoint(point);
+
+    // Update last written
+    this.lastWritten.set(bindingId, { value, timestamp: Date.now() });
+  }
+
+  // ============================================================
+  // Private: deduplication
+  // ============================================================
+
+  private shouldWrite(
+    bindingId: string,
+    meta: BindingMeta,
+    value: unknown,
+    previous: unknown,
+  ): boolean {
+    // Force write on boolean/enum state transitions
+    if (meta.type === "boolean" || meta.type === "enum") {
+      if (value !== previous) return true;
+      return false; // Same value → skip
+    }
+
+    const last = this.lastWritten.get(bindingId);
+    if (!last) return true; // First write
+
+    // Minimum interval check
+    const elapsed = Date.now() - last.timestamp;
+    if (elapsed < this.minWriteInterval) return false;
+
+    // Deadband check for numeric values
+    if (meta.type === "number" && typeof value === "number" && typeof last.value === "number") {
+      const deadband = DEADBAND[meta.category];
+      if (deadband !== undefined) {
+        // Special case: luminosity uses relative deadband (5%)
+        if (meta.category === "luminosity") {
+          const threshold = Math.abs(last.value as number) * deadband;
+          if (Math.abs(value - (last.value as number)) < Math.max(threshold, 1)) return false;
+        } else {
+          if (Math.abs(value - (last.value as number)) < deadband) return false;
+        }
+      }
+      // No deadband configured → write on any change
+      return value !== last.value;
+    }
+
+    // Default: write on any change
+    return value !== last.value;
+  }
+}
+
+interface BindingMeta {
+  alias: string;
+  category: DataCategory;
+  type: string;
+  equipmentId: string;
+  zoneId: string;
+}

--- a/src/history/influx-client.ts
+++ b/src/history/influx-client.ts
@@ -1,0 +1,142 @@
+import { InfluxDB, Point } from "@influxdata/influxdb-client";
+import type { WriteApi } from "@influxdata/influxdb-client";
+import type { Logger } from "../core/logger.js";
+
+export interface InfluxConfig {
+  url: string;
+  token: string;
+  org: string;
+  bucket: string;
+}
+
+/**
+ * Thin wrapper around the InfluxDB 2.x client.
+ * Provides connect, disconnect, health check, and buffered write.
+ */
+export class InfluxClient {
+  private logger: Logger;
+  private client: InfluxDB | null = null;
+  private writeApi: WriteApi | null = null;
+  private config: InfluxConfig | null = null;
+  private _connected = false;
+
+  /** Counters for /api/v1/history/status */
+  private pointsWritten24h = 0;
+  private errors24h = 0;
+  private counterResetAt = Date.now();
+
+  constructor(logger: Logger) {
+    this.logger = logger.child({ module: "influx-client" });
+  }
+
+  /**
+   * Connect to InfluxDB with the given config.
+   * Initializes the write API with batch settings.
+   */
+  connect(config: InfluxConfig): void {
+    this.disconnect();
+
+    this.config = config;
+    this.client = new InfluxDB({
+      url: config.url,
+      token: config.token,
+    });
+
+    this.writeApi = this.client.getWriteApi(config.org, config.bucket, "s", {
+      batchSize: 100,
+      flushInterval: 5000,
+      maxRetries: 3,
+      retryJitter: 200,
+    });
+
+    this._connected = true;
+    this.logger.info(
+      { url: config.url, org: config.org, bucket: config.bucket },
+      "InfluxDB client connected",
+    );
+  }
+
+  /** Flush pending writes and close the client. */
+  async disconnect(): Promise<void> {
+    if (this.writeApi) {
+      try {
+        await this.writeApi.close();
+      } catch (err) {
+        this.logger.warn({ err }, "Error flushing InfluxDB write buffer on disconnect");
+      }
+      this.writeApi = null;
+    }
+    this.client = null;
+    this._connected = false;
+    this.config = null;
+  }
+
+  isConnected(): boolean {
+    return this._connected;
+  }
+
+  /** Health check: ping InfluxDB. Returns true if reachable. */
+  async ping(): Promise<boolean> {
+    if (!this.config) return false;
+    try {
+      const response = await fetch(`${this.config.url}/ping`);
+      return response.ok || response.status === 204;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Buffer a single data point. Non-blocking, fire-and-forget. */
+  writePoint(point: Point): void {
+    if (!this.writeApi) {
+      this.logger.debug("writePoint called but writeApi not initialized — skipping");
+      return;
+    }
+    try {
+      this.writeApi.writePoint(point);
+      this.tickPointWritten();
+    } catch (err) {
+      this.tickError();
+      this.logger.warn({ err }, "Error buffering InfluxDB point");
+    }
+  }
+
+  /** Force flush buffered writes. */
+  async flush(): Promise<void> {
+    if (!this.writeApi) return;
+    try {
+      await this.writeApi.flush();
+    } catch (err) {
+      this.tickError();
+      this.logger.warn({ err }, "Error flushing InfluxDB write buffer");
+    }
+  }
+
+  /** Get 24h stats (auto-resets after 24h). */
+  getStats(): { pointsWritten24h: number; errors24h: number } {
+    this.maybeResetCounters();
+    return { pointsWritten24h: this.pointsWritten24h, errors24h: this.errors24h };
+  }
+
+  private tickPointWritten(): void {
+    this.maybeResetCounters();
+    this.pointsWritten24h++;
+  }
+
+  private tickError(): void {
+    this.maybeResetCounters();
+    this.errors24h++;
+  }
+
+  private maybeResetCounters(): void {
+    const now = Date.now();
+    if (now - this.counterResetAt > 86_400_000) {
+      this.pointsWritten24h = 0;
+      this.errors24h = 0;
+      this.counterResetAt = now;
+    }
+  }
+}
+
+// Re-export Point for convenience
+export { Point };

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { PanasonicCCIntegration } from "./integrations/panasonic-cc/index.js";
 import { MczMaestroIntegration } from "./integrations/mcz-maestro/index.js";
 import { NetatmoHCIntegration } from "./integrations/netatmo-hc/index.js";
 import { Lora2MqttIntegration } from "./integrations/lora2mqtt/index.js";
+import { HistoryWriter } from "./history/history-writer.js";
 import { createServer } from "./api/server.js";
 
 async function main() {
@@ -116,7 +117,10 @@ async function main() {
   const sunlightManager = new SunlightManager(settingsManager, eventBus, logger);
   zoneAggregator.setSunlightManager(sunlightManager);
 
-  // 11. Create Recipe Manager
+  // 11. Create History Writer (passive observer — subscribes to events, writes to InfluxDB)
+  const historyWriter = new HistoryWriter(db, eventBus, settingsManager, equipmentManager, logger);
+
+  // 12. Create Recipe Manager
   const recipeManager = new RecipeManager(
     db,
     eventBus,
@@ -165,6 +169,7 @@ async function main() {
     authService,
     settingsManager,
     buttonActionManager,
+    historyWriter,
     eventBus,
     integrationRegistry,
     logBuffer,
@@ -187,7 +192,10 @@ async function main() {
   // 17. Initialize recipe manager (restore persisted instances — after aggregation is ready)
   recipeManager.init();
 
-  // 18. Initialize mode manager, calendar, and button actions
+  // 18. Initialize history writer (connects to InfluxDB if configured, subscribes to events)
+  historyWriter.init();
+
+  // 19. Initialize mode manager, calendar, and button actions
   modeManager.init();
   calendarManager.init();
   buttonActionManager.init();
@@ -215,6 +223,11 @@ async function main() {
       recipeManager.stopAll();
     } catch (err) {
       logger.error({ err }, "Error stopping recipe manager");
+    }
+    try {
+      await historyWriter.destroy();
+    } catch (err) {
+      logger.error({ err }, "Error stopping history writer");
     }
     try {
       await server.close();

--- a/src/modes/mode-manager.test.ts
+++ b/src/modes/mode-manager.test.ts
@@ -17,6 +17,7 @@ function createTestDb(): Database.Database {
     "003_equipments.sql",
     "010_modes.sql",
     "013_button_action_bindings.sql",
+    "020_history.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),

--- a/src/recipes/engine/recipe-manager.test.ts
+++ b/src/recipes/engine/recipe-manager.test.ts
@@ -26,6 +26,7 @@ function createTestDb(): Database.Database {
     "005_recipes.sql",
     "007_settings.sql",
     "011_integration_architecture.sql",
+    "020_history.sql",
   ];
   for (const file of migrations) {
     const sql = readFileSync(

--- a/src/recipes/motion-light-dimmable.test.ts
+++ b/src/recipes/motion-light-dimmable.test.ts
@@ -27,6 +27,7 @@ function createTestDb(): Database.Database {
     "005_recipes.sql",
     "007_settings.sql",
     "011_integration_architecture.sql",
+    "020_history.sql",
   ];
   for (const file of migrations) {
     const sql = readFileSync(

--- a/src/recipes/motion-light.test.ts
+++ b/src/recipes/motion-light.test.ts
@@ -26,6 +26,7 @@ function createTestDb(): Database.Database {
     "005_recipes.sql",
     "007_settings.sql",
     "011_integration_architecture.sql",
+    "020_history.sql",
   ];
   for (const file of migrations) {
     const sql = readFileSync(

--- a/src/recipes/presence-thermostat.test.ts
+++ b/src/recipes/presence-thermostat.test.ts
@@ -26,6 +26,7 @@ function createTestDb(): Database.Database {
     "005_recipes.sql",
     "007_settings.sql",
     "011_integration_architecture.sql",
+    "020_history.sql",
   ];
   for (const file of migrations) {
     const sql = readFileSync(

--- a/src/recipes/switch-light.test.ts
+++ b/src/recipes/switch-light.test.ts
@@ -26,6 +26,7 @@ function createTestDb(): Database.Database {
     "005_recipes.sql",
     "007_settings.sql",
     "011_integration_architecture.sql",
+    "020_history.sql",
   ];
   for (const file of migrations) {
     const sql = readFileSync(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -173,6 +173,27 @@ export interface DataBinding {
   equipmentId: string;
   deviceDataId: string;
   alias: string;
+  historize?: number | null; // NULL = category default, 1 = force ON, 0 = force OFF
+}
+
+// ============================================================
+// History (InfluxDB)
+// ============================================================
+
+export interface HistoryStatus {
+  configured: boolean;
+  connected: boolean;
+  enabled: boolean;
+  historizedBindings: number;
+  stats: { pointsWritten24h: number; errors24h: number };
+}
+
+export interface HistoryBindingState {
+  bindingId: string;
+  alias: string;
+  category: DataCategory;
+  historize: number | null; // NULL = default, 1 = force ON, 0 = force OFF
+  effectiveOn: boolean; // Resolved from override → alias default → category default
 }
 
 export interface OrderBinding {
@@ -191,6 +212,7 @@ export interface DataBindingWithValue extends DataBinding {
   value: unknown;
   unit?: string;
   lastUpdated: string | null;
+  historize?: number | null;
 }
 
 export interface OrderBindingWithDetails extends OrderBinding {

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -33,11 +33,16 @@ function createTestDb(): Database.Database {
     resolve(import.meta.dirname ?? ".", "../../migrations/011_integration_architecture.sql"),
     "utf-8",
   );
+  const migration20 = readFileSync(
+    resolve(import.meta.dirname ?? ".", "../../migrations/020_history.sql"),
+    "utf-8",
+  );
   db.exec(migration1);
   db.exec(migration2);
   db.exec(migration3);
   db.exec(migration7);
   db.exec(migration11);
+  db.exec(migration20);
   return db;
 }
 

--- a/src/zones/zone-manager.test.ts
+++ b/src/zones/zone-manager.test.ts
@@ -22,9 +22,14 @@ function createTestDb(): Database.Database {
     resolve(import.meta.dirname ?? ".", "../../migrations/003_equipments.sql"),
     "utf-8",
   );
+  const migration20 = readFileSync(
+    resolve(import.meta.dirname ?? ".", "../../migrations/020_history.sql"),
+    "utf-8",
+  );
   db.exec(migration1);
   db.exec(migration2);
   db.exec(migration3);
+  db.exec(migration20);
   return db;
 }
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -11,6 +11,7 @@ import type {
   CalendarProfile, CalendarSlot, CalendarModeAction,
   IntegrationInfo,
   LogsResponse, LogLevel,
+  HistoryStatus, HistoryBindingState,
 } from "./types";
 
 const API_BASE = "/api/v1";
@@ -685,5 +686,34 @@ export async function setLogLevel(level: LogLevel): Promise<{ level: string; pre
   return fetchJSON(`${API_BASE}/logs/level`, {
     method: "PUT",
     body: JSON.stringify({ level }),
+  });
+}
+
+// ============================================================
+// History (InfluxDB)
+// ============================================================
+
+export async function getHistoryStatus(): Promise<HistoryStatus> {
+  return fetchJSON<HistoryStatus>(`${API_BASE}/history/status`);
+}
+
+export async function testHistoryConnection(): Promise<{ success: boolean; message: string }> {
+  return fetchJSON<{ success: boolean; message: string }>(`${API_BASE}/history/test-connection`, {
+    method: "POST",
+  });
+}
+
+export async function getHistoryBindings(equipmentId: string): Promise<HistoryBindingState[]> {
+  return fetchJSON<HistoryBindingState[]>(`${API_BASE}/history/bindings/${equipmentId}`);
+}
+
+export async function setHistorize(
+  equipmentId: string,
+  bindingId: string,
+  historize: number | null,
+): Promise<void> {
+  return fetchJSON<void>(`${API_BASE}/history/bindings/${equipmentId}/${bindingId}`, {
+    method: "PUT",
+    body: JSON.stringify({ historize }),
   });
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -556,5 +556,26 @@
   "logs.allModules": "All modules",
   "logs.entries": "{{count}} entries",
   "logs.engineLevel": "Engine level",
-  "logs.levelChanged": "Log level changed to {{level}}"
+  "logs.levelChanged": "Log level changed to {{level}}",
+
+  "history.influxdb": "InfluxDB",
+  "history.influxdbDescription": "Time-series database for data historization",
+  "history.url": "URL",
+  "history.token": "Token",
+  "history.org": "Organization",
+  "history.bucket": "Bucket",
+  "history.enabled": "Historization enabled",
+  "history.testConnection": "Test connection",
+  "history.testSuccess": "Connection successful",
+  "history.testFailed": "Connection failed",
+  "history.notConfigured": "Not configured",
+  "history.connected": "Connected",
+  "history.disconnected": "Disconnected",
+  "history.status": "Status",
+  "history.historizedBindings": "Historized data",
+  "history.title": "History",
+  "history.default": "default",
+  "history.override": "modified",
+  "history.on": "ON",
+  "history.off": "OFF"
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -556,5 +556,26 @@
   "logs.allModules": "Tous les modules",
   "logs.entries": "{{count}} entrées",
   "logs.engineLevel": "Niveau moteur",
-  "logs.levelChanged": "Niveau de log changé à {{level}}"
+  "logs.levelChanged": "Niveau de log changé à {{level}}",
+
+  "history.influxdb": "InfluxDB",
+  "history.influxdbDescription": "Base de données time-series pour l'historisation des données",
+  "history.url": "URL",
+  "history.token": "Token",
+  "history.org": "Organisation",
+  "history.bucket": "Bucket",
+  "history.enabled": "Historisation activée",
+  "history.testConnection": "Tester la connexion",
+  "history.testSuccess": "Connexion réussie",
+  "history.testFailed": "Échec de la connexion",
+  "history.notConfigured": "Non configuré",
+  "history.connected": "Connecté",
+  "history.disconnected": "Déconnecté",
+  "history.status": "Statut",
+  "history.historizedBindings": "Données historisées",
+  "history.title": "Historique",
+  "history.default": "défaut",
+  "history.override": "modifié",
+  "history.on": "ON",
+  "history.off": "OFF"
 }

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, useNavigate, useLocation, Link } from "react-router-dom";
 import { useDevices } from "../store/useDevices";
 import { useEquipments } from "../store/useEquipments";
 import { useZones } from "../store/useZones";
-import { getEquipment } from "../api";
+import { getEquipment, getHistoryStatus, getHistoryBindings, setHistorize } from "../api";
 import { EquipmentForm } from "../components/equipments/EquipmentForm";
 import { LightControl } from "../components/equipments/LightControl";
 import { ShutterControl } from "../components/equipments/ShutterControl";
@@ -34,9 +34,10 @@ import {
   Clock,
   RefreshCw,
   X,
+  Database,
 } from "lucide-react";
 import { RelativeTime } from "../components/RelativeTime";
-import type { EquipmentWithDetails } from "../types";
+import type { EquipmentWithDetails, HistoryBindingState } from "../types";
 import { useWsSubscription } from "../hooks/useWsSubscription";
 
 export function EquipmentDetailPage() {
@@ -273,6 +274,9 @@ export function EquipmentDetailPage() {
       {/* Devices */}
       <DevicesSection equipment={equipment} onChangeDevice={() => setShowChangeDevice(true)} />
 
+      {/* History (per-binding ON/OFF toggles) */}
+      <HistorySection equipmentId={equipment.id} />
+
       {/* Technical: Bindings (collapsible) */}
       <div className="bg-surface rounded-[10px] border border-border mb-6">
         <button
@@ -430,6 +434,120 @@ export function EquipmentDetailPage() {
           }}
           onClose={() => setShowChangeDevice(false)}
         />
+      )}
+    </div>
+  );
+}
+
+// ============================================================
+// History section (per-binding ON/OFF toggles)
+// ============================================================
+
+function HistorySection({ equipmentId }: { equipmentId: string }) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [bindings, setBindings] = useState<HistoryBindingState[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [historyEnabled, setHistoryEnabled] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [status, data] = await Promise.all([
+        getHistoryStatus(),
+        getHistoryBindings(equipmentId),
+      ]);
+      setHistoryEnabled(status.enabled);
+      setBindings(data);
+    } finally {
+      setLoading(false);
+      setLoaded(true);
+    }
+  }, [equipmentId]);
+
+  // Load on first open
+  useEffect(() => {
+    if (open && !loaded) {
+      load();
+    }
+  }, [open, loaded, load]);
+
+  const handleToggle = async (binding: HistoryBindingState) => {
+    // Cycle: default → ON → OFF → default
+    let next: number | null;
+    if (binding.historize === null) {
+      next = binding.effectiveOn ? 0 : 1; // flip from default
+    } else if (binding.historize === 1) {
+      next = 0;
+    } else {
+      next = null; // back to default
+    }
+    await setHistorize(equipmentId, binding.bindingId, next);
+    // Refresh
+    const data = await getHistoryBindings(equipmentId);
+    setBindings(data);
+  };
+
+  // Don't render anything until we know if history is enabled (only after first load)
+  // Show the section header always but only expand content when history is enabled
+  return (
+    <div className="bg-surface rounded-[10px] border border-border mb-6">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-2 w-full p-4 text-left cursor-pointer"
+      >
+        {open
+          ? <ChevronDown size={14} strokeWidth={1.5} className="text-text-tertiary" />
+          : <ChevronRight size={14} strokeWidth={1.5} className="text-text-tertiary" />
+        }
+        <Database size={14} strokeWidth={1.5} className="text-text-tertiary" />
+        <span className="text-[13px] font-medium text-text-secondary">{t("history.title")}</span>
+      </button>
+
+      {open && (
+        <div className="px-4 pb-4">
+          {loading ? (
+            <Loader2 size={16} className="animate-spin text-text-tertiary" />
+          ) : !historyEnabled ? (
+            <p className="text-[12px] text-text-tertiary">{t("history.notConfigured")}</p>
+          ) : bindings.length === 0 ? (
+            <p className="text-[12px] text-text-tertiary">{t("common.none")}</p>
+          ) : (
+            <div className="space-y-1">
+              {bindings.map((b) => (
+                <div
+                  key={b.bindingId}
+                  className="flex items-center justify-between px-2.5 py-1.5 rounded-[4px] bg-border-light/50 text-[12px]"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono font-medium text-primary">{b.alias}</span>
+                    <span className="text-text-tertiary">({b.category})</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-[11px] text-text-tertiary">
+                      {b.historize === null
+                        ? `(${t("history.default")})`
+                        : `(${t("history.override")})`
+                      }
+                    </span>
+                    <button
+                      onClick={() => handleToggle(b)}
+                      className={`px-2 py-0.5 rounded text-[11px] font-medium cursor-pointer transition-colors ${
+                        b.effectiveOn
+                          ? "bg-success/10 text-success hover:bg-success/20"
+                          : "bg-border-light text-text-tertiary hover:bg-border"
+                      }`}
+                    >
+                      {b.effectiveOn ? t("history.on") : t("history.off")}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2, Plus, Trash2, Copy, Check, Eye, EyeOff, Settings } from "lucide-react";
+import { Loader2, Plus, Trash2, Copy, Check, Eye, EyeOff, Settings, Database } from "lucide-react";
 import { useAuth } from "../store/useAuth";
 import {
   updateMe,
@@ -14,10 +14,12 @@ import {
   deleteUser,
   getSettings,
   updateSettings,
+  getHistoryStatus,
+  testHistoryConnection,
 } from "../api";
 import { setTheme } from "../theme";
 import type { ThemeSetting } from "../theme";
-import type { ApiToken, User, UserRole } from "../types";
+import type { ApiToken, User, UserRole, HistoryStatus } from "../types";
 
 export function SettingsPage() {
   const { t, i18n } = useTranslation();
@@ -69,10 +71,11 @@ export function SettingsPage() {
           <ChangePasswordSection />
         </div>
 
-        {/* Right column: API Tokens + User Management + Backup */}
+        {/* Right column: API Tokens + User Management + InfluxDB */}
         <div className="space-y-6">
           <ApiTokensSection />
           {isAdmin && <UserManagementSection currentUserId={user?.id ?? ""} />}
+          {isAdmin && <InfluxDbSettingsSection />}
         </div>
       </div>
     </div>
@@ -773,6 +776,229 @@ function UserManagementSection({ currentUserId }: { currentUserId: string }) {
           ))}
         </div>
       )}
+    </section>
+  );
+}
+
+// ============================================================
+// InfluxDB Settings (admin only)
+// ============================================================
+
+function InfluxDbSettingsSection() {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [status, setStatus] = useState<HistoryStatus | null>(null);
+
+  const [url, setUrl] = useState("");
+  const [token, setToken] = useState("");
+  const [org, setOrg] = useState("");
+  const [bucket, setBucket] = useState("");
+  const [enabled, setEnabled] = useState(false);
+  const [initial, setInitial] = useState({ url: "", token: "", org: "", bucket: "", enabled: false });
+
+  const loadAll = useCallback(async () => {
+    try {
+      const [settings, histStatus] = await Promise.all([getSettings(), getHistoryStatus()]);
+      const u = settings["history.influx.url"] ?? "";
+      const tk = settings["history.influx.token"] ?? "";
+      const o = settings["history.influx.org"] ?? "";
+      const b = settings["history.influx.bucket"] ?? "";
+      const en = settings["history.enabled"] === "true";
+      setUrl(u);
+      setToken(tk);
+      setOrg(o);
+      setBucket(b);
+      setEnabled(en);
+      setInitial({ url: u, token: tk, org: o, bucket: b, enabled: en });
+      setStatus(histStatus);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadAll(); }, [loadAll]);
+
+  const dirty = url !== initial.url || token !== initial.token || org !== initial.org || bucket !== initial.bucket || enabled !== initial.enabled;
+
+  const handleSave = async () => {
+    setSaving(true);
+    setTestResult(null);
+    try {
+      await updateSettings({
+        "history.influx.url": url,
+        "history.influx.token": token,
+        "history.influx.org": org,
+        "history.influx.bucket": bucket,
+        "history.enabled": enabled ? "true" : "false",
+      });
+      setInitial({ url, token, org, bucket, enabled });
+      // Refresh status after save
+      const histStatus = await getHistoryStatus();
+      setStatus(histStatus);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await testHistoryConnection();
+      setTestResult(result);
+    } catch {
+      setTestResult({ success: false, message: "Connection error" });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <section className="bg-surface rounded-[10px] border border-border p-5">
+        <h2 className="text-[14px] font-semibold text-text flex items-center gap-2 mb-4">
+          <Database size={16} strokeWidth={1.5} className="text-text-tertiary" />
+          {t("history.influxdb")}
+        </h2>
+        <Loader2 size={16} className="animate-spin text-text-tertiary" />
+      </section>
+    );
+  }
+
+  const configured = !!(url && token && org && bucket);
+
+  return (
+    <section className="bg-surface rounded-[10px] border border-border p-5">
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="text-[14px] font-semibold text-text flex items-center gap-2">
+          <Database size={16} strokeWidth={1.5} className="text-text-tertiary" />
+          {t("history.influxdb")}
+        </h2>
+        {status && (
+          <span className={`text-[11px] font-medium px-2 py-0.5 rounded ${
+            status.connected
+              ? "bg-success/10 text-success"
+              : configured
+                ? "bg-error/10 text-error"
+                : "bg-border-light text-text-tertiary"
+          }`}>
+            {status.connected
+              ? t("history.connected")
+              : configured
+                ? t("history.disconnected")
+                : t("history.notConfigured")}
+          </span>
+        )}
+      </div>
+      <p className="text-[12px] text-text-tertiary mb-4">{t("history.influxdbDescription")}</p>
+
+      <div className="space-y-3">
+        <div>
+          <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+            {t("history.url")}
+          </label>
+          <input
+            type="text"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="http://localhost:8086"
+            className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text placeholder:text-text-tertiary focus:outline-none focus:border-primary"
+          />
+        </div>
+        <div>
+          <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+            {t("history.token")}
+          </label>
+          <input
+            type="password"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder="influxdb-token"
+            className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text placeholder:text-text-tertiary focus:outline-none focus:border-primary"
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+              {t("history.org")}
+            </label>
+            <input
+              type="text"
+              value={org}
+              onChange={(e) => setOrg(e.target.value)}
+              placeholder="winch"
+              className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text placeholder:text-text-tertiary focus:outline-none focus:border-primary"
+            />
+          </div>
+          <div>
+            <label className="block text-[12px] text-text-tertiary uppercase tracking-wider mb-1">
+              {t("history.bucket")}
+            </label>
+            <input
+              type="text"
+              value={bucket}
+              onChange={(e) => setBucket(e.target.value)}
+              placeholder="winch"
+              className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text placeholder:text-text-tertiary focus:outline-none focus:border-primary"
+            />
+          </div>
+        </div>
+
+        {/* Enable toggle */}
+        <label className="flex items-center gap-2.5 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            className="w-4 h-4 rounded border-border text-primary focus:ring-primary"
+          />
+          <span className="text-[13px] text-text">{t("history.enabled")}</span>
+        </label>
+
+        {/* Status info */}
+        {status && status.connected && (
+          <div className="text-[12px] text-text-tertiary">
+            {t("history.historizedBindings")}: <span className="font-medium text-text">{status.historizedBindings}</span>
+          </div>
+        )}
+
+        {/* Test result */}
+        {testResult && (
+          <div className={`text-[12px] px-3 py-2 rounded-[6px] ${
+            testResult.success
+              ? "bg-success/10 text-success"
+              : "bg-error/10 text-error"
+          }`}>
+            {testResult.success ? t("history.testSuccess") : t("history.testFailed")}
+            {testResult.message && ` — ${testResult.message}`}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex gap-2">
+          {dirty && (
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="px-4 py-2 text-[13px] font-medium bg-primary text-white rounded-[6px] hover:bg-primary-hover transition-colors disabled:opacity-50"
+            >
+              {saving ? t("common.saving") : t("common.save")}
+            </button>
+          )}
+          {configured && !dirty && (
+            <button
+              onClick={handleTest}
+              disabled={testing}
+              className="px-4 py-2 text-[13px] font-medium text-primary border border-primary/30 rounded-[6px] hover:bg-primary-light transition-colors disabled:opacity-50"
+            >
+              {testing ? t("common.loading") : t("history.testConnection")}
+            </button>
+          )}
+        </div>
+      </div>
     </section>
   );
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -168,6 +168,7 @@ export interface DataBinding {
   equipmentId: string;
   deviceDataId: string;
   alias: string;
+  historize?: number | null;
 }
 
 export interface OrderBinding {
@@ -186,6 +187,7 @@ export interface DataBindingWithValue extends DataBinding {
   value: unknown;
   unit?: string;
   lastUpdated: string | null;
+  historize?: number | null;
 }
 
 export interface OrderBindingWithDetails extends OrderBinding {
@@ -203,6 +205,26 @@ export interface OrderBindingWithDetails extends OrderBinding {
 export interface EquipmentWithDetails extends Equipment {
   dataBindings: DataBindingWithValue[];
   orderBindings: OrderBindingWithDetails[];
+}
+
+// ============================================================
+// History (InfluxDB)
+// ============================================================
+
+export interface HistoryStatus {
+  configured: boolean;
+  connected: boolean;
+  enabled: boolean;
+  historizedBindings: number;
+  stats: { pointsWritten24h: number; errors24h: number };
+}
+
+export interface HistoryBindingState {
+  bindingId: string;
+  alias: string;
+  category: DataCategory;
+  historize: number | null;
+  effectiveOn: boolean;
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
- **InfluxDB client wrapper** with batch writes (100 points / 5s flush), retry, and 24h error counters
- **Event-driven HistoryWriter** subscribing to `equipment.data.changed` with deadband deduplication per category
- **Convention-over-configuration defaults**: 15 categories ON by default (temperature, humidity, power, energy, etc.), rest OFF
- **Per-binding historize flag** with 3-level resolution: explicit override > alias default > category default
- **REST API**: `GET /history/status`, `POST /history/test-connection`, `GET/PUT /history/bindings/:equipmentId`
- **Settings page**: InfluxDB configuration section (URL, token, org, bucket, enable toggle, test connection)
- **Equipment detail**: collapsible History section with per-binding ON/OFF toggles showing default vs override
- **Docker-compose**: InfluxDB 2.7 service with auto-init (org=winch, bucket=winch)
- **Migration 020**: adds `historize` column to `data_bindings`

## Files changed (32 files, +1888 -39)

| Area | Files |
|------|-------|
| Backend core | `src/history/influx-client.ts`, `src/history/history-writer.ts` |
| API | `src/api/routes/history.ts`, `src/api/server.ts` |
| Types | `src/shared/types.ts`, `ui/src/types.ts` |
| Equipment mgr | `src/equipments/equipment-manager.ts` |
| Entry point | `src/index.ts` |
| Migration | `migrations/020_history.sql` |
| Docker | `docker-compose.yml` |
| UI | `SettingsPage.tsx`, `EquipmentDetailPage.tsx`, `api.ts`, `en.json`, `fr.json` |
| Tests | 11 test files updated with migration 020 |
| Spec | `specs/025-V0.13-history/` (spec, architecture, plan) |

## Test plan
- [x] TypeScript compiles (zero errors backend + frontend)
- [x] ESLint passes
- [x] Prettier format check passes
- [x] All 408 tests pass (16 test files)
- [ ] Manual: configure InfluxDB in Settings, test connection
- [ ] Manual: check History section on equipment detail page
- [ ] Manual: verify data points written to InfluxDB

## Roadmap
Implements V0.13 IT1 from `specs/025-V0.13-history/plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)