### PR TITLE
feat(history): History API + Equipment Charts (V0.13 IT2)

### DIFF
--- a/src/api/routes/history.ts
+++ b/src/api/routes/history.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import type { Logger } from "../../core/logger.js";
 import { HistoryWriter } from "../../history/history-writer.js";
+import { queryHistory, queryHistorizedAliases } from "../../history/history-query.js";
 import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import type { SettingsManager } from "../../core/settings-manager.js";
 import type { EventBus } from "../../core/event-bus.js";
@@ -122,6 +123,73 @@ export function registerHistoryRoutes(
     eventBus.emit({ type: "equipment.updated", equipment });
 
     return { success: true };
+  });
+
+  // ============================================================
+  // GET /api/v1/history/:equipmentId — list historized aliases
+  // ============================================================
+
+  app.get<{ Params: { equipmentId: string } }>(
+    "/api/v1/history/:equipmentId",
+    async (req, reply) => {
+      const { equipmentId } = req.params;
+      const equipment = equipmentManager.getById(equipmentId);
+      if (!equipment) {
+        return reply.status(404).send({ error: "Equipment not found" });
+      }
+
+      const influx = historyWriter.getInfluxClient();
+      if (!influx.isConnected()) {
+        return { aliases: [] };
+      }
+
+      const aliases = await queryHistorizedAliases(influx, equipmentId, logger);
+      return { aliases };
+    },
+  );
+
+  // ============================================================
+  // GET /api/v1/history/:equipmentId/:alias — query time-series data
+  // ============================================================
+
+  app.get<{
+    Params: { equipmentId: string; alias: string };
+    Querystring: { from?: string; to?: string; aggregation?: string };
+  }>("/api/v1/history/:equipmentId/:alias", async (req, reply) => {
+    const { equipmentId, alias } = req.params;
+    const { from, to, aggregation } = req.query;
+
+    const equipment = equipmentManager.getById(equipmentId);
+    if (!equipment) {
+      return reply.status(404).send({ error: "Equipment not found" });
+    }
+
+    const influx = historyWriter.getInfluxClient();
+    if (!influx.isConnected()) {
+      return { points: [], resolution: "raw" };
+    }
+
+    // Validate aggregation parameter
+    const validAggregations = ["raw", "1h", "1d", "auto"];
+    if (aggregation && !validAggregations.includes(aggregation)) {
+      return reply
+        .status(400)
+        .send({ error: "Invalid aggregation. Must be: raw, 1h, 1d, or auto" });
+    }
+
+    const result = await queryHistory(
+      influx,
+      {
+        equipmentId,
+        alias,
+        from: from ?? "-24h",
+        to,
+        aggregation: (aggregation as "raw" | "1h" | "1d" | "auto") ?? "auto",
+      },
+      logger,
+    );
+
+    return result;
   });
 
   logger.debug("History routes registered");

--- a/src/history/history-query.ts
+++ b/src/history/history-query.ts
@@ -1,0 +1,238 @@
+import type { Logger } from "../core/logger.js";
+import type { InfluxClient } from "./influx-client.js";
+import type { HistoryPoint, HistoryQueryResult } from "../shared/types.js";
+
+type Resolution = "raw" | "1h" | "1d";
+
+/**
+ * Auto-select resolution based on time range.
+ * ≤6h → raw, ≤7d → 1h, >7d → 1d
+ */
+function autoResolution(fromMs: number, toMs: number): Resolution {
+  const rangeMs = toMs - fromMs;
+  const hours = rangeMs / 3_600_000;
+  if (hours <= 6) return "raw";
+  if (hours <= 168) return "1h"; // 7 days
+  return "1d";
+}
+
+/**
+ * Parse a "from" string into a Date.
+ * Accepts ISO 8601 or relative like "-24h", "-7d", "-30d".
+ */
+function parseFrom(from: string): Date {
+  if (from.startsWith("-")) {
+    const match = from.match(/^-(\d+)([hdm])$/);
+    if (match) {
+      const amount = parseInt(match[1], 10);
+      const unit = match[2];
+      const now = Date.now();
+      const ms =
+        unit === "h" ? amount * 3_600_000 : unit === "d" ? amount * 86_400_000 : amount * 60_000;
+      return new Date(now - ms);
+    }
+  }
+  return new Date(from);
+}
+
+/**
+ * Build a Flux query for time-series data.
+ */
+function buildFluxQuery(params: {
+  bucket: string;
+  equipmentId: string;
+  alias: string;
+  from: Date;
+  to: Date;
+  resolution: Resolution;
+}): string {
+  const { bucket, equipmentId, alias, from, to, resolution } = params;
+
+  const fromStr = from.toISOString();
+  const toStr = to.toISOString();
+
+  // Base query: filter by measurement, equipmentId, alias
+  let query = `from(bucket: "${bucket}")
+  |> range(start: ${fromStr}, stop: ${toStr})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => r.alias == "${alias}")
+  |> filter(fn: (r) => r._field == "value_number")`;
+
+  if (resolution === "raw") {
+    // Raw data — just sort and limit
+    query += `
+  |> sort(columns: ["_time"])
+  |> limit(n: 500)`;
+  } else {
+    // Aggregated data — window + mean/min/max
+    const every = resolution === "1h" ? "1h" : "1d";
+    query += `
+  |> aggregateWindow(every: ${every}, fn: mean, createEmpty: false)
+  |> sort(columns: ["_time"])
+  |> limit(n: 500)`;
+  }
+
+  return query;
+}
+
+/**
+ * Build a Flux query that returns min/max alongside mean for aggregated data.
+ */
+function buildAggregatedFluxQuery(params: {
+  bucket: string;
+  equipmentId: string;
+  alias: string;
+  from: Date;
+  to: Date;
+  resolution: "1h" | "1d";
+}): string {
+  const { bucket, equipmentId, alias, from, to, resolution } = params;
+  const fromStr = from.toISOString();
+  const toStr = to.toISOString();
+  const every = resolution === "1h" ? "1h" : "1d";
+
+  // Query mean, min, max in a single request using pivot
+  return `import "experimental"
+
+data = from(bucket: "${bucket}")
+  |> range(start: ${fromStr}, stop: ${toStr})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => r.alias == "${alias}")
+  |> filter(fn: (r) => r._field == "value_number")
+
+mean = data |> aggregateWindow(every: ${every}, fn: mean, createEmpty: false) |> set(key: "_field", value: "mean")
+min = data |> aggregateWindow(every: ${every}, fn: min, createEmpty: false) |> set(key: "_field", value: "min")
+max = data |> aggregateWindow(every: ${every}, fn: max, createEmpty: false) |> set(key: "_field", value: "max")
+
+union(tables: [mean, min, max])
+  |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+  |> sort(columns: ["_time"])
+  |> limit(n: 500)`;
+}
+
+/**
+ * Query historical data for an equipment binding.
+ */
+export async function queryHistory(
+  influxClient: InfluxClient,
+  params: {
+    equipmentId: string;
+    alias: string;
+    from: string;
+    to?: string;
+    aggregation?: "raw" | "1h" | "1d" | "auto";
+  },
+  logger: Logger,
+): Promise<HistoryQueryResult> {
+  const config = influxClient.getConfig();
+  const client = influxClient.getClient();
+  if (!config || !client) {
+    return { points: [], resolution: "raw" };
+  }
+
+  const fromDate = parseFrom(params.from);
+  const toDate = params.to ? new Date(params.to) : new Date();
+  const resolution =
+    params.aggregation === "auto" || !params.aggregation
+      ? autoResolution(fromDate.getTime(), toDate.getTime())
+      : params.aggregation;
+
+  const queryApi = client.getQueryApi(config.org);
+  const points: HistoryPoint[] = [];
+
+  try {
+    if (resolution === "raw") {
+      // Simple raw query
+      const flux = buildFluxQuery({
+        bucket: config.bucket,
+        equipmentId: params.equipmentId,
+        alias: params.alias,
+        from: fromDate,
+        to: toDate,
+        resolution: "raw",
+      });
+
+      for await (const { values, tableMeta } of queryApi.iterateRows(flux)) {
+        const o = tableMeta.toObject(values);
+        const time = o._time as string | undefined;
+        const value = o._value as number | undefined;
+        if (time && typeof value === "number") {
+          points.push({ time, value });
+        }
+      }
+    } else {
+      // Aggregated query with min/max
+      const flux = buildAggregatedFluxQuery({
+        bucket: config.bucket,
+        equipmentId: params.equipmentId,
+        alias: params.alias,
+        from: fromDate,
+        to: toDate,
+        resolution,
+      });
+
+      for await (const { values, tableMeta } of queryApi.iterateRows(flux)) {
+        const o = tableMeta.toObject(values);
+        const time = o._time as string | undefined;
+        const mean = o.mean as number | undefined;
+        const min = o.min as number | undefined;
+        const max = o.max as number | undefined;
+        if (time && typeof mean === "number") {
+          points.push({
+            time,
+            value: mean,
+            min: typeof min === "number" ? min : undefined,
+            max: typeof max === "number" ? max : undefined,
+          });
+        }
+      }
+    }
+  } catch (err) {
+    logger.error(
+      { err, equipmentId: params.equipmentId, alias: params.alias },
+      "InfluxDB query failed",
+    );
+  }
+
+  return { points, resolution };
+}
+
+/**
+ * List historized aliases for an equipment.
+ * Returns aliases that have data in InfluxDB.
+ */
+export async function queryHistorizedAliases(
+  influxClient: InfluxClient,
+  equipmentId: string,
+  logger: Logger,
+): Promise<string[]> {
+  const config = influxClient.getConfig();
+  const client = influxClient.getClient();
+  if (!config || !client) return [];
+
+  const queryApi = client.getQueryApi(config.org);
+  const aliases: string[] = [];
+
+  try {
+    const flux = `from(bucket: "${config.bucket}")
+  |> range(start: -30d)
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> keep(columns: ["alias"])
+  |> distinct(column: "alias")`;
+
+    for await (const { values, tableMeta } of queryApi.iterateRows(flux)) {
+      const o = tableMeta.toObject(values);
+      const alias = o._value;
+      if (typeof alias === "string") {
+        aliases.push(alias);
+      }
+    }
+  } catch (err) {
+    logger.error({ err, equipmentId }, "Failed to query historized aliases");
+  }
+
+  return aliases;
+}

--- a/src/history/influx-client.ts
+++ b/src/history/influx-client.ts
@@ -112,6 +112,16 @@ export class InfluxClient {
     }
   }
 
+  /** Get the current config (org/bucket needed by query builder). */
+  getConfig(): InfluxConfig | null {
+    return this.config;
+  }
+
+  /** Get underlying InfluxDB client instance (for queries). */
+  getClient(): InfluxDB | null {
+    return this.client;
+  }
+
   /** Get 24h stats (auto-resets after 24h). */
   getStats(): { pointsWritten24h: number; errors24h: number } {
     this.maybeResetCounters();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -196,6 +196,26 @@ export interface HistoryBindingState {
   effectiveOn: boolean; // Resolved from override → alias default → category default
 }
 
+export interface HistoryPoint {
+  time: string; // ISO 8601
+  value: number;
+  min?: number; // Only for aggregated data
+  max?: number; // Only for aggregated data
+}
+
+export interface HistoryQueryParams {
+  equipmentId: string;
+  alias: string;
+  from: string; // ISO 8601 or relative (-24h, -7d)
+  to?: string; // ISO 8601, defaults to now()
+  aggregation?: "raw" | "1h" | "1d" | "auto"; // auto picks based on range
+}
+
+export interface HistoryQueryResult {
+  points: HistoryPoint[];
+  resolution: "raw" | "1h" | "1d";
+}
+
 export interface OrderBinding {
   id: string;
   equipmentId: string;

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "^19.2.0",
         "react-i18next": "^16.5.4",
         "react-router-dom": "^7.13.0",
+        "recharts": "^3.7.0",
         "tailwindcss": "^4.2.0",
         "zustand": "^5.0.11"
       },
@@ -1015,6 +1016,42 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1347,6 +1384,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.0.tgz",
@@ -1649,6 +1698,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1691,6 +1803,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
@@ -2171,6 +2289,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2240,6 +2367,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2257,6 +2505,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2293,6 +2547,16 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2542,6 +2806,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2773,6 +3043,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2798,6 +3078,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -3479,6 +3768,36 @@
         }
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -3526,6 +3845,57 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3680,6 +4050,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3815,6 +4191,28 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^19.2.0",
     "react-i18next": "^16.5.4",
     "react-router-dom": "^7.13.0",
+    "recharts": "^3.7.0",
     "tailwindcss": "^4.2.0",
     "zustand": "^5.0.11"
   },

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -11,7 +11,7 @@ import type {
   CalendarProfile, CalendarSlot, CalendarModeAction,
   IntegrationInfo,
   LogsResponse, LogLevel,
-  HistoryStatus, HistoryBindingState,
+  HistoryStatus, HistoryBindingState, HistoryQueryResult,
 } from "./types";
 
 const API_BASE = "/api/v1";
@@ -716,4 +716,23 @@ export async function setHistorize(
     method: "PUT",
     body: JSON.stringify({ historize }),
   });
+}
+
+export async function getHistoryAliases(equipmentId: string): Promise<{ aliases: string[] }> {
+  return fetchJSON<{ aliases: string[] }>(`${API_BASE}/history/${equipmentId}`);
+}
+
+export async function getHistoryData(
+  equipmentId: string,
+  alias: string,
+  params?: { from?: string; to?: string; aggregation?: string },
+): Promise<HistoryQueryResult> {
+  const query = new URLSearchParams();
+  if (params?.from) query.set("from", params.from);
+  if (params?.to) query.set("to", params.to);
+  if (params?.aggregation) query.set("aggregation", params.aggregation);
+  const qs = query.toString();
+  return fetchJSON<HistoryQueryResult>(
+    `${API_BASE}/history/${equipmentId}/${alias}${qs ? `?${qs}` : ""}`,
+  );
 }

--- a/ui/src/components/history/HistoryPanel.tsx
+++ b/ui/src/components/history/HistoryPanel.tsx
@@ -3,8 +3,9 @@ import { useTranslation } from "react-i18next";
 import { Loader2, BarChart3 } from "lucide-react";
 import { getHistoryData, getHistoryStatus } from "../../api";
 import type { HistoryPoint, HistoryBindingState } from "../../types";
-import { TimeRangeSelector, rangeToFrom } from "./TimeRangeSelector";
-import type { TimeRange } from "./TimeRangeSelector";
+import { TimeRangeSelector } from "./TimeRangeSelector";
+import { rangeToFrom } from "./history-utils";
+import type { TimeRange } from "./history-utils";
 import { TimeSeriesChart } from "./TimeSeriesChart";
 
 interface HistoryPanelProps {

--- a/ui/src/components/history/HistoryPanel.tsx
+++ b/ui/src/components/history/HistoryPanel.tsx
@@ -1,0 +1,201 @@
+import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Loader2, BarChart3 } from "lucide-react";
+import { getHistoryData, getHistoryStatus } from "../../api";
+import type { HistoryPoint, HistoryBindingState } from "../../types";
+import { TimeRangeSelector, rangeToFrom } from "./TimeRangeSelector";
+import type { TimeRange } from "./TimeRangeSelector";
+import { TimeSeriesChart } from "./TimeSeriesChart";
+
+interface HistoryPanelProps {
+  equipmentId: string;
+  bindings: HistoryBindingState[];
+}
+
+interface ChartState {
+  points: HistoryPoint[];
+  resolution: "raw" | "1h" | "1d";
+  loading: boolean;
+  error: string | null;
+}
+
+const RESOLUTION_I18N: Record<string, string> = {
+  raw: "history.raw",
+  "1h": "history.hourly",
+  "1d": "history.daily",
+};
+
+/**
+ * History charts panel — shows expandable charts for each historized binding.
+ * Only visible when history is enabled and the equipment has historized bindings.
+ */
+export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
+  const { t } = useTranslation();
+  const [historyEnabled, setHistoryEnabled] = useState<boolean | null>(null);
+  const [range, setRange] = useState<TimeRange>("24h");
+  const [expandedAlias, setExpandedAlias] = useState<string | null>(null);
+  const [charts, setCharts] = useState<Record<string, ChartState>>({});
+
+  // Check if history is enabled on mount
+  useEffect(() => {
+    getHistoryStatus()
+      .then((status) => setHistoryEnabled(status.enabled && status.connected))
+      .catch(() => setHistoryEnabled(false));
+  }, []);
+
+  const historizedBindings = bindings.filter((b) => b.effectiveOn);
+
+  const fetchChart = useCallback(
+    async (alias: string, timeRange: TimeRange) => {
+      setCharts((prev) => ({
+        ...prev,
+        [alias]: { points: [], resolution: "raw", loading: true, error: null },
+      }));
+
+      try {
+        const result = await getHistoryData(equipmentId, alias, {
+          from: rangeToFrom(timeRange),
+          aggregation: "auto",
+        });
+        setCharts((prev) => ({
+          ...prev,
+          [alias]: {
+            points: result.points,
+            resolution: result.resolution,
+            loading: false,
+            error: null,
+          },
+        }));
+      } catch (err) {
+        setCharts((prev) => ({
+          ...prev,
+          [alias]: {
+            points: [],
+            resolution: "raw",
+            loading: false,
+            error: err instanceof Error ? err.message : "Failed to load",
+          },
+        }));
+      }
+    },
+    [equipmentId],
+  );
+
+  // Fetch chart data when expanding or changing range
+  useEffect(() => {
+    if (expandedAlias) {
+      fetchChart(expandedAlias, range);
+    }
+  }, [expandedAlias, range, fetchChart]);
+
+  // Don't render if history is not enabled or no historized bindings
+  if (historyEnabled === null) return null; // Still loading
+  if (!historyEnabled || historizedBindings.length === 0) return null;
+
+  const handleToggle = (alias: string) => {
+    setExpandedAlias((prev) => (prev === alias ? null : alias));
+  };
+
+  // Find the unit for a binding from its category
+  const getUnit = (binding: HistoryBindingState): string | undefined => {
+    const CATEGORY_UNITS: Record<string, string> = {
+      temperature: "\u00b0C",
+      humidity: "%",
+      pressure: "hPa",
+      luminosity: "lx",
+      power: "W",
+      energy: "kWh",
+      voltage: "V",
+      current: "A",
+      battery: "%",
+      noise: "dB",
+      co2: "ppm",
+      rain: "mm",
+      wind: "km/h",
+      shutter_position: "%",
+    };
+    return CATEGORY_UNITS[binding.category];
+  };
+
+  return (
+    <div className="bg-surface rounded-[10px] border border-border mb-6">
+      <div className="flex items-center justify-between p-4">
+        <div className="flex items-center gap-2">
+          <BarChart3 size={14} strokeWidth={1.5} className="text-text-tertiary" />
+          <span className="text-[13px] font-medium text-text-secondary">
+            {t("history.chart")}
+          </span>
+          <span className="text-[11px] text-text-tertiary">
+            {historizedBindings.length}
+          </span>
+        </div>
+        <TimeRangeSelector value={range} onChange={setRange} />
+      </div>
+
+      <div className="px-4 pb-4 space-y-1">
+        {historizedBindings.map((binding) => {
+          const isExpanded = expandedAlias === binding.alias;
+          const chart = charts[binding.alias];
+          const unit = getUnit(binding);
+
+          return (
+            <div key={binding.bindingId}>
+              {/* Binding row — clickable to expand */}
+              <button
+                type="button"
+                onClick={() => handleToggle(binding.alias)}
+                className={`flex items-center justify-between w-full px-2.5 py-1.5 rounded-[4px] text-[12px] cursor-pointer transition-colors ${
+                  isExpanded
+                    ? "bg-primary-light"
+                    : "bg-border-light/50 hover:bg-border-light"
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="font-mono font-medium text-primary">{binding.alias}</span>
+                  <span className="text-text-tertiary">({binding.category})</span>
+                </div>
+                <BarChart3
+                  size={12}
+                  strokeWidth={1.5}
+                  className={isExpanded ? "text-primary" : "text-text-tertiary"}
+                />
+              </button>
+
+              {/* Chart (expanded) */}
+              {isExpanded && (
+                <div className="mt-2 mb-3 px-1">
+                  {chart?.loading ? (
+                    <div className="flex items-center justify-center py-8">
+                      <Loader2 size={16} className="animate-spin text-text-tertiary" />
+                      <span className="ml-2 text-[12px] text-text-tertiary">
+                        {t("history.loading")}
+                      </span>
+                    </div>
+                  ) : chart?.error ? (
+                    <div className="text-[12px] text-error text-center py-8">
+                      {chart.error}
+                    </div>
+                  ) : (
+                    <>
+                      <TimeSeriesChart
+                        points={chart?.points ?? []}
+                        range={range}
+                        resolution={chart?.resolution ?? "raw"}
+                        unit={unit}
+                      />
+                      {chart?.resolution && (
+                        <div className="text-[10px] text-text-tertiary text-right mt-1">
+                          {t("history.resolution")}: {t(RESOLUTION_I18N[chart.resolution])}
+                        </div>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/history/TimeRangeSelector.tsx
+++ b/ui/src/components/history/TimeRangeSelector.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
-
-export type TimeRange = "6h" | "24h" | "7d" | "30d";
+import type { TimeRange } from "./history-utils";
 
 interface TimeRangeSelectorProps {
   value: TimeRange;
@@ -14,16 +13,6 @@ const RANGE_I18N: Record<TimeRange, string> = {
   "7d": "history.range7d",
   "30d": "history.range30d",
 };
-
-/** Convert a TimeRange to a relative "from" string for the API. */
-export function rangeToFrom(range: TimeRange): string {
-  switch (range) {
-    case "6h": return "-6h";
-    case "24h": return "-24h";
-    case "7d": return "-168h"; // 7 * 24
-    case "30d": return "-720h"; // 30 * 24
-  }
-}
 
 export function TimeRangeSelector({ value, onChange }: TimeRangeSelectorProps) {
   const { t } = useTranslation();

--- a/ui/src/components/history/TimeRangeSelector.tsx
+++ b/ui/src/components/history/TimeRangeSelector.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from "react-i18next";
+
+export type TimeRange = "6h" | "24h" | "7d" | "30d";
+
+interface TimeRangeSelectorProps {
+  value: TimeRange;
+  onChange: (range: TimeRange) => void;
+}
+
+const RANGES: TimeRange[] = ["6h", "24h", "7d", "30d"];
+const RANGE_I18N: Record<TimeRange, string> = {
+  "6h": "history.range6h",
+  "24h": "history.range24h",
+  "7d": "history.range7d",
+  "30d": "history.range30d",
+};
+
+/** Convert a TimeRange to a relative "from" string for the API. */
+export function rangeToFrom(range: TimeRange): string {
+  switch (range) {
+    case "6h": return "-6h";
+    case "24h": return "-24h";
+    case "7d": return "-168h"; // 7 * 24
+    case "30d": return "-720h"; // 30 * 24
+  }
+}
+
+export function TimeRangeSelector({ value, onChange }: TimeRangeSelectorProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex items-center gap-1">
+      {RANGES.map((range) => (
+        <button
+          key={range}
+          type="button"
+          onClick={() => onChange(range)}
+          className={`px-2 py-0.5 rounded text-[11px] font-medium transition-colors cursor-pointer ${
+            value === range
+              ? "bg-primary text-white"
+              : "bg-border-light text-text-secondary hover:bg-border"
+          }`}
+        >
+          {t(RANGE_I18N[range])}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/history/TimeSeriesChart.tsx
+++ b/ui/src/components/history/TimeSeriesChart.tsx
@@ -11,7 +11,7 @@ import {
   CartesianGrid,
 } from "recharts";
 import type { HistoryPoint } from "../../types";
-import type { TimeRange } from "./TimeRangeSelector";
+import type { TimeRange } from "./history-utils";
 
 interface TimeSeriesChartProps {
   points: HistoryPoint[];

--- a/ui/src/components/history/TimeSeriesChart.tsx
+++ b/ui/src/components/history/TimeSeriesChart.tsx
@@ -1,0 +1,171 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Area,
+  CartesianGrid,
+} from "recharts";
+import type { HistoryPoint } from "../../types";
+import type { TimeRange } from "./TimeRangeSelector";
+
+interface TimeSeriesChartProps {
+  points: HistoryPoint[];
+  range: TimeRange;
+  resolution: "raw" | "1h" | "1d";
+  unit?: string;
+  height?: number;
+}
+
+function formatTime(iso: string, range: TimeRange): string {
+  const d = new Date(iso);
+  if (range === "6h" || range === "24h") {
+    return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+  }
+  if (range === "7d") {
+    return d.toLocaleDateString(undefined, { weekday: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+  }
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function formatTooltipTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatValue(v: number, unit?: string): string {
+  const formatted = Number.isInteger(v) ? String(v) : v.toFixed(1);
+  return unit ? `${formatted} ${unit}` : formatted;
+}
+
+export function TimeSeriesChart({ points, range, resolution, unit, height = 200 }: TimeSeriesChartProps) {
+  const { t } = useTranslation();
+
+  const data = useMemo(
+    () =>
+      points.map((p) => ({
+        time: p.time,
+        label: formatTime(p.time, range),
+        value: p.value,
+        min: p.min,
+        max: p.max,
+      })),
+    [points, range],
+  );
+
+  if (data.length === 0) {
+    return (
+      <div className="flex items-center justify-center text-[12px] text-text-tertiary" style={{ height }}>
+        {t("history.noData")}
+      </div>
+    );
+  }
+
+  const hasMinMax = resolution !== "raw" && data.some((d) => d.min !== undefined);
+
+  // Use CSS variables for chart colors — works in both light and dark mode
+  const primaryColor = "var(--color-primary)";
+  const primaryLightColor = "var(--color-primary-light)";
+  const textSecondary = "var(--color-text-secondary)";
+  const textTertiary = "var(--color-text-tertiary)";
+  const borderColor = "var(--color-border-light)";
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <LineChart data={data} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke={borderColor} />
+        <XAxis
+          dataKey="label"
+          tick={{ fontSize: 10, fill: textTertiary }}
+          tickLine={false}
+          axisLine={{ stroke: borderColor }}
+          interval="preserveStartEnd"
+          minTickGap={40}
+        />
+        <YAxis
+          tick={{ fontSize: 10, fill: textTertiary }}
+          tickLine={false}
+          axisLine={false}
+          width={48}
+          tickFormatter={(v: number) => (Number.isInteger(v) ? String(v) : v.toFixed(1))}
+        />
+        <Tooltip
+          contentStyle={{
+            backgroundColor: "var(--color-surface)",
+            border: `1px solid var(--color-border)`,
+            borderRadius: "6px",
+            fontSize: "12px",
+            color: "var(--color-text)",
+          }}
+          labelFormatter={(_, payload) => {
+            if (payload?.[0]?.payload?.time) {
+              return formatTooltipTime(payload[0].payload.time as string);
+            }
+            return "";
+          }}
+          formatter={(value: number, name: string) => {
+            if (name === "min" || name === "max") return [formatValue(value, unit), name];
+            return [formatValue(value, unit), ""];
+          }}
+        />
+
+        {/* Min/Max area fill for aggregated data */}
+        {hasMinMax && (
+          <Area
+            type="monotone"
+            dataKey="max"
+            stroke="none"
+            fill={primaryLightColor}
+            fillOpacity={0.5}
+            isAnimationActive={false}
+          />
+        )}
+
+        {/* Main value line */}
+        <Line
+          type="monotone"
+          dataKey="value"
+          stroke={primaryColor}
+          strokeWidth={1.5}
+          dot={false}
+          activeDot={{ r: 3, fill: primaryColor }}
+          isAnimationActive={false}
+        />
+
+        {/* Min line (subtle) */}
+        {hasMinMax && (
+          <Line
+            type="monotone"
+            dataKey="min"
+            stroke={textTertiary}
+            strokeWidth={0.5}
+            strokeDasharray="3 3"
+            dot={false}
+            isAnimationActive={false}
+          />
+        )}
+        {/* Max line (subtle) */}
+        {hasMinMax && (
+          <Line
+            type="monotone"
+            dataKey="max"
+            stroke={textSecondary}
+            strokeWidth={0.5}
+            strokeDasharray="3 3"
+            dot={false}
+            isAnimationActive={false}
+          />
+        )}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/ui/src/components/history/TimeSeriesChart.tsx
+++ b/ui/src/components/history/TimeSeriesChart.tsx
@@ -112,9 +112,10 @@ export function TimeSeriesChart({ points, range, resolution, unit, height = 200 
             }
             return "";
           }}
-          formatter={(value: number, name: string) => {
-            if (name === "min" || name === "max") return [formatValue(value, unit), name];
-            return [formatValue(value, unit), ""];
+          formatter={(value?: number, name?: string) => {
+            const v = value ?? 0;
+            if (name === "min" || name === "max") return [formatValue(v, unit), name];
+            return [formatValue(v, unit), ""];
           }}
         />
 

--- a/ui/src/components/history/history-utils.ts
+++ b/ui/src/components/history/history-utils.ts
@@ -1,0 +1,15 @@
+export type TimeRange = "6h" | "24h" | "7d" | "30d";
+
+/** Convert a TimeRange to a relative "from" string for the API. */
+export function rangeToFrom(range: TimeRange): string {
+  switch (range) {
+    case "6h":
+      return "-6h";
+    case "24h":
+      return "-24h";
+    case "7d":
+      return "-168h"; // 7 * 24
+    case "30d":
+      return "-720h"; // 30 * 24
+  }
+}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -577,5 +577,16 @@
   "history.default": "default",
   "history.override": "modified",
   "history.on": "ON",
-  "history.off": "OFF"
+  "history.off": "OFF",
+  "history.chart": "Chart",
+  "history.noData": "No data for this period",
+  "history.loading": "Loading data...",
+  "history.range6h": "6h",
+  "history.range24h": "24h",
+  "history.range7d": "7d",
+  "history.range30d": "30d",
+  "history.resolution": "Resolution",
+  "history.raw": "Raw",
+  "history.hourly": "Hourly",
+  "history.daily": "Daily"
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -577,5 +577,16 @@
   "history.default": "défaut",
   "history.override": "modifié",
   "history.on": "ON",
-  "history.off": "OFF"
+  "history.off": "OFF",
+  "history.chart": "Graphique",
+  "history.noData": "Aucune donnée pour cette période",
+  "history.loading": "Chargement des données...",
+  "history.range6h": "6h",
+  "history.range24h": "24h",
+  "history.range7d": "7j",
+  "history.range30d": "30j",
+  "history.resolution": "Résolution",
+  "history.raw": "Brut",
+  "history.hourly": "Horaire",
+  "history.daily": "Journalier"
 }

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -39,6 +39,7 @@ import {
 import { RelativeTime } from "../components/RelativeTime";
 import type { EquipmentWithDetails, HistoryBindingState } from "../types";
 import { useWsSubscription } from "../hooks/useWsSubscription";
+import { HistoryPanel } from "../components/history/HistoryPanel";
 
 export function EquipmentDetailPage() {
   useWsSubscription(["equipments", "devices"]);
@@ -68,6 +69,7 @@ export function EquipmentDetailPage() {
   const [deleting, setDeleting] = useState(false);
   const [showBindings, setShowBindings] = useState(false);
   const [showChangeDevice, setShowChangeDevice] = useState(false);
+  const [historyBindings, setHistoryBindings] = useState<HistoryBindingState[]>([]);
 
   useEffect(() => {
     fetchZones();
@@ -275,7 +277,10 @@ export function EquipmentDetailPage() {
       <DevicesSection equipment={equipment} onChangeDevice={() => setShowChangeDevice(true)} />
 
       {/* History (per-binding ON/OFF toggles) */}
-      <HistorySection equipmentId={equipment.id} />
+      <HistorySection equipmentId={equipment.id} onBindingsLoaded={setHistoryBindings} />
+
+      {/* History charts */}
+      <HistoryPanel equipmentId={equipment.id} bindings={historyBindings} />
 
       {/* Technical: Bindings (collapsible) */}
       <div className="bg-surface rounded-[10px] border border-border mb-6">
@@ -443,7 +448,7 @@ export function EquipmentDetailPage() {
 // History section (per-binding ON/OFF toggles)
 // ============================================================
 
-function HistorySection({ equipmentId }: { equipmentId: string }) {
+function HistorySection({ equipmentId, onBindingsLoaded }: { equipmentId: string; onBindingsLoaded?: (bindings: HistoryBindingState[]) => void }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [bindings, setBindings] = useState<HistoryBindingState[]>([]);
@@ -460,11 +465,12 @@ function HistorySection({ equipmentId }: { equipmentId: string }) {
       ]);
       setHistoryEnabled(status.enabled);
       setBindings(data);
+      onBindingsLoaded?.(data);
     } finally {
       setLoading(false);
       setLoaded(true);
     }
-  }, [equipmentId]);
+  }, [equipmentId, onBindingsLoaded]);
 
   // Load on first open
   useEffect(() => {
@@ -487,6 +493,7 @@ function HistorySection({ equipmentId }: { equipmentId: string }) {
     // Refresh
     const data = await getHistoryBindings(equipmentId);
     setBindings(data);
+    onBindingsLoaded?.(data);
   };
 
   // Don't render anything until we know if history is enabled (only after first load)

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -227,6 +227,18 @@ export interface HistoryBindingState {
   effectiveOn: boolean;
 }
 
+export interface HistoryPoint {
+  time: string; // ISO 8601
+  value: number;
+  min?: number;
+  max?: number;
+}
+
+export interface HistoryQueryResult {
+  points: HistoryPoint[];
+  resolution: "raw" | "1h" | "1d";
+}
+
 // ============================================================
 // Engine Events (received via WebSocket)
 // ============================================================


### PR DESCRIPTION
## Summary
- Backend: Flux query builder (`history-query.ts`) with auto-aggregation (raw ≤6h, hourly ≤7d, daily >7d) and min/max for aggregated data
- API: `GET /api/v1/history/:equipmentId` (list historized aliases), `GET /api/v1/history/:equipmentId/:alias` (time-series query with time range + aggregation)
- Frontend: `recharts`-based charting with 3 new components:
  - `TimeRangeSelector` — 6h/24h/7d/30d presets
  - `TimeSeriesChart` — responsive LineChart with dark mode, min/max area fill, tooltip
  - `HistoryPanel` — expandable per-binding charts in equipment detail page
- InfluxDB client extended with `getConfig()` and `getClient()` for query access
- i18n: 12 new keys (en + fr) for chart UI

## Changes
- Backend: `src/history/history-query.ts` (NEW), `src/history/influx-client.ts`, `src/api/routes/history.ts`, `src/shared/types.ts`
- Frontend: `ui/src/components/history/` (4 new files), `ui/src/pages/EquipmentDetailPage.tsx`, `ui/src/api.ts`, `ui/src/types.ts`
- Dependencies: `recharts` added to `ui/package.json`

## Test plan
- [x] TypeScript compiles (zero errors — backend + UI)
- [x] All 408 tests pass
- [x] ESLint + Prettier pass
- [ ] Manual: open equipment detail → expand a historized binding chart → data loads from InfluxDB
- [ ] Manual: switch time range (6h → 7d → 30d) → resolution changes accordingly

## Roadmap
- Implements V0.13 IT2 from specs/025-V0.13-history/plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)