### PR TITLE
feat: MQTT Publishers — generic key/value MQTT output

### DIFF
--- a/migrations/022_mqtt_publishers.sql
+++ b/migrations/022_mqtt_publishers.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS mqtt_publisher_mappings (
   id TEXT PRIMARY KEY,
   publisher_id TEXT NOT NULL REFERENCES mqtt_publishers(id) ON DELETE CASCADE,
   publish_key TEXT NOT NULL,
-  source_type TEXT NOT NULL CHECK(source_type IN ('equipment', 'zone')),
+  source_type TEXT NOT NULL CHECK(source_type IN ('equipment', 'zone', 'recipe')),
   source_id TEXT NOT NULL,
   source_key TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),

--- a/migrations/022_mqtt_publishers.sql
+++ b/migrations/022_mqtt_publishers.sql
@@ -1,0 +1,20 @@
+-- MQTT Publishers: generic key/value MQTT output
+CREATE TABLE IF NOT EXISTS mqtt_publishers (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  topic TEXT NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS mqtt_publisher_mappings (
+  id TEXT PRIMARY KEY,
+  publisher_id TEXT NOT NULL REFERENCES mqtt_publishers(id) ON DELETE CASCADE,
+  publish_key TEXT NOT NULL,
+  source_type TEXT NOT NULL CHECK(source_type IN ('equipment', 'zone')),
+  source_id TEXT NOT NULL,
+  source_key TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(publisher_id, publish_key)
+);

--- a/migrations/023_mqtt_publisher_recipe_source.sql
+++ b/migrations/023_mqtt_publisher_recipe_source.sql
@@ -1,0 +1,21 @@
+-- Add 'recipe' to mqtt_publisher_mappings source_type CHECK constraint
+-- SQLite does not support ALTER CONSTRAINT, so we recreate the table
+
+CREATE TABLE mqtt_publisher_mappings_new (
+  id TEXT PRIMARY KEY,
+  publisher_id TEXT NOT NULL REFERENCES mqtt_publishers(id) ON DELETE CASCADE,
+  publish_key TEXT NOT NULL,
+  source_type TEXT NOT NULL CHECK(source_type IN ('equipment', 'zone', 'recipe')),
+  source_id TEXT NOT NULL,
+  source_key TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(publisher_id, publish_key)
+);
+
+INSERT INTO mqtt_publisher_mappings_new
+  SELECT id, publisher_id, publish_key, source_type, source_id, source_key, created_at
+  FROM mqtt_publisher_mappings;
+
+DROP TABLE mqtt_publisher_mappings;
+
+ALTER TABLE mqtt_publisher_mappings_new RENAME TO mqtt_publisher_mappings;

--- a/specs/028-mqtt-publishers/architecture.md
+++ b/specs/028-mqtt-publishers/architecture.md
@@ -1,0 +1,69 @@
+# Architecture: MQTT Publishers
+
+## Data Model Changes
+
+### New SQLite tables
+
+```sql
+mqtt_publishers (id TEXT PK, name TEXT, topic TEXT, enabled INTEGER, created_at TEXT, updated_at TEXT)
+mqtt_publisher_mappings (id TEXT PK, publisher_id TEXT FK, publish_key TEXT, source_type TEXT, source_id TEXT, source_key TEXT, created_at TEXT, UNIQUE(publisher_id, publish_key))
+```
+
+### New types in types.ts
+
+- `MqttPublisher`: id, name, topic, enabled, createdAt, updatedAt
+- `MqttPublisherMapping`: id, publisherId, publishKey, sourceType, sourceId, sourceKey, createdAt
+- `MqttPublisherWithMappings`: MqttPublisher + mappings array
+
+## Event Bus Events
+
+### New events emitted
+
+- `mqtt-publisher.created` / `.updated` / `.removed`
+- `mqtt-publisher.mapping.created` / `.mapping.removed`
+
+### Events consumed
+
+- `equipment.data.changed` → lookup matching mappings → publish
+- `zone.data.changed` → for each aggregation key → lookup → publish
+- `settings.changed` → reconnect if mqtt-publisher.\* keys changed
+- `mqtt-publisher.*` events → rebuild internal index
+
+## MQTT Topics
+
+- Publishes to user-configured topics (e.g., `winch/homedisplay/livingroom`)
+- Payload: `{"publishKey": value}` with retain=true
+
+## API Changes
+
+- `GET    /api/v1/mqtt-publishers` — list all with mappings
+- `POST   /api/v1/mqtt-publishers` — create publisher
+- `GET    /api/v1/mqtt-publishers/:id` — get with mappings
+- `PUT    /api/v1/mqtt-publishers/:id` — update publisher
+- `DELETE /api/v1/mqtt-publishers/:id` — delete publisher
+- `POST   /api/v1/mqtt-publishers/:id/mappings` — add mapping
+- `DELETE /api/v1/mqtt-publishers/:id/mappings/:mappingId` — remove mapping
+
+## UI Changes
+
+- New page: MqttPublishersPage (Administration section)
+- Sidebar nav item with Radio/Send icon
+
+## File Changes
+
+| File                                            | Change                           |
+| ----------------------------------------------- | -------------------------------- |
+| `migrations/022_mqtt_publishers.sql`            | New tables                       |
+| `src/shared/types.ts`                           | New types + EngineEvent variants |
+| `src/mqtt-publishers/mqtt-publisher-manager.ts` | New — CRUD                       |
+| `src/mqtt-publishers/mqtt-publish-service.ts`   | New — reactive publisher         |
+| `src/api/routes/mqtt-publishers.ts`             | New — REST API                   |
+| `src/api/server.ts`                             | Wire routes                      |
+| `src/api/websocket.ts`                          | Add topic                        |
+| `src/index.ts`                                  | Bootstrap + shutdown             |
+| `ui/src/types.ts`                               | Frontend types                   |
+| `ui/src/api.ts`                                 | API functions                    |
+| `ui/src/pages/MqttPublishersPage.tsx`           | New page                         |
+| `ui/src/App.tsx`                                | Route                            |
+| `ui/src/components/layout/Sidebar.tsx`          | Nav item                         |
+| `ui/src/i18n/locales/{en,fr}.json`              | Translations                     |

--- a/specs/028-mqtt-publishers/plan.md
+++ b/specs/028-mqtt-publishers/plan.md
@@ -1,0 +1,29 @@
+# Implementation Plan: MQTT Publishers
+
+## Tasks
+
+1. [ ] Migration SQL (022_mqtt_publishers.sql)
+2. [ ] Backend types (src/shared/types.ts + EngineEvent)
+3. [ ] MqttPublisherManager CRUD (src/mqtt-publishers/mqtt-publisher-manager.ts)
+4. [ ] API routes (src/api/routes/mqtt-publishers.ts)
+5. [ ] MqttPublishService (src/mqtt-publishers/mqtt-publish-service.ts)
+6. [ ] Wiring: server.ts, index.ts, websocket.ts
+7. [ ] Frontend types + API functions
+8. [ ] MqttPublishersPage UI
+9. [ ] Routing, sidebar, i18n
+10. [ ] TypeScript compilation (zero errors)
+
+## Dependencies
+
+- Requires existing MqttConnector (src/mqtt/mqtt-connector.ts)
+- Requires existing EquipmentManager, ZoneAggregator for snapshot
+- Follows HistoryWriter pattern for event listening
+- Follows ChartManager pattern for CRUD
+
+## Testing
+
+- Create publisher via UI with topic `winch/homedisplay/livingroom`
+- Add mappings to existing equipments/zones
+- `mosquitto_sub -t "winch/homedisplay/#" -v` to verify published messages
+- Change equipment state → verify immediate MQTT publication
+- Verify retain=true (reconnect subscriber → receives last values)

--- a/specs/028-mqtt-publishers/spec.md
+++ b/specs/028-mqtt-publishers/spec.md
@@ -1,0 +1,48 @@
+# MQTT Publishers
+
+## Summary
+
+Generic MQTT key/value publisher that listens to Winch state changes (equipment data, zone aggregations) and publishes them to configurable MQTT topics. Each publisher has a topic and a list of mappings that bind a Winch data source to a publish key. Messages are published with retain=true.
+
+## Reference
+
+- Custom feature, not part of existing roadmap milestones
+- Pattern: HistoryWriter (passive event observer)
+
+## Acceptance Criteria
+
+- [ ] Users can create/edit/delete MQTT publishers via the Admin UI
+- [ ] Each publisher has a name, MQTT topic, and enabled toggle
+- [ ] Users can add/remove mappings (publish key + source type/id/key)
+- [ ] Source types: equipment data binding alias OR zone aggregation key
+- [ ] On equipment.data.changed or zone.data.changed, matching mappings publish `{"key": value}` to the publisher's topic
+- [ ] Messages are published with retain=true
+- [ ] MQTT broker settings are configurable (fallback to Zigbee2MQTT broker)
+- [ ] Publisher uses its own MQTT connection (client ID: winch-publisher)
+- [ ] TypeScript compiles with zero errors (backend + frontend)
+
+## Scope
+
+### In Scope
+
+- CRUD for publishers and mappings (backend + API + UI)
+- Reactive MQTT publishing on state changes
+- MQTT retain=true for all published messages
+- MQTT broker settings (URL, username, password) via settings
+- Fallback to Zigbee2MQTT broker settings
+- Admin UI page under Administration section
+
+### Out of Scope
+
+- Combined JSON mode (all mappings in single message)
+- Per-mapping retain toggle
+- QoS configuration
+- Webhook or other output channels (notification system)
+- Templated payloads (always `{"key": value}`)
+
+## Edge Cases
+
+- No MQTT broker configured: service disabled, warning logged
+- Equipment/zone deleted: orphaned mapping ignored (warning log)
+- MQTT broker disconnected: messages silently dropped (MqttConnector handles reconnect)
+- Settings changed: automatic MQTT reconnection

--- a/src/api/routes/mqtt-publishers.ts
+++ b/src/api/routes/mqtt-publishers.ts
@@ -1,13 +1,15 @@
 import type { FastifyInstance } from "fastify";
 import type { MqttPublisherManager } from "../../mqtt-publishers/mqtt-publisher-manager.js";
+import type { MqttPublishService } from "../../mqtt-publishers/mqtt-publish-service.js";
 import { MqttPublisherError } from "../../mqtt-publishers/mqtt-publisher-manager.js";
 
 interface MqttPublishersDeps {
   mqttPublisherManager: MqttPublisherManager;
+  mqttPublishService: MqttPublishService;
 }
 
 export function registerMqttPublisherRoutes(app: FastifyInstance, deps: MqttPublishersDeps): void {
-  const { mqttPublisherManager } = deps;
+  const { mqttPublisherManager, mqttPublishService } = deps;
 
   // GET /api/v1/mqtt-publishers
   app.get("/api/v1/mqtt-publishers", async () => {
@@ -66,12 +68,24 @@ export function registerMqttPublisherRoutes(app: FastifyInstance, deps: MqttPubl
     }
   });
 
+  // POST /api/v1/mqtt-publishers/:id/test
+  app.post<{ Params: { id: string } }>(
+    "/api/v1/mqtt-publishers/:id/test",
+    async (request, reply) => {
+      const publisher = mqttPublisherManager.getById(request.params.id);
+      if (!publisher) return reply.code(404).send({ error: "Publisher not found" });
+
+      const published = mqttPublishService.publishSnapshotForPublisher(request.params.id);
+      return { published };
+    },
+  );
+
   // POST /api/v1/mqtt-publishers/:id/mappings
   app.post<{
     Params: { id: string };
     Body: {
       publishKey: string;
-      sourceType: "equipment" | "zone";
+      sourceType: "equipment" | "zone" | "recipe";
       sourceId: string;
       sourceKey: string;
     };

--- a/src/api/routes/mqtt-publishers.ts
+++ b/src/api/routes/mqtt-publishers.ts
@@ -1,0 +1,114 @@
+import type { FastifyInstance } from "fastify";
+import type { MqttPublisherManager } from "../../mqtt-publishers/mqtt-publisher-manager.js";
+import { MqttPublisherError } from "../../mqtt-publishers/mqtt-publisher-manager.js";
+
+interface MqttPublishersDeps {
+  mqttPublisherManager: MqttPublisherManager;
+}
+
+export function registerMqttPublisherRoutes(app: FastifyInstance, deps: MqttPublishersDeps): void {
+  const { mqttPublisherManager } = deps;
+
+  // GET /api/v1/mqtt-publishers
+  app.get("/api/v1/mqtt-publishers", async () => {
+    return mqttPublisherManager.getAllWithMappings();
+  });
+
+  // GET /api/v1/mqtt-publishers/:id
+  app.get<{ Params: { id: string } }>("/api/v1/mqtt-publishers/:id", async (request, reply) => {
+    const publisher = mqttPublisherManager.getByIdWithMappings(request.params.id);
+    if (!publisher) return reply.code(404).send({ error: "Publisher not found" });
+    return publisher;
+  });
+
+  // POST /api/v1/mqtt-publishers
+  app.post<{
+    Body: { name: string; topic: string; enabled?: boolean };
+  }>("/api/v1/mqtt-publishers", async (request, reply) => {
+    const { name, topic, enabled } = request.body ?? {};
+    if (!name) return reply.code(400).send({ error: "name is required" });
+    if (!topic) return reply.code(400).send({ error: "topic is required" });
+
+    try {
+      const publisher = mqttPublisherManager.create({ name, topic, enabled });
+      return reply.code(201).send(publisher);
+    } catch (err) {
+      if (err instanceof MqttPublisherError)
+        return reply.code(err.status).send({ error: err.message });
+      throw err;
+    }
+  });
+
+  // PUT /api/v1/mqtt-publishers/:id
+  app.put<{
+    Params: { id: string };
+    Body: { name?: string; topic?: string; enabled?: boolean };
+  }>("/api/v1/mqtt-publishers/:id", async (request, reply) => {
+    try {
+      const publisher = mqttPublisherManager.update(request.params.id, request.body ?? {});
+      return publisher;
+    } catch (err) {
+      if (err instanceof MqttPublisherError)
+        return reply.code(err.status).send({ error: err.message });
+      throw err;
+    }
+  });
+
+  // DELETE /api/v1/mqtt-publishers/:id
+  app.delete<{ Params: { id: string } }>("/api/v1/mqtt-publishers/:id", async (request, reply) => {
+    try {
+      mqttPublisherManager.delete(request.params.id);
+      return reply.code(204).send();
+    } catch (err) {
+      if (err instanceof MqttPublisherError)
+        return reply.code(err.status).send({ error: err.message });
+      throw err;
+    }
+  });
+
+  // POST /api/v1/mqtt-publishers/:id/mappings
+  app.post<{
+    Params: { id: string };
+    Body: {
+      publishKey: string;
+      sourceType: "equipment" | "zone";
+      sourceId: string;
+      sourceKey: string;
+    };
+  }>("/api/v1/mqtt-publishers/:id/mappings", async (request, reply) => {
+    const { publishKey, sourceType, sourceId, sourceKey } = request.body ?? {};
+    if (!publishKey) return reply.code(400).send({ error: "publishKey is required" });
+    if (!sourceType) return reply.code(400).send({ error: "sourceType is required" });
+    if (!sourceId) return reply.code(400).send({ error: "sourceId is required" });
+    if (!sourceKey) return reply.code(400).send({ error: "sourceKey is required" });
+
+    try {
+      const mapping = mqttPublisherManager.addMapping(request.params.id, {
+        publishKey,
+        sourceType,
+        sourceId,
+        sourceKey,
+      });
+      return reply.code(201).send(mapping);
+    } catch (err) {
+      if (err instanceof MqttPublisherError)
+        return reply.code(err.status).send({ error: err.message });
+      throw err;
+    }
+  });
+
+  // DELETE /api/v1/mqtt-publishers/:id/mappings/:mappingId
+  app.delete<{ Params: { id: string; mappingId: string } }>(
+    "/api/v1/mqtt-publishers/:id/mappings/:mappingId",
+    async (request, reply) => {
+      try {
+        mqttPublisherManager.removeMapping(request.params.id, request.params.mappingId);
+        return reply.code(204).send();
+      } catch (err) {
+        if (err instanceof MqttPublisherError)
+          return reply.code(err.status).send({ error: err.message });
+        throw err;
+      }
+    },
+  );
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -24,6 +24,7 @@ import type { ButtonActionManager } from "../buttons/button-action-manager.js";
 import type { HistoryWriter } from "../history/history-writer.js";
 import type { ChartManager } from "../charts/chart-manager.js";
 import type { MqttPublisherManager } from "../mqtt-publishers/mqtt-publisher-manager.js";
+import type { MqttPublishService } from "../mqtt-publishers/mqtt-publish-service.js";
 import { registerAuthMiddleware } from "../auth/auth-middleware.js";
 import { registerDeviceRoutes } from "./routes/devices.js";
 import { registerHealthRoutes } from "./routes/health.js";
@@ -61,6 +62,7 @@ interface ServerDeps {
   historyWriter: HistoryWriter;
   chartManager: ChartManager;
   mqttPublisherManager: MqttPublisherManager;
+  mqttPublishService: MqttPublishService;
   eventBus: EventBus;
   integrationRegistry: IntegrationRegistry;
   logBuffer: LogRingBuffer;
@@ -85,6 +87,7 @@ export async function createServer(deps: ServerDeps) {
     historyWriter,
     chartManager,
     mqttPublisherManager,
+    mqttPublishService,
     eventBus,
     integrationRegistry,
     logBuffer,
@@ -137,7 +140,7 @@ export async function createServer(deps: ServerDeps) {
     logger,
   });
   registerChartRoutes(app, { chartManager });
-  registerMqttPublisherRoutes(app, { mqttPublisherManager });
+  registerMqttPublisherRoutes(app, { mqttPublisherManager, mqttPublishService });
   registerLogRoutes(app, { logBuffer, logger });
   registerWebSocket(app, { eventBus, authService, logBuffer, logger });
 

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -23,6 +23,7 @@ import type { SettingsManager } from "../core/settings-manager.js";
 import type { ButtonActionManager } from "../buttons/button-action-manager.js";
 import type { HistoryWriter } from "../history/history-writer.js";
 import type { ChartManager } from "../charts/chart-manager.js";
+import type { MqttPublisherManager } from "../mqtt-publishers/mqtt-publisher-manager.js";
 import { registerAuthMiddleware } from "../auth/auth-middleware.js";
 import { registerDeviceRoutes } from "./routes/devices.js";
 import { registerHealthRoutes } from "./routes/health.js";
@@ -41,6 +42,7 @@ import { registerButtonActionRoutes } from "./routes/button-actions.js";
 import { registerLogRoutes } from "./routes/logs.js";
 import { registerHistoryRoutes } from "./routes/history.js";
 import { registerChartRoutes } from "./routes/charts.js";
+import { registerMqttPublisherRoutes } from "./routes/mqtt-publishers.js";
 import { registerWebSocket } from "./websocket.js";
 
 interface ServerDeps {
@@ -58,6 +60,7 @@ interface ServerDeps {
   buttonActionManager: ButtonActionManager;
   historyWriter: HistoryWriter;
   chartManager: ChartManager;
+  mqttPublisherManager: MqttPublisherManager;
   eventBus: EventBus;
   integrationRegistry: IntegrationRegistry;
   logBuffer: LogRingBuffer;
@@ -81,6 +84,7 @@ export async function createServer(deps: ServerDeps) {
     buttonActionManager,
     historyWriter,
     chartManager,
+    mqttPublisherManager,
     eventBus,
     integrationRegistry,
     logBuffer,
@@ -133,6 +137,7 @@ export async function createServer(deps: ServerDeps) {
     logger,
   });
   registerChartRoutes(app, { chartManager });
+  registerMqttPublisherRoutes(app, { mqttPublisherManager });
   registerLogRoutes(app, { logBuffer, logger });
   registerWebSocket(app, { eventBus, authService, logBuffer, logger });
 

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -20,6 +20,7 @@ type WsTopic =
   | "modes"
   | "recipes"
   | "calendar"
+  | "mqtt-publishers"
   | "system"
   | "logs";
 
@@ -30,6 +31,7 @@ const VALID_TOPICS = new Set<WsTopic>([
   "modes",
   "recipes",
   "calendar",
+  "mqtt-publishers",
   "system",
   "logs",
 ]);
@@ -57,6 +59,8 @@ function getEventTopic(event: EngineEvent): WsTopic {
       return "recipes";
     case "calendar":
       return "calendar";
+    case "mqtt-publisher":
+      return "mqtt-publishers";
     default:
       return "system";
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,16 +127,8 @@ async function main() {
   // 11b. Create Chart Manager
   const chartManager = new ChartManager(db, logger);
 
-  // 11c. Create MQTT Publisher Manager + Service
+  // 11c. Create MQTT Publisher Manager (service created after RecipeManager)
   const mqttPublisherManager = new MqttPublisherManager(db, eventBus, logger);
-  const mqttPublishService = new MqttPublishService(
-    eventBus,
-    settingsManager,
-    mqttPublisherManager,
-    equipmentManager,
-    zoneAggregator,
-    logger,
-  );
 
   // 12. Create Recipe Manager
   const recipeManager = new RecipeManager(
@@ -153,7 +145,18 @@ async function main() {
   recipeManager.register(PresenceThermostatRecipe);
   recipeManager.register(PresenceHeaterRecipe);
 
-  // 12. Create Mode Manager + Calendar Manager
+  // 12b. Create MQTT Publish Service (needs RecipeManager)
+  const mqttPublishService = new MqttPublishService(
+    eventBus,
+    settingsManager,
+    mqttPublisherManager,
+    equipmentManager,
+    zoneAggregator,
+    recipeManager,
+    logger,
+  );
+
+  // 13. Create Mode Manager + Calendar Manager
   const modeManager = new ModeManager(db, eventBus, equipmentManager, recipeManager, logger);
   const calendarManager = new CalendarManager(db, eventBus, settingsManager, modeManager, logger);
 
@@ -191,6 +194,7 @@ async function main() {
     historyWriter,
     chartManager,
     mqttPublisherManager,
+    mqttPublishService,
     eventBus,
     integrationRegistry,
     logBuffer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ import { NetatmoHCIntegration } from "./integrations/netatmo-hc/index.js";
 import { Lora2MqttIntegration } from "./integrations/lora2mqtt/index.js";
 import { HistoryWriter } from "./history/history-writer.js";
 import { ChartManager } from "./charts/chart-manager.js";
+import { MqttPublisherManager } from "./mqtt-publishers/mqtt-publisher-manager.js";
+import { MqttPublishService } from "./mqtt-publishers/mqtt-publish-service.js";
 import { createServer } from "./api/server.js";
 
 async function main() {
@@ -125,6 +127,17 @@ async function main() {
   // 11b. Create Chart Manager
   const chartManager = new ChartManager(db, logger);
 
+  // 11c. Create MQTT Publisher Manager + Service
+  const mqttPublisherManager = new MqttPublisherManager(db, eventBus, logger);
+  const mqttPublishService = new MqttPublishService(
+    eventBus,
+    settingsManager,
+    mqttPublisherManager,
+    equipmentManager,
+    zoneAggregator,
+    logger,
+  );
+
   // 12. Create Recipe Manager
   const recipeManager = new RecipeManager(
     db,
@@ -177,6 +190,7 @@ async function main() {
     buttonActionManager,
     historyWriter,
     chartManager,
+    mqttPublisherManager,
     eventBus,
     integrationRegistry,
     logBuffer,
@@ -201,6 +215,9 @@ async function main() {
 
   // 18. Initialize history writer (connects to InfluxDB if configured, subscribes to events)
   historyWriter.init();
+
+  // 18b. Initialize MQTT publish service (connects to MQTT broker, subscribes to events)
+  mqttPublishService.init();
 
   // 19. Initialize mode manager, calendar, and button actions
   modeManager.init();
@@ -230,6 +247,11 @@ async function main() {
       recipeManager.stopAll();
     } catch (err) {
       logger.error({ err }, "Error stopping recipe manager");
+    }
+    try {
+      await mqttPublishService.destroy();
+    } catch (err) {
+      logger.error({ err }, "Error stopping MQTT publish service");
     }
     try {
       await historyWriter.destroy();

--- a/src/mqtt-publishers/mqtt-publish-service.ts
+++ b/src/mqtt-publishers/mqtt-publish-service.ts
@@ -5,6 +5,7 @@ import type { SettingsManager } from "../core/settings-manager.js";
 import type { MqttPublisherManager } from "./mqtt-publisher-manager.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { ZoneAggregator } from "../zones/zone-aggregator.js";
+import type { RecipeManager } from "../recipes/engine/recipe-manager.js";
 import type { ZoneAggregatedData } from "../shared/types.js";
 
 // ============================================================
@@ -18,6 +19,19 @@ interface MappingRef {
 }
 
 // ============================================================
+// Value conversion — booleans and binary states → 0/1
+// ============================================================
+
+const TRUTHY = new Set<unknown>([true, "ON", "open"]);
+const FALSY = new Set<unknown>([false, "OFF", "closed"]);
+
+function toMqttValue(value: unknown): unknown {
+  if (TRUTHY.has(value)) return 1;
+  if (FALSY.has(value)) return 0;
+  return value;
+}
+
+// ============================================================
 // MqttPublishService
 // ============================================================
 
@@ -28,7 +42,7 @@ export class MqttPublishService {
 
   /**
    * In-memory lookup index:
-   * key = "equipment:{sourceId}:{sourceKey}" or "zone:{sourceId}:{sourceKey}"
+   * key = "equipment:{sourceId}:{sourceKey}" or "zone:{sourceId}:{sourceKey}" or "recipe:{instanceId}:{stateKey}"
    * value = array of mapping refs to publish to
    */
   private index: Map<string, MappingRef[]> = new Map();
@@ -39,6 +53,7 @@ export class MqttPublishService {
     private readonly publisherManager: MqttPublisherManager,
     private readonly equipmentManager: EquipmentManager,
     private readonly zoneAggregator: ZoneAggregator,
+    private readonly recipeManager: RecipeManager,
     logger: Logger,
   ) {
     this.logger = logger.child({ module: "mqtt-publish-service" });
@@ -168,6 +183,10 @@ export class MqttPublishService {
             this.handleZoneDataChanged(event.zoneId, event.aggregatedData);
             break;
 
+          case "recipe.instance.state.changed":
+            this.handleRecipeStateChanged(event.instanceId);
+            break;
+
           case "mqtt-publisher.created":
           case "mqtt-publisher.updated":
           case "mqtt-publisher.removed":
@@ -213,12 +232,27 @@ export class MqttPublishService {
     }
   }
 
+  private handleRecipeStateChanged(instanceId: string): void {
+    const state = this.recipeManager.getInstanceState(instanceId);
+    for (const [stateKey, value] of Object.entries(state)) {
+      const key = `recipe:${instanceId}:${stateKey}`;
+      const refs = this.index.get(key);
+      if (!refs) continue;
+
+      for (const ref of refs) {
+        if (!ref.enabled) continue;
+        this.publish(ref.publisherTopic, ref.publishKey, value);
+      }
+    }
+  }
+
   // ── Publishing ───────────────────────────────────────────────
 
   private publish(topic: string, publishKey: string, value: unknown): void {
     if (!this.client?.connected) return;
 
-    const payload = JSON.stringify({ [publishKey]: value });
+    const mqttValue = toMqttValue(value);
+    const payload = JSON.stringify({ [publishKey]: mqttValue });
     this.client.publish(topic, payload, { retain: true }, (err) => {
       if (err) {
         this.logger.error({ err, topic, publishKey }, "MQTT publish error");
@@ -257,8 +291,33 @@ export class MqttPublishService {
     }
   }
 
+  // ── Test publish ────────────────────────────────────────────
+
+  publishSnapshotForPublisher(publisherId: string): number {
+    if (!this.client?.connected) return 0;
+
+    const publisher = this.publisherManager.getByIdWithMappings(publisherId);
+    if (!publisher) return 0;
+
+    let published = 0;
+    for (const mapping of publisher.mappings) {
+      const value = this.resolveCurrentValue(
+        mapping.sourceType,
+        mapping.sourceId,
+        mapping.sourceKey,
+      );
+      if (value !== undefined) {
+        this.publish(publisher.topic, mapping.publishKey, value);
+        published++;
+      }
+    }
+
+    this.logger.info({ publisherId, published }, "Test publish triggered");
+    return published;
+  }
+
   private resolveCurrentValue(
-    sourceType: "equipment" | "zone",
+    sourceType: "equipment" | "zone" | "recipe",
     sourceId: string,
     sourceKey: string,
   ): unknown {
@@ -273,6 +332,11 @@ export class MqttPublishService {
       const zoneData = allAggregated[sourceId];
       if (!zoneData) return undefined;
       return zoneData[sourceKey as keyof ZoneAggregatedData];
+    }
+
+    if (sourceType === "recipe") {
+      const state = this.recipeManager.getInstanceState(sourceId);
+      return state[sourceKey];
     }
 
     return undefined;

--- a/src/mqtt-publishers/mqtt-publish-service.ts
+++ b/src/mqtt-publishers/mqtt-publish-service.ts
@@ -1,0 +1,280 @@
+import mqtt, { type MqttClient } from "mqtt";
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { SettingsManager } from "../core/settings-manager.js";
+import type { MqttPublisherManager } from "./mqtt-publisher-manager.js";
+import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import type { ZoneAggregator } from "../zones/zone-aggregator.js";
+import type { ZoneAggregatedData } from "../shared/types.js";
+
+// ============================================================
+// Internal types
+// ============================================================
+
+interface MappingRef {
+  publisherTopic: string;
+  publishKey: string;
+  enabled: boolean;
+}
+
+// ============================================================
+// MqttPublishService
+// ============================================================
+
+export class MqttPublishService {
+  private readonly logger: Logger;
+  private client: MqttClient | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  /**
+   * In-memory lookup index:
+   * key = "equipment:{sourceId}:{sourceKey}" or "zone:{sourceId}:{sourceKey}"
+   * value = array of mapping refs to publish to
+   */
+  private index: Map<string, MappingRef[]> = new Map();
+
+  constructor(
+    private readonly eventBus: EventBus,
+    private readonly settingsManager: SettingsManager,
+    private readonly publisherManager: MqttPublisherManager,
+    private readonly equipmentManager: EquipmentManager,
+    private readonly zoneAggregator: ZoneAggregator,
+    logger: Logger,
+  ) {
+    this.logger = logger.child({ module: "mqtt-publish-service" });
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────
+
+  init(): void {
+    this.tryConnect();
+    this.rebuildIndex();
+    this.subscribeToEvents();
+    this.publishInitialSnapshot();
+    this.logger.info({ mappings: this.index.size }, "MQTT publish service initialized");
+  }
+
+  async destroy(): Promise<void> {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    if (this.client) {
+      try {
+        await this.client.endAsync();
+      } catch {
+        // Ignore disconnect errors during shutdown
+      }
+      this.client = null;
+    }
+  }
+
+  // ── MQTT connection ──────────────────────────────────────────
+
+  private tryConnect(): void {
+    // Read publisher-specific MQTT settings, fallback to Z2M settings
+    const brokerUrl =
+      this.settingsManager.get("mqtt-publisher.brokerUrl") ||
+      this.settingsManager.get("integration.zigbee2mqtt.mqtt_url");
+
+    if (!brokerUrl) {
+      this.logger.warn(
+        "No MQTT broker configured for publisher (set mqtt-publisher.brokerUrl or configure Zigbee2MQTT)",
+      );
+      return;
+    }
+
+    const username =
+      this.settingsManager.get("mqtt-publisher.username") ||
+      this.settingsManager.get("integration.zigbee2mqtt.mqtt_username") ||
+      undefined;
+    const password =
+      this.settingsManager.get("mqtt-publisher.password") ||
+      this.settingsManager.get("integration.zigbee2mqtt.mqtt_password") ||
+      undefined;
+
+    // Disconnect existing client if any
+    if (this.client) {
+      this.client.end(true);
+      this.client = null;
+    }
+
+    this.client = mqtt.connect(brokerUrl, {
+      clientId: "winch-publisher",
+      username,
+      password,
+      clean: true,
+      reconnectPeriod: 5000,
+    });
+
+    this.client.on("connect", () => {
+      this.logger.info({ brokerUrl }, "MQTT publish service connected");
+      // Re-publish snapshot on reconnect so retained values are up-to-date
+      this.publishInitialSnapshot();
+    });
+
+    this.client.on("reconnect", () => {
+      this.logger.warn("MQTT publish service reconnecting...");
+    });
+
+    this.client.on("error", (err) => {
+      this.logger.error({ err }, "MQTT publish service error");
+    });
+  }
+
+  private async tryReconnect(): Promise<void> {
+    if (this.client) {
+      try {
+        await this.client.endAsync(true);
+      } catch {
+        // Ignore
+      }
+      this.client = null;
+    }
+    this.tryConnect();
+  }
+
+  // ── Index management ─────────────────────────────────────────
+
+  private rebuildIndex(): void {
+    this.index.clear();
+
+    const publishers = this.publisherManager.getAllWithMappings();
+    for (const pub of publishers) {
+      for (const mapping of pub.mappings) {
+        const key = `${mapping.sourceType}:${mapping.sourceId}:${mapping.sourceKey}`;
+        const refs = this.index.get(key) ?? [];
+        refs.push({
+          publisherTopic: pub.topic,
+          publishKey: mapping.publishKey,
+          enabled: pub.enabled,
+        });
+        this.index.set(key, refs);
+      }
+    }
+
+    this.logger.debug({ indexKeys: this.index.size }, "Publisher index rebuilt");
+  }
+
+  // ── Event handling ───────────────────────────────────────────
+
+  private subscribeToEvents(): void {
+    this.unsubscribe = this.eventBus.on((event) => {
+      try {
+        switch (event.type) {
+          case "equipment.data.changed":
+            this.handleEquipmentDataChanged(event.equipmentId, event.alias, event.value);
+            break;
+
+          case "zone.data.changed":
+            this.handleZoneDataChanged(event.zoneId, event.aggregatedData);
+            break;
+
+          case "mqtt-publisher.created":
+          case "mqtt-publisher.updated":
+          case "mqtt-publisher.removed":
+          case "mqtt-publisher.mapping.created":
+          case "mqtt-publisher.mapping.removed":
+            this.rebuildIndex();
+            break;
+
+          case "settings.changed":
+            if (event.keys.some((k) => k.startsWith("mqtt-publisher."))) {
+              this.tryReconnect();
+            }
+            break;
+        }
+      } catch (err) {
+        this.logger.error({ err }, "Error in MQTT publish service event handler");
+      }
+    });
+  }
+
+  private handleEquipmentDataChanged(equipmentId: string, alias: string, value: unknown): void {
+    const key = `equipment:${equipmentId}:${alias}`;
+    const refs = this.index.get(key);
+    if (!refs) return;
+
+    for (const ref of refs) {
+      if (!ref.enabled) continue;
+      this.publish(ref.publisherTopic, ref.publishKey, value);
+    }
+  }
+
+  private handleZoneDataChanged(zoneId: string, aggregatedData: ZoneAggregatedData): void {
+    const entries = Object.entries(aggregatedData) as [keyof ZoneAggregatedData, unknown][];
+    for (const [field, value] of entries) {
+      const key = `zone:${zoneId}:${field}`;
+      const refs = this.index.get(key);
+      if (!refs) continue;
+
+      for (const ref of refs) {
+        if (!ref.enabled) continue;
+        this.publish(ref.publisherTopic, ref.publishKey, value);
+      }
+    }
+  }
+
+  // ── Publishing ───────────────────────────────────────────────
+
+  private publish(topic: string, publishKey: string, value: unknown): void {
+    if (!this.client?.connected) return;
+
+    const payload = JSON.stringify({ [publishKey]: value });
+    this.client.publish(topic, payload, { retain: true }, (err) => {
+      if (err) {
+        this.logger.error({ err, topic, publishKey }, "MQTT publish error");
+      }
+    });
+
+    this.logger.trace({ topic, publishKey, value }, "MQTT published");
+  }
+
+  // ── Initial snapshot ─────────────────────────────────────────
+
+  private publishInitialSnapshot(): void {
+    if (!this.client?.connected) return;
+
+    const publishers = this.publisherManager.getAllWithMappings();
+    let published = 0;
+
+    for (const pub of publishers) {
+      if (!pub.enabled) continue;
+
+      for (const mapping of pub.mappings) {
+        const value = this.resolveCurrentValue(
+          mapping.sourceType,
+          mapping.sourceId,
+          mapping.sourceKey,
+        );
+        if (value !== undefined) {
+          this.publish(pub.topic, mapping.publishKey, value);
+          published++;
+        }
+      }
+    }
+
+    if (published > 0) {
+      this.logger.debug({ published }, "Initial snapshot published");
+    }
+  }
+
+  private resolveCurrentValue(
+    sourceType: "equipment" | "zone",
+    sourceId: string,
+    sourceKey: string,
+  ): unknown {
+    if (sourceType === "equipment") {
+      const bindings = this.equipmentManager.getDataBindingsWithValues(sourceId);
+      const binding = bindings.find((b) => b.alias === sourceKey);
+      return binding?.value;
+    }
+
+    if (sourceType === "zone") {
+      const allAggregated = this.zoneAggregator.getAll();
+      const zoneData = allAggregated[sourceId];
+      if (!zoneData) return undefined;
+      return zoneData[sourceKey as keyof ZoneAggregatedData];
+    }
+
+    return undefined;
+  }
+}

--- a/src/mqtt-publishers/mqtt-publisher-manager.ts
+++ b/src/mqtt-publishers/mqtt-publisher-manager.ts
@@ -1,0 +1,259 @@
+import { randomUUID } from "node:crypto";
+import type Database from "better-sqlite3";
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import { toISOUtc } from "../core/database.js";
+import type {
+  MqttPublisher,
+  MqttPublisherMapping,
+  MqttPublisherWithMappings,
+} from "../shared/types.js";
+
+// ── Row types ────────────────────────────────────────────────
+
+interface PublisherRow {
+  id: string;
+  name: string;
+  topic: string;
+  enabled: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface MappingRow {
+  id: string;
+  publisher_id: string;
+  publish_key: string;
+  source_type: string;
+  source_id: string;
+  source_key: string;
+  created_at: string;
+}
+
+// ── Row mappers ──────────────────────────────────────────────
+
+function rowToPublisher(row: PublisherRow): MqttPublisher {
+  return {
+    id: row.id,
+    name: row.name,
+    topic: row.topic,
+    enabled: row.enabled === 1,
+    createdAt: toISOUtc(row.created_at),
+    updatedAt: toISOUtc(row.updated_at),
+  };
+}
+
+function rowToMapping(row: MappingRow): MqttPublisherMapping {
+  return {
+    id: row.id,
+    publisherId: row.publisher_id,
+    publishKey: row.publish_key,
+    sourceType: row.source_type as "equipment" | "zone",
+    sourceId: row.source_id,
+    sourceKey: row.source_key,
+    createdAt: toISOUtc(row.created_at),
+  };
+}
+
+// ── Manager ──────────────────────────────────────────────────
+
+export class MqttPublisherManager {
+  private readonly logger;
+  private readonly stmts;
+
+  constructor(
+    private readonly db: Database.Database,
+    private readonly eventBus: EventBus,
+    logger: Logger,
+  ) {
+    this.logger = logger.child({ module: "mqtt-publisher-manager" });
+    this.stmts = this.prepareStatements();
+  }
+
+  private prepareStatements() {
+    return {
+      listPublishers: this.db.prepare(`SELECT * FROM mqtt_publishers ORDER BY name`),
+      getPublisher: this.db.prepare(`SELECT * FROM mqtt_publishers WHERE id = ?`),
+      insertPublisher: this.db.prepare(
+        `INSERT INTO mqtt_publishers (id, name, topic, enabled, created_at, updated_at)
+         VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      ),
+      updatePublisher: this.db.prepare(
+        `UPDATE mqtt_publishers SET name = ?, topic = ?, enabled = ?, updated_at = datetime('now')
+         WHERE id = ?`,
+      ),
+      deletePublisher: this.db.prepare(`DELETE FROM mqtt_publishers WHERE id = ?`),
+      listMappings: this.db.prepare(
+        `SELECT * FROM mqtt_publisher_mappings WHERE publisher_id = ? ORDER BY publish_key`,
+      ),
+      insertMapping: this.db.prepare(
+        `INSERT INTO mqtt_publisher_mappings (id, publisher_id, publish_key, source_type, source_id, source_key, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
+      ),
+      getMapping: this.db.prepare(`SELECT * FROM mqtt_publisher_mappings WHERE id = ?`),
+      deleteMapping: this.db.prepare(
+        `DELETE FROM mqtt_publisher_mappings WHERE id = ? AND publisher_id = ?`,
+      ),
+      listAllMappings: this.db.prepare(
+        `SELECT * FROM mqtt_publisher_mappings ORDER BY publish_key`,
+      ),
+    };
+  }
+
+  // ── Publisher CRUD ───────────────────────────────────────────
+
+  getAll(): MqttPublisher[] {
+    const rows = this.stmts.listPublishers.all() as PublisherRow[];
+    return rows.map(rowToPublisher);
+  }
+
+  getById(id: string): MqttPublisher | null {
+    const row = this.stmts.getPublisher.get(id) as PublisherRow | undefined;
+    return row ? rowToPublisher(row) : null;
+  }
+
+  getAllWithMappings(): MqttPublisherWithMappings[] {
+    const publishers = this.getAll();
+    return publishers.map((p) => ({
+      ...p,
+      mappings: this.getMappings(p.id),
+    }));
+  }
+
+  getByIdWithMappings(id: string): MqttPublisherWithMappings | null {
+    const publisher = this.getById(id);
+    if (!publisher) return null;
+    return { ...publisher, mappings: this.getMappings(id) };
+  }
+
+  create(input: { name: string; topic: string; enabled?: boolean }): MqttPublisher {
+    if (!input.name?.trim()) throw new MqttPublisherError("name is required", 400);
+    if (!input.topic?.trim()) throw new MqttPublisherError("topic is required", 400);
+
+    const id = randomUUID();
+    const enabled = input.enabled !== false ? 1 : 0;
+    this.stmts.insertPublisher.run(id, input.name.trim(), input.topic.trim(), enabled);
+
+    const publisher = this.getById(id)!;
+    this.eventBus.emit({ type: "mqtt-publisher.created", publisher });
+    this.logger.info({ publisherId: id, name: input.name }, "MQTT publisher created");
+    return publisher;
+  }
+
+  update(id: string, updates: { name?: string; topic?: string; enabled?: boolean }): MqttPublisher {
+    const existing = this.getById(id);
+    if (!existing) throw new MqttPublisherError(`Publisher not found: ${id}`, 404);
+
+    const name = updates.name?.trim() ?? existing.name;
+    const topic = updates.topic?.trim() ?? existing.topic;
+    const enabled =
+      updates.enabled !== undefined ? (updates.enabled ? 1 : 0) : existing.enabled ? 1 : 0;
+
+    this.stmts.updatePublisher.run(name, topic, enabled, id);
+    const publisher = this.getById(id)!;
+    this.eventBus.emit({ type: "mqtt-publisher.updated", publisher });
+    this.logger.info({ publisherId: id }, "MQTT publisher updated");
+    return publisher;
+  }
+
+  delete(id: string): void {
+    const existing = this.getById(id);
+    if (!existing) throw new MqttPublisherError(`Publisher not found: ${id}`, 404);
+
+    this.stmts.deletePublisher.run(id);
+    this.eventBus.emit({
+      type: "mqtt-publisher.removed",
+      publisherId: id,
+      publisherName: existing.name,
+    });
+    this.logger.info({ publisherId: id, name: existing.name }, "MQTT publisher deleted");
+  }
+
+  // ── Mapping CRUD ─────────────────────────────────────────────
+
+  getMappings(publisherId: string): MqttPublisherMapping[] {
+    const rows = this.stmts.listMappings.all(publisherId) as MappingRow[];
+    return rows.map(rowToMapping);
+  }
+
+  addMapping(
+    publisherId: string,
+    input: {
+      publishKey: string;
+      sourceType: "equipment" | "zone";
+      sourceId: string;
+      sourceKey: string;
+    },
+  ): MqttPublisherMapping {
+    const publisher = this.getById(publisherId);
+    if (!publisher) throw new MqttPublisherError(`Publisher not found: ${publisherId}`, 404);
+    if (!input.publishKey?.trim()) throw new MqttPublisherError("publishKey is required", 400);
+    if (!input.sourceId?.trim()) throw new MqttPublisherError("sourceId is required", 400);
+    if (!input.sourceKey?.trim()) throw new MqttPublisherError("sourceKey is required", 400);
+    if (input.sourceType !== "equipment" && input.sourceType !== "zone") {
+      throw new MqttPublisherError("sourceType must be 'equipment' or 'zone'", 400);
+    }
+
+    const id = randomUUID();
+    try {
+      this.stmts.insertMapping.run(
+        id,
+        publisherId,
+        input.publishKey.trim(),
+        input.sourceType,
+        input.sourceId.trim(),
+        input.sourceKey.trim(),
+      );
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message.includes("UNIQUE constraint")) {
+        throw new MqttPublisherError(
+          `Publish key '${input.publishKey}' already exists in this publisher`,
+          409,
+        );
+      }
+      throw err;
+    }
+
+    const row = this.stmts.getMapping.get(id) as MappingRow;
+    const mapping = rowToMapping(row);
+    this.eventBus.emit({
+      type: "mqtt-publisher.mapping.created",
+      publisherId,
+      mapping,
+    });
+    this.logger.info(
+      { publisherId, mappingId: id, publishKey: input.publishKey },
+      "MQTT publisher mapping added",
+    );
+    return mapping;
+  }
+
+  removeMapping(publisherId: string, mappingId: string): void {
+    const publisher = this.getById(publisherId);
+    if (!publisher) throw new MqttPublisherError(`Publisher not found: ${publisherId}`, 404);
+
+    const result = this.stmts.deleteMapping.run(mappingId, publisherId);
+    if (result.changes === 0) {
+      throw new MqttPublisherError(`Mapping not found: ${mappingId}`, 404);
+    }
+
+    this.eventBus.emit({
+      type: "mqtt-publisher.mapping.removed",
+      publisherId,
+      mappingId,
+    });
+    this.logger.info({ publisherId, mappingId }, "MQTT publisher mapping removed");
+  }
+}
+
+// ── Error ────────────────────────────────────────────────────
+
+export class MqttPublisherError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "MqttPublisherError";
+  }
+}

--- a/src/mqtt-publishers/mqtt-publisher-manager.ts
+++ b/src/mqtt-publishers/mqtt-publisher-manager.ts
@@ -48,7 +48,7 @@ function rowToMapping(row: MappingRow): MqttPublisherMapping {
     id: row.id,
     publisherId: row.publisher_id,
     publishKey: row.publish_key,
-    sourceType: row.source_type as "equipment" | "zone",
+    sourceType: row.source_type as "equipment" | "zone" | "recipe",
     sourceId: row.source_id,
     sourceKey: row.source_key,
     createdAt: toISOUtc(row.created_at),
@@ -180,7 +180,7 @@ export class MqttPublisherManager {
     publisherId: string,
     input: {
       publishKey: string;
-      sourceType: "equipment" | "zone";
+      sourceType: "equipment" | "zone" | "recipe";
       sourceId: string;
       sourceKey: string;
     },
@@ -190,8 +190,12 @@ export class MqttPublisherManager {
     if (!input.publishKey?.trim()) throw new MqttPublisherError("publishKey is required", 400);
     if (!input.sourceId?.trim()) throw new MqttPublisherError("sourceId is required", 400);
     if (!input.sourceKey?.trim()) throw new MqttPublisherError("sourceKey is required", 400);
-    if (input.sourceType !== "equipment" && input.sourceType !== "zone") {
-      throw new MqttPublisherError("sourceType must be 'equipment' or 'zone'", 400);
+    if (
+      input.sourceType !== "equipment" &&
+      input.sourceType !== "zone" &&
+      input.sourceType !== "recipe"
+    ) {
+      throw new MqttPublisherError("sourceType must be 'equipment', 'zone', or 'recipe'", 400);
     }
 
     const id = randomUUID();

--- a/src/recipes/engine/motion-light-base.ts
+++ b/src/recipes/engine/motion-light-base.ts
@@ -97,6 +97,8 @@ export abstract class MotionLightBase extends Recipe {
   protected disableWhenDaylight = false;
   /** Grace period: ignore light-off echoes for 5s after the recipe itself sends a turnOff */
   protected turnOffGraceUntil = 0;
+  /** Defence flag: set by stop(), checked by all event handlers to prevent orphaned execution */
+  protected stopped = false;
 
   // ============================================================
   // Template methods — override in subclasses
@@ -216,6 +218,7 @@ export abstract class MotionLightBase extends Recipe {
   // ============================================================
 
   start(params: Record<string, unknown>, ctx: RecipeContext): void {
+    this.stopped = false;
     this.ctx = ctx;
     this.zoneId = params.zone as string;
     this.lightIds = this.normalizeLights(params);
@@ -283,6 +286,7 @@ export abstract class MotionLightBase extends Recipe {
   // ============================================================
 
   stop(): void {
+    this.stopped = true;
     this.cancelOffTimer();
     this.cancelFailsafeTimer();
     for (const unsub of this.unsubs) {
@@ -351,6 +355,8 @@ export abstract class MotionLightBase extends Recipe {
   // ============================================================
 
   private onZoneChanged(motion: boolean, luminosity: number | null): void {
+    if (this.stopped) return;
+
     // Override mode: recipe is suspended, only track room vacancy
     if (this.overrideMode) {
       if (motion) {
@@ -427,6 +433,7 @@ export abstract class MotionLightBase extends Recipe {
   }
 
   protected onLightChanged(value: unknown): void {
+    if (this.stopped) return;
     if (this.overrideMode) return;
 
     const lightOn = value === true || String(value).toUpperCase() === "ON";
@@ -506,6 +513,7 @@ export abstract class MotionLightBase extends Recipe {
   // ============================================================
 
   private onButtonAction(): void {
+    if (this.stopped) return;
     if (isAnyLightOn(this.lightIds, this.ctx)) {
       this.lightsOnByRecipe = false;
       this.turnOffGraceUntil = Date.now() + 5000;

--- a/src/recipes/engine/recipe-manager.ts
+++ b/src/recipes/engine/recipe-manager.ts
@@ -271,20 +271,22 @@ export class RecipeManager {
     // Update params in DB
     this.stmts.updateInstanceParams.run(JSON.stringify(params), instanceId);
 
-    // Reload and restart
+    // Reload and restart only if enabled
     const updatedRow = this.stmts.getInstanceById.get(instanceId) as InstanceRow;
     const instance = rowToInstance(updatedRow);
 
-    try {
-      const runRecipe = registered.create();
-      this.startInstance(runRecipe, instance);
-    } catch (err) {
-      this.logger.error({ err, instanceId }, "Failed to restart recipe instance after update");
-      this.writeLog(
-        instanceId,
-        `Failed to restart: ${err instanceof Error ? err.message : String(err)}`,
-        "error",
-      );
+    if (updatedRow.enabled === 1) {
+      try {
+        const runRecipe = registered.create();
+        this.startInstance(runRecipe, instance);
+      } catch (err) {
+        this.logger.error({ err, instanceId }, "Failed to restart recipe instance after update");
+        this.writeLog(
+          instanceId,
+          `Failed to restart: ${err instanceof Error ? err.message : String(err)}`,
+          "error",
+        );
+      }
     }
 
     this.logger.info({ instanceId, recipeId: row.recipe_id }, "Recipe instance updated");
@@ -316,9 +318,12 @@ export class RecipeManager {
   disableInstance(instanceId: string): void {
     const row = this.stmts.getInstanceById.get(instanceId) as InstanceRow | undefined;
     if (!row) throw new RecipeError("Instance not found", 404);
+
+    // Always stop in-memory runner even if DB says disabled — prevents orphaned runners
+    this.stopInstance(instanceId);
+
     if (row.enabled === 0) return;
 
-    this.stopInstance(instanceId);
     this.stmts.setInstanceEnabled.run(0, instanceId);
 
     this.logger.info({ instanceId, recipeId: row.recipe_id }, "Recipe instance disabled");
@@ -345,6 +350,9 @@ export class RecipeManager {
   // ============================================================
 
   private startInstance(recipe: Recipe, instance: RecipeInstance): void {
+    // Stop any existing runner for this instance first (prevents orphaned subscriptions)
+    this.stopInstance(instance.id);
+
     const ctx = this.buildContext(instance.id, instance.recipeId);
 
     recipe.validate(instance.params, ctx);

--- a/src/recipes/motion-light-dimmable.ts
+++ b/src/recipes/motion-light-dimmable.ts
@@ -307,6 +307,7 @@ export class MotionLightDimmableRecipe extends MotionLightBase {
   // ============================================================
 
   private onBrightnessChanged(value: unknown): void {
+    if (this.stopped) return;
     if (this.overrideMode) return;
     if (!isAnyLightOn(this.lightIds, this.ctx)) return;
     if (this.lastSentBrightness === null) return;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -634,7 +634,7 @@ export interface MqttPublisherMapping {
   id: string;
   publisherId: string;
   publishKey: string;
-  sourceType: "equipment" | "zone";
+  sourceType: "equipment" | "zone" | "recipe";
   sourceId: string;
   sourceKey: string;
   createdAt: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -503,6 +503,12 @@ export type EngineEvent =
   | { type: "settings.changed"; keys: string[] }
   // Sunlight events
   | { type: "sunlight.changed" }
+  // MQTT Publisher events
+  | { type: "mqtt-publisher.created"; publisher: MqttPublisher }
+  | { type: "mqtt-publisher.updated"; publisher: MqttPublisher }
+  | { type: "mqtt-publisher.removed"; publisherId: string; publisherName: string }
+  | { type: "mqtt-publisher.mapping.created"; publisherId: string; mapping: MqttPublisherMapping }
+  | { type: "mqtt-publisher.mapping.removed"; publisherId: string; mappingId: string }
   // System events
   | { type: "system.started" }
   | { type: "system.integration.connected"; integrationId: string }
@@ -609,6 +615,33 @@ export interface SavedChart {
   config: SavedChartConfig;
   createdAt: string;
   updatedAt: string;
+}
+
+// ============================================================
+// MQTT Publishers
+// ============================================================
+
+export interface MqttPublisher {
+  id: string;
+  name: string;
+  topic: string;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MqttPublisherMapping {
+  id: string;
+  publisherId: string;
+  publishKey: string;
+  sourceType: "equipment" | "zone";
+  sourceId: string;
+  sourceKey: string;
+  createdAt: string;
+}
+
+export interface MqttPublisherWithMappings extends MqttPublisher {
+  mappings: MqttPublisherMapping[];
 }
 
 // ============================================================

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,6 +19,7 @@ import { CalendarPage } from "./pages/CalendarPage";
 import { LogsPage } from "./pages/LogsPage";
 import { BackupPage } from "./pages/BackupPage";
 import { AnalysePage } from "./pages/AnalysePage";
+import { MqttPublishersPage } from "./pages/MqttPublishersPage";
 
 export default function App() {
   return (
@@ -55,6 +56,7 @@ export default function App() {
           <Route path="/analyse/:chartId" element={<AnalysePage />} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/integrations" element={<IntegrationsPage />} />
+          <Route path="/mqtt-publishers" element={<MqttPublishersPage />} />
           <Route path="/logs" element={<LogsPage />} />
           <Route path="/backup" element={<BackupPage />} />
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -831,7 +831,7 @@ export async function addMqttPublisherMapping(
   publisherId: string,
   data: {
     publishKey: string;
-    sourceType: "equipment" | "zone";
+    sourceType: "equipment" | "zone" | "recipe";
     sourceId: string;
     sourceKey: string;
   },
@@ -848,5 +848,11 @@ export async function removeMqttPublisherMapping(
 ): Promise<void> {
   return fetchJSON<void>(`${API_BASE}/mqtt-publishers/${publisherId}/mappings/${mappingId}`, {
     method: "DELETE",
+  });
+}
+
+export async function testMqttPublisher(publisherId: string): Promise<{ published: number }> {
+  return fetchJSON<{ published: number }>(`${API_BASE}/mqtt-publishers/${publisherId}/test`, {
+    method: "POST",
   });
 }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -13,6 +13,7 @@ import type {
   LogsResponse, LogLevel,
   HistoryStatus, HistoryBindingState, HistoryQueryResult,
   SavedChart, SavedChartConfig,
+  MqttPublisher, MqttPublisherMapping, MqttPublisherWithMappings,
 } from "./types";
 
 const API_BASE = "/api/v1";
@@ -787,4 +788,65 @@ export async function updateChart(
 
 export async function deleteChart(id: string): Promise<void> {
   return fetchJSON<void>(`${API_BASE}/charts/${id}`, { method: "DELETE" });
+}
+
+// ============================================================
+// MQTT Publishers
+// ============================================================
+
+export async function getMqttPublishers(): Promise<MqttPublisherWithMappings[]> {
+  return fetchJSON<MqttPublisherWithMappings[]>(`${API_BASE}/mqtt-publishers`);
+}
+
+export async function getMqttPublisher(id: string): Promise<MqttPublisherWithMappings> {
+  return fetchJSON<MqttPublisherWithMappings>(`${API_BASE}/mqtt-publishers/${id}`);
+}
+
+export async function createMqttPublisher(data: {
+  name: string;
+  topic: string;
+  enabled?: boolean;
+}): Promise<MqttPublisher> {
+  return fetchJSON<MqttPublisher>(`${API_BASE}/mqtt-publishers`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateMqttPublisher(
+  id: string,
+  data: { name?: string; topic?: string; enabled?: boolean },
+): Promise<MqttPublisher> {
+  return fetchJSON<MqttPublisher>(`${API_BASE}/mqtt-publishers/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteMqttPublisher(id: string): Promise<void> {
+  return fetchJSON<void>(`${API_BASE}/mqtt-publishers/${id}`, { method: "DELETE" });
+}
+
+export async function addMqttPublisherMapping(
+  publisherId: string,
+  data: {
+    publishKey: string;
+    sourceType: "equipment" | "zone";
+    sourceId: string;
+    sourceKey: string;
+  },
+): Promise<MqttPublisherMapping> {
+  return fetchJSON<MqttPublisherMapping>(`${API_BASE}/mqtt-publishers/${publisherId}/mappings`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function removeMqttPublisherMapping(
+  publisherId: string,
+  mappingId: string,
+): Promise<void> {
+  return fetchJSON<void>(`${API_BASE}/mqtt-publishers/${publisherId}/mappings/${mappingId}`, {
+    method: "DELETE",
+  });
 }

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   BarChart3,
   ScrollText,
   DatabaseBackup,
+  Send,
 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -35,6 +36,7 @@ const ADMIN_ITEMS: NavItem[] = [
   { to: "/zones", label: "nav.zones", icon: <Map size={18} strokeWidth={1.5} /> },
   { to: "/calendar", label: "nav.calendar", icon: <Calendar size={18} strokeWidth={1.5} /> },
   { to: "/integrations", label: "nav.integrations", icon: <Plug size={18} strokeWidth={1.5} /> },
+  { to: "/mqtt-publishers", label: "nav.mqttPublishers", icon: <Send size={18} strokeWidth={1.5} /> },
   { to: "/logs", label: "nav.logs", icon: <ScrollText size={18} strokeWidth={1.5} /> },
   { to: "/backup", label: "nav.backup", icon: <DatabaseBackup size={18} strokeWidth={1.5} /> },
 ];

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -623,7 +623,7 @@
   "analyse.new": "New chart",
 
   "mqttPublishers.title": "MQTT Publishers",
-  "mqttPublishers.subtitle": "Publish equipment and zone data to MQTT topics",
+  "mqttPublishers.subtitle": "Publish equipment, zone and recipe data to MQTT topics",
   "mqttPublishers.newPublisher": "New Publisher",
   "mqttPublishers.name": "Name",
   "mqttPublishers.topic": "MQTT Topic",
@@ -636,6 +636,8 @@
   "mqttPublishers.sourceKey": "Data Key",
   "mqttPublishers.equipment": "Equipment",
   "mqttPublishers.zone": "Zone",
+  "mqttPublishers.recipe": "Recipe",
+  "mqttPublishers.recipeInstance": "Recipe instance",
   "mqttPublishers.selectSource": "Select source...",
   "mqttPublishers.selectKey": "Select key...",
   "mqttPublishers.empty": "No publishers configured yet",
@@ -644,5 +646,9 @@
   "mqttPublishers.brokerHint": "Leave empty to use the Zigbee2MQTT broker",
   "mqttPublishers.brokerUrl": "Broker URL",
   "mqttPublishers.brokerUsername": "Username",
-  "mqttPublishers.brokerPassword": "Password"
+  "mqttPublishers.brokerPassword": "Password",
+  "mqttPublishers.allZones": "All zones",
+  "mqttPublishers.test": "Test",
+  "mqttPublishers.testPublish": "Publish a test snapshot",
+  "mqttPublishers.testResult": "{{count}} message(s) published"
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -10,6 +10,7 @@
   "nav.modes": "Modes",
   "nav.calendar": "Calendar",
   "nav.settings": "Settings",
+  "nav.mqttPublishers": "MQTT Publishers",
   "nav.maison": "Home",
 
   "auth.login": "Log in",
@@ -619,5 +620,29 @@
   "analyse.deleteConfirm": "Delete chart \"{{name}}\"?",
   "analyse.noSavedCharts": "No saved charts",
   "analyse.saved": "Chart saved",
-  "analyse.new": "New chart"
+  "analyse.new": "New chart",
+
+  "mqttPublishers.title": "MQTT Publishers",
+  "mqttPublishers.subtitle": "Publish equipment and zone data to MQTT topics",
+  "mqttPublishers.newPublisher": "New Publisher",
+  "mqttPublishers.name": "Name",
+  "mqttPublishers.topic": "MQTT Topic",
+  "mqttPublishers.mappings": "Mappings",
+  "mqttPublishers.noMappings": "No mappings configured",
+  "mqttPublishers.addMapping": "Add mapping",
+  "mqttPublishers.publishKey": "Publish Key",
+  "mqttPublishers.sourceType": "Source Type",
+  "mqttPublishers.source": "Source",
+  "mqttPublishers.sourceKey": "Data Key",
+  "mqttPublishers.equipment": "Equipment",
+  "mqttPublishers.zone": "Zone",
+  "mqttPublishers.selectSource": "Select source...",
+  "mqttPublishers.selectKey": "Select key...",
+  "mqttPublishers.empty": "No publishers configured yet",
+  "mqttPublishers.confirmDelete": "Delete this publisher and all its mappings?",
+  "mqttPublishers.brokerSettings": "MQTT Broker Settings",
+  "mqttPublishers.brokerHint": "Leave empty to use the Zigbee2MQTT broker",
+  "mqttPublishers.brokerUrl": "Broker URL",
+  "mqttPublishers.brokerUsername": "Username",
+  "mqttPublishers.brokerPassword": "Password"
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -10,6 +10,7 @@
   "nav.modes": "Modes",
   "nav.calendar": "Calendrier",
   "nav.settings": "Réglages",
+  "nav.mqttPublishers": "Publications MQTT",
   "nav.maison": "Maison",
 
   "auth.login": "Se connecter",
@@ -619,5 +620,29 @@
   "analyse.deleteConfirm": "Supprimer le graphique « {{name}} » ?",
   "analyse.noSavedCharts": "Aucun graphique sauvegardé",
   "analyse.saved": "Graphique enregistré",
-  "analyse.new": "Nouveau graphique"
+  "analyse.new": "Nouveau graphique",
+
+  "mqttPublishers.title": "Publications MQTT",
+  "mqttPublishers.subtitle": "Publier les données d'équipements et de zones vers des topics MQTT",
+  "mqttPublishers.newPublisher": "Nouveau publisher",
+  "mqttPublishers.name": "Nom",
+  "mqttPublishers.topic": "Topic MQTT",
+  "mqttPublishers.mappings": "Mappings",
+  "mqttPublishers.noMappings": "Aucun mapping configuré",
+  "mqttPublishers.addMapping": "Ajouter un mapping",
+  "mqttPublishers.publishKey": "Clé de publication",
+  "mqttPublishers.sourceType": "Type de source",
+  "mqttPublishers.source": "Source",
+  "mqttPublishers.sourceKey": "Clé de donnée",
+  "mqttPublishers.equipment": "Équipement",
+  "mqttPublishers.zone": "Zone",
+  "mqttPublishers.selectSource": "Sélectionner une source...",
+  "mqttPublishers.selectKey": "Sélectionner une clé...",
+  "mqttPublishers.empty": "Aucun publisher configuré",
+  "mqttPublishers.confirmDelete": "Supprimer ce publisher et tous ses mappings ?",
+  "mqttPublishers.brokerSettings": "Paramètres du broker MQTT",
+  "mqttPublishers.brokerHint": "Laisser vide pour utiliser le broker Zigbee2MQTT",
+  "mqttPublishers.brokerUrl": "URL du broker",
+  "mqttPublishers.brokerUsername": "Nom d'utilisateur",
+  "mqttPublishers.brokerPassword": "Mot de passe"
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -623,7 +623,7 @@
   "analyse.new": "Nouveau graphique",
 
   "mqttPublishers.title": "Publications MQTT",
-  "mqttPublishers.subtitle": "Publier les données d'équipements et de zones vers des topics MQTT",
+  "mqttPublishers.subtitle": "Publier les données d'équipements, zones et recettes vers des topics MQTT",
   "mqttPublishers.newPublisher": "Nouveau publisher",
   "mqttPublishers.name": "Nom",
   "mqttPublishers.topic": "Topic MQTT",
@@ -636,6 +636,8 @@
   "mqttPublishers.sourceKey": "Clé de donnée",
   "mqttPublishers.equipment": "Équipement",
   "mqttPublishers.zone": "Zone",
+  "mqttPublishers.recipe": "Recette",
+  "mqttPublishers.recipeInstance": "Instance de recette",
   "mqttPublishers.selectSource": "Sélectionner une source...",
   "mqttPublishers.selectKey": "Sélectionner une clé...",
   "mqttPublishers.empty": "Aucun publisher configuré",
@@ -644,5 +646,9 @@
   "mqttPublishers.brokerHint": "Laisser vide pour utiliser le broker Zigbee2MQTT",
   "mqttPublishers.brokerUrl": "URL du broker",
   "mqttPublishers.brokerUsername": "Nom d'utilisateur",
-  "mqttPublishers.brokerPassword": "Mot de passe"
+  "mqttPublishers.brokerPassword": "Mot de passe",
+  "mqttPublishers.allZones": "Toutes les zones",
+  "mqttPublishers.test": "Test",
+  "mqttPublishers.testPublish": "Publier un snapshot de test",
+  "mqttPublishers.testResult": "{{count}} message(s) publié(s)"
 }

--- a/ui/src/pages/MqttPublishersPage.tsx
+++ b/ui/src/pages/MqttPublishersPage.tsx
@@ -1,0 +1,645 @@
+import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Loader2,
+  Send,
+  Plus,
+  Trash2,
+  Power,
+  PowerOff,
+  ChevronDown,
+  ChevronUp,
+  Settings2,
+} from "lucide-react";
+import {
+  getMqttPublishers,
+  createMqttPublisher,
+  updateMqttPublisher,
+  deleteMqttPublisher,
+  addMqttPublisherMapping,
+  removeMqttPublisherMapping,
+  getEquipments,
+  getZones,
+  getSettings,
+  updateSettings,
+} from "../api";
+import type {
+  MqttPublisherWithMappings,
+  MqttPublisherMapping,
+  EquipmentWithDetails,
+  ZoneWithChildren,
+} from "../types";
+
+const ZONE_AGG_KEYS = [
+  "temperature",
+  "humidity",
+  "luminosity",
+  "motion",
+  "motionSensors",
+  "openDoors",
+  "openWindows",
+  "waterLeak",
+  "smoke",
+  "lightsOn",
+  "lightsTotal",
+  "shuttersOpen",
+  "shuttersTotal",
+  "averageShutterPosition",
+  "isDaylight",
+];
+
+export function MqttPublishersPage() {
+  const { t } = useTranslation();
+  const [publishers, setPublishers] = useState<MqttPublisherWithMappings[]>([]);
+  const [equipments, setEquipments] = useState<EquipmentWithDetails[]>([]);
+  const [zones, setZones] = useState<ZoneWithChildren[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [showBrokerSettings, setShowBrokerSettings] = useState(false);
+  const [brokerUrl, setBrokerUrl] = useState("");
+  const [brokerUsername, setBrokerUsername] = useState("");
+  const [brokerPassword, setBrokerPassword] = useState("");
+  const [savingBroker, setSavingBroker] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const [pubs, eqs, zs, settings] = await Promise.all([
+        getMqttPublishers(),
+        getEquipments(),
+        getZones(),
+        getSettings(),
+      ]);
+      setPublishers(pubs);
+      setEquipments(eqs);
+      setZones(zs);
+      setBrokerUrl(settings["mqtt-publisher.brokerUrl"] ?? "");
+      setBrokerUsername(settings["mqtt-publisher.username"] ?? "");
+      setBrokerPassword(settings["mqtt-publisher.password"] ?? "");
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleSaveBroker = async () => {
+    setSavingBroker(true);
+    try {
+      const entries: Record<string, string> = {
+        "mqtt-publisher.brokerUrl": brokerUrl,
+        "mqtt-publisher.username": brokerUsername,
+        "mqtt-publisher.password": brokerPassword,
+      };
+      await updateSettings(entries);
+    } catch {
+      // ignore
+    } finally {
+      setSavingBroker(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="p-6 flex items-center justify-center py-20">
+        <Loader2 size={20} className="animate-spin text-text-tertiary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <div className="mb-6">
+        <div className="flex items-center gap-2.5 mb-1">
+          <Send size={22} strokeWidth={1.5} className="text-text-secondary" />
+          <h1 className="text-[24px] font-semibold text-text leading-[32px]">
+            {t("mqttPublishers.title")}
+          </h1>
+        </div>
+        <p className="text-[13px] text-text-secondary mt-1">
+          {t("mqttPublishers.subtitle")}
+        </p>
+      </div>
+
+      {/* Broker settings */}
+      <div className="mb-6">
+        <button
+          onClick={() => setShowBrokerSettings(!showBrokerSettings)}
+          className="flex items-center gap-2 text-[13px] text-text-secondary hover:text-text transition-colors"
+        >
+          <Settings2 size={16} strokeWidth={1.5} />
+          {t("mqttPublishers.brokerSettings")}
+          {showBrokerSettings ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </button>
+        {showBrokerSettings && (
+          <div className="mt-3 p-4 bg-surface rounded-[10px] border border-border max-w-lg">
+            <p className="text-[12px] text-text-tertiary mb-3">
+              {t("mqttPublishers.brokerHint")}
+            </p>
+            <div className="space-y-3">
+              <div>
+                <label className="block text-[12px] text-text-secondary mb-1">
+                  {t("mqttPublishers.brokerUrl")}
+                </label>
+                <input
+                  type="text"
+                  value={brokerUrl}
+                  onChange={(e) => setBrokerUrl(e.target.value)}
+                  placeholder="mqtt://192.168.0.45:1883"
+                  className="w-full px-3 py-1.5 text-[13px] bg-bg border border-border rounded-[6px] text-text placeholder:text-text-tertiary"
+                />
+              </div>
+              <div>
+                <label className="block text-[12px] text-text-secondary mb-1">
+                  {t("mqttPublishers.brokerUsername")}
+                </label>
+                <input
+                  type="text"
+                  value={brokerUsername}
+                  onChange={(e) => setBrokerUsername(e.target.value)}
+                  className="w-full px-3 py-1.5 text-[13px] bg-bg border border-border rounded-[6px] text-text"
+                />
+              </div>
+              <div>
+                <label className="block text-[12px] text-text-secondary mb-1">
+                  {t("mqttPublishers.brokerPassword")}
+                </label>
+                <input
+                  type="password"
+                  value={brokerPassword}
+                  onChange={(e) => setBrokerPassword(e.target.value)}
+                  className="w-full px-3 py-1.5 text-[13px] bg-bg border border-border rounded-[6px] text-text"
+                />
+              </div>
+              <button
+                onClick={handleSaveBroker}
+                disabled={savingBroker}
+                className="px-4 py-1.5 bg-primary text-white text-[13px] rounded-[6px] hover:bg-primary-hover disabled:opacity-50"
+              >
+                {savingBroker ? <Loader2 size={14} className="animate-spin" /> : t("common.save")}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-3 mb-4">
+        <button
+          onClick={() => setShowCreate(true)}
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-primary text-white text-[13px] rounded-[6px] hover:bg-primary-hover transition-colors"
+        >
+          <Plus size={14} />
+          {t("mqttPublishers.newPublisher")}
+        </button>
+      </div>
+
+      {/* Create form */}
+      {showCreate && (
+        <CreatePublisherForm
+          onCreated={() => {
+            setShowCreate(false);
+            load();
+          }}
+          onCancel={() => setShowCreate(false)}
+        />
+      )}
+
+      {/* Publisher cards */}
+      {publishers.length === 0 ? (
+        <div className="text-[13px] text-text-tertiary py-10 text-center">
+          {t("mqttPublishers.empty")}
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {publishers.map((pub) => (
+            <PublisherCard
+              key={pub.id}
+              publisher={pub}
+              equipments={equipments}
+              zones={zones}
+              onRefresh={load}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Create form ──────────────────────────────────────────────
+
+function CreatePublisherForm({
+  onCreated,
+  onCancel,
+}: {
+  onCreated: () => void;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation();
+  const [name, setName] = useState("");
+  const [topic, setTopic] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !topic.trim()) return;
+    setSaving(true);
+    try {
+      await createMqttPublisher({ name: name.trim(), topic: topic.trim() });
+      onCreated();
+    } catch {
+      // ignore
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mb-4 p-4 bg-surface rounded-[10px] border border-border max-w-lg">
+      <div className="space-y-3">
+        <div>
+          <label className="block text-[12px] text-text-secondary mb-1">
+            {t("mqttPublishers.name")}
+          </label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Living Room Display"
+            className="w-full px-3 py-1.5 text-[13px] bg-bg border border-border rounded-[6px] text-text placeholder:text-text-tertiary"
+            autoFocus
+          />
+        </div>
+        <div>
+          <label className="block text-[12px] text-text-secondary mb-1">
+            {t("mqttPublishers.topic")}
+          </label>
+          <input
+            type="text"
+            value={topic}
+            onChange={(e) => setTopic(e.target.value)}
+            placeholder="winch/homedisplay/livingroom"
+            className="w-full px-3 py-1.5 text-[13px] bg-bg border border-border rounded-[6px] text-text placeholder:text-text-tertiary font-mono"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="submit"
+            disabled={saving || !name.trim() || !topic.trim()}
+            className="px-4 py-1.5 bg-primary text-white text-[13px] rounded-[6px] hover:bg-primary-hover disabled:opacity-50"
+          >
+            {t("common.create")}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-1.5 text-[13px] text-text-secondary hover:text-text transition-colors"
+          >
+            {t("common.cancel")}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+// ── Publisher card ────────────────────────────────────────────
+
+function PublisherCard({
+  publisher,
+  equipments,
+  zones,
+  onRefresh,
+}: {
+  publisher: MqttPublisherWithMappings;
+  equipments: EquipmentWithDetails[];
+  zones: ZoneWithChildren[];
+  onRefresh: () => void;
+}) {
+  const { t } = useTranslation();
+  const [showAddMapping, setShowAddMapping] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [toggling, setToggling] = useState(false);
+
+  const flatZones = flattenZones(zones);
+
+  const handleToggle = async () => {
+    setToggling(true);
+    try {
+      await updateMqttPublisher(publisher.id, { enabled: !publisher.enabled });
+      onRefresh();
+    } catch {
+      // ignore
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm(t("mqttPublishers.confirmDelete"))) return;
+    setDeleting(true);
+    try {
+      await deleteMqttPublisher(publisher.id);
+      onRefresh();
+    } catch {
+      // ignore
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleRemoveMapping = async (mappingId: string) => {
+    try {
+      await removeMqttPublisherMapping(publisher.id, mappingId);
+      onRefresh();
+    } catch {
+      // ignore
+    }
+  };
+
+  const resolveSourceLabel = (mapping: MqttPublisherMapping): string => {
+    if (mapping.sourceType === "equipment") {
+      const eq = equipments.find((e) => e.id === mapping.sourceId);
+      return eq ? `${eq.name} → ${mapping.sourceKey}` : `??? → ${mapping.sourceKey}`;
+    }
+    const zone = flatZones.find((z) => z.id === mapping.sourceId);
+    return zone ? `${zone.name} → ${mapping.sourceKey}` : `??? → ${mapping.sourceKey}`;
+  };
+
+  return (
+    <div className={`p-4 bg-surface rounded-[10px] border ${publisher.enabled ? "border-border" : "border-border opacity-60"}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-3">
+          <Send size={18} strokeWidth={1.5} className="text-text-secondary" />
+          <div>
+            <h3 className="text-[14px] font-medium text-text">{publisher.name}</h3>
+            <span className="text-[12px] text-text-tertiary font-mono">{publisher.topic}</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleToggle}
+            disabled={toggling}
+            className="p-1.5 rounded-[6px] hover:bg-bg transition-colors"
+            title={publisher.enabled ? t("common.disable") : t("common.enable")}
+          >
+            {publisher.enabled ? (
+              <Power size={16} className="text-green-500" />
+            ) : (
+              <PowerOff size={16} className="text-text-tertiary" />
+            )}
+          </button>
+          <button
+            onClick={handleDelete}
+            disabled={deleting}
+            className="p-1.5 rounded-[6px] hover:bg-bg transition-colors text-text-tertiary hover:text-red-500"
+            title={t("common.delete")}
+          >
+            <Trash2 size={16} />
+          </button>
+        </div>
+      </div>
+
+      {/* Mappings */}
+      <div className="mb-3">
+        <div className="text-[12px] text-text-secondary mb-2">
+          {t("mqttPublishers.mappings")} ({publisher.mappings.length})
+        </div>
+        {publisher.mappings.length === 0 ? (
+          <div className="text-[12px] text-text-tertiary italic">
+            {t("mqttPublishers.noMappings")}
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {publisher.mappings.map((mapping) => (
+              <div
+                key={mapping.id}
+                className="flex items-center justify-between px-3 py-1.5 bg-bg rounded-[6px] text-[12px]"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="font-mono font-medium text-text">
+                    {mapping.publishKey}
+                  </span>
+                  <span className="text-text-tertiary">←</span>
+                  <span className="text-text-secondary">
+                    {resolveSourceLabel(mapping)}
+                  </span>
+                  <span className="text-text-tertiary text-[11px]">
+                    ({mapping.sourceType})
+                  </span>
+                </div>
+                <button
+                  onClick={() => handleRemoveMapping(mapping.id)}
+                  className="text-text-tertiary hover:text-red-500 transition-colors"
+                >
+                  <Trash2 size={13} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Add mapping */}
+      {showAddMapping ? (
+        <AddMappingForm
+          publisherId={publisher.id}
+          equipments={equipments}
+          zones={flatZones}
+          onAdded={() => {
+            setShowAddMapping(false);
+            onRefresh();
+          }}
+          onCancel={() => setShowAddMapping(false)}
+        />
+      ) : (
+        <button
+          onClick={() => setShowAddMapping(true)}
+          className="flex items-center gap-1.5 text-[12px] text-primary hover:text-primary-hover transition-colors"
+        >
+          <Plus size={13} />
+          {t("mqttPublishers.addMapping")}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Add mapping form ─────────────────────────────────────────
+
+interface FlatZone {
+  id: string;
+  name: string;
+}
+
+function flattenZones(zones: ZoneWithChildren[]): FlatZone[] {
+  const result: FlatZone[] = [];
+  const recurse = (list: ZoneWithChildren[], depth: number) => {
+    for (const z of list) {
+      result.push({ id: z.id, name: "  ".repeat(depth) + z.name });
+      if (z.children.length > 0) recurse(z.children, depth + 1);
+    }
+  };
+  recurse(zones, 0);
+  return result;
+}
+
+function AddMappingForm({
+  publisherId,
+  equipments,
+  zones,
+  onAdded,
+  onCancel,
+}: {
+  publisherId: string;
+  equipments: EquipmentWithDetails[];
+  zones: FlatZone[];
+  onAdded: () => void;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation();
+  const [publishKey, setPublishKey] = useState("");
+  const [sourceType, setSourceType] = useState<"equipment" | "zone">("equipment");
+  const [sourceId, setSourceId] = useState("");
+  const [sourceKey, setSourceKey] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  // Available keys depend on source type and selected source
+  const availableKeys: string[] = (() => {
+    if (sourceType === "zone") return ZONE_AGG_KEYS;
+    if (sourceType === "equipment" && sourceId) {
+      const eq = equipments.find((e) => e.id === sourceId);
+      if (eq) return eq.dataBindings.map((b) => b.alias);
+    }
+    return [];
+  })();
+
+  // Reset sourceId and sourceKey when sourceType changes
+  const handleSourceTypeChange = (val: "equipment" | "zone") => {
+    setSourceType(val);
+    setSourceId("");
+    setSourceKey("");
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!publishKey.trim() || !sourceId || !sourceKey) return;
+    setSaving(true);
+    setError("");
+    try {
+      await addMqttPublisherMapping(publisherId, {
+        publishKey: publishKey.trim(),
+        sourceType,
+        sourceId,
+        sourceKey,
+      });
+      onAdded();
+    } catch (err: unknown) {
+      if (err instanceof Error) setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-3 bg-bg rounded-[6px] border border-border">
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-[11px] text-text-secondary mb-1">
+            {t("mqttPublishers.publishKey")}
+          </label>
+          <input
+            type="text"
+            value={publishKey}
+            onChange={(e) => setPublishKey(e.target.value)}
+            placeholder="Thome"
+            className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text font-mono placeholder:text-text-tertiary"
+            autoFocus
+          />
+        </div>
+        <div>
+          <label className="block text-[11px] text-text-secondary mb-1">
+            {t("mqttPublishers.sourceType")}
+          </label>
+          <select
+            value={sourceType}
+            onChange={(e) => handleSourceTypeChange(e.target.value as "equipment" | "zone")}
+            className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
+          >
+            <option value="equipment">{t("mqttPublishers.equipment")}</option>
+            <option value="zone">{t("mqttPublishers.zone")}</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-[11px] text-text-secondary mb-1">
+            {t("mqttPublishers.source")}
+          </label>
+          <select
+            value={sourceId}
+            onChange={(e) => {
+              setSourceId(e.target.value);
+              setSourceKey("");
+            }}
+            className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
+          >
+            <option value="">{t("mqttPublishers.selectSource")}</option>
+            {sourceType === "equipment"
+              ? equipments.map((eq) => (
+                  <option key={eq.id} value={eq.id}>
+                    {eq.name}
+                  </option>
+                ))
+              : zones.map((z) => (
+                  <option key={z.id} value={z.id}>
+                    {z.name}
+                  </option>
+                ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-[11px] text-text-secondary mb-1">
+            {t("mqttPublishers.sourceKey")}
+          </label>
+          <select
+            value={sourceKey}
+            onChange={(e) => setSourceKey(e.target.value)}
+            className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
+            disabled={!sourceId && sourceType === "equipment"}
+          >
+            <option value="">{t("mqttPublishers.selectKey")}</option>
+            {availableKeys.map((k) => (
+              <option key={k} value={k}>
+                {k}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      {error && (
+        <div className="mt-2 text-[11px] text-red-500">{error}</div>
+      )}
+      <div className="flex items-center gap-2 mt-3">
+        <button
+          type="submit"
+          disabled={saving || !publishKey.trim() || !sourceId || !sourceKey}
+          className="px-3 py-1 bg-primary text-white text-[12px] rounded-[4px] hover:bg-primary-hover disabled:opacity-50"
+        >
+          {t("mqttPublishers.addMapping")}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-3 py-1 text-[12px] text-text-secondary hover:text-text transition-colors"
+        >
+          {t("common.cancel")}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/ui/src/pages/MqttPublishersPage.tsx
+++ b/ui/src/pages/MqttPublishersPage.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   ChevronUp,
   Settings2,
+  Zap,
 } from "lucide-react";
 import {
   getMqttPublishers,
@@ -18,8 +19,11 @@ import {
   deleteMqttPublisher,
   addMqttPublisherMapping,
   removeMqttPublisherMapping,
+  testMqttPublisher,
   getEquipments,
   getZones,
+  getRecipeInstances,
+  getRecipes,
   getSettings,
   updateSettings,
 } from "../api";
@@ -28,6 +32,8 @@ import type {
   MqttPublisherMapping,
   EquipmentWithDetails,
   ZoneWithChildren,
+  RecipeInstance,
+  RecipeInfo,
 } from "../types";
 
 const ZONE_AGG_KEYS = [
@@ -53,6 +59,8 @@ export function MqttPublishersPage() {
   const [publishers, setPublishers] = useState<MqttPublisherWithMappings[]>([]);
   const [equipments, setEquipments] = useState<EquipmentWithDetails[]>([]);
   const [zones, setZones] = useState<ZoneWithChildren[]>([]);
+  const [recipeInstances, setRecipeInstances] = useState<RecipeInstance[]>([]);
+  const [recipes, setRecipes] = useState<RecipeInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
   const [showBrokerSettings, setShowBrokerSettings] = useState(false);
@@ -63,15 +71,19 @@ export function MqttPublishersPage() {
 
   const load = useCallback(async () => {
     try {
-      const [pubs, eqs, zs, settings] = await Promise.all([
+      const [pubs, eqs, zs, ri, recs, settings] = await Promise.all([
         getMqttPublishers(),
         getEquipments(),
         getZones(),
+        getRecipeInstances(),
+        getRecipes(),
         getSettings(),
       ]);
       setPublishers(pubs);
       setEquipments(eqs);
       setZones(zs);
+      setRecipeInstances(ri);
+      setRecipes(recs);
       setBrokerUrl(settings["mqtt-publisher.brokerUrl"] ?? "");
       setBrokerUsername(settings["mqtt-publisher.username"] ?? "");
       setBrokerPassword(settings["mqtt-publisher.password"] ?? "");
@@ -221,6 +233,8 @@ export function MqttPublishersPage() {
               publisher={pub}
               equipments={equipments}
               zones={zones}
+              recipeInstances={recipeInstances}
+              recipes={recipes}
               onRefresh={load}
             />
           ))}
@@ -313,19 +327,39 @@ function PublisherCard({
   publisher,
   equipments,
   zones,
+  recipeInstances,
+  recipes,
   onRefresh,
 }: {
   publisher: MqttPublisherWithMappings;
   equipments: EquipmentWithDetails[];
   zones: ZoneWithChildren[];
+  recipeInstances: RecipeInstance[];
+  recipes: RecipeInfo[];
   onRefresh: () => void;
 }) {
   const { t } = useTranslation();
   const [showAddMapping, setShowAddMapping] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [toggling, setToggling] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<number | null>(null);
 
   const flatZones = flattenZones(zones);
+
+  const handleTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const { published } = await testMqttPublisher(publisher.id);
+      setTestResult(published);
+      setTimeout(() => setTestResult(null), 3000);
+    } catch {
+      // ignore
+    } finally {
+      setTesting(false);
+    }
+  };
 
   const handleToggle = async () => {
     setToggling(true);
@@ -366,6 +400,12 @@ function PublisherCard({
       const eq = equipments.find((e) => e.id === mapping.sourceId);
       return eq ? `${eq.name} → ${mapping.sourceKey}` : `??? → ${mapping.sourceKey}`;
     }
+    if (mapping.sourceType === "recipe") {
+      const inst = recipeInstances.find((i) => i.id === mapping.sourceId);
+      const recipe = inst ? recipes.find((r) => r.id === inst.recipeId) : undefined;
+      const label = recipe ? recipe.name : "???";
+      return `${label} → ${mapping.sourceKey}`;
+    }
     const zone = flatZones.find((z) => z.id === mapping.sourceId);
     return zone ? `${zone.name} → ${mapping.sourceKey}` : `??? → ${mapping.sourceKey}`;
   };
@@ -382,6 +422,24 @@ function PublisherCard({
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <button
+            onClick={handleTest}
+            disabled={testing || publisher.mappings.length === 0}
+            className="flex items-center gap-1 px-2 py-1 text-[11px] rounded-[6px] hover:bg-bg transition-colors text-text-secondary hover:text-accent disabled:opacity-40"
+            title={t("mqttPublishers.testPublish")}
+          >
+            {testing ? (
+              <Loader2 size={13} className="animate-spin" />
+            ) : (
+              <Zap size={13} />
+            )}
+            {t("mqttPublishers.test")}
+          </button>
+          {testResult !== null && (
+            <span className="text-[11px] text-green-500">
+              {t("mqttPublishers.testResult", { count: testResult })}
+            </span>
+          )}
           <button
             onClick={handleToggle}
             disabled={toggling}
@@ -451,6 +509,8 @@ function PublisherCard({
           publisherId={publisher.id}
           equipments={equipments}
           zones={flatZones}
+          recipeInstances={recipeInstances}
+          recipes={recipes}
           onAdded={() => {
             setShowAddMapping(false);
             onRefresh();
@@ -479,13 +539,14 @@ interface FlatZone {
 
 function flattenZones(zones: ZoneWithChildren[]): FlatZone[] {
   const result: FlatZone[] = [];
-  const recurse = (list: ZoneWithChildren[], depth: number) => {
+  const recurse = (list: ZoneWithChildren[], parentLabel?: string) => {
     for (const z of list) {
-      result.push({ id: z.id, name: "  ".repeat(depth) + z.name });
-      if (z.children.length > 0) recurse(z.children, depth + 1);
+      const label = parentLabel ? `${parentLabel} › ${z.name}` : z.name;
+      result.push({ id: z.id, name: label });
+      if (z.children.length > 0) recurse(z.children, label);
     }
   };
-  recurse(zones, 0);
+  recurse(zones, undefined);
   return result;
 }
 
@@ -493,22 +554,37 @@ function AddMappingForm({
   publisherId,
   equipments,
   zones,
+  recipeInstances,
+  recipes,
   onAdded,
   onCancel,
 }: {
   publisherId: string;
   equipments: EquipmentWithDetails[];
   zones: FlatZone[];
+  recipeInstances: RecipeInstance[];
+  recipes: RecipeInfo[];
   onAdded: () => void;
   onCancel: () => void;
 }) {
   const { t } = useTranslation();
   const [publishKey, setPublishKey] = useState("");
-  const [sourceType, setSourceType] = useState<"equipment" | "zone">("equipment");
+  const [sourceType, setSourceType] = useState<"equipment" | "zone" | "recipe">("equipment");
+  const [filterZoneId, setFilterZoneId] = useState("");
   const [sourceId, setSourceId] = useState("");
   const [sourceKey, setSourceKey] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
+
+  // Equipments filtered by selected zone
+  const filteredEquipments = filterZoneId
+    ? equipments.filter((e) => e.zoneId === filterZoneId)
+    : equipments;
+
+  // Recipe instances filtered by selected zone (zone stored in params.zone)
+  const filteredRecipeInstances = filterZoneId
+    ? recipeInstances.filter((i) => i.params.zone === filterZoneId)
+    : recipeInstances;
 
   // Available keys depend on source type and selected source
   const availableKeys: string[] = (() => {
@@ -517,12 +593,17 @@ function AddMappingForm({
       const eq = equipments.find((e) => e.id === sourceId);
       if (eq) return eq.dataBindings.map((b) => b.alias);
     }
+    if (sourceType === "recipe" && sourceId) {
+      const inst = recipeInstances.find((i) => i.id === sourceId);
+      if (inst?.state) return Object.keys(inst.state);
+    }
     return [];
   })();
 
-  // Reset sourceId and sourceKey when sourceType changes
-  const handleSourceTypeChange = (val: "equipment" | "zone") => {
+  // Reset downstream selections when sourceType changes
+  const handleSourceTypeChange = (val: "equipment" | "zone" | "recipe") => {
     setSourceType(val);
+    setFilterZoneId("");
     setSourceId("");
     setSourceKey("");
   };
@@ -569,39 +650,98 @@ function AddMappingForm({
           </label>
           <select
             value={sourceType}
-            onChange={(e) => handleSourceTypeChange(e.target.value as "equipment" | "zone")}
+            onChange={(e) => handleSourceTypeChange(e.target.value as "equipment" | "zone" | "recipe")}
             className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
           >
             <option value="equipment">{t("mqttPublishers.equipment")}</option>
             <option value="zone">{t("mqttPublishers.zone")}</option>
+            <option value="recipe">{t("mqttPublishers.recipe")}</option>
           </select>
         </div>
+
+        {/* Zone selector — filter for equipment/recipe, direct source for zone */}
         <div>
           <label className="block text-[11px] text-text-secondary mb-1">
-            {t("mqttPublishers.source")}
+            {t("mqttPublishers.zone")}
           </label>
           <select
-            value={sourceId}
+            value={sourceType === "zone" ? sourceId : filterZoneId}
             onChange={(e) => {
-              setSourceId(e.target.value);
-              setSourceKey("");
+              if (sourceType === "zone") {
+                setSourceId(e.target.value);
+                setSourceKey("");
+              } else {
+                setFilterZoneId(e.target.value);
+                setSourceId("");
+                setSourceKey("");
+              }
             }}
             className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
           >
-            <option value="">{t("mqttPublishers.selectSource")}</option>
-            {sourceType === "equipment"
-              ? equipments.map((eq) => (
-                  <option key={eq.id} value={eq.id}>
-                    {eq.name}
-                  </option>
-                ))
-              : zones.map((z) => (
-                  <option key={z.id} value={z.id}>
-                    {z.name}
-                  </option>
-                ))}
+            <option value="">
+              {sourceType === "zone"
+                ? t("mqttPublishers.selectSource")
+                : t("mqttPublishers.allZones")}
+            </option>
+            {zones.map((z) => (
+              <option key={z.id} value={z.id}>
+                {z.name}
+              </option>
+            ))}
           </select>
         </div>
+
+        {/* Equipment selector — only when sourceType is equipment */}
+        {sourceType === "equipment" && (
+          <div>
+            <label className="block text-[11px] text-text-secondary mb-1">
+              {t("mqttPublishers.equipment")}
+            </label>
+            <select
+              value={sourceId}
+              onChange={(e) => {
+                setSourceId(e.target.value);
+                setSourceKey("");
+              }}
+              className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
+            >
+              <option value="">{t("mqttPublishers.selectSource")}</option>
+              {filteredEquipments.map((eq) => (
+                <option key={eq.id} value={eq.id}>
+                  {eq.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* Recipe instance selector — only when sourceType is recipe */}
+        {sourceType === "recipe" && (
+          <div>
+            <label className="block text-[11px] text-text-secondary mb-1">
+              {t("mqttPublishers.recipeInstance")}
+            </label>
+            <select
+              value={sourceId}
+              onChange={(e) => {
+                setSourceId(e.target.value);
+                setSourceKey("");
+              }}
+              className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
+            >
+              <option value="">{t("mqttPublishers.selectSource")}</option>
+              {filteredRecipeInstances.map((inst) => {
+                const recipe = recipes.find((r) => r.id === inst.recipeId);
+                return (
+                  <option key={inst.id} value={inst.id}>
+                    {recipe?.name ?? inst.recipeId}
+                  </option>
+                );
+              })}
+            </select>
+          </div>
+        )}
+
         <div>
           <label className="block text-[11px] text-text-secondary mb-1">
             {t("mqttPublishers.sourceKey")}
@@ -610,7 +750,7 @@ function AddMappingForm({
             value={sourceKey}
             onChange={(e) => setSourceKey(e.target.value)}
             className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-            disabled={!sourceId && sourceType === "equipment"}
+            disabled={!sourceId}
           >
             <option value="">{t("mqttPublishers.selectKey")}</option>
             {availableKeys.map((k) => (

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -515,6 +515,33 @@ export interface SavedChart {
 }
 
 // ============================================================
+// MQTT Publishers
+// ============================================================
+
+export interface MqttPublisher {
+  id: string;
+  name: string;
+  topic: string;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MqttPublisherMapping {
+  id: string;
+  publisherId: string;
+  publishKey: string;
+  sourceType: "equipment" | "zone";
+  sourceId: string;
+  sourceKey: string;
+  createdAt: string;
+}
+
+export interface MqttPublisherWithMappings extends MqttPublisher {
+  mappings: MqttPublisherMapping[];
+}
+
+// ============================================================
 // Integration
 // ============================================================
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -531,7 +531,7 @@ export interface MqttPublisherMapping {
   id: string;
   publisherId: string;
   publishKey: string;
-  sourceType: "equipment" | "zone";
+  sourceType: "equipment" | "zone" | "recipe";
   sourceId: string;
   sourceKey: string;
   createdAt: string;


### PR DESCRIPTION
## Summary
- Generic MQTT publisher that pushes Winch data (equipment aliases, zone aggregations) to configurable MQTT topics on state change
- Each publisher has a topic + list of mappings (publish key ← source)
- Messages published as `{"key": value}` with `retain=true`
- Admin UI page for full CRUD (publishers, mappings, broker settings)
- Own MQTT connection with fallback to Zigbee2MQTT broker

## Changes
- **Backend**: SQLite migration, MqttPublisherManager (CRUD), MqttPublishService (reactive event listener → MQTT publish), REST API (7 endpoints), WebSocket topic
- **Frontend**: MqttPublishersPage, source picker (equipments/zones), broker settings panel, sidebar nav, i18n (EN+FR)
- **Spec**: `specs/028-mqtt-publishers/`

## Test plan
- [x] TypeScript compiles (zero errors — backend + frontend)
- [x] All 454 tests pass
- [x] ESLint + Prettier pass
- [ ] Manually create publisher via UI, add mappings, verify MQTT messages with `mosquitto_sub`
- [ ] Verify retain=true (reconnect subscriber → receives last values)
- [ ] Verify initial snapshot on engine restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)