### PR TITLE
fix(ui): mobile responsiveness and PWA improvements

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,11 +1,27 @@
-alarme batterie
-Telegram ou messagerie
+Retirer le script temporaire de nettoyage du service worker dans ui/index.html (désinscription SW + vidage caches) — à faire une fois que tous les clients ont chargé la nouvelle version (après ~1 semaine)
+Notifications : problème UI sur la config, et fréquence 300 min
+
+Alarme batterie
 Google Home
 Plugin / modularité
 Progressive Web App ou autre solution mobile
 Dashboard
 IA
-Chauffage Fille
 Forecast météo
-Connexion afficheur maison
-Pouvoir mettre des commande de groupe dans des modes
+Pouvoir mettre des commandes de groupe dans des modes
+intégration station netatmo indoor
+Intégrer le dotmatrix display par mqtt
+Rendre les intégrations installables à chaud et mettre un market en place De même pour les recettes
+Faire une page résumants les intégrations et recettes disponibles - un peu trop le bordel les IDcards des recettes 
+Revoir l’ordre des menus administration
+Identifier les devices non utilisés (filtre)
+Développer une documentation
+Licence
+Mettre en place un système de versioning
+Mettre en place un système de backup réseau automatique
+Refaire un audit de l’architecture
+Voir si la séparation des droits entre admin et user est vraiment gérée correctement en limitant uniquement l’accès au menu administration
+Calendar dans Administration est ce vraiment le bon endroit
+Créer un Dashboard avec des thuiles / widget qui synthétise chaque pièce - faire un truc auto finalement assez proche de la synthèse par pièce qui te donne une vue auto de ta maison.
+Avoir aussi une synthèse de la maisonÉquipement virtuel ? (Bouton ?)Couper chauffage
+Poele en erreur granules

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -10,7 +10,7 @@ import { useZones } from "../../store/useZones";
 import { useEquipments } from "../../store/useEquipments";
 import { useZoneAggregation } from "../../store/useZoneAggregation";
 import { useAuth } from "../../store/useAuth";
-import { Home, LayoutDashboard, LogOut, Settings, User } from "lucide-react";
+import { Home, Layers, LayoutDashboard, LogOut, Settings, User } from "lucide-react";
 import { SowelLogo } from "./SowelLogo";
 import { OfflineBanner } from "./OfflineBanner";
 import { InstallPrompt } from "./InstallPrompt";
@@ -126,6 +126,7 @@ function MobileNav() {
       <div className="flex items-center justify-around min-h-[56px] px-2">
         <MobileNavLink to="/dashboard" label={t("nav.dashboard")} icon={<LayoutDashboard size={18} strokeWidth={1.5} />} />
         <MobileNavLink to="/home" label={t("nav.maison")} icon={<Home size={18} strokeWidth={1.5} />} />
+        <MobileNavLink to="/modes" label={t("nav.modes")} icon={<Layers size={18} strokeWidth={1.5} />} />
         <MobileNavLink to="/settings" label={t("nav.settings")} icon={<Settings size={18} strokeWidth={1.5} />} />
       </div>
       {/* Safe area spacer for iOS PWA home indicator */}

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -173,7 +173,7 @@ export function EquipmentDetailPage() {
   const { isLight, isShutter, isSensor, isThermostat, isHeater, isGate, actionBinding } = equipmentState;
 
   return (
-    <div className="p-6">
+    <div className="p-4 sm:p-6">
       {/* Back link */}
       {fromZone ? (
         <button onClick={() => navigate(-1)} className="inline-flex items-center gap-1.5 text-[13px] text-text-secondary hover:text-text mb-4">
@@ -188,13 +188,13 @@ export function EquipmentDetailPage() {
       )}
 
       {/* Header */}
-      <div className="flex items-start justify-between mb-8">
+      <div className="flex items-start justify-between mb-4 sm:mb-8">
         <div className="flex items-center gap-3">
           <div className="w-10 h-10 rounded-[8px] bg-primary-light flex items-center justify-center text-primary">
             {TYPE_ICONS[equipment.type]}
           </div>
           <div>
-            <h1 className="text-[24px] font-semibold text-text leading-[32px]">
+            <h1 className="text-[18px] sm:text-[24px] font-semibold text-text leading-[24px] sm:leading-[32px]">
               {equipment.name}
             </h1>
             <p className="text-[13px] text-text-secondary">
@@ -218,18 +218,20 @@ export function EquipmentDetailPage() {
         <div className="flex items-center gap-2">
           <button
             onClick={() => setShowEditForm(true)}
-            className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors duration-150"
+            className="p-2 sm:px-3 sm:py-2 text-[13px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors duration-150"
+            title={t("common.edit")}
           >
             <Pencil size={14} strokeWidth={1.5} />
-            {t("common.edit")}
+            <span className="hidden sm:inline ml-2">{t("common.edit")}</span>
           </button>
           <button
             onClick={handleDelete}
             disabled={deleting}
-            className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-error border border-error/30 rounded-[6px] hover:bg-error/10 transition-colors duration-150 disabled:opacity-50"
+            className="p-2 sm:px-3 sm:py-2 text-[13px] font-medium text-error border border-error/30 rounded-[6px] hover:bg-error/10 transition-colors duration-150 disabled:opacity-50"
+            title={t("common.delete")}
           >
             <Trash2 size={14} strokeWidth={1.5} />
-            {deleting ? t("common.deleting") : t("common.delete")}
+            <span className="hidden sm:inline ml-2">{deleting ? t("common.deleting") : t("common.delete")}</span>
           </button>
         </div>
       </div>

--- a/ui/src/pages/ModeDetailPage.tsx
+++ b/ui/src/pages/ModeDetailPage.tsx
@@ -126,7 +126,7 @@ export function ModeDetailPage() {
   };
 
   return (
-    <div className="p-6">
+    <div className="p-4 sm:p-6">
       {/* Back link */}
       <Link
         to="/modes"
@@ -137,29 +137,29 @@ export function ModeDetailPage() {
       </Link>
 
       {/* Header */}
-      <div className="flex items-start justify-between mb-8 max-w-[720px]">
-        <div className="flex items-center gap-4">
+      <div className="flex items-start justify-between mb-4 sm:mb-8 max-w-[720px]">
+        <div className="flex items-center gap-3 sm:gap-4 min-w-0">
           <div
-            className={`w-12 h-12 rounded-[10px] flex items-center justify-center ${
+            className={`w-10 h-10 sm:w-12 sm:h-12 rounded-[8px] sm:rounded-[10px] flex items-center justify-center flex-shrink-0 ${
               mode.active ? "bg-primary/10" : "bg-border-light"
             }`}
           >
             {mode.active ? (
-              <ToggleRight size={24} strokeWidth={1.5} className="text-primary" />
+              <ToggleRight size={20} strokeWidth={1.5} className="text-primary" />
             ) : (
-              <ToggleLeft size={24} strokeWidth={1.5} className="text-text-tertiary" />
+              <ToggleLeft size={20} strokeWidth={1.5} className="text-text-tertiary" />
             )}
           </div>
-          <div>
-            <h1 className="text-[24px] font-semibold text-text leading-[32px]">
+          <div className="min-w-0">
+            <h1 className="text-[18px] sm:text-[24px] font-semibold text-text leading-[24px] sm:leading-[32px] truncate">
               {mode.name}
             </h1>
             {mode.description && (
-              <p className="text-[13px] text-text-secondary mt-0.5">{mode.description}</p>
+              <p className="text-[13px] text-text-secondary mt-0.5 truncate">{mode.description}</p>
             )}
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-shrink-0">
           <button
             onClick={handleToggle}
             className="relative w-10 h-[22px] rounded-full transition-colors duration-200 flex-shrink-0 cursor-pointer"
@@ -175,17 +175,17 @@ export function ModeDetailPage() {
           </button>
           <button
             onClick={() => setShowEditForm(true)}
-            className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors duration-150"
+            className="p-2 text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors duration-150"
+            title={t("common.edit")}
           >
             <Pencil size={14} strokeWidth={1.5} />
-            {t("common.edit")}
           </button>
           <button
             onClick={handleDelete}
-            className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-error border border-error/30 rounded-[6px] hover:bg-error/10 transition-colors duration-150"
+            className="p-2 text-error border border-error/30 rounded-[6px] hover:bg-error/10 transition-colors duration-150"
+            title={t("common.delete")}
           >
             <Trash2 size={14} strokeWidth={1.5} />
-            {t("common.delete")}
           </button>
         </div>
       </div>
@@ -209,7 +209,7 @@ export function ModeDetailPage() {
         />
 
         {/* Zone impacts section */}
-        <section className="bg-surface rounded-[10px] border border-border p-5">
+        <section className="bg-surface rounded-[10px] border border-border p-3 sm:p-5">
           <h2 className="text-[14px] font-semibold text-text flex items-center gap-2 mb-4">
             <MapPin size={16} strokeWidth={1.5} className="text-primary" />
             {t("modes.impacts")}
@@ -366,7 +366,7 @@ function ButtonTriggersSection({
   if (triggers.length === 0) return null;
 
   return (
-    <section className="bg-surface rounded-[10px] border border-border p-5">
+    <section className="bg-surface rounded-[10px] border border-border p-3 sm:p-5">
       <h2 className="text-[14px] font-semibold text-text flex items-center gap-2 mb-4">
         <Zap size={16} strokeWidth={1.5} className="text-accent" />
         {t("modes.triggers")}
@@ -460,7 +460,7 @@ function CalendarScheduleSection({
   };
 
   return (
-    <section className="bg-surface rounded-[10px] border border-border p-5">
+    <section className="bg-surface rounded-[10px] border border-border p-3 sm:p-5">
       <h2 className="text-[14px] font-semibold text-text flex items-center gap-2 mb-4">
         <Clock size={16} strokeWidth={1.5} className="text-accent" />
         {t("modes.schedule")}

--- a/ui/src/pages/ModesPage.tsx
+++ b/ui/src/pages/ModesPage.tsx
@@ -63,24 +63,24 @@ export function ModesPage() {
   }
 
   return (
-    <div className="p-6">
+    <div className="p-4 sm:p-6">
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between mb-4 sm:mb-6">
         <div>
-          <h1 className="text-[24px] font-semibold text-text leading-[32px]">
+          <h1 className="text-[18px] sm:text-[24px] font-semibold text-text leading-[24px] sm:leading-[32px]">
             {t("modes.title")}
           </h1>
-          <p className="text-[13px] text-text-secondary mt-0.5">
+          <p className="text-[13px] text-text-secondary mt-0.5 hidden sm:block">
             {t("modes.subtitle")}
           </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 sm:gap-3">
           <button
             onClick={() => setShowForm(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-primary text-white text-[13px] font-medium rounded-[6px] hover:bg-primary-hover transition-colors duration-150"
+            className="flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-2 bg-primary text-white text-[13px] font-medium rounded-[6px] hover:bg-primary-hover transition-colors duration-150"
           >
             <Plus size={16} strokeWidth={1.5} />
-            {t("modes.addMode")}
+            <span className="hidden sm:inline">{t("modes.addMode")}</span>
           </button>
           <span className="text-[13px] font-medium text-primary bg-primary-light px-3 py-1.5 rounded-[6px] tabular-nums">
             {modes.length}

--- a/ui/src/pages/ZoneDetailPage.tsx
+++ b/ui/src/pages/ZoneDetailPage.tsx
@@ -154,7 +154,7 @@ export function ZoneDetailPage() {
 
   if (error || !zone) {
     return (
-      <div className="p-6">
+      <div className="p-4 sm:p-6">
         <Link to="/zones" className="inline-flex items-center gap-1.5 text-[13px] text-text-secondary hover:text-text mb-4">
           <ArrowLeft size={14} strokeWidth={1.5} />
           {t("zones.backToZones")}
@@ -186,7 +186,7 @@ export function ZoneDetailPage() {
   const breadcrumb = buildBreadcrumb(zone.id, tree);
 
   return (
-    <div className="p-6">
+    <div className="p-4 sm:p-6">
       {/* Breadcrumb */}
       <div className="flex items-center gap-1.5 text-[13px] text-text-secondary mb-4">
         <Link to="/zones" className="hover:text-text transition-colors">{t("zones.title")}</Link>
@@ -205,10 +205,10 @@ export function ZoneDetailPage() {
       </div>
 
       {/* Zone header */}
-      <div className="flex items-start justify-between mb-8">
+      <div className="flex items-start justify-between mb-4 sm:mb-8">
         <div>
           <div className="flex items-center gap-3">
-            <h1 className="text-[24px] font-semibold text-text leading-[32px]">
+            <h1 className="text-[18px] sm:text-[24px] font-semibold text-text leading-[24px] sm:leading-[32px]">
               {zone.name}
             </h1>
             {/* Recipe mode pills */}
@@ -236,19 +236,21 @@ export function ZoneDetailPage() {
         <div className="flex items-center gap-2">
           <button
             onClick={() => setShowEditForm(true)}
-            className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors duration-150"
+            className="p-2 sm:px-3 sm:py-2 text-[13px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light transition-colors duration-150"
+            title={t("common.edit")}
           >
             <Pencil size={14} strokeWidth={1.5} />
-            {t("common.edit")}
+            <span className="hidden sm:inline ml-2">{t("common.edit")}</span>
           </button>
           {zone.id !== ROOT_ZONE_ID && (
             <button
               onClick={handleDelete}
               disabled={deleting}
-              className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-error border border-error/30 rounded-[6px] hover:bg-error/10 transition-colors duration-150 disabled:opacity-50"
+              className="p-2 sm:px-3 sm:py-2 text-[13px] font-medium text-error border border-error/30 rounded-[6px] hover:bg-error/10 transition-colors duration-150 disabled:opacity-50"
+              title={t("common.delete")}
             >
               <Trash2 size={14} strokeWidth={1.5} />
-              {deleting ? t("common.deleting") : t("common.delete")}
+              <span className="hidden sm:inline ml-2">{deleting ? t("common.deleting") : t("common.delete")}</span>
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Sidebar hidden on mobile (breakpoint raised from `md:` to `lg:` — no phone reaches 1024px)
- Portrait orientation lock for installed PWA (manifest + `screen.orientation.lock`)
- One-time service worker cache purge to fix blank pages after deployment
- Responsive titles (18px mobile, 24px desktop) across all detail pages
- Edit/Delete buttons: icon-only on mobile (Pencil/Trash2), full text on desktop
- Modes added to mobile bottom navigation
- ModesPage and ModeDetailPage made mobile-friendly

## Test plan
- [x] TypeScript compiles (zero errors backend + frontend)
- [x] All 454 tests pass
- [x] ESLint + Prettier clean
- [x] Manually verified on mobile (portrait, landscape)
- [ ] Remove SW cleanup script from `ui/index.html` after ~1 week (noted in `docs/todo.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)