### PR TITLE
fix(history): step chart for boolean/enum data

### DIFF
--- a/src/api/routes/history.ts
+++ b/src/api/routes/history.ts
@@ -100,6 +100,7 @@ export function registerHistoryRoutes(
           bindingId: b.id,
           alias: b.alias,
           category: b.category,
+          type: b.type,
           historize: b.historize ?? null,
           effectiveOn: HistoryWriter.resolveHistorize(
             b.historize ?? null,
@@ -241,6 +242,11 @@ export function registerHistoryRoutes(
         .send({ error: "Invalid aggregation. Must be: raw, 1h, 1d, or auto" });
     }
 
+    // Look up binding type for proper aggregation strategy
+    const bindings = equipmentManager.getDataBindingsWithValues(equipmentId);
+    const binding = bindings.find((b) => b.alias === alias);
+    const dataType = binding?.type ?? "number";
+
     const result = await queryHistory(
       influx,
       {
@@ -249,11 +255,12 @@ export function registerHistoryRoutes(
         from: from ?? "-24h",
         to,
         aggregation: (aggregation as "raw" | "1h" | "1d" | "auto") ?? "auto",
+        dataType,
       },
       logger,
     );
 
-    return result;
+    return { ...result, dataType };
   });
 
   logger.debug("History routes registered");

--- a/src/history/history-query.ts
+++ b/src/history/history-query.ts
@@ -60,8 +60,9 @@ function buildFluxQuery(params: {
   from: Date;
   to: Date;
   resolution: Resolution;
+  isDiscrete?: boolean;
 }): string {
-  const { bucket, equipmentId, alias, from, to, resolution } = params;
+  const { bucket, equipmentId, alias, from, to, resolution, isDiscrete } = params;
 
   const fromStr = from.toISOString();
   const toStr = to.toISOString();
@@ -75,10 +76,11 @@ function buildFluxQuery(params: {
   |> filter(fn: (r) => r._field == "value_number")`;
 
   if (resolution === "raw") {
-    // Raw data — just sort and limit
+    // Raw data — higher limit for discrete state data over long ranges
+    const limit = isDiscrete ? 2000 : 500;
     query += `
   |> sort(columns: ["_time"])
-  |> limit(n: 500)`;
+  |> limit(n: ${limit})`;
   } else {
     // Aggregated data — window + mean/min/max
     const every = resolution === "1h" ? "1h" : "1d";
@@ -156,6 +158,7 @@ export async function queryHistory(
     from: string;
     to?: string;
     aggregation?: "raw" | "1h" | "1d" | "auto";
+    dataType?: string;
   },
   logger: Logger,
 ): Promise<HistoryQueryResult> {
@@ -167,8 +170,12 @@ export async function queryHistory(
 
   const fromDate = parseFrom(params.from);
   const toDate = params.to ? new Date(params.to) : new Date();
-  const resolution =
-    params.aggregation === "auto" || !params.aggregation
+  const isDiscrete = params.dataType === "boolean" || params.dataType === "enum";
+
+  // Boolean/enum types always use raw resolution — mean aggregation is meaningless for state data
+  const resolution = isDiscrete
+    ? ("raw" as Resolution)
+    : params.aggregation === "auto" || !params.aggregation
       ? autoResolution(fromDate.getTime(), toDate.getTime())
       : params.aggregation;
 
@@ -188,6 +195,7 @@ export async function queryHistory(
         from: fromDate,
         to: toDate,
         resolution: "raw",
+        isDiscrete,
       });
 
       for await (const { values, tableMeta } of queryApi.iterateRows(flux)) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -215,6 +215,7 @@ export interface HistoryQueryParams {
 export interface HistoryQueryResult {
   points: HistoryPoint[];
   resolution: "raw" | "1h" | "1d";
+  dataType?: string; // "number" | "boolean" | "enum" — helps frontend choose chart style
 }
 
 export interface OrderBinding {

--- a/ui/src/components/history/HistoryPanel.tsx
+++ b/ui/src/components/history/HistoryPanel.tsx
@@ -16,6 +16,7 @@ interface HistoryPanelProps {
 interface ChartState {
   points: HistoryPoint[];
   resolution: "raw" | "1h" | "1d";
+  dataType?: string;
   loading: boolean;
   error: string | null;
   fetchTime: number;
@@ -65,6 +66,7 @@ export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
           [alias]: {
             points: result.points,
             resolution: result.resolution,
+            dataType: result.dataType,
             loading: false,
             error: null,
             fetchTime: Date.now(),
@@ -198,6 +200,7 @@ export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
                         resolution={chart?.resolution ?? "raw"}
                         unit={unit}
                         fetchTime={chart?.fetchTime}
+                        dataType={chart?.dataType}
                       />
                       {chart?.resolution && (
                         <div className="text-[10px] text-text-tertiary text-right mt-1">

--- a/ui/src/components/history/TimeSeriesChart.tsx
+++ b/ui/src/components/history/TimeSeriesChart.tsx
@@ -21,6 +21,8 @@ interface TimeSeriesChartProps {
   height?: number;
   /** Timestamp (ms) when the data was fetched — used to extend chart to "now". */
   fetchTime?: number;
+  /** Data type — "boolean" or "enum" use step interpolation instead of smooth curves. */
+  dataType?: string;
 }
 
 function formatTime(iso: string, range: TimeRange): string {
@@ -73,8 +75,9 @@ function formatRelativeTime(isoTime: string, now: number, tFn: (key: string) => 
   return `${minutes}${tFn("time.min")}`;
 }
 
-export function TimeSeriesChart({ points, range, resolution, unit, height = 200, fetchTime }: TimeSeriesChartProps) {
+export function TimeSeriesChart({ points, range, resolution, unit, height = 200, fetchTime, dataType }: TimeSeriesChartProps) {
   const { t } = useTranslation();
+  const isDiscrete = dataType === "boolean" || dataType === "enum";
 
   const { data, lastRealTime } = useMemo(() => {
     const mapped = points.map((p) => ({
@@ -141,7 +144,10 @@ export function TimeSeriesChart({ points, range, resolution, unit, height = 200,
           tickLine={false}
           axisLine={false}
           width={48}
-          tickFormatter={(v: number) => (Number.isInteger(v) ? String(v) : v.toFixed(1))}
+          {...(isDiscrete
+            ? { domain: [0, 1], ticks: [0, 1], tickFormatter: (v: number) => (v === 1 ? "ON" : "OFF") }
+            : { tickFormatter: (v: number) => (Number.isInteger(v) ? String(v) : v.toFixed(1)) }
+          )}
         />
         <Tooltip
           contentStyle={{
@@ -160,6 +166,7 @@ export function TimeSeriesChart({ points, range, resolution, unit, height = 200,
           formatter={(value?: number, name?: string) => {
             const v = value ?? 0;
             if (name === "min" || name === "max") return [formatValue(v, unit), name];
+            if (isDiscrete) return [v === 1 ? "ON" : "OFF", ""];
             return [formatValue(v, unit), ""];
           }}
         />
@@ -178,7 +185,7 @@ export function TimeSeriesChart({ points, range, resolution, unit, height = 200,
 
         {/* Main value line */}
         <Line
-          type="monotone"
+          type={isDiscrete ? "stepAfter" : "monotone"}
           dataKey="value"
           stroke={primaryColor}
           strokeWidth={1.5}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -224,6 +224,7 @@ export interface HistoryBindingState {
   bindingId: string;
   alias: string;
   category: DataCategory;
+  type: string; // "number" | "boolean" | "enum"
   historize: number | null;
   effectiveOn: boolean;
 }
@@ -238,6 +239,7 @@ export interface HistoryPoint {
 export interface HistoryQueryResult {
   points: HistoryPoint[];
   resolution: "raw" | "1h" | "1d";
+  dataType?: string; // "number" | "boolean" | "enum"
 }
 
 export interface RetentionStatus {


### PR DESCRIPTION
## Summary
- Boolean/enum values (light_state, motion, etc.) now render as **step charts** instead of smooth curves
- Backend forces raw resolution for discrete data — no more meaningless `mean(0,1)=0.5`
- API returns `dataType` so frontend can adapt chart rendering (stepAfter, ON/OFF axis)

## Changes
- Backend: `history-query.ts` forces `raw` resolution for boolean/enum types
- Backend: `history.ts` route looks up binding type and returns `dataType` in response
- Frontend: `TimeSeriesChart` uses `stepAfter` interpolation + ON/OFF Y-axis for discrete data
- Types: `HistoryQueryResult.dataType` and `HistoryBindingState.type` added

## Test plan
- [x] TypeScript compiles (zero errors, all 3 modes)
- [x] All 454 tests pass
- [x] Lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)