### PR TITLE
feat(energy): HP/HC tariff classification

### DIFF
--- a/scripts/energy/README.md
+++ b/scripts/energy/README.md
@@ -81,6 +81,23 @@ Affiche les points raw bruts pour un jour et les définitions Flux des tasks Inf
 npx tsx scripts/energy/raw-inspect.ts
 ```
 
+## Migration HP/HC
+
+### `classify-hphc.ts`
+
+Classifie les données energy historiques en `energy_hp` / `energy_hc` selon le schedule tarif configuré dans les settings.
+
+**Prérequis** : configurer le tarif dans Settings > Énergie **avant** d'exécuter. Faire une **sauvegarde InfluxDB** au préalable.
+
+```bash
+npx tsx scripts/energy/classify-hphc.ts
+```
+
+- Lit les points `energy` des 3 buckets (raw, hourly, daily)
+- Classifie chaque point selon le schedule courant (prorata si transition mid-window)
+- Écrit `energy_hp` et `energy_hc` avec les mêmes tags + timestamp
+- Idempotent : peut être relancé sans risque
+
 ## Administration InfluxDB
 
 ### `fix-task.ts`

--- a/scripts/energy/classify-hphc.ts
+++ b/scripts/energy/classify-hphc.ts
@@ -1,0 +1,355 @@
+#!/usr/bin/env npx tsx
+/**
+ * Classify existing historical energy data into energy_hp / energy_hc.
+ *
+ * Strategy per bucket:
+ * - Raw (30-min windows): classify each point with 30-min prorata
+ * - Hourly: classify each point with 60-min prorata
+ * - Daily: sum hourly HP/HC for each day (no prorata — uses actual consumption distribution)
+ *
+ * IMPORTANT: Backup your InfluxDB data before running this script!
+ *
+ * Usage:
+ *   npx tsx scripts/energy/classify-hphc.ts
+ */
+
+import Database from "better-sqlite3";
+import { InfluxDB, Point } from "@influxdata/influxdb-client";
+
+const DB_PATH = "./data/sowel.db";
+
+// ============================================================
+// Config from SQLite
+// ============================================================
+
+const db = new Database(DB_PATH, { readonly: true });
+
+function getSetting(key: string): string | undefined {
+  const row = db.prepare("SELECT value FROM settings WHERE key = ?").get(key) as
+    | { value: string }
+    | undefined;
+  return row?.value;
+}
+
+const influxUrl = getSetting("history.influx.url");
+const influxToken = getSetting("history.influx.token");
+const influxOrg = getSetting("history.influx.org");
+const influxBucket = getSetting("history.influx.bucket");
+
+if (!influxUrl || !influxToken || !influxOrg || !influxBucket) {
+  console.error("InfluxDB not configured in settings.");
+  process.exit(1);
+}
+
+// ============================================================
+// Tariff schedule from settings
+// ============================================================
+
+interface TariffSlot {
+  start: string;
+  end: string;
+  tariff: "hp" | "hc";
+}
+
+interface DaySchedule {
+  days: number[];
+  slots: TariffSlot[];
+}
+
+interface TariffConfig {
+  schedules: DaySchedule[];
+  prices: { hp: number; hc: number };
+}
+
+const tariffRaw = getSetting("energy.tariff");
+if (!tariffRaw) {
+  console.error(
+    "No tariff schedule configured. Configure it in Settings > Énergie first.",
+  );
+  process.exit(1);
+}
+
+const tariffConfig: TariffConfig = JSON.parse(tariffRaw);
+console.log(
+  `Tariff schedule loaded: ${tariffConfig.schedules.length} schedule(s), HP=${tariffConfig.prices.hp} €/kWh, HC=${tariffConfig.prices.hc} €/kWh`,
+);
+
+db.close();
+
+// ============================================================
+// Tariff classification
+// ============================================================
+
+function parseTimeToMinutes(time: string): number {
+  const [h, m] = time.split(":").map(Number);
+  return h * 60 + m;
+}
+
+/**
+ * Classify a fixed-duration window into HP/HC split using linear prorata.
+ * @param totalWh Total energy in Wh for the window
+ * @param timestampEpochS Window start as Unix epoch seconds
+ * @param windowMinutes Duration of the window in minutes (30 for raw, 60 for hourly)
+ */
+function classify(
+  totalWh: number,
+  timestampEpochS: number,
+  windowMinutes: number,
+): { hp: number; hc: number } {
+  const d = new Date(timestampEpochS * 1000);
+  const dayOfWeek = d.getDay();
+
+  const daySchedule = tariffConfig.schedules.find((s) =>
+    s.days.includes(dayOfWeek),
+  );
+  if (!daySchedule || daySchedule.slots.length === 0) {
+    return { hp: totalWh, hc: 0 };
+  }
+
+  const windowStartMinutes = d.getHours() * 60 + d.getMinutes();
+  const windowEndMinutes = windowStartMinutes + windowMinutes;
+
+  let hpMinutes = 0;
+  let hcMinutes = 0;
+
+  for (const slot of daySchedule.slots) {
+    const slotStart = parseTimeToMinutes(slot.start);
+    let slotEnd = parseTimeToMinutes(slot.end);
+    if (slotEnd === 0) slotEnd = 1440;
+
+    // Handle midnight wrap: e.g. 17:04 → 00:04 becomes [17:04, 24:00) + [00:00, 00:04)
+    const ranges: Array<[number, number]> =
+      slotEnd <= slotStart
+        ? [[slotStart, 1440], [0, slotEnd]]
+        : [[slotStart, slotEnd]];
+
+    for (const [rangeStart, rangeEnd] of ranges) {
+      const overlapStart = Math.max(windowStartMinutes, rangeStart);
+      const overlapEnd = Math.min(windowEndMinutes, rangeEnd);
+      const overlap = Math.max(0, overlapEnd - overlapStart);
+
+      if (overlap > 0) {
+        if (slot.tariff === "hp") hpMinutes += overlap;
+        else hcMinutes += overlap;
+      }
+    }
+  }
+
+  const totalMinutes = hpMinutes + hcMinutes;
+  if (totalMinutes === 0) return { hp: totalWh, hc: 0 };
+
+  return {
+    hp: Math.round((totalWh * hpMinutes) / totalMinutes),
+    hc: Math.round((totalWh * hcMinutes) / totalMinutes),
+  };
+}
+
+// ============================================================
+// InfluxDB processing
+// ============================================================
+
+const influx = new InfluxDB({ url: influxUrl, token: influxToken });
+const queryApi = influx.getQueryApi(influxOrg);
+
+interface EnergyRow {
+  _time: string;
+  _value: number;
+  equipmentId: string;
+  category: string;
+  zoneId: string;
+  type: string;
+}
+
+/**
+ * Delete existing energy_hp / energy_hc points from a bucket before re-writing.
+ */
+async function deleteHpHc(bucketName: string, range: string): Promise<void> {
+  console.log(`  Deleting existing energy_hp/energy_hc from ${bucketName}...`);
+
+  for (const alias of ["energy_hp", "energy_hc"]) {
+    const resp = await fetch(
+      `${influxUrl}/api/v2/delete?org=${encodeURIComponent(influxOrg!)}&bucket=${encodeURIComponent(bucketName)}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Token ${influxToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          start: "2020-01-01T00:00:00Z",
+          stop: "2030-01-01T00:00:00Z",
+          predicate: `alias="${alias}"`,
+        }),
+      },
+    );
+    if (!resp.ok) {
+      const text = await resp.text();
+      console.error(`  Failed to delete ${alias}: ${resp.status} ${text}`);
+    }
+  }
+}
+
+/**
+ * Process raw or hourly bucket: classify each energy point with the appropriate window size.
+ */
+async function processWithProrata(
+  bucketName: string,
+  range: string,
+  windowMinutes: number,
+): Promise<number> {
+  console.log(`\nProcessing bucket: ${bucketName} (range: ${range}, window: ${windowMinutes}min)...`);
+
+  await deleteHpHc(bucketName, range);
+
+  const flux = `from(bucket: "${bucketName}")
+  |> range(start: ${range})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.alias == "energy")
+  |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> sort(columns: ["_time"])`;
+
+  const rows: EnergyRow[] = [];
+  const queryRows = queryApi.iterateRows(flux);
+  for await (const { values, tableMeta } of queryRows) {
+    const row = tableMeta.toObject(values) as EnergyRow;
+    if (row._value != null && row._value > 0) {
+      rows.push(row);
+    }
+  }
+
+  console.log(`  Found ${rows.length} energy points to classify.`);
+
+  if (rows.length === 0) return 0;
+
+  const writeApi = influx.getWriteApi(influxOrg!, bucketName, "s", {
+    batchSize: 500,
+    flushInterval: 10000,
+    maxRetries: 3,
+  });
+
+  let written = 0;
+
+  for (const row of rows) {
+    const epochS = Math.floor(new Date(row._time).getTime() / 1000);
+    const split = classify(row._value, epochS, windowMinutes);
+
+    for (const [alias, value] of [
+      ["energy_hp", split.hp],
+      ["energy_hc", split.hc],
+    ] as const) {
+      const point = new Point("equipment_data")
+        .tag("equipmentId", row.equipmentId)
+        .tag("alias", alias)
+        .tag("category", row.category)
+        .tag("zoneId", row.zoneId)
+        .tag("type", row.type)
+        .floatField("value_number", value)
+        .timestamp(epochS);
+
+      writeApi.writePoint(point);
+    }
+
+    written++;
+  }
+
+  await writeApi.close();
+  console.log(`  Wrote ${written * 2} HP/HC points (${written} energy × 2).`);
+  return written;
+}
+
+/**
+ * Process daily bucket by summing hourly HP/HC data for each day.
+ * This is more accurate than prorata because it respects the actual
+ * consumption distribution across hours.
+ */
+async function processDailyFromHourly(
+  hourlyBucket: string,
+  dailyBucket: string,
+  range: string,
+): Promise<number> {
+  console.log(`\nProcessing daily bucket by summing hourly HP/HC...`);
+
+  await deleteHpHc(dailyBucket, range);
+
+  // Read hourly HP/HC data
+  let totalWritten = 0;
+
+  for (const alias of ["energy_hp", "energy_hc"] as const) {
+    const flux = `from(bucket: "${hourlyBucket}")
+    |> range(start: ${range})
+    |> filter(fn: (r) => r._measurement == "equipment_data")
+    |> filter(fn: (r) => r.alias == "${alias}")
+    |> filter(fn: (r) => r.category == "energy")
+    |> filter(fn: (r) => r._field == "value_number")
+    |> aggregateWindow(every: 1d, fn: sum, createEmpty: false, timeSrc: "_start")`;
+
+    const rows: EnergyRow[] = [];
+    const queryRows = queryApi.iterateRows(flux);
+    for await (const { values, tableMeta } of queryRows) {
+      const row = tableMeta.toObject(values) as EnergyRow;
+      if (row._value != null && row._value > 0) {
+        rows.push(row);
+      }
+    }
+
+    console.log(`  ${alias}: ${rows.length} daily aggregations from hourly data.`);
+
+    if (rows.length === 0) continue;
+
+    const writeApi = influx.getWriteApi(influxOrg!, dailyBucket, "s", {
+      batchSize: 500,
+      flushInterval: 10000,
+      maxRetries: 3,
+    });
+
+    for (const row of rows) {
+      const epochS = Math.floor(new Date(row._time).getTime() / 1000);
+      const point = new Point("equipment_data")
+        .tag("equipmentId", row.equipmentId)
+        .tag("alias", alias)
+        .tag("category", row.category)
+        .tag("zoneId", row.zoneId)
+        .tag("type", row.type)
+        .floatField("value_number", row._value)
+        .timestamp(epochS);
+
+      writeApi.writePoint(point);
+      totalWritten++;
+    }
+
+    await writeApi.close();
+  }
+
+  console.log(`  Wrote ${totalWritten} daily HP/HC points.`);
+  return totalWritten;
+}
+
+// ============================================================
+// Main
+// ============================================================
+
+async function main() {
+  console.log("=== Energy HP/HC Classification Script (v2) ===");
+  console.log("IMPORTANT: Make sure you have backed up your InfluxDB data!\n");
+
+  const rawBucket = influxBucket!;
+  const hourlyBucket = `${influxBucket}-energy-hourly`;
+  const dailyBucket = `${influxBucket}-energy-daily`;
+
+  // 1. Raw bucket (30-min windows, last 7 days — retention limit)
+  await processWithProrata(rawBucket, "-7d", 30);
+
+  // 2. Energy-hourly bucket (60-min windows, up to 2 years)
+  await processWithProrata(hourlyBucket, "-730d", 60);
+
+  // 3. Energy-daily bucket: sum hourly HP/HC (not prorata!)
+  await processDailyFromHourly(hourlyBucket, dailyBucket, "-730d");
+
+  console.log(`\n=== Done! ===`);
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/specs/035-energy-dashboard/architecture.md
+++ b/specs/035-energy-dashboard/architecture.md
@@ -205,39 +205,111 @@ On first setup (no `energy.legrand.lastBackfill` setting):
 
 **Important**: backfill bypasses the standard pipeline because raw retention is only 7 days. Historical hourly data is written directly to the pre-aggregated bucket. The `energy_sum_daily` task will then aggregate it into `sowel-energy-daily`.
 
-## Tariff Configuration
+## Tariff Configuration (IT2)
 
 ### Settings keys
 
 ```
-energy.tariff.schedule = JSON string
+energy.tariff = JSON string
 ```
 
 Schema:
 
 ```typescript
-interface TariffSchedule {
+interface TariffConfig {
+  schedules: DaySchedule[];
+  prices: TariffPrices;
+}
+
+interface DaySchedule {
+  days: number[]; // 0=Sunday..6=Saturday
   slots: TariffSlot[];
-  defaultTariff: "hp" | "hc";
 }
 
 interface TariffSlot {
-  start: string; // "HH:MM" (e.g., "22:30")
-  end: string; // "HH:MM" (e.g., "06:30")
+  start: string; // "HH:MM" (e.g., "06:00")
+  end: string; // "HH:MM" (e.g., "15:00")
   tariff: "hp" | "hc";
-  days?: number[]; // 0=Sunday..6=Saturday — if omitted, all days
+}
+
+interface TariffPrices {
+  hp: number; // €/kWh (e.g., 0.2146)
+  hc: number; // €/kWh (e.g., 0.1696)
+}
+```
+
+Example (from Legrand screenshot):
+
+```json
+{
+  "schedules": [
+    {
+      "days": [0, 1, 2, 3, 4, 5, 6],
+      "slots": [
+        { "start": "00:00", "end": "06:00", "tariff": "hc" },
+        { "start": "06:00", "end": "15:00", "tariff": "hp" },
+        { "start": "15:00", "end": "17:00", "tariff": "hc" },
+        { "start": "17:00", "end": "00:00", "tariff": "hp" }
+      ]
+    }
+  ],
+  "prices": { "hp": 0.2146, "hc": 0.1696 }
 }
 ```
 
 Default (no config): all hours are HP.
 
-### Classification
+Slots must cover 00:00→00:00 without gaps or overlaps. Different `days` arrays can have different slot configurations (e.g., weekend = all HC).
 
-Applied at query time in the energy API. For each energy data point, the timestamp is checked against the tariff schedule to classify as HP or HC.
+### Classification — at write time, not query time
+
+Classification happens in the **HistoryWriter**, not in the energy API. When the HistoryWriter receives an `equipment.data.changed` event with `alias=energy` and `category=energy`, it:
+
+1. Reads the tariff schedule from settings
+2. Determines the day-of-week from `sourceTimestamp` (or current time)
+3. Finds which tariff slot(s) the 30-min window falls into
+4. Applies prorata if the window straddles a tariff transition
+5. Writes 2 additional points: `energy_hp` and `energy_hc` with the same tags (except alias) and same `sourceTimestamp`
+
+### Prorata for mid-window transitions
+
+A 30-min energy window (e.g., 06:00-06:30) may straddle a tariff transition (e.g., HC→HP at 06:15):
+
+```
+Window: 06:00-06:30, energy = 500 Wh
+Transition: HC→HP at 06:15
+→ energy_hc = 500 × 15/30 = 250 Wh (06:00-06:15 = HC)
+→ energy_hp = 500 × 15/30 = 250 Wh (06:15-06:30 = HP)
+```
+
+Energy is assumed to be distributed uniformly within the 30-min window (linear prorata).
+
+## TariffClassifier module (IT2)
+
+New module: `src/energy/tariff-classifier.ts`
+
+```typescript
+interface TariffSplit {
+  hp: number; // Wh attributed to HP
+  hc: number; // Wh attributed to HC
+}
+
+class TariffClassifier {
+  constructor(settingsManager: SettingsManager, logger: Logger);
+
+  /** Classify a 30-min energy window. Returns HP/HC split with prorata. */
+  classify(totalWh: number, windowStartEpoch: number): TariffSplit;
+
+  /** Get the current tariff config (for API). */
+  getConfig(): TariffConfig | null;
+}
+```
+
+The classifier is injected into the HistoryWriter at construction. The HistoryWriter calls `classify()` for every energy point it writes.
 
 ## API Endpoints
 
-### `GET /api/v1/energy/history`
+### `GET /api/v1/energy/history` (updated for IT2)
 
 Query params:
 
@@ -246,21 +318,85 @@ Query params:
 
 Resolution mapping:
 
-- `day` → reads `sowel-energy-hourly` (hourly sums)
-- `week` → reads `sowel-energy-hourly` (hourly sums)
-- `month` / `year` → reads `sowel-energy-daily` (daily sums)
+- `day` → reads raw bucket (recent) or `sowel-energy-hourly` (older)
+- `week` → reads `sowel-energy-hourly`
+- `month` / `year` → reads `sowel-energy-daily`
+
+**IT2 change**: queries `energy_hp` and `energy_hc` aliases instead of `energy`. Returns:
+
+```typescript
+interface EnergyPoint {
+  time: string;
+  hp: number; // Wh attributed to Heures Pleines
+  hc: number; // Wh attributed to Heures Creuses
+}
+
+interface EnergyTotals {
+  total_consumption: number; // hp + hc
+  total_hp: number;
+  total_hc: number;
+}
+```
+
+For raw bucket day view, aggregates 30-min windows to hourly with `aggregateWindow(every: 1h, fn: sum)` — one query per alias (`energy_hp`, `energy_hc`), results merged by timestamp.
+
+For pre-aggregated buckets (hourly, daily), reads `energy_hp` and `energy_hc` directly (already aggregated by InfluxDB tasks).
 
 ### `GET /api/v1/energy/status`
 
 ```typescript
 interface EnergyStatus {
   available: boolean;
-  hasSolar: boolean;
   sources: string[];
   lastDataAt: string | null;
   tariffConfigured: boolean;
 }
 ```
+
+### `GET /api/v1/settings/energy/tariff` (new — IT2)
+
+Returns the current tariff configuration.
+
+```typescript
+// Response: TariffConfig | null
+```
+
+### `PUT /api/v1/settings/energy/tariff` (new — IT2)
+
+Updates the tariff configuration. Validates:
+
+- Slots cover 00:00→00:00 without gaps
+- Days arrays are valid (0-6)
+- Prices are positive numbers
+
+```typescript
+// Body: TariffConfig
+// Response: { ok: true }
+```
+
+## Migration Script: `scripts/energy/classify-hphc.ts` (IT2)
+
+One-time script to classify existing historical `energy` data into `energy_hp`/`energy_hc`.
+
+### Pre-requisites
+
+1. **Backup InfluxDB** before running (mandatory)
+2. Tariff schedule must be configured in settings before running
+
+### Algorithm
+
+1. Read all `energy` points from raw bucket (last 7 days)
+2. Read all `energy` points from `sowel-energy-hourly` (all data)
+3. Read all `energy` points from `sowel-energy-daily` (all data)
+4. For each point: classify using the current tariff schedule → compute `energy_hp` and `energy_hc`
+5. Write `energy_hp` and `energy_hc` points with same tags + timestamp to same bucket
+6. Summary: report total points processed per bucket
+
+### Important
+
+- Uses the **current** tariff schedule for all historical data (since no schedule history exists before IT2)
+- After IT2 goes live, future data is classified at write time — this script is only for bootstrapping
+- Idempotent: re-running overwrites existing `energy_hp`/`energy_hc` points (same tags + timestamp)
 
 ## UI Components
 
@@ -268,12 +404,32 @@ interface EnergyStatus {
 
 Displays 4 cumul tiles (hour/day/month/year) in 2x2 grid for `main_energy_meter` equipment type. Data comes from EnergyAggregator computed data (aliases: `energy_hour`, `energy_day`, `energy_month`, `energy_year`).
 
-### `/energy` page
+### `/energy` page (IT2 updates)
 
 Period selectors: Jour / Semaine / Mois / Annee with date navigation.
-Bar chart showing consumption per period unit (hour for day/week, day for month/year).
+
+**IT2 changes:**
+
+- **Stacked bars**: each bar has 2 segments — HP (`#4F7BE8` blue) + HC (`#93B5F0` light blue)
+- **Day view**: each hourly bar is either fully HP or fully HC (transitions on hour boundaries) or split if transition is mid-hour
+- **Week/month/year view**: each bar (day) is stacked HP + HC
+- **Total**: global total in large font at top right (unchanged)
+- **Legend**: below chart, shows `● H. pleines : XX kWh   ● H. creuses : YY kWh`
+- **No tariff configured**: bars display single color (all HP), legend shows only "Total"
+
+### Settings > Énergie (new — IT2)
+
+Tariff configuration form:
+
+- Day selector (all days / weekdays / weekends / individual days)
+- Time slot list: start time, end time, tariff type (HP/HC)
+- Add/remove slots
+- Price fields: HP €/kWh, HC €/kWh
+- Save button → `PUT /api/v1/settings/energy/tariff`
 
 ## File Changes
+
+### IT1 (done)
 
 | File                                               | Change                                                                              |
 | -------------------------------------------------- | ----------------------------------------------------------------------------------- |
@@ -290,3 +446,18 @@ Bar chart showing consumption per period unit (hour for day/week, day for month/
 | `ui/src/components/energy/EnergyBarChart.tsx`      | Bar chart component                                                                 |
 | `ui/src/components/energy/EnergyPage.tsx`          | Main energy page                                                                    |
 | `ui/src/components/energy/PeriodSelector.tsx`      | Period/date navigation                                                              |
+
+### IT2 — HP/HC tariff classification
+
+| File                                            | Change                                                                                                                                                   |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/shared/types.ts`                           | Add `TariffConfig`, `DaySchedule`, `TariffSlot`, `TariffPrices` types. Update `EnergyPoint` (`hp`, `hc` fields), `EnergyTotals` (`total_hp`, `total_hc`) |
+| `src/energy/tariff-classifier.ts`               | **New** — TariffClassifier: reads schedule from settings, classifies 30-min windows with prorata                                                         |
+| `src/history/history-writer.ts`                 | On `energy` write, also writes `energy_hp` and `energy_hc` using TariffClassifier                                                                        |
+| `src/api/routes/energy.ts`                      | Query `energy_hp`/`energy_hc` instead of `energy`. New tariff CRUD endpoints                                                                             |
+| `ui/src/components/energy/EnergyBarChart.tsx`   | Stacked bars (HP blue + HC light blue)                                                                                                                   |
+| `ui/src/components/energy/EnergyPage.tsx`       | Legend with HP/HC totals below chart                                                                                                                     |
+| `ui/src/components/settings/TariffSettings.tsx` | **New** — Tariff configuration form                                                                                                                      |
+| `ui/src/store/useEnergy.ts`                     | Update types for HP/HC points                                                                                                                            |
+| `ui/src/api.ts`                                 | Add tariff API functions                                                                                                                                 |
+| `scripts/energy/classify-hphc.ts`               | **New** — Migration script: classify existing data into HP/HC                                                                                            |

--- a/specs/035-energy-dashboard/plan.md
+++ b/specs/035-energy-dashboard/plan.md
@@ -62,20 +62,50 @@ Scope: bridge-level consumption only. No solar, no HP/HC, no individual NLPCs.
 
 ## IT2 — HP/HC tariff classification — `feat/035b-energy-hphc`
 
-Scope: add tariff schedule configuration, classify energy data as HP/HC at query time, stacked bar chart.
+Scope: tariff schedule configuration, HP/HC classification at write time, stacked bar chart, historical data migration.
 
-### Backend
+### Backend — Types & Tariff Classifier
 
-1. [ ] Add `TariffSchedule`, `TariffSlot` types to `src/shared/types.ts`
-2. [ ] Create `src/energy/tariff.ts` — classify timestamp → `hp` | `hc` given a schedule
-3. [ ] Add tariff endpoints to `energy.ts`
-4. [ ] Update `GET /api/v1/energy/history` — apply tariff classification to each point
+1. [ ] Add `TariffConfig`, `DaySchedule`, `TariffSlot`, `TariffPrices` types to `src/shared/types.ts`
+2. [ ] Update `EnergyPoint` type: `{ time, hp, hc }` instead of `{ time, consumption }`
+3. [ ] Update `EnergyTotals` type: add `total_hp`, `total_hc`
+4. [ ] Create `src/energy/tariff-classifier.ts` — classify 30-min window → HP/HC split with prorata
 
-### UI
+### Backend — HistoryWriter integration
 
-5. [ ] Update `EnergyBarChart.tsx` — stacked bars: H.pleines + H.creuses + Autoconso
-6. [ ] Add legend with totals per category
-7. [ ] Add tariff configuration UI in Settings
+5. [ ] Inject `TariffClassifier` into `HistoryWriter`
+6. [ ] On `energy` point write (category=energy, alias=energy): also write `energy_hp` and `energy_hc` points
+7. [ ] Add `energy_hp` and `energy_hc` to `ALIAS_DEFAULTS_ON` (or handle via category default)
+
+### Backend — API
+
+8. [ ] Add tariff CRUD endpoints: `GET/PUT /api/v1/settings/energy/tariff`
+9. [ ] Update `GET /api/v1/energy/history`: query `energy_hp`/`energy_hc`, return `{ time, hp, hc }`
+10. [ ] Update `EnergyStatus` to include `tariffConfigured`
+
+### UI — Stacked bars
+
+11. [ ] Update `EnergyBarChart.tsx`: stacked bars HP (`#4F7BE8`) + HC (`#93B5F0`)
+12. [ ] Update `EnergyPage.tsx`: legend with HP/HC totals below chart
+13. [ ] Update `useEnergy.ts` store: new point format `{ time, hp, hc }`
+14. [ ] Update `ui/src/api.ts`: tariff API functions
+
+### UI — Settings
+
+15. [ ] Create `TariffSettings.tsx`: time slot editor per day of week + prices
+16. [ ] Integrate into Settings page (section Énergie)
+
+### Migration
+
+17. [ ] Create `scripts/energy/classify-hphc.ts`: classify existing historical data
+18. [ ] Script must backup data before migration (or prompt user to backup)
+19. [ ] Script reads tariff from settings, processes raw + hourly + daily buckets
+
+### Validation
+
+20. [ ] TypeScript compilation — zero errors (backend + frontend)
+21. [ ] HP + HC totals = total consumption (consistency check)
+22. [ ] Stacked bars render correctly for all periods (day/week/month/year)
 
 ---
 

--- a/specs/035-energy-dashboard/spec.md
+++ b/specs/035-energy-dashboard/spec.md
@@ -59,13 +59,15 @@ An Energy Meter Equipment has the same Data model regardless of the source (Legr
 | Alias          | Unit | Category | Historized | Description                                            |
 | -------------- | ---- | -------- | ---------- | ------------------------------------------------------ |
 | `energy`       | Wh   | energy   | **yes**    | Wh per 30-min bucket — the real measurement            |
+| `energy_hp`    | Wh   | energy   | **yes**    | HP portion of energy (IT2 — written by HistoryWriter)  |
+| `energy_hc`    | Wh   | energy   | **yes**    | HC portion of energy (IT2 — written by HistoryWriter)  |
 | `demand_30min` | W    | power    | no         | Average power over last 30 min (`energy x 2`)          |
 | `energy_day`   | Wh   | energy   | no         | Today's cumulative (EnergyAggregator → InfluxDB query) |
 | `energy_hour`  | Wh   | energy   | no         | Current hour cumulative                                |
 | `energy_month` | Wh   | energy   | no         | Current month cumulative                               |
 | `energy_year`  | Wh   | energy   | no         | Current year cumulative                                |
 
-Only `energy` (Wh per 30 min) is historized. Cumuls are computed live by the EnergyAggregator from InfluxDB.
+`energy` (total), `energy_hp`, and `energy_hc` are historized. `energy_hp + energy_hc = energy` always. Cumuls are computed live by the EnergyAggregator from InfluxDB.
 
 Two Equipment types, distinguished by a `energyMeterType` field on the Equipment:
 
@@ -82,18 +84,33 @@ Two Equipment types, distinguished by a `energyMeterType` field on the Equipment
 
 All sources produce the same `energy` data: Wh per aligned 30-min interval, written with `sourceTimestamp` for clean aggregation.
 
-### HP/HC is a Sowel feature
+### HP/HC is a Sowel feature — classification at write time
 
 Tariff time slots (Heures Pleines / Heures Creuses) are configured in Sowel settings, not derived from the energy source. This means:
 
 - Any energy source benefits from HP/HC classification
-- User can change tariff schedule without reconfiguring integration
 - Works even if the source doesn't know about tariffs (e.g., Shelly)
-- Classification is applied at query time — no data rewrite needed
+- Classification happens **at write time** in the HistoryWriter
+- Three aliases stored in InfluxDB: `energy` (total), `energy_hp`, `energy_hc`
+- Historical data is immutable: when the tariff schedule changes, only future writes use the new schedule — no rewrite of existing data
+
+### Write-time classification (not query-time)
+
+Initial design considered query-time classification (apply schedule retroactively at each API request). This was rejected because:
+
+- A tariff schedule change would retroactively reclassify historical data — incorrect for billing
+- Historical data should reflect the actual tariff in effect at the time of consumption
+- Write-time classification is simpler: the HistoryWriter reads the current schedule and splits each `energy` point into `energy_hp` and `energy_hc` at write time
+
+The HistoryWriter applies **prorata** when a 30-min window straddles a tariff transition. Example: transition at 06:15, window 06:00-06:30 with 500 Wh → `energy_hp=250 Wh` (15 min) + `energy_hc=250 Wh` (15 min).
+
+### Tariff schedule with per-day configuration
+
+The schedule supports different time slots per day of the week (e.g., different weekend tariffs). Prices (€/kWh) are stored alongside the schedule for future cost calculation (IT4).
 
 ### Legrand-specific: reverse calculation (calcul inverse)
 
-Legrand provides HP/HC breakdown via `buy_from_grid$1` (HP) and `$2` (HC). We **do NOT store the HP/HC split** — we sum them back into a single total consumption. Sowel re-classifies HP/HC at query time based on the user's configured tariff schedule.
+Legrand provides HP/HC breakdown via `buy_from_grid$1` (HP) and `$2` (HC). We **do NOT use** the Legrand HP/HC split — we sum them back into a single total consumption. Sowel re-classifies HP/HC based on the user's configured tariff schedule.
 
 ## Acceptance Criteria
 
@@ -111,28 +128,35 @@ Legrand provides HP/HC breakdown via `buy_from_grid$1` (HP) and `$2` (HC). We **
 - [ ] Handles missing/null values gracefully
 - [ ] Totals validated against home.netatmo.com (+-1%)
 
-### IT2 — Energy API + tariff configuration
+### IT2 — HP/HC tariff classification — `feat/035b-energy-hphc`
 
 - [x] `GET /api/v1/energy/history` — returns energy time-series from InfluxDB (sum-aggregated buckets)
 - [x] `GET /api/v1/energy/status` — detect energy data availability
-- [ ] `GET /api/v1/settings/energy/tariff` — tariff schedule CRUD (HP/HC time slots)
-- [ ] HP/HC classification applied at query time based on configured schedule
+- [ ] Tariff schedule configuration: per-day HP/HC time slots + unit prices (€/kWh)
+- [ ] `GET/PUT /api/v1/settings/energy/tariff` — tariff schedule CRUD
+- [ ] HistoryWriter: on `energy` write, also writes `energy_hp` and `energy_hc` (prorata for mid-window transitions)
+- [ ] InfluxDB tasks automatically aggregate `energy_hp`/`energy_hc` (no task changes — alias tag preserved)
+- [ ] Energy API: query `energy_hp` and `energy_hc` separately, return `{ time, hp, hc }`
+- [ ] Migration script: classify existing historical `energy` data into `energy_hp`/`energy_hc`
+- [ ] Stacked bars: H. pleines (`#4F7BE8`) + H. creuses (`#93B5F0`)
+- [ ] Total global en haut + légende HP/HC avec totaux sous le chart
+- [ ] Settings UI: section Énergie — config créneaux par jour de semaine + prix €/kWh
 
-### IT3 — Energy Dashboard UI
+### IT3 — Energy Dashboard UI (remaining)
 
 - [x] New `/energy` page in sidebar, visible only if energy data exists
 - [x] Bar chart with period selectors: Jour / Semaine / Mois / Annee
 - [x] Date navigation with arrows
 - [x] Total kWh displayed (2 decimal places)
-- [ ] Stacked bars: Autoconso (green) + H. pleines (blue) + H. creuses (light blue)
-- [ ] Production chart (hidden if no solar)
-- [ ] Legend with totals per category
+- [ ] Production chart (hidden if no solar) — deferred to IT4
+- [ ] Autoconsumption as separate category — deferred to IT4
 
 ### IT4 (future) — Solar production + costs
 
 - [ ] Virtual device `legrand_energy_production`
 - [ ] `energyMeterType` field on Equipment (consumption/production)
 - [ ] Cost calculation from HP/HC unit prices
+- [ ] Autoconsumption stacking (green) in consumption chart
 
 ## Scope
 
@@ -173,5 +197,6 @@ Legrand provides HP/HC breakdown via `buy_from_grid$1` (HP) and `$2` (HC). We **
 - Backend restart → poller replays 6h sliding window, InfluxDB overwrites (idempotent)
 - Backend down for <6h → poller fills the gap automatically on restart
 - Backend down for >6h → gap in raw data, but hourly task (-7h) re-aggregates what's available
-- Tariff schedule not configured → all consumption shown as "Heures Pleines" (default)
-- Tariff schedule changed → no need to rewrite InfluxDB data (classification is at query time)
+- Tariff schedule not configured → all consumption written as `energy_hp` (default: everything is HP)
+- Tariff schedule changed → only future writes use new schedule; historical data stays unchanged
+- Migration script: must backup InfluxDB data before reclassifying historical points

--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -1,22 +1,33 @@
 import type { FastifyInstance } from "fastify";
 import type { Logger } from "../../core/logger.js";
+import type { SettingsManager } from "../../core/settings-manager.js";
 import type { EquipmentManager } from "../../equipments/equipment-manager.js";
+import type { TariffClassifier } from "../../energy/tariff-classifier.js";
 import type { InfluxClient } from "../../history/influx-client.js";
 import type {
   EnergyPoint,
   EnergyTotals,
   EnergyHistoryResponse,
   EnergyStatus,
+  TariffConfig,
 } from "../../shared/types.js";
 
 interface EnergyDeps {
   equipmentManager: EquipmentManager;
   influxClient: InfluxClient;
+  settingsManager: SettingsManager;
+  tariffClassifier: TariffClassifier;
   logger: Logger;
 }
 
 export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): void {
-  const { equipmentManager, influxClient, logger: parentLogger } = deps;
+  const {
+    equipmentManager,
+    influxClient,
+    settingsManager,
+    tariffClassifier,
+    logger: parentLogger,
+  } = deps;
   const logger = parentLogger.child({ module: "energy-api" });
 
   // ============================================================
@@ -28,6 +39,7 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
       available: eqId !== null,
       sources: eqId ? ["legrand"] : [],
       lastDataAt: null, // TODO: query InfluxDB for latest point
+      tariffConfigured: tariffClassifier.getConfig() !== null,
     };
   });
 
@@ -58,29 +70,60 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
     const { from, to, resolution, bucket } = computeRange(period, dateStr, config.bucket);
 
     try {
-      let points = await queryEnergyPoints(
-        client,
-        config.org,
-        bucket,
-        equipmentId,
-        from,
-        to,
-        resolution,
-      );
-
-      // For day view reading from raw bucket: if no data found (e.g. raw expired
-      // but hourly exists from backfill), fall back to hourly bucket
-      if (points.length === 0 && period === "day" && !bucket.includes("-energy-")) {
-        points = await queryEnergyPoints(
-          client,
-          config.org,
-          `${config.bucket}-energy-hourly`,
-          equipmentId,
-          from,
-          to,
-          resolution,
-        );
+      // Query HP/HC points and legacy (total energy) points, then merge.
+      // For timestamps with HP/HC data, use those. For timestamps with only
+      // legacy data (pre-migration or written before tariff config), use legacy as HP.
+      const buckets = [bucket];
+      if (period === "day" && !bucket.includes("-energy-")) {
+        buckets.push(`${config.bucket}-energy-hourly`);
       }
+
+      let hpHcPoints: EnergyPoint[] = [];
+      let legacyPoints: EnergyPoint[] = [];
+
+      for (const b of buckets) {
+        if (hpHcPoints.length === 0) {
+          hpHcPoints = await queryEnergyHpHcPoints(
+            client,
+            config.org,
+            b,
+            equipmentId,
+            from,
+            to,
+            resolution,
+          );
+        }
+        if (legacyPoints.length === 0) {
+          legacyPoints = await queryEnergyLegacyPoints(
+            client,
+            config.org,
+            b,
+            equipmentId,
+            from,
+            to,
+            resolution,
+          );
+        }
+        if (hpHcPoints.length > 0 || legacyPoints.length > 0) break;
+      }
+
+      // Merge: HP/HC points take priority; fill gaps with legacy
+      const hpHcByTime = new Map(hpHcPoints.map((p) => [p.time, p]));
+      const points: EnergyPoint[] = [];
+      const allTimes = new Set([
+        ...hpHcPoints.map((p) => p.time),
+        ...legacyPoints.map((p) => p.time),
+      ]);
+      for (const time of allTimes) {
+        const hpHc = hpHcByTime.get(time);
+        if (hpHc) {
+          points.push(hpHc);
+        } else {
+          const legacy = legacyPoints.find((p) => p.time === time);
+          if (legacy) points.push(legacy);
+        }
+      }
+      points.sort((a, b) => a.time.localeCompare(b.time));
 
       const totals = computeTotals(points);
 
@@ -99,27 +142,68 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
       return reply.status(500).send({ error: "Failed to query energy data" });
     }
   });
+
+  // ============================================================
+  // GET /api/v1/settings/energy/tariff
+  // ============================================================
+  app.get("/api/v1/settings/energy/tariff", async () => {
+    const config = tariffClassifier.getConfig();
+    return config ?? { schedules: [], prices: { hp: 0, hc: 0 } };
+  });
+
+  // ============================================================
+  // PUT /api/v1/settings/energy/tariff
+  // ============================================================
+  app.put<{ Body: TariffConfig }>("/api/v1/settings/energy/tariff", async (request, reply) => {
+    const config = request.body;
+
+    // Validate structure
+    if (!config || !Array.isArray(config.schedules) || !config.prices) {
+      return reply
+        .status(400)
+        .send({ error: "Invalid tariff config: missing schedules or prices" });
+    }
+
+    // Validate prices
+    if (typeof config.prices.hp !== "number" || typeof config.prices.hc !== "number") {
+      return reply.status(400).send({ error: "Invalid prices: hp and hc must be numbers" });
+    }
+
+    // Validate schedules
+    for (const schedule of config.schedules) {
+      if (!Array.isArray(schedule.days) || !Array.isArray(schedule.slots)) {
+        return reply.status(400).send({ error: "Invalid schedule: missing days or slots" });
+      }
+      for (const day of schedule.days) {
+        if (typeof day !== "number" || day < 0 || day > 6) {
+          return reply.status(400).send({ error: "Invalid day: must be 0-6" });
+        }
+      }
+      for (const slot of schedule.slots) {
+        if (!slot.start || !slot.end || !["hp", "hc"].includes(slot.tariff)) {
+          return reply
+            .status(400)
+            .send({ error: "Invalid slot: must have start, end, and tariff (hp/hc)" });
+        }
+      }
+    }
+
+    settingsManager.set("energy.tariff", JSON.stringify(config));
+    logger.info("Tariff configuration updated");
+    return { ok: true };
+  });
 }
 
 // ============================================================
 // Helpers
 // ============================================================
 
-/**
- * Find the Equipment ID for the main energy meter.
- */
 function findEnergyEquipmentId(equipmentManager: EquipmentManager): string | null {
   const equipments = equipmentManager.getAll();
   const meter = equipments.find((eq) => eq.type === "main_energy_meter");
   return meter?.id ?? null;
 }
 
-/**
- * Compute time range and resolution based on period.
- *
- * Day/week views read from the energy-hourly bucket (populated by InfluxDB task).
- * Month/year views read from the energy-daily bucket.
- */
 function computeRange(
   period: string,
   dateStr: string,
@@ -132,10 +216,8 @@ function computeRange(
       const from = new Date(date);
       const to = new Date(date);
       to.setDate(to.getDate() + 1);
-      // Raw bucket has 7-day retention; use it for recent days (real-time data),
-      // fall back to hourly bucket for older days
       const ageMs = Date.now() - from.getTime();
-      const isRecent = ageMs < 6 * 24 * 60 * 60 * 1000; // < 6 days (safe margin)
+      const isRecent = ageMs < 6 * 24 * 60 * 60 * 1000;
       return {
         from,
         to,
@@ -172,9 +254,9 @@ function computeRange(
 }
 
 /**
- * Query energy points from InfluxDB.
+ * Query energy_hp and energy_hc points from InfluxDB, merge by timestamp.
  */
-async function queryEnergyPoints(
+async function queryEnergyHpHcPoints(
   client: import("@influxdata/influxdb-client").InfluxDB,
   org: string,
   bucket: string,
@@ -184,10 +266,73 @@ async function queryEnergyPoints(
   _resolution: "5min" | "1h" | "1d",
 ): Promise<EnergyPoint[]> {
   const queryApi = client.getQueryApi(org);
+  const needsAggregation = _resolution === "1h" && !bucket.includes("-energy-");
 
-  const field = "value_number";
+  // Query both energy_hp and energy_hc in a single Flux query using alias filter
+  const aliasFilter = `r.alias == "energy_hp" or r.alias == "energy_hc"`;
+  const flux = needsAggregation
+    ? `from(bucket: "${bucket}")
+  |> range(start: ${from.toISOString()}, stop: ${to.toISOString()})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => ${aliasFilter})
+  |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> aggregateWindow(every: 1h, fn: sum, createEmpty: false, timeSrc: "_start")
+  |> sort(columns: ["_time"])`
+    : `from(bucket: "${bucket}")
+  |> range(start: ${from.toISOString()}, stop: ${to.toISOString()})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => ${aliasFilter})
+  |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> sort(columns: ["_time"])`;
 
-  // When reading raw 30-min data for day/week views, aggregate to hourly in the query
+  // Collect HP and HC values indexed by timestamp
+  const hpMap = new Map<string, number>();
+  const hcMap = new Map<string, number>();
+
+  const rows = queryApi.iterateRows(flux);
+  for await (const { values, tableMeta } of rows) {
+    const row = tableMeta.toObject(values) as { _time: string; _value: number; alias: string };
+    if (row._value == null) continue;
+    if (row.alias === "energy_hp") {
+      hpMap.set(row._time, (hpMap.get(row._time) ?? 0) + row._value);
+    } else if (row.alias === "energy_hc") {
+      hcMap.set(row._time, (hcMap.get(row._time) ?? 0) + row._value);
+    }
+  }
+
+  // Merge into EnergyPoint array
+  const allTimes = new Set([...hpMap.keys(), ...hcMap.keys()]);
+  const points: EnergyPoint[] = [];
+  for (const time of allTimes) {
+    const hp = hpMap.get(time) ?? 0;
+    const hc = hcMap.get(time) ?? 0;
+    if (hp + hc > 0) {
+      points.push({ time, hp, hc });
+    }
+  }
+
+  points.sort((a, b) => a.time.localeCompare(b.time));
+  return points;
+}
+
+/**
+ * Fallback: query legacy `energy` alias (pre-HP/HC migration).
+ * Returns all consumption as HP.
+ */
+async function queryEnergyLegacyPoints(
+  client: import("@influxdata/influxdb-client").InfluxDB,
+  org: string,
+  bucket: string,
+  equipmentId: string,
+  from: Date,
+  to: Date,
+  _resolution: "5min" | "1h" | "1d",
+): Promise<EnergyPoint[]> {
+  const queryApi = client.getQueryApi(org);
   const needsAggregation = _resolution === "1h" && !bucket.includes("-energy-");
 
   const flux = needsAggregation
@@ -197,7 +342,7 @@ async function queryEnergyPoints(
   |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
   |> filter(fn: (r) => r.alias == "energy")
   |> filter(fn: (r) => r.category == "energy")
-  |> filter(fn: (r) => r._field == "${field}")
+  |> filter(fn: (r) => r._field == "value_number")
   |> aggregateWindow(every: 1h, fn: sum, createEmpty: false, timeSrc: "_start")
   |> sort(columns: ["_time"])`
     : `from(bucket: "${bucket}")
@@ -206,32 +351,31 @@ async function queryEnergyPoints(
   |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
   |> filter(fn: (r) => r.alias == "energy")
   |> filter(fn: (r) => r.category == "energy")
-  |> filter(fn: (r) => r._field == "${field}")
+  |> filter(fn: (r) => r._field == "value_number")
   |> sort(columns: ["_time"])`;
 
   const points: EnergyPoint[] = [];
-
   const rows = queryApi.iterateRows(flux);
   for await (const { values, tableMeta } of rows) {
     const row = tableMeta.toObject(values) as { _time: string; _value: number };
     if (row._value != null && row._value > 0) {
-      points.push({
-        time: row._time,
-        consumption: row._value,
-      });
+      points.push({ time: row._time, hp: row._value, hc: 0 });
     }
   }
 
   return points;
 }
 
-/**
- * Compute totals from energy points.
- */
 function computeTotals(points: EnergyPoint[]): EnergyTotals {
-  let totalConsumption = 0;
+  let totalHp = 0;
+  let totalHc = 0;
   for (const p of points) {
-    totalConsumption += p.consumption;
+    totalHp += p.hp;
+    totalHc += p.hc;
   }
-  return { total_consumption: totalConsumption };
+  return {
+    total_consumption: totalHp + totalHc,
+    total_hp: totalHp,
+    total_hc: totalHc,
+  };
 }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -163,6 +163,8 @@ export async function createServer(deps: ServerDeps) {
   registerEnergyRoutes(app, {
     equipmentManager,
     influxClient: historyWriter.getInfluxClient(),
+    settingsManager,
+    tariffClassifier: historyWriter.getTariffClassifier(),
     logger,
   });
   registerDashboardRoutes(app, { db });

--- a/src/energy/tariff-classifier.ts
+++ b/src/energy/tariff-classifier.ts
@@ -1,0 +1,143 @@
+/**
+ * TariffClassifier — Classifies energy windows into HP/HC based on tariff schedule.
+ *
+ * Reads the tariff schedule from settings and splits energy (Wh) for a 30-min
+ * window into HP and HC portions using linear prorata when a window straddles
+ * a tariff transition.
+ *
+ * Used by the HistoryWriter at write time to produce `energy_hp` and `energy_hc`
+ * data points alongside the total `energy` point.
+ */
+
+import type { Logger } from "../core/logger.js";
+import type { SettingsManager } from "../core/settings-manager.js";
+import type { TariffConfig, TariffSplit } from "../shared/types.js";
+
+const SETTINGS_KEY = "energy.tariff";
+const HALF_HOUR_S = 1800;
+
+export class TariffClassifier {
+  private logger: Logger;
+  private settingsManager: SettingsManager;
+  private cachedConfig: TariffConfig | null = null;
+  private cacheKey: string | null = null;
+
+  constructor(settingsManager: SettingsManager, logger: Logger) {
+    this.settingsManager = settingsManager;
+    this.logger = logger.child({ module: "tariff-classifier" });
+  }
+
+  /**
+   * Classify a 30-min energy window into HP/HC split.
+   * Uses the tariff schedule in effect for the window's day-of-week.
+   * Applies linear prorata if the window straddles a tariff transition.
+   *
+   * @param totalWh Total energy in Wh for the 30-min window
+   * @param windowStartEpoch Window start as Unix epoch seconds
+   * @returns HP/HC split in Wh
+   */
+  classify(totalWh: number, windowStartEpoch: number): TariffSplit {
+    const config = this.getConfig();
+    if (!config) {
+      // No tariff configured → everything is HP
+      return { hp: totalWh, hc: 0 };
+    }
+
+    const windowStart = new Date(windowStartEpoch * 1000);
+    const dayOfWeek = windowStart.getDay(); // 0=Sunday..6=Saturday
+
+    // Find the schedule for this day
+    const daySchedule = config.schedules.find((s) => s.days.includes(dayOfWeek));
+    if (!daySchedule || daySchedule.slots.length === 0) {
+      // No schedule for this day → everything is HP
+      return { hp: totalWh, hc: 0 };
+    }
+
+    const windowStartMinutes = windowStart.getHours() * 60 + windowStart.getMinutes();
+    const windowEndMinutes = windowStartMinutes + 30;
+
+    let hpMinutes = 0;
+    let hcMinutes = 0;
+
+    for (const slot of daySchedule.slots) {
+      const slotStart = parseTimeToMinutes(slot.start);
+      let slotEnd = parseTimeToMinutes(slot.end);
+
+      // Handle midnight wrap: "00:00" means 24:00 (end of day)
+      if (slotEnd === 0) slotEnd = 1440;
+
+      // Build slot ranges — if end < start, the slot wraps around midnight
+      // e.g. 17:04 → 00:04 becomes [17:04, 24:00) + [00:00, 00:04)
+      const ranges: Array<[number, number]> =
+        slotEnd <= slotStart
+          ? [
+              [slotStart, 1440],
+              [0, slotEnd],
+            ]
+          : [[slotStart, slotEnd]];
+
+      for (const [rangeStart, rangeEnd] of ranges) {
+        const overlapStart = Math.max(windowStartMinutes, rangeStart);
+        const overlapEnd = Math.min(windowEndMinutes, rangeEnd);
+        const overlap = Math.max(0, overlapEnd - overlapStart);
+
+        if (overlap > 0) {
+          if (slot.tariff === "hp") {
+            hpMinutes += overlap;
+          } else {
+            hcMinutes += overlap;
+          }
+        }
+      }
+    }
+
+    const totalMinutes = hpMinutes + hcMinutes;
+    if (totalMinutes === 0) {
+      // No slot covers this window → default to HP
+      return { hp: totalWh, hc: 0 };
+    }
+
+    return {
+      hp: Math.round((totalWh * hpMinutes) / totalMinutes),
+      hc: Math.round((totalWh * hcMinutes) / totalMinutes),
+    };
+  }
+
+  /** Get the current tariff config from settings (cached). */
+  getConfig(): TariffConfig | null {
+    const raw = this.settingsManager.get(SETTINGS_KEY);
+    if (!raw) {
+      this.cachedConfig = null;
+      this.cacheKey = null;
+      return null;
+    }
+
+    // Use raw string as cache key to avoid re-parsing on every call
+    if (raw === this.cacheKey) {
+      return this.cachedConfig;
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as TariffConfig;
+      this.cachedConfig = parsed;
+      this.cacheKey = raw;
+      return parsed;
+    } catch (err) {
+      this.logger.warn({ err }, "Invalid tariff config in settings");
+      this.cachedConfig = null;
+      this.cacheKey = null;
+      return null;
+    }
+  }
+
+  /** Get the window duration in seconds (for testing/external use). */
+  static get WINDOW_DURATION_S(): number {
+    return HALF_HOUR_S;
+  }
+}
+
+/** Parse "HH:MM" to minutes since midnight. */
+function parseTimeToMinutes(time: string): number {
+  const [h, m] = time.split(":").map(Number);
+  return h * 60 + m;
+}

--- a/src/history/history-writer.ts
+++ b/src/history/history-writer.ts
@@ -4,6 +4,7 @@ import type { EventBus } from "../core/event-bus.js";
 import type { SettingsManager } from "../core/settings-manager.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { DataCategory } from "../shared/types.js";
+import { TariffClassifier } from "../energy/tariff-classifier.js";
 import { InfluxClient, Point } from "./influx-client.js";
 
 // ============================================================
@@ -70,6 +71,7 @@ export class HistoryWriter {
   private settingsManager: SettingsManager;
   private equipmentManager: EquipmentManager;
   private influxClient: InfluxClient;
+  private tariffClassifier: TariffClassifier;
   private unsubscribe: (() => void) | null = null;
 
   /** Cache of historized binding IDs for fast lookup. */
@@ -99,6 +101,7 @@ export class HistoryWriter {
     this.equipmentManager = equipmentManager;
     this.logger = logger.child({ module: "history-writer" });
     this.influxClient = new InfluxClient(logger);
+    this.tariffClassifier = new TariffClassifier(settingsManager, logger);
   }
 
   /** Initialize: connect to InfluxDB if configured, subscribe to events. */
@@ -346,8 +349,61 @@ export class HistoryWriter {
 
     this.influxClient.writePoint(point);
 
+    // Write HP/HC split for energy data points
+    if (meta.category === "energy" && alias === "energy" && typeof value === "number") {
+      this.writeEnergyHpHc(equipmentId, meta, value, sourceTimestamp);
+    }
+
     // Update last written
     this.lastWritten.set(bindingId, { value, timestamp: Date.now() });
+  }
+
+  /** Get the TariffClassifier instance (for API routes). */
+  getTariffClassifier(): TariffClassifier {
+    return this.tariffClassifier;
+  }
+
+  // ============================================================
+  // Private: energy HP/HC classification
+  // ============================================================
+
+  /**
+   * Write energy_hp and energy_hc points based on tariff classification.
+   * Called after the main `energy` point is written.
+   */
+  private writeEnergyHpHc(
+    equipmentId: string,
+    meta: BindingMeta,
+    totalWh: number,
+    sourceTimestamp?: number,
+  ): void {
+    const windowEpoch = sourceTimestamp ?? Math.floor(Date.now() / 1000);
+    const split = this.tariffClassifier.classify(totalWh, windowEpoch);
+
+    for (const [alias, value] of [
+      ["energy_hp", split.hp],
+      ["energy_hc", split.hc],
+    ] as const) {
+      const hpHcPoint = new Point("equipment_data")
+        .tag("equipmentId", equipmentId)
+        .tag("alias", alias)
+        .tag("category", meta.category)
+        .tag("zoneId", meta.zoneId)
+        .tag("type", meta.type);
+
+      hpHcPoint.floatField("value_number", value);
+
+      if (sourceTimestamp !== undefined) {
+        hpHcPoint.timestamp(sourceTimestamp);
+      }
+
+      this.influxClient.writePoint(hpHcPoint);
+    }
+
+    this.logger.trace(
+      { equipmentId, totalWh, hp: split.hp, hc: split.hc },
+      "Energy HP/HC points written",
+    );
   }
 
   // ============================================================

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -804,11 +804,14 @@ export interface AppConfig {
 
 export interface EnergyPoint {
   time: string;
-  consumption: number; // Wh
+  hp: number; // Wh attributed to Heures Pleines
+  hc: number; // Wh attributed to Heures Creuses
 }
 
 export interface EnergyTotals {
-  total_consumption: number; // Wh
+  total_consumption: number; // hp + hc (Wh)
+  total_hp: number; // Wh
+  total_hc: number; // Wh
 }
 
 export interface EnergyHistoryResponse {
@@ -824,4 +827,35 @@ export interface EnergyStatus {
   available: boolean;
   sources: string[];
   lastDataAt: string | null;
+  tariffConfigured: boolean;
+}
+
+// ============================================================
+// Tariff Configuration
+// ============================================================
+
+export interface TariffSlot {
+  start: string; // "HH:MM"
+  end: string; // "HH:MM"
+  tariff: "hp" | "hc";
+}
+
+export interface DaySchedule {
+  days: number[]; // 0=Sunday..6=Saturday
+  slots: TariffSlot[];
+}
+
+export interface TariffPrices {
+  hp: number; // €/kWh
+  hc: number; // €/kWh
+}
+
+export interface TariffConfig {
+  schedules: DaySchedule[];
+  prices: TariffPrices;
+}
+
+export interface TariffSplit {
+  hp: number; // Wh attributed to HP
+  hc: number; // Wh attributed to HC
 }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -16,7 +16,7 @@ import type {
   MqttBroker,
   MqttPublisher, MqttPublisherMapping, MqttPublisherWithMappings,
   DashboardWidget, WidgetConfig, WidgetFamily,
-  EnergyHistoryResponse, EnergyStatus,
+  EnergyHistoryResponse, EnergyStatus, TariffConfig,
 } from "./types";
 
 const API_BASE = "/api/v1";
@@ -1102,4 +1102,15 @@ export async function getEnergyHistory(
   return fetchJSON<EnergyHistoryResponse>(
     `${API_BASE}/energy/history?period=${period}&date=${date}`,
   );
+}
+
+export async function getTariffConfig(): Promise<TariffConfig> {
+  return fetchJSON<TariffConfig>(`${API_BASE}/settings/energy/tariff`);
+}
+
+export async function saveTariffConfig(config: TariffConfig): Promise<void> {
+  await fetchJSON(`${API_BASE}/settings/energy/tariff`, {
+    method: "PUT",
+    body: JSON.stringify(config),
+  });
 }

--- a/ui/src/components/energy/EnergyBarChart.tsx
+++ b/ui/src/components/energy/EnergyBarChart.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import {
   ResponsiveContainer,
   BarChart,
@@ -22,10 +23,12 @@ interface ChartDatum {
   label: string;
   /** Tooltip label — e.g. "14h00 – 15h00" for day view */
   tooltipLabel?: string;
-  consumption: number; // always in kWh for display
+  hp: number; // kWh
+  hc: number; // kWh
 }
 
-const CONSUMPTION_COLOR = "#4F7BE8";
+const HP_COLOR = "#4F7BE8";
+const HC_COLOR = "#93B5F0";
 
 // ============================================================
 // Aggregation: collapse raw points into period-appropriate bars
@@ -33,39 +36,41 @@ const CONSUMPTION_COLOR = "#4F7BE8";
 
 /** Day view: always 24 bars (00:00–23:00), empty bars for hours without data */
 function aggregateDay(points: EnergyPoint[]): ChartDatum[] {
-  const byHour = new Map<number, number>();
+  const hpByHour = new Map<number, number>();
+  const hcByHour = new Map<number, number>();
 
   for (const p of points) {
     const d = new Date(p.time);
     const hour = d.getHours();
-    byHour.set(hour, (byHour.get(hour) ?? 0) + p.consumption);
+    hpByHour.set(hour, (hpByHour.get(hour) ?? 0) + p.hp);
+    hcByHour.set(hour, (hcByHour.get(hour) ?? 0) + p.hc);
   }
 
   return Array.from({ length: 24 }, (_, hour) => ({
     label: `${String(hour).padStart(2, "0")}h`,
     tooltipLabel: `${String(hour).padStart(2, "0")}h00 – ${String((hour + 1) % 24).padStart(2, "0")}h00`,
-    consumption: (byHour.get(hour) ?? 0) / 1000,
+    hp: (hpByHour.get(hour) ?? 0) / 1000,
+    hc: (hcByHour.get(hour) ?? 0) / 1000,
   }));
 }
 
 /** Week view: always 7 bars (Mon–Sun), empty bars for days without data */
 function aggregateWeek(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
-  // Sum hourly points by local date
-  const byDay = new Map<string, number>();
+  const hpByDay = new Map<string, number>();
+  const hcByDay = new Map<string, number>();
   for (const p of points) {
     const d = new Date(p.time);
     const key = localDateKey(d);
-    byDay.set(key, (byDay.get(key) ?? 0) + p.consumption);
+    hpByDay.set(key, (hpByDay.get(key) ?? 0) + p.hp);
+    hcByDay.set(key, (hcByDay.get(key) ?? 0) + p.hc);
   }
 
-  // Compute Monday of the week containing the given date
   const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
   const dayOfWeek = ref.getDay();
   const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
   const monday = new Date(ref);
   monday.setDate(monday.getDate() + mondayOffset);
 
-  // Generate 7 days
   return Array.from({ length: 7 }, (_, i) => {
     const day = new Date(monday);
     day.setDate(day.getDate() + i);
@@ -79,18 +84,21 @@ function aggregateWeek(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
     return {
       label,
       tooltipLabel,
-      consumption: (byDay.get(key) ?? 0) / 1000,
+      hp: (hpByDay.get(key) ?? 0) / 1000,
+      hc: (hcByDay.get(key) ?? 0) / 1000,
     };
   });
 }
 
 /** Month view: always N bars (1 per day of the month), empty bars for days without data */
 function aggregateMonth(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
-  const byDay = new Map<string, number>();
+  const hpByDay = new Map<string, number>();
+  const hcByDay = new Map<string, number>();
   for (const p of points) {
     const d = new Date(p.time);
     const key = localDateKey(d);
-    byDay.set(key, (byDay.get(key) ?? 0) + p.consumption);
+    hpByDay.set(key, (hpByDay.get(key) ?? 0) + p.hp);
+    hcByDay.set(key, (hcByDay.get(key) ?? 0) + p.hc);
   }
 
   const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
@@ -107,7 +115,8 @@ function aggregateMonth(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
     return {
       label: String(i + 1),
       tooltipLabel,
-      consumption: (byDay.get(key) ?? 0) / 1000,
+      hp: (hpByDay.get(key) ?? 0) / 1000,
+      hc: (hcByDay.get(key) ?? 0) / 1000,
     };
   });
 }
@@ -117,10 +126,12 @@ function aggregateYear(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
   const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
   const year = ref.getFullYear();
 
-  const monthTotals = new Array<number>(12).fill(0);
+  const hpTotals = new Array<number>(12).fill(0);
+  const hcTotals = new Array<number>(12).fill(0);
   for (const p of points) {
     const d = new Date(p.time);
-    monthTotals[d.getMonth()] += p.consumption;
+    hpTotals[d.getMonth()] += p.hp;
+    hcTotals[d.getMonth()] += p.hc;
   }
 
   return Array.from({ length: 12 }, (_, i) => {
@@ -131,7 +142,8 @@ function aggregateYear(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
     return {
       label: capitalizeFirst(d.toLocaleDateString("fr-FR", { month: "short" })),
       tooltipLabel,
-      consumption: monthTotals[i] / 1000,
+      hp: hpTotals[i] / 1000,
+      hc: hcTotals[i] / 1000,
     };
   });
 }
@@ -182,7 +194,12 @@ function formatYAxis(kwh: number): string {
 // ============================================================
 
 export function EnergyBarChart({ points, period, date, height = 300 }: EnergyBarChartProps) {
+  const { t } = useTranslation();
   const data = useMemo(() => buildChartData(points, period, date), [points, period, date]);
+
+  const hasHpHc = useMemo(() => {
+    return data.some((d) => d.hc > 0);
+  }, [data]);
 
   // Fixed gridline intervals per period
   const yTicks = useMemo(() => {
@@ -193,7 +210,7 @@ export function EnergyBarChart({ points, period, date, height = 300 }: EnergyBar
       year: 500,
     };
     const step = stepByPeriod[period] ?? 1;
-    const max = Math.ceil(Math.max(...data.map((d) => d.consumption), step) / step) * step;
+    const max = Math.ceil(Math.max(...data.map((d) => d.hp + d.hc), step) / step) * step;
     return Array.from({ length: max / step + 1 }, (_, i) => i * step);
   }, [data, period]);
 
@@ -236,18 +253,55 @@ export function EnergyBarChart({ points, period, date, height = 300 }: EnergyBar
             borderRadius: "6px",
             fontSize: "12px",
           }}
-          formatter={(value: number | undefined) => [formatKWh(value ?? 0), "Consommation"]}
+          formatter={(value: number | undefined, name: string) => {
+            const label = name === "hp" ? t("energy.peakHours") : name === "hc" ? t("energy.offPeakHours") : name;
+            return [formatKWh(value ?? 0), label];
+          }}
           labelFormatter={(_label: unknown, payload: ReadonlyArray<{ payload?: ChartDatum }>) =>
             payload[0]?.payload?.tooltipLabel ?? String(_label)
           }
         />
-        <Bar
-          dataKey="consumption"
-          fill={CONSUMPTION_COLOR}
-          activeBar={{ fill: "#6B93F0" }}
-          radius={[4, 4, 0, 0]}
-          maxBarSize={period === "day" ? 20 : 40}
-        />
+        {hasHpHc ? (
+          <>
+            <Bar
+              dataKey="hp"
+              stackId="energy"
+              fill={HP_COLOR}
+              maxBarSize={period === "day" ? 20 : 40}
+              name="hp"
+              shape={(props: Record<string, unknown>) => {
+                const { x, y, width, height, fill: f, hc: hcVal } = props as {
+                  x: number; y: number; width: number; height: number; fill: string; hc: number;
+                };
+                if (!height || height <= 0) return null;
+                const r = hcVal > 0 ? 0 : 4;
+                return (
+                  <path
+                    d={`M${x},${y + height}V${y + r}${r ? `Q${x},${y} ${x + r},${y}` : ""}H${x + width - r}${r ? `Q${x + width},${y} ${x + width},${y + r}` : ""}V${y + height}Z`}
+                    fill={f as string}
+                  />
+                );
+              }}
+            />
+            <Bar
+              dataKey="hc"
+              stackId="energy"
+              fill={HC_COLOR}
+              radius={[4, 4, 0, 0]}
+              maxBarSize={period === "day" ? 20 : 40}
+              name="hc"
+            />
+          </>
+        ) : (
+          <Bar
+            dataKey="hp"
+            fill={HP_COLOR}
+            activeBar={{ fill: "#6B93F0" }}
+            radius={[4, 4, 0, 0]}
+            maxBarSize={period === "day" ? 20 : 40}
+            name="hp"
+          />
+        )}
       </BarChart>
     </ResponsiveContainer>
   );

--- a/ui/src/components/energy/EnergyBarChart.tsx
+++ b/ui/src/components/energy/EnergyBarChart.tsx
@@ -253,8 +253,9 @@ export function EnergyBarChart({ points, period, date, height = 300 }: EnergyBar
             borderRadius: "6px",
             fontSize: "12px",
           }}
-          formatter={(value: number | undefined, name: string) => {
-            const label = name === "hp" ? t("energy.peakHours") : name === "hc" ? t("energy.offPeakHours") : name;
+          formatter={(value: number | undefined, name: string | undefined) => {
+            const n = name ?? "";
+            const label = n === "hp" ? t("energy.peakHours") : n === "hc" ? t("energy.offPeakHours") : n;
             return [formatKWh(value ?? 0), label];
           }}
           labelFormatter={(_label: unknown, payload: ReadonlyArray<{ payload?: ChartDatum }>) =>
@@ -269,10 +270,10 @@ export function EnergyBarChart({ points, period, date, height = 300 }: EnergyBar
               fill={HP_COLOR}
               maxBarSize={period === "day" ? 20 : 40}
               name="hp"
-              shape={(props: Record<string, unknown>) => {
-                const { x, y, width, height, fill: f, hc: hcVal } = props as {
-                  x: number; y: number; width: number; height: number; fill: string; hc: number;
-                };
+              shape={(props: unknown) => {
+                const p = props as Record<string, unknown>;
+                const x = p.x as number, y = p.y as number, width = p.width as number, height = p.height as number;
+                const f = p.fill as string, hcVal = p.hc as number;
                 if (!height || height <= 0) return null;
                 const r = hcVal > 0 ? 0 : 4;
                 return (

--- a/ui/src/components/energy/EnergyPage.tsx
+++ b/ui/src/components/energy/EnergyPage.tsx
@@ -22,6 +22,8 @@ export function EnergyPage() {
     fetchHistory();
   }, [fetchHistory]);
 
+  const hasHpHc = history ? history.totals.total_hc > 0 : false;
+
   return (
     <div className="p-4 sm:p-6">
       {/* Header */}
@@ -37,16 +39,6 @@ export function EnergyPage() {
         </div>
       ) : (
         <div className="bg-surface border border-border rounded-[10px] p-4 sm:p-6">
-          {/* Total */}
-          <div className="flex items-center justify-end mb-4">
-            {history && (
-              <span className="text-[18px] font-bold text-text tabular-nums">
-                {formatKWh(history.totals.total_consumption, period)}
-                <span className="text-[13px] font-medium text-text-secondary ml-1">kWh</span>
-              </span>
-            )}
-          </div>
-
           {/* Chart */}
           <EnergyBarChart
             points={history?.points ?? []}
@@ -54,6 +46,27 @@ export function EnergyPage() {
             date={date}
             height={350}
           />
+
+          {/* Legend below chart */}
+          {history && (
+            <div className="flex flex-col items-center mt-3 gap-1">
+              {hasHpHc && (
+                <div className="flex items-center gap-4 text-[13px] text-text-secondary">
+                  <span className="flex items-center gap-1.5">
+                    <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: "#4F7BE8" }} />
+                    {t("energy.peakHours")} : {formatKWh(history.totals.total_hp, period)} kWh
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: "#93B5F0" }} />
+                    {t("energy.offPeakHours")} : {formatKWh(history.totals.total_hc, period)} kWh
+                  </span>
+                </div>
+              )}
+              <div className="text-[13px] font-semibold text-text tabular-nums">
+                Total : {formatKWh(history.totals.total_consumption, period)} kWh
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/ui/src/components/settings/TariffSettings.tsx
+++ b/ui/src/components/settings/TariffSettings.tsx
@@ -1,0 +1,373 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Zap, Plus, Trash2, Loader2 } from "lucide-react";
+import { getTariffConfig, saveTariffConfig } from "../../api";
+import type { TariffConfig, TariffSlot } from "../../types";
+
+const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
+const HP_COLOR = "#4F7BE8";
+const HC_COLOR = "#93B5F0";
+const TOTAL_MINUTES = 1440;
+
+function defaultSlots(): TariffSlot[] {
+  return [
+    { start: "06:00", end: "22:00", tariff: "hp" },
+    { start: "22:00", end: "06:00", tariff: "hc" },
+  ];
+}
+
+function emptyConfig(): TariffConfig {
+  return {
+    schedules: [{ days: [...ALL_DAYS], slots: defaultSlots() }],
+    prices: { hp: 0, hc: 0 },
+  };
+}
+
+/** Parse "HH:MM" to minutes since midnight */
+function timeToMinutes(time: string): number {
+  const [h, m] = time.split(":").map(Number);
+  return h * 60 + m;
+}
+
+/** Format minutes to "HHhMM" for display */
+function minutesToLabel(minutes: number): string {
+  const h = Math.floor(minutes / 60) % 24;
+  const m = minutes % 60;
+  return m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, "0")}`;
+}
+
+/** Build a flat minute-by-minute array of HP/HC for the 24h timeline */
+function buildTimeline(slots: TariffSlot[]): Array<"hp" | "hc" | null> {
+  const timeline = new Array<"hp" | "hc" | null>(TOTAL_MINUTES).fill(null);
+  for (const slot of slots) {
+    const start = timeToMinutes(slot.start);
+    let end = timeToMinutes(slot.end);
+    if (end === 0) end = TOTAL_MINUTES;
+
+    if (end > start) {
+      // Normal range
+      for (let i = start; i < end; i++) timeline[i] = slot.tariff;
+    } else {
+      // Midnight wrap: e.g. 17:04 → 00:04
+      for (let i = start; i < TOTAL_MINUTES; i++) timeline[i] = slot.tariff;
+      for (let i = 0; i < end; i++) timeline[i] = slot.tariff;
+    }
+  }
+  return timeline;
+}
+
+/** Convert timeline to contiguous segments for rendering */
+interface Segment {
+  startMin: number;
+  endMin: number;
+  tariff: "hp" | "hc" | null;
+}
+
+function timelineToSegments(timeline: Array<"hp" | "hc" | null>): Segment[] {
+  const segments: Segment[] = [];
+  let current: Segment | null = null;
+
+  for (let i = 0; i < TOTAL_MINUTES; i++) {
+    const t = timeline[i];
+    if (!current || current.tariff !== t) {
+      if (current) segments.push(current);
+      current = { startMin: i, endMin: i + 1, tariff: t };
+    } else {
+      current.endMin = i + 1;
+    }
+  }
+  if (current) segments.push(current);
+  return segments;
+}
+
+/** Timeline bar component */
+function TariffTimeline({ slots }: { slots: TariffSlot[] }) {
+  const { t } = useTranslation();
+  const timeline = buildTimeline(slots);
+  const segments = timelineToSegments(timeline);
+
+  // Collect transition labels (skip last 0h — redundant)
+  const labels: Array<{ min: number; text: string }> = [];
+  labels.push({ min: 0, text: minutesToLabel(0) });
+  for (let i = 1; i < segments.length; i++) {
+    labels.push({ min: segments[i].startMin, text: minutesToLabel(segments[i].startMin) });
+  }
+
+  // Split labels into above (even) and below (odd)
+  const aboveLabels = labels.filter((_, i) => i % 2 === 0);
+  const belowLabels = labels.filter((_, i) => i % 2 === 1);
+
+  return (
+    <div className="mb-4">
+      {/* Labels above the bar */}
+      <div className="relative h-4 mb-1">
+        {aboveLabels.map((label, i) => (
+          <span
+            key={i}
+            className="absolute text-[10px] text-text-secondary -translate-x-1/2 bottom-0"
+            style={{ left: `${(label.min / TOTAL_MINUTES) * 100}%` }}
+          >
+            {label.text}
+          </span>
+        ))}
+      </div>
+
+      {/* Bar */}
+      <div className="flex h-7 rounded-md overflow-hidden">
+        {segments.map((seg, i) => {
+          const widthPct = ((seg.endMin - seg.startMin) / TOTAL_MINUTES) * 100;
+          const color =
+            seg.tariff === "hp" ? HP_COLOR : seg.tariff === "hc" ? HC_COLOR : "#e5e7eb";
+          return (
+            <div
+              key={i}
+              style={{ width: `${widthPct}%`, backgroundColor: color }}
+              className="transition-all"
+            />
+          );
+        })}
+      </div>
+
+      {/* Labels below the bar */}
+      <div className="relative h-4 mt-1">
+        {belowLabels.map((label, i) => (
+          <span
+            key={i}
+            className="absolute text-[10px] text-text-secondary -translate-x-1/2 top-0"
+            style={{ left: `${(label.min / TOTAL_MINUTES) * 100}%` }}
+          >
+            {label.text}
+          </span>
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 mt-2 text-[12px] text-text-secondary">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded-sm" style={{ backgroundColor: HP_COLOR }} />
+          {t("energy.peakHours")}
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded-sm" style={{ backgroundColor: HC_COLOR }} />
+          {t("energy.offPeakHours")}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function TariffSettings() {
+  const { t } = useTranslation();
+  const [config, setConfig] = useState<TariffConfig>(emptyConfig());
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getTariffConfig()
+      .then((c) => {
+        if (c.schedules.length > 0) setConfig(c);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  // Always work with schedule index 0 (single schedule for all days)
+  const slots = config.schedules[0]?.slots ?? [];
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      // Ensure all days are included in the single schedule
+      const toSave: TariffConfig = {
+        ...config,
+        schedules: [{ days: [...ALL_DAYS], slots }],
+      };
+      await saveTariffConfig(toSave);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("tariff.saveError"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const updateSlot = (slotIdx: number, patch: Partial<TariffSlot>) => {
+    setConfig((prev) => {
+      const schedules = [...prev.schedules];
+      const newSlots = [...schedules[0].slots];
+      newSlots[slotIdx] = { ...newSlots[slotIdx], ...patch };
+      schedules[0] = { ...schedules[0], slots: newSlots };
+      return { ...prev, schedules };
+    });
+  };
+
+  const addSlot = () => {
+    setConfig((prev) => {
+      const schedules = [...prev.schedules];
+      const newSlots = [...schedules[0].slots, { start: "00:00", end: "00:00", tariff: "hp" as const }];
+      schedules[0] = { ...schedules[0], slots: newSlots };
+      return { ...prev, schedules };
+    });
+  };
+
+  const removeSlot = (slotIdx: number) => {
+    setConfig((prev) => {
+      const schedules = [...prev.schedules];
+      const newSlots = schedules[0].slots.filter((_, i) => i !== slotIdx);
+      schedules[0] = { ...schedules[0], slots: newSlots };
+      return { ...prev, schedules };
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-surface border border-border rounded-[10px] p-5">
+        <div className="flex items-center gap-2 text-text-secondary text-[13px]">
+          <Loader2 size={14} className="animate-spin" />
+          {t("common.loading")}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-[10px] p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <Zap size={18} strokeWidth={1.5} className="text-text-secondary" />
+        <h2 className="text-[15px] font-semibold text-text">{t("tariff.title")}</h2>
+      </div>
+
+      {/* Prices */}
+      <div className="grid grid-cols-2 gap-4 mb-5">
+        <div>
+          <label className="block text-[12px] text-text-secondary mb-1">
+            {t("tariff.priceHp")}
+          </label>
+          <input
+            type="number"
+            step="0.0001"
+            min="0"
+            value={config.prices.hp || ""}
+            onChange={(e) =>
+              setConfig((prev) => ({
+                ...prev,
+                prices: { ...prev.prices, hp: parseFloat(e.target.value) || 0 },
+              }))
+            }
+            className="w-full px-3 py-1.5 border border-border rounded-md text-[13px] text-text bg-background"
+          />
+        </div>
+        <div>
+          <label className="block text-[12px] text-text-secondary mb-1">
+            {t("tariff.priceHc")}
+          </label>
+          <input
+            type="number"
+            step="0.0001"
+            min="0"
+            value={config.prices.hc || ""}
+            onChange={(e) =>
+              setConfig((prev) => ({
+                ...prev,
+                prices: { ...prev.prices, hc: parseFloat(e.target.value) || 0 },
+              }))
+            }
+            className="w-full px-3 py-1.5 border border-border rounded-md text-[13px] text-text bg-background"
+          />
+        </div>
+      </div>
+
+      {/* Visual timeline */}
+      <TariffTimeline slots={slots} />
+
+      {/* Time slots */}
+      <div className="mb-5 border border-border-light rounded-lg p-4">
+        <h3 className="text-[13px] font-medium text-text mb-3">
+          {t("tariff.timeSlots")}
+        </h3>
+
+        <div className="space-y-2">
+          {slots.map((slot, slotIdx) => (
+            <div key={slotIdx} className="flex items-center gap-2">
+              <span
+                className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
+                style={{ backgroundColor: slot.tariff === "hp" ? HP_COLOR : HC_COLOR }}
+              />
+              <input
+                type="time"
+                step="60"
+                value={slot.start}
+                onChange={(e) => updateSlot(slotIdx, { start: e.target.value })}
+                className="px-2 py-1 border border-border rounded text-[13px] text-text bg-background"
+              />
+              <span className="text-text-tertiary text-[12px]">→</span>
+              <input
+                type="time"
+                step="60"
+                value={slot.end}
+                onChange={(e) => updateSlot(slotIdx, { end: e.target.value })}
+                className="px-2 py-1 border border-border rounded text-[13px] text-text bg-background"
+              />
+              <select
+                value={slot.tariff}
+                onChange={(e) =>
+                  updateSlot(slotIdx, { tariff: e.target.value as "hp" | "hc" })
+                }
+                className="px-2 py-1 border border-border rounded text-[13px] text-text bg-background"
+              >
+                <option value="hp">{t("energy.peakHours")}</option>
+                <option value="hc">{t("energy.offPeakHours")}</option>
+              </select>
+              {slots.length > 1 && (
+                <button
+                  onClick={() => removeSlot(slotIdx)}
+                  className="p-1 text-text-tertiary hover:text-red-500 transition-colors"
+                  title={t("tariff.delete")}
+                >
+                  <Trash2 size={14} />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <button
+          onClick={addSlot}
+          className="mt-2 flex items-center gap-1 text-[12px] text-primary hover:text-primary-hover transition-colors"
+        >
+          <Plus size={14} />
+          {t("tariff.addSlot")}
+        </button>
+      </div>
+
+      {/* Save */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="px-4 py-1.5 bg-primary text-white text-[13px] font-medium rounded-md hover:bg-primary-hover disabled:opacity-50 transition-colors"
+        >
+          {saving ? (
+            <span className="flex items-center gap-1.5">
+              <Loader2 size={14} className="animate-spin" />
+              {t("tariff.saving")}
+            </span>
+          ) : (
+            t("tariff.save")
+          )}
+        </button>
+        {saved && (
+          <span className="text-[12px] text-green-600">{t("tariff.saved")}</span>
+        )}
+        {error && (
+          <span className="text-[12px] text-red-500">{error}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -780,5 +780,19 @@
   "energy.cumul.hour": "Current hour",
   "energy.cumul.day": "Today",
   "energy.cumul.month": "This month",
-  "energy.cumul.year": "This year"
+  "energy.cumul.year": "This year",
+  "energy.totalConsumption": "Total consumption",
+  "energy.peakHours": "Peak hours",
+  "energy.offPeakHours": "Off-peak hours",
+
+  "tariff.title": "Energy tariffs",
+  "tariff.priceHp": "Peak price (€/kWh)",
+  "tariff.priceHc": "Off-peak price (€/kWh)",
+  "tariff.timeSlots": "Time slots",
+  "tariff.addSlot": "Add slot",
+  "tariff.delete": "Delete",
+  "tariff.saving": "Saving...",
+  "tariff.save": "Save",
+  "tariff.saved": "Tariffs saved",
+  "tariff.saveError": "Error saving tariffs"
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -780,5 +780,19 @@
   "energy.cumul.hour": "Heure en cours",
   "energy.cumul.day": "Aujourd'hui",
   "energy.cumul.month": "Ce mois",
-  "energy.cumul.year": "Cette année"
+  "energy.cumul.year": "Cette année",
+  "energy.totalConsumption": "Consommation totale",
+  "energy.peakHours": "H. pleines",
+  "energy.offPeakHours": "H. creuses",
+
+  "tariff.title": "Tarifs énergie",
+  "tariff.priceHp": "Prix HP (€/kWh)",
+  "tariff.priceHc": "Prix HC (€/kWh)",
+  "tariff.timeSlots": "Créneaux horaires",
+  "tariff.addSlot": "Ajouter un créneau",
+  "tariff.delete": "Supprimer",
+  "tariff.saving": "Enregistrement...",
+  "tariff.save": "Enregistrer",
+  "tariff.saved": "Tarifs enregistrés",
+  "tariff.saveError": "Erreur lors de l'enregistrement"
 }

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -22,6 +22,7 @@ import { setTheme } from "../theme";
 import type { ThemeSetting } from "../theme";
 import type { ApiToken, User, UserRole, HistoryStatus, RetentionStatus } from "../types";
 import { MobileSection } from "../components/settings/MobileSection";
+import { TariffSettings } from "../components/settings/TariffSettings";
 import { useIsMobile } from "../hooks/useIsMobile";
 
 export function SettingsPage() {
@@ -106,6 +107,7 @@ export function SettingsPage() {
             <ApiTokensSection />
             {isAdmin && <UserManagementSection currentUserId={user?.id ?? ""} />}
             {isAdmin && <InfluxDbSettingsSection />}
+            {isAdmin && <TariffSettings />}
           </div>
         </div>
       )}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -687,11 +687,14 @@ export interface DashboardWidget {
 
 export interface EnergyPoint {
   time: string;
-  consumption: number; // Wh
+  hp: number; // Wh attributed to Heures Pleines
+  hc: number; // Wh attributed to Heures Creuses
 }
 
 export interface EnergyTotals {
-  total_consumption: number; // Wh
+  total_consumption: number; // hp + hc (Wh)
+  total_hp: number; // Wh
+  total_hc: number; // Wh
 }
 
 export interface EnergyHistoryResponse {
@@ -707,4 +710,26 @@ export interface EnergyStatus {
   available: boolean;
   sources: string[];
   lastDataAt: string | null;
+  tariffConfigured: boolean;
+}
+
+export interface TariffSlot {
+  start: string;
+  end: string;
+  tariff: "hp" | "hc";
+}
+
+export interface DaySchedule {
+  days: number[];
+  slots: TariffSlot[];
+}
+
+export interface TariffPrices {
+  hp: number;
+  hc: number;
+}
+
+export interface TariffConfig {
+  schedules: DaySchedule[];
+  prices: TariffPrices;
 }


### PR DESCRIPTION
## Summary
- Classify energy consumption into peak (HP) and off-peak (HC) based on user-configured tariff schedules
- TariffClassifier with linear prorata and midnight wrap support
- HistoryWriter writes energy_hp/energy_hc at write-time
- Energy API merges HP/HC and legacy sources
- TariffSettings UI with visual timeline bar (Legrand-style), slot editor, prices
- Stacked HP/HC bar chart with conditional rounded corners
- i18n for all energy/tariff labels (fr + en)
- Migration script v2: correct 60-min window for hourly, daily summed from hourly HP/HC

## Test plan
- [x] TypeScript compiles (zero errors backend + UI)
- [x] All 454 tests pass
- [x] Lint passes
- [x] Tariff save/load works (auth bug fixed)
- [x] Midnight wrap HP/HC classification verified
- [x] Historical data reclassified with corrected prorata
- [x] Chart displays stacked HP/HC with proper rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)