### PR TITLE
feat(recipes): add cocoon mode to presence-thermostat

### DIFF
--- a/specs/026-V0.8-cocoon-thermostat/architecture.md
+++ b/specs/026-V0.8-cocoon-thermostat/architecture.md
@@ -1,0 +1,46 @@
+# Architecture: V0.8 Cocoon Mode for Presence Thermostat
+
+## Data Model Changes
+
+No database changes. No new types in types.ts.
+
+The `currentMode` field in recipe state gains a new value: `"cocoon"` (alongside existing `"comfort"` and `"eco"`).
+
+New state keys persisted in `recipe_state`:
+
+- `cocoonMode: boolean` — whether cocoon is active
+- `currentMode: "cocoon"` — when cocoon is the active mode
+
+## Event Bus Events
+
+**Consumed (existing):**
+
+- `equipment.data.changed` — button "action" alias (new subscription)
+- `zone.data.changed` — motion (existing subscription)
+- `equipment.data.changed` — thermostat "setpoint" (existing subscription)
+
+**No new events emitted.**
+
+## State Machine
+
+```
+ECO ──motion──→ COMFORT ──timeout──→ ECO
+ │                │
+ │ button         │ button
+ ↓                ↓
+COCOON (cocoonTemp)
+   │
+   ├─ timeout without motion → ECO
+   ├─ nightStart → ECO
+   ├─ 2nd button press → COMFORT (motion) or ECO (no motion)
+   └─ manual setpoint → OVERRIDE
+```
+
+## File Changes
+
+| File                                      | Change                                                            |
+| ----------------------------------------- | ----------------------------------------------------------------- |
+| `src/recipes/presence-thermostat.ts`      | Add slots, cocoon state machine, button subscription, night check |
+| `src/recipes/presence-thermostat.test.ts` | Add ~10 cocoon test cases                                         |
+| `ui/src/i18n/locales/fr.json`             | Add translations for buttons/cocoonTemp slots                     |
+| `ui/src/i18n/locales/en.json`             | Add translations for buttons/cocoonTemp slots                     |

--- a/specs/026-V0.8-cocoon-thermostat/plan.md
+++ b/specs/026-V0.8-cocoon-thermostat/plan.md
@@ -1,0 +1,31 @@
+# Implementation Plan: V0.8 Cocoon Mode for Presence Thermostat
+
+## Tasks
+
+1. [ ] Add `buttons` and `cocoonTemp` slot definitions
+2. [ ] Add i18n entries for new slots (fr)
+3. [ ] Add instance fields: `buttonIds`, `cocoonTemp`
+4. [ ] Add validation for buttons (has "action" binding) and cocoonTemp (paired)
+5. [ ] Add button action subscription in `start()`
+6. [ ] Extend `currentMode` type to include `"cocoon"`
+7. [ ] Add `setCocoon()` method
+8. [ ] Add `onButtonAction()` handler (toggle cocoon)
+9. [ ] Modify `onZoneChanged()` to handle cocoon mode (presence logic)
+10. [ ] Modify `setEco()`/`setComfort()` to clear cocoon state
+11. [ ] Add night check for cocoon exit in periodic timer
+12. [ ] Extend periodic timer start condition for cocoon+night
+13. [ ] Clean cocoon state in `stop()`
+14. [ ] Add i18n keys in en.json and fr.json
+15. [ ] Write tests: validation, cocoon on/off, absence exit, night exit, override interaction, preheat interaction
+16. [ ] TypeScript compile check
+17. [ ] Run all tests
+
+## Dependencies
+
+- Requires presence-thermostat recipe (V0.8) — already implemented
+
+## Testing
+
+- Run `npx tsc --noEmit` — zero errors
+- Run `npm test` — all tests pass
+- Manual: create instance with buttons + cocoonTemp, press button → verify setpoint changes

--- a/specs/026-V0.8-cocoon-thermostat/spec.md
+++ b/specs/026-V0.8-cocoon-thermostat/spec.md
@@ -1,0 +1,47 @@
+# V0.8: Cocoon Mode for Presence Thermostat
+
+## Summary
+
+Add a "cocoon" temperature level to the presence-thermostat recipe, triggered by a physical button press. Cocoon provides a temporary comfort boost (e.g., 23°C) that follows the same presence logic as comfort — it exits on absence timeout or when night starts.
+
+## Reference
+
+- Recipe system: §12 of winch-spec.md
+- Presence-thermostat recipe: `src/recipes/presence-thermostat.ts`
+- Button action pattern: `src/recipes/switch-light.ts`
+
+## Acceptance Criteria
+
+- [ ] Two new optional slots: `buttons` (equipment list, type button) and `cocoonTemp` (number)
+- [ ] Button press toggles cocoon mode on/off
+- [ ] Cocoon sends `cocoonTemp` to thermostat
+- [ ] No motion for `timeout` duration exits cocoon → eco (same timer as comfort)
+- [ ] Night window start exits cocoon → eco
+- [ ] Second button press exits cocoon → comfort (if motion) or eco (if no motion)
+- [ ] Manual setpoint change during cocoon → override (existing behavior)
+- [ ] Preheat does NOT prevent cocoon from exiting on absence
+- [ ] Without buttons configured, recipe works exactly as before (backward compatible)
+- [ ] `cocoonMode` and `currentMode: "cocoon"` exposed in recipe state for UI
+
+## Scope
+
+### In Scope
+
+- Cocoon mode state machine within existing presence-thermostat recipe
+- Button action subscription (same pattern as switch-light)
+- Night window check exits cocoon via periodic timer
+- i18n for new slots (fr/en)
+- Tests for all cocoon scenarios
+
+### Out of Scope
+
+- Separate cocoon recipe (would conflict with presence-thermostat)
+- Cocoon-specific timeout (uses existing `timeout` parameter)
+- UI changes (state is already displayed via recipe state)
+
+## Edge Cases
+
+- Button press during override mode: ignored (override takes precedence)
+- Button press during eco: enters cocoon directly from eco
+- Cocoon during preheat window: cocoon takes precedence, absence still causes eco
+- Recipe restart: cocoon state is lost (runtime only, same as comfort/eco)

--- a/src/recipes/presence-thermostat.test.ts
+++ b/src/recipes/presence-thermostat.test.ts
@@ -243,6 +243,30 @@ const BASE_PARAMS = {
   timeout: "30m",
 };
 
+function createButton(setup: TestSetup): string {
+  const buttonDevice = seedDevice(setup.db, {
+    name: "Button Salon",
+    dataKeys: [{ key: "action", type: "text", category: "action", value: JSON.stringify("") }],
+  });
+  const buttonEq = setup.equipmentManager.create({
+    name: "Button Salon",
+    type: "button",
+    zoneId: setup.zoneId,
+  });
+  setup.equipmentManager.addDataBinding(buttonEq.id, buttonDevice.dataIds[0], "action");
+  return buttonEq.id;
+}
+
+function simulateButtonPress(setup: TestSetup, buttonId: string): void {
+  setup.eventBus.emit({
+    type: "equipment.data.changed",
+    equipmentId: buttonId,
+    alias: "action",
+    value: "single",
+    previous: "",
+  });
+}
+
 // ============================================================
 // Tests
 // ============================================================
@@ -927,5 +951,321 @@ describe("PresenceThermostatRecipe", () => {
     vi.advanceTimersByTime(60_000); // trigger preheat check
     vi.advanceTimersByTime(30 * 60 * 1000 + 100);
     expect(getSetpointCommands(setup.published)).toContain(17);
+  });
+
+  // ============================================================
+  // Cocoon mode
+  // ============================================================
+
+  it("validates cocoonTemp required when buttons provided", () => {
+    const buttonId = createButton(setup);
+    expect(() =>
+      setup.manager.createInstance("presence-thermostat", {
+        zone: setup.zoneId,
+        thermostat: setup.thermostatId,
+        ...BASE_PARAMS,
+        buttons: [buttonId],
+      }),
+    ).toThrow("Invalid params");
+  });
+
+  it("validates buttons required when cocoonTemp provided", () => {
+    expect(() =>
+      setup.manager.createInstance("presence-thermostat", {
+        zone: setup.zoneId,
+        thermostat: setup.thermostatId,
+        ...BASE_PARAMS,
+        cocoonTemp: 23,
+      }),
+    ).toThrow("Invalid params");
+  });
+
+  it("validates button has action data binding", () => {
+    // Create button WITHOUT action binding
+    const btnDevice = seedDevice(setup.db, {
+      name: "Bad Button",
+      dataKeys: [{ key: "battery", type: "number", category: "battery", value: "100" }],
+    });
+    const btnEq = setup.equipmentManager.create({
+      name: "Bad Button",
+      type: "button",
+      zoneId: setup.zoneId,
+    });
+    setup.equipmentManager.addDataBinding(btnEq.id, btnDevice.dataIds[0], "battery");
+
+    expect(() =>
+      setup.manager.createInstance("presence-thermostat", {
+        zone: setup.zoneId,
+        thermostat: setup.thermostatId,
+        ...BASE_PARAMS,
+        buttons: [btnEq.id],
+        cocoonTemp: 23,
+      }),
+    ).toThrow("Invalid params");
+  });
+
+  it("creates valid instance with cocoon config", () => {
+    const buttonId = createButton(setup);
+    const instance = setup.manager.createInstance("presence-thermostat", {
+      zone: setup.zoneId,
+      thermostat: setup.thermostatId,
+      ...BASE_PARAMS,
+      buttons: [buttonId],
+      cocoonTemp: 23,
+    });
+    expect(instance.recipeId).toBe("presence-thermostat");
+    expect(instance.enabled).toBe(true);
+  });
+
+  it("button press activates cocoon mode and sends cocoonTemp", () => {
+    const buttonId = createButton(setup);
+    setup.manager.createInstance("presence-thermostat", {
+      zone: setup.zoneId,
+      thermostat: setup.thermostatId,
+      ...BASE_PARAMS,
+      buttons: [buttonId],
+      cocoonTemp: 23,
+    });
+    setup.published.length = 0;
+
+    simulateButtonPress(setup, buttonId);
+
+    const setpoints = getSetpointCommands(setup.published);
+    expect(setpoints).toContain(23);
+  });
+
+  it("second button press exits cocoon — comfort if motion, eco if not", () => {
+    const buttonId = createButton(setup);
+    setup.manager.createInstance("presence-thermostat", {
+      zone: setup.zoneId,
+      thermostat: setup.thermostatId,
+      ...BASE_PARAMS,
+      buttons: [buttonId],
+      cocoonTemp: 23,
+    });
+
+    // Enter cocoon
+    simulateButtonPress(setup, buttonId);
+    setup.published.length = 0;
+
+    // Exit cocoon without motion → eco
+    simulateButtonPress(setup, buttonId);
+
+    const setpoints = getSetpointCommands(setup.published);
+    expect(setpoints).toContain(17); // eco (no motion)
+  });
+
+  it("second button press during cocoon with motion returns to comfort", () => {
+    const buttonId = createButton(setup);
+    setup.manager.createInstance("presence-thermostat", {
+      zone: setup.zoneId,
+      thermostat: setup.thermostatId,
+      ...BASE_PARAMS,
+      buttons: [buttonId],
+      cocoonTemp: 23,
+    });
+
+    simulateMotion(setup, true); // comfort
+    simulateButtonPress(setup, buttonId); // cocoon
+    setup.published.length = 0;
+
+    // Exit cocoon with motion present → comfort
+    simulateButtonPress(setup, buttonId);
+
+    const setpoints = getSetpointCommands(setup.published);
+    expect(setpoints).toContain(21); // comfort (motion present)
+    expect(setpoints).not.toContain(23); // not cocoon
+  });
+
+  it("cocoon exits to eco after absence timeout", () => {
+    const buttonId = createButton(setup);
+    setup.manager.createInstance("presence-thermostat", {
+      zone: setup.zoneId,
+      thermostat: setup.thermostatId,
+      ...BASE_PARAMS,
+      buttons: [buttonId],
+      cocoonTemp: 23,
+    });
+
+    simulateMotion(setup, true); // comfort
+    simulateButtonPress(setup, buttonId); // cocoon
+
+    // No motion → start eco timer
+    simulateMotion(setup, false);
+    setup.published.length = 0;
+
+    // Advance past timeout
+    vi.advanceTimersByTime(30 * 60 * 1000 + 100);
+
+    const setpoints = getSetpointCommands(setup.published);
+    expect(setpoints).toContain(17); // eco
+  });
+
+  it("motion during cocoon cancels eco timer and keeps cocoon", () => {
+    const buttonId = createButton(setup);
+    setup.manager.createInstance("presence-thermostat", {
+      zone: setup.zoneId,
+      thermostat: setup.thermostatId,
+      ...BASE_PARAMS,
+      buttons: [buttonId],
+      cocoonTemp: 23,
+    });
+
+    simulateMotion(setup, true); // comfort
+    simulateButtonPress(setup, buttonId); // cocoon
+    simulateMotion(setup, false); // start eco timer
+    setup.published.length = 0;
+
+    // Motion resumes before timeout → cancel eco timer, stay in cocoon
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    simulateMotion(setup, true);
+
+    // Advance past original timeout — should NOT fire
+    vi.advanceTimersByTime(25 * 60 * 1000);
+
+    const setpoints = getSetpointCommands(setup.published);
+    expect(setpoints).not.toContain(17); // no eco
+  });
+
+  it("cocoon exits when night window starts", () => {
+    vi.setSystemTime(new Date("2026-02-27T21:50:00")); // 21:50, just before night
+
+    const buttonId = createButton(setup);
+    setup.manager.createInstance("presence-thermostat", {
+      zone: setup.zoneId,
+      thermostat: setup.thermostatId,
+      ...BASE_PARAMS,
+      buttons: [buttonId],
+      cocoonTemp: 23,
+      nightTemp: 18,
+      nightStart: "22:00",
+      nightEnd: "06:00",
+    });
+
+    simulateMotion(setup, true); // comfort
+    simulateButtonPress(setup, buttonId); // cocoon
+    setup.published.length = 0;
+
+    // Advance into night window — periodic check should exit cocoon
+    vi.setSystemTime(new Date("2026-02-27T22:01:00"));
+    vi.advanceTimersByTime(60_000); // trigger periodic check
+
+    const setpoints = getSetpointCommands(setup.published);
+    expect(setpoints).toContain(17); // eco (night forces eco)
+    expect(setpoints).not.toContain(23); // not cocoon
+  });
+
+  it("button press during override is ignored", () => {
+    const buttonId = createButton(setup);
+    setup.manager.createInstance("presence-thermostat", {
+      zone: setup.zoneId,
+      thermostat: setup.thermostatId,
+      ...BASE_PARAMS,
+      buttons: [buttonId],
+      cocoonTemp: 23,
+    });
+
+    simulateMotion(setup, true); // comfort (lastSentSetpoint = 21)
+    vi.advanceTimersByTime(6000); // wait past grace period
+    simulateSetpointChange(setup, 25); // manual change → override
+    setup.published.length = 0;
+
+    // Button press during override — should be ignored
+    simulateButtonPress(setup, buttonId);
+
+    const setpoints = getSetpointCommands(setup.published);
+    expect(setpoints).not.toContain(23); // no cocoon
+  });
+
+  it("manual setpoint change during cocoon enters override", () => {
+    const buttonId = createButton(setup);
+    setup.manager.createInstance("presence-thermostat", {
+      zone: setup.zoneId,
+      thermostat: setup.thermostatId,
+      ...BASE_PARAMS,
+      buttons: [buttonId],
+      cocoonTemp: 23,
+    });
+
+    simulateButtonPress(setup, buttonId); // cocoon (lastSentSetpoint = 23)
+    vi.advanceTimersByTime(6000); // wait past grace period
+    simulateSetpointChange(setup, 25); // manual change (25 ≠ 23 → override)
+    setup.published.length = 0;
+
+    // Next motion should be ignored (override)
+    simulateMotion(setup, true);
+    simulateMotion(setup, false);
+    simulateMotion(setup, true);
+
+    const setpoints = getSetpointCommands(setup.published);
+    expect(setpoints).not.toContain(21); // no comfort
+    expect(setpoints).not.toContain(23); // no cocoon
+  });
+
+  it("preheat does not prevent cocoon from exiting on absence", () => {
+    // Wednesday 06:30 — inside preheat
+    vi.setSystemTime(new Date("2026-02-25T06:30:00"));
+
+    const buttonId = createButton(setup);
+    setup.manager.createInstance("presence-thermostat", {
+      zone: setup.zoneId,
+      thermostat: setup.thermostatId,
+      ...BASE_PARAMS,
+      buttons: [buttonId],
+      cocoonTemp: 23,
+      preheatStart: "06:00",
+      preheatEnd: "08:00",
+    });
+
+    simulateMotion(setup, true); // comfort
+    simulateButtonPress(setup, buttonId); // cocoon
+    simulateMotion(setup, false); // start eco timer (preheat should NOT protect cocoon)
+    setup.published.length = 0;
+
+    vi.advanceTimersByTime(30 * 60 * 1000 + 100);
+
+    const setpoints = getSetpointCommands(setup.published);
+    expect(setpoints).toContain(17); // eco despite being in preheat window
+  });
+
+  it("button press from eco enters cocoon directly", () => {
+    const buttonId = createButton(setup);
+    setup.manager.createInstance("presence-thermostat", {
+      zone: setup.zoneId,
+      thermostat: setup.thermostatId,
+      ...BASE_PARAMS,
+      buttons: [buttonId],
+      cocoonTemp: 23,
+    });
+    setup.published.length = 0;
+
+    // In eco, no motion — press button
+    simulateButtonPress(setup, buttonId);
+
+    const setpoints = getSetpointCommands(setup.published);
+    expect(setpoints).toContain(23); // cocoon directly from eco
+  });
+
+  it("cocoonMode state is exposed and cleared correctly", () => {
+    const buttonId = createButton(setup);
+    const instance = setup.manager.createInstance("presence-thermostat", {
+      zone: setup.zoneId,
+      thermostat: setup.thermostatId,
+      ...BASE_PARAMS,
+      buttons: [buttonId],
+      cocoonTemp: 23,
+    });
+
+    // Enter cocoon
+    simulateButtonPress(setup, buttonId);
+    const stateAfterCocoon = setup.manager.getInstanceState(instance.id);
+    expect(stateAfterCocoon.cocoonMode).toBe(true);
+    expect(stateAfterCocoon.currentMode).toBe("cocoon");
+
+    // Exit cocoon
+    simulateButtonPress(setup, buttonId);
+    const stateAfterExit = setup.manager.getInstanceState(instance.id);
+    expect(stateAfterExit.cocoonMode).toBeUndefined();
+    expect(stateAfterExit.currentMode).not.toBe("cocoon");
   });
 });

--- a/src/recipes/presence-thermostat.ts
+++ b/src/recipes/presence-thermostat.ts
@@ -10,7 +10,7 @@ export class PresenceThermostatRecipe extends Recipe {
   readonly id = "presence-thermostat";
   readonly name = "Presence Thermostat";
   readonly description =
-    "Adjusts thermostat setpoint based on zone presence. Sends comfort temperature when motion is detected, switches to eco after a timeout with no motion. Supports night setpoint, weekday/weekend preheat windows, and manual override detection.";
+    "Adjusts thermostat setpoint based on zone presence. Sends comfort temperature when motion is detected, switches to eco after a timeout with no motion. Supports night setpoint, weekday/weekend preheat windows, cocoon mode (button-triggered boost), and manual override detection.";
   readonly slots: RecipeSlotDef[] = [
     {
       id: "zone",
@@ -98,13 +98,29 @@ export class PresenceThermostatRecipe extends Recipe {
       type: "time",
       required: false,
     },
+    {
+      id: "buttons",
+      name: "Cocoon Buttons",
+      description: "Button equipments that toggle cocoon mode (optional)",
+      type: "equipment",
+      required: false,
+      list: true,
+      constraints: { equipmentType: "button" },
+    },
+    {
+      id: "cocoonTemp",
+      name: "Cocoon Temperature",
+      description: "Boosted setpoint when cocoon is activated by button (°C)",
+      type: "number",
+      required: false,
+    },
   ];
 
   override readonly i18n: Record<string, RecipeLangPack> = {
     fr: {
       name: "Thermostat présence",
       description:
-        "Ajuste la consigne du thermostat en fonction de la présence dans la zone. Envoie la température confort quand un mouvement est détecté, passe en éco après un délai sans mouvement. Supporte une consigne nuit, des plages de préchauffe semaine/week-end, et la détection de changement manuel.",
+        "Ajuste la consigne du thermostat en fonction de la présence dans la zone. Envoie la température confort quand un mouvement est détecté, passe en éco après un délai sans mouvement. Supporte une consigne nuit, des plages de préchauffe semaine/week-end, un mode cocoon (boost par bouton), et la détection de changement manuel.",
       slots: {
         zone: { name: "Zone", description: "Zone à surveiller" },
         thermostat: {
@@ -142,6 +158,14 @@ export class PresenceThermostatRecipe extends Recipe {
           name: "Fin préchauffe (week-end)",
           description: "Fin de la préchauffe le week-end (HH:MM, sam-dim)",
         },
+        buttons: {
+          name: "Boutons cocoon",
+          description: "Boutons qui activent le mode cocoon (optionnel)",
+        },
+        cocoonTemp: {
+          name: "Température cocoon",
+          description: "Consigne boostée quand le cocoon est activé par bouton (°C)",
+        },
       },
     },
   };
@@ -165,14 +189,18 @@ export class PresenceThermostatRecipe extends Recipe {
   private weekendPreheatStart: string | null = null;
   private weekendPreheatEnd: string | null = null;
 
+  // Cocoon
+  private buttonIds: string[] = [];
+  private cocoonTemp: number | null = null;
+
   // Runtime state
-  private currentMode: "comfort" | "eco" = "eco";
+  private currentMode: "comfort" | "eco" | "cocoon" = "eco";
   private overrideMode = false;
   private lastSentSetpoint: number | null = null;
   /** Grace period: ignore setpoint echoes for 5s after we send a setpoint command */
   private setpointGraceUntil = 0;
   private ecoTimer: ReturnType<typeof setTimeout> | null = null;
-  private preheatCheckTimer: ReturnType<typeof setInterval> | null = null;
+  private periodicCheckTimer: ReturnType<typeof setInterval> | null = null;
   private wasInPreheat = false;
   private unsubs: (() => void)[] = [];
 
@@ -256,6 +284,33 @@ export class PresenceThermostatRecipe extends Recipe {
 
     // Validate preheat weekend
     this.validateTimePair(params, "weekendPreheatStart", "weekendPreheatEnd");
+
+    // Validate cocoon (buttons + cocoonTemp must be provided together)
+    const buttonIds = this.normalizeStringArray(params.buttons);
+    const hasCocoonTemp =
+      params.cocoonTemp !== undefined && params.cocoonTemp !== null && params.cocoonTemp !== "";
+
+    if (buttonIds.length > 0 && !hasCocoonTemp) {
+      throw new Error("cocoonTemp is required when buttons are configured");
+    }
+    if (hasCocoonTemp && buttonIds.length === 0) {
+      throw new Error("buttons are required when cocoonTemp is configured");
+    }
+    if (hasCocoonTemp && isNaN(Number(params.cocoonTemp))) {
+      throw new Error("cocoonTemp must be a number");
+    }
+
+    // Validate each button has an "action" data binding
+    for (const buttonId of buttonIds) {
+      const btn = ctx.equipmentManager.getByIdWithDetails(buttonId);
+      if (!btn) {
+        throw new Error(`Button equipment not found: ${buttonId}`);
+      }
+      const hasActionData = btn.dataBindings.some((db) => db.alias === "action");
+      if (!hasActionData) {
+        throw new Error(`Button "${btn.name}" has no "action" data binding`);
+      }
+    }
   }
 
   private validateTimePair(
@@ -277,6 +332,13 @@ export class PresenceThermostatRecipe extends Recipe {
     if (hasEnd && typeof end === "string" && !/^\d{2}:\d{2}$/.test(end)) {
       throw new Error(`${endKey} must be in HH:MM format`);
     }
+  }
+
+  private normalizeStringArray(value: unknown): string[] {
+    if (Array.isArray(value)) {
+      return value.filter((id): id is string => typeof id === "string");
+    }
+    return [];
   }
 
   // ── Start ────────────────────────────────────────────────
@@ -312,12 +374,20 @@ export class PresenceThermostatRecipe extends Recipe {
         ? params.weekendPreheatEnd
         : null;
 
-    // Reset runtime state (clear any stale override from previous run)
+    // Cocoon
+    this.buttonIds = this.normalizeStringArray(params.buttons);
+    this.cocoonTemp =
+      params.cocoonTemp !== undefined && params.cocoonTemp !== null && params.cocoonTemp !== ""
+        ? Number(params.cocoonTemp)
+        : null;
+
+    // Reset runtime state (clear any stale state from previous run)
     this.currentMode = "eco";
     this.overrideMode = false;
     this.lastSentSetpoint = null;
     this.wasInPreheat = false;
     ctx.state.delete("overrideMode");
+    ctx.state.delete("cocoonMode");
     ctx.notifyStateChanged();
 
     // Subscribe to zone changes (motion)
@@ -335,11 +405,21 @@ export class PresenceThermostatRecipe extends Recipe {
     });
     this.unsubs.push(unsubSetpoint);
 
-    // Preheat periodic check (every 60s)
-    if (this.hasPreheatConfig()) {
+    // Subscribe to button actions (cocoon toggle)
+    if (this.buttonIds.length > 0) {
+      const unsubButton = ctx.eventBus.onType("equipment.data.changed", (event) => {
+        if (!this.buttonIds.includes(event.equipmentId)) return;
+        if (event.alias !== "action") return;
+        this.onButtonAction();
+      });
+      this.unsubs.push(unsubButton);
+    }
+
+    // Periodic check (preheat transitions + cocoon night exit)
+    if (this.needsPeriodicCheck()) {
       this.wasInPreheat = this.isInPreheatWindow();
-      this.preheatCheckTimer = setInterval(() => {
-        this.checkPreheatTransition();
+      this.periodicCheckTimer = setInterval(() => {
+        this.checkPeriodicTransitions();
       }, 60_000);
     }
 
@@ -351,9 +431,9 @@ export class PresenceThermostatRecipe extends Recipe {
 
   stop(): void {
     this.cancelEcoTimer();
-    if (this.preheatCheckTimer) {
-      clearInterval(this.preheatCheckTimer);
-      this.preheatCheckTimer = null;
+    if (this.periodicCheckTimer) {
+      clearInterval(this.periodicCheckTimer);
+      this.periodicCheckTimer = null;
     }
     for (const unsub of this.unsubs) {
       unsub();
@@ -363,6 +443,7 @@ export class PresenceThermostatRecipe extends Recipe {
     this.lastSentSetpoint = null;
     this.setpointGraceUntil = 0;
     this.ctx.state.delete("overrideMode");
+    this.ctx.state.delete("cocoonMode");
     this.ctx.state.delete("timerExpiresAt");
     this.ctx.state.delete("currentMode");
     this.ctx.notifyStateChanged();
@@ -405,15 +486,16 @@ export class PresenceThermostatRecipe extends Recipe {
       if (this.currentMode === "eco") {
         this.setComfort("Motion detected");
       }
+      // If cocoon or comfort → stay in current mode, just cancel eco timer
     } else {
-      // No motion — but skip eco transition if in preheat window
-      if (this.isInPreheatWindow()) {
+      // No motion — preheat protects comfort but NOT cocoon
+      if (this.currentMode === "comfort" && this.isInPreheatWindow()) {
         this.cancelEcoTimer();
         this.clearTimerState();
         return;
       }
 
-      if (this.currentMode === "comfort") {
+      if (this.currentMode === "comfort" || this.currentMode === "cocoon") {
         this.startEcoTimer();
       }
     }
@@ -431,6 +513,25 @@ export class PresenceThermostatRecipe extends Recipe {
     this.ctx.log("Manual setpoint change detected — entering override mode");
   }
 
+  private onButtonAction(): void {
+    // Ignore during override
+    if (this.overrideMode) return;
+
+    if (this.currentMode === "cocoon") {
+      // Second press → exit cocoon
+      this.cancelEcoTimer();
+      this.clearTimerState();
+      if (this.hasMotion()) {
+        this.setComfort("Cocoon deactivated by button — motion present");
+      } else {
+        this.setEco("Cocoon deactivated by button — no motion");
+      }
+    } else {
+      // Enter cocoon from any non-override mode
+      this.setCocoon("Button pressed");
+    }
+  }
+
   // ── Preheat logic ───────────────────────────────────────
 
   private hasPreheatConfig(): boolean {
@@ -438,6 +539,10 @@ export class PresenceThermostatRecipe extends Recipe {
       (this.preheatStart !== null && this.preheatEnd !== null) ||
       (this.weekendPreheatStart !== null && this.weekendPreheatEnd !== null)
     );
+  }
+
+  private needsPeriodicCheck(): boolean {
+    return this.hasPreheatConfig() || (this.buttonIds.length > 0 && this.hasNightConfig());
   }
 
   private isInPreheatWindow(): boolean {
@@ -455,6 +560,20 @@ export class PresenceThermostatRecipe extends Recipe {
     }
 
     return false;
+  }
+
+  private checkPeriodicTransitions(): void {
+    // Cocoon exit on night start
+    if (this.currentMode === "cocoon" && this.isInNightWindow()) {
+      this.cancelEcoTimer();
+      this.clearTimerState();
+      this.setEco("Night started — cocoon deactivated");
+      this.wasInPreheat = this.isInPreheatWindow();
+      return;
+    }
+
+    // Preheat transitions
+    this.checkPreheatTransition();
   }
 
   private checkPreheatTransition(): void {
@@ -483,6 +602,17 @@ export class PresenceThermostatRecipe extends Recipe {
     }
 
     this.wasInPreheat = inPreheat;
+  }
+
+  // ── Night window helpers ──────────────────────────────────
+
+  private hasNightConfig(): boolean {
+    return this.nightStart !== null && this.nightEnd !== null && this.nightTemp !== null;
+  }
+
+  private isInNightWindow(): boolean {
+    if (!this.hasNightConfig()) return false;
+    return isInTimeWindow(new Date(), this.nightStart!, this.nightEnd!);
   }
 
   // ── Temperature resolution ──────────────────────────────
@@ -516,6 +646,7 @@ export class PresenceThermostatRecipe extends Recipe {
     }
     this.currentMode = "comfort";
     this.ctx.state.set("currentMode", "comfort");
+    this.clearCocoonState();
     this.ctx.notifyStateChanged();
     this.ctx.log(`${reason} — setpoint → ${target}°C (comfort)`);
   }
@@ -530,9 +661,33 @@ export class PresenceThermostatRecipe extends Recipe {
     }
     this.currentMode = "eco";
     this.ctx.state.set("currentMode", "eco");
+    this.clearCocoonState();
     this.clearOverrideMode();
     this.ctx.notifyStateChanged();
     this.ctx.log(`${reason} — setpoint → ${this.ecoTemp}°C (eco)`);
+  }
+
+  private setCocoon(reason: string): void {
+    this.cancelEcoTimer();
+    this.clearTimerState();
+    this.setpointGraceUntil = Date.now() + 5000;
+    this.lastSentSetpoint = this.cocoonTemp!;
+    try {
+      this.ctx.equipmentManager.executeOrder(this.thermostatId, "setpoint", this.cocoonTemp!);
+    } catch (err) {
+      this.ctx.log(`Error setting cocoon setpoint: ${String(err)}`, "error");
+    }
+    this.currentMode = "cocoon";
+    this.ctx.state.set("currentMode", "cocoon");
+    this.ctx.state.set("cocoonMode", true);
+    this.ctx.notifyStateChanged();
+    this.ctx.log(`${reason} — setpoint → ${this.cocoonTemp}°C (cocoon)`);
+  }
+
+  // ── Cocoon state management ───────────────────────────────
+
+  private clearCocoonState(): void {
+    this.ctx.state.delete("cocoonMode");
   }
 
   // ── Override management ──────────────────────────────────

--- a/src/recipes/presence-thermostat.ts
+++ b/src/recipes/presence-thermostat.ts
@@ -55,6 +55,7 @@ export class PresenceThermostatRecipe extends Recipe {
       description: "Setpoint during the night window (°C, optional)",
       type: "number",
       required: false,
+      group: "night",
     },
     {
       id: "nightStart",
@@ -62,6 +63,7 @@ export class PresenceThermostatRecipe extends Recipe {
       description: "Start of night window (HH:MM)",
       type: "time",
       required: false,
+      group: "night",
     },
     {
       id: "nightEnd",
@@ -69,6 +71,7 @@ export class PresenceThermostatRecipe extends Recipe {
       description: "End of night window (HH:MM)",
       type: "time",
       required: false,
+      group: "night",
     },
     {
       id: "preheatStart",
@@ -76,6 +79,7 @@ export class PresenceThermostatRecipe extends Recipe {
       description: "Start of weekday preheat window (HH:MM, Mon-Fri)",
       type: "time",
       required: false,
+      group: "preheat",
     },
     {
       id: "preheatEnd",
@@ -83,6 +87,7 @@ export class PresenceThermostatRecipe extends Recipe {
       description: "End of weekday preheat window (HH:MM, Mon-Fri)",
       type: "time",
       required: false,
+      group: "preheat",
     },
     {
       id: "weekendPreheatStart",
@@ -90,6 +95,7 @@ export class PresenceThermostatRecipe extends Recipe {
       description: "Start of weekend preheat window (HH:MM, Sat-Sun)",
       type: "time",
       required: false,
+      group: "preheat",
     },
     {
       id: "weekendPreheatEnd",
@@ -97,6 +103,7 @@ export class PresenceThermostatRecipe extends Recipe {
       description: "End of weekend preheat window (HH:MM, Sat-Sun)",
       type: "time",
       required: false,
+      group: "preheat",
     },
     {
       id: "buttons",
@@ -106,6 +113,7 @@ export class PresenceThermostatRecipe extends Recipe {
       required: false,
       list: true,
       constraints: { equipmentType: "button" },
+      group: "cocoon",
     },
     {
       id: "cocoonTemp",
@@ -113,6 +121,7 @@ export class PresenceThermostatRecipe extends Recipe {
       description: "Boosted setpoint when cocoon is activated by button (°C)",
       type: "number",
       required: false,
+      group: "cocoon",
     },
   ];
 
@@ -166,6 +175,21 @@ export class PresenceThermostatRecipe extends Recipe {
           name: "Température cocoon",
           description: "Consigne boostée quand le cocoon est activé par bouton (°C)",
         },
+      },
+      groups: {
+        night: "Nuit",
+        preheat: "Préchauffe",
+        cocoon: "Cocoon",
+      },
+    },
+    en: {
+      name: "Presence Thermostat",
+      description:
+        "Adjusts thermostat setpoint based on zone presence. Sends comfort temperature when motion is detected, switches to eco after a timeout with no motion.",
+      groups: {
+        night: "Night",
+        preheat: "Preheat",
+        cocoon: "Cocoon",
       },
     },
   };

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -153,6 +153,15 @@ function RecipeInstanceRow({
   const allInstances = useRecipes((s) => s.instances);
   const equipments = useEquipments((s) => s.equipments);
   const zoneAggregation = useZoneAggregation((s) => s.data);
+  const zoneTree = useZones((s) => s.tree);
+  const allZones = useMemo(() => {
+    const flat: { id: string; name: string }[] = [];
+    const walk = (nodes: ZoneWithChildren[]) => {
+      for (const n of nodes) { flat.push({ id: n.id, name: n.name }); if (n.children.length > 0) walk(n.children); }
+    };
+    walk(zoneTree);
+    return flat;
+  }, [zoneTree]);
   const [showLog, setShowLog] = useState(false);
   const [logs, setLogs] = useState<RecipeLogEntry[]>([]);
   const [deleting, setDeleting] = useState(false);
@@ -326,7 +335,7 @@ function RecipeInstanceRow({
       return agg?.luminosity !== undefined && agg?.luminosity !== null;
     }
     if (slotId === "buttons") {
-      return equipments.some((eq) => eq.zoneId === zoneId && eq.type === "button");
+      return equipments.some((eq) => eq.type === "button");
     }
     return true;
   };
@@ -469,29 +478,62 @@ function RecipeInstanceRow({
                               <Minus size={14} strokeWidth={1.5} />
                             </button>
                           </div>
-                          <div className="grid grid-cols-3 gap-1.5">
-                            {chunk.slots.map((slot) => (
-                              <div key={slot.id}>
-                                <label className={`block text-[10px] tracking-wider mb-0.5 ${isSlotChanged(slot.id) ? "text-success" : "text-text-tertiary"}`}>
-                                  {recipeSlotName(recipe, slot, lang)}
-                                </label>
-                                {slot.type === "time" ? (
-                                  <TimeInput
-                                    value={editParams[slot.id] ?? ""}
-                                    onChange={(v) => setEditParams({ ...editParams, [slot.id]: v })}
-                                  />
-                                ) : (
-                                  <input
-                                    type="text"
-                                    value={editParams[slot.id] ?? ""}
-                                    onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
-                                    placeholder={slot.constraints?.max ? `1-${slot.constraints.max}` : ""}
-                                    className="w-full px-2 py-1 text-[13px] bg-surface border border-border rounded-[6px] text-text placeholder:text-text-tertiary"
-                                  />
-                                )}
+                          {/* Full-width equipment list slots — cross-zone picker */}
+                          {chunk.slots.filter((s) => s.type === "equipment" && s.list).map((slot) => (
+                            <EquipmentListPicker
+                              key={slot.id}
+                              slot={slot}
+                              value={editParams[slot.id] ?? ""}
+                              onChange={(v) => setEditParams({ ...editParams, [slot.id]: v })}
+                              equipments={equipments}
+                              zones={allZones}
+                              recipe={recipe}
+                              lang={lang}
+                              labelClassName={`block text-[10px] tracking-wider mb-0.5 ${isSlotChanged(slot.id) ? "text-success" : "text-text-tertiary"}`}
+                            />
+                          ))}
+                          {/* Compact grid for non-list slots */}
+                          {(() => {
+                            const compactSlots = chunk.slots.filter((s) => !(s.type === "equipment" && s.list));
+                            if (compactSlots.length === 0) return null;
+                            const cols = Math.min(compactSlots.length, 3);
+                            return (
+                              <div className={`grid gap-1.5 ${cols === 1 ? "grid-cols-1" : cols === 2 ? "grid-cols-2" : "grid-cols-3"}`}>
+                                {compactSlots.map((slot) => (
+                                  <div key={slot.id}>
+                                    <label className={`block text-[10px] tracking-wider mb-0.5 ${isSlotChanged(slot.id) ? "text-success" : "text-text-tertiary"}`}>
+                                      {recipeSlotName(recipe, slot, lang)}
+                                    </label>
+                                    {slot.type === "equipment" ? (
+                                      <select
+                                        value={editParams[slot.id] ?? ""}
+                                        onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
+                                        className="w-full px-2 py-1 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                                      >
+                                        <option value="">{t("common.select")}</option>
+                                        {getEquipmentOptions(slot.id).map((eq) => (
+                                          <option key={eq.id} value={eq.id}>{eq.name}</option>
+                                        ))}
+                                      </select>
+                                    ) : slot.type === "time" ? (
+                                      <TimeInput
+                                        value={editParams[slot.id] ?? ""}
+                                        onChange={(v) => setEditParams({ ...editParams, [slot.id]: v })}
+                                      />
+                                    ) : (
+                                      <input
+                                        type="text"
+                                        value={editParams[slot.id] ?? ""}
+                                        onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
+                                        placeholder={slot.constraints?.max ? `1-${slot.constraints.max}` : ""}
+                                        className="w-full px-2 py-1 text-[13px] bg-surface border border-border rounded-[6px] text-text placeholder:text-text-tertiary"
+                                      />
+                                    )}
+                                  </div>
+                                ))}
                               </div>
-                            ))}
-                          </div>
+                            );
+                          })()}
                         </div>
                       );
                     }
@@ -984,6 +1026,131 @@ function TimeInput({
 }
 
 // ============================================================
+// Equipment list picker — zone + equipment + add button
+// ============================================================
+
+function EquipmentListPicker({
+  slot,
+  value,
+  onChange,
+  equipments,
+  zones,
+  recipe,
+  lang,
+  labelClassName,
+}: {
+  slot: RecipeSlotDef;
+  value: string;
+  onChange: (value: string) => void;
+  equipments: EquipmentWithDetails[];
+  zones: { id: string; name: string }[];
+  recipe: RecipeInfo;
+  lang: string;
+  labelClassName?: string;
+}) {
+  const { t } = useTranslation();
+  const [pickerZoneId, setPickerZoneId] = useState("");
+  const [pickerEqId, setPickerEqId] = useState("");
+
+  const selectedIds = value.split(",").filter(Boolean);
+
+  const matchesConstraint = (eq: EquipmentWithDetails) => {
+    if (!slot.constraints?.equipmentType) return true;
+    return matchesEquipmentType(eq.type, slot.constraints.equipmentType);
+  };
+
+  // Zones that have matching, non-selected equipments
+  const zonesWithOptions = useMemo(() => {
+    return zones.filter((z) =>
+      equipments.some((eq) => eq.zoneId === z.id && !selectedIds.includes(eq.id) && matchesConstraint(eq))
+    );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [zones, equipments, selectedIds, slot.constraints?.equipmentType]);
+
+  // Equipments in picked zone matching constraints
+  const pickerOptions = useMemo(() => {
+    if (!pickerZoneId) return [];
+    return equipments.filter((eq) =>
+      eq.zoneId === pickerZoneId && !selectedIds.includes(eq.id) && matchesConstraint(eq)
+    );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pickerZoneId, equipments, selectedIds, slot.constraints?.equipmentType]);
+
+  const handleAdd = () => {
+    if (!pickerEqId) return;
+    const next = [...selectedIds, pickerEqId];
+    onChange(next.join(","));
+    setPickerEqId("");
+    // If no more options in this zone, reset zone too
+    const remaining = pickerOptions.filter((eq) => eq.id !== pickerEqId);
+    if (remaining.length === 0) setPickerZoneId("");
+  };
+
+  const handleRemove = (eqId: string) => {
+    const next = selectedIds.filter((id) => id !== eqId);
+    onChange(next.join(","));
+  };
+
+  return (
+    <div className="mb-1.5">
+      <label className={labelClassName ?? "block text-[10px] tracking-wider mb-0.5 text-text-tertiary"}>
+        {recipeSlotName(recipe, slot, lang)}
+      </label>
+
+      {/* Selected items */}
+      {selectedIds.map((id) => {
+        const eq = equipments.find((e) => e.id === id);
+        const zone = eq ? zones.find((z) => z.id === eq.zoneId) : null;
+        return (
+          <div key={id} className="flex items-center gap-2 px-2 py-1 mb-1 text-[13px] bg-surface border border-border rounded-[6px]">
+            <span className="flex-1 text-text truncate">{eq?.name ?? id}</span>
+            {zone && <span className="text-[11px] text-text-tertiary shrink-0">{zone.name}</span>}
+            <button type="button" onClick={() => handleRemove(id)} className="p-0.5 text-text-tertiary hover:text-error transition-colors">
+              <X size={12} strokeWidth={1.5} />
+            </button>
+          </div>
+        );
+      })}
+
+      {/* Add row: zone + equipment + button */}
+      {zonesWithOptions.length > 0 && (
+        <div className="flex items-center gap-1.5">
+          <select
+            value={pickerZoneId}
+            onChange={(e) => { setPickerZoneId(e.target.value); setPickerEqId(""); }}
+            className="flex-1 px-2 py-1 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+          >
+            <option value="">Zone…</option>
+            {zonesWithOptions.map((z) => (
+              <option key={z.id} value={z.id}>{z.name}</option>
+            ))}
+          </select>
+          <select
+            value={pickerEqId}
+            onChange={(e) => setPickerEqId(e.target.value)}
+            disabled={!pickerZoneId}
+            className="flex-1 px-2 py-1 text-[13px] bg-surface border border-border rounded-[6px] text-text disabled:opacity-40"
+          >
+            <option value="">{t("common.select")}</option>
+            {pickerOptions.map((eq) => (
+              <option key={eq.id} value={eq.id}>{eq.name}</option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={!pickerEqId}
+            className="p-1 rounded-[4px] text-accent hover:text-accent-hover hover:bg-accent/5 disabled:opacity-40 disabled:hover:bg-transparent transition-colors"
+          >
+            <Plus size={16} strokeWidth={1.5} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================
 // Add recipe wizard (step 1: choose recipe, step 2: configure)
 // ============================================================
 
@@ -1004,6 +1171,7 @@ function AddRecipeForm({
   const instances = useRecipes((s) => s.instances);
   const equipments = useEquipments((s) => s.equipments);
   const zoneAggregation = useZoneAggregation((s) => s.data);
+  const zoneTree = useZones((s) => s.tree);
   const [step, setStep] = useState<WizardStep>("choose");
   const [selectedRecipeId, setSelectedRecipeId] = useState("");
   const [params, setParams] = useState<Record<string, string>>({});
@@ -1012,6 +1180,16 @@ function AddRecipeForm({
   const [visibleGroups, setVisibleGroups] = useState<Set<string>>(new Set());
 
   const selectedRecipe = recipes.find((r) => r.id === selectedRecipeId);
+
+  // Flatten zone tree for equipment list picker
+  const allZones = useMemo(() => {
+    const flat: { id: string; name: string }[] = [];
+    const walk = (nodes: ZoneWithChildren[]) => {
+      for (const n of nodes) { flat.push({ id: n.id, name: n.name }); if (n.children.length > 0) walk(n.children); }
+    };
+    walk(zoneTree);
+    return flat;
+  }, [zoneTree]);
 
   // Light IDs already managed by a recipe instance in this zone
   const usedLightIds = useMemo(() => {
@@ -1067,7 +1245,7 @@ function AddRecipeForm({
       return agg?.luminosity !== undefined && agg?.luminosity !== null;
     }
     if (slotId === "buttons") {
-      return equipments.some((eq) => eq.zoneId === zoneId && eq.type === "button");
+      return equipments.some((eq) => eq.type === "button");
     }
     return true;
   };
@@ -1260,29 +1438,62 @@ function AddRecipeForm({
                             <Minus size={14} strokeWidth={1.5} />
                           </button>
                         </div>
-                        <div className="grid grid-cols-3 gap-1.5">
-                          {chunk.slots.map((slot) => (
-                            <div key={slot.id}>
-                              <label className="block text-[10px] tracking-wider mb-0.5 text-text-tertiary">
-                                {recipeSlotName(selectedRecipe, slot, lang)}
-                              </label>
-                              {slot.type === "time" ? (
-                                <TimeInput
-                                  value={params[slot.id] ?? ""}
-                                  onChange={(v) => setParams({ ...params, [slot.id]: v })}
-                                />
-                              ) : (
-                                <input
-                                  type="text"
-                                  value={params[slot.id] ?? ""}
-                                  onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
-                                  placeholder={slot.constraints?.max ? `1-${slot.constraints.max}` : ""}
-                                  className="w-full px-2 py-1 text-[13px] bg-surface border border-border rounded-[6px] text-text placeholder:text-text-tertiary"
-                                />
-                              )}
+                        {/* Full-width equipment list slots — cross-zone picker */}
+                        {chunk.slots.filter((s) => s.type === "equipment" && s.list).map((slot) => (
+                          <EquipmentListPicker
+                            key={slot.id}
+                            slot={slot}
+                            value={params[slot.id] ?? ""}
+                            onChange={(v) => setParams({ ...params, [slot.id]: v })}
+                            equipments={equipments}
+                            zones={allZones}
+                            recipe={selectedRecipe}
+                            lang={lang}
+                          />
+                        ))}
+                        {/* Compact grid for non-list slots */}
+                        {(() => {
+                          const compactSlots = chunk.slots.filter((s) => !(s.type === "equipment" && s.list));
+                          if (compactSlots.length === 0) return null;
+                          const n = compactSlots.length;
+                          const cols = n <= 3 ? n : n % 3 === 0 ? 3 : 2;
+                          return (
+                            <div className={`grid gap-1.5 ${cols === 1 ? "grid-cols-1" : cols === 2 ? "grid-cols-2" : "grid-cols-3"}`}>
+                              {compactSlots.map((slot) => (
+                                <div key={slot.id}>
+                                  <label className="block text-[10px] tracking-wider mb-0.5 text-text-tertiary">
+                                    {recipeSlotName(selectedRecipe, slot, lang)}
+                                  </label>
+                                  {slot.type === "equipment" ? (
+                                    <select
+                                      value={params[slot.id] ?? ""}
+                                      onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
+                                      className="w-full px-2 py-1 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                                    >
+                                      <option value="">{t("common.select")}</option>
+                                      {getEquipmentOptions(slot.id).map((eq) => (
+                                        <option key={eq.id} value={eq.id}>{eq.name}</option>
+                                      ))}
+                                    </select>
+                                  ) : slot.type === "time" ? (
+                                    <TimeInput
+                                      value={params[slot.id] ?? ""}
+                                      onChange={(v) => setParams({ ...params, [slot.id]: v })}
+                                    />
+                                  ) : (
+                                    <input
+                                      type="text"
+                                      value={params[slot.id] ?? ""}
+                                      onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
+                                      placeholder={slot.constraints?.max ? `1-${slot.constraints.max}` : ""}
+                                      className="w-full px-2 py-1 text-[13px] bg-surface border border-border rounded-[6px] text-text placeholder:text-text-tertiary"
+                                    />
+                                  )}
+                                </div>
+                              ))}
                             </div>
-                          ))}
-                        </div>
+                          );
+                        })()}
                       </div>
                     );
                   }


### PR DESCRIPTION
## Summary
- Add button-triggered **cocoon temperature boost** to the presence-thermostat recipe
- Two new optional slots: `buttons` (equipment list, type button) and `cocoonTemp` (number)
- Fully backward compatible — without buttons configured, recipe works exactly as before

## Cocoon behavior
- Button press → **COCOON** mode: sends `cocoonTemp` to thermostat
- No motion for `timeout` → **ECO** (same timer as comfort)
- Night window starts → **ECO** (night overrides cocoon)
- Second button press → **COMFORT** (if motion) or **ECO** (if no motion)
- Manual setpoint change → **OVERRIDE** (existing behavior)
- Preheat does NOT prevent cocoon from exiting on absence
- Button press during override is ignored

## Changes
- Backend: `src/recipes/presence-thermostat.ts` — new slots, cocoon state machine, button subscription, periodic night check
- Tests: `src/recipes/presence-thermostat.test.ts` — 15 new test cases (35 → 50 total)
- Spec: `specs/026-V0.8-cocoon-thermostat/`

## Test plan
- [x] TypeScript compiles (zero errors)
- [x] All 423 tests pass
- [x] Lint + format + UI typecheck pass
- [ ] Manual: create instance with buttons + cocoonTemp, press button → verify setpoint

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>