### PR TITLE
fix: device offline preserves equipment bindings

### DIFF
--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -229,14 +229,22 @@ describe("DeviceManager", () => {
       }
     });
 
-    it("deletes device on offline status", () => {
+    it("marks device as offline and preserves data", () => {
       manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", sampleDevice);
       events.length = 0;
 
       manager.updateDeviceStatus("zigbee2mqtt", "salon_pir", "offline");
 
-      expect(manager.getAll()).toHaveLength(0);
-      expect(events.find((e) => e.type === "device.removed")).toBeDefined();
+      const devices = manager.getAll();
+      expect(devices).toHaveLength(1);
+      expect(devices[0].status).toBe("offline");
+
+      const statusEvent = events.find((e) => e.type === "device.status_changed");
+      expect(statusEvent).toBeDefined();
+      if (statusEvent?.type === "device.status_changed") {
+        expect(statusEvent.status).toBe("offline");
+      }
+      expect(events.find((e) => e.type === "device.removed")).toBeUndefined();
     });
 
     it("does not emit event if status unchanged", () => {

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -402,8 +402,8 @@ export class DeviceManager {
 
   /**
    * Update device status.
-   * "online" → update status in DB.
-   * "offline" → delete device from DB (will be re-created on next discovery if still present).
+   * "online" / "offline" → update status in DB.
+   * Device data and bindings are preserved across offline/online transitions.
    */
   updateDeviceStatus(
     integrationId: string,
@@ -415,23 +415,9 @@ export class DeviceManager {
       | undefined;
     if (!device) return;
 
-    if (status === "offline") {
-      this.stmts.deleteDevice.run(device.id);
-      this.logger.info(
-        { deviceId: device.id, name: sourceDeviceId },
-        "Device offline — deleted from DB",
-      );
-      this.eventBus.emit({
-        type: "device.removed",
-        deviceId: device.id,
-        deviceName: device.name,
-      });
-      return;
-    }
-
     if (device.status !== status) {
       this.stmts.updateDeviceStatus.run(status, device.id);
-      this.logger.debug(
+      this.logger.info(
         { deviceId: device.id, name: sourceDeviceId, status },
         "Device status changed",
       );


### PR DESCRIPTION
## Summary
- Device going offline no longer deletes the device from DB
- Status is updated to "offline" instead, preserving all equipment data/order bindings
- Fixes binding loss when LoRa/Zigbee devices temporarily go offline (battery, radio loss, gateway restart)

## Root cause
`updateDeviceStatus("offline")` was calling `DELETE FROM devices`, which triggered `ON DELETE CASCADE` on `device_data` → `data_bindings` and `device_orders` → `order_bindings`.

## Changes
- `src/devices/device-manager.ts`: `updateDeviceStatus("offline")` now does `UPDATE status` instead of `DELETE`
- `src/devices/device-manager.test.ts`: updated test to verify device is preserved with offline status

## What still deletes devices
- `removeStaleDevices()` — device no longer in discovery list
- `markRemoved()` — device explicitly removed by integration
- `delete()` — user-initiated deletion via API

## Test plan
- [x] TypeScript compiles (zero errors)
- [x] All 454 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)