### PR TITLE
refactor(logging): complete deferred logging audit items

### DIFF
--- a/specs/030-logging-audit/plan.md
+++ b/specs/030-logging-audit/plan.md
@@ -18,12 +18,12 @@
 11. [x] equipment-manager.ts — add trace log in handleDeviceDataUpdated
 12. [x] mqtt-publish-service.ts — add debug summary per event handler
 13. [x] auth-service.ts — add login success/failure and token refresh logs
-14. [ ] recipe execution (motion-light-base, etc.) — deferred (requires ctx.log refactor)
-15. [ ] history-writer.ts — deferred (requires deadband logic inspection)
+14. [x] recipe execution — ctx.log() now also emits to pino with structured context
+15. [x] history-writer.ts — trace logs for every shouldWrite() decision (deadband, throttle, state)
 16. [x] button-action-manager.ts — add debug for effect execution
 17. [x] backup.ts — add info with row counts on export and restore
 18. [x] Type-check + test
-19. [ ] Commit + PR
+19. [x] Commit + PR
 
 ## Testing
 

--- a/src/history/history-writer.ts
+++ b/src/history/history-writer.ts
@@ -344,40 +344,75 @@ export class HistoryWriter {
     value: unknown,
     previous: unknown,
   ): boolean {
+    const logCtx = { bindingId, category: meta.category, alias: meta.alias, value };
+
     // Force write on boolean/enum state transitions
     if (meta.type === "boolean" || meta.type === "enum") {
-      if (value !== previous) return true;
-      return false; // Same value → skip
+      if (value !== previous) {
+        this.logger.trace({ ...logCtx, previous, reason: "state-transition" }, "History write");
+        return true;
+      }
+      this.logger.trace({ ...logCtx, reason: "same-value" }, "History skip");
+      return false;
     }
 
     const last = this.lastWritten.get(bindingId);
-    if (!last) return true; // First write
+    if (!last) {
+      this.logger.trace({ ...logCtx, reason: "first-write" }, "History write");
+      return true;
+    }
 
     // Minimum interval check
     const elapsed = Date.now() - last.timestamp;
-    if (elapsed < this.minWriteInterval) return false;
+    if (elapsed < this.minWriteInterval) {
+      this.logger.trace({ ...logCtx, elapsedMs: elapsed, reason: "min-interval" }, "History skip");
+      return false;
+    }
 
     // Maximum interval — force write even if value unchanged (keeps charts fresh)
-    if (elapsed > this.maxWriteInterval) return true;
+    if (elapsed > this.maxWriteInterval) {
+      this.logger.trace({ ...logCtx, elapsedMs: elapsed, reason: "max-interval" }, "History write");
+      return true;
+    }
 
     // Deadband check for numeric values
     if (meta.type === "number" && typeof value === "number" && typeof last.value === "number") {
       const deadband = DEADBAND[meta.category];
       if (deadband !== undefined) {
+        const delta = Math.abs(value - (last.value as number));
         // Special case: luminosity uses relative deadband (5%)
         if (meta.category === "luminosity") {
           const threshold = Math.abs(last.value as number) * deadband;
-          if (Math.abs(value - (last.value as number)) < Math.max(threshold, 1)) return false;
+          if (delta < Math.max(threshold, 1)) {
+            this.logger.trace(
+              { ...logCtx, delta, threshold: Math.max(threshold, 1), reason: "deadband-lux" },
+              "History skip",
+            );
+            return false;
+          }
         } else {
-          if (Math.abs(value - (last.value as number)) < deadband) return false;
+          if (delta < deadband) {
+            this.logger.trace({ ...logCtx, delta, deadband, reason: "deadband" }, "History skip");
+            return false;
+          }
         }
       }
       // No deadband configured → write on any change
-      return value !== last.value;
+      if (value !== last.value) {
+        this.logger.trace({ ...logCtx, reason: "value-changed" }, "History write");
+        return true;
+      }
+      this.logger.trace({ ...logCtx, reason: "same-value" }, "History skip");
+      return false;
     }
 
     // Default: write on any change
-    return value !== last.value;
+    if (value !== last.value) {
+      this.logger.trace({ ...logCtx, reason: "value-changed" }, "History write");
+      return true;
+    }
+    this.logger.trace({ ...logCtx, reason: "same-value" }, "History skip");
+    return false;
   }
 }
 

--- a/src/recipes/engine/recipe-manager.ts
+++ b/src/recipes/engine/recipe-manager.ts
@@ -442,6 +442,9 @@ export class RecipeManager {
       state: stateStore,
       log: (message: string, level: "info" | "warn" | "error" = "info") => {
         this.writeLog(instanceId, message, level);
+        const recipeName = this.registry.get(recipeId)?.info.name;
+        const childLogger = this.logger.child({ instanceId, recipeId, recipeName });
+        childLogger[level]({ instanceId, recipeId, recipeName }, message);
       },
       notifyStateChanged: () => {
         this.eventBus.emit({ type: "recipe.instance.state.changed", instanceId, recipeId });


### PR DESCRIPTION
## Summary
- **Recipe execution**: `ctx.log()` now also emits to pino with structured context (`instanceId`, `recipeId`, `recipeName`), making all recipe execution events (motion detected, lights on/off, override mode, failsafe, etc.) visible in the main log stream alongside SQLite `recipe_log`
- **History writer**: trace logs in `shouldWrite()` for every write/skip decision with reason (`deadband`, `deadband-lux`, `min-interval`, `max-interval`, `state-transition`, `first-write`, `same-value`, `value-changed`)

Completes the two deferred items from PR #49.

## Test plan
- [x] TypeScript compiles (zero errors, backend + UI)
- [x] All 454 tests pass
- [x] ESLint + Prettier pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)