### PR TITLE
fix(recipes): motion-light manual override not detected

### DIFF
--- a/src/recipes/engine/motion-light-base.ts
+++ b/src/recipes/engine/motion-light-base.ts
@@ -449,6 +449,21 @@ export abstract class MotionLightBase extends Recipe {
       this.cancelOffTimer();
       this.clearOffTimerState();
     } else if (!lightOn) {
+      // Manual turn-off while motion active → enter override mode
+      // Must check BEFORE resetting lightsOnByRecipe
+      if (this.lightsOnByRecipe && motion && Date.now() >= this.turnOffGraceUntil) {
+        this.lightsOnByRecipe = false;
+        this.overrideMode = true;
+        this.ctx.state.set("overrideMode", true);
+        this.ctx.notifyStateChanged();
+        this.cancelOffTimer();
+        this.cancelFailsafeTimer();
+        this.clearOffTimerState();
+        this.clearFailsafeTimerState();
+        this.startOffTimerForOverrideClear();
+        this.ctx.log("Light turned off manually while motion active — entering override mode");
+        return;
+      }
       this.lightsOnByRecipe = false;
       if (this.offTimer || this.failsafeTimer) {
         this.cancelOffTimer();
@@ -457,8 +472,6 @@ export abstract class MotionLightBase extends Recipe {
         this.clearFailsafeTimerState();
         this.ctx.log("Light turned off externally — timers cancelled");
       }
-      // Note: manual-off override detection is handled in onZoneChanged
-      // (which fires first) using the lightsOnByRecipe flag.
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix manual light turn-off not entering override mode when motion is active
- The recipe was immediately re-triggering lights because `onLightChanged` fires before `onZoneChanged`, resetting `lightsOnByRecipe` before override detection

## Root cause
Event order: `equipment.data.changed` (light OFF) → `zone.data.changed` (motion still active). The override detection was only in `onZoneChanged`, but `onLightChanged` already cleared the `lightsOnByRecipe` flag.

## Fix
Detect manual-off override directly in `onLightChanged` when `lightsOnByRecipe && motion && outside grace period`.

## Test plan
- [x] 454 tests pass (53 motion-light specific)
- [x] TypeScript compiles with zero errors
- [x] ESLint + Prettier pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)