### PR TITLE
fix(ui): alarm visibility on mobile PWA + persist on refresh

### DIFF
--- a/ui/src/components/layout/ConnectionStatus.tsx
+++ b/ui/src/components/layout/ConnectionStatus.tsx
@@ -1,7 +1,7 @@
 import { useWebSocket } from "../../store/useWebSocket";
 import { Wifi, WifiOff, AlertTriangle } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { INTEGRATION_LABELS } from "../../constants";
+import { INTEGRATION_LABELS, INTEGRATION_SHORT_LABELS } from "../../constants";
 
 export function ConnectionStatus() {
   const { t } = useTranslation();
@@ -27,16 +27,18 @@ export function ConnectionStatus() {
   }
 
   // status === "connected" — check if any integration has issues
-  const disconnectedNames = Object.entries(integrationStatuses)
-    .filter(([, s]) => s === "disconnected" || s === "error")
-    .map(([id]) => INTEGRATION_LABELS[id] ?? id);
+  const errorEntries = Object.entries(integrationStatuses)
+    .filter(([, s]) => s === "disconnected" || s === "error");
+  const shortNames = errorEntries.map(([id]) => INTEGRATION_SHORT_LABELS[id] ?? id);
+  const fullNames = errorEntries.map(([id]) => INTEGRATION_LABELS[id] ?? id);
 
-  if (disconnectedNames.length > 0) {
+  if (errorEntries.length > 0) {
     return (
       <div className="flex items-center gap-2 px-2 py-1 sm:px-3 sm:py-1.5 rounded-full bg-warning/10 text-warning">
         <AlertTriangle size={14} strokeWidth={1.5} />
-        <span className="text-[12px] font-medium hidden sm:inline">
-          {t("status.integrationWarning", { names: disconnectedNames.join(", ") })}
+        <span className="text-[12px] font-medium">
+          <span className="sm:hidden">{shortNames.join(", ")}</span>
+          <span className="hidden sm:inline">{t("status.integrationWarning", { names: fullNames.join(", ") })}</span>
         </span>
       </div>
     );

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -9,3 +9,15 @@ export const INTEGRATION_LABELS: Record<string, string> = {
   shelly: "Shelly",
   custom_mqtt: "MQTT",
 };
+
+/** Short labels for mobile / compact display. */
+export const INTEGRATION_SHORT_LABELS: Record<string, string> = {
+  zigbee2mqtt: "Z2M",
+  panasonic_cc: "Panasonic",
+  mcz_maestro: "MCZ",
+  netatmo_hc: "Legrand",
+  tasmota: "Tasmota",
+  esphome: "ESPHome",
+  shelly: "Shelly",
+  custom_mqtt: "MQTT",
+};

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -6,6 +6,7 @@ import { useEquipments } from "./useEquipments";
 import { useZoneAggregation } from "./useZoneAggregation";
 import { useRecipes } from "./useRecipes";
 import { useModes } from "./useModes";
+import { INTEGRATION_LABELS } from "../constants";
 
 export type WsTopic = "devices" | "equipments" | "zones" | "modes" | "recipes" | "calendar" | "system";
 
@@ -192,10 +193,21 @@ export const useWebSocket = create<WebSocketState>((set) => ({
         .then((data: { integrations?: Record<string, { status: string }> }) => {
           if (data.integrations) {
             const statuses: Record<string, string> = {};
+            const alarms = new Map<string, SystemAlarm>();
             for (const [id, info] of Object.entries(data.integrations)) {
               statuses[id] = info.status;
+              // Restore alarm banner for integrations in error state
+              if (info.status === "error") {
+                const label = INTEGRATION_LABELS[id] ?? id;
+                alarms.set(`poll-fail:${id}`, {
+                  alarmId: `poll-fail:${id}`,
+                  level: "error",
+                  source: label,
+                  message: "Communication en échec",
+                });
+              }
             }
-            set({ integrationStatuses: statuses });
+            set({ integrationStatuses: statuses, alarms });
           }
         })
         .catch(() => {


### PR DESCRIPTION
## Summary
- Show short integration names (e.g. "MCZ") next to warning icon on mobile — was icon-only before
- Restore AlarmBanner after page refresh by synthesizing alarms from `/api/v1/health` integration statuses
- Add `INTEGRATION_SHORT_LABELS` map for compact mobile display

## Test plan
- [x] TypeScript compiles (zero errors)
- [x] All 454 tests pass
- [x] Verify on mobile: warning shows "MCZ" not just triangle icon
- [x] Verify refresh: AlarmBanner reappears if integration is in error

🤖 Generated with [Claude Code](https://claude.com/claude-code)