### PR TITLE
feat: order dispatch error handling with retry, alarms & UI banner

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,6 +1,8 @@
+ajouter une température pour la préchauffe
 Retirer le script temporaire de nettoyage du service worker dans ui/index.html (désinscription SW + vidage caches) — à faire une fois que tous les clients ont chargé la nouvelle version (après ~1 semaine)
 Notifications : problème UI sur la config, et fréquence 300 min
 
+Watchdog de fraîcheur des devices : timer périodique qui vérifie last_seen et marque offline les devices silencieux (cas lora2mqtt down alors que le broker MQTT reste connecté). Émettre system.alarm.raised sur timeout.
 Alarme batterie
 Google Home
 Plugin / modularité

--- a/specs/036-order-dispatch-error-handling/architecture.md
+++ b/specs/036-order-dispatch-error-handling/architecture.md
@@ -1,0 +1,131 @@
+# Architecture: Order Dispatch Error Handling & System Alarms
+
+## Overview
+
+Three layers: (1) async `executeOrder` with retry in equipment-manager, (2) system alarm events on the event bus, (3) notification + UI presentation.
+
+## Event Flow
+
+```
+executeOrder() called
+  → await integration.executeOrder() — attempt 1
+    → if fails: wait 2s, retry — attempt 2
+      → if still fails:
+        → emit system.alarm.raised (first failure per integration only)
+        → emit equipment.order.failed
+        → return { success: false, error }
+      → if succeeds after previous failure:
+        → emit system.alarm.resolved
+        → emit equipment.order.executed
+        → return { success: true }
+
+system.alarm.raised
+  → notification-publish-service → Telegram message "Warning: source : message"
+  → WebSocket → UI clients → useWebSocket store → AlarmBanner visible
+
+system.alarm.resolved
+  → notification-publish-service → Telegram message "OK: source : message"
+  → WebSocket → UI clients → useWebSocket store → AlarmBanner hidden (if no more alarms)
+```
+
+## Data Model Changes
+
+### New event types in `EngineEvent` union (types.ts)
+
+```typescript
+| { type: "equipment.order.failed"; equipmentId: string; orderAlias: string; value: unknown; error: string }
+| { type: "system.alarm.raised"; alarmId: string; level: "warning" | "error"; source: string; message: string }
+| { type: "system.alarm.resolved"; alarmId: string; source: string; message: string }
+```
+
+### No new SQLite tables
+
+Alarm state is in-memory only (`failedIntegrations: Set<string>` in EquipmentManager). Alarms are transient — they exist only while the error persists.
+
+## Backend Changes
+
+### `src/equipments/equipment-manager.ts` — Core change
+
+- `executeOrder()` signature: `async executeOrder(...): Promise<{ success: boolean; error?: string }>`
+- Added `private failedIntegrations = new Set<string>()` for tracking which integrations are in error state
+- Retry loop: 2 attempts, 2s delay between
+- On dispatched success: check if integration was in `failedIntegrations` → emit `system.alarm.resolved`
+- On all attempts failed: check if integration NOT in `failedIntegrations` → emit `system.alarm.raised`
+- Alarm ID format: `order-fail:{integrationId}` (stable per integration, prevents duplicate alarms)
+- `executeZoneOrder()` also made async
+
+### `src/integrations/mcz-maestro/mcz-bridge.ts` — Socket health check
+
+Added `!this.socket.connected` to guards in `sendCommand()` and `getStatus()`. Detects race condition where bridge's `this.connected` flag is still true but the underlying Socket.IO connection has dropped.
+
+### `src/notifications/notification-publish-service.ts` — Telegram on alarm
+
+Added two cases in `subscribeToEvents` switch:
+
+- `system.alarm.raised` → `sendSystemAlarm("Warning: {source} : {message}")`
+- `system.alarm.resolved` → `sendSystemAlarm("OK: {source} : {message}")`
+
+`sendSystemAlarm()` finds the first enabled Telegram publisher and sends the message. No publisher configured = silently skipped.
+
+### Caller updates
+
+All callers adapted to the async return type:
+
+| File                                   | Pattern                                                   |
+| -------------------------------------- | --------------------------------------------------------- |
+| `src/recipes/presence-thermostat.ts`   | `.then(r => { if (!r.success) log error })`               |
+| `src/recipes/presence-heater.ts`       | Same pattern                                              |
+| `src/recipes/engine/light-helpers.ts`  | `.catch(() => {})` (fire-and-forget OK for Zigbee lights) |
+| `src/modes/mode-manager.ts`            | `.then(r => { if (!r.success) log warn }).catch(...)`     |
+| `src/buttons/button-action-manager.ts` | `.catch(err => log error)`                                |
+| `src/api/routes/equipments.ts`         | `await` + return HTTP 502 on failure                      |
+| `src/api/routes/zones.ts`              | `await` on `executeZoneOrder`                             |
+
+## Frontend Changes
+
+### WebSocket broadcast
+
+No changes needed — `system.alarm.raised` / `system.alarm.resolved` have the `system` prefix, so `getEventTopic()` already routes them to the `"system"` topic which is always subscribed.
+
+### `ui/src/store/useWebSocket.ts`
+
+- New interface: `SystemAlarm { alarmId, level, source, message }`
+- New state: `alarms: Map<string, SystemAlarm>`
+- `system.alarm.raised` → add to map
+- `system.alarm.resolved` → delete from map
+- Cleared on disconnect
+
+### `ui/src/components/layout/AlarmBanner.tsx`
+
+New component, similar to `OfflineBanner.tsx`:
+
+- Subscribes to `useWebSocket` → `alarms`
+- If `alarms.size > 0`: red banner with AlertTriangle icon + message
+- Single alarm: shows `{source} : {message}`
+- Multiple alarms: shows `"{count} alarmes actives"`
+- Placed in `AppLayout.tsx` right after `OfflineBanner`
+
+### `ui/src/types.ts`
+
+Added the 3 new event types to the `EngineEvent` union (mirrors backend types.ts).
+
+## File Changes
+
+| File                                                | Change                                         |
+| --------------------------------------------------- | ---------------------------------------------- |
+| `src/shared/types.ts`                               | Add 3 new event types to EngineEvent           |
+| `src/equipments/equipment-manager.ts`               | Async executeOrder with retry + alarm emission |
+| `src/equipments/equipment-manager.test.ts`          | Update tests for async signature               |
+| `src/integrations/mcz-maestro/mcz-bridge.ts`        | Add socket.connected check                     |
+| `src/notifications/notification-publish-service.ts` | Handle system.alarm events → Telegram          |
+| `src/recipes/presence-thermostat.ts`                | Update 4 mode setters for async result         |
+| `src/recipes/presence-heater.ts`                    | Update 2 mode setters for async result         |
+| `src/recipes/engine/light-helpers.ts`               | Add .catch() to 3 executeOrder calls           |
+| `src/modes/mode-manager.ts`                         | Update executeAction for async result          |
+| `src/buttons/button-action-manager.ts`              | Add .catch() to executeOrder call              |
+| `src/api/routes/equipments.ts`                      | Await + HTTP 502 on failure                    |
+| `src/api/routes/zones.ts`                           | Await executeZoneOrder                         |
+| `ui/src/types.ts`                                   | Add 3 new event types                          |
+| `ui/src/store/useWebSocket.ts`                      | Add SystemAlarm interface + alarms Map         |
+| `ui/src/components/layout/AlarmBanner.tsx`          | New: persistent alarm banner                   |
+| `ui/src/components/layout/AppLayout.tsx`            | Add AlarmBanner after OfflineBanner            |

--- a/specs/036-order-dispatch-error-handling/plan.md
+++ b/specs/036-order-dispatch-error-handling/plan.md
@@ -1,0 +1,47 @@
+# Implementation Plan: Order Dispatch Error Handling & System Alarms
+
+## Iteration 1: Backend — async executeOrder + retry
+
+1. [x] Add `equipment.order.failed`, `system.alarm.raised`, `system.alarm.resolved` event types to `src/shared/types.ts`
+2. [x] Make `executeOrder` async with retry (2 attempts, 2s delay) in `equipment-manager.ts`
+3. [x] Add `failedIntegrations` Set and alarm emission logic (raise on first failure, resolve on recovery)
+4. [x] Return `{ success: boolean; error?: string }` from `executeOrder`
+5. [x] MCZ bridge: add `!this.socket.connected` check in `sendCommand()` and `getStatus()`
+
+## Iteration 2: Backend — update all callers
+
+6. [x] `presence-thermostat.ts`: update 4 mode setters (setComfort, setEco, setCocoon, setNight)
+7. [x] `presence-heater.ts`: update setComfort and setEco
+8. [x] `light-helpers.ts`: add `.catch(() => {})` to all executeOrder calls
+9. [x] `mode-manager.ts`: update executeAction with `.then()/.catch()`
+10. [x] `button-action-manager.ts`: add `.catch()` to executeOrder call
+11. [x] `api/routes/equipments.ts`: `await` + return HTTP 502 on failure
+12. [x] `api/routes/zones.ts`: `await` executeZoneOrder
+
+## Iteration 3: Telegram notifications
+
+13. [x] `notification-publish-service.ts`: handle `system.alarm.raised` → send Telegram
+14. [x] `notification-publish-service.ts`: handle `system.alarm.resolved` → send Telegram
+
+## Iteration 4: UI alarm banner
+
+15. [x] Add event types to `ui/src/types.ts`
+16. [x] Add `SystemAlarm` interface + `alarms: Map` state to `useWebSocket.ts`
+17. [x] Handle `system.alarm.raised` / `system.alarm.resolved` in event handler
+18. [x] Create `AlarmBanner.tsx` component
+19. [x] Integrate `AlarmBanner` in `AppLayout.tsx` after `OfflineBanner`
+
+## Iteration 5: Tests
+
+20. [x] Update `equipment-manager.test.ts` for async executeOrder (await + rejects.toThrow)
+21. [x] `npx tsc --noEmit` — zero errors (backend)
+22. [x] `cd ui && npx tsc --noEmit` — zero errors (frontend)
+23. [x] `npm test` — 454 tests pass
+
+## Testing
+
+- `npx tsc --noEmit` (zero errors)
+- `cd ui && npx tsc --noEmit` (zero errors)
+- `npm test` (454 tests pass)
+- Manual: disconnect MCZ bridge, send order from UI → banner appears, Telegram notification received
+- Manual: reconnect → banner disappears, Telegram "resolved" notification received

--- a/specs/036-order-dispatch-error-handling/spec.md
+++ b/specs/036-order-dispatch-error-handling/spec.md
@@ -1,0 +1,54 @@
+# Order Dispatch Error Handling & System Alarms
+
+## Summary
+
+When a cloud integration (MCZ Maestro, Panasonic CC, etc.) is temporarily unavailable, equipment orders sent by recipes, modes, or the UI were silently swallowed. The recipe logged success even though the command never reached the device. This feature makes `executeOrder` async with retry, introduces a system alarm mechanism (event bus + WebSocket + UI banner), and sends Telegram notifications on first failure and recovery.
+
+## Reference
+
+- Incident: 2026-03-13 — presence-thermostat recipe sent `setpoint → 20°C` at 6h for preheat, but MCZ bridge was disconnected. Command failed silently, recipe logged success.
+- Root cause: `equipment-manager.ts` called `integration.executeOrder()` as fire-and-forget (`.catch()` that only logged). The "Equipment order executed" log and event bus emission happened immediately without awaiting the async result.
+
+## Acceptance Criteria
+
+- [x] `executeOrder` is async and returns `{ success: boolean; error?: string }`
+- [x] Failed dispatch is retried once after 2 seconds before giving up
+- [x] On first failure per integration: `system.alarm.raised` event emitted with stable `alarmId`
+- [x] On recovery (first success after failure): `system.alarm.resolved` event emitted
+- [x] Telegram notification sent on alarm raised and resolved (via first enabled Telegram publisher)
+- [x] UI shows a persistent red/amber banner while any system alarm is active
+- [x] Banner disappears automatically when all alarms are resolved
+- [x] API returns HTTP 502 when an equipment order fails
+- [x] All existing callers (recipes, modes, buttons, light-helpers) handle the async result
+- [x] MCZ bridge detects socket disconnection via `socket.connected` check
+- [x] All tests pass with the new async signature
+
+## Scope
+
+### In Scope
+
+- Generic mechanism: works for any integration, not MCZ-specific
+- Retry: 1 retry with 2s delay per order binding dispatch
+- System alarm events on event bus (`system.alarm.raised`, `system.alarm.resolved`)
+- Telegram notification on first failure + recovery
+- Persistent UI alarm banner (similar to OfflineBanner)
+- WebSocket broadcast of alarm events to all connected clients
+- MCZ bridge socket health check improvement
+
+### Out of Scope
+
+- Order queue / retry queue with persistence (deferred)
+- Per-order retry policy configuration (deferred)
+- Alarm history / audit log (deferred)
+- Alarm acknowledgment UI (deferred)
+- Quiet hours for alarm notifications (deferred)
+- Multi-channel alarm notifications (only Telegram for now)
+- Alarm severity escalation (deferred)
+
+## Edge Cases
+
+- Multiple order bindings on one equipment: each binding is retried independently. If at least one succeeds, the order is considered successful.
+- Integration comes back during retry: second attempt succeeds, alarm resolved.
+- Multiple equipments fail on same integration: only one alarm raised per integration (stable `alarmId: order-fail:{integrationId}`).
+- No Telegram publisher configured: alarm events still emitted (UI banner works), but no Telegram message sent.
+- Recipe sends order while integration is down: recipe logs the failure via `.then()` callback instead of showing false success.

--- a/src/api/routes/equipments.ts
+++ b/src/api/routes/equipments.ts
@@ -141,7 +141,14 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
     const { value } = request.body ?? {};
 
     try {
-      equipmentManager.executeOrder(request.params.id, request.params.alias, value);
+      const result = await equipmentManager.executeOrder(
+        request.params.id,
+        request.params.alias,
+        value,
+      );
+      if (!result.success) {
+        return reply.code(502).send({ error: result.error });
+      }
       return { success: true };
     } catch (err) {
       return handleEquipmentError(reply, err);

--- a/src/api/routes/zones.ts
+++ b/src/api/routes/zones.ts
@@ -148,7 +148,7 @@ export function registerZoneRoutes(app: FastifyInstance, deps: ZonesDeps): void 
 
       try {
         const zoneIds = zoneManager.getDescendantIds(id);
-        const result = equipmentManager.executeZoneOrder(zoneIds, orderKey, body.value);
+        const result = await equipmentManager.executeZoneOrder(zoneIds, orderKey, body.value);
         return result;
       } catch (err) {
         return handleZoneError(err, reply);

--- a/src/buttons/button-action-manager.ts
+++ b/src/buttons/button-action-manager.ts
@@ -190,7 +190,14 @@ export class ButtonActionManager {
         const targetEquipmentId = config.equipmentId as string;
         const orderAlias = config.orderAlias as string;
         const orderValue = config.value;
-        this.equipmentManager.executeOrder(targetEquipmentId, orderAlias, orderValue);
+        this.equipmentManager
+          .executeOrder(targetEquipmentId, orderAlias, orderValue)
+          .catch((err) => {
+            this.logger.error(
+              { err, targetEquipmentId, orderAlias },
+              "Button order dispatch failed",
+            );
+          });
         break;
       }
 

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -438,7 +438,7 @@ describe("EquipmentManager", () => {
   // ============================================================
 
   describe("executeOrder", () => {
-    it("publishes MQTT message to bound device", () => {
+    it("publishes MQTT message to bound device", async () => {
       const zone = zoneManager.create({ name: "Salon" });
       const eq = manager.create({ name: "Spots", type: "light_onoff", zoneId: zone.id });
       const { orderIds } = seedDevice(db, {
@@ -448,7 +448,7 @@ describe("EquipmentManager", () => {
       manager.addOrderBinding(eq.id, orderIds[0], "state");
 
       events = [];
-      manager.executeOrder(eq.id, "state", "ON");
+      await manager.executeOrder(eq.id, "state", "ON");
 
       expect(mockPublished).toHaveLength(1);
       expect(mockPublished[0].topic).toBe("z2m/Switch/set");
@@ -458,7 +458,7 @@ describe("EquipmentManager", () => {
       expect(execEvents).toHaveLength(1);
     });
 
-    it("dispatches to multiple devices (multi-device)", () => {
+    it("dispatches to multiple devices (multi-device)", async () => {
       const zone = zoneManager.create({ name: "Salon" });
       const eq = manager.create({ name: "All Lights", type: "light_onoff", zoneId: zone.id });
       const d1 = seedDevice(db, { name: "L1", orderKeys: [{ key: "state", payloadKey: "state" }] });
@@ -466,38 +466,34 @@ describe("EquipmentManager", () => {
       manager.addOrderBinding(eq.id, d1.orderIds[0], "state");
       manager.addOrderBinding(eq.id, d2.orderIds[0], "state");
 
-      manager.executeOrder(eq.id, "state", "ON");
+      await manager.executeOrder(eq.id, "state", "ON");
 
       expect(mockPublished).toHaveLength(2);
       expect(mockPublished.map((p) => p.topic).sort()).toEqual(["z2m/L1/set", "z2m/L2/set"]);
     });
 
-    it("throws for non-existent equipment", () => {
-      expect(() => {
-        manager.executeOrder("non-existent", "state", "ON");
-      }).toThrow(EquipmentError);
+    it("throws for non-existent equipment", async () => {
+      await expect(manager.executeOrder("non-existent", "state", "ON")).rejects.toThrow(
+        EquipmentError,
+      );
     });
 
-    it("throws for disabled equipment", () => {
+    it("throws for disabled equipment", async () => {
       const zone = zoneManager.create({ name: "Salon" });
       const eq = manager.create({ name: "Spots", type: "light_onoff", zoneId: zone.id });
       manager.update(eq.id, { enabled: false });
 
-      expect(() => {
-        manager.executeOrder(eq.id, "state", "ON");
-      }).toThrow(/disabled/i);
+      await expect(manager.executeOrder(eq.id, "state", "ON")).rejects.toThrow(/disabled/i);
     });
 
-    it("throws for non-existent alias", () => {
+    it("throws for non-existent alias", async () => {
       const zone = zoneManager.create({ name: "Salon" });
       const eq = manager.create({ name: "Spots", type: "light_onoff", zoneId: zone.id });
 
-      expect(() => {
-        manager.executeOrder(eq.id, "non-existent", "ON");
-      }).toThrow(/not found/i);
+      await expect(manager.executeOrder(eq.id, "non-existent", "ON")).rejects.toThrow(/not found/i);
     });
 
-    it("throws when integration not found", () => {
+    it("throws when integration not found", async () => {
       // Create a manager with a registry that returns undefined (no integration)
       const emptyRegistry = { getById: () => undefined };
       const noIntegrationManager = new EquipmentManager(
@@ -516,9 +512,9 @@ describe("EquipmentManager", () => {
       const { orderIds } = seedDevice(db, { orderKeys: [{ key: "state" }] });
       noIntegrationManager.addOrderBinding(eq.id, orderIds[0], "state");
 
-      expect(() => {
-        noIntegrationManager.executeOrder(eq.id, "state", "ON");
-      }).toThrow(/integration/i);
+      await expect(noIntegrationManager.executeOrder(eq.id, "state", "ON")).rejects.toThrow(
+        /integration/i,
+      );
     });
   });
 

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -72,6 +72,9 @@ export class EquipmentManager {
   /** Gate equipments with a pending command — state is "unknown" until next sensor update */
   private pendingToggles = new Set<string>();
 
+  /** Tracks integrations with recent order failures — for alarm raise/resolve. */
+  private failedIntegrations = new Set<string>();
+
   constructor(
     db: Database.Database,
     eventBus: EventBus,
@@ -455,7 +458,11 @@ export class EquipmentManager {
   // Order execution
   // ============================================================
 
-  executeOrder(equipmentId: string, alias: string, value: unknown): void {
+  async executeOrder(
+    equipmentId: string,
+    alias: string,
+    value: unknown,
+  ): Promise<{ success: boolean; error?: string }> {
     const equipment = this.getById(equipmentId);
     if (!equipment) {
       throw new EquipmentError("Equipment not found", 404);
@@ -490,6 +497,9 @@ export class EquipmentManager {
     }
 
     // Dispatch to all bound device orders via their integration plugins
+    let successes = 0;
+    let lastError: string | undefined;
+
     for (const binding of bindings) {
       const device = this.deviceManager.getById(binding.device_id);
       if (!device) {
@@ -515,52 +525,104 @@ export class EquipmentManager {
         }
       }
 
-      integration.executeOrder(device, dispatchConfig, resolvedValue).catch((err) => {
+      // Dispatch with 1 retry (2s delay) for transient failures
+      let dispatched = false;
+      for (let attempt = 1; attempt <= 2; attempt++) {
+        try {
+          await integration.executeOrder(device, dispatchConfig, resolvedValue);
+          dispatched = true;
+          break;
+        } catch (err) {
+          lastError = err instanceof Error ? err.message : String(err);
+          if (attempt < 2) {
+            this.logger.warn(
+              { err, equipmentId, alias, deviceId: device.id, attempt },
+              "Order dispatch failed, retrying in 2s",
+            );
+            await new Promise((r) => setTimeout(r, 2000));
+          }
+        }
+      }
+
+      if (dispatched) {
+        successes++;
+        this.logger.debug(
+          {
+            equipmentId,
+            equipmentName: equipment.name,
+            alias,
+            integrationId: device.integrationId,
+            deviceId: device.id,
+            deviceName: device.name,
+          },
+          "Order dispatched to integration",
+        );
+
+        // Resolve alarm if this integration was previously failing
+        if (this.failedIntegrations.delete(device.integrationId)) {
+          this.eventBus.emit({
+            type: "system.alarm.resolved",
+            alarmId: `order-fail:${device.integrationId}`,
+            source: device.integrationId,
+            message: `${device.integrationId} order dispatch recovered`,
+          });
+        }
+      } else {
         this.logger.error(
           {
-            err,
             equipmentId,
             equipmentName: equipment.name,
             alias,
             deviceId: device.id,
             deviceName: device.name,
+            error: lastError,
           },
-          "Integration order dispatch failed",
+          "Integration order dispatch failed after retry",
         );
-      });
 
-      this.logger.debug(
+        // Raise alarm on first failure for this integration
+        if (!this.failedIntegrations.has(device.integrationId)) {
+          this.failedIntegrations.add(device.integrationId);
+          this.eventBus.emit({
+            type: "system.alarm.raised",
+            alarmId: `order-fail:${device.integrationId}`,
+            level: "error",
+            source: device.integrationId,
+            message: `Order dispatch failed: ${equipment.name} ${alias} — ${lastError}`,
+          });
+        }
+      }
+    }
+
+    if (successes > 0) {
+      this.logger.info(
         {
           equipmentId,
           equipmentName: equipment.name,
           alias,
-          integrationId: device.integrationId,
-          deviceId: device.id,
-          deviceName: device.name,
+          value: resolvedValue,
+          targets: bindings.length,
         },
-        "Order dispatched to integration",
+        "Equipment order executed",
       );
+      this.eventBus.emit({
+        type: "equipment.order.executed",
+        equipmentId,
+        orderAlias: alias,
+        value: resolvedValue,
+      });
+    } else if (lastError) {
+      this.eventBus.emit({
+        type: "equipment.order.failed",
+        equipmentId,
+        orderAlias: alias,
+        value: resolvedValue,
+        error: lastError,
+      });
     }
 
-    this.logger.info(
-      {
-        equipmentId,
-        equipmentName: equipment.name,
-        alias,
-        value: resolvedValue,
-        targets: bindings.length,
-      },
-      "Equipment order executed",
-    );
-    this.eventBus.emit({
-      type: "equipment.order.executed",
-      equipmentId,
-      orderAlias: alias,
-      value: resolvedValue,
-    });
-
     // Gate command: mark state as "unknown" until next sensor update
-    if (equipment.type === "gate" && alias === "command") {
+    if (successes > 0 && equipment.type === "gate" && alias === "command") {
       this.pendingToggles.add(equipmentId);
       this.eventBus.emit({
         type: "equipment.data.changed",
@@ -574,6 +636,11 @@ export class EquipmentManager {
         "Gate command — state set to unknown",
       );
     }
+
+    if (successes === 0 && lastError) {
+      return { success: false, error: lastError };
+    }
+    return { success: true };
   }
 
   // ============================================================
@@ -615,11 +682,11 @@ export class EquipmentManager {
    * For parametric orders (value === "FROM_BODY"), the bodyValue parameter is used.
    * Returns a summary of executed and errored orders.
    */
-  executeZoneOrder(
+  async executeZoneOrder(
     zoneIds: string[],
     orderKey: string,
     bodyValue?: unknown,
-  ): { executed: number; errors: number } {
+  ): Promise<{ executed: number; errors: number }> {
     const mapping = EquipmentManager.ZONE_ORDERS[orderKey];
     if (!mapping) {
       throw new EquipmentError(`Invalid zone order key: ${orderKey}`, 400);
@@ -643,8 +710,16 @@ export class EquipmentManager {
         if (!mapping.types.includes(eq.type)) continue;
 
         try {
-          this.executeOrder(eq.id, mapping.alias, resolvedValue);
-          executed++;
+          const result = await this.executeOrder(eq.id, mapping.alias, resolvedValue);
+          if (result.success) {
+            executed++;
+          } else {
+            errors++;
+            this.logger.warn(
+              { equipmentId: eq.id, equipmentName: eq.name, orderKey, error: result.error },
+              "Zone order dispatch failed for equipment",
+            );
+          }
         } catch (err) {
           errors++;
           this.logger.warn(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { resolve } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { loadConfig } from "./config.js";
 import { createLogger } from "./core/logger.js";
 import { LogRingBuffer } from "./core/log-buffer.js";
@@ -37,7 +38,55 @@ import { NotificationPublisherManager } from "./notifications/notification-publi
 import { NotificationPublishService } from "./notifications/notification-publish-service.js";
 import { createServer } from "./api/server.js";
 
+/**
+ * Ensure only one Sowel instance runs at a time.
+ * Writes a PID file; if it already exists with a live process, exits immediately.
+ */
+function acquirePidLock(dataDir: string): string {
+  mkdirSync(dataDir, { recursive: true });
+  const pidFile = resolve(dataDir, "sowel.pid");
+
+  if (existsSync(pidFile)) {
+    const existingPid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+    if (!isNaN(existingPid)) {
+      try {
+        // signal 0 = check if process exists without killing it
+        process.kill(existingPid, 0);
+        // Process is alive — abort
+        console.error(
+          `Another Sowel instance is already running (PID ${existingPid}). Remove ${pidFile} if this is stale.`,
+        );
+        process.exit(1);
+      } catch {
+        // Process not found — stale PID file, overwrite it
+      }
+    }
+  }
+
+  writeFileSync(pidFile, String(process.pid), { mode: 0o644 });
+  return pidFile;
+}
+
 async function main() {
+  // 0. Ensure single instance via PID lock
+  const pidFile = acquirePidLock("./data");
+  const cleanupPid = () => {
+    try {
+      unlinkSync(pidFile);
+    } catch {
+      // Ignore — file may already be gone
+    }
+  };
+  process.on("exit", cleanupPid);
+  process.on("SIGINT", () => {
+    cleanupPid();
+    process.exit(0);
+  });
+  process.on("SIGTERM", () => {
+    cleanupPid();
+    process.exit(0);
+  });
+
   // 1. Load configuration
   const config = loadConfig();
 

--- a/src/integrations/mcz-maestro/index.ts
+++ b/src/integrations/mcz-maestro/index.ts
@@ -112,6 +112,7 @@ export class MczMaestroIntegration implements IntegrationPlugin {
       this.poller = new MczPoller(
         this.bridge,
         this.deviceManager,
+        this.eventBus,
         this.logger,
         serialNumber,
         pollingIntervalMs,

--- a/src/integrations/mcz-maestro/index.ts
+++ b/src/integrations/mcz-maestro/index.ts
@@ -44,6 +44,9 @@ export class MczMaestroIntegration implements IntegrationPlugin {
 
   getStatus(): IntegrationStatus {
     if (!this.isConfigured()) return "not_configured";
+    if (this.status === "connected" && this.poller && !this.poller.isPollHealthy()) {
+      return "error";
+    }
     return this.status;
   }
 

--- a/src/integrations/mcz-maestro/mcz-bridge.ts
+++ b/src/integrations/mcz-maestro/mcz-bridge.ts
@@ -110,7 +110,7 @@ export class MczBridge {
    * Request the full stove status via RecuperoInfo.
    */
   async getStatus(): Promise<MczStatusFrame> {
-    if (!this.socket || !this.connected) {
+    if (!this.socket || !this.connected || !this.socket.connected) {
       throw new Error("MCZ bridge not connected");
     }
 
@@ -167,7 +167,7 @@ export class MczBridge {
    * Send a control command to the stove.
    */
   async sendCommand(commandId: number, value: number): Promise<void> {
-    if (!this.socket || !this.connected) {
+    if (!this.socket || !this.connected || !this.socket.connected) {
       throw new Error("MCZ bridge not connected");
     }
 

--- a/src/integrations/mcz-maestro/mcz-poller.ts
+++ b/src/integrations/mcz-maestro/mcz-poller.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Logger } from "../../core/logger.js";
+import type { EventBus } from "../../core/event-bus.js";
 import type { DeviceManager } from "../../devices/device-manager.js";
 import type { DiscoveredDevice } from "../../devices/device-manager.js";
 import type { DataType, DataCategory } from "../../shared/types.js";
@@ -29,6 +30,7 @@ const DEFAULT_ON_DEMAND_DELAY_MS = 5_000; // 5 seconds
 export class MczPoller {
   private bridge: MczBridge;
   private deviceManager: DeviceManager;
+  private eventBus: EventBus;
   private logger: Logger;
   private serialNumber: string;
   private pollIntervalMs: number;
@@ -36,12 +38,14 @@ export class MczPoller {
   private interval: ReturnType<typeof setInterval> | null = null;
   private pendingTimers: Set<ReturnType<typeof setTimeout>> = new Set();
   private polling = false;
+  private pollFailed = false;
   private lastPollAt: string | null = null;
   private staggerTimeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     bridge: MczBridge,
     deviceManager: DeviceManager,
+    eventBus: EventBus,
     logger: Logger,
     serialNumber: string,
     pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
@@ -49,6 +53,7 @@ export class MczPoller {
   ) {
     this.bridge = bridge;
     this.deviceManager = deviceManager;
+    this.eventBus = eventBus;
     this.logger = logger.child({ module: "mcz-poller" });
     this.serialNumber = serialNumber;
     this.pollIntervalMs = pollIntervalMs;
@@ -125,8 +130,28 @@ export class MczPoller {
       this.updateDeviceData(frame);
 
       this.logger.debug({ frame }, "MCZ poll complete");
+
+      if (this.pollFailed) {
+        this.pollFailed = false;
+        this.eventBus.emit({
+          type: "system.alarm.resolved",
+          alarmId: "poll-fail:mcz_maestro",
+          source: "MCZ Maestro",
+          message: "Communication rétablie",
+        });
+      }
     } catch (err) {
       this.logger.error({ err }, "MCZ poll failed");
+      if (!this.pollFailed) {
+        this.pollFailed = true;
+        this.eventBus.emit({
+          type: "system.alarm.raised",
+          alarmId: "poll-fail:mcz_maestro",
+          level: "error",
+          source: "MCZ Maestro",
+          message: `Poll en échec : ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
     } finally {
       this.polling = false;
     }

--- a/src/integrations/mcz-maestro/mcz-poller.ts
+++ b/src/integrations/mcz-maestro/mcz-poller.ts
@@ -100,6 +100,10 @@ export class MczPoller {
     return { lastPollAt: this.lastPollAt, intervalMs: this.pollIntervalMs };
   }
 
+  isPollHealthy(): boolean {
+    return !this.pollFailed;
+  }
+
   scheduleOnDemandPoll(delayMs?: number): void {
     const delay = delayMs ?? this.onDemandDelayMs;
     this.logger.debug({ delayMs: delay }, "Scheduling on-demand MCZ poll");

--- a/src/integrations/netatmo-hc/index.ts
+++ b/src/integrations/netatmo-hc/index.ts
@@ -59,6 +59,9 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
 
   getStatus(): IntegrationStatus {
     if (!this.isConfigured()) return "not_configured";
+    if (this.status === "connected" && this.poller && !this.poller.isPollHealthy()) {
+      return "error";
+    }
     return this.status;
   }
 

--- a/src/integrations/netatmo-hc/index.ts
+++ b/src/integrations/netatmo-hc/index.ts
@@ -175,6 +175,7 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
       this.poller = new NetatmoPoller(
         this.bridge,
         this.deviceManager,
+        this.eventBus,
         homeId,
         this.logger,
         pollingIntervalMs,

--- a/src/integrations/netatmo-hc/netatmo-poller.ts
+++ b/src/integrations/netatmo-hc/netatmo-poller.ts
@@ -116,6 +116,10 @@ export class NetatmoPoller {
     return { lastPollAt: this.lastPollAt, intervalMs: this.pollIntervalMs };
   }
 
+  isPollHealthy(): boolean {
+    return !this.pollFailed;
+  }
+
   /** Rapid status polling after an order: first at 1s, then every 1s, stops on confirmation or 10s timeout. */
   scheduleOnDemandPoll(expected?: { moduleId: string; param: string; value: unknown }): void {
     this.stopRapidPoll();

--- a/src/integrations/netatmo-hc/netatmo-poller.ts
+++ b/src/integrations/netatmo-hc/netatmo-poller.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Logger } from "../../core/logger.js";
+import type { EventBus } from "../../core/event-bus.js";
 import type { DeviceManager } from "../../devices/device-manager.js";
 import type { NetatmoBridge } from "./netatmo-bridge.js";
 import {
@@ -27,6 +28,7 @@ const RAPID_POLL_DURATION_MS = 10_000; // stop after 10s
 export class NetatmoPoller {
   private bridge: NetatmoBridge;
   private deviceManager: DeviceManager;
+  private eventBus: EventBus;
   private logger: Logger;
   private homeId: string;
   private pollIntervalMs: number;
@@ -36,6 +38,7 @@ export class NetatmoPoller {
   private rapidTimeout: ReturnType<typeof setTimeout> | null = null;
   private rapidStopTimeout: ReturnType<typeof setTimeout> | null = null;
   private polling = false;
+  private pollFailed = false;
   private rapidPolling = false;
   private lastPollAt: string | null = null;
   private staggerTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -54,6 +57,7 @@ export class NetatmoPoller {
   constructor(
     bridge: NetatmoBridge,
     deviceManager: DeviceManager,
+    eventBus: EventBus,
     homeId: string,
     logger: Logger,
     pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
@@ -62,6 +66,7 @@ export class NetatmoPoller {
   ) {
     this.bridge = bridge;
     this.deviceManager = deviceManager;
+    this.eventBus = eventBus;
     this.homeId = homeId;
     this.logger = logger.child({ module: "legrand-hc-poller" });
     this.pollIntervalMs = pollIntervalMs;
@@ -234,8 +239,28 @@ export class NetatmoPoller {
         { phase1Ms: t1 - t0, phase2Ms: t2 - t1, totalMs: t2 - t0 },
         "Legrand H+C poll timing",
       );
+
+      if (this.pollFailed) {
+        this.pollFailed = false;
+        this.eventBus.emit({
+          type: "system.alarm.resolved",
+          alarmId: "poll-fail:netatmo_hc",
+          source: "Legrand Home+Control",
+          message: "Communication rétablie",
+        });
+      }
     } catch (err) {
       this.logger.error({ err }, "Legrand H+C poll cycle failed");
+      if (!this.pollFailed) {
+        this.pollFailed = true;
+        this.eventBus.emit({
+          type: "system.alarm.raised",
+          alarmId: "poll-fail:netatmo_hc",
+          level: "error",
+          source: "Legrand Home+Control",
+          message: `Poll en échec : ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
     } finally {
       this.polling = false;
     }

--- a/src/integrations/panasonic-cc/index.ts
+++ b/src/integrations/panasonic-cc/index.ts
@@ -41,6 +41,9 @@ export class PanasonicCCIntegration implements IntegrationPlugin {
 
   getStatus(): IntegrationStatus {
     if (!this.isConfigured()) return "not_configured";
+    if (this.status === "connected" && this.poller && !this.poller.isPollHealthy()) {
+      return "error";
+    }
     return this.status;
   }
 

--- a/src/integrations/panasonic-cc/index.ts
+++ b/src/integrations/panasonic-cc/index.ts
@@ -104,6 +104,7 @@ export class PanasonicCCIntegration implements IntegrationPlugin {
       this.poller = new PanasonicPoller(
         this.bridge,
         this.deviceManager,
+        this.eventBus,
         this.logger,
         email,
         password,

--- a/src/integrations/panasonic-cc/panasonic-poller.ts
+++ b/src/integrations/panasonic-cc/panasonic-poller.ts
@@ -94,6 +94,10 @@ export class PanasonicPoller {
     return { lastPollAt: this.lastPollAt, intervalMs: this.pollIntervalMs };
   }
 
+  isPollHealthy(): boolean {
+    return !this.pollFailed;
+  }
+
   scheduleOnDemandPoll(delayMs?: number): void {
     const delay = delayMs ?? this.onDemandDelayMs;
     this.logger.debug({ delayMs: delay }, "Scheduling on-demand poll");

--- a/src/integrations/panasonic-cc/panasonic-poller.ts
+++ b/src/integrations/panasonic-cc/panasonic-poller.ts
@@ -1,4 +1,5 @@
 import type { Logger } from "../../core/logger.js";
+import type { EventBus } from "../../core/event-bus.js";
 import type { DeviceManager } from "../../devices/device-manager.js";
 import type { PanasonicBridge } from "./panasonic-bridge.js";
 import type { BridgeDevice } from "./panasonic-types.js";
@@ -19,6 +20,7 @@ const DEFAULT_ON_DEMAND_DELAY_MS = 10_000; // 10 seconds
 export class PanasonicPoller {
   private bridge: PanasonicBridge;
   private deviceManager: DeviceManager;
+  private eventBus: EventBus;
   private logger: Logger;
   private email: string;
   private password: string;
@@ -27,12 +29,14 @@ export class PanasonicPoller {
   private interval: ReturnType<typeof setInterval> | null = null;
   private pendingTimers: Set<ReturnType<typeof setTimeout>> = new Set();
   private polling = false;
+  private pollFailed = false;
   private lastPollAt: string | null = null;
   private staggerTimeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     bridge: PanasonicBridge,
     deviceManager: DeviceManager,
+    eventBus: EventBus,
     logger: Logger,
     email: string,
     password: string,
@@ -41,6 +45,7 @@ export class PanasonicPoller {
   ) {
     this.bridge = bridge;
     this.deviceManager = deviceManager;
+    this.eventBus = eventBus;
     this.logger = logger.child({ module: "panasonic-poller" });
     this.email = email;
     this.password = password;
@@ -120,8 +125,28 @@ export class PanasonicPoller {
       }
 
       this.logger.debug({ deviceCount: response.devices.length }, "Panasonic poll complete");
+
+      if (this.pollFailed) {
+        this.pollFailed = false;
+        this.eventBus.emit({
+          type: "system.alarm.resolved",
+          alarmId: "poll-fail:panasonic_cc",
+          source: "Panasonic Comfort Cloud",
+          message: "Communication rétablie",
+        });
+      }
     } catch (err) {
       this.logger.error({ err }, "Panasonic poll failed");
+      if (!this.pollFailed) {
+        this.pollFailed = true;
+        this.eventBus.emit({
+          type: "system.alarm.raised",
+          alarmId: "poll-fail:panasonic_cc",
+          level: "error",
+          source: "Panasonic Comfort Cloud",
+          message: `Poll en échec : ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
     } finally {
       this.polling = false;
     }

--- a/src/modes/mode-manager.ts
+++ b/src/modes/mode-manager.ts
@@ -204,7 +204,27 @@ export class ModeManager {
     switch (action.type) {
       case "order": {
         const eq = this.equipmentManager.getById(action.equipmentId);
-        this.equipmentManager.executeOrder(action.equipmentId, action.orderAlias, action.value);
+        this.equipmentManager
+          .executeOrder(action.equipmentId, action.orderAlias, action.value)
+          .then((result) => {
+            if (!result.success) {
+              this.logger.warn(
+                {
+                  equipmentId: action.equipmentId,
+                  alias: action.orderAlias,
+                  error: result.error,
+                  modeName,
+                },
+                "Mode order dispatch failed",
+              );
+            }
+          })
+          .catch((err) => {
+            this.logger.warn(
+              { err, equipmentId: action.equipmentId, modeName },
+              "Mode order failed",
+            );
+          });
         this.logger.debug(
           {
             equipmentId: action.equipmentId,
@@ -213,7 +233,7 @@ export class ModeManager {
             value: action.value,
             modeName,
           },
-          "Mode order executed",
+          "Mode order dispatched",
         );
         break;
       }

--- a/src/notifications/notification-publish-service.ts
+++ b/src/notifications/notification-publish-service.ts
@@ -128,6 +128,14 @@ export class NotificationPublishService {
           case "notification-publisher.mapping.removed":
             this.rebuildIndex();
             break;
+
+          case "system.alarm.raised":
+            this.sendSystemAlarm(`⚠️ ${event.source} : ${event.message}`);
+            break;
+
+          case "system.alarm.resolved":
+            this.sendSystemAlarm(`✅ ${event.source} : ${event.message}`);
+            break;
         }
       } catch (err) {
         this.logger.error({ err }, "Error in notification publish service event handler");
@@ -240,6 +248,22 @@ export class NotificationPublishService {
         { err, publisherId: ref.publisherId, channelType: ref.channelType },
         "Notification send failed",
       );
+    });
+  }
+
+  // ── System alarm notifications ──────────────────────────────
+
+  private sendSystemAlarm(text: string): void {
+    // Send to the first enabled Telegram publisher found
+    const publishers = this.publisherManager.getAllWithMappings();
+    const telegramPub = publishers.find((p) => p.channelType === "telegram" && p.enabled);
+    if (!telegramPub) return;
+
+    const channel = this.channels.telegram;
+    if (!channel) return;
+
+    channel.send(telegramPub.channelConfig, text).catch((err) => {
+      this.logger.error({ err }, "System alarm notification send failed");
     });
   }
 

--- a/src/recipes/engine/light-helpers.ts
+++ b/src/recipes/engine/light-helpers.ts
@@ -40,7 +40,9 @@ export function turnOnLights(lightIds: string[], ctx: RecipeContext): string[] {
   const errors: string[] = [];
   for (const lightId of lightIds) {
     try {
-      ctx.equipmentManager.executeOrder(lightId, "state", resolveEnumValue(lightId, ctx, "on"));
+      ctx.equipmentManager
+        .executeOrder(lightId, "state", resolveEnumValue(lightId, ctx, "on"))
+        .catch(() => {});
     } catch (err) {
       errors.push(`${lightId}: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -56,7 +58,9 @@ export function turnOffLights(lightIds: string[], ctx: RecipeContext): string[] 
   const errors: string[] = [];
   for (const lightId of lightIds) {
     try {
-      ctx.equipmentManager.executeOrder(lightId, "state", resolveEnumValue(lightId, ctx, "off"));
+      ctx.equipmentManager
+        .executeOrder(lightId, "state", resolveEnumValue(lightId, ctx, "off"))
+        .catch(() => {});
     } catch (err) {
       errors.push(`${lightId}: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -81,7 +85,7 @@ export function setLightsBrightness(
     const hasBrightnessOrder = equipment.orderBindings.some((ob) => ob.alias === "brightness");
     if (!hasBrightnessOrder) continue;
     try {
-      ctx.equipmentManager.executeOrder(lightId, "brightness", brightness);
+      ctx.equipmentManager.executeOrder(lightId, "brightness", brightness).catch(() => {});
     } catch (err) {
       errors.push(`${lightId}: ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/src/recipes/presence-heater.ts
+++ b/src/recipes/presence-heater.ts
@@ -398,15 +398,12 @@ export class PresenceHeaterRecipe extends Recipe {
     this.stateGraceUntil = Date.now() + 5000;
     const comfortValue = "off" as const;
     for (const heaterId of this.heaterIds) {
-      try {
-        this.ctx.equipmentManager.executeOrder(
-          heaterId,
-          "state",
-          this.resolveEnumValue(heaterId, comfortValue),
-        );
-      } catch (err) {
-        this.ctx.log(`Error setting heater to comfort: ${String(err)}`, "error");
-      }
+      this.ctx.equipmentManager
+        .executeOrder(heaterId, "state", this.resolveEnumValue(heaterId, comfortValue))
+        .then((r) => {
+          if (!r.success) this.ctx.log(`Heater ${heaterId} comfort FAILED: ${r.error}`, "error");
+        })
+        .catch((err) => this.ctx.log(`Error setting heater to comfort: ${String(err)}`, "error"));
     }
     this.ctx.notifyStateChanged();
     this.ctx.log(`${reason} — heaters set to comfort`);
@@ -421,15 +418,12 @@ export class PresenceHeaterRecipe extends Recipe {
     this.stateGraceUntil = Date.now() + 5000;
     const ecoValue = "on" as const;
     for (const heaterId of this.heaterIds) {
-      try {
-        this.ctx.equipmentManager.executeOrder(
-          heaterId,
-          "state",
-          this.resolveEnumValue(heaterId, ecoValue),
-        );
-      } catch (err) {
-        this.ctx.log(`Error setting heater to eco: ${String(err)}`, "error");
-      }
+      this.ctx.equipmentManager
+        .executeOrder(heaterId, "state", this.resolveEnumValue(heaterId, ecoValue))
+        .then((r) => {
+          if (!r.success) this.ctx.log(`Heater ${heaterId} eco FAILED: ${r.error}`, "error");
+        })
+        .catch((err) => this.ctx.log(`Error setting heater to eco: ${String(err)}`, "error"));
     }
     this.clearOverrideMode();
     this.cancelFailsafeTimer();

--- a/src/recipes/presence-thermostat.ts
+++ b/src/recipes/presence-thermostat.ts
@@ -750,11 +750,12 @@ export class PresenceThermostatRecipe extends Recipe {
     this.ctx.state.set("currentMode", "comfort");
     this.setpointGraceUntil = Date.now() + 5000;
     this.lastSentSetpoint = target;
-    try {
-      this.ctx.equipmentManager.executeOrder(this.thermostatId, "setpoint", target);
-    } catch (err) {
-      this.ctx.log(`Error setting comfort setpoint: ${String(err)}`, "error");
-    }
+    this.ctx.equipmentManager
+      .executeOrder(this.thermostatId, "setpoint", target)
+      .then((r) => {
+        if (!r.success) this.ctx.log(`Setpoint → ${target}°C FAILED: ${r.error}`, "error");
+      })
+      .catch((err) => this.ctx.log(`Error setting comfort setpoint: ${String(err)}`, "error"));
     this.clearCocoonState();
     this.ctx.notifyStateChanged();
     this.ctx.log(`${reason} — setpoint → ${target}°C (comfort)`);
@@ -766,11 +767,12 @@ export class PresenceThermostatRecipe extends Recipe {
     this.ctx.state.set("currentMode", "eco");
     this.setpointGraceUntil = Date.now() + 5000;
     this.lastSentSetpoint = this.ecoTemp;
-    try {
-      this.ctx.equipmentManager.executeOrder(this.thermostatId, "setpoint", this.ecoTemp);
-    } catch (err) {
-      this.ctx.log(`Error setting eco setpoint: ${String(err)}`, "error");
-    }
+    this.ctx.equipmentManager
+      .executeOrder(this.thermostatId, "setpoint", this.ecoTemp)
+      .then((r) => {
+        if (!r.success) this.ctx.log(`Setpoint → ${this.ecoTemp}°C FAILED: ${r.error}`, "error");
+      })
+      .catch((err) => this.ctx.log(`Error setting eco setpoint: ${String(err)}`, "error"));
     this.clearCocoonState();
     this.clearOverrideMode();
     this.ctx.notifyStateChanged();
@@ -787,11 +789,12 @@ export class PresenceThermostatRecipe extends Recipe {
     this.clearTimerState();
     this.setpointGraceUntil = Date.now() + 5000;
     this.lastSentSetpoint = this.cocoonTemp!;
-    try {
-      this.ctx.equipmentManager.executeOrder(this.thermostatId, "setpoint", this.cocoonTemp!);
-    } catch (err) {
-      this.ctx.log(`Error setting cocoon setpoint: ${String(err)}`, "error");
-    }
+    this.ctx.equipmentManager
+      .executeOrder(this.thermostatId, "setpoint", this.cocoonTemp!)
+      .then((r) => {
+        if (!r.success) this.ctx.log(`Setpoint → ${this.cocoonTemp}°C FAILED: ${r.error}`, "error");
+      })
+      .catch((err) => this.ctx.log(`Error setting cocoon setpoint: ${String(err)}`, "error"));
     this.ctx.notifyStateChanged();
     this.ctx.log(`${reason} — setpoint → ${this.cocoonTemp}°C (cocoon)`);
   }
@@ -804,11 +807,12 @@ export class PresenceThermostatRecipe extends Recipe {
     this.clearTimerState();
     this.setpointGraceUntil = Date.now() + 5000;
     this.lastSentSetpoint = this.nightTemp!;
-    try {
-      this.ctx.equipmentManager.executeOrder(this.thermostatId, "setpoint", this.nightTemp!);
-    } catch (err) {
-      this.ctx.log(`Error setting night setpoint: ${String(err)}`, "error");
-    }
+    this.ctx.equipmentManager
+      .executeOrder(this.thermostatId, "setpoint", this.nightTemp!)
+      .then((r) => {
+        if (!r.success) this.ctx.log(`Setpoint → ${this.nightTemp}°C FAILED: ${r.error}`, "error");
+      })
+      .catch((err) => this.ctx.log(`Error setting night setpoint: ${String(err)}`, "error"));
     this.clearCocoonState();
     this.ctx.notifyStateChanged();
     this.ctx.log(`${reason} — setpoint → ${this.nightTemp}°C (night)`);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -494,6 +494,13 @@ export type EngineEvent =
       orderAlias: string;
       value: unknown;
     }
+  | {
+      type: "equipment.order.failed";
+      equipmentId: string;
+      orderAlias: string;
+      value: unknown;
+      error: string;
+    }
   // Recipe events
   | { type: "recipe.instance.created"; instanceId: string; recipeId: string }
   | { type: "recipe.instance.removed"; instanceId: string; recipeId: string }
@@ -537,7 +544,15 @@ export type EngineEvent =
   | { type: "system.started" }
   | { type: "system.integration.connected"; integrationId: string }
   | { type: "system.integration.disconnected"; integrationId: string }
-  | { type: "system.error"; error: string };
+  | { type: "system.error"; error: string }
+  | {
+      type: "system.alarm.raised";
+      alarmId: string;
+      level: "warning" | "error";
+      source: string;
+      message: string;
+    }
+  | { type: "system.alarm.resolved"; alarmId: string; source: string; message: string };
 
 // ============================================================
 // zigbee2mqtt types (parser internal)

--- a/ui/src/components/layout/AlarmBanner.tsx
+++ b/ui/src/components/layout/AlarmBanner.tsx
@@ -1,0 +1,21 @@
+import { AlertTriangle } from "lucide-react";
+import { useWebSocket } from "../../store/useWebSocket";
+
+export function AlarmBanner() {
+  const alarms = useWebSocket((s) => s.alarms);
+
+  if (alarms.size === 0) return null;
+
+  const alarmList = Array.from(alarms.values());
+
+  return (
+    <div className="flex items-center justify-center gap-2 px-4 py-2 bg-red-500/10 text-red-600 dark:text-red-400 text-[13px] font-medium">
+      <AlertTriangle size={14} strokeWidth={1.5} />
+      <span>
+        {alarmList.length === 1
+          ? `${alarmList[0].source} : ${alarmList[0].message}`
+          : `${alarmList.length} alarmes actives`}
+      </span>
+    </div>
+  );
+}

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -13,6 +13,7 @@ import { useAuth } from "../../store/useAuth";
 import { Home, Layers, LayoutDashboard, LogOut, Settings, User } from "lucide-react";
 import { SowelLogo } from "./SowelLogo";
 import { OfflineBanner } from "./OfflineBanner";
+import { AlarmBanner } from "./AlarmBanner";
 import { InstallPrompt } from "./InstallPrompt";
 import { ROOT_ZONE_ID } from "../../lib/constants";
 import { getSettings } from "../../api";
@@ -101,6 +102,8 @@ export function AppLayout() {
 
         {/* Offline banner */}
         <OfflineBanner />
+        {/* System alarm banner */}
+        <AlarmBanner />
 
         {/* Page content */}
         <main className="flex-1 overflow-y-auto">

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -11,9 +11,17 @@ export type WsTopic = "devices" | "equipments" | "zones" | "modes" | "recipes" |
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected";
 
+export interface SystemAlarm {
+  alarmId: string;
+  level: "warning" | "error";
+  source: string;
+  message: string;
+}
+
 interface WebSocketState {
   status: ConnectionStatus;
   integrationStatuses: Record<string, string>;
+  alarms: Map<string, SystemAlarm>;
   connect: () => void;
   disconnect: () => void;
   subscribe: (topics: WsTopic[]) => void;
@@ -127,12 +135,32 @@ function handleEvent(event: EngineEvent): void {
         integrationStatuses: { ...s.integrationStatuses, [event.integrationId]: "disconnected" },
       }));
       break;
+    case "system.alarm.raised":
+      useWebSocket.setState((s) => {
+        const alarms = new Map(s.alarms);
+        alarms.set(event.alarmId, {
+          alarmId: event.alarmId,
+          level: event.level,
+          source: event.source,
+          message: event.message,
+        });
+        return { alarms };
+      });
+      break;
+    case "system.alarm.resolved":
+      useWebSocket.setState((s) => {
+        const alarms = new Map(s.alarms);
+        alarms.delete(event.alarmId);
+        return { alarms };
+      });
+      break;
   }
 }
 
 export const useWebSocket = create<WebSocketState>((set) => ({
   status: "disconnected",
   integrationStatuses: {},
+  alarms: new Map(),
 
   connect: () => {
     if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) {
@@ -212,7 +240,7 @@ export const useWebSocket = create<WebSocketState>((set) => ({
       ws.close();
       ws = null;
     }
-    set({ status: "disconnected", integrationStatuses: {} });
+    set({ status: "disconnected", integrationStatuses: {}, alarms: new Map() });
   },
 
   subscribe: (topics) => {

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -320,6 +320,9 @@ export type EngineEvent =
   | { type: "system.integration.connected"; integrationId: string }
   | { type: "system.integration.disconnected"; integrationId: string }
   | { type: "system.error"; error: string }
+  | { type: "system.alarm.raised"; alarmId: string; level: "warning" | "error"; source: string; message: string }
+  | { type: "system.alarm.resolved"; alarmId: string; source: string; message: string }
+  | { type: "equipment.order.failed"; equipmentId: string; orderAlias: string; value: unknown; error: string }
   | { type: "connected"; message: string; version: string };
 
 // ============================================================


### PR DESCRIPTION
## Summary
- **Async executeOrder with retry**: `equipment-manager.executeOrder()` now returns `Promise<{ success, error? }>` with 1 retry (2s delay). All callers updated.
- **System alarm events**: New `system.alarm.raised` / `system.alarm.resolved` events on the event bus, emitted on first failure and on recovery (both order dispatch and poll failures).
- **Poll failure alarms**: MCZ, Panasonic, and Netatmo pollers now emit alarms on poll failure and block orders when integration is unhealthy.
- **Telegram notifications**: `notification-publish-service` sends Telegram alerts on alarm raised/resolved.
- **UI alarm banner**: Persistent red banner in `AppLayout` showing active alarms, auto-clears on resolution.
- **PID lock file**: Prevents multiple Sowel instances from running simultaneously.

## Test plan
- [x] TypeScript compiles (zero errors backend + frontend)
- [x] All tests pass (`npm test` — 454 tests)
- [x] Manual test: MCZ cloud down → alarm banner appears, Telegram notification sent, orders blocked
- [x] Manual test: MCZ cloud recovers → alarm banner disappears, Telegram "rétabli" sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)