### PR TITLE
feat(recipes): add StateWatch recipe

### DIFF
--- a/specs/032-state-watch-recipe/architecture.md
+++ b/specs/032-state-watch-recipe/architecture.md
@@ -1,0 +1,95 @@
+# Architecture: StateWatch Recipe
+
+## Overview
+
+A new Recipe implementation following the existing pattern (extends Recipe base class). No database changes, no new API routes — recipes are already fully managed by RecipeManager.
+
+## File Structure
+
+```
+src/recipes/
+  state-watch.ts          # New: StateWatch recipe implementation
+```
+
+## Recipe Registration
+
+In `src/index.ts`, add:
+
+```typescript
+import { StateWatchRecipe } from "./recipes/state-watch.js";
+recipeManager.register(StateWatchRecipe);
+```
+
+## Slot Definitions
+
+| Slot           | type      | required | constraints                        |
+| -------------- | --------- | -------- | ---------------------------------- |
+| zone           | zone      | yes      | —                                  |
+| equipment      | equipment | yes      | equipmentType: any (no constraint) |
+| dataKey        | text      | yes      | —                                  |
+| watchValue     | text      | yes      | —                                  |
+| delay          | duration  | no       | min: "0s"                          |
+| repeatInterval | duration  | no       | min: "1m"                          |
+| checkTime      | time      | no       | —                                  |
+
+## State Keys (persisted in recipe_state)
+
+| Key              | Type         | Description                                       |
+| ---------------- | ------------ | ------------------------------------------------- |
+| `alarm`          | boolean      | Currently in alarm                                |
+| `alarmSince`     | string (ISO) | When alarm was first raised                       |
+| `alarmCount`     | number       | Total state.changed emissions since alarm started |
+| `currentValue`   | unknown      | Last observed value                               |
+| `watchStartedAt` | string (ISO) | When value entered watched state (for delay calc) |
+
+## Timer Management
+
+Three independent timers managed in memory:
+
+| Timer         | Type       | Lifecycle                                                                         |
+| ------------- | ---------- | --------------------------------------------------------------------------------- |
+| `delayTimer`  | setTimeout | Started when value enters watched state; cleared on value exit or alarm trigger   |
+| `repeatTimer` | setTimeout | Started after delay expires (or immediately if no delay); cleared on value exit   |
+| `checkTimer`  | setTimeout | Scheduled for next occurrence of checkTime; always running while recipe is active |
+
+### checkTime scheduling
+
+```typescript
+function msUntilNextOccurrence(timeStr: string): number {
+  const [h, m] = timeStr.split(":").map(Number);
+  const now = new Date();
+  const target = new Date();
+  target.setHours(h, m, 0, 0);
+  if (target <= now) target.setDate(target.getDate() + 1);
+  return target.getTime() - now.getTime();
+}
+```
+
+## Value Comparison
+
+String coercion for comparison: `String(currentValue) === String(watchValue)`
+
+This handles:
+
+- `"open" === "open"` (string)
+- `true` vs `"true"` (boolean stored as string in params)
+- `1` vs `"1"` (number)
+
+## Event Subscriptions
+
+| Event                    | Handler                                                 |
+| ------------------------ | ------------------------------------------------------- |
+| `equipment.data.changed` | Check if equipmentId and dataKey match → evaluate state |
+
+## i18n
+
+Provide `fr` and `en` translations for recipe name, description, and slot labels.
+
+## File Changes
+
+| File                         | Change                                |
+| ---------------------------- | ------------------------------------- |
+| `src/recipes/state-watch.ts` | New: StateWatch recipe implementation |
+| `src/index.ts`               | Register StateWatchRecipe             |
+
+No migration, no API changes, no UI changes — existing recipe UI handles all recipe types generically.

--- a/specs/032-state-watch-recipe/plan.md
+++ b/specs/032-state-watch-recipe/plan.md
@@ -1,0 +1,14 @@
+# Implementation Plan: StateWatch Recipe
+
+## Tasks
+
+1. [ ] Create `src/recipes/state-watch.ts` with slots, validate, start, stop
+2. [ ] Register in `src/index.ts`
+3. [ ] Type-check + tests
+4. [ ] Manual test: create instance, verify alarm triggers after delay, repeat works, checkTime works
+
+## Testing
+
+- `npx tsc --noEmit` (zero errors)
+- `npm test` (all pass)
+- Manual: create StateWatch instance for a door sensor, verify alarm after delay, verify repeat, verify scheduled check, verify alarm clears on value change

--- a/specs/032-state-watch-recipe/spec.md
+++ b/specs/032-state-watch-recipe/spec.md
@@ -1,0 +1,123 @@
+# Recipe: StateWatch
+
+## Summary
+
+A generic recipe that monitors an equipment data key and raises an alarm when the value matches a watched state. Supports three independent, combinable trigger modes: delayed alarm (after X minutes in state), periodic repeat (every X minutes while in state), and scheduled check (at a fixed time of day).
+
+The recipe exposes its alarm state so that notification publishers (or MQTT publishers) can react to state transitions.
+
+## Acceptance Criteria
+
+- [ ] Recipe registers as "state-watch" with proper slots
+- [ ] Delayed alarm: alarm triggers after `delay` elapses while value === watchValue
+- [ ] Repeat alarm: alarm re-triggers every `repeatInterval` while still in watched state
+- [ ] Scheduled check: alarm triggers at `checkTime` if value === watchValue at that moment
+- [ ] All three modes are optional and combinable
+- [ ] Alarm clears (alarm=false) when value leaves watched state, emitting state.changed
+- [ ] State persists across restarts (timers restored from persisted timestamps)
+- [ ] Recipe logs transitions (alarm raised, alarm cleared, repeat, scheduled check)
+- [ ] Existing UI recipe page works without changes (slots render via existing mechanism)
+
+## Slots
+
+| Slot             | Type      | Required | Default | Description                                             |
+| ---------------- | --------- | -------- | ------- | ------------------------------------------------------- |
+| `zone`           | zone      | yes      | —       | Zone of the equipment                                   |
+| `equipment`      | equipment | yes      | —       | Equipment to monitor                                    |
+| `dataKey`        | text      | yes      | —       | Data binding alias to watch (e.g., "contact", "state")  |
+| `watchValue`     | text      | yes      | —       | Value that triggers surveillance (e.g., "open", "true") |
+| `delay`          | duration  | no       | —       | Time in watched state before first alarm (e.g., "10m")  |
+| `repeatInterval` | duration  | no       | —       | Repeat interval while in alarm (e.g., "1h")             |
+| `checkTime`      | time      | no       | —       | Daily check time (e.g., "23:00")                        |
+
+At least one of `delay`, `repeatInterval`, or `checkTime` must be provided.
+
+## Exposed State
+
+```
+{
+  alarm: boolean,            // true when in alarm state
+  alarmSince: string | null, // ISO timestamp when alarm was first raised
+  alarmCount: number,        // total notifications emitted since alarm started
+  currentValue: unknown      // current value of the watched data key
+}
+```
+
+State changes emit `recipe.instance.state.changed` events, consumable by notification publishers and MQTT publishers.
+
+## Behavior
+
+### Value enters watched state (value === watchValue)
+
+1. Persist `watchStartedAt` = now
+2. If `delay` configured → start delay timer
+3. If `checkTime` configured → daily check timer already running, will evaluate at next occurrence
+
+### Delay timer expires
+
+1. Set alarm=true, alarmSince=now, alarmCount=1
+2. Persist state, emit `notifyStateChanged()`
+3. Log "Alarm raised: {dataKey}={watchValue} for {delay}"
+4. If `repeatInterval` configured → start repeat timer
+
+### Repeat timer fires
+
+1. Increment alarmCount
+2. Persist state, emit `notifyStateChanged()`
+3. Log "Alarm repeat #{alarmCount}: {dataKey}={watchValue}"
+4. Reschedule next repeat
+
+### Scheduled check fires (checkTime)
+
+1. Read current value of equipment data key
+2. If value === watchValue:
+   - If not already in alarm: set alarm=true, alarmSince=now, alarmCount=1
+   - If already in alarm: increment alarmCount
+   - Persist state, emit `notifyStateChanged()`
+   - Log "Scheduled check: {dataKey}={watchValue} at {checkTime}"
+3. If value !== watchValue: no action (alarm state unchanged)
+4. Reschedule for next day
+
+### Value leaves watched state (value !== watchValue)
+
+1. Cancel delay timer (if pending)
+2. Cancel repeat timer (if running)
+3. If alarm was active:
+   - Set alarm=false, alarmCount=0, alarmSince=null
+   - Persist state, emit `notifyStateChanged()`
+   - Log "Alarm cleared: {dataKey} changed to {currentValue}"
+4. Clear `watchStartedAt`
+
+### App restart
+
+1. Read persisted state (watchStartedAt, alarm, alarmSince, alarmCount)
+2. Read current equipment value
+3. If value === watchValue:
+   - If delay timer was pending → recalculate remaining time, restart timer
+   - If delay already expired → trigger alarm immediately
+   - If repeat was active → recalculate next repeat time
+4. If value !== watchValue → clear state, no timers
+5. Always restart checkTime daily timer if configured
+
+## Edge Cases
+
+- Equipment has no data for `dataKey` yet → no action, wait for first value
+- Equipment deleted while recipe running → recipe stops gracefully (equipment.data.changed stops arriving)
+- Value flickers (open→closed→open quickly) → delay timer resets each time value returns to watchValue
+- `delay` = "0s" → alarm immediately when value matches (no delay)
+- Only `checkTime` set, no delay/repeat → pure scheduled check, no event-driven alarm
+- Only `repeatInterval` set, no delay → first alarm immediately, then repeat
+
+## Scope
+
+### In Scope
+
+- Single equipment + single data key per instance
+- Equality comparison only (value === watchValue, with string coercion for booleans/numbers)
+- Three combinable trigger modes
+
+### Out of Scope (future)
+
+- Threshold comparisons (>, <, >=, <=) for numeric values
+- Multiple data keys per instance
+- Zone-level watching (zone aggregation keys)

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { MotionLightDimmableRecipe } from "./recipes/motion-light-dimmable.js";
 import { SwitchLightRecipe } from "./recipes/switch-light.js";
 import { PresenceThermostatRecipe } from "./recipes/presence-thermostat.js";
 import { PresenceHeaterRecipe } from "./recipes/presence-heater.js";
+import { StateWatchRecipe } from "./recipes/state-watch.js";
 import { UserManager } from "./auth/user-manager.js";
 import { AuthService } from "./auth/auth-service.js";
 import { SettingsManager } from "./core/settings-manager.js";
@@ -148,6 +149,7 @@ async function main() {
   recipeManager.register(SwitchLightRecipe);
   recipeManager.register(PresenceThermostatRecipe);
   recipeManager.register(PresenceHeaterRecipe);
+  recipeManager.register(StateWatchRecipe);
 
   // 12b. Create Notification Publisher Manager & Service
   const notificationPublisherManager = new NotificationPublisherManager(db, eventBus, logger);

--- a/src/notifications/notification-publish-service.ts
+++ b/src/notifications/notification-publish-service.ts
@@ -161,7 +161,7 @@ export class NotificationPublishService {
       if (!ref.enabled) continue;
       if (!this.shouldNotify(ref, value, previous)) continue;
 
-      const text = `${ref.message} : ${value}`;
+      const text = `${ref.message} : ${formatDisplayValue(value)}`;
       this.sendNotification(ref, text);
       this.lastSent.set(ref.mappingId, Date.now());
       sent++;
@@ -240,7 +240,7 @@ export class NotificationPublishService {
       );
       if (value === undefined) continue;
 
-      const text = `${mapping.message} : ${value}`;
+      const text = `${mapping.message} : ${formatDisplayValue(value)}`;
       await channel.send(publisher.channelConfig, text);
       sent++;
     }
@@ -248,6 +248,8 @@ export class NotificationPublishService {
     this.logger.info({ publisherId, sent }, "Notification test publish completed");
     return sent;
   }
+
+  // ── Resolve current value ──────────────────────────────────
 
   private resolveCurrentValue(
     sourceType: "equipment" | "zone" | "recipe",
@@ -274,4 +276,25 @@ export class NotificationPublishService {
 
     return undefined;
   }
+}
+
+// ============================================================
+// Helper: format values for human-readable display
+// ============================================================
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+
+function formatDisplayValue(value: unknown): string {
+  if (typeof value === "string" && ISO_DATE_RE.test(value)) {
+    const d = new Date(value);
+    if (!isNaN(d.getTime())) {
+      const dd = String(d.getDate()).padStart(2, "0");
+      const mm = String(d.getMonth() + 1).padStart(2, "0");
+      const yyyy = d.getFullYear();
+      const hh = String(d.getHours()).padStart(2, "0");
+      const min = String(d.getMinutes()).padStart(2, "0");
+      return `${dd}/${mm}/${yyyy} ${hh}:${min}`;
+    }
+  }
+  return String(value);
 }

--- a/src/notifications/notification-publish-service.ts
+++ b/src/notifications/notification-publish-service.ts
@@ -161,7 +161,7 @@ export class NotificationPublishService {
       if (!ref.enabled) continue;
       if (!this.shouldNotify(ref, value, previous)) continue;
 
-      const text = `${ref.message} : ${formatDisplayValue(value)}`;
+      const text = formatNotificationText(ref.message, value);
       this.sendNotification(ref, text);
       this.lastSent.set(ref.mappingId, Date.now());
       sent++;
@@ -240,7 +240,7 @@ export class NotificationPublishService {
       );
       if (value === undefined) continue;
 
-      const text = `${mapping.message} : ${formatDisplayValue(value)}`;
+      const text = formatNotificationText(mapping.message, value);
       await channel.send(publisher.channelConfig, text);
       sent++;
     }
@@ -283,6 +283,14 @@ export class NotificationPublishService {
 // ============================================================
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+
+function formatNotificationText(message: string, value: unknown): string {
+  // Booleans: just send the message, no value suffix
+  if (typeof value === "boolean") return message;
+  // null: just send the message
+  if (value === null) return message;
+  return `${message} : ${formatDisplayValue(value)}`;
+}
 
 function formatDisplayValue(value: unknown): string {
   if (typeof value === "string" && ISO_DATE_RE.test(value)) {

--- a/src/recipes/state-watch.ts
+++ b/src/recipes/state-watch.ts
@@ -30,7 +30,7 @@ export class StateWatchRecipe extends Recipe {
       id: "dataKey",
       name: "Data Key",
       description: "Data binding alias to watch (e.g., contact, state)",
-      type: "text",
+      type: "data-key",
       required: true,
     },
     {

--- a/src/recipes/state-watch.ts
+++ b/src/recipes/state-watch.ts
@@ -267,26 +267,25 @@ export class StateWatchRecipe extends Recipe {
     const wasInAlarm = this.ctx.state.get("alarm") === true;
     const watchStartedAt = this.ctx.state.get("watchStartedAt") as string | undefined;
 
+    this.ctx.log(`Current: ${this.dataKey}=${String(currentValue)}`);
+
     if (!isInWatchedState) {
-      // Value is not in watched state — clear everything
       if (wasInAlarm) {
         this.ctx.state.set("alarm", false);
         this.ctx.state.set("alarmSince", null);
         this.ctx.state.set("alarmCount", 0);
         this.ctx.state.delete("watchStartedAt");
         this.ctx.notifyStateChanged();
-        this.ctx.log("Alarm cleared on restart: value no longer in watched state");
+        this.ctx.log("Alarm cleared on restart");
       }
       return;
     }
 
-    // Value is in watched state
     if (wasInAlarm) {
-      // Was already in alarm — restore repeat timer
       if (this.repeatIntervalMs) {
         this.startRepeatTimer();
       }
-      this.ctx.log("Alarm restored on restart — still in watched state");
+      this.ctx.log("Alarm still active after restart");
     } else if (watchStartedAt && this.delayMs !== null) {
       // Was waiting for delay — recalculate
       const elapsed = Date.now() - new Date(watchStartedAt).getTime();
@@ -327,19 +326,16 @@ export class StateWatchRecipe extends Recipe {
     this.ctx.state.set("watchStartedAt", now);
 
     if (this.delayMs !== null && this.delayMs > 0) {
-      // Start delay timer
       this.delayTimer = setTimeout(() => {
         this.delayTimer = null;
         this.raiseAlarm();
       }, this.delayMs);
-      this.ctx.log(
-        `Value entered watched state (${this.dataKey}=${this.watchValue}), alarm in ${formatDuration(this.delayMs)}`,
-      );
+      this.ctx.log(`${this.dataKey}=${this.watchValue} — alarm in ${formatDuration(this.delayMs)}`);
     } else if (this.delayMs === 0 || (this.delayMs === null && this.repeatIntervalMs !== null)) {
-      // No delay or delay=0 — alarm immediately
       this.raiseAlarm();
+    } else if (this.checkTimeStr) {
+      this.ctx.log(`${this.dataKey}=${this.watchValue} — check at ${this.checkTimeStr}`);
     }
-    // If only checkTime is configured, no immediate action — wait for scheduled check
   }
 
   private onValueLeavesWatchedState(newValue: unknown): void {
@@ -354,7 +350,9 @@ export class StateWatchRecipe extends Recipe {
       this.ctx.state.set("alarmSince", null);
       this.ctx.state.set("alarmCount", 0);
       this.ctx.notifyStateChanged();
-      this.ctx.log(`Alarm cleared: ${this.dataKey} changed to ${String(newValue)}`);
+      this.ctx.log(`${this.dataKey}=${String(newValue)} — alarm cleared`);
+    } else {
+      this.ctx.log(`${this.dataKey}=${String(newValue)}`);
     }
   }
 
@@ -374,10 +372,9 @@ export class StateWatchRecipe extends Recipe {
     this.ctx.notifyStateChanged();
 
     if (!wasInAlarm) {
-      const delayLabel = this.delayMs ? ` after ${formatDuration(this.delayMs)}` : "";
-      this.ctx.log(`Alarm raised: ${this.dataKey}=${this.watchValue}${delayLabel}`);
+      this.ctx.log(`ALARM: ${this.dataKey}=${this.watchValue}`);
     } else {
-      this.ctx.log(`Alarm repeat #${alarmCount}: ${this.dataKey}=${this.watchValue}`);
+      this.ctx.log(`ALARM repeat #${alarmCount}`);
     }
 
     // Start repeat timer if configured
@@ -429,7 +426,7 @@ export class StateWatchRecipe extends Recipe {
     this.ctx.state.set("alarmCount", alarmCount);
     this.ctx.notifyStateChanged();
     this.ctx.log(
-      `Scheduled check at ${this.checkTimeStr}: ${this.dataKey}=${this.watchValue} (alarm #${alarmCount})`,
+      `Check ${this.checkTimeStr}: ${this.dataKey}=${this.watchValue} — ALARM #${alarmCount}`,
     );
   }
 

--- a/src/recipes/state-watch.ts
+++ b/src/recipes/state-watch.ts
@@ -199,12 +199,25 @@ export class StateWatchRecipe extends Recipe {
         ? String(params.checkTime)
         : null;
 
-    // Initialize all state keys so they are visible in notification publisher mappings
-    if (ctx.state.get("alarm") === undefined) {
-      ctx.state.set("alarm", false);
-      ctx.state.set("alarmSince", null);
-      ctx.state.set("alarmCount", 0);
-      ctx.state.set("currentValue", null);
+    // Ensure all state keys exist in DB so they appear in notification publisher dropdowns.
+    // Only write defaults for keys not yet set (alarm=false/true distinguishes from null=missing).
+    const defaults: Record<string, unknown> = {
+      alarm: false,
+      alarmSince: null,
+      alarmCount: 0,
+      currentValue: null,
+    };
+    for (const [key, defaultVal] of Object.entries(defaults)) {
+      const current = ctx.state.get(key);
+      // state.get() returns null both for missing keys and for keys set to null.
+      // For "alarm", check specifically — false/true means it was already set.
+      if (key === "alarm" && (current === true || current === false)) continue;
+      // For others, always write to ensure the row exists in recipe_state table.
+      if (key !== "alarm") {
+        ctx.state.set(key, current ?? defaultVal);
+      } else {
+        ctx.state.set(key, defaultVal);
+      }
     }
 
     // Subscribe to equipment data changes

--- a/src/recipes/state-watch.ts
+++ b/src/recipes/state-watch.ts
@@ -1,0 +1,469 @@
+import type { RecipeSlotDef, RecipeLangPack } from "../shared/types.js";
+import { Recipe, type RecipeContext } from "./engine/recipe.js";
+import { parseDuration, formatDuration } from "./engine/duration.js";
+
+// ============================================================
+// StateWatch Recipe
+// ============================================================
+
+export class StateWatchRecipe extends Recipe {
+  readonly id = "state-watch";
+  readonly name = "State Watch";
+  readonly description =
+    "Monitor an equipment data key and raise an alarm when the value stays in a watched state. Supports delayed alarm, periodic repeat, and daily scheduled check.";
+  readonly slots: RecipeSlotDef[] = [
+    {
+      id: "zone",
+      name: "Zone",
+      description: "Zone of the equipment to monitor",
+      type: "zone",
+      required: true,
+    },
+    {
+      id: "equipment",
+      name: "Equipment",
+      description: "Equipment to monitor",
+      type: "equipment",
+      required: true,
+    },
+    {
+      id: "dataKey",
+      name: "Data Key",
+      description: "Data binding alias to watch (e.g., contact, state)",
+      type: "text",
+      required: true,
+    },
+    {
+      id: "watchValue",
+      name: "Watch Value",
+      description: "Value that triggers the alarm (e.g., open, true)",
+      type: "text",
+      required: true,
+    },
+    {
+      id: "delay",
+      name: "Delay",
+      description: "Time in watched state before first alarm (e.g., 10m)",
+      type: "duration",
+      required: false,
+    },
+    {
+      id: "repeatInterval",
+      name: "Repeat Interval",
+      description: "Re-alarm interval while still in watched state (e.g., 1h)",
+      type: "duration",
+      required: false,
+    },
+    {
+      id: "checkTime",
+      name: "Check Time",
+      description: "Daily check time — alarm if still in watched state (e.g., 23:00)",
+      type: "time",
+      required: false,
+    },
+  ];
+
+  override readonly i18n: Record<string, RecipeLangPack> = {
+    fr: {
+      name: "Surveillance d'état",
+      description:
+        "Surveille une donnée d'équipement et déclenche une alarme si la valeur reste dans un état donné. Supporte un délai, une répétition périodique et un check quotidien à heure fixe.",
+      slots: {
+        zone: { name: "Zone", description: "Zone de l'équipement à surveiller" },
+        equipment: { name: "Équipement", description: "Équipement à surveiller" },
+        dataKey: {
+          name: "Clé de donnée",
+          description: "Alias de la donnée à surveiller (ex: contact, state)",
+        },
+        watchValue: {
+          name: "Valeur surveillée",
+          description: "Valeur qui déclenche la surveillance (ex: open, true)",
+        },
+        delay: {
+          name: "Délai",
+          description: "Durée avant la première alarme (ex: 10m)",
+        },
+        repeatInterval: {
+          name: "Intervalle de répétition",
+          description: "Intervalle de rappel tant que l'état persiste (ex: 1h)",
+        },
+        checkTime: {
+          name: "Heure de vérification",
+          description: "Heure de check quotidien — alarme si encore dans l'état (ex: 23:00)",
+        },
+      },
+    },
+  };
+
+  private ctx!: RecipeContext;
+  private equipmentId!: string;
+  private dataKey!: string;
+  private watchValue!: string;
+  private delayMs: number | null = null;
+  private repeatIntervalMs: number | null = null;
+  private checkTimeStr: string | null = null;
+
+  private unsubs: (() => void)[] = [];
+  private delayTimer: ReturnType<typeof setTimeout> | null = null;
+  private repeatTimer: ReturnType<typeof setTimeout> | null = null;
+  private checkTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // ============================================================
+  // Validation
+  // ============================================================
+
+  validate(params: Record<string, unknown>, ctx: RecipeContext): void {
+    const { zone, equipment, dataKey, watchValue, delay, repeatInterval, checkTime } = params;
+
+    // Validate zone
+    if (!zone || typeof zone !== "string") {
+      throw new Error("Zone parameter is required");
+    }
+    if (!ctx.zoneManager.getById(zone)) {
+      throw new Error(`Zone not found: ${zone}`);
+    }
+
+    // Validate equipment
+    if (!equipment || typeof equipment !== "string") {
+      throw new Error("Equipment parameter is required");
+    }
+    const eq = ctx.equipmentManager.getByIdWithDetails(equipment);
+    if (!eq) {
+      throw new Error(`Equipment not found: ${equipment}`);
+    }
+    if (eq.zoneId !== zone) {
+      throw new Error(`Equipment "${eq.name}" does not belong to the selected zone`);
+    }
+
+    // Validate dataKey
+    if (!dataKey || typeof dataKey !== "string") {
+      throw new Error("Data key parameter is required");
+    }
+    const hasBinding = eq.dataBindings.some((b) => b.alias === dataKey);
+    if (!hasBinding) {
+      throw new Error(`Equipment "${eq.name}" has no data binding with alias "${dataKey}"`);
+    }
+
+    // Validate watchValue
+    if (watchValue === undefined || watchValue === null || watchValue === "") {
+      throw new Error("Watch value parameter is required");
+    }
+
+    // Validate at least one trigger mode
+    const hasDelay = delay !== undefined && delay !== null && delay !== "";
+    const hasRepeat =
+      repeatInterval !== undefined && repeatInterval !== null && repeatInterval !== "";
+    const hasCheck = checkTime !== undefined && checkTime !== null && checkTime !== "";
+
+    if (!hasDelay && !hasRepeat && !hasCheck) {
+      throw new Error("At least one trigger mode is required: delay, repeatInterval, or checkTime");
+    }
+
+    // Validate duration formats
+    if (hasDelay) parseDuration(delay);
+    if (hasRepeat) parseDuration(repeatInterval);
+
+    // Validate time format
+    if (hasCheck) {
+      const timeStr = String(checkTime);
+      if (!/^\d{1,2}:\d{2}$/.test(timeStr)) {
+        throw new Error(`Invalid time format: ${timeStr}. Use HH:MM (e.g., "23:00")`);
+      }
+    }
+  }
+
+  // ============================================================
+  // Lifecycle
+  // ============================================================
+
+  start(params: Record<string, unknown>, ctx: RecipeContext): void {
+    this.ctx = ctx;
+    this.equipmentId = params.equipment as string;
+    this.dataKey = params.dataKey as string;
+    this.watchValue = String(params.watchValue);
+
+    this.delayMs =
+      params.delay !== undefined && params.delay !== null && params.delay !== ""
+        ? parseDuration(params.delay)
+        : null;
+
+    this.repeatIntervalMs =
+      params.repeatInterval !== undefined &&
+      params.repeatInterval !== null &&
+      params.repeatInterval !== ""
+        ? parseDuration(params.repeatInterval)
+        : null;
+
+    this.checkTimeStr =
+      params.checkTime !== undefined && params.checkTime !== null && params.checkTime !== ""
+        ? String(params.checkTime)
+        : null;
+
+    // Subscribe to equipment data changes
+    const unsub = ctx.eventBus.onType("equipment.data.changed", (event) => {
+      if (event.equipmentId !== this.equipmentId) return;
+      if (event.alias !== this.dataKey) return;
+      this.onValueChanged(event.value);
+    });
+    this.unsubs.push(unsub);
+
+    // Start daily check timer if configured
+    if (this.checkTimeStr) {
+      this.scheduleNextCheck();
+    }
+
+    // Restore state from persistence
+    this.restoreState();
+  }
+
+  stop(): void {
+    this.clearDelayTimer();
+    this.clearRepeatTimer();
+    this.clearCheckTimer();
+    for (const unsub of this.unsubs) {
+      unsub();
+    }
+    this.unsubs = [];
+
+    // Clear persisted state
+    this.ctx.state.delete("alarm");
+    this.ctx.state.delete("alarmSince");
+    this.ctx.state.delete("alarmCount");
+    this.ctx.state.delete("currentValue");
+    this.ctx.state.delete("watchStartedAt");
+    this.ctx.notifyStateChanged();
+  }
+
+  // ============================================================
+  // State restoration (after app restart)
+  // ============================================================
+
+  private restoreState(): void {
+    const currentValue = this.readCurrentValue();
+    this.ctx.state.set("currentValue", currentValue);
+
+    const isInWatchedState = this.matchesWatchValue(currentValue);
+    const wasInAlarm = this.ctx.state.get("alarm") === true;
+    const watchStartedAt = this.ctx.state.get("watchStartedAt") as string | undefined;
+
+    if (!isInWatchedState) {
+      // Value is not in watched state — clear everything
+      if (wasInAlarm) {
+        this.ctx.state.set("alarm", false);
+        this.ctx.state.set("alarmSince", null);
+        this.ctx.state.set("alarmCount", 0);
+        this.ctx.state.delete("watchStartedAt");
+        this.ctx.notifyStateChanged();
+        this.ctx.log("Alarm cleared on restart: value no longer in watched state");
+      }
+      return;
+    }
+
+    // Value is in watched state
+    if (wasInAlarm) {
+      // Was already in alarm — restore repeat timer
+      if (this.repeatIntervalMs) {
+        this.startRepeatTimer();
+      }
+      this.ctx.log("Alarm restored on restart — still in watched state");
+    } else if (watchStartedAt && this.delayMs !== null) {
+      // Was waiting for delay — recalculate
+      const elapsed = Date.now() - new Date(watchStartedAt).getTime();
+      const remaining = this.delayMs - elapsed;
+      if (remaining <= 0) {
+        // Delay already expired during downtime
+        this.raiseAlarm();
+      } else {
+        this.delayTimer = setTimeout(() => {
+          this.delayTimer = null;
+          this.raiseAlarm();
+        }, remaining);
+      }
+    } else if (!watchStartedAt) {
+      // No watchStartedAt but value is in watched state — treat as fresh entry
+      this.onValueEntersWatchedState();
+    }
+  }
+
+  // ============================================================
+  // Event handlers
+  // ============================================================
+
+  private onValueChanged(value: unknown): void {
+    this.ctx.state.set("currentValue", value);
+
+    if (this.matchesWatchValue(value)) {
+      if (!this.ctx.state.get("watchStartedAt")) {
+        this.onValueEntersWatchedState();
+      }
+    } else {
+      this.onValueLeavesWatchedState(value);
+    }
+  }
+
+  private onValueEntersWatchedState(): void {
+    const now = new Date().toISOString();
+    this.ctx.state.set("watchStartedAt", now);
+
+    if (this.delayMs !== null && this.delayMs > 0) {
+      // Start delay timer
+      this.delayTimer = setTimeout(() => {
+        this.delayTimer = null;
+        this.raiseAlarm();
+      }, this.delayMs);
+      this.ctx.log(
+        `Value entered watched state (${this.dataKey}=${this.watchValue}), alarm in ${formatDuration(this.delayMs)}`,
+      );
+    } else if (this.delayMs === 0 || (this.delayMs === null && this.repeatIntervalMs !== null)) {
+      // No delay or delay=0 — alarm immediately
+      this.raiseAlarm();
+    }
+    // If only checkTime is configured, no immediate action — wait for scheduled check
+  }
+
+  private onValueLeavesWatchedState(newValue: unknown): void {
+    this.clearDelayTimer();
+    this.clearRepeatTimer();
+
+    const wasInAlarm = this.ctx.state.get("alarm") === true;
+    this.ctx.state.delete("watchStartedAt");
+
+    if (wasInAlarm) {
+      this.ctx.state.set("alarm", false);
+      this.ctx.state.set("alarmSince", null);
+      this.ctx.state.set("alarmCount", 0);
+      this.ctx.notifyStateChanged();
+      this.ctx.log(`Alarm cleared: ${this.dataKey} changed to ${String(newValue)}`);
+    }
+  }
+
+  // ============================================================
+  // Alarm management
+  // ============================================================
+
+  private raiseAlarm(): void {
+    const wasInAlarm = this.ctx.state.get("alarm") === true;
+    const alarmCount = ((this.ctx.state.get("alarmCount") as number) ?? 0) + 1;
+
+    if (!wasInAlarm) {
+      this.ctx.state.set("alarm", true);
+      this.ctx.state.set("alarmSince", new Date().toISOString());
+    }
+    this.ctx.state.set("alarmCount", alarmCount);
+    this.ctx.notifyStateChanged();
+
+    if (!wasInAlarm) {
+      const delayLabel = this.delayMs ? ` after ${formatDuration(this.delayMs)}` : "";
+      this.ctx.log(`Alarm raised: ${this.dataKey}=${this.watchValue}${delayLabel}`);
+    } else {
+      this.ctx.log(`Alarm repeat #${alarmCount}: ${this.dataKey}=${this.watchValue}`);
+    }
+
+    // Start repeat timer if configured
+    if (this.repeatIntervalMs) {
+      this.startRepeatTimer();
+    }
+  }
+
+  private startRepeatTimer(): void {
+    this.clearRepeatTimer();
+    this.repeatTimer = setTimeout(() => {
+      this.repeatTimer = null;
+      // Only repeat if still in watched state
+      const currentValue = this.readCurrentValue();
+      if (this.matchesWatchValue(currentValue)) {
+        this.raiseAlarm();
+      }
+    }, this.repeatIntervalMs!);
+  }
+
+  // ============================================================
+  // Scheduled check (checkTime)
+  // ============================================================
+
+  private scheduleNextCheck(): void {
+    this.clearCheckTimer();
+    const ms = msUntilNextOccurrence(this.checkTimeStr!);
+    this.checkTimer = setTimeout(() => {
+      this.checkTimer = null;
+      this.onScheduledCheck();
+      // Reschedule for next day
+      this.scheduleNextCheck();
+    }, ms);
+  }
+
+  private onScheduledCheck(): void {
+    const currentValue = this.readCurrentValue();
+    this.ctx.state.set("currentValue", currentValue);
+
+    if (!this.matchesWatchValue(currentValue)) return;
+
+    const wasInAlarm = this.ctx.state.get("alarm") === true;
+    const alarmCount = ((this.ctx.state.get("alarmCount") as number) ?? 0) + 1;
+
+    if (!wasInAlarm) {
+      this.ctx.state.set("alarm", true);
+      this.ctx.state.set("alarmSince", new Date().toISOString());
+    }
+    this.ctx.state.set("alarmCount", alarmCount);
+    this.ctx.notifyStateChanged();
+    this.ctx.log(
+      `Scheduled check at ${this.checkTimeStr}: ${this.dataKey}=${this.watchValue} (alarm #${alarmCount})`,
+    );
+  }
+
+  // ============================================================
+  // Value comparison
+  // ============================================================
+
+  private matchesWatchValue(value: unknown): boolean {
+    return String(value) === this.watchValue;
+  }
+
+  private readCurrentValue(): unknown {
+    const eq = this.ctx.equipmentManager.getByIdWithDetails(this.equipmentId);
+    if (!eq) return undefined;
+    const binding = eq.dataBindings.find((b) => b.alias === this.dataKey);
+    return binding?.value;
+  }
+
+  // ============================================================
+  // Timer cleanup
+  // ============================================================
+
+  private clearDelayTimer(): void {
+    if (this.delayTimer) {
+      clearTimeout(this.delayTimer);
+      this.delayTimer = null;
+    }
+  }
+
+  private clearRepeatTimer(): void {
+    if (this.repeatTimer) {
+      clearTimeout(this.repeatTimer);
+      this.repeatTimer = null;
+    }
+  }
+
+  private clearCheckTimer(): void {
+    if (this.checkTimer) {
+      clearTimeout(this.checkTimer);
+      this.checkTimer = null;
+    }
+  }
+}
+
+// ============================================================
+// Helper: compute ms until next occurrence of HH:MM today/tomorrow
+// ============================================================
+
+function msUntilNextOccurrence(timeStr: string): number {
+  const [h, m] = timeStr.split(":").map(Number);
+  const now = new Date();
+  const target = new Date();
+  target.setHours(h, m, 0, 0);
+  if (target.getTime() <= now.getTime()) {
+    target.setDate(target.getDate() + 1);
+  }
+  return target.getTime() - now.getTime();
+}

--- a/src/recipes/state-watch.ts
+++ b/src/recipes/state-watch.ts
@@ -199,6 +199,14 @@ export class StateWatchRecipe extends Recipe {
         ? String(params.checkTime)
         : null;
 
+    // Initialize all state keys so they are visible in notification publisher mappings
+    if (ctx.state.get("alarm") === undefined) {
+      ctx.state.set("alarm", false);
+      ctx.state.set("alarmSince", null);
+      ctx.state.set("alarmCount", 0);
+      ctx.state.set("currentValue", null);
+    }
+
     // Subscribe to equipment data changes
     const unsub = ctx.eventBus.onType("equipment.data.changed", (event) => {
       if (event.equipmentId !== this.equipmentId) return;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -263,7 +263,7 @@ export interface RecipeSlotDef {
   id: string;
   name: string;
   description: string;
-  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean";
+  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean" | "text";
   required: boolean;
   list?: boolean;
   defaultValue?: unknown;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -263,7 +263,7 @@ export interface RecipeSlotDef {
   id: string;
   name: string;
   description: string;
-  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean" | "text";
+  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean" | "text" | "data-key";
   required: boolean;
   list?: boolean;
   defaultValue?: unknown;

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -603,6 +603,25 @@ function RecipeInstanceRow({
                                           <option key={eq.id} value={eq.id}>{eq.name}</option>
                                         ))}
                                       </select>
+                                    ) : slot.type === "data-key" ? (
+                                      (() => {
+                                        const eqSlot = recipe?.slots.find((s) => s.type === "equipment" && !s.list);
+                                        const eqId = eqSlot ? editParams[eqSlot.id] : undefined;
+                                        const eq = eqId ? equipments.find((e) => e.id === eqId) : undefined;
+                                        const bindings = eq?.dataBindings ?? [];
+                                        return (
+                                          <select
+                                            value={editParams[slot.id] ?? ""}
+                                            onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
+                                            className="w-full px-2 py-1 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                                          >
+                                            <option value="">{t("common.select")}</option>
+                                            {bindings.map((b) => (
+                                              <option key={b.alias} value={b.alias}>{b.alias}</option>
+                                            ))}
+                                          </select>
+                                        );
+                                      })()
                                     ) : slot.type === "time" ? (
                                       <TimeInput
                                         value={editParams[slot.id] ?? ""}
@@ -678,6 +697,25 @@ function RecipeInstanceRow({
                               <option key={eq.id} value={eq.id}>{eq.name}</option>
                             ))}
                           </select>
+                        ) : slot.type === "data-key" ? (
+                          (() => {
+                            const eqSlot = recipe?.slots.find((s) => s.type === "equipment" && !s.list);
+                            const eqId = eqSlot ? editParams[eqSlot.id] : undefined;
+                            const eq = eqId ? equipments.find((e) => e.id === eqId) : undefined;
+                            const bindings = eq?.dataBindings ?? [];
+                            return (
+                              <select
+                                value={editParams[slot.id] ?? ""}
+                                onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
+                                className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                              >
+                                <option value="">{t("common.select")}</option>
+                                {bindings.map((b) => (
+                                  <option key={b.alias} value={b.alias}>{b.alias}</option>
+                                ))}
+                              </select>
+                            );
+                          })()
                         ) : slot.type === "duration" ? (
                           <DurationInput
                             value={editParams[slot.id] ?? ""}
@@ -1554,6 +1592,25 @@ function AddRecipeForm({
                                         <option key={eq.id} value={eq.id}>{eq.name}</option>
                                       ))}
                                     </select>
+                                  ) : slot.type === "data-key" ? (
+                                    (() => {
+                                      const eqSlot = selectedRecipe?.slots.find((s) => s.type === "equipment" && !s.list);
+                                      const eqId = eqSlot ? params[eqSlot.id] : undefined;
+                                      const eq = eqId ? equipments.find((e) => e.id === eqId) : undefined;
+                                      const bindings = eq?.dataBindings ?? [];
+                                      return (
+                                        <select
+                                          value={params[slot.id] ?? ""}
+                                          onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
+                                          className="w-full px-2 py-1 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                                        >
+                                          <option value="">{t("common.select")}</option>
+                                          {bindings.map((b) => (
+                                            <option key={b.alias} value={b.alias}>{b.alias}</option>
+                                          ))}
+                                        </select>
+                                      );
+                                    })()
                                   ) : slot.type === "time" ? (
                                     <TimeInput
                                       value={params[slot.id] ?? ""}
@@ -1628,6 +1685,25 @@ function AddRecipeForm({
                             <option key={eq.id} value={eq.id}>{eq.name}</option>
                           ))}
                         </select>
+                      ) : slot.type === "data-key" ? (
+                        (() => {
+                          const eqSlot = selectedRecipe?.slots.find((s) => s.type === "equipment" && !s.list);
+                          const eqId = eqSlot ? params[eqSlot.id] : undefined;
+                          const eq = eqId ? equipments.find((e) => e.id === eqId) : undefined;
+                          const bindings = eq?.dataBindings ?? [];
+                          return (
+                            <select
+                              value={params[slot.id] ?? ""}
+                              onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
+                              className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                            >
+                              <option value="">{t("common.select")}</option>
+                              {bindings.map((b) => (
+                                <option key={b.alias} value={b.alias}>{b.alias}</option>
+                              ))}
+                            </select>
+                          );
+                        })()
                       ) : slot.type === "duration" ? (
                         <DurationInput
                           value={params[slot.id] ?? ""}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -330,7 +330,7 @@ export interface RecipeSlotDef {
   id: string;
   name: string;
   description: string;
-  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean" | "text";
+  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean" | "text" | "data-key";
   required: boolean;
   list?: boolean;
   defaultValue?: unknown;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -330,7 +330,7 @@ export interface RecipeSlotDef {
   id: string;
   name: string;
   description: string;
-  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean";
+  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean" | "text";
   required: boolean;
   list?: boolean;
   defaultValue?: unknown;


### PR DESCRIPTION
## Summary
- New `StateWatch` recipe that monitors an equipment data key and raises an alarm when the value stays in a watched state
- Three independent, combinable trigger modes: delayed alarm, periodic repeat, daily scheduled check
- Exposes alarm state (`alarm`, `alarmSince`, `alarmCount`, `currentValue`) for notification publishers
- Added `"text"` type to `RecipeSlotDef` for free-form string slots

## Changes
- `src/recipes/state-watch.ts`: Full recipe implementation with validation, timer management, state persistence, restart restoration, i18n (fr)
- `src/index.ts`: Register `StateWatchRecipe`
- `src/shared/types.ts` + `ui/src/types.ts`: Add `"text"` to slot type union
- `specs/032-state-watch-recipe/`: Spec, architecture, and plan docs

## Test plan
- [x] TypeScript compiles with zero errors (backend + frontend)
- [x] All 454 tests pass
- [x] Lint + format checks pass
- [ ] Manual: create StateWatch instance for a door sensor, verify alarm after delay, repeat, scheduled check, and alarm clear on value change

🤖 Generated with [Claude Code](https://claude.com/claude-code)