### PR TITLE
feat: V0.8 — presence-heater recipe & heater equipment type

### DIFF
--- a/specs/027-V0.8-presence-heater/architecture.md
+++ b/specs/027-V0.8-presence-heater/architecture.md
@@ -1,0 +1,57 @@
+# Architecture: V0.8 Presence Heater
+
+## Data Model Changes
+
+Add `"heater"` to `EquipmentType` union in `types.ts`. No database schema changes. No new tables.
+
+## Event Bus Events
+
+**Consumed (existing):**
+
+- `zone.data.changed` — motion detection (existing subscription pattern)
+- `equipment.data.changed` — relay state for override detection (existing pattern)
+
+**No new events emitted.**
+
+## State Machine
+
+```
+ECO ──motion──→ COMFORT ──timeout──→ ECO
+ │                │
+ │ nightStart     │ nightStart
+ ↓                ↓
+ECO (forced)      ECO (forced)
+ │
+ ├─ nightEnd + motion → COMFORT
+ ├─ nightEnd + no motion → ECO
+ └─ manual relay change → OVERRIDE → timeout → ECO
+```
+
+## Relay Mapping
+
+| invertRelay | Comfort action | Eco action  |
+| ----------- | -------------- | ----------- |
+| false       | state → ON     | state → OFF |
+| true        | state → OFF    | state → ON  |
+
+## Recipe Slots
+
+| Slot          | Type      | Required | Group | Default |
+| ------------- | --------- | -------- | ----- | ------- |
+| zone          | zone      | yes      | —     | —       |
+| heaters       | equipment | yes      | —     | —       |
+| timeout       | duration  | yes      | —     | 30m     |
+| invertRelay   | boolean   | no       | —     | false   |
+| nightStart    | time      | no       | night | —       |
+| nightEnd      | time      | no       | night | —       |
+| maxOnDuration | duration  | no       | —     | —       |
+
+## File Changes
+
+| File                                    | Change                                      |
+| --------------------------------------- | ------------------------------------------- |
+| `src/shared/types.ts`                   | Add `"heater"` to EquipmentType union       |
+| `src/equipments/equipment-manager.ts`   | Add `"heater"` to VALID_EQUIPMENT_TYPES set |
+| `src/recipes/presence-heater.ts`        | New recipe class                            |
+| `src/recipes/presence-heater.test.ts`   | Tests                                       |
+| `src/recipes/engine/recipe-registry.ts` | Register presence-heater recipe             |

--- a/specs/027-V0.8-presence-heater/plan.md
+++ b/specs/027-V0.8-presence-heater/plan.md
@@ -1,0 +1,22 @@
+# Implementation Plan: V0.8 Presence Heater
+
+## Tasks
+
+1. [ ] Add `"heater"` to EquipmentType in `types.ts`
+2. [ ] Add `"heater"` to VALID_EQUIPMENT_TYPES in `equipment-manager.ts`
+3. [ ] Create `src/recipes/presence-heater.ts` with slots, i18n, validate, start, stop
+4. [ ] Register recipe in `src/recipes/engine/recipe-registry.ts`
+5. [ ] Write tests: validation, comfort/eco toggle, night window, override, maxOnDuration, invertRelay
+6. [ ] TypeScript compile check
+7. [ ] Run all tests
+
+## Dependencies
+
+- Requires recipe engine (V0.8) — already implemented
+- Reuses `isInTimeWindow()` helper from presence-thermostat or shared
+
+## Testing
+
+- Run `npx tsc --noEmit` — zero errors
+- Run `npm test` — all tests pass
+- Manual: create heater equipment with relay binding, instantiate recipe, verify relay toggles on motion

--- a/specs/027-V0.8-presence-heater/spec.md
+++ b/specs/027-V0.8-presence-heater/spec.md
@@ -1,0 +1,50 @@
+# V0.8: Presence Heater Recipe + Heater Equipment Type
+
+## Summary
+
+Add a `"heater"` equipment type for electric radiators controlled via Zigbee relay modules (fil pilote). Create a `presence-heater` recipe that switches heaters to comfort on motion and eco on absence timeout, with an optional night window that forces eco regardless of motion.
+
+## Reference
+
+- Recipe system: §12 of winch-spec.md
+- Motion-light base recipe: `src/recipes/engine/motion-light-base.ts`
+- Presence-thermostat recipe: `src/recipes/presence-thermostat.ts` (night window pattern)
+
+## Acceptance Criteria
+
+- [ ] New `"heater"` equipment type in `EquipmentType` union
+- [ ] `presence-heater` recipe registered and instantiable
+- [ ] Motion detected → heaters set to comfort (relay state depends on `invertRelay`)
+- [ ] No motion for `timeout` → heaters set to eco
+- [ ] Night window (optional): forces eco regardless of motion between nightStart and nightEnd
+- [ ] Night window end with motion present → resume comfort
+- [ ] `invertRelay` parameter: when true, comfort = OFF / eco = ON (fil pilote wiring)
+- [ ] `maxOnDuration` (optional): force eco after this duration even with continued motion
+- [ ] Manual relay change → override mode (recipe suspended until eco timer clears)
+- [ ] Without night window, recipe works as simple motion-on / timeout-off
+- [ ] Backward compatible: no impact on existing recipes or equipment types
+
+## Scope
+
+### In Scope
+
+- `"heater"` equipment type (types.ts, constants.ts, equipment-manager validation)
+- `presence-heater` recipe with slots, validation, start/stop
+- Night window periodic check (same pattern as presence-thermostat)
+- Override detection on manual relay state change
+- i18n fr/en for recipe and slots
+- Tests for all scenarios
+
+### Out of Scope
+
+- Zone aggregation for heaters (no `heatersOn` count — deferred)
+- UI heater-specific components (uses standard equipment UI)
+- Temperature feedback from heaters (no thermostat integration)
+- Button toggle support (not requested)
+
+## Edge Cases
+
+- Night window overlaps midnight (e.g., 22:00 → 06:00): handled by `isInTimeWindow()` existing helper
+- Recipe restart during night window: sync checks night window on start, forces eco if applicable
+- Manual relay change during night: enters override, eco timer will clear override after timeout
+- All heaters offline: executeOrder will log error, recipe continues

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -32,6 +32,7 @@ const VALID_EQUIPMENT_TYPES: Set<string> = new Set([
   "thermostat",
   "weather",
   "gate",
+  "heater",
 ]);
 
 // ============================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { MotionLightRecipe } from "./recipes/motion-light.js";
 import { MotionLightDimmableRecipe } from "./recipes/motion-light-dimmable.js";
 import { SwitchLightRecipe } from "./recipes/switch-light.js";
 import { PresenceThermostatRecipe } from "./recipes/presence-thermostat.js";
+import { PresenceHeaterRecipe } from "./recipes/presence-heater.js";
 import { UserManager } from "./auth/user-manager.js";
 import { AuthService } from "./auth/auth-service.js";
 import { SettingsManager } from "./core/settings-manager.js";
@@ -137,6 +138,7 @@ async function main() {
   recipeManager.register(MotionLightDimmableRecipe);
   recipeManager.register(SwitchLightRecipe);
   recipeManager.register(PresenceThermostatRecipe);
+  recipeManager.register(PresenceHeaterRecipe);
 
   // 12. Create Mode Manager + Calendar Manager
   const modeManager = new ModeManager(db, eventBus, equipmentManager, recipeManager, logger);

--- a/src/recipes/presence-heater.test.ts
+++ b/src/recipes/presence-heater.test.ts
@@ -1,0 +1,889 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { ZoneManager } from "../zones/zone-manager.js";
+import { ZoneAggregator } from "../zones/zone-aggregator.js";
+import { EquipmentManager } from "../equipments/equipment-manager.js";
+import { DeviceManager } from "../devices/device-manager.js";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+import { RecipeManager } from "./engine/recipe-manager.js";
+import { PresenceHeaterRecipe } from "./presence-heater.js";
+import type { EngineEvent } from "../shared/types.js";
+
+// ============================================================
+// Test helpers
+// ============================================================
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  const migrations = [
+    "001_devices.sql",
+    "002_zones.sql",
+    "003_equipments.sql",
+    "005_recipes.sql",
+    "007_settings.sql",
+    "011_integration_architecture.sql",
+    "020_history.sql",
+  ];
+  for (const file of migrations) {
+    const sql = readFileSync(
+      resolve(import.meta.dirname ?? ".", "../../migrations", file),
+      "utf-8",
+    );
+    db.exec(sql);
+  }
+  return db;
+}
+
+const logger = createLogger("silent").logger;
+
+function seedDevice(
+  db: Database.Database,
+  opts: {
+    name?: string;
+    dataKeys?: { id?: string; key: string; type?: string; category?: string; value?: string }[];
+    orderKeys?: { id?: string; key: string; type?: string; payloadKey?: string }[];
+  } = {},
+) {
+  const deviceId = crypto.randomUUID();
+  const name = opts.name ?? "Test Device";
+  db.prepare(
+    `INSERT INTO devices (id, mqtt_base_topic, mqtt_name, name, source, status, integration_id, source_device_id)
+     VALUES (?, ?, ?, ?, 'zigbee2mqtt', 'online', 'zigbee2mqtt', ?)`,
+  ).run(deviceId, `z2m/${name}`, name, name, name);
+
+  const dataIds: string[] = [];
+  for (const d of opts.dataKeys ?? []) {
+    const id = d.id ?? crypto.randomUUID();
+    db.prepare(
+      `INSERT INTO device_data (id, device_id, key, type, category, value)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(id, deviceId, d.key, d.type ?? "boolean", d.category ?? "generic", d.value ?? null);
+    dataIds.push(id);
+  }
+
+  const orderIds: string[] = [];
+  for (const o of opts.orderKeys ?? []) {
+    const id = o.id ?? crypto.randomUUID();
+    db.prepare(
+      `INSERT INTO device_orders (id, device_id, key, type, mqtt_set_topic, payload_key, dispatch_config)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      id,
+      deviceId,
+      o.key,
+      o.type ?? "enum",
+      `z2m/${name}/set`,
+      o.payloadKey ?? o.key,
+      JSON.stringify({ topic: `z2m/${name}/set`, payloadKey: o.payloadKey ?? o.key }),
+    );
+    orderIds.push(id);
+  }
+
+  return { deviceId, dataIds, orderIds };
+}
+
+// ============================================================
+// Setup helpers
+// ============================================================
+
+interface TestSetup {
+  db: Database.Database;
+  eventBus: EventBus;
+  zoneManager: ZoneManager;
+  equipmentManager: EquipmentManager;
+  aggregator: ZoneAggregator;
+  manager: RecipeManager;
+  events: EngineEvent[];
+  published: Array<{ topic: string; payload: string }>;
+  zoneId: string;
+  heaterId: string;
+  pirDataId: string;
+  stateDataId: string;
+}
+
+function createTestSetup(): TestSetup {
+  const db = createTestDb();
+  const eventBus = new EventBus(logger);
+  const published: Array<{ topic: string; payload: string }> = [];
+  const mockIntegrationRegistry = {
+    getById: (id: string) => ({
+      id,
+      getStatus: () => "connected" as const,
+      executeOrder: async (
+        _device: unknown,
+        dispatchConfig: Record<string, unknown>,
+        value: unknown,
+      ) => {
+        const topic = dispatchConfig.topic as string;
+        const payloadKey = dispatchConfig.payloadKey as string;
+        published.push({ topic, payload: JSON.stringify({ [payloadKey]: value }) });
+      },
+    }),
+  };
+
+  const zoneManager = new ZoneManager(db, eventBus, logger);
+  const deviceManager = new DeviceManager(db, eventBus, logger);
+  const equipmentManager = new EquipmentManager(
+    db,
+    eventBus,
+    mockIntegrationRegistry as never,
+    deviceManager,
+    logger,
+  );
+  const aggregator = new ZoneAggregator(zoneManager, equipmentManager, eventBus, logger);
+  const manager = new RecipeManager(
+    db,
+    eventBus,
+    equipmentManager,
+    zoneManager,
+    aggregator,
+    logger,
+  );
+  manager.register(PresenceHeaterRecipe);
+
+  // Create zone
+  const zone = zoneManager.create({ name: "Chambre" });
+
+  // Create PIR sensor device + equipment
+  const pirDevice = seedDevice(db, {
+    name: "PIR Chambre",
+    dataKeys: [{ key: "occupancy", type: "boolean", category: "motion", value: "false" }],
+  });
+  const pirEq = equipmentManager.create({ name: "PIR Chambre", type: "sensor", zoneId: zone.id });
+  equipmentManager.addDataBinding(pirEq.id, pirDevice.dataIds[0], "occupancy");
+
+  // Create heater device + equipment with state data + order
+  const heaterDevice = seedDevice(db, {
+    name: "Heater Chambre",
+    dataKeys: [
+      {
+        key: "state",
+        type: "enum",
+        category: "generic",
+        value: JSON.stringify("OFF"),
+      },
+    ],
+    orderKeys: [{ key: "state", type: "enum", payloadKey: "state" }],
+  });
+  const heaterEq = equipmentManager.create({
+    name: "Radiateur Chambre",
+    type: "heater",
+    zoneId: zone.id,
+  });
+  equipmentManager.addDataBinding(heaterEq.id, heaterDevice.dataIds[0], "state");
+  equipmentManager.addOrderBinding(heaterEq.id, heaterDevice.orderIds[0], "state");
+
+  // Compute initial aggregation
+  aggregator.computeAll();
+
+  const events: EngineEvent[] = [];
+  eventBus.on((event) => events.push(event));
+
+  return {
+    db,
+    eventBus,
+    zoneManager,
+    equipmentManager,
+    aggregator,
+    manager,
+    events,
+    published,
+    zoneId: zone.id,
+    heaterId: heaterEq.id,
+    pirDataId: pirDevice.dataIds[0],
+    stateDataId: heaterDevice.dataIds[0],
+  };
+}
+
+function simulateMotion(setup: TestSetup, active: boolean): void {
+  setup.db
+    .prepare("UPDATE device_data SET value = ? WHERE id = ?")
+    .run(JSON.stringify(active), setup.pirDataId);
+  setup.eventBus.emit({
+    type: "device.data.updated",
+    deviceId: "pir-device",
+    deviceName: "PIR Chambre",
+    dataId: setup.pirDataId,
+    key: "occupancy",
+    value: active,
+    previous: !active,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+function simulateHeaterStateChange(setup: TestSetup, value: string): void {
+  setup.db
+    .prepare("UPDATE device_data SET value = ? WHERE id = ?")
+    .run(JSON.stringify(value), setup.stateDataId);
+  setup.eventBus.emit({
+    type: "equipment.data.changed",
+    equipmentId: setup.heaterId,
+    alias: "state",
+    value,
+    previous: value === "ON" ? "OFF" : "ON",
+  });
+}
+
+function getStateCommands(published: Array<{ topic: string; payload: string }>): string[] {
+  return published
+    .map((p) => JSON.parse(p.payload) as Record<string, unknown>)
+    .filter((p) => p.state !== undefined)
+    .map((p) => p.state as string);
+}
+
+const BASE_PARAMS = {
+  timeout: "30m",
+};
+
+// ============================================================
+// Tests
+// Fil pilote convention: relay OFF = comfort, relay ON = eco
+// ============================================================
+
+describe("PresenceHeaterRecipe", () => {
+  let setup: TestSetup;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setup = createTestSetup();
+  });
+
+  afterEach(() => {
+    setup.manager.stopAll();
+    setup.db.close();
+    vi.useRealTimers();
+  });
+
+  // ============================================================
+  // Validation
+  // ============================================================
+
+  it("validates required params", () => {
+    expect(() => setup.manager.createInstance("presence-heater", {})).toThrow("Invalid params");
+  });
+
+  it("validates zone exists", () => {
+    expect(() =>
+      setup.manager.createInstance("presence-heater", {
+        zone: "nonexistent",
+        heaters: [setup.heaterId],
+        ...BASE_PARAMS,
+      }),
+    ).toThrow("Invalid params");
+  });
+
+  it("validates heater exists", () => {
+    expect(() =>
+      setup.manager.createInstance("presence-heater", {
+        zone: setup.zoneId,
+        heaters: ["nonexistent"],
+        ...BASE_PARAMS,
+      }),
+    ).toThrow("Invalid params");
+  });
+
+  it("validates heater has state order binding", () => {
+    // Create heater WITHOUT state order
+    const heaterDevice = seedDevice(setup.db, {
+      name: "Heater No Order",
+      dataKeys: [{ key: "state", type: "enum", category: "generic", value: JSON.stringify("OFF") }],
+    });
+    const heaterEq = setup.equipmentManager.create({
+      name: "Heater No Order",
+      type: "heater",
+      zoneId: setup.zoneId,
+    });
+    setup.equipmentManager.addDataBinding(heaterEq.id, heaterDevice.dataIds[0], "state");
+
+    expect(() =>
+      setup.manager.createInstance("presence-heater", {
+        zone: setup.zoneId,
+        heaters: [heaterEq.id],
+        ...BASE_PARAMS,
+      }),
+    ).toThrow("Invalid params");
+  });
+
+  it("validates nightStart requires nightEnd", () => {
+    expect(() =>
+      setup.manager.createInstance("presence-heater", {
+        zone: setup.zoneId,
+        heaters: [setup.heaterId],
+        ...BASE_PARAMS,
+        nightStart: "22:00",
+      }),
+    ).toThrow("Invalid params");
+  });
+
+  it("validates time format", () => {
+    expect(() =>
+      setup.manager.createInstance("presence-heater", {
+        zone: setup.zoneId,
+        heaters: [setup.heaterId],
+        ...BASE_PARAMS,
+        nightStart: "invalid",
+        nightEnd: "06:00",
+      }),
+    ).toThrow("Invalid params");
+  });
+
+  it("creates a valid instance", () => {
+    const instance = setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+    expect(instance.recipeId).toBe("presence-heater");
+    expect(instance.enabled).toBe(true);
+  });
+
+  // ============================================================
+  // Normal cycle: motion → comfort (relay OFF), absence → eco (relay ON)
+  // ============================================================
+
+  it("sends comfort (relay OFF) when motion detected", () => {
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+    setup.published.length = 0;
+
+    simulateMotion(setup, true);
+
+    const states = getStateCommands(setup.published);
+    expect(states).toContain("OFF"); // comfort = relay OFF
+  });
+
+  it("sends eco (relay ON) after timeout with no motion", () => {
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+
+    // Motion on → comfort
+    simulateMotion(setup, true);
+    setup.published.length = 0;
+
+    // Motion off → start timer
+    simulateMotion(setup, false);
+
+    // Advance past timeout
+    vi.advanceTimersByTime(30 * 60 * 1000 + 100);
+
+    const states = getStateCommands(setup.published);
+    expect(states).toContain("ON"); // eco = relay ON
+  });
+
+  it("does not send redundant comfort command if already in comfort", () => {
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+
+    simulateMotion(setup, true);
+    setup.published.length = 0;
+
+    // Another motion event while already in comfort
+    simulateMotion(setup, true);
+
+    expect(setup.published).toHaveLength(0);
+  });
+
+  it("cancels eco timer when motion resumes", () => {
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+
+    simulateMotion(setup, true);
+    simulateMotion(setup, false); // starts eco timer
+    setup.published.length = 0;
+
+    // Motion resumes before timeout
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    simulateMotion(setup, true);
+
+    // Advance past original timeout — should NOT fire
+    vi.advanceTimersByTime(25 * 60 * 1000);
+
+    const states = getStateCommands(setup.published);
+    expect(states).not.toContain("ON"); // eco (relay ON) did not fire
+  });
+
+  it("does not send eco command if already in eco", () => {
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+    setup.published.length = 0;
+
+    // No motion, already eco — nothing to do
+    simulateMotion(setup, false);
+
+    expect(setup.published).toHaveLength(0);
+  });
+
+  // ============================================================
+  // Night window
+  // ============================================================
+
+  it("forces eco when recipe starts during night window", () => {
+    vi.setSystemTime(new Date("2026-02-27T23:30:00")); // inside 22:00-06:00
+
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+      nightStart: "22:00",
+      nightEnd: "06:00",
+    });
+
+    const states = getStateCommands(setup.published);
+    expect(states).toContain("ON"); // eco = relay ON
+  });
+
+  it("forces eco on night window entry when in comfort", () => {
+    vi.setSystemTime(new Date("2026-02-27T21:50:00")); // just before night
+
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+      nightStart: "22:00",
+      nightEnd: "06:00",
+    });
+
+    simulateMotion(setup, true); // comfort
+    setup.published.length = 0;
+
+    // Advance into night window — periodic check triggers
+    vi.setSystemTime(new Date("2026-02-27T22:01:00"));
+    vi.advanceTimersByTime(60_000); // trigger night check
+
+    const states = getStateCommands(setup.published);
+    expect(states).toContain("ON"); // eco = relay ON
+  });
+
+  it("ignores motion during night window", () => {
+    vi.setSystemTime(new Date("2026-02-27T23:30:00")); // during night
+
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+      nightStart: "22:00",
+      nightEnd: "06:00",
+    });
+    setup.published.length = 0;
+
+    simulateMotion(setup, true);
+
+    // Should NOT send comfort (night forces eco)
+    const states = getStateCommands(setup.published);
+    expect(states).not.toContain("OFF"); // comfort (relay OFF) blocked
+  });
+
+  it("resumes comfort after night window ends if motion present", () => {
+    vi.setSystemTime(new Date("2026-02-27T23:30:00")); // during night
+
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+      nightStart: "22:00",
+      nightEnd: "06:00",
+    });
+
+    // Simulate motion present (but night forces eco)
+    simulateMotion(setup, true);
+    setup.published.length = 0;
+
+    // Advance past night end
+    vi.setSystemTime(new Date("2026-02-28T06:01:00"));
+    vi.advanceTimersByTime(60_000); // trigger night check
+
+    const states = getStateCommands(setup.published);
+    expect(states).toContain("OFF"); // comfort = relay OFF
+  });
+
+  it("stays eco after night window ends if no motion", () => {
+    vi.setSystemTime(new Date("2026-02-27T23:30:00")); // during night
+
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+      nightStart: "22:00",
+      nightEnd: "06:00",
+    });
+    setup.published.length = 0;
+
+    // Advance past night end — no motion
+    vi.setSystemTime(new Date("2026-02-28T06:01:00"));
+    vi.advanceTimersByTime(60_000); // trigger night check
+
+    // Should stay eco (no motion detected)
+    const states = getStateCommands(setup.published);
+    expect(states).not.toContain("OFF"); // comfort (relay OFF) not sent
+  });
+
+  // ============================================================
+  // Manual override
+  // ============================================================
+
+  it("enters override on manual relay change", () => {
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+
+    simulateMotion(setup, true); // comfort (relay OFF)
+    vi.advanceTimersByTime(6000); // wait past grace period
+    setup.published.length = 0;
+
+    // Manual relay change — ON while recipe expects OFF → override
+    simulateHeaterStateChange(setup, "ON");
+
+    // Next motion should be ignored (override active)
+    simulateMotion(setup, false);
+    simulateMotion(setup, true);
+
+    const states = getStateCommands(setup.published);
+    expect(states).not.toContain("OFF"); // no comfort command
+  });
+
+  it("does not enter override on self-triggered state change", () => {
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+
+    // Motion on → comfort (relay OFF)
+    simulateMotion(setup, true);
+
+    // MQTT echo with same value (OFF during comfort) — should NOT trigger override
+    simulateHeaterStateChange(setup, "OFF");
+
+    // Go to eco and back — should work (no override)
+    simulateMotion(setup, false);
+    vi.advanceTimersByTime(30 * 60 * 1000 + 100);
+    setup.published.length = 0;
+
+    simulateMotion(setup, true);
+
+    const states = getStateCommands(setup.published);
+    expect(states).toContain("OFF"); // comfort works — not in override
+  });
+
+  it("ignores state echo during grace period after command", () => {
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+
+    // Motion → comfort (starts 5s grace)
+    simulateMotion(setup, true);
+
+    // Device echoes ON within grace window — should NOT trigger override
+    vi.advanceTimersByTime(1000);
+    simulateHeaterStateChange(setup, "ON");
+
+    // Go to eco and back — should work (no override)
+    simulateMotion(setup, false);
+    vi.advanceTimersByTime(30 * 60 * 1000 + 100);
+    setup.published.length = 0;
+
+    simulateMotion(setup, true);
+
+    const states = getStateCommands(setup.published);
+    expect(states).toContain("OFF"); // comfort works — not in override
+  });
+
+  it("clears override after absence timeout", () => {
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+
+    simulateMotion(setup, true); // comfort (relay OFF)
+    vi.advanceTimersByTime(6000); // wait past grace period
+    simulateHeaterStateChange(setup, "ON"); // manual change → override
+
+    // No motion → start override-clear timer
+    simulateMotion(setup, false);
+    setup.published.length = 0;
+
+    vi.advanceTimersByTime(30 * 60 * 1000 + 100);
+
+    // Override cleared → eco sent
+    const states = getStateCommands(setup.published);
+    expect(states).toContain("ON"); // eco = relay ON
+
+    // Now motion should work again
+    setup.published.length = 0;
+    simulateMotion(setup, true);
+
+    const newStates = getStateCommands(setup.published);
+    expect(newStates).toContain("OFF"); // comfort = relay OFF
+  });
+
+  it("motion during override cancels eco timer but does not change state", () => {
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+
+    simulateMotion(setup, true); // comfort (relay OFF)
+    vi.advanceTimersByTime(6000); // wait past grace period
+    simulateHeaterStateChange(setup, "ON"); // manual change → override
+
+    simulateMotion(setup, false); // start override-clear timer
+    setup.published.length = 0;
+
+    // Motion resumes during override
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    simulateMotion(setup, true);
+
+    // No state command (override still active)
+    expect(getStateCommands(setup.published)).toHaveLength(0);
+
+    // Original timer should NOT fire
+    vi.advanceTimersByTime(25 * 60 * 1000);
+    expect(getStateCommands(setup.published)).toHaveLength(0);
+  });
+
+  // ============================================================
+  // Max comfort duration (failsafe)
+  // ============================================================
+
+  it("forces eco after maxOnDuration even with continued motion", () => {
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+      maxOnDuration: "2h",
+    });
+
+    simulateMotion(setup, true); // comfort
+    setup.published.length = 0;
+
+    // Advance past maxOnDuration
+    vi.advanceTimersByTime(2 * 60 * 60 * 1000 + 100);
+
+    const states = getStateCommands(setup.published);
+    expect(states).toContain("ON"); // failsafe → eco = relay ON
+  });
+
+  it("does not trigger failsafe if eco happens before maxOnDuration", () => {
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+      maxOnDuration: "2h",
+    });
+
+    simulateMotion(setup, true); // comfort
+    simulateMotion(setup, false); // start eco timer
+    vi.advanceTimersByTime(30 * 60 * 1000 + 100); // eco fires at 30m
+    setup.published.length = 0;
+
+    // Advance well past maxOnDuration — no failsafe since already eco
+    vi.advanceTimersByTime(2 * 60 * 60 * 1000);
+
+    const states = getStateCommands(setup.published);
+    expect(states).not.toContain("ON"); // no extra eco
+  });
+
+  // ============================================================
+  // Startup evaluation
+  // ============================================================
+
+  it("sends comfort immediately if motion present on startup", () => {
+    // Set motion BEFORE creating the recipe
+    simulateMotion(setup, true);
+    setup.published.length = 0;
+
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+
+    const states = getStateCommands(setup.published);
+    expect(states).toContain("OFF"); // comfort = relay OFF
+  });
+
+  it("sends eco on startup if no motion", () => {
+    setup.published.length = 0;
+
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+
+    const states = getStateCommands(setup.published);
+    expect(states).toContain("ON"); // eco = relay ON
+  });
+
+  it("sends eco on startup during night window even with motion", () => {
+    vi.setSystemTime(new Date("2026-02-27T23:30:00")); // during night
+
+    simulateMotion(setup, true);
+    setup.published.length = 0;
+
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+      nightStart: "22:00",
+      nightEnd: "06:00",
+    });
+
+    const states = getStateCommands(setup.published);
+    expect(states).toContain("ON"); // eco = relay ON (night forced)
+    expect(states).not.toContain("OFF"); // no comfort
+  });
+
+  // ============================================================
+  // Multiple heaters
+  // ============================================================
+
+  it("commands all heaters on comfort", () => {
+    // Create second heater
+    const heater2Device = seedDevice(setup.db, {
+      name: "Heater 2",
+      dataKeys: [{ key: "state", type: "enum", category: "generic", value: JSON.stringify("OFF") }],
+      orderKeys: [{ key: "state", type: "enum", payloadKey: "state" }],
+    });
+    const heater2Eq = setup.equipmentManager.create({
+      name: "Radiateur 2",
+      type: "heater",
+      zoneId: setup.zoneId,
+    });
+    setup.equipmentManager.addDataBinding(heater2Eq.id, heater2Device.dataIds[0], "state");
+    setup.equipmentManager.addOrderBinding(heater2Eq.id, heater2Device.orderIds[0], "state");
+
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId, heater2Eq.id],
+      ...BASE_PARAMS,
+    });
+    setup.published.length = 0;
+
+    simulateMotion(setup, true);
+
+    const states = getStateCommands(setup.published);
+    // Both heaters should receive OFF (comfort = relay OFF)
+    expect(states.filter((s) => s === "OFF")).toHaveLength(2);
+  });
+
+  // ============================================================
+  // Full cycle integration
+  // ============================================================
+
+  it("full cycle: eco → motion comfort → absence eco → night eco → morning resume", () => {
+    vi.setSystemTime(new Date("2026-02-27T14:00:00")); // afternoon
+
+    setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+      nightStart: "22:00",
+      nightEnd: "06:00",
+    });
+
+    // 1. Motion → comfort (relay OFF)
+    setup.published.length = 0;
+    simulateMotion(setup, true);
+    expect(getStateCommands(setup.published)).toContain("OFF");
+
+    // 2. No motion → eco (relay ON) after timeout
+    simulateMotion(setup, false);
+    setup.published.length = 0;
+    vi.advanceTimersByTime(30 * 60 * 1000 + 100);
+    expect(getStateCommands(setup.published)).toContain("ON");
+
+    // 3. Evening motion → comfort again (relay OFF)
+    vi.setSystemTime(new Date("2026-02-27T20:00:00"));
+    setup.published.length = 0;
+    simulateMotion(setup, true);
+    expect(getStateCommands(setup.published)).toContain("OFF");
+
+    // 4. Night window starts → forced eco (relay ON)
+    vi.setSystemTime(new Date("2026-02-27T22:01:00"));
+    setup.published.length = 0;
+    vi.advanceTimersByTime(60_000); // trigger night check
+    expect(getStateCommands(setup.published)).toContain("ON");
+
+    // 5. Morning motion after night ends → comfort (relay OFF)
+    vi.setSystemTime(new Date("2026-02-28T06:01:00"));
+    simulateMotion(setup, true); // motion present
+    setup.published.length = 0;
+    vi.advanceTimersByTime(60_000); // trigger night check
+    expect(getStateCommands(setup.published)).toContain("OFF");
+  });
+
+  // ============================================================
+  // State exposed
+  // ============================================================
+
+  it("currentMode state is exposed correctly", () => {
+    const instance = setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+
+    // Start in eco
+    const stateEco = setup.manager.getInstanceState(instance.id);
+    expect(stateEco.currentMode).toBe("eco");
+
+    // Motion → comfort
+    simulateMotion(setup, true);
+    const stateComfort = setup.manager.getInstanceState(instance.id);
+    expect(stateComfort.currentMode).toBe("comfort");
+
+    // No motion → eco after timeout
+    simulateMotion(setup, false);
+    vi.advanceTimersByTime(30 * 60 * 1000 + 100);
+    const stateEcoAgain = setup.manager.getInstanceState(instance.id);
+    expect(stateEcoAgain.currentMode).toBe("eco");
+  });
+
+  it("overrideMode state is exposed and cleared correctly", () => {
+    const instance = setup.manager.createInstance("presence-heater", {
+      zone: setup.zoneId,
+      heaters: [setup.heaterId],
+      ...BASE_PARAMS,
+    });
+
+    simulateMotion(setup, true); // comfort
+    vi.advanceTimersByTime(6000); // wait past grace period
+
+    // Manual relay change → override
+    simulateHeaterStateChange(setup, "ON"); // ON while comfort expects OFF
+    const stateOverride = setup.manager.getInstanceState(instance.id);
+    expect(stateOverride.overrideMode).toBe(true);
+
+    // Clear override via absence timeout
+    simulateMotion(setup, false);
+    vi.advanceTimersByTime(30 * 60 * 1000 + 100);
+    const stateCleared = setup.manager.getInstanceState(instance.id);
+    expect(stateCleared.overrideMode).toBeUndefined();
+  });
+});

--- a/src/recipes/presence-heater.ts
+++ b/src/recipes/presence-heater.ts
@@ -15,14 +15,14 @@ export class PresenceHeaterRecipe extends Recipe {
     {
       id: "zone",
       name: "Zone",
-      description: "Zone to monitor for presence",
+      description: "Room monitored by the motion sensor",
       type: "zone",
       required: true,
     },
     {
       id: "heaters",
       name: "Heaters",
-      description: "Electric heater equipments (relay-controlled)",
+      description: "Heaters to control (fil pilote relay modules)",
       type: "equipment",
       required: true,
       list: true,
@@ -30,32 +30,32 @@ export class PresenceHeaterRecipe extends Recipe {
     },
     {
       id: "timeout",
-      name: "Timeout",
-      description: "Delay with no motion before switching to eco",
+      name: "Eco delay",
+      description: "Duration without motion before switching to eco (e.g. 30m, 1h)",
       type: "duration",
       required: true,
       defaultValue: "30m",
     },
     {
       id: "nightStart",
-      name: "Night Start",
-      description: "Start of forced eco window (HH:MM)",
+      name: "Night mode start",
+      description: "Time when heating switches to eco (e.g. 22:00)",
       type: "time",
       required: false,
       group: "night",
     },
     {
       id: "nightEnd",
-      name: "Night End",
-      description: "End of forced eco window (HH:MM)",
+      name: "Night mode end",
+      description: "Time when heating can switch back to comfort (e.g. 06:30)",
       type: "time",
       required: false,
       group: "night",
     },
     {
       id: "maxOnDuration",
-      name: "Max Comfort Duration",
-      description: "Force eco after this duration even with continued motion (safety)",
+      name: "Max comfort duration",
+      description: "Safety: switch to eco after this duration even if motion is detected (e.g. 4h)",
       type: "duration",
       required: false,
     },
@@ -67,23 +67,30 @@ export class PresenceHeaterRecipe extends Recipe {
       description:
         "Passe les radiateurs électriques en confort sur mouvement, éco après un délai sans présence. Convention fil pilote : relais OFF = confort, relais ON = éco.",
       slots: {
-        zone: { name: "Zone", description: "Zone à surveiller" },
+        zone: {
+          name: "Zone",
+          description: "Pièce surveillée par le détecteur de mouvement",
+        },
         heaters: {
           name: "Radiateurs",
-          description: "Radiateurs électriques (contrôlés par relais)",
+          description: "Radiateurs à piloter (modules relais fil pilote)",
         },
-        timeout: { name: "Délai", description: "Délai sans mouvement avant passage en éco" },
+        timeout: {
+          name: "Délai avant éco",
+          description: "Durée sans mouvement avant de repasser en éco (ex : 30m, 1h)",
+        },
         nightStart: {
-          name: "Début nuit",
-          description: "Début de la plage éco forcé (HH:MM)",
+          name: "Début mode nuit",
+          description: "Heure à partir de laquelle le chauffage passe en éco (ex : 22:00)",
         },
         nightEnd: {
-          name: "Fin nuit",
-          description: "Fin de la plage éco forcé (HH:MM)",
+          name: "Fin mode nuit",
+          description: "Heure à laquelle le chauffage peut repasser en confort (ex : 06:30)",
         },
         maxOnDuration: {
           name: "Durée max confort",
-          description: "Forcer éco après cette durée même si mouvement continu (sécurité)",
+          description:
+            "Sécurité : repasse en éco après cette durée même si du mouvement est détecté (ex : 4h)",
         },
       },
       groups: {

--- a/src/recipes/presence-heater.ts
+++ b/src/recipes/presence-heater.ts
@@ -15,14 +15,14 @@ export class PresenceHeaterRecipe extends Recipe {
     {
       id: "zone",
       name: "Zone",
-      description: "Room monitored by the motion sensor",
+      description: "Zone to monitor for presence",
       type: "zone",
       required: true,
     },
     {
       id: "heaters",
       name: "Heaters",
-      description: "Heaters to control (fil pilote relay modules)",
+      description: "Electric heater equipments (relay-controlled)",
       type: "equipment",
       required: true,
       list: true,
@@ -30,32 +30,32 @@ export class PresenceHeaterRecipe extends Recipe {
     },
     {
       id: "timeout",
-      name: "Eco delay",
-      description: "Duration without motion before switching to eco (e.g. 30m, 1h)",
+      name: "Timeout",
+      description: "Delay with no motion before switching to eco",
       type: "duration",
       required: true,
       defaultValue: "30m",
     },
     {
       id: "nightStart",
-      name: "Night mode start",
-      description: "Time when heating switches to eco (e.g. 22:00)",
+      name: "Night Start",
+      description: "Start of forced eco window (HH:MM)",
       type: "time",
       required: false,
       group: "night",
     },
     {
       id: "nightEnd",
-      name: "Night mode end",
-      description: "Time when heating can switch back to comfort (e.g. 06:30)",
+      name: "Night End",
+      description: "End of forced eco window (HH:MM)",
       type: "time",
       required: false,
       group: "night",
     },
     {
       id: "maxOnDuration",
-      name: "Max comfort duration",
-      description: "Safety: switch to eco after this duration even if motion is detected (e.g. 4h)",
+      name: "Max Comfort Duration",
+      description: "Force eco after this duration even with continued motion (safety)",
       type: "duration",
       required: false,
     },
@@ -67,30 +67,23 @@ export class PresenceHeaterRecipe extends Recipe {
       description:
         "Passe les radiateurs électriques en confort sur mouvement, éco après un délai sans présence. Convention fil pilote : relais OFF = confort, relais ON = éco.",
       slots: {
-        zone: {
-          name: "Zone",
-          description: "Pièce surveillée par le détecteur de mouvement",
-        },
+        zone: { name: "Zone", description: "Zone à surveiller" },
         heaters: {
           name: "Radiateurs",
-          description: "Radiateurs à piloter (modules relais fil pilote)",
+          description: "Radiateurs électriques (contrôlés par relais)",
         },
-        timeout: {
-          name: "Délai avant éco",
-          description: "Durée sans mouvement avant de repasser en éco (ex : 30m, 1h)",
-        },
+        timeout: { name: "Délai", description: "Délai sans mouvement avant passage en éco" },
         nightStart: {
-          name: "Début mode nuit",
-          description: "Heure à partir de laquelle le chauffage passe en éco (ex : 22:00)",
+          name: "Début nuit",
+          description: "Début de la plage éco forcé (HH:MM)",
         },
         nightEnd: {
-          name: "Fin mode nuit",
-          description: "Heure à laquelle le chauffage peut repasser en confort (ex : 06:30)",
+          name: "Fin nuit",
+          description: "Fin de la plage éco forcé (HH:MM)",
         },
         maxOnDuration: {
           name: "Durée max confort",
-          description:
-            "Sécurité : repasse en éco après cette durée même si du mouvement est détecté (ex : 4h)",
+          description: "Forcer éco après cette durée même si mouvement continu (sécurité)",
         },
       },
       groups: {

--- a/src/recipes/presence-heater.ts
+++ b/src/recipes/presence-heater.ts
@@ -1,0 +1,528 @@
+import type { RecipeSlotDef, RecipeLangPack } from "../shared/types.js";
+import { Recipe, type RecipeContext } from "./engine/recipe.js";
+import { parseDuration, formatDuration } from "./engine/duration.js";
+
+// ============================================================
+// Presence-Heater Recipe
+// ============================================================
+
+export class PresenceHeaterRecipe extends Recipe {
+  readonly id = "presence-heater";
+  readonly name = "Presence Heater";
+  readonly description =
+    "Switches electric heaters to comfort on motion, eco after absence timeout. Fil pilote convention: relay OFF = comfort, relay ON = eco.";
+  readonly slots: RecipeSlotDef[] = [
+    {
+      id: "zone",
+      name: "Zone",
+      description: "Zone to monitor for presence",
+      type: "zone",
+      required: true,
+    },
+    {
+      id: "heaters",
+      name: "Heaters",
+      description: "Electric heater equipments (relay-controlled)",
+      type: "equipment",
+      required: true,
+      list: true,
+      constraints: { equipmentType: "heater" },
+    },
+    {
+      id: "timeout",
+      name: "Timeout",
+      description: "Delay with no motion before switching to eco",
+      type: "duration",
+      required: true,
+      defaultValue: "30m",
+    },
+    {
+      id: "nightStart",
+      name: "Night Start",
+      description: "Start of forced eco window (HH:MM)",
+      type: "time",
+      required: false,
+      group: "night",
+    },
+    {
+      id: "nightEnd",
+      name: "Night End",
+      description: "End of forced eco window (HH:MM)",
+      type: "time",
+      required: false,
+      group: "night",
+    },
+    {
+      id: "maxOnDuration",
+      name: "Max Comfort Duration",
+      description: "Force eco after this duration even with continued motion (safety)",
+      type: "duration",
+      required: false,
+    },
+  ];
+
+  override readonly i18n: Record<string, RecipeLangPack> = {
+    fr: {
+      name: "Chauffage présence",
+      description:
+        "Passe les radiateurs électriques en confort sur mouvement, éco après un délai sans présence. Convention fil pilote : relais OFF = confort, relais ON = éco.",
+      slots: {
+        zone: { name: "Zone", description: "Zone à surveiller" },
+        heaters: {
+          name: "Radiateurs",
+          description: "Radiateurs électriques (contrôlés par relais)",
+        },
+        timeout: { name: "Délai", description: "Délai sans mouvement avant passage en éco" },
+        nightStart: {
+          name: "Début nuit",
+          description: "Début de la plage éco forcé (HH:MM)",
+        },
+        nightEnd: {
+          name: "Fin nuit",
+          description: "Fin de la plage éco forcé (HH:MM)",
+        },
+        maxOnDuration: {
+          name: "Durée max confort",
+          description: "Forcer éco après cette durée même si mouvement continu (sécurité)",
+        },
+      },
+      groups: {
+        night: "Nuit",
+      },
+    },
+    en: {
+      name: "Presence Heater",
+      description:
+        "Switches electric heaters to comfort on motion, eco after absence timeout. Fil pilote: relay OFF = comfort, relay ON = eco.",
+      groups: {
+        night: "Night",
+      },
+    },
+  };
+
+  // ── Instance fields ──────────────────────────────────────
+  private ctx!: RecipeContext;
+  private zoneId!: string;
+  private heaterIds!: string[];
+  private timeoutMs!: number;
+  private nightStart: string | null = null;
+  private nightEnd: string | null = null;
+  private maxOnDurationMs: number | null = null;
+
+  // Runtime state
+  private currentMode: "comfort" | "eco" = "eco";
+  private overrideMode = false;
+  private ecoTimer: ReturnType<typeof setTimeout> | null = null;
+  private failsafeTimer: ReturnType<typeof setTimeout> | null = null;
+  private nightCheckTimer: ReturnType<typeof setInterval> | null = null;
+  private stateGraceUntil = 0;
+  private unsubs: (() => void)[] = [];
+
+  // ── Validation ───────────────────────────────────────────
+
+  validate(params: Record<string, unknown>, ctx: RecipeContext): void {
+    const { zone, timeout, maxOnDuration } = params;
+
+    // Validate zone
+    if (!zone || typeof zone !== "string") {
+      throw new Error("Zone parameter is required");
+    }
+    const zoneObj = ctx.zoneManager.getById(zone);
+    if (!zoneObj) {
+      throw new Error(`Zone not found: ${zone}`);
+    }
+    const zoneData = ctx.zoneAggregator.getByZoneId(zone);
+    if (zoneData && zoneData.motionSensors === 0) {
+      ctx.log("Zone has no motion sensors — recipe will only work with night window", "warn");
+    }
+
+    // Validate heaters
+    const heaterIds = this.normalizeStringArray(params.heaters);
+    if (heaterIds.length === 0) {
+      throw new Error("At least one heater is required");
+    }
+    for (const heaterId of heaterIds) {
+      const equipment = ctx.equipmentManager.getByIdWithDetails(heaterId);
+      if (!equipment) {
+        throw new Error(`Heater equipment not found: ${heaterId}`);
+      }
+      if (equipment.type !== "heater") {
+        throw new Error(`Equipment "${equipment.name}" is not a heater`);
+      }
+      const hasStateOrder = equipment.orderBindings.some((ob) => ob.alias === "state");
+      if (!hasStateOrder) {
+        throw new Error(`Heater "${equipment.name}" has no "state" order binding`);
+      }
+    }
+
+    // Validate timeout
+    parseDuration(timeout ?? "30m");
+
+    // Validate night window
+    const { nightStart: ns, nightEnd: ne } = params;
+    const hasNightStart = ns !== undefined && ns !== null && ns !== "";
+    const hasNightEnd = ne !== undefined && ne !== null && ne !== "";
+    if (hasNightStart !== hasNightEnd) {
+      throw new Error("nightStart and nightEnd must both be provided or both omitted");
+    }
+    if (hasNightStart && typeof ns === "string" && !/^\d{2}:\d{2}$/.test(ns)) {
+      throw new Error("nightStart must be in HH:MM format");
+    }
+    if (hasNightEnd && typeof ne === "string" && !/^\d{2}:\d{2}$/.test(ne)) {
+      throw new Error("nightEnd must be in HH:MM format");
+    }
+
+    // Validate maxOnDuration
+    if (maxOnDuration !== undefined && maxOnDuration !== null && maxOnDuration !== "") {
+      parseDuration(maxOnDuration);
+    }
+  }
+
+  private normalizeStringArray(value: unknown): string[] {
+    if (Array.isArray(value)) {
+      return value.filter((id): id is string => typeof id === "string");
+    }
+    return [];
+  }
+
+  // ── Start ────────────────────────────────────────────────
+
+  start(params: Record<string, unknown>, ctx: RecipeContext): void {
+    this.ctx = ctx;
+    this.zoneId = params.zone as string;
+    this.heaterIds = this.normalizeStringArray(params.heaters);
+    this.timeoutMs = parseDuration(params.timeout ?? "30m");
+
+    // Night window
+    this.nightStart =
+      typeof params.nightStart === "string" && params.nightStart ? params.nightStart : null;
+    this.nightEnd = typeof params.nightEnd === "string" && params.nightEnd ? params.nightEnd : null;
+
+    // Max on duration
+    this.maxOnDurationMs =
+      params.maxOnDuration !== undefined &&
+      params.maxOnDuration !== null &&
+      params.maxOnDuration !== ""
+        ? parseDuration(params.maxOnDuration)
+        : null;
+
+    // Reset runtime state
+    this.currentMode = "eco";
+    this.overrideMode = false;
+    this.stateGraceUntil = 0;
+    ctx.state.delete("overrideMode");
+    ctx.notifyStateChanged();
+
+    // Subscribe to zone changes (motion)
+    const unsubZone = ctx.eventBus.onType("zone.data.changed", (event) => {
+      if (event.zoneId !== this.zoneId) return;
+      this.onZoneChanged(event.aggregatedData.motion);
+    });
+    this.unsubs.push(unsubZone);
+
+    // Subscribe to heater state changes (manual override detection)
+    const unsubState = ctx.eventBus.onType("equipment.data.changed", (event) => {
+      if (!this.heaterIds.includes(event.equipmentId)) return;
+      if (event.alias !== "state") return;
+      this.onHeaterStateChanged(event.value);
+    });
+    this.unsubs.push(unsubState);
+
+    // Night check timer (every 60s)
+    if (this.hasNightConfig()) {
+      this.nightCheckTimer = setInterval(() => {
+        this.checkNightTransition();
+      }, 60_000);
+    }
+
+    // Sync on start
+    this.syncOnStart();
+  }
+
+  // ── Stop ─────────────────────────────────────────────────
+
+  stop(): void {
+    this.cancelEcoTimer();
+    this.cancelFailsafeTimer();
+    if (this.nightCheckTimer) {
+      clearInterval(this.nightCheckTimer);
+      this.nightCheckTimer = null;
+    }
+    for (const unsub of this.unsubs) {
+      unsub();
+    }
+    this.unsubs = [];
+    this.overrideMode = false;
+    this.stateGraceUntil = 0;
+    this.ctx.state.delete("overrideMode");
+    this.ctx.state.delete("timerExpiresAt");
+    this.ctx.state.delete("failsafeExpiresAt");
+    this.ctx.state.delete("currentMode");
+    this.ctx.notifyStateChanged();
+  }
+
+  // ── Initial sync ─────────────────────────────────────────
+
+  private syncOnStart(): void {
+    const zoneData = this.ctx.zoneAggregator.getByZoneId(this.zoneId);
+    const motion = zoneData?.motion ?? false;
+
+    if (this.isInNightWindow()) {
+      this.setEco("Recipe activated — night window active");
+    } else if (motion) {
+      this.setComfort("Recipe activated — motion detected");
+    } else {
+      this.setEco("Recipe activated — no motion");
+    }
+  }
+
+  // ── Event handlers ───────────────────────────────────────
+
+  private onZoneChanged(motion: boolean): void {
+    // Override mode: recipe is suspended, only track room vacancy
+    if (this.overrideMode) {
+      if (motion) {
+        this.cancelEcoTimer();
+        this.clearTimerState();
+      } else {
+        this.startEcoTimerForOverrideClear();
+      }
+      return;
+    }
+
+    // Night window: force eco regardless of motion
+    if (this.isInNightWindow()) {
+      if (this.currentMode === "comfort") {
+        this.cancelEcoTimer();
+        this.clearTimerState();
+        this.cancelFailsafeTimer();
+        this.setEco("Night window — forced eco");
+      }
+      return;
+    }
+
+    if (motion) {
+      this.cancelEcoTimer();
+      this.clearTimerState();
+      if (this.currentMode === "eco") {
+        this.setComfort("Motion detected");
+      }
+    } else {
+      if (this.currentMode === "comfort") {
+        this.startEcoTimer();
+      }
+    }
+  }
+
+  private onHeaterStateChanged(value: unknown): void {
+    if (this.overrideMode) return;
+    if (Date.now() < this.stateGraceUntil) return;
+
+    // Detect if the state change was unexpected (manual override)
+    const isComfortState = this.isComfortState(value);
+    if (
+      (this.currentMode === "comfort" && !isComfortState) ||
+      (this.currentMode === "eco" && isComfortState)
+    ) {
+      this.overrideMode = true;
+      this.ctx.state.set("overrideMode", true);
+      this.ctx.notifyStateChanged();
+      this.ctx.log("Manual relay change detected — entering override mode");
+    }
+  }
+
+  // ── Night window ─────────────────────────────────────────
+
+  private hasNightConfig(): boolean {
+    return this.nightStart !== null && this.nightEnd !== null;
+  }
+
+  private isInNightWindow(): boolean {
+    if (!this.hasNightConfig()) return false;
+    return isInTimeWindow(new Date(), this.nightStart!, this.nightEnd!);
+  }
+
+  private checkNightTransition(): void {
+    if (this.overrideMode) return;
+
+    const inNight = this.isInNightWindow();
+
+    // Entering night window → force eco
+    if (inNight && this.currentMode === "comfort") {
+      this.cancelEcoTimer();
+      this.clearTimerState();
+      this.cancelFailsafeTimer();
+      this.setEco("Night window started — forced eco");
+    }
+
+    // Leaving night window → resume based on motion
+    if (!inNight && this.currentMode === "eco") {
+      if (this.hasMotion()) {
+        this.setComfort("Night window ended — motion present");
+      }
+    }
+  }
+
+  // ── Relay state helpers ──────────────────────────────────
+
+  // Fil pilote: relay OFF = comfort, relay ON = eco
+  private isComfortState(value: unknown): boolean {
+    const isOn = value === true || String(value).toUpperCase() === "ON";
+    return !isOn; // comfort = relay OFF
+  }
+
+  private resolveEnumValue(heaterId: string, target: "on" | "off"): string {
+    const equipment = this.ctx.equipmentManager.getByIdWithDetails(heaterId);
+    const stateOrder = equipment?.orderBindings.find((ob) => ob.alias === "state");
+    const match = stateOrder?.enumValues?.find((v) => v.toLowerCase() === target);
+    return match ?? target.toUpperCase();
+  }
+
+  // ── Motion helper ────────────────────────────────────────
+
+  private hasMotion(): boolean {
+    const zoneData = this.ctx.zoneAggregator.getByZoneId(this.zoneId);
+    return zoneData?.motion ?? false;
+  }
+
+  // ── Actions ──────────────────────────────────────────────
+
+  // Fil pilote: comfort = relay OFF
+  private setComfort(reason: string): void {
+    this.stateGraceUntil = Date.now() + 5000;
+    const comfortValue = "off" as const;
+    for (const heaterId of this.heaterIds) {
+      try {
+        this.ctx.equipmentManager.executeOrder(
+          heaterId,
+          "state",
+          this.resolveEnumValue(heaterId, comfortValue),
+        );
+      } catch (err) {
+        this.ctx.log(`Error setting heater to comfort: ${String(err)}`, "error");
+      }
+    }
+    this.currentMode = "comfort";
+    this.ctx.state.set("currentMode", "comfort");
+    this.ctx.notifyStateChanged();
+    this.ctx.log(`${reason} — heaters set to comfort`);
+    this.startFailsafeTimer();
+  }
+
+  // Fil pilote: eco = relay ON
+  private setEco(reason: string): void {
+    this.stateGraceUntil = Date.now() + 5000;
+    const ecoValue = "on" as const;
+    for (const heaterId of this.heaterIds) {
+      try {
+        this.ctx.equipmentManager.executeOrder(
+          heaterId,
+          "state",
+          this.resolveEnumValue(heaterId, ecoValue),
+        );
+      } catch (err) {
+        this.ctx.log(`Error setting heater to eco: ${String(err)}`, "error");
+      }
+    }
+    this.currentMode = "eco";
+    this.clearOverrideMode();
+    this.cancelFailsafeTimer();
+    this.ctx.state.set("currentMode", "eco");
+    this.ctx.notifyStateChanged();
+    this.ctx.log(`${reason} — heaters set to eco`);
+  }
+
+  // ── Override management ──────────────────────────────────
+
+  private clearOverrideMode(): void {
+    if (!this.overrideMode) return;
+    this.overrideMode = false;
+    this.ctx.state.delete("overrideMode");
+    this.ctx.notifyStateChanged();
+  }
+
+  private startEcoTimerForOverrideClear(): void {
+    this.cancelEcoTimer();
+    this.ecoTimer = setTimeout(() => {
+      this.ecoTimer = null;
+      this.clearTimerState();
+      this.setEco(`No motion for ${formatDuration(this.timeoutMs)} — override cleared`);
+    }, this.timeoutMs);
+    this.persistTimerState();
+  }
+
+  // ── Eco timer management ─────────────────────────────────
+
+  private startEcoTimer(): void {
+    this.cancelEcoTimer();
+    this.ecoTimer = setTimeout(() => {
+      this.ecoTimer = null;
+      this.clearTimerState();
+      this.setEco(`No motion for ${formatDuration(this.timeoutMs)}`);
+    }, this.timeoutMs);
+    this.persistTimerState();
+  }
+
+  private cancelEcoTimer(): void {
+    if (this.ecoTimer) {
+      clearTimeout(this.ecoTimer);
+      this.ecoTimer = null;
+    }
+  }
+
+  private persistTimerState(): void {
+    const expiresAt = new Date(Date.now() + this.timeoutMs).toISOString();
+    this.ctx.state.set("timerExpiresAt", expiresAt);
+    this.ctx.notifyStateChanged();
+  }
+
+  private clearTimerState(): void {
+    this.ctx.state.delete("timerExpiresAt");
+    this.ctx.notifyStateChanged();
+  }
+
+  // ── Failsafe timer management ────────────────────────────
+
+  private startFailsafeTimer(): void {
+    if (this.maxOnDurationMs === null) return;
+    this.cancelFailsafeTimer();
+    this.failsafeTimer = setTimeout(() => {
+      this.failsafeTimer = null;
+      this.ctx.state.delete("failsafeExpiresAt");
+      this.cancelEcoTimer();
+      this.clearTimerState();
+      this.setEco(
+        `Failsafe: forced eco after ${formatDuration(this.maxOnDurationMs!)} max comfort duration`,
+      );
+    }, this.maxOnDurationMs);
+    const expiresAt = new Date(Date.now() + this.maxOnDurationMs).toISOString();
+    this.ctx.state.set("failsafeExpiresAt", expiresAt);
+    this.ctx.notifyStateChanged();
+  }
+
+  private cancelFailsafeTimer(): void {
+    if (this.failsafeTimer) {
+      clearTimeout(this.failsafeTimer);
+      this.failsafeTimer = null;
+      this.ctx.state.delete("failsafeExpiresAt");
+      this.ctx.notifyStateChanged();
+    }
+  }
+}
+
+// ── Time window helper ──────────────────────────────────────
+
+function isInTimeWindow(now: Date, startTime: string, endTime: string): boolean {
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+  const [startH, startM] = startTime.split(":").map(Number);
+  const [endH, endM] = endTime.split(":").map(Number);
+  const startMinutes = startH * 60 + startM;
+  const endMinutes = endH * 60 + endM;
+
+  if (startMinutes <= endMinutes) {
+    // Same-day range (e.g., 06:00 to 08:00)
+    return currentMinutes >= startMinutes && currentMinutes < endMinutes;
+  }
+  // Overnight range (e.g., 22:00 to 06:00)
+  return currentMinutes >= startMinutes || currentMinutes < endMinutes;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -154,7 +154,8 @@ export type EquipmentType =
   | "button"
   | "thermostat"
   | "weather"
-  | "gate";
+  | "gate"
+  | "heater";
 
 export interface Equipment {
   id: string;

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -15,6 +15,7 @@ const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> 
   button: ["action"],
   weather: ["temperature", "humidity", "pressure", "wind", "rain", "noise"],
   gate: ["generic", "contact_door"],
+  heater: ["generic", "light_state"],
 };
 
 /** Maps EquipmentType to required data keys for filtering (when category alone is too broad). */

--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -10,6 +10,7 @@ import {
   Thermometer,
   CloudSun,
   DoorOpen,
+  Heater,
 } from "lucide-react";
 import { ShutterClosedIcon } from "../icons/ShutterIcons";
 import type { EquipmentType, EquipmentWithDetails } from "../../types";
@@ -31,6 +32,7 @@ const TYPE_ICONS: Record<EquipmentType, React.ReactNode> = {
   thermostat: <Thermometer size={18} strokeWidth={1.5} />,
   weather: <CloudSun size={18} strokeWidth={1.5} />,
   gate: <DoorOpen size={18} strokeWidth={1.5} />,
+  heater: <Heater size={18} strokeWidth={1.5} />,
 };
 
 const TYPE_LABELS: Record<EquipmentType, string> = {
@@ -44,6 +46,7 @@ const TYPE_LABELS: Record<EquipmentType, string> = {
   thermostat: "equipments.type.thermostat",
   weather: "equipments.type.weather",
   gate: "equipments.type.gate",
+  heater: "equipments.type.heater",
 };
 
 interface EquipmentCardProps {

--- a/ui/src/components/equipments/EquipmentForm.tsx
+++ b/ui/src/components/equipments/EquipmentForm.tsx
@@ -15,6 +15,7 @@ const EQUIPMENT_TYPE_KEYS: { value: EquipmentType; labelKey: string }[] = [
   { value: "thermostat", labelKey: "equipments.type.thermostat" },
   { value: "weather", labelKey: "equipments.type.weather" },
   { value: "gate", labelKey: "equipments.type.gate" },
+  { value: "heater", labelKey: "equipments.type.heater" },
 ];
 
 interface EquipmentFormProps {

--- a/ui/src/components/equipments/HeaterControl.tsx
+++ b/ui/src/components/equipments/HeaterControl.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Flame, Snowflake, Loader2 } from "lucide-react";
+import type { EquipmentWithDetails } from "../../types";
+
+interface HeaterControlProps {
+  equipment: EquipmentWithDetails;
+  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+  compact?: boolean;
+}
+
+export function HeaterControl({ equipment, onExecuteOrder, compact }: HeaterControlProps) {
+  const { t } = useTranslation();
+  const [executing, setExecuting] = useState(false);
+
+  const stateBinding = equipment.dataBindings.find(
+    (db) => db.alias === "state" || db.category === "light_state",
+  );
+  const isOn = stateBinding
+    ? stateBinding.value === true || String(stateBinding.value).toUpperCase() === "ON"
+    : false;
+
+  // Fil pilote convention: relay ON = éco, relay OFF = confort
+  const isComfort = !isOn;
+
+  const toggleBinding = equipment.orderBindings.find(
+    (ob) => ob.alias === "state" && (ob.type === "enum" || ob.type === "boolean"),
+  );
+  const hasToggle = !!toggleBinding;
+
+  const handleToggle = async (e?: React.MouseEvent) => {
+    e?.preventDefault();
+    e?.stopPropagation();
+    if (executing || !toggleBinding) return;
+    setExecuting(true);
+    try {
+      const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
+      const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
+      const value = isOn ? offVal : onVal;
+      await onExecuteOrder("state", value);
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  if (compact) {
+    return (
+      <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+        {/* State badge */}
+        <span
+          className={`
+            text-[11px] font-medium px-2 py-0.5 rounded-full flex-shrink-0
+            ${isComfort
+              ? "bg-error/10 text-error"
+              : "bg-primary/10 text-primary"
+            }
+          `}
+        >
+          {isComfort ? t("controls.heater.comfort") : t("controls.heater.eco")}
+        </span>
+
+        {/* Toggle button */}
+        {hasToggle && (
+          <button
+            onClick={handleToggle}
+            disabled={executing}
+            className={`
+              p-1.5 rounded-[6px] transition-colors duration-150 cursor-pointer
+              ${isComfort
+                ? "bg-error/10 text-error hover:bg-error/20"
+                : "bg-primary/10 text-primary hover:bg-primary/20"
+              }
+              disabled:opacity-50 disabled:cursor-not-allowed
+            `}
+            title={isComfort ? t("controls.heater.switchEco") : t("controls.heater.switchComfort")}
+          >
+            {executing
+              ? <Loader2 size={14} strokeWidth={1.5} className="animate-spin" />
+              : isComfort
+                ? <Flame size={14} strokeWidth={1.5} />
+                : <Snowflake size={14} strokeWidth={1.5} />
+            }
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // Full view
+  return (
+    <div className="space-y-4">
+      {/* State display */}
+      <div className="flex items-center gap-3">
+        <div
+          className={`
+            w-10 h-10 rounded-[8px] flex items-center justify-center
+            ${isComfort
+              ? "bg-error/10 text-error"
+              : "bg-primary/10 text-primary"
+            }
+          `}
+        >
+          {isComfort
+            ? <Flame size={22} strokeWidth={1.5} />
+            : <Snowflake size={22} strokeWidth={1.5} />
+          }
+        </div>
+        <div>
+          <div className="text-[16px] font-medium text-text">
+            {isComfort ? t("controls.heater.comfort") : t("controls.heater.eco")}
+          </div>
+          <div className="text-[12px] text-text-tertiary">
+            {isOn ? t("controls.heater.relayOn") : t("controls.heater.relayOff")}
+          </div>
+        </div>
+      </div>
+
+      {/* Toggle button */}
+      {hasToggle && (
+        <button
+          onClick={handleToggle}
+          disabled={executing}
+          className={`
+            flex items-center gap-2 px-4 py-2 rounded-[6px] text-[13px] font-medium
+            transition-colors duration-150
+            ${isComfort
+              ? "bg-primary/10 text-primary hover:bg-primary/20"
+              : "bg-error/10 text-error hover:bg-error/20"
+            }
+            disabled:opacity-50
+          `}
+        >
+          {isComfort
+            ? <><Snowflake size={16} strokeWidth={1.5} /> {t("controls.heater.switchEco")}</>
+            : <><Flame size={16} strokeWidth={1.5} /> {t("controls.heater.switchComfort")}</>
+          }
+        </button>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -19,6 +19,7 @@ const RELEVANT_DATA: Record<string, string[]> = {
   thermostat: ["temperature", "generic"],
   weather: ["temperature", "humidity", "pressure", "wind", "rain", "noise", "battery"],
   gate: ["generic", "contact_door"],
+  heater: ["generic", "light_state"],
 };
 
 /** Maps equipment types to relevant order keys for auto-binding. */
@@ -32,6 +33,7 @@ const RELEVANT_ORDERS: Record<string, string[]> = {
   thermostat: ["power", "operationMode", "targetTemperature", "fanSpeed", "airSwingUD", "airSwingLR", "ecoMode", "nanoe", "profile", "resetAlarm"],
   weather: [],
   gate: ["R1", "R2", "R3", "R4", "command"],
+  heater: ["state", "on", "R1", "R2", "R3", "R4"],
 };
 
 /**
@@ -70,6 +72,12 @@ const STANDARD_ALIASES: Record<string, Record<string, string>> = {
     R4: "state",
   },
   switch: {
+    R1: "state",
+    R2: "state",
+    R3: "state",
+    R4: "state",
+  },
+  heater: {
     R1: "state",
     R2: "state",
     R3: "state",

--- a/ui/src/components/equipments/useEquipmentState.ts
+++ b/ui/src/components/equipments/useEquipmentState.ts
@@ -17,6 +17,7 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
   const isShutter = equipment.type === "shutter";
   const isSensor = equipment.type === "sensor" || equipment.type === "button" || equipment.type === "weather";
   const isThermostat = equipment.type === "thermostat";
+  const isHeater = equipment.type === "heater";
   const isGate = equipment.type === "gate";
 
   // State binding
@@ -80,6 +81,10 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
       ? isOn
         ? "bg-error/10 text-error"
         : "bg-border-light text-text-tertiary"
+      : isHeater
+        ? !isOn // fil pilote: relay OFF = comfort (warm)
+          ? "bg-error/10 text-error"
+          : "bg-border-light text-text-tertiary"
       : isShutter
         ? shutterIsOpen
           ? "bg-primary/10 text-primary"
@@ -99,6 +104,7 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
     isShutter,
     isSensor,
     isThermostat,
+    isHeater,
     isGate,
     stateBinding,
     isOn,

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -7,6 +7,7 @@ import { LightControl } from "../equipments/LightControl";
 import { ShutterControl } from "../equipments/ShutterControl";
 import { ThermostatCard } from "../equipments/ThermostatCard";
 import { GateControl } from "../equipments/GateControl";
+import { HeaterControl } from "../equipments/HeaterControl";
 
 interface CompactEquipmentCardProps {
   equipment: EquipmentWithDetails;
@@ -22,6 +23,7 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
     isShutter,
     isSensor,
     isThermostat,
+    isHeater,
     isGate,
     stateBinding,
     isOn,
@@ -31,8 +33,8 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
     iconColor,
   } = useEquipmentState(equipment);
 
-  // Find primary data value for non-light, non-sensor, non-shutter, non-thermostat, non-gate equipments
-  const primaryBinding = !isLight && !isSensor && !isShutter && !isThermostat && !isGate
+  // Find primary data value for non-light, non-sensor, non-shutter, non-thermostat, non-heater, non-gate equipments
+  const primaryBinding = !isLight && !isSensor && !isShutter && !isThermostat && !isHeater && !isGate
     ? equipment.dataBindings[0] ?? null
     : null;
 
@@ -82,7 +84,7 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
       )}
 
       {/* Primary value for other equipments */}
-      {primaryBinding && !isLight && !isSensor && !isShutter && !isThermostat && !isGate && (
+      {primaryBinding && !isLight && !isSensor && !isShutter && !isThermostat && !isHeater && !isGate && (
         <span className="text-[13px] text-text-secondary tabular-nums flex-shrink-0">
           {formatValue(primaryBinding.value, primaryBinding.unit)}
         </span>
@@ -124,8 +126,17 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
         />
       )}
 
-      {/* Boolean state badge for non-light, non-sensor, non-shutter, non-gate equipments */}
-      {!isLight && !isSensor && !isShutter && !isThermostat && !isGate && stateBinding && (
+      {/* Heater controls */}
+      {isHeater && equipment.enabled && (
+        <HeaterControl
+          equipment={equipment}
+          onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
+          compact
+        />
+      )}
+
+      {/* Boolean state badge for non-light, non-sensor, non-shutter, non-heater, non-gate equipments */}
+      {!isLight && !isSensor && !isShutter && !isThermostat && !isHeater && !isGate && stateBinding && (
         <span
           className={`
             text-[11px] font-medium px-2 py-0.5 rounded-full flex-shrink-0

--- a/ui/src/components/home/ZoneEquipmentsView.tsx
+++ b/ui/src/components/home/ZoneEquipmentsView.tsx
@@ -5,7 +5,6 @@ import {
   Gauge,
   ToggleRight,
   Thermometer,
-  Heater,
 } from "lucide-react";
 import { ShutterClosedIcon } from "../icons/ShutterIcons";
 import { useTranslation } from "react-i18next";

--- a/ui/src/components/home/ZoneEquipmentsView.tsx
+++ b/ui/src/components/home/ZoneEquipmentsView.tsx
@@ -5,6 +5,7 @@ import {
   Gauge,
   ToggleRight,
   Thermometer,
+  Heater,
 } from "lucide-react";
 import { ShutterClosedIcon } from "../icons/ShutterIcons";
 import { useTranslation } from "react-i18next";
@@ -22,7 +23,7 @@ interface EquipmentGroup {
 const EQUIPMENT_GROUPS: EquipmentGroup[] = [
   { labelKey: "equipments.group.lights", types: ["light_onoff", "light_dimmable", "light_color"], icon: <Lightbulb size={14} strokeWidth={1.5} />, headerBg: "bg-active/8", iconColor: "text-active-text" },
   { labelKey: "equipments.group.shutters", types: ["shutter"], icon: <ShutterClosedIcon size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
-  { labelKey: "equipments.group.climate", types: ["thermostat"], icon: <Thermometer size={14} strokeWidth={1.5} />, headerBg: "bg-error/6", iconColor: "text-error" },
+  { labelKey: "equipments.group.climate", types: ["thermostat", "heater"], icon: <Thermometer size={14} strokeWidth={1.5} />, headerBg: "bg-error/6", iconColor: "text-error" },
   { labelKey: "equipments.group.sensors", types: ["sensor"], icon: <Gauge size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
   { labelKey: "equipments.group.weather", types: ["weather"], icon: <CloudSun size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
   { labelKey: "equipments.group.other", types: ["switch", "button", "gate"], icon: <ToggleRight size={14} strokeWidth={1.5} />, headerBg: "bg-text-tertiary/6", iconColor: "text-text-secondary" },

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -529,6 +529,7 @@ function RecipeInstanceRow({
                                         className="w-full px-2 py-1 text-[13px] bg-surface border border-border rounded-[6px] text-text placeholder:text-text-tertiary"
                                       />
                                     )}
+                                    <p className="text-[10px] text-text-tertiary mt-0.5">{recipeSlotDescription(recipe, slot, lang)}</p>
                                   </div>
                                 ))}
                               </div>
@@ -610,6 +611,7 @@ function RecipeInstanceRow({
                             className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text placeholder:text-text-tertiary"
                           />
                         )}
+                        <p className="text-[11px] text-text-tertiary mt-0.5">{recipeSlotDescription(recipe, slot, lang)}</p>
                         </>
                         )}
                       </div>

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -185,6 +185,7 @@
   "equipments.type.thermostat": "Thermostat",
   "equipments.type.weather": "Weather Station",
   "equipments.type.gate": "Gate",
+  "equipments.type.heater": "Electric Heater",
 
   "equipments.group.lights": "Lights",
   "equipments.group.shutters": "Shutters",
@@ -225,6 +226,13 @@
   "controls.gate.unknown": "Moving",
   "controls.gate.toggle": "Toggle",
   "controls.gate.command": "Command",
+
+  "controls.heater.comfort": "Comfort",
+  "controls.heater.eco": "Eco",
+  "controls.heater.switchComfort": "Switch to comfort",
+  "controls.heater.switchEco": "Switch to eco",
+  "controls.heater.relayOn": "Relay on",
+  "controls.heater.relayOff": "Relay off",
 
   "sensors.title": "Sensors",
   "sensors.noData": "No sensor data.",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -185,6 +185,7 @@
   "equipments.type.thermostat": "Thermostat",
   "equipments.type.weather": "Station Météo",
   "equipments.type.gate": "Ouvrant",
+  "equipments.type.heater": "Radiateur électrique",
 
   "equipments.group.lights": "Éclairages",
   "equipments.group.shutters": "Volets",
@@ -225,6 +226,13 @@
   "controls.gate.unknown": "En mouvement",
   "controls.gate.toggle": "Actionner",
   "controls.gate.command": "Actionner",
+
+  "controls.heater.comfort": "Confort",
+  "controls.heater.eco": "Éco",
+  "controls.heater.switchComfort": "Passer en confort",
+  "controls.heater.switchEco": "Passer en éco",
+  "controls.heater.relayOn": "Relais activé",
+  "controls.heater.relayOff": "Relais désactivé",
 
   "sensors.title": "Capteurs",
   "sensors.noData": "Aucune donnée capteur.",

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -17,6 +17,7 @@ import { TYPE_ICONS, TYPE_LABELS } from "../components/equipments/EquipmentCard"
 import { useEquipmentState } from "../components/equipments/useEquipmentState";
 import { autoCreateBindings, removeAllBindings } from "../components/equipments/bindingUtils";
 import { GateControl } from "../components/equipments/GateControl";
+import { HeaterControl } from "../components/equipments/HeaterControl";
 import { ButtonActionsSection } from "../components/equipments/ButtonActionsSection";
 import {
   ArrowLeft,
@@ -169,7 +170,7 @@ export function EquipmentDetailPage() {
     }
   };
 
-  const { isLight, isShutter, isSensor, isThermostat, isGate, actionBinding } = equipmentState;
+  const { isLight, isShutter, isSensor, isThermostat, isHeater, isGate, actionBinding } = equipmentState;
 
   return (
     <div className="p-6">
@@ -271,6 +272,17 @@ export function EquipmentDetailPage() {
         <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
           <h3 className="text-[14px] font-semibold text-text mb-3">{t("equipments.controls")}</h3>
           <GateControl
+            equipment={equipment}
+            onExecuteOrder={(alias, value) => executeOrder(equipment.id, alias, value)}
+          />
+        </div>
+      )}
+
+      {/* Heater controls */}
+      {isHeater && equipment.enabled && (
+        <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
+          <h3 className="text-[14px] font-semibold text-text mb-3">{t("equipments.controls")}</h3>
+          <HeaterControl
             equipment={equipment}
             onExecuteOrder={(alias, value) => executeOrder(equipment.id, alias, value)}
           />

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -149,7 +149,8 @@ export type EquipmentType =
   | "button"
   | "thermostat"
   | "weather"
-  | "gate";
+  | "gate"
+  | "heater";
 
 export interface Equipment {
   id: string;


### PR DESCRIPTION
## Summary
- New **heater** equipment type for electric heaters controlled via fil pilote relay modules
- New **presence-heater** recipe: motion → comfort (relay OFF), timeout → eco (relay ON), optional night window forces eco, maxOnDuration failsafe
- Full UI support: HeaterControl component (Confort/Éco with Flame/Snowflake), equipment creation form, zone home page, detail page

## Changes

### Backend
- `src/shared/types.ts`: added `"heater"` to `EquipmentType`
- `src/equipments/equipment-manager.ts`: added `"heater"` to `VALID_EQUIPMENT_TYPES`
- `src/recipes/presence-heater.ts`: full recipe with fil pilote convention (relay OFF = comfort, relay ON = eco), manual override detection with grace period, night window, failsafe timer
- `src/index.ts`: register `PresenceHeaterRecipe`

### UI
- `ui/src/components/equipments/HeaterControl.tsx`: compact + full controls with Flame/Snowflake icons
- Equipment type added to: types, form, card, device selector, binding utils, state hook
- `ZoneEquipmentsView.tsx`: heater in climate group
- i18n keys (fr/en) for heater controls

### Tests
- 31 tests covering validation, normal cycle, night window, manual override, failsafe, startup, multiple heaters, full integration cycle

### Specs
- `specs/027-V0.8-presence-heater/`: spec, architecture, plan

## Test plan
- [x] TypeScript compiles (zero errors backend + frontend)
- [x] All 454 tests pass
- [x] ESLint clean
- [x] Prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)