### PR TITLE
fix(mqtt): use category from lora2mqtt payload

### DIFF
--- a/src/mqtt/parsers/lora2mqtt.ts
+++ b/src/mqtt/parsers/lora2mqtt.ts
@@ -34,7 +34,10 @@ interface ParsedDevice {
 interface LoraNode {
   node_id: number;
   friendly_name: string | null;
-  data_keys: Record<string, { type: string; access: string; values?: string[] }>;
+  data_keys: Record<
+    string,
+    { type: string; access: string; values?: string[]; description?: string; category?: string }
+  >;
   is_active: boolean;
 }
 
@@ -161,7 +164,8 @@ export class Lora2MqttParser {
 
     for (const [key, meta] of Object.entries(node.data_keys ?? {})) {
       const dataType: DataType = LORA_TYPE_TO_DATA_TYPE[meta.type] ?? "text";
-      const category: DataCategory = PROPERTY_TO_CATEGORY[key] ?? "generic";
+      const category: DataCategory =
+        (meta.category as DataCategory) ?? PROPERTY_TO_CATEGORY[key] ?? "generic";
 
       // All keys are readable → create DeviceData
       data.push({ key, type: dataType, category });


### PR DESCRIPTION
## Summary
- LoRa2MQTT parser now reads the optional `category` field from each node's `data_keys`
- Falls back to `PROPERTY_TO_CATEGORY` then `"generic"` when not provided
- Allows lora2mqttpy to declare per-key categories (e.g. `light_state` for `lumiere_garage` R1) so devices can be properly associated with typed equipments

## Test plan
- [x] TypeScript compiles (zero errors)
- [x] All 408 tests pass
- [x] Backward compatible: nodes without `category` field still work via fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)