### PR TITLE
refactor: rename Winch to Sowel

### DIFF
--- a/.claude/skills/sowel-feature/SKILL.md
+++ b/.claude/skills/sowel-feature/SKILL.md
@@ -1,14 +1,14 @@
 ---
-name: winch-feature
+name: sowel-feature
 description: |
-  Creates features for Winch — a home automation engine. Use when:
-  - User asks to "create a feature", "implement X", "add VX.Y" for Winch
+  Creates features for Sowel — a home automation engine. Use when:
+  - User asks to "create a feature", "implement X", "add VX.Y" for Sowel
   - Working on a roadmap version (V0.1, V0.2, etc.)
   - User says "créer une feature", "ajouter une fonctionnalité", "implémenter"
-  Specific to Winch project: MQTT, devices, equipments, zones, scenarios, recipes, AI assistant.
+  Specific to Sowel project: MQTT, devices, equipments, zones, scenarios, recipes, AI assistant.
 ---
 
-# Winch Feature Workflow
+# Sowel Feature Workflow
 
 ## Phase 1: Understand & Clarify
 
@@ -18,7 +18,7 @@ Before starting, read these files:
 
 | Document                  | Purpose                                         |
 | ------------------------- | ----------------------------------------------- |
-| `docs/winch-spec.md`      | Full specification — the single source of truth |
+| `docs/sowel-spec.md`      | Full specification — the single source of truth |
 | `src/shared/types.ts`     | All TypeScript types and interfaces             |
 | `src/shared/constants.ts` | DataCategory mappings, EquipmentType, etc.      |
 | `CLAUDE.md`               | Project conventions and rules                   |
@@ -112,7 +112,7 @@ Brief description.
 
 ## Reference
 
-- Spec sections: §X, §Y (reference winch-spec.md sections)
+- Spec sections: §X, §Y (reference sowel-spec.md sections)
 
 ## Acceptance Criteria
 
@@ -417,7 +417,7 @@ Before final commit, update:
 
 | Document                           | What to update                                                                     |
 | ---------------------------------- | ---------------------------------------------------------------------------------- |
-| `docs/winch-spec.md`               | Mark completed items, add any spec clarifications discovered during implementation |
+| `docs/sowel-spec.md`               | Mark completed items, add any spec clarifications discovered during implementation |
 | `specs/XXX-<version>-name/plan.md` | Mark tasks as completed [x]                                                        |
 | `specs/XXX-<version>-name/spec.md` | Mark acceptance criteria as completed [x]                                          |
 | `CLAUDE.md`                        | Add new commands, patterns, or conventions discovered                              |
@@ -470,7 +470,7 @@ gh pr create --title "feat: V0.X — feature description" --body "$(cat <<'EOF'
 - [x] Spec acceptance criteria all checked
 
 ## Roadmap
-- Implements V0.X from winch-spec.md
+- Implements V0.X from sowel-spec.md
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
@@ -501,7 +501,7 @@ git pull
 
 | Purpose            | Location                              |
 | ------------------ | ------------------------------------- |
-| Full specification | `docs/winch-spec.md`                  |
+| Full specification | `docs/sowel-spec.md`                  |
 | Feature specs      | `specs/XXX-version-name/`             |
 | TypeScript types   | `src/shared/types.ts`                 |
 | Constants          | `src/shared/constants.ts`             |
@@ -536,7 +536,7 @@ git pull
 | Run tests          | `npm run test`                    |
 | Run single test    | `npx vitest run <file>`           |
 | Lint               | `npx eslint src/ --ext .ts`       |
-| Reset DB           | `rm data/winch.db && npm run dev` |
+| Reset DB           | `rm data/sowel.db && npm run dev` |
 
 ### Event-Driven Pipeline
 

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Winch — all settings are optional (sensible defaults built-in)
 
 # Database
-# SQLITE_PATH=./data/winch.db
+# SQLITE_PATH=./data/sowel.db
 
 # Server
 # API_PORT=3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Winch** is a home automation engine with a plugin-based integration architecture. It supports multiple device sources (Zigbee2MQTT, Panasonic Comfort Cloud, MCZ Maestro, and more via the IntegrationPlugin interface). It separates physical **Devices** (auto-discovered from integrations) from user-facing **Equipments** (functional units like "Spots Salon"), provides automatic **Zone** aggregation, a **Scenario** engine with reusable **Recipe** templates, and exposes a reactive web UI.
+**Sowel** is a home automation engine with a plugin-based integration architecture. It supports multiple device sources (Zigbee2MQTT, Panasonic Comfort Cloud, MCZ Maestro, and more via the IntegrationPlugin interface). It separates physical **Devices** (auto-discovered from integrations) from user-facing **Equipments** (functional units like "Spots Salon"), provides automatic **Zone** aggregation, a **Scenario** engine with reusable **Recipe** templates, and exposes a reactive web UI.
 
-The full specification is in [winch-spec.md](winch-spec.md) — it is the single source of truth. It is a living document that evolves alongside feature development; always re-read the relevant sections before implementing a milestone.
+The full specification is in [sowel-spec.md](sowel-spec.md) — it is the single source of truth. It is a living document that evolves alongside feature development; always re-read the relevant sections before implementing a milestone.
 
 ## Architecture
 
@@ -47,7 +47,7 @@ Integration message (MQTT, cloud API poll, etc.)
 ### Project Structure
 
 ```
-winch/
+sowel/
 ├── src/
 │   ├── index.ts                 # Entry point
 │   ├── config.ts                # Env config loading
@@ -139,7 +139,7 @@ npm test -- --grep "pattern"  # Run specific tests
 ### Authentication
 
 - bcrypt (cost 12) for passwords, `jsonwebtoken` (HS256) for JWT
-- API tokens: `wch_` prefix (legacy `cbl_` also accepted), SHA-256 hash stored, generated via `crypto.randomBytes(32)`
+- API tokens: `swl_` prefix (legacy `wch_` and `cbl_` also accepted), SHA-256 hash stored, generated via `crypto.randomBytes(32)`
 - Auth middleware: try JWT decode first, then API token lookup
 - Roles: admin > user > viewer (hierarchical permissions)
 
@@ -216,11 +216,11 @@ V0.1 Devices → V0.2 Zones → V0.3 Equipments+Bindings → V0.4 UI Home → V0
 
 ## Environment Variables
 
-All settings are optional with sensible defaults — Winch runs zero-config out of the box. Override via `.env` if needed:
+All settings are optional with sensible defaults — Sowel runs zero-config out of the box. Override via `.env` if needed:
 
 | Variable          | Default           | Notes                                           |
 | ----------------- | ----------------- | ----------------------------------------------- |
-| `SQLITE_PATH`     | `./data/winch.db` | SQLite database path                            |
+| `SQLITE_PATH`     | `./data/sowel.db` | SQLite database path                            |
 | `API_PORT`        | `3000`            | HTTP server port                                |
 | `API_HOST`        | `0.0.0.0`         | Bind address                                    |
 | `JWT_SECRET`      | auto-generated    | Persisted in `data/.jwt-secret` on first launch |

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY recipes/ recipes/
 VOLUME /app/data
 
 ENV NODE_ENV=production
-ENV SQLITE_PATH=/app/data/winch.db
+ENV SQLITE_PATH=/app/data/sowel.db
 
 EXPOSE 3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
-  winch:
+  sowel:
     build: .
-    container_name: winch
+    container_name: sowel
     restart: unless-stopped
     ports:
       - "3000:3000"
     volumes:
-      - winch-data:/app/data
+      - sowel-data:/app/data
     # No .env needed — all settings have sensible defaults.
     # Override with environment variables if needed:
     # environment:
@@ -14,10 +14,10 @@ services:
     #   LOG_LEVEL: info
 
   # InfluxDB 2.x — optional time-series backend for data history (V0.13)
-  # Configure connection in Winch Settings > InfluxDB after first start.
+  # Configure connection in Sowel Settings > InfluxDB after first start.
   influxdb:
     image: influxdb:2.7
-    container_name: winch-influxdb
+    container_name: sowel-influxdb
     restart: unless-stopped
     ports:
       - "8086:8086"
@@ -25,12 +25,12 @@ services:
       - influxdb-data:/var/lib/influxdb2
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup
-      - DOCKER_INFLUXDB_INIT_USERNAME=winch
-      - DOCKER_INFLUXDB_INIT_PASSWORD=winch-secret
-      - DOCKER_INFLUXDB_INIT_ORG=winch
-      - DOCKER_INFLUXDB_INIT_BUCKET=winch
-      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=winch-dev-token
+      - DOCKER_INFLUXDB_INIT_USERNAME=sowel
+      - DOCKER_INFLUXDB_INIT_PASSWORD=sowel-secret
+      - DOCKER_INFLUXDB_INIT_ORG=sowel
+      - DOCKER_INFLUXDB_INIT_BUCKET=sowel
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=sowel-dev-token
 
 volumes:
-  winch-data:
+  sowel-data:
   influxdb-data:

--- a/docs/dark-mode-proposal.html
+++ b/docs/dark-mode-proposal.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Winch Dark Mode — Design System Proposal</title>
+<title>Sowel Dark Mode — Design System Proposal</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
   /* ============================================================
@@ -155,7 +155,7 @@
 </head>
 <body>
 
-<h1>Winch Dark Mode &mdash; Design System Proposal</h1>
+<h1>Sowel Dark Mode &mdash; Design System Proposal</h1>
 <p class="subtitle">Deep navy palette &bull; Side-by-side comparison &bull; Based on design-system-preview.html</p>
 
 <!-- ============================================================
@@ -491,7 +491,7 @@
     <div class="login-card" style="text-align:left">
       <div style="text-align:center;margin-bottom:16px">
         <div class="login-logo" style="margin-bottom:8px">W</div>
-        <div style="font-size:18px;font-weight:600;color:var(--text)">Winch</div>
+        <div style="font-size:18px;font-weight:600;color:var(--text)">Sowel</div>
       </div>
       <div style="margin-bottom:12px"><div class="login-label">Username</div><input class="login-input" value="admin" readonly></div>
       <div style="margin-bottom:16px"><div class="login-label">Password</div><input class="login-input" type="password" value="password" readonly></div>
@@ -502,7 +502,7 @@
     <div class="login-card" style="text-align:left">
       <div style="text-align:center;margin-bottom:16px">
         <div class="login-logo" style="margin-bottom:8px">W</div>
-        <div style="font-size:18px;font-weight:600;color:var(--text)">Winch</div>
+        <div style="font-size:18px;font-weight:600;color:var(--text)">Sowel</div>
       </div>
       <div style="margin-bottom:12px"><div class="login-label">Username</div><input class="login-input" value="admin" readonly></div>
       <div style="margin-bottom:16px"><div class="login-label">Password</div><input class="login-input" type="password" value="password" readonly></div>

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,14 +1,14 @@
-# Winch — Data Model
+# Sowel — Data Model
 
 > Version: 1.0 — 2026-02-19
 >
-> This document is the reference for Winch's core data model. It describes the three-layer architecture (Topology → Functional → Physical), all entities, their relationships, and the aggregation rules.
+> This document is the reference for Sowel's core data model. It describes the three-layer architecture (Topology → Functional → Physical), all entities, their relationships, and the aggregation rules.
 
 ---
 
 ## 1. Three-Layer Architecture
 
-Winch separates concerns into three distinct layers:
+Sowel separates concerns into three distinct layers:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐

--- a/docs/design-system-preview.html
+++ b/docs/design-system-preview.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Winch Design System</title>
+<title>Sowel Design System</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
   :root {
@@ -93,7 +93,7 @@
     <line x1="16" y1="16" x2="23.5" y2="10.5" stroke="white" stroke-width="2" stroke-linecap="round"/>
     <circle cx="23.5" cy="10.5" r="2" fill="white"/>
   </svg>
-  <h1>Winch Design System</h1>
+  <h1>Sowel Design System</h1>
 </div>
 <p class="subtitle">One turn. Full control. &mdash; Home automation engine</p>
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,4 +1,4 @@
-# Winch Design System
+# Sowel Design System
 
 ## Typography
 
@@ -71,7 +71,7 @@
 
 ## Logo
 
-Winch logo: white drum + crank on `primary` rounded square. Drum centered at (16,16) in a 32x32 viewBox.
+Sowel logo: white drum + crank on `primary` rounded square. Drum centered at (16,16) in a 32x32 viewBox.
 
 ## Shadows
 
@@ -86,7 +86,7 @@ Winch logo: white drum + crank on `primary` rounded square. Drum centered at (16
 ### Strategy
 
 - **Tailwind `class` strategy**: `class="dark"` on `<html>` activates `.dark {}` CSS variable overrides in `ui/src/index.css`
-- **User preference**: Light / Dark / System — stored in `UserPreferences.theme` and `localStorage("winch_theme")`
+- **User preference**: Light / Dark / System — stored in `UserPreferences.theme` and `localStorage("sowel_theme")`
 - **System detection**: `prefers-color-scheme: dark` media query, with live listener for "system" mode
 - **No component changes**: all components use semantic tokens (`bg-surface`, `text-text`, `border-border`) — only CSS variables change
 

--- a/docs/equipment-types.md
+++ b/docs/equipment-types.md
@@ -1,8 +1,8 @@
-# Winch — Equipment Types Specification
+# Sowel — Equipment Types Specification
 
 > **Version:** 0.1 — February 2026
 >
-> Winch separates **Devices** (physical hardware, auto-discovered) from **Equipments** (user-facing functional units). An equipment binds to one or more devices via **data bindings** (read) and **order bindings** (write). This abstraction is a core differentiator: the user thinks in terms of "garage door", not "LoRa node 12 + relay R1 + reed switches RS1/RS2".
+> Sowel separates **Devices** (physical hardware, auto-discovered) from **Equipments** (user-facing functional units). An equipment binds to one or more devices via **data bindings** (read) and **order bindings** (write). This abstraction is a core differentiator: the user thinks in terms of "garage door", not "LoRa node 12 + relay R1 + reed switches RS1/RS2".
 
 ---
 
@@ -487,7 +487,7 @@ Categories drive zone aggregation, UI icon/color selection, and history defaults
 
 ## History Defaults (V0.13)
 
-When InfluxDB is configured, Winch historizes data bindings using **convention over configuration**. Each binding's effective historize state is resolved in priority order:
+When InfluxDB is configured, Sowel historizes data bindings using **convention over configuration**. Each binding's effective historize state is resolved in priority order:
 
 1. **Explicit override** (`data_bindings.historize = 1` or `0`) → force ON or OFF
 2. **Alias default** (see below) → handles semantically important bindings in `generic` category

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -1,4 +1,4 @@
-# Winch — Implementation Status
+# Sowel — Implementation Status
 
 > Updated: 2026-02-24 — V0.1 through V0.11 done, Auth + i18n, Backup/Restore + Integrations
 
@@ -57,7 +57,7 @@
 | Feature         | Detail                                                                                      |
 | --------------- | ------------------------------------------------------------------------------------------- |
 | Tech stack      | React 18 + Vite + Tailwind v4 + Zustand + React Router v6                                   |
-| Design system   | Inter + JetBrains Mono fonts, Winch color palette, Lucide icons                             |
+| Design system   | Inter + JetBrains Mono fonts, Sowel color palette, Lucide icons                             |
 | Devices list    | Sortable table (name, manufacturer, model, source, battery, LQI, last seen), filter by name |
 | Device detail   | Data table, Orders list, raw expose viewer, inline name editor                              |
 | Layout          | Collapsible sidebar, connection status indicator, mobile bottom nav                         |
@@ -368,7 +368,7 @@
 ### What it does
 
 - JWT authentication (access + refresh tokens) with bcrypt password hashing
-- API token support (`wch_` prefix, SHA-256 hashed)
+- API token support (`swl_` prefix, SHA-256 hashed)
 - Two roles: `admin` (full access) and `standard` (control equipments, view data, manage recipes — cannot manage devices, zones, users, or system settings)
 - First-run setup flow: create first admin user
 - Auth middleware on all API routes (whitelist: status, setup, login, refresh, health)
@@ -417,11 +417,11 @@
 - **Integrations page**: Admin UI to configure integrations (connection settings, credentials, polling intervals), with status and connect/disconnect buttons
 - **Dynamic reconnect**: Change integration settings from UI and reconnect without engine restart
 - **Conditional startup**: Engine starts without integrations if none are yet configured
-- **Backup/restore**: Export/import full Winch configuration as JSON (all config tables in dependency order)
+- **Backup/restore**: Export/import full Sowel configuration as JSON (all config tables in dependency order)
 - **Backup UI**: Export/Import buttons in Settings page (admin only)
 - **Device auto-cleanup**: Offline devices are automatically cleaned up based on integration events
 - **Stale device cleanup**: Devices in DB not seen by the integration are removed
-- **Manual device delete**: Delete button on device detail page (Winch DB only)
+- **Manual device delete**: Delete button on device detail page (Sowel DB only)
 
 ### API Endpoints
 
@@ -578,7 +578,7 @@
 - **PanasonicCCIntegration** implements IntegrationPlugin
 - **Cloud API bridge**: authenticates with Panasonic cloud, fetches device list and state
 - **Polling**: periodic state refresh (configurable interval, default 300s)
-- **Device discovery**: AC units appear as Winch Devices with source `panasonic_cc`
+- **Device discovery**: AC units appear as Sowel Devices with source `panasonic_cc`
 - **DeviceData**: temperature (indoor/outdoor), operating mode, fan speed, power state, eco mode
 - **DeviceOrders**: set temperature, mode, fan speed, power on/off
 - **Thermostat equipment type**: full UI support with mode selector, temperature controls, fan speed
@@ -612,7 +612,7 @@
 - **MczMaestroIntegration** implements IntegrationPlugin
 - **Socket.IO bridge**: connects to MCZ cloud via socket.io, authenticates, receives real-time state
 - **Polling**: periodic state refresh (configurable interval, default 300s)
-- **Device discovery**: stoves appear as Winch Devices with source `mcz_maestro`
+- **Device discovery**: stoves appear as Sowel Devices with source `mcz_maestro`
 - **DeviceData**: ambient temperature, smoke temperature, water temperature, stove state, power level, fan speeds, eco mode, chrono mode, alarms
 - **DeviceOrders**: set temperature, power on/off, power level, eco mode, chrono mode, silent mode, reset alarm
 - **Thermostat equipment type**: reused ThermostatCard with MCZ-specific stove state badge + reset alarm button
@@ -646,7 +646,7 @@
 - **NetatmoHCIntegration** implements IntegrationPlugin
 - **OAuth2 authentication**: token-based auth with automatic refresh
 - **Polling**: periodic state refresh (configurable interval, default 300s)
-- **Device discovery**: Netatmo devices appear as Winch Devices with source `netatmo_hc`
+- **Device discovery**: Netatmo devices appear as Sowel Devices with source `netatmo_hc`
 - **DeviceData**: temperature, humidity, CO2, noise, pressure, rain, wind, battery, WiFi signal
 - **DeviceOrders**: thermostat setpoint, mode changes
 

--- a/docs/mockups/sparkline-mockup.html
+++ b/docs/mockups/sparkline-mockup.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Winch — Sparkline Mockup (IT3)</title>
+<title>Sowel — Sparkline Mockup (IT3)</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
 

--- a/docs/recipe-developer-guide.md
+++ b/docs/recipe-developer-guide.md
@@ -1,6 +1,6 @@
 # Recipe Developer Guide
 
-How to create a new recipe for Winch.
+How to create a new recipe for Sowel.
 
 ## Architecture
 

--- a/docs/sowel-spec.md
+++ b/docs/sowel-spec.md
@@ -1,15 +1,15 @@
-# Winch — Functional Specification
+# Sowel — Functional Specification
 
 > Version: 0.8 — February 2026
 > Author: Marc
 > Purpose: This document is the single source of truth for Claude Code to build the project.
-> **Winch** — the invisible structure of your smart home.
+> **Sowel** — the invisible structure of your smart home.
 
 ---
 
 ## 1. Vision
 
-**Winch** is a modern, lightweight home automation engine that:
+**Sowel** is a modern, lightweight home automation engine that:
 
 - Uses **MQTT as its only data source** (zigbee2mqtt, tasmota, ESPHome, or any MQTT-publishing device)
 - Separates **physical devices** (what's on the network) from **functional equipments** (how the user lives their home)
@@ -1118,7 +1118,7 @@ Downsampling is handled by InfluxDB continuous queries / tasks.
 ## 10. Project Structure
 
 ```
-winch/
+sowel/
 ├── docker-compose.yml              # Engine + InfluxDB
 ├── package.json
 ├── tsconfig.json
@@ -1381,20 +1381,20 @@ winch/
 ### V0.10b — Panasonic Comfort Cloud Integration
 
 - `PanasonicCCIntegration` plugin (cloud API bridge + polling)
-- Auto-discovery of AC units as Winch Devices (source: `panasonic_cc`)
+- Auto-discovery of AC units as Sowel Devices (source: `panasonic_cc`)
 - Data: indoor/outdoor temperature, operating mode, fan speed, power state
 - Orders: set temperature, mode, fan speed, power on/off
 - `thermostat` equipment type with full UI (ThermostatCard)
-- **Deliverable**: Panasonic AC control from Winch
+- **Deliverable**: Panasonic AC control from Sowel
 
 ### V0.10c — MCZ Maestro Integration
 
 - `MczMaestroIntegration` plugin (Socket.IO cloud bridge + polling)
-- Auto-discovery of pellet stoves as Winch Devices (source: `mcz_maestro`)
+- Auto-discovery of pellet stoves as Sowel Devices (source: `mcz_maestro`)
 - Data: ambient/smoke/water temperature, stove state, power level, fan speeds, alarms
 - Orders: set temperature, power on/off, power level, eco/chrono/silent mode, reset alarm
 - Stove state badge on ThermostatCard + always-visible reset alarm button
-- **Deliverable**: MCZ pellet stove control from Winch
+- **Deliverable**: MCZ pellet stove control from Sowel
 
 ### V0.11 — History
 
@@ -1464,19 +1464,19 @@ The engine is configured via environment variables (`.env` file):
 MQTT_URL=mqtt://localhost:1883
 MQTT_USERNAME=
 MQTT_PASSWORD=
-MQTT_CLIENT_ID=winch
+MQTT_CLIENT_ID=sowel
 
 # Zigbee2MQTT
 Z2M_BASE_TOPIC=zigbee2mqtt
 
 # Database
-SQLITE_PATH=./data/winch.db
+SQLITE_PATH=./data/sowel.db
 
 # InfluxDB
 INFLUX_URL=http://localhost:8086
 INFLUX_TOKEN=my-token
-INFLUX_ORG=winch
-INFLUX_BUCKET=winch
+INFLUX_ORG=sowel
+INFLUX_BUCKET=sowel
 
 # Server
 API_PORT=3000
@@ -1599,16 +1599,16 @@ POST /api/v1/auth/logout
 # Create via API (requires admin role)
 POST /api/v1/auth/tokens
   Body: { "name": "iPhone Marc", "scopes": ["*"], "expiresAt": null }
-  Response: { "token": "wch_xxxxxxxxxxxx", "id": "..." }
+  Response: { "token": "swl_xxxxxxxxxxxx", "id": "..." }
   # The raw token is returned ONCE at creation. Store it securely.
 
 # Usage: pass as Bearer token or as query param (for WebSocket)
-Authorization: Bearer wch_xxxxxxxxxxxx
+Authorization: Bearer swl_xxxxxxxxxxxx
 # or
-ws://host:3000/ws?token=wch_xxxxxxxxxxxx
+ws://host:3000/ws?token=swl_xxxxxxxxxxxx
 ```
 
-- Token prefix: `wch_` (winch) for easy identification
+- Token prefix: `swl_` (sowel) for easy identification
 - Scopes: `["*"]` (all), `["read"]` (view only), `["read", "control"]` (view + execute orders), `["read", "control", "admin"]` (everything)
 - Tokens can be revoked individually
 
@@ -1618,7 +1618,7 @@ WebSocket connections must authenticate on connect:
 
 ```
 // Option A: token as query parameter
-ws://host:3000/ws?token=wch_xxxxxxxxxxxx
+ws://host:3000/ws?token=swl_xxxxxxxxxxxx
 
 // Option B: token in first message after connect
 → Client sends: { "type": "auth", "token": "eyJ..." }
@@ -1795,7 +1795,7 @@ The engine itself runs HTTP (no TLS). For remote access (mobile app outside loca
 The engine must:
 
 - Trust `X-Forwarded-For`, `X-Forwarded-Proto` headers (configurable: `TRUST_PROXY=true`)
-- Work correctly behind a path prefix (e.g. `/winch/api/v1/...`) if needed
+- Work correctly behind a path prefix (e.g. `/sowel/api/v1/...`) if needed
 - Support CORS with configurable allowed origins (for web and mobile WebView)
 
 ```env
@@ -1828,7 +1828,7 @@ This ensures the engine is never exposed without authentication.
 
 ### 14.1 Overview
 
-Winch integrates an optional AI assistant that allows users to interact with their home in natural language. The AI layer is **provider-agnostic** — it can use Claude API, OpenAI API, or a local model via Ollama.
+Sowel integrates an optional AI assistant that allows users to interact with their home in natural language. The AI layer is **provider-agnostic** — it can use Claude API, OpenAI API, or a local model via Ollama.
 
 The AI is never autonomous — it always proposes, the user confirms.
 
@@ -1937,7 +1937,7 @@ User says: _"Éteins les lumières du salon si personne depuis 10 minutes après
 System prompt template:
 
 ```
-You are the AI assistant for Winch, a home automation engine.
+You are the AI assistant for Sowel, a home automation engine.
 
 The user wants to create an automation scenario. Based on their request and the home context below, generate a valid Scenario JSON object.
 
@@ -1979,7 +1979,7 @@ User says: _"Quelle est la température du salon ?"_ or _"Combien de lumières s
 System prompt:
 
 ```
-You are the AI assistant for Winch. Answer the user's question about their home based on the current state.
+You are the AI assistant for Sowel. Answer the user's question about their home based on the current state.
 Answer in the same language as the user. Be concise.
 
 CURRENT HOME STATE:
@@ -1995,7 +1995,7 @@ User says: _"Éteins tout dans le salon"_ or _"Mets la lumière de la chambre à
 System prompt:
 
 ```
-You are the AI assistant for Winch. The user wants to perform an action on their home.
+You are the AI assistant for Sowel. The user wants to perform an action on their home.
 Generate a JSON array of actions to execute.
 
 Respond ONLY with a JSON array of action objects:
@@ -2023,7 +2023,7 @@ This is triggered by the engine periodically (e.g. weekly) or on-demand. The eng
 System prompt:
 
 ```
-You are the AI assistant for Winch. Analyze the user's home setup and suggest useful automation scenarios they might want.
+You are the AI assistant for Sowel. Analyze the user's home setup and suggest useful automation scenarios they might want.
 
 Consider:
 - Equipments that exist but are not used in any scenario
@@ -2082,14 +2082,14 @@ The AI assistant appears as a **chat panel** accessible from any page (floating 
 
 ```
 ┌──────────────────────────────────┐
-│  🤖 Winch Assistant             │
+│  🤖 Sowel Assistant             │
 ├──────────────────────────────────┤
 │                                  │
 │  User: Éteins tout dans le       │
 │  salon si personne pendant       │
 │  10 minutes le soir              │
 │                                  │
-│  Winch: J'ai préparé ce         │
+│  Sowel: J'ai préparé ce         │
 │  scénario:                       │
 │  ┌────────────────────────────┐  │
 │  │ Extinction salon            │  │
@@ -2118,9 +2118,9 @@ For execute_action intents, the confirmation shows the list of actions about to 
 
 ### 14.1 Brand Identity
 
-**Winch** — the invisible structure of your smart home.
+**Sowel** — the invisible structure of your smart home.
 
-The design language draws from the winch: structural elegance, hidden strength, clean lines. The beauty of architecture that holds everything together invisibly. The UI should feel warm but precise, calm but informative. Not dark-tech aggressive, not corporate cold.
+The design language draws from the sowel: structural elegance, hidden strength, clean lines. The beauty of architecture that holds everything together invisibly. The UI should feel warm but precise, calm but informative. Not dark-tech aggressive, not corporate cold.
 
 ### 14.2 Color Palette
 
@@ -2197,7 +2197,7 @@ Single font family for consistency. Inter is geometric, modern, highly legible o
 
 ### 14.4 Logo
 
-Concept: a stylized winch bracket — a supportive architectural element in profile, suggesting hidden structural strength.
+Concept: a stylized sowel bracket — a supportive architectural element in profile, suggesting hidden structural strength.
 
 ```
         ┌───────┐
@@ -2219,7 +2219,7 @@ Execution:
 Variants:
 
 - **Icon only**: the square with cutout (used as favicon, app icon)
-- **Wordmark**: icon + "Winch" in Inter Semibold, spaced generously
+- **Wordmark**: icon + "Sowel" in Inter Semibold, spaced generously
 - **Monochrome**: single color version for dark/light backgrounds
 
 ### 14.5 Spacing & Layout
@@ -2398,7 +2398,7 @@ module.exports = {
 - API keys must be stored encrypted in SQLite (AES-256-GCM, encryption key derived from JWT_SECRET)
 - Always validate LLM JSON output with a strict schema validator before accepting
 - Set temperature low (0.1-0.2) for structured output (scenario creation, actions), higher (0.7) for conversational answers
-- Implement a timeout on LLM calls (30s default) — if the provider is down, the rest of Winch must keep working
+- Implement a timeout on LLM calls (30s default) — if the provider is down, the rest of Sowel must keep working
 - The AI feature is entirely optional — if `provider: "none"`, all AI routes return 404 and UI hides AI elements
 - For Ollama: use the `/api/generate` endpoint with `format: "json"` for structured output
 - Context builder must be efficient — cache the context and invalidate only when zones/equipments change, not on every data update
@@ -2408,7 +2408,7 @@ module.exports = {
 
 - Use `bcrypt` for password hashing (cost factor 12)
 - Use `jsonwebtoken` for JWT (HS256, secret from env)
-- API tokens: generate with `crypto.randomBytes(32).toString('hex')`, prefix with `wch_`, store SHA-256 hash only
+- API tokens: generate with `crypto.randomBytes(32).toString('hex')`, prefix with `swl_`, store SHA-256 hash only
 - Auth middleware: check `Authorization: Bearer <token>` header. Try JWT decode first, if it fails try API token lookup.
 - Fastify `onRequest` hook for auth, with route whitelist for public endpoints (`/auth/login`, `/auth/setup`)
 - Role-based authorization: use a `requireRole(minRole)` decorator on routes

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,16 +1,16 @@
-# Winch — User Manual
+# Sowel — User Manual
 
 > Updated: 2026-02-24 — V0.11 Logging
 
 ---
 
-## Why Winch?
+## Why Sowel?
 
 Home automation platforms are powerful but complex. Home Assistant drowns users in YAML and flat entity lists. Jeedom buries features behind paid plugins. Both demand hours of configuration before anything works.
 
-Winch takes the opposite approach: **structure first, simplicity always**.
+Sowel takes the opposite approach: **structure first, simplicity always**.
 
-|                     | Home Assistant                                                    | Jeedom                               | **Winch**                                                                            |
+|                     | Home Assistant                                                    | Jeedom                               | **Sowel**                                                                            |
 | ------------------- | ----------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------ |
 | **Architecture**    | Flat entity list (thousands of `sensor.`, `light.`, `switch.`...) | Nested objects & commands            | **3 clear layers**: Device → Equipment → Zone                                        |
 | **Device setup**    | Integration + entity config per device                            | Plugin per protocol (often paid)     | **Zero config** — auto-discovery from configured integrations                        |
@@ -24,7 +24,7 @@ Winch takes the opposite approach: **structure first, simplicity always**.
 
 > A **Device** is what's on the network. An **Equipment** is what's in the room. The user thinks _"Spots Salon"_, not _"IKEA TRADFRI LED1837R5 0x00158D00062B1234"_.
 
-Winch separates the physical (Device) from the functional (Equipment), then organizes everything spatially (Zone). This is what makes aggregation, recipes, and modes possible without any configuration.
+Sowel separates the physical (Device) from the functional (Equipment), then organizes everything spatially (Zone). This is what makes aggregation, recipes, and modes possible without any configuration.
 
 ---
 
@@ -32,7 +32,7 @@ Winch separates the physical (Device) from the functional (Equipment), then orga
 
 ### 1. Devices — auto-discovered, never configured
 
-Devices are physical hardware discovered from configured integrations (Zigbee2MQTT, Panasonic Comfort Cloud, MCZ Maestro, Netatmo Home Control, etc.). Winch discovers everything automatically: sensors, lights, switches, shutters, buttons, thermostats. Each device exposes **Data** (readable properties like temperature, state, brightness) and **Orders** (writable commands).
+Devices are physical hardware discovered from configured integrations (Zigbee2MQTT, Panasonic Comfort Cloud, MCZ Maestro, Netatmo Home Control, etc.). Sowel discovers everything automatically: sensors, lights, switches, shutters, buttons, thermostats. Each device exposes **Data** (readable properties like temperature, state, brightness) and **Orders** (writable commands).
 
 You never configure a Device. You just look at the list, and they're there.
 
@@ -56,7 +56,7 @@ An Equipment is what the user actually interacts with. "Spots Salon" is an Equip
 
 Zones form a tree: `Maison → Étage 1 → Salon`. Each Equipment belongs to exactly one Zone.
 
-**Automatic aggregation**: Winch computes real-time status for every zone:
+**Automatic aggregation**: Sowel computes real-time status for every zone:
 
 - **Temperature, humidity, luminosity** — averaged across all sensors in the zone
 - **Motion** — OR across all motion sensors (plus duration tracking)
@@ -77,7 +77,7 @@ A Recipe is a pre-built automation template. Instead of writing rules from scrat
 - Pick a light (Spots Salon)
 - Set a timeout (10 minutes)
 
-That's it. Winch handles all the edge cases: motion detected → light ON, motion stops → start timer, timer expires → light OFF, manual turn-on → start timer if no motion, manual turn-off → cancel timer.
+That's it. Sowel handles all the edge cases: motion detected → light ON, motion stops → start timer, timer expires → light OFF, manual turn-on → start timer if no motion, manual turn-off → cancel timer.
 
 ### 5. Modes — house-level operating states
 
@@ -170,7 +170,7 @@ Browse auto-discovered hardware:
 
 - Sortable table (name, manufacturer, model, battery, LQI, last seen)
 - Click for detail: raw data, orders, expose viewer
-- Delete removes from Winch only (re-discovered if still active)
+- Delete removes from Sowel only (re-discovered if still active)
 
 ### Administration > Integrations
 
@@ -203,7 +203,7 @@ Configure device source connections:
 
 ```bash
 git clone <repo>
-cd winch
+cd sowel
 npm install
 ```
 
@@ -212,7 +212,7 @@ npm install
 Optionally edit `.env` for engine settings:
 
 ```env
-SQLITE_PATH=./data/winch.db
+SQLITE_PATH=./data/sowel.db
 API_PORT=3000
 JWT_SECRET=your-secret-here
 LOG_LEVEL=info
@@ -358,9 +358,9 @@ curl -X POST http://localhost:3000/api/v1/recipe-instances \
 ### Backup / Restore
 
 ```bash
-curl http://localhost:3000/api/v1/backup -o winch-backup.json
+curl http://localhost:3000/api/v1/backup -o sowel-backup.json
 curl -X POST http://localhost:3000/api/v1/backup \
-  -H "Content-Type: application/json" -d @winch-backup.json
+  -H "Content-Type: application/json" -d @sowel-backup.json
 ```
 
 ### WebSocket

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "winch",
+  "name": "sowel",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "winch",
+      "name": "sowel",
       "version": "0.1.0",
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "winch",
+  "name": "sowel",
   "version": "0.1.0",
-  "description": "Winch — Home automation engine powered by MQTT",
+  "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/specs/001-V0.1-mqtt-devices/spec.md
+++ b/specs/001-V0.1-mqtt-devices/spec.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The foundational milestone of Winch. The engine connects to an MQTT broker (zigbee2mqtt), auto-discovers all Zigbee devices, parses their capabilities (Data and Orders), tracks their state in real-time, and persists everything in SQLite. A REST API and WebSocket endpoint expose device data for testing and future UI integration.
+The foundational milestone of Sowel. The engine connects to an MQTT broker (zigbee2mqtt), auto-discovers all Zigbee devices, parses their capabilities (Data and Orders), tracks their state in real-time, and persists everything in SQLite. A REST API and WebSocket endpoint expose device data for testing and future UI integration.
 
 ## Reference
 

--- a/specs/002-V0.1-ui-scaffolding-devices/architecture.md
+++ b/specs/002-V0.1-ui-scaffolding-devices/architecture.md
@@ -167,7 +167,7 @@ This allows the UI dev server (port 5173) to proxy API and WS calls to the backe
 ### AppLayout
 
 - Left sidebar (collapsible on mobile) with navigation links
-- Top header bar with app name "Winch" and connection status indicator
+- Top header bar with app name "Sowel" and connection status indicator
 - Main content area with `<Outlet/>` for routed pages
 
 ### DeviceCard

--- a/specs/002-V0.1-ui-scaffolding-devices/plan.md
+++ b/specs/002-V0.1-ui-scaffolding-devices/plan.md
@@ -11,7 +11,7 @@
 
 1. [ ] Initialize Vite + React + TypeScript project in `ui/`
 2. [ ] Install dependencies: tailwindcss, postcss, autoprefixer, zustand, react-router-dom, lucide-react
-3. [ ] Configure Tailwind with Winch design system tokens (colors, fonts, spacing, border-radius) — light mode only
+3. [ ] Configure Tailwind with Sowel design system tokens (colors, fonts, spacing, border-radius) — light mode only
 4. [ ] Configure Vite proxy for `/api` and `/ws` to backend (localhost:3000)
 5. [ ] Set up Inter + JetBrains Mono fonts (via @fontsource or CDN)
 6. [ ] Create `ui/src/index.css` with Tailwind directives and base styles

--- a/specs/002-V0.1-ui-scaffolding-devices/spec.md
+++ b/specs/002-V0.1-ui-scaffolding-devices/spec.md
@@ -22,7 +22,7 @@ This is part of the new incremental UI strategy: each backend version ships its 
 ## Acceptance Criteria
 
 - [ ] `ui/` directory contains a working React + Vite + TypeScript project
-- [ ] Tailwind CSS configured with the Winch design system tokens (light mode)
+- [ ] Tailwind CSS configured with the Sowel design system tokens (light mode)
 - [ ] Zustand WebSocket store connects to `ws://host:port/ws` and dispatches events
 - [ ] Zustand device store hydrates from `GET /api/v1/devices` on startup
 - [ ] Device store updates in real-time from WebSocket events (device.discovered, device.removed, device.status_changed, device.data.updated)

--- a/specs/003-V0.2-zones/spec.md
+++ b/specs/003-V0.2-zones/spec.md
@@ -2,12 +2,12 @@
 
 ## Summary
 
-Implement the spatial topology layer of Winch. Users can define hierarchical Zones (Home → Floor → Room) and Equipment Groups within Zones. This establishes the structure into which Equipments will be placed in V0.3.
+Implement the spatial topology layer of Sowel. Users can define hierarchical Zones (Home → Floor → Room) and Equipment Groups within Zones. This establishes the structure into which Equipments will be placed in V0.3.
 
 ## Reference
 
 - Data model: [docs/data-model.md](../../docs/data-model.md) — §3 Zone, §4 Equipment Group
-- Spec: [docs/winch-spec.md](../../docs/winch-spec.md) — §5.4 Zone, §7.5 Zone API
+- Spec: [docs/sowel-spec.md](../../docs/sowel-spec.md) — §5.4 Zone, §7.5 Zone API
 
 ## Acceptance Criteria
 

--- a/specs/004-V0.3-equipments/spec.md
+++ b/specs/004-V0.3-equipments/spec.md
@@ -9,7 +9,7 @@ V0.3 builds the **generic Equipment infrastructure** but focuses on **lighting**
 ## Reference
 
 - Data model: `docs/data-model.md` — sections 5, 6, 7
-- Spec: `docs/winch-spec.md` — Equipment, Binding, Order concepts
+- Spec: `docs/sowel-spec.md` — Equipment, Binding, Order concepts
 
 ## Acceptance Criteria
 

--- a/specs/005-V0.5-ui-restructuring/spec.md
+++ b/specs/005-V0.5-ui-restructuring/spec.md
@@ -6,8 +6,8 @@ Reorganize the UI sidebar into two distinct sections: **Maison** (a dynamic zone
 
 ## Reference
 
-- Spec sections: V0.5 (winch-spec.md lines 1241-1257)
-- Design system: §15 (winch-spec.md)
+- Spec sections: V0.5 (sowel-spec.md lines 1241-1257)
+- Design system: §15 (sowel-spec.md)
 
 ## Acceptance Criteria
 

--- a/specs/007-V0.7-zone-aggregation/spec.md
+++ b/specs/007-V0.7-zone-aggregation/spec.md
@@ -6,7 +6,7 @@ Implement automatic zone-level data aggregation. When a zone contains sensor or 
 
 ## Reference
 
-- Spec sections: winch-spec.md §Zone auto-aggregation, data-model.md §3.3
+- Spec sections: sowel-spec.md §Zone auto-aggregation, data-model.md §3.3
 
 ## Acceptance Criteria
 

--- a/specs/011-V0.10a-integration-plugin-architecture/spec.md
+++ b/specs/011-V0.10a-integration-plugin-architecture/spec.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Refactor Winch's device layer to support multiple data source integrations beyond MQTT. Introduce an `IntegrationPlugin` interface that abstracts device discovery, data updates, and order execution. The existing Zigbee2MQTT code becomes the first built-in plugin. This is a pure architectural refactoring — zero functional change for the end user.
+Refactor Sowel's device layer to support multiple data source integrations beyond MQTT. Introduce an `IntegrationPlugin` interface that abstracts device discovery, data updates, and order execution. The existing Zigbee2MQTT code becomes the first built-in plugin. This is a pure architectural refactoring — zero functional change for the end user.
 
 ## Reference
 

--- a/specs/012-V0.10b-panasonic-comfort-cloud/architecture.md
+++ b/specs/012-V0.10b-panasonic-comfort-cloud/architecture.md
@@ -149,7 +149,7 @@ class PanasonicPoller {
 On each poll cycle:
 
 1. Call `bridge.getDevices()` (single Python invocation returns all devices + status)
-2. For each device, map to Winch `DiscoveredDevice` format
+2. For each device, map to Sowel `DiscoveredDevice` format
 3. Call `deviceManager.upsertFromDiscovery()` to update/create devices + data
 
 ### PanasonicCCIntegration (`index.ts`)
@@ -185,11 +185,11 @@ class PanasonicCCIntegration implements IntegrationPlugin {
 
 ## Data Model
 
-### Panasonic Device → Winch Device Mapping
+### Panasonic Device → Sowel Device Mapping
 
-Each AC unit becomes a Winch Device:
+Each AC unit becomes a Sowel Device:
 
-| Winch field      | Source                         |
+| Sowel field      | Source                         |
 | ---------------- | ------------------------------ |
 | `integrationId`  | `"panasonic_cc"`               |
 | `sourceDeviceId` | `device.id` from bridge output |

--- a/specs/012-V0.10b-panasonic-comfort-cloud/spec.md
+++ b/specs/012-V0.10b-panasonic-comfort-cloud/spec.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add a Panasonic Comfort Cloud integration plugin that discovers AC units from the Panasonic cloud API, exposes them as Devices with Data and Orders, and allows controlling them from the Winch UI. Uses a **Python bridge** wrapping the community-maintained `aio-panasonic-comfort-cloud` library (Home Assistant ecosystem) for authentication and API calls. Introduces the `thermostat` EquipmentType with a dedicated dashboard widget. Uses polling-based data updates with configurable interval (default 5 min) and on-demand polling after order execution.
+Add a Panasonic Comfort Cloud integration plugin that discovers AC units from the Panasonic cloud API, exposes them as Devices with Data and Orders, and allows controlling them from the Sowel UI. Uses a **Python bridge** wrapping the community-maintained `aio-panasonic-comfort-cloud` library (Home Assistant ecosystem) for authentication and API calls. Introduces the `thermostat` EquipmentType with a dedicated dashboard widget. Uses polling-based data updates with configurable interval (default 5 min) and on-demand polling after order execution.
 
 ## Reference
 
@@ -53,7 +53,7 @@ Add a Panasonic Comfort Cloud integration plugin that discovers AC units from th
 - Aquarea heat pump devices (different protocol, deferred)
 - Energy/history data from Panasonic API (deferred)
 - Zone parameters for ducted systems (multi-zone AC, rare)
-- Multi-account support (one Panasonic account per Winch instance)
+- Multi-account support (one Panasonic account per Sowel instance)
 - Docker configuration for Python runtime (deferred)
 
 ## Edge Cases

--- a/specs/013-V0.10c-mcz-maestro/architecture.md
+++ b/specs/013-V0.10c-mcz-maestro/architecture.md
@@ -3,7 +3,7 @@
 ## Communication Protocol
 
 ```
-Winch Engine
+Sowel Engine
   └─ MczMaestroIntegration (IntegrationPlugin)
        └─ MczPoller (periodic polling loop)
             └─ MczBridge (Socket.IO client)

--- a/specs/013-V0.10c-mcz-maestro/spec.md
+++ b/specs/013-V0.10c-mcz-maestro/spec.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add a native TypeScript integration for MCZ pellet stoves equipped with the Maestro controller. Communication happens via the MCZ cloud (Socket.IO to `app.mcz.it:9000`), authenticated with the stove's serial number and MAC address. The integration polls stove data periodically and exposes it as a Winch Device with thermostat-type Equipment bindings.
+Add a native TypeScript integration for MCZ pellet stoves equipped with the Maestro controller. Communication happens via the MCZ cloud (Socket.IO to `app.mcz.it:9000`), authenticated with the stove's serial number and MAC address. The integration polls stove data periodically and exposes it as a Sowel Device with thermostat-type Equipment bindings.
 
 ## Reference
 
@@ -43,7 +43,7 @@ Add a native TypeScript integration for MCZ pellet stoves equipped with the Maes
 
 - [ ] MCZ integration appears in Administration > Integrations
 - [ ] Configuring serial + MAC and starting connects to MCZ cloud via Socket.IO
-- [ ] Stove appears as a Device in Winch with all 8 data points
+- [ ] Stove appears as a Device in Sowel with all 8 data points
 - [ ] Data is polled every N seconds (configurable, default 30s)
 - [ ] Creating an Equipment of type "thermostat" and binding to MCZ device works
 - [ ] Orders (targetTemperature, profile, ecoMode, resetAlarm) execute correctly

--- a/specs/014-V0.10d-netatmo-home-control/spec.md
+++ b/specs/014-V0.10d-netatmo-home-control/spec.md
@@ -2,19 +2,19 @@
 
 ## Summary
 
-Integration plugin for Legrand Home+Control devices via the Netatmo Connect cloud API. Exposes teleruptors, contactors, and energy meters as Winch devices with polling-based state updates and order execution via REST API.
+Integration plugin for Legrand Home+Control devices via the Netatmo Connect cloud API. Exposes teleruptors, contactors, and energy meters as Sowel devices with polling-based state updates and order execution via REST API.
 
 ## Reference
 
 - Netatmo Connect API: https://dev.netatmo.com/apidocumentation/control
-- Winch spec: Integration Plugin Architecture (V0.10a)
+- Sowel spec: Integration Plugin Architecture (V0.10a)
 - Existing plugins: Panasonic CC (V0.10b), MCZ Maestro (V0.10c)
 
 ## Acceptance Criteria
 
 - [ ] Plugin appears in Administration > Integrations with status "not_configured"
 - [ ] After entering client_id, client_secret, refresh_token → status becomes "connected"
-- [ ] All Legrand modules appear as Devices in Winch (teleruptors, contactors, energy meters)
+- [ ] All Legrand modules appear as Devices in Sowel (teleruptors, contactors, energy meters)
 - [ ] Teleruptor/contactor state (on/off) is polled and visible as DeviceData
 - [ ] Energy meter readings (power W, energy Wh) are polled and visible as DeviceData
 - [ ] Executing an order on a teleruptor/contactor sends `setstate` to Netatmo API
@@ -40,7 +40,7 @@ Integration plugin for Legrand Home+Control devices via the Netatmo Connect clou
 ### Out of Scope
 
 - Full OAuth2 browser redirect flow (user provides refresh_token manually from dev portal)
-- Netatmo topology mapping to Winch zones (user creates their own)
+- Netatmo topology mapping to Sowel zones (user creates their own)
 - Netatmo webhooks (not available for Home+Control)
 - Netatmo weather station / camera / thermostat devices (different scopes)
 - UI components specific to Netatmo devices

--- a/specs/015-V0.11-logging-system/architecture.md
+++ b/specs/015-V0.11-logging-system/architecture.md
@@ -8,7 +8,7 @@ Single pino root logger → 3 simultaneous outputs via `pino.multistream()`:
 pino root logger (formatters, redaction, ISO timestamps)
         |
         +-- stdout (pino-pretty in dev, JSON in prod)
-        +-- pino-roll file transport (data/logs/winch.log, daily rotation)
+        +-- pino-roll file transport (data/logs/sowel.log, daily rotation)
         +-- Writable stream → LogRingBuffer (in-memory, 2000 entries)
                                     |
                                     +-- WebSocket "logs" topic (live tail)

--- a/specs/015-V0.11-logging-system/plan.md
+++ b/specs/015-V0.11-logging-system/plan.md
@@ -71,7 +71,7 @@
 
 1. Start engine with `npm run dev`
 2. Verify pino-pretty logs appear in console with module context
-3. Check `data/logs/` directory is created and `winch.log` exists (production mode)
+3. Check `data/logs/` directory is created and `sowel.log` exists (production mode)
 4. Call `GET /api/v1/logs` — verify entries returned
 5. Call `GET /api/v1/logs?level=warn` — verify filtering works
 6. Call `GET /api/v1/logs?module=mqtt` — verify module filter works

--- a/specs/015-V0.11-logging-system/spec.md
+++ b/specs/015-V0.11-logging-system/spec.md
@@ -22,7 +22,7 @@ The system builds on the existing Pino logger with minimal changes to current lo
 
 - [ ] Pino logger outputs to 3 destinations simultaneously: stdout, file (pino-roll), in-memory ring buffer
 - [ ] File transport rotates daily + at 10 MB, keeps 14 days of history
-- [ ] Log files written to `data/logs/winch.log` with auto-created directory
+- [ ] Log files written to `data/logs/sowel.log` with auto-created directory
 - [ ] Ring buffer holds last 2000 entries in memory (configurable)
 - [ ] Ring buffer captures at `debug` level; file transport at `info` level
 - [ ] Sensitive fields (password, token, secret, apiKey) are redacted with `[REDACTED]`

--- a/specs/018-recipes-roadmap/spec.md
+++ b/specs/018-recipes-roadmap/spec.md
@@ -1,6 +1,6 @@
 # Recipes Roadmap
 
-Specification of future recipes to implement for Winch.
+Specification of future recipes to implement for Sowel.
 
 ## Design Principles
 

--- a/specs/022-dark-mode/architecture.md
+++ b/specs/022-dark-mode/architecture.md
@@ -15,7 +15,7 @@ Tailwind `class` strategy: adding `class="dark"` on `<html>` triggers `.dark {}`
 
 ## Theme Initialization
 
-- `ui/src/main.tsx`: read `localStorage("winch_theme")` before React render, apply `dark` class immediately to prevent flash
+- `ui/src/main.tsx`: read `localStorage("sowel_theme")` before React render, apply `dark` class immediately to prevent flash
 - System detection: `window.matchMedia("(prefers-color-scheme: dark)")` listener
 
 ## UI Changes

--- a/specs/022-dark-mode/spec.md
+++ b/specs/022-dark-mode/spec.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add dark mode support to Winch UI using a deep navy slate palette. Theme is toggled from Settings > Preferences (alongside language), persisted in user preferences, and applied via Tailwind's `class` strategy on `<html>`.
+Add dark mode support to Sowel UI using a deep navy slate palette. Theme is toggled from Settings > Preferences (alongside language), persisted in user preferences, and applied via Tailwind's `class` strategy on `<html>`.
 
 ## Reference
 

--- a/specs/025-V0.13-history/architecture.md
+++ b/specs/025-V0.13-history/architecture.md
@@ -3,7 +3,7 @@
 ## Design Principles
 
 1. **Zero performance impact** — The history writer is a passive observer. It subscribes to events, buffers, and writes asynchronously. It never blocks the event loop or slows down the reactive pipeline.
-2. **Optional dependency** — Winch boots and operates fully without InfluxDB. History features are hidden when not configured.
+2. **Optional dependency** — Sowel boots and operates fully without InfluxDB. History features are hidden when not configured.
 3. **Per-binding granularity** — Users opt-in per equipment data binding. No unnecessary storage.
 4. **Iterative UI** — Charts appear progressively: first inline in equipment detail, then sparklines everywhere, then a full analyse page.
 
@@ -29,7 +29,7 @@
 | hourly | 90 days  | 1 hour      | InfluxDB task  |
 | daily  | 5 years  | 1 day       | InfluxDB task  |
 
-Downsampling tasks compute `mean`, `min`, `max`, `count` per window and write to dedicated buckets (`winch-hourly`, `winch-daily`).
+Downsampling tasks compute `mean`, `min`, `max`, `count` per window and write to dedicated buckets (`sowel-hourly`, `sowel-daily`).
 
 ## SQLite Changes
 
@@ -94,8 +94,8 @@ InfluxDB connection stored in `settings` table with prefix `history.`:
 | --------------------- | --------------------- |
 | history.influx.url    | http://localhost:8086 |
 | history.influx.token  | my-super-secret-token |
-| history.influx.org    | winch                 |
-| history.influx.bucket | winch                 |
+| history.influx.org    | sowel                 |
+| history.influx.bucket | sowel                 |
 | history.enabled       | true                  |
 
 ## Backend Architecture
@@ -341,7 +341,7 @@ Add InfluxDB service:
 services:
   influxdb:
     image: influxdb:2.7
-    container_name: winch-influxdb
+    container_name: sowel-influxdb
     restart: unless-stopped
     ports:
       - "8086:8086"
@@ -349,11 +349,11 @@ services:
       - influxdb-data:/var/lib/influxdb2
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup
-      - DOCKER_INFLUXDB_INIT_USERNAME=winch
-      - DOCKER_INFLUXDB_INIT_PASSWORD=winch-secret
-      - DOCKER_INFLUXDB_INIT_ORG=winch
-      - DOCKER_INFLUXDB_INIT_BUCKET=winch
-      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=winch-dev-token
+      - DOCKER_INFLUXDB_INIT_USERNAME=sowel
+      - DOCKER_INFLUXDB_INIT_PASSWORD=sowel-secret
+      - DOCKER_INFLUXDB_INIT_ORG=sowel
+      - DOCKER_INFLUXDB_INIT_BUCKET=sowel
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=sowel-dev-token
 
 volumes:
   influxdb-data:

--- a/specs/025-V0.13-history/plan.md
+++ b/specs/025-V0.13-history/plan.md
@@ -26,7 +26,7 @@ Each iteration is independently deployable and delivers visible value to the use
 **Deployment / InfluxDB Setup**:
 
 - [ ] Update `docker-compose.yml` with InfluxDB 2.7 service (auto-init: org, bucket, admin token)
-- [ ] Auto-setup on first connect: InfluxClient verifies/creates required buckets (winch, winch-hourly, winch-daily) with correct retention policies
+- [ ] Auto-setup on first connect: InfluxClient verifies/creates required buckets (sowel, sowel-hourly, sowel-daily) with correct retention policies
 - [ ] Test connection endpoint validates: ping OK + bucket exists + write permission
 - [ ] Graceful startup: if InfluxDB is in docker-compose but slow to start, HistoryWriter retries connection silently (no crash)
 - [ ] Add `history.enabled` setting — master switch (default: false until configured)
@@ -142,8 +142,8 @@ Each iteration is independently deployable and delivers visible value to the use
 **Backend**:
 
 - [x] Create InfluxDB downsampling tasks on first connection (or via setup endpoint):
-  - Task `downsample-hourly`: aggregate raw → `winch-hourly` bucket (mean, min, max per 1h)
-  - Task `downsample-daily`: aggregate hourly → `winch-daily` bucket (mean, min, max per 1d)
+  - Task `downsample-hourly`: aggregate raw → `sowel-hourly` bucket (mean, min, max per 1h)
+  - Task `downsample-daily`: aggregate hourly → `sowel-daily` bucket (mean, min, max per 1d)
 - [x] Bucket retention: raw=7d, hourly=90d, daily=5y (configurable in settings)
 - [x] `GET /api/v1/history/retention` returns bucket retention + task status
 - [x] HistoryQuery auto-selects bucket based on time range (with fallback to raw)
@@ -174,7 +174,7 @@ Each iteration is independently deployable and delivers visible value to the use
 
 ## Dependencies
 
-- Winch V0.12 (Computed Data) is NOT a prerequisite — history can be built independently
+- Sowel V0.12 (Computed Data) is NOT a prerequisite — history can be built independently
 - InfluxDB 2.7+ (Docker image: `influxdb:2.7`)
 - npm: `@influxdata/influxdb-client` (backend)
 - npm: `recharts` (frontend)
@@ -191,12 +191,12 @@ Each iteration is independently deployable and delivers visible value to the use
 
 ## Manual Testing Checklist
 
-- [ ] Start Winch without InfluxDB → no errors, history features hidden
+- [ ] Start Sowel without InfluxDB → no errors, history features hidden
 - [ ] Configure InfluxDB in Settings → test connection succeeds
 - [ ] Enable historize on a temperature binding → data appears in InfluxDB
 - [ ] Open equipment detail → chart shows last 24h of temperature
 - [ ] Switch to 7d range → hourly aggregation loads
 - [ ] Home page sparklines show trends
 - [ ] Analyse page: overlay temperature from 2 zones
-- [ ] Kill InfluxDB → Winch continues running, warning in logs
+- [ ] Kill InfluxDB → Sowel continues running, warning in logs
 - [ ] Restart InfluxDB → writes resume automatically

--- a/specs/025-V0.13-history/spec.md
+++ b/specs/025-V0.13-history/spec.md
@@ -2,15 +2,15 @@
 
 ## Summary
 
-Add time-series data historization to Winch using InfluxDB 2.x as an **optional** backend. Users configure which equipment data bindings to historize. Mini-charts appear inline in equipment/zone views, and a dedicated "Analyse" page enables deep exploration. The system has zero impact on Winch core performance — writes are async, batched, and fire-and-forget.
+Add time-series data historization to Sowel using InfluxDB 2.x as an **optional** backend. Users configure which equipment data bindings to historize. Mini-charts appear inline in equipment/zone views, and a dedicated "Analyse" page enables deep exploration. The system has zero impact on Sowel core performance — writes are async, batched, and fire-and-forget.
 
 ## Reference
 
-- Spec sections: winch-spec.md §9 (InfluxDB Schema), §7.6 (History API), §10 (influx.ts), §12 (env vars)
+- Spec sections: sowel-spec.md §9 (InfluxDB Schema), §7.6 (History API), §10 (influx.ts), §12 (env vars)
 
 ## Acceptance Criteria
 
-- [ ] Winch starts and runs normally without InfluxDB configured
+- [ ] Sowel starts and runs normally without InfluxDB configured
 - [ ] Admin can configure InfluxDB connection in Settings (URL, token, org, bucket) with a "Test" button
 - [ ] Admin can toggle historization per equipment data binding (checkbox in equipment detail)
 - [ ] Historized data points are written to InfluxDB asynchronously with batch buffering
@@ -19,7 +19,7 @@ Add time-series data historization to Winch using InfluxDB 2.x as an **optional*
 - [ ] Zone/home cards show mini sparkline charts for key metrics (temperature, humidity, etc.)
 - [ ] Dedicated "Analyse" page allows multi-metric overlay with time range selector
 - [x] InfluxDB downsampling tasks auto-created (raw→hourly→daily)
-- [ ] If InfluxDB goes down, Winch continues operating — data points are silently dropped with warning logs
+- [ ] If InfluxDB goes down, Sowel continues operating — data points are silently dropped with warning logs
 
 ## Scope
 

--- a/specs/026-V0.8-cocoon-thermostat/spec.md
+++ b/specs/026-V0.8-cocoon-thermostat/spec.md
@@ -6,7 +6,7 @@ Add a "cocoon" temperature level to the presence-thermostat recipe, triggered by
 
 ## Reference
 
-- Recipe system: §12 of winch-spec.md
+- Recipe system: §12 of sowel-spec.md
 - Presence-thermostat recipe: `src/recipes/presence-thermostat.ts`
 - Button action pattern: `src/recipes/switch-light.ts`
 

--- a/specs/027-V0.8-presence-heater/spec.md
+++ b/specs/027-V0.8-presence-heater/spec.md
@@ -6,7 +6,7 @@ Add a `"heater"` equipment type for electric radiators controlled via Zigbee rel
 
 ## Reference
 
-- Recipe system: §12 of winch-spec.md
+- Recipe system: §12 of sowel-spec.md
 - Motion-light base recipe: `src/recipes/engine/motion-light-base.ts`
 - Presence-thermostat recipe: `src/recipes/presence-thermostat.ts` (night window pattern)
 

--- a/specs/028-mqtt-publishers/architecture.md
+++ b/specs/028-mqtt-publishers/architecture.md
@@ -31,7 +31,7 @@ mqtt_publisher_mappings (id TEXT PK, publisher_id TEXT FK, publish_key TEXT, sou
 
 ## MQTT Topics
 
-- Publishes to user-configured topics (e.g., `winch/homedisplay/livingroom`)
+- Publishes to user-configured topics (e.g., `sowel/homedisplay/livingroom`)
 - Payload: `{"publishKey": value}` with retain=true
 
 ## API Changes

--- a/specs/028-mqtt-publishers/plan.md
+++ b/specs/028-mqtt-publishers/plan.md
@@ -22,8 +22,8 @@
 
 ## Testing
 
-- Create publisher via UI with topic `winch/homedisplay/livingroom`
+- Create publisher via UI with topic `sowel/homedisplay/livingroom`
 - Add mappings to existing equipments/zones
-- `mosquitto_sub -t "winch/homedisplay/#" -v` to verify published messages
+- `mosquitto_sub -t "sowel/homedisplay/#" -v` to verify published messages
 - Change equipment state → verify immediate MQTT publication
 - Verify retain=true (reconnect subscriber → receives last values)

--- a/specs/028-mqtt-publishers/spec.md
+++ b/specs/028-mqtt-publishers/spec.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Generic MQTT key/value publisher that listens to Winch state changes (equipment data, zone aggregations) and publishes them to configurable MQTT topics. Each publisher has a topic and a list of mappings that bind a Winch data source to a publish key. Messages are published with retain=true.
+Generic MQTT key/value publisher that listens to Sowel state changes (equipment data, zone aggregations) and publishes them to configurable MQTT topics. Each publisher has a topic and a list of mappings that bind a Sowel data source to a publish key. Messages are published with retain=true.
 
 ## Reference
 
@@ -18,7 +18,7 @@ Generic MQTT key/value publisher that listens to Winch state changes (equipment 
 - [ ] On equipment.data.changed or zone.data.changed, matching mappings publish `{"key": value}` to the publisher's topic
 - [ ] Messages are published with retain=true
 - [ ] MQTT broker settings are configurable (fallback to Zigbee2MQTT broker)
-- [ ] Publisher uses its own MQTT connection (client ID: winch-publisher)
+- [ ] Publisher uses its own MQTT connection (client ID: sowel-publisher)
 - [ ] TypeScript compiles with zero errors (backend + frontend)
 
 ## Scope

--- a/src/api/routes/backup.ts
+++ b/src/api/routes/backup.ts
@@ -63,7 +63,7 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupDeps): vo
     return reply
       .header(
         "Content-Disposition",
-        `attachment; filename="winch-backup-${new Date().toISOString().slice(0, 10)}.json"`,
+        `attachment; filename="sowel-backup-${new Date().toISOString().slice(0, 10)}.json"`,
       )
       .send(payload);
   });

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -171,7 +171,7 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
 
     if (token) {
       try {
-        if (token.startsWith("wch_") || token.startsWith("cbl_")) {
+        if (token.startsWith("swl_") || token.startsWith("wch_") || token.startsWith("cbl_")) {
           const result = authService.verifyApiToken(token);
           if (!result) {
             socket.close(4001, "Invalid token");
@@ -236,7 +236,7 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
     socket.send(
       JSON.stringify({
         type: "connected",
-        message: "Connected to Winch engine",
+        message: "Connected to Sowel engine",
         version: "0.1.0",
       }),
     );

--- a/src/auth/auth-middleware.ts
+++ b/src/auth/auth-middleware.ts
@@ -68,8 +68,8 @@ export function registerAuthMiddleware(
     try {
       let payload: JwtPayload;
 
-      if (token.startsWith("wch_") || token.startsWith("cbl_")) {
-        // API token (wch_ = new prefix, cbl_ = legacy)
+      if (token.startsWith("swl_") || token.startsWith("wch_") || token.startsWith("cbl_")) {
+        // API token (swl_ = current, wch_ and cbl_ = legacy)
         const result = authService.verifyApiToken(token);
         if (!result) {
           return reply.code(401).send({ error: "Invalid API token" });

--- a/src/auth/auth-service.ts
+++ b/src/auth/auth-service.ts
@@ -167,7 +167,7 @@ export class AuthService {
     expiresAt: string | null,
   ): { token: string; id: string } {
     const id = randomUUID();
-    const rawToken = `wch_${randomBytes(32).toString("hex")}`;
+    const rawToken = `swl_${randomBytes(32).toString("hex")}`;
     const tokenHash = sha256(rawToken);
 
     this.stmts.insertApiToken.run({

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ function resolveJwtSecret(dataDir: string): string {
 }
 
 export function loadConfig(): AppConfig {
-  const sqlitePath = env("SQLITE_PATH", "./data/winch.db");
+  const sqlitePath = env("SQLITE_PATH", "./data/sowel.db");
   const dataDir = dirname(resolve(sqlitePath));
 
   return {

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -83,7 +83,7 @@ export function createLogger(level: string, logBuffer?: LogRingBuffer): LoggerHa
     const fileTransport = pino.transport({
       target: "pino-roll",
       options: {
-        file: "data/logs/winch",
+        file: "data/logs/sowel",
         frequency: "daily",
         limit: { count: 14 },
         mkdir: true,

--- a/src/core/settings-manager.ts
+++ b/src/core/settings-manager.ts
@@ -90,7 +90,7 @@ export class SettingsManager {
       url: this.get(`${prefix}mqtt_url`) ?? "mqtt://localhost:1883",
       username: this.get(`${prefix}mqtt_username`) || undefined,
       password: this.get(`${prefix}mqtt_password`) || undefined,
-      clientId: this.get(`${prefix}mqtt_client_id`) ?? "winch",
+      clientId: this.get(`${prefix}mqtt_client_id`) ?? "sowel",
     };
   }
 

--- a/src/history/history-query.ts
+++ b/src/history/history-query.ts
@@ -37,9 +37,9 @@ function parseFrom(from: string): Date {
 
 /**
  * Resolve the bucket name based on resolution.
- * - raw → base bucket (e.g. "winch")
- * - 1h  → base bucket + "-hourly" (e.g. "winch-hourly")
- * - 1d  → base bucket + "-daily" (e.g. "winch-daily")
+ * - raw → base bucket (e.g. "sowel")
+ * - 1h  → base bucket + "-hourly" (e.g. "sowel-hourly")
+ * - 1d  → base bucket + "-daily" (e.g. "sowel-daily")
  */
 function resolveBucket(baseBucket: string, resolution: Resolution): string {
   if (resolution === "1h") return `${baseBucket}-hourly`;

--- a/src/history/influx-client.ts
+++ b/src/history/influx-client.ts
@@ -219,11 +219,11 @@ export class InfluxClient {
 
       // Hourly downsampling task
       const hourlyFlux = buildDownsampleHourlyFlux(rawBucket, hourlyBucket, org);
-      await this.ensureTask("winch-downsample-hourly", hourlyFlux, orgId);
+      await this.ensureTask("sowel-downsample-hourly", hourlyFlux, orgId);
 
       // Daily downsampling task
       const dailyFlux = buildDownsampleDailyFlux(hourlyBucket, dailyBucket, org);
-      await this.ensureTask("winch-downsample-daily", dailyFlux, orgId);
+      await this.ensureTask("sowel-downsample-daily", dailyFlux, orgId);
 
       this.logger.info("Downsampling tasks configured");
     } catch (err) {
@@ -252,8 +252,8 @@ export class InfluxClient {
       const hourlyBucket = buckets.find((b) => b.name === `${this.config!.bucket}-hourly`);
       const dailyBucket = buckets.find((b) => b.name === `${this.config!.bucket}-daily`);
 
-      const hourlyTask = tasks.find((t) => t.name === "winch-downsample-hourly");
-      const dailyTask = tasks.find((t) => t.name === "winch-downsample-daily");
+      const hourlyTask = tasks.find((t) => t.name === "sowel-downsample-hourly");
+      const dailyTask = tasks.find((t) => t.name === "sowel-downsample-daily");
 
       const result: RetentionStatus = {
         buckets: {
@@ -499,7 +499,7 @@ export class InfluxClient {
 // ============================================================
 
 function buildDownsampleHourlyFlux(rawBucket: string, hourlyBucket: string, org: string): string {
-  return `option task = {name: "winch-downsample-hourly", every: 1h}
+  return `option task = {name: "sowel-downsample-hourly", every: 1h}
 
 data = from(bucket: "${rawBucket}")
   |> range(start: -task.every)
@@ -523,7 +523,7 @@ union(tables: [mean_data, min_data, max_data])
 }
 
 function buildDownsampleDailyFlux(hourlyBucket: string, dailyBucket: string, org: string): string {
-  return `option task = {name: "winch-downsample-daily", every: 1d}
+  return `option task = {name: "sowel-downsample-daily", every: 1d}
 
 data = from(bucket: "${hourlyBucket}")
   |> range(start: -task.every)

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ async function main() {
   const logBuffer = new LogRingBuffer();
   const logHandle = createLogger(config.log.level, logBuffer);
   const logger = logHandle.logger;
-  logger.info("Winch — Founded by Marc Chachereau — AGPL-3.0");
+  logger.info("Sowel — Founded by Marc Chachereau — AGPL-3.0");
 
   // 3. Open SQLite database and run migrations
   const db = openDatabase(config.sqlite.path, logger);
@@ -205,7 +205,7 @@ async function main() {
   await server.listen({ port: config.api.port, host: config.api.host });
   logger.info(
     { port: config.api.port, host: config.api.host },
-    `Winch API listening on http://${config.api.host}:${config.api.port}`,
+    `Sowel API listening on http://${config.api.host}:${config.api.port}`,
   );
 
   // 16. Start Sunlight Manager (before system.started so aggregation has sunlight data)
@@ -232,7 +232,7 @@ async function main() {
     logger.info("No users found — setup required. Navigate to the UI to create the first admin.");
   }
 
-  logger.info("Winch engine started successfully");
+  logger.info("Sowel engine started successfully");
 
   // Graceful shutdown — each step is isolated so one failure doesn't block the rest
   const shutdown = async () => {

--- a/src/integrations/lora2mqtt/index.ts
+++ b/src/integrations/lora2mqtt/index.ts
@@ -70,7 +70,7 @@ export class Lora2MqttIntegration implements IntegrationPlugin {
         label: "MQTT Client ID",
         type: "text",
         required: false,
-        defaultValue: "winch-lora",
+        defaultValue: "sowel-lora",
       },
       {
         key: "base_topic",
@@ -91,7 +91,7 @@ export class Lora2MqttIntegration implements IntegrationPlugin {
     const mqttUrl = this.getSetting("mqtt_url")!;
     const mqttUsername = this.getSetting("mqtt_username") || undefined;
     const mqttPassword = this.getSetting("mqtt_password") || undefined;
-    const mqttClientId = this.getSetting("mqtt_client_id") ?? "winch-lora";
+    const mqttClientId = this.getSetting("mqtt_client_id") ?? "sowel-lora";
     const baseTopic = this.getSetting("base_topic") ?? "lora2mqtt";
 
     try {

--- a/src/integrations/mcz-maestro/mcz-poller.ts
+++ b/src/integrations/mcz-maestro/mcz-poller.ts
@@ -155,7 +155,7 @@ export class MczPoller {
 }
 
 /**
- * Map an MCZ status frame to a Winch DiscoveredDevice for upsert.
+ * Map an MCZ status frame to a Sowel DiscoveredDevice for upsert.
  */
 function mapFrameToDiscovered(_serial: string, _frame: MczStatusFrame): DiscoveredDevice {
   const stoveStates = [

--- a/src/integrations/netatmo-hc/index.ts
+++ b/src/integrations/netatmo-hc/index.ts
@@ -16,7 +16,7 @@ const BOOLEAN_PARAMS = new Set(["on"]);
 /** Numeric params expected by Netatmo setstate API. */
 const NUMERIC_PARAMS = new Set(["brightness", "target_position"]);
 
-/** Coerce Winch order value to the type Netatmo API expects. */
+/** Coerce Sowel order value to the type Netatmo API expects. */
 function coerceValue(param: string, value: unknown): unknown {
   if (BOOLEAN_PARAMS.has(param)) {
     if (typeof value === "boolean") return value;

--- a/src/integrations/panasonic-cc/panasonic-poller.ts
+++ b/src/integrations/panasonic-cc/panasonic-poller.ts
@@ -149,7 +149,7 @@ export class PanasonicPoller {
 }
 
 /**
- * Map a bridge device to a Winch DiscoveredDevice for upsert.
+ * Map a bridge device to a Sowel DiscoveredDevice for upsert.
  */
 function mapBridgeDeviceToDiscovered(bridgeDevice: BridgeDevice): DiscoveredDevice {
   const features = bridgeDevice.features;

--- a/src/integrations/zigbee2mqtt/index.ts
+++ b/src/integrations/zigbee2mqtt/index.ts
@@ -70,7 +70,7 @@ export class Zigbee2MqttIntegration implements IntegrationPlugin {
         label: "MQTT Client ID",
         type: "text",
         required: false,
-        defaultValue: "winch",
+        defaultValue: "sowel",
       },
       {
         key: "base_topic",
@@ -91,7 +91,7 @@ export class Zigbee2MqttIntegration implements IntegrationPlugin {
     const mqttUrl = this.getSetting("mqtt_url")!;
     const mqttUsername = this.getSetting("mqtt_username") || undefined;
     const mqttPassword = this.getSetting("mqtt_password") || undefined;
-    const mqttClientId = this.getSetting("mqtt_client_id") ?? "winch";
+    const mqttClientId = this.getSetting("mqtt_client_id") ?? "sowel";
     const baseTopic = this.getSetting("base_topic") ?? "zigbee2mqtt";
 
     try {

--- a/src/mqtt-publishers/mqtt-publish-service.ts
+++ b/src/mqtt-publishers/mqtt-publish-service.ts
@@ -113,7 +113,7 @@ export class MqttPublishService {
     }
 
     this.client = mqtt.connect(brokerUrl, {
-      clientId: "winch-publisher",
+      clientId: "sowel-publisher",
       username,
       password,
       clean: true,

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>Winch</title>
+    <title>Sowel</title>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/public/favicon.svg
+++ b/ui/public/favicon.svg
@@ -1,9 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="0.5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
   <rect width="32" height="32" rx="7" fill="#1A4F6E"/>
-  <!-- Winch drum — centered in square -->
-  <circle cx="16" cy="16" r="6.5" stroke="white" stroke-width="2" fill="none"/>
-  <circle cx="16" cy="16" r="2" fill="white"/>
-  <!-- Handle/crank -->
-  <line x1="16" y1="16" x2="23.5" y2="10.5" stroke="white" stroke-width="2" stroke-linecap="round"/>
-  <circle cx="23.5" cy="10.5" r="2" fill="white"/>
+  <!-- Concentric circles with glow diffusion -->
+  <circle cx="16" cy="16" r="2.85" fill="white" stroke="white" stroke-width="0.3"/>
+  <circle cx="16" cy="16" r="7" stroke="white" stroke-width="1.5" opacity="0.8" fill="none" filter="url(#glow)"/>
+  <circle cx="16" cy="16" r="11.5" stroke="white" stroke-width="1.2" opacity="0.45" fill="none"/>
 </svg>

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -11,7 +11,7 @@ import { useEquipments } from "../../store/useEquipments";
 import { useZoneAggregation } from "../../store/useZoneAggregation";
 import { useAuth } from "../../store/useAuth";
 import { LogOut, User } from "lucide-react";
-import { WinchLogo } from "./WinchLogo";
+import { SowelLogo } from "./SowelLogo";
 import { ROOT_ZONE_ID } from "../../lib/constants";
 
 export function AppLayout() {
@@ -49,7 +49,7 @@ export function AppLayout() {
           <div className="flex items-center gap-4">
             {/* Mobile logo */}
             <div className="flex md:hidden items-center gap-2">
-              <WinchLogo size={28} />
+              <SowelLogo size={28} />
               <span className="font-semibold text-[15px] text-text">{t("app.name")}</span>
             </div>
             {/* Sunlight banner — visible on desktop */}

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from "react-i18next";
 import { SidebarZoneTree } from "./SidebarZoneTree";
 import { SidebarModeList } from "./SidebarModeList";
 import { SidebarChartList } from "./SidebarChartList";
-import { WinchLogo } from "./WinchLogo";
+import { SowelLogo } from "./SowelLogo";
 import { useAuth } from "../../store/useAuth";
 
 interface NavItem {
@@ -58,7 +58,7 @@ export function Sidebar() {
       {/* Logo area */}
       <div className="flex items-center h-[60px] px-4 border-b border-border-light">
         <div className="flex items-center gap-3 min-w-0">
-          <WinchLogo size={32} className="flex-shrink-0" />
+          <SowelLogo size={32} className="flex-shrink-0" />
           {!collapsed && (
             <span className="font-semibold text-[16px] tracking-[-0.01em] text-text truncate">
               {t("app.name")}

--- a/ui/src/components/layout/SowelLogo.tsx
+++ b/ui/src/components/layout/SowelLogo.tsx
@@ -13,13 +13,20 @@ export function SowelLogo({ size = 32, className = "" }: SowelLogoProps) {
       fill="none"
       className={className}
     >
+      <defs>
+        <filter id="glow">
+          <feGaussianBlur stdDeviation="0.5" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
       <rect width="32" height="32" rx="7" className="fill-primary" />
-      {/* Sowel drum — centered in square */}
-      <circle cx="16" cy="16" r="6.5" stroke="white" strokeWidth="2" fill="none" />
-      <circle cx="16" cy="16" r="2" fill="white" />
-      {/* Handle/crank */}
-      <line x1="16" y1="16" x2="23.5" y2="10.5" stroke="white" strokeWidth="2" strokeLinecap="round" />
-      <circle cx="23.5" cy="10.5" r="2" fill="white" />
+      {/* Concentric circles with glow diffusion */}
+      <circle cx="16" cy="16" r="2.85" fill="white" stroke="white" strokeWidth="0.3" />
+      <circle cx="16" cy="16" r="7" stroke="white" strokeWidth="1.5" opacity="0.8" fill="none" filter="url(#glow)" />
+      <circle cx="16" cy="16" r="11.5" stroke="white" strokeWidth="1.2" opacity="0.45" fill="none" />
     </svg>
   );
 }

--- a/ui/src/components/layout/SowelLogo.tsx
+++ b/ui/src/components/layout/SowelLogo.tsx
@@ -1,9 +1,9 @@
-interface WinchLogoProps {
+interface SowelLogoProps {
   size?: number;
   className?: string;
 }
 
-export function WinchLogo({ size = 32, className = "" }: WinchLogoProps) {
+export function SowelLogo({ size = 32, className = "" }: SowelLogoProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -14,7 +14,7 @@ export function WinchLogo({ size = 32, className = "" }: WinchLogoProps) {
       className={className}
     >
       <rect width="32" height="32" rx="7" className="fill-primary" />
-      {/* Winch drum — centered in square */}
+      {/* Sowel drum — centered in square */}
       <circle cx="16" cy="16" r="6.5" stroke="white" strokeWidth="2" fill="none" />
       <circle cx="16" cy="16" r="2" fill="white" />
       {/* Handle/crank */}

--- a/ui/src/i18n/index.ts
+++ b/ui/src/i18n/index.ts
@@ -18,7 +18,7 @@ i18n
     },
     detection: {
       order: ["localStorage", "navigator"],
-      lookupLocalStorage: "winch_language",
+      lookupLocalStorage: "sowel_language",
     },
   });
 

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1,5 +1,5 @@
 {
-  "app.name": "Winch",
+  "app.name": "Sowel",
 
   "nav.home": "Home",
   "nav.devices": "Devices",
@@ -105,7 +105,7 @@
   "devices.col.updated": "Updated",
   "devices.col.range": "Range / Values",
   "devices.col.topic": "Topic",
-  "devices.deleteConfirm": "Delete this device from Winch? It will be re-discovered automatically if still active on the bridge.",
+  "devices.deleteConfirm": "Delete this device from Sowel? It will be re-discovered automatically if still active on the bridge.",
 
   "zones.title": "Home Topology",
   "zones.subtitle": "Define the topology of your home",
@@ -426,7 +426,7 @@
   "settings.sunsetOffsetHelp": "Minutes before sunset to anticipate night",
 
   "backup.title": "Backup / Restore",
-  "backup.description": "Export or import the full Winch configuration (zones, devices, equipments, users, recipes, integrations).",
+  "backup.description": "Export or import the full Sowel configuration (zones, devices, equipments, users, recipes, integrations).",
   "backup.export": "Export",
   "backup.import": "Import",
   "backup.exported": "Backup exported successfully",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1,5 +1,5 @@
 {
-  "app.name": "Winch",
+  "app.name": "Sowel",
 
   "nav.home": "Maison",
   "nav.devices": "Appareils",
@@ -105,7 +105,7 @@
   "devices.col.updated": "Mis à jour",
   "devices.col.range": "Plage / Valeurs",
   "devices.col.topic": "Topic",
-  "devices.deleteConfirm": "Supprimer cet appareil de Winch ? Il sera redécouvert automatiquement s'il est toujours actif sur le bridge.",
+  "devices.deleteConfirm": "Supprimer cet appareil de Sowel ? Il sera redécouvert automatiquement s'il est toujours actif sur le bridge.",
 
   "zones.title": "Topologie",
   "zones.subtitle": "Définissez la topologie de votre maison",
@@ -426,7 +426,7 @@
   "settings.sunsetOffsetHelp": "Minutes avant le coucher pour anticiper la nuit",
 
   "backup.title": "Sauvegarde / Restauration",
-  "backup.description": "Exportez ou importez la configuration complète de Winch (zones, appareils, équipements, utilisateurs, recettes, intégrations).",
+  "backup.description": "Exportez ou importez la configuration complète de Sowel (zones, appareils, équipements, utilisateurs, recettes, intégrations).",
   "backup.export": "Exporter",
   "backup.import": "Importer",
   "backup.exported": "Sauvegarde exportée avec succès",

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -6,10 +6,10 @@ import App from "./App";
 import { useAuth } from "./store/useAuth";
 import { applyTheme } from "./theme";
 
-console.log("Winch — Founded by Marc Chachereau — AGPL-3.0");
+console.log("Sowel — Founded by Marc Chachereau — AGPL-3.0");
 
 // Apply theme immediately to prevent flash of wrong theme
-applyTheme(localStorage.getItem("winch_theme") as "light" | "dark" | "system" | null);
+applyTheme(localStorage.getItem("sowel_theme") as "light" | "dark" | "system" | null);
 
 // Trigger auth status check before rendering
 useAuth.getState().checkStatus();

--- a/ui/src/pages/BackupPage.tsx
+++ b/ui/src/pages/BackupPage.tsx
@@ -20,7 +20,7 @@ export function BackupPage() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `winch-backup-${new Date().toISOString().slice(0, 10)}.json`;
+      a.download = `sowel-backup-${new Date().toISOString().slice(0, 10)}.json`;
       a.click();
       URL.revokeObjectURL(url);
       setSuccess(t("backup.exported"));

--- a/ui/src/pages/LoginPage.tsx
+++ b/ui/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { Navigate } from "react-router-dom";
 import { Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../store/useAuth";
+import { SowelLogo } from "../components/layout/SowelLogo";
 
 export function LoginPage() {
   const isAuthenticated = useAuth((s) => s.isAuthenticated);
@@ -34,9 +35,7 @@ export function LoginPage() {
     <div className="flex items-center justify-center min-h-screen bg-background">
       <div className="w-full max-w-sm mx-4">
         <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-12 h-12 rounded-[10px] bg-primary text-white text-lg font-bold mb-3">
-            C
-          </div>
+          <SowelLogo size={48} className="inline-block mb-3" />
           <h1 className="text-xl font-semibold text-text">{t("app.name")}</h1>
         </div>
 

--- a/ui/src/pages/MqttPublishersPage.tsx
+++ b/ui/src/pages/MqttPublishersPage.tsx
@@ -296,7 +296,7 @@ function CreatePublisherForm({
             type="text"
             value={topic}
             onChange={(e) => setTopic(e.target.value)}
-            placeholder="winch/homedisplay/livingroom"
+            placeholder="sowel/homedisplay/livingroom"
             className="w-full px-3 py-1.5 text-[13px] bg-bg border border-border rounded-[6px] text-text placeholder:text-text-tertiary font-mono"
           />
         </div>

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -55,12 +55,12 @@ export function SettingsPage() {
             language={user?.preferences?.language ?? (i18n.language.startsWith("fr") ? "fr" : "en")}
             onLanguageChange={async (lang) => {
               i18n.changeLanguage(lang);
-              localStorage.setItem("winch_language", lang);
+              localStorage.setItem("sowel_language", lang);
               if (user) {
                 await updatePreferences({ ...user.preferences, language: lang });
               }
             }}
-            theme={user?.preferences?.theme ?? (localStorage.getItem("winch_theme") as ThemeSetting | null) ?? "system"}
+            theme={user?.preferences?.theme ?? (localStorage.getItem("sowel_theme") as ThemeSetting | null) ?? "system"}
             onThemeChange={async (theme) => {
               setTheme(theme);
               if (user) {
@@ -938,7 +938,7 @@ function InfluxDbSettingsSection() {
               type="text"
               value={org}
               onChange={(e) => setOrg(e.target.value)}
-              placeholder="winch"
+              placeholder="sowel"
               className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text placeholder:text-text-tertiary focus:outline-none focus:border-primary"
             />
           </div>
@@ -950,7 +950,7 @@ function InfluxDbSettingsSection() {
               type="text"
               value={bucket}
               onChange={(e) => setBucket(e.target.value)}
-              placeholder="winch"
+              placeholder="sowel"
               className="w-full px-3 py-2 text-[14px] bg-background border border-border rounded-[6px] text-text placeholder:text-text-tertiary focus:outline-none focus:border-primary"
             />
           </div>

--- a/ui/src/pages/SetupPage.tsx
+++ b/ui/src/pages/SetupPage.tsx
@@ -3,6 +3,7 @@ import { Navigate } from "react-router-dom";
 import { Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../store/useAuth";
+import { SowelLogo } from "../components/layout/SowelLogo";
 
 export function SetupPage() {
   const isAuthenticated = useAuth((s) => s.isAuthenticated);
@@ -50,9 +51,7 @@ export function SetupPage() {
     <div className="flex items-center justify-center min-h-screen bg-background">
       <div className="w-full max-w-sm mx-4">
         <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-12 h-12 rounded-[10px] bg-primary text-white text-lg font-bold mb-3">
-            C
-          </div>
+          <SowelLogo size={48} className="inline-block mb-3" />
           <h1 className="text-xl font-semibold text-text">{t("app.name")}</h1>
           <p className="text-[13px] text-text-secondary mt-2">
             {t("auth.setupTitle")}

--- a/ui/src/store/useAuth.ts
+++ b/ui/src/store/useAuth.ts
@@ -29,8 +29,8 @@ interface AuthState {
   fetchMe: () => Promise<void>;
 }
 
-const STORAGE_KEY_ACCESS = "winch_access_token";
-const STORAGE_KEY_REFRESH = "winch_refresh_token";
+const STORAGE_KEY_ACCESS = "sowel_access_token";
+const STORAGE_KEY_REFRESH = "sowel_refresh_token";
 
 function saveTokens(accessToken: string, refreshToken: string): void {
   localStorage.setItem(STORAGE_KEY_ACCESS, accessToken);

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -26,7 +26,7 @@ let currentTopics: WsTopic[] = ["system"];
 const MAX_RECONNECT_DELAY = 30_000;
 
 function getWsUrl(): string {
-  const token = localStorage.getItem("winch_access_token");
+  const token = localStorage.getItem("sowel_access_token");
   // In dev mode, connect directly to the backend to avoid Vite proxy EPIPE issues
   const wsHost = import.meta.env.DEV ? `${window.location.hostname}:3000` : window.location.host;
   const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -7,7 +7,7 @@
 
 export type ThemeSetting = "light" | "dark" | "system";
 
-const STORAGE_KEY = "winch_theme";
+const STORAGE_KEY = "sowel_theme";
 
 let mediaQuery: MediaQueryList | null = null;
 let mediaListener: (() => void) | null = null;


### PR DESCRIPTION
## Summary
- Rename entire codebase from Winch to Sowel (So Well)
- New logo: concentric circles with subtle glow diffusion
- Update favicon, login page, setup page with SowelLogo component
- API token prefix: `swl_` (legacy `wch_` and `cbl_` still accepted)
- SQLite default path: `./data/sowel.db`
- InfluxDB task names: `sowel-downsample-hourly/daily`
- localStorage keys, MQTT client IDs, all UI text updated

## Changes
- **73+ files** across backend, frontend, docs, specs, config
- File renames: `winch-spec.md` → `sowel-spec.md`, `WinchLogo.tsx` → `SowelLogo.tsx`
- Skill folder renamed: `.claude/skills/winch-feature` → `sowel-feature`

## Test plan
- [x] TypeScript compiles (zero errors backend + frontend)
- [x] All 454 tests pass
- [x] ESLint + Prettier pass
- [x] Logo renders correctly on login, setup, sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)