### PR TITLE
feat: IT3 — Solar production + autoconsumption tracking

### DIFF
--- a/scripts/energy/backfill-production.ts
+++ b/scripts/energy/backfill-production.ts
@@ -1,0 +1,349 @@
+#!/usr/bin/env npx tsx
+/**
+ * Backfill solar production data (energy, autoconso, injection) from Netatmo into InfluxDB.
+ * Queries 5-min granularity, aggregates into 30-min windows, writes to raw + hourly + daily buckets.
+ *
+ * Usage:
+ *   npx tsx scripts/energy/backfill-production.ts 2026-02-15 2026-03-15
+ */
+
+import Database from "better-sqlite3";
+import { readFileSync, writeFileSync } from "node:fs";
+import { InfluxDB, Point } from "@influxdata/influxdb-client";
+
+const DB_PATH = "./data/sowel.db";
+const TOKEN_PATH = "./data/netatmo-tokens.json";
+
+const startDate = process.argv[2];
+const endDate = process.argv[3];
+
+if (!startDate || !endDate) {
+  console.error("Usage: npx tsx scripts/energy/backfill-production.ts YYYY-MM-DD YYYY-MM-DD");
+  process.exit(1);
+}
+
+// ============================================================
+// Config from SQLite
+// ============================================================
+
+const db = new Database(DB_PATH, { readonly: true });
+
+function getSetting(key: string): string | undefined {
+  const row = db.prepare("SELECT value FROM settings WHERE key = ?").get(key) as
+    | { value: string }
+    | undefined;
+  return row?.value;
+}
+
+const influxUrl = getSetting("history.influx.url")!;
+const influxToken = getSetting("history.influx.token")!;
+const influxOrg = getSetting("history.influx.org")!;
+const influxBucket = getSetting("history.influx.bucket")!;
+const clientId = getSetting("integration.netatmo_hc.client_id")!;
+const clientSecret = getSetting("integration.netatmo_hc.client_secret")!;
+
+const eqRow = db.prepare("SELECT id, zone_id FROM equipments WHERE type = 'energy_production_meter'").get() as
+  | { id: string; zone_id: string }
+  | undefined;
+if (!eqRow) { console.error("No energy_production_meter found."); process.exit(1); }
+const equipmentId = eqRow.id;
+const zoneId = eqRow.zone_id ?? "00000000-0000-0000-0000-000000000001";
+
+const BRIDGE_ID = "00:04:74:44:d3:7c";
+db.close();
+
+// ============================================================
+// Netatmo auth
+// ============================================================
+
+let tokens: { refreshToken: string; accessToken: string; expiresAt: number };
+try {
+  tokens = JSON.parse(readFileSync(TOKEN_PATH, "utf-8"));
+} catch {
+  console.error(`Cannot read ${TOKEN_PATH}.`);
+  process.exit(1);
+}
+
+const NETATMO_BASE = "https://api.netatmo.com";
+
+async function refreshAccessToken(): Promise<string> {
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: tokens.refreshToken,
+    client_id: clientId,
+    client_secret: clientSecret,
+  });
+  const res = await fetch(`${NETATMO_BASE}/oauth2/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) throw new Error(`Token refresh failed: ${await res.text()}`);
+  const data = (await res.json()) as { access_token: string; refresh_token: string; expires_in: number };
+  tokens.accessToken = data.access_token;
+  tokens.refreshToken = data.refresh_token;
+  tokens.expiresAt = Date.now() + data.expires_in * 1000;
+  writeFileSync(TOKEN_PATH, JSON.stringify(tokens, null, 2));
+  return data.access_token;
+}
+
+async function getAccessToken(): Promise<string> {
+  if (tokens.accessToken && tokens.expiresAt > Date.now() + 60_000) return tokens.accessToken;
+  return refreshAccessToken();
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+const HALF_HOUR = 1800;
+const rawBucket = influxBucket;
+const hourlyBucket = `${influxBucket}-energy-hourly`;
+const dailyBucket = `${influxBucket}-energy-daily`;
+
+const influxClient = new InfluxDB({ url: influxUrl, token: influxToken });
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function dateRange(from: string, to: string): string[] {
+  const dates: string[] = [];
+  const d = new Date(from + "T12:00:00");
+  const end = new Date(to + "T12:00:00");
+  while (d <= end) {
+    dates.push(d.toISOString().slice(0, 10));
+    d.setDate(d.getDate() + 1);
+  }
+  return dates;
+}
+
+interface WindowData {
+  production: number;
+  autoconso: number;
+  injection: number;
+}
+
+// ============================================================
+// Process one day
+// ============================================================
+
+async function processDay(targetDate: string): Promise<{ windows: number; hourly: number; dailyWh: number }> {
+  const dayStart = new Date(targetDate + "T00:00:00");
+  const dayStartTs = Math.floor(dayStart.getTime() / 1000);
+  const dayEnd = new Date(dayStart);
+  dayEnd.setDate(dayEnd.getDate() + 1);
+  const dayEndTs = Math.floor(dayEnd.getTime() / 1000);
+
+  // 1. Fetch 5-min production data from Netatmo
+  const accessToken = await getAccessToken();
+  const params = new URLSearchParams({
+    device_id: BRIDGE_ID,
+    module_id: BRIDGE_ID,
+    type: "sum_energy_self_consumption,sum_energy_resell_to_grid",
+    scale: "5min",
+    optimize: "false",
+    date_begin: String(dayStartTs),
+    date_end: String(dayEndTs),
+  });
+
+  const res = await fetch(`${NETATMO_BASE}/api/getmeasure?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!res.ok) throw new Error(`getMeasure failed for ${targetDate}: ${await res.text()}`);
+  const data = (await res.json()) as { body: Record<string, (number | null)[]> };
+
+  // 2. Aggregate 5-min buckets into 30-min windows
+  const windowMap = new Map<number, WindowData>();
+  const timestamps = Object.keys(data.body).sort();
+
+  for (const ts of timestamps) {
+    const tsNum = parseInt(ts, 10);
+    if (tsNum >= dayEndTs) continue;
+
+    const values = data.body[ts]!;
+    const selfConso = values[0] ?? 0;
+    const resellToGrid = values[1] ?? 0;
+    const production = selfConso + resellToGrid;
+    if (production <= 0) continue;
+
+    const windowTs = Math.floor(tsNum / HALF_HOUR) * HALF_HOUR;
+    const existing = windowMap.get(windowTs) ?? { production: 0, autoconso: 0, injection: 0 };
+    existing.production += production;
+    existing.autoconso += selfConso;
+    existing.injection += resellToGrid;
+    windowMap.set(windowTs, existing);
+  }
+
+  if (windowMap.size === 0) {
+    return { windows: 0, hourly: 0, dailyWh: 0 };
+  }
+
+  // 3. Write raw 30-min points — skip if older than 7 days (raw bucket retention)
+  const RAW_RETENTION_S = 7 * 86400;
+  const nowTs = Math.floor(Date.now() / 1000);
+  if (dayStartTs > nowTs - RAW_RETENTION_S) {
+    const rawWriteApi = influxClient.getWriteApi(influxOrg, rawBucket, "s", {
+      batchSize: 200,
+      flushInterval: 5000,
+      maxRetries: 3,
+    });
+
+    for (const [windowTs, w] of windowMap) {
+      for (const [alias, value] of [
+        ["energy", w.production],
+        ["autoconso", w.autoconso],
+        ["injection", w.injection],
+      ] as const) {
+        const point = new Point("equipment_data")
+          .tag("equipmentId", equipmentId)
+          .tag("alias", alias)
+          .tag("category", "energy")
+          .tag("type", "number")
+          .tag("zoneId", zoneId)
+          .floatField("value_number", value)
+          .timestamp(windowTs);
+        rawWriteApi.writePoint(point);
+      }
+    }
+    await rawWriteApi.close();
+  }
+
+  // 4. Aggregate into hourly
+  const hourlyMap = new Map<number, WindowData>();
+  for (const [windowTs, w] of windowMap) {
+    const hourTs = Math.floor(windowTs / 3600) * 3600;
+    const existing = hourlyMap.get(hourTs) ?? { production: 0, autoconso: 0, injection: 0 };
+    existing.production += w.production;
+    existing.autoconso += w.autoconso;
+    existing.injection += w.injection;
+    hourlyMap.set(hourTs, existing);
+  }
+
+  // 5. Delete existing hourly + daily for this day, then write
+  await Promise.all([
+    fetch(`${influxUrl}/api/v2/delete?org=${influxOrg}&bucket=${hourlyBucket}`, {
+      method: "POST",
+      headers: { Authorization: `Token ${influxToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        start: dayStart.toISOString(),
+        stop: dayEnd.toISOString(),
+        predicate: `_measurement="equipment_data" AND equipmentId="${equipmentId}"`,
+      }),
+    }),
+    fetch(`${influxUrl}/api/v2/delete?org=${influxOrg}&bucket=${dailyBucket}`, {
+      method: "POST",
+      headers: { Authorization: `Token ${influxToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        start: dayStart.toISOString(),
+        stop: dayEnd.toISOString(),
+        predicate: `_measurement="equipment_data" AND equipmentId="${equipmentId}"`,
+      }),
+    }),
+  ]);
+
+  const hourlyWriteApi = influxClient.getWriteApi(influxOrg, hourlyBucket, "s", {
+    batchSize: 200,
+    flushInterval: 5000,
+    maxRetries: 3,
+  });
+
+  let dayTotal = 0;
+  let dayAutoconso = 0;
+  let dayInjection = 0;
+
+  for (const [hourTs, h] of hourlyMap) {
+    for (const [alias, value] of [
+      ["energy", h.production],
+      ["autoconso", h.autoconso],
+      ["injection", h.injection],
+    ] as const) {
+      const point = new Point("equipment_data")
+        .tag("equipmentId", equipmentId)
+        .tag("alias", alias)
+        .tag("category", "energy")
+        .tag("type", "number")
+        .tag("zoneId", zoneId)
+        .floatField("value_number", value)
+        .timestamp(hourTs);
+      hourlyWriteApi.writePoint(point);
+    }
+    dayTotal += h.production;
+    dayAutoconso += h.autoconso;
+    dayInjection += h.injection;
+  }
+  await hourlyWriteApi.close();
+
+  // 6. Write daily point
+  const dailyWriteApi = influxClient.getWriteApi(influxOrg, dailyBucket, "s", {
+    batchSize: 10,
+    flushInterval: 5000,
+    maxRetries: 3,
+  });
+
+  for (const [alias, value] of [
+    ["energy", dayTotal],
+    ["autoconso", dayAutoconso],
+    ["injection", dayInjection],
+  ] as const) {
+    const point = new Point("equipment_data")
+      .tag("equipmentId", equipmentId)
+      .tag("alias", alias)
+      .tag("category", "energy")
+      .tag("type", "number")
+      .tag("zoneId", zoneId)
+      .floatField("value_number", value)
+      .timestamp(dayStartTs);
+    dailyWriteApi.writePoint(point);
+  }
+  await dailyWriteApi.close();
+
+  return { windows: windowMap.size, hourly: hourlyMap.size, dailyWh: dayTotal };
+}
+
+// ============================================================
+// Main
+// ============================================================
+
+async function run(): Promise<void> {
+  const dates = dateRange(startDate, endDate);
+  console.log(`\nProduction backfill: ${dates.length} days (${startDate} → ${endDate})`);
+  console.log(`Equipment: ${equipmentId} (energy_production_meter), zoneId: ${zoneId}`);
+  console.log(`Buckets: raw=${rawBucket}, hourly=${hourlyBucket}, daily=${dailyBucket}\n`);
+
+  let totalWindows = 0;
+  let totalDays = 0;
+  let skippedDays = 0;
+
+  for (let i = 0; i < dates.length; i++) {
+    const date = dates[i];
+    try {
+      const result = await processDay(date);
+      if (result.windows === 0) {
+        process.stdout.write(`  ${date}  —  no production\n`);
+        skippedDays++;
+      } else {
+        process.stdout.write(
+          `  ${date}  ✓  ${result.windows} windows, ${result.hourly} hourly, daily=${(result.dailyWh / 1000).toFixed(2)} kWh\n`,
+        );
+        totalWindows += result.windows;
+        totalDays++;
+      }
+
+      // Rate limit: Netatmo allows ~50 req/10s
+      if ((i + 1) % 10 === 0) {
+        process.stdout.write(`  ... pause 3s (rate limit) ...\n`);
+        await sleep(3000);
+      }
+    } catch (err) {
+      console.error(`  ${date}  ✗  ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  console.log(`\nDone! ${totalDays} days with production, ${skippedDays} skipped, ${totalWindows} total 30-min windows.`);
+}
+
+run().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/specs/035-energy-dashboard/architecture-it3.md
+++ b/specs/035-energy-dashboard/architecture-it3.md
@@ -1,0 +1,163 @@
+# Architecture: IT3 — Solar Production + Autoconsumption
+
+## Data Model Changes
+
+### types.ts
+
+```typescript
+// Add to EquipmentType union
+| "energy_production_meter"
+
+// Update EnergyPoint
+interface EnergyPoint {
+  time: string;
+  hp: number;
+  hc: number;
+  prod: number;
+  autoconso: number;
+  injection: number;
+}
+
+// Update EnergyTotals
+interface EnergyTotals {
+  total_consumption: number;
+  total_hp: number;
+  total_hc: number;
+  total_production: number;
+  total_autoconso: number;
+  total_injection: number;
+}
+```
+
+### SQLite
+
+No schema change. `energy_production_meter` is just a new value in the `type` column of `equipments` table.
+
+### InfluxDB
+
+Production data uses the same `equipment_data` measurement with:
+
+- `alias=energy` on the production Equipment
+- Same aggregation tasks (hourly/daily) — alias tag preserved, no task changes needed
+
+## Backend Changes
+
+### Netatmo Poller (`src/integrations/netatmo-hc/netatmo-poller.ts`)
+
+1. Add `sum_energy_resell_to_grid` to `ENERGY_TYPES` query string
+2. In `queryEnergyWindow()`: return both consumption and production
+   - consumption = `values[0] + values[1] + values[2]` (unchanged)
+   - production = `values[2] + values[3]` (self_consumption + resell_to_grid)
+3. In `pollEnergyMeters()`: write `energy_production` data on Device alongside `energy`
+
+```
+queryEnergyWindow() returns { consumption: number, production: number }
+
+pollEnergyMeters():
+  // Existing: write consumption
+  deviceManager.updateDeviceData("netatmo_hc", mainMeterName, { energy: windowWh }, windowStart)
+
+  // New: write production (if > 0)
+  deviceManager.updateDeviceData("netatmo_hc", mainMeterName, { energy_production: prodWh }, windowStart)
+```
+
+### Equipment Manager (`src/equipments/equipment-manager.ts`)
+
+1. Add `"energy_production_meter"` to `VALID_TYPES`
+2. Add singleton enforcement for `energy_production_meter` (same pattern as `main_energy_meter`)
+
+### HistoryWriter
+
+- No HP/HC classification for production data
+- Production `energy` alias goes through standard write path (already works)
+
+### EnergyAggregator (`src/equipments/energy-aggregator.ts`)
+
+- Extend to also compute cumuls for `energy_production_meter` Equipment
+- Same logic: query InfluxDB for hour/day/month/year sums
+
+### Energy API (`src/api/routes/energy.ts`)
+
+1. `findEnergyEquipmentId()` → also find `energy_production_meter`
+2. `GET /api/v1/energy/history`:
+   - Query both consumption and production from InfluxDB
+   - Align timestamps
+   - Compute `autoconso = min(prod, consumption)` and `injection = max(0, prod - consumption)` per point
+   - Return updated `EnergyPoint[]` with all fields
+3. `GET /api/v1/energy/status`:
+   - Add `hasProduction: boolean` field
+
+## Frontend Changes
+
+### Types (`ui/src/types.ts`)
+
+- Add `"energy_production_meter"` to `EquipmentType`
+- Update `EnergyPoint`, `EnergyTotals` interfaces
+
+### Store (`ui/src/store/useEnergy.ts`)
+
+- Update to handle new point format (prod, autoconso, injection)
+
+### Equipment UI
+
+| File                     | Change                                                  |
+| ------------------------ | ------------------------------------------------------- |
+| `EquipmentForm.tsx`      | Add `energy_production_meter` option                    |
+| `EquipmentCard.tsx`      | Add icon + label mapping                                |
+| `bindingUtils.ts`        | Add data/order categories for `energy_production_meter` |
+| `DeviceSelector.tsx`     | Add category filter                                     |
+| `useEquipmentState.ts`   | Add `isEnergyMeter` check                               |
+| `EquipmentsPage.tsx`     | Add to singleton types                                  |
+| `HomePage.tsx`           | Add to singleton exclude                                |
+| `ZoneEquipmentsView.tsx` | Add to energy group                                     |
+
+### Energy UI
+
+| File                 | Change                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| `EnergyPage.tsx`     | Add Production chart (Step A), autoconso in consumption chart (Step B) |
+| `EnergyBarChart.tsx` | Support production mode (autoconso + injection stacking)               |
+| `PeriodSelector.tsx` | No change (shared)                                                     |
+
+### i18n
+
+```json
+// fr.json
+"energy.production": "Production solaire",
+"energy.autoconsumption": "Autoconsommation",
+"energy.gridInjection": "Injection réseau",
+"energy.totalProduction": "Production totale",
+"equipments.type.energy_production_meter": "Compteur d'Énergie (production)"
+
+// en.json
+"energy.production": "Solar Production",
+"energy.autoconsumption": "Self-consumption",
+"energy.gridInjection": "Grid Injection",
+"energy.totalProduction": "Total Production",
+"equipments.type.energy_production_meter": "Energy Meter (production)"
+```
+
+### Colors
+
+| Segment         | Color             | Usage                           |
+| --------------- | ----------------- | ------------------------------- |
+| HP (peak)       | `#4F7BE8`         | Consumption chart               |
+| HC (off-peak)   | `#93B5F0`         | Consumption chart               |
+| Autoconsumption | light green (TBD) | Production + Consumption charts |
+| Injection       | dark green (TBD)  | Production chart                |
+
+## File Changes Summary
+
+| File                                            | Change                                                              |
+| ----------------------------------------------- | ------------------------------------------------------------------- |
+| `src/shared/types.ts`                           | Add `energy_production_meter`, update `EnergyPoint`, `EnergyTotals` |
+| `src/integrations/netatmo-hc/netatmo-poller.ts` | Fetch `resell_to_grid`, write `energy_production`                   |
+| `src/equipments/equipment-manager.ts`           | Add type + singleton                                                |
+| `src/equipments/energy-aggregator.ts`           | Handle production cumuls                                            |
+| `src/api/routes/energy.ts`                      | Production queries, autoconso/injection calc                        |
+| `ui/src/types.ts`                               | Mirror backend type changes                                         |
+| `ui/src/store/useEnergy.ts`                     | New point format                                                    |
+| `ui/src/components/energy/EnergyPage.tsx`       | Production chart + autoconso segment                                |
+| `ui/src/components/energy/EnergyBarChart.tsx`   | Production stacking mode                                            |
+| `ui/src/components/equipments/*.tsx`            | Add `energy_production_meter` everywhere                            |
+| `ui/src/i18n/locales/*.json`                    | New translation keys                                                |

--- a/specs/035-energy-dashboard/plan.md
+++ b/specs/035-energy-dashboard/plan.md
@@ -111,20 +111,70 @@ Scope: tariff schedule configuration, HP/HC classification at write time, stacke
 
 ## IT3 — Solar production + autoconsumption — `feat/035c-energy-solar`
 
-Scope: add production virtual device, distinguish consumption/production Equipments.
+Scope: production data collection, production chart, autoconsumption derivation at query time.
 
-### Backend
+Detailed spec: [spec-it3.md](spec-it3.md) | Architecture: [architecture-it3.md](architecture-it3.md)
 
-1. [ ] Add `energyMeterType` field to Equipment — DB migration + types
-2. [ ] Create virtual device `legrand_energy_production` from bridge data
-3. [ ] Backfill 6 months production data
-4. [ ] Update energy API: derive autoconsumption at query time
+### Backend — Types & Equipment
 
-### UI
+1. [ ] Add `energy_production_meter` to `EquipmentType` in `src/shared/types.ts` + `ui/src/types.ts`
+2. [ ] Update `EnergyPoint` and `EnergyTotals` types (add prod, autoconso, injection)
+3. [ ] Add `energy_production_meter` to `VALID_TYPES` + singleton enforcement in `equipment-manager.ts`
 
-5. [ ] Consumption chart with Autoconso stacking
-6. [ ] Production chart (hidden if no solar)
-7. [ ] `energyMeterType` dropdown in Equipment form
+### Backend — Poller
+
+4. [ ] Add `sum_energy_resell_to_grid` to Netatmo API query
+5. [ ] Compute production = self_consumption + resell_to_grid per 30-min window
+6. [ ] Write `energy_production` data on bridge Device with `sourceTimestamp`
+7. [ ] Write `demand_30min_production` for real-time power (production × 2)
+
+### Backend — Aggregation & API
+
+8. [ ] Extend EnergyAggregator to compute production cumuls (hour/day/month/year)
+9. [ ] Update `GET /api/v1/energy/history`: query production, compute autoconso/injection at query time
+10. [ ] Update `GET /api/v1/energy/status`: add `hasProduction` flag
+
+### UI — Equipment support
+
+11. [ ] Add `energy_production_meter` to EquipmentForm, EquipmentCard, bindingUtils, DeviceSelector, useEquipmentState
+12. [ ] Add to singleton types (EquipmentsPage, HomePage)
+13. [ ] Add to energy group in ZoneEquipmentsView
+14. [ ] Add i18n keys (fr + en)
+
+### UI — Step A: Production chart
+
+15. [ ] Create production bar chart: stacked autoconso (light green) + injection (dark green)
+16. [ ] Add to EnergyPage below consumption chart (hidden if no production Equipment)
+17. [ ] Legend with production totals (autoconso + injection)
+18. [ ] Update useEnergy store for new point format
+
+### Backfill — Step A.1: 1 day
+
+19. [ ] Script to backfill production for a single day (query Netatmo, write to InfluxDB)
+20. [ ] Validate pipeline end-to-end on 1 day of data
+
+### Backfill — Step A.2: 1 month
+
+21. [ ] Extend backfill script to a full month
+22. [ ] Validate aggregation (hourly/daily) over the month
+23. [ ] Compare totals with Legrand dashboard
+
+### UI — Step B: Autoconso in consumption chart
+
+24. [ ] Add autoconso segment (light green) on top of HP/HC bars
+25. [ ] Update legend with autoconso total
+26. [ ] Total = HP + HC + autoconso = total house consumption
+
+### Backfill — Step C: Full backfill (6 months)
+
+27. [ ] Full 6-month production backfill script
+28. [ ] Same pattern as consumption backfill (`energy-backfill.ts`)
+
+### Validation
+
+29. [ ] TypeScript compilation — zero errors (backend + frontend)
+30. [ ] Production + autoconso + injection values coherent
+31. [ ] Charts render correctly for all periods
 
 ---
 

--- a/specs/035-energy-dashboard/spec-it3.md
+++ b/specs/035-energy-dashboard/spec-it3.md
@@ -1,0 +1,175 @@
+# IT3: Solar Production + Autoconsumption
+
+## Summary
+
+Add solar production tracking to the Energy Dashboard. A new Equipment type `energy_production_meter` stores total production (Wh/30min). Autoconsumption and grid injection are derived at query time from existing consumption and production data. A new Production chart displays stacked bars (autoconsumption + injection). The existing Consumption chart is later extended with an autoconsumption segment.
+
+## Context
+
+### What exists today
+
+- Legrand poller fetches `sum_energy_buy_from_grid$1`, `$2`, and `sum_energy_self_consumption` from the Netatmo bridge API
+- These 3 values are summed → total house consumption (Wh/30min), written as `energy` on the bridge Device
+- User binds this Device data to an Equipment of type `main_energy_meter`
+- Pipeline: Device → Equipment binding → HistoryWriter → InfluxDB → aggregation tasks
+- `sum_energy_resell_to_grid` is available in the API but **not yet fetched**
+
+### Key insight
+
+`buy_from_grid$1 + $2 + self_consumption` = total house consumption (not just grid import). The API naming is misleading — `buy_from_grid` includes self-consumed solar energy.
+
+## Design Decisions
+
+### Production = self_consumption + resell_to_grid
+
+The Legrand poller will also fetch `sum_energy_resell_to_grid` and compute:
+
+```
+production = self_consumption + resell_to_grid
+```
+
+This value is written as `energy_production` on the same bridge Device, with the same `sourceTimestamp` alignment.
+
+### Same pipeline as consumption
+
+The production data follows the exact same path:
+
+- Poller writes `energy_production` data on Device
+- User creates Equipment `energy_production_meter`, binds the Device data
+- HistoryWriter writes to InfluxDB
+- Aggregation tasks handle `energy_production` (no HP/HC classification for production)
+
+### Autoconsumption and injection derived at query time
+
+No separate storage needed. Given:
+
+- `consumption` = total house consumption (from `main_energy_meter` Equipment)
+- `production` = total solar production (from `energy_production_meter` Equipment)
+
+Derived values:
+
+- `autoconsumption = min(production, consumption)`
+- `injection = max(0, production - consumption)`
+
+### No HP/HC on production
+
+Tariff classification (HP/HC) applies only to grid consumption, not to production.
+
+### Virtual binding proposal at Equipment creation
+
+When creating an `energy_production_meter` Equipment:
+
+- User selects a physical Device (e.g., Legrand NLPC on solar circuit → provides real-time power)
+- If Legrand integration is active with energy data available AND `energy_production` data exists on the bridge Device AND not already bound → propose to also bind this virtual energy data
+
+## Equipment Types
+
+Three `energyMeterType` values (mapped to EquipmentType):
+
+| EquipmentType             | Label (fr)                         | Description                             |
+| ------------------------- | ---------------------------------- | --------------------------------------- |
+| `main_energy_meter`       | Compteur d'Énergie (principal)     | Total house consumption — singleton     |
+| `energy_production_meter` | Compteur d'Énergie (production)    | Solar production — singleton            |
+| `energy_meter`            | Compteur d'Énergie (sous-compteur) | Sub-meter (EV charger, heat pump, etc.) |
+
+`energy_production_meter` is a singleton (only one allowed), like `main_energy_meter`.
+
+## Data Model
+
+### Production Equipment aliases
+
+| Alias          | Unit | Category | Historized | Description                           |
+| -------------- | ---- | -------- | ---------- | ------------------------------------- |
+| `energy`       | Wh   | energy   | **yes**    | Production Wh per 30-min bucket       |
+| `demand_30min` | W    | power    | no         | Average production power (energy × 2) |
+| `energy_day`   | Wh   | energy   | no         | Today's cumulative production         |
+| `energy_hour`  | Wh   | energy   | no         | Current hour cumulative               |
+| `energy_month` | Wh   | energy   | no         | Current month cumulative              |
+| `energy_year`  | Wh   | energy   | no         | Current year cumulative               |
+
+Cumuls computed by EnergyAggregator (same as consumption).
+
+### Energy History API response (updated)
+
+```typescript
+interface EnergyPoint {
+  time: string;
+  hp: number; // consumption HP (Wh)
+  hc: number; // consumption HC (Wh)
+  prod: number; // production total (Wh)
+  autoconso: number; // min(prod, consumption) (Wh)
+  injection: number; // max(0, prod - consumption) (Wh)
+}
+```
+
+## UI
+
+### Step A: Production chart (new)
+
+- Second chart below consumption chart on `/energy` page
+- Title: "Production solaire" (i18n)
+- Stacked bars:
+  - Autoconsommation: light green
+  - Injection réseau: dark green
+- Same period selector (shared with consumption chart)
+- Legend below chart with totals
+- Hidden if no `energy_production_meter` Equipment exists
+
+### Step B: Autoconsumption in consumption chart
+
+- Add autoconsumption as a 3rd stacked segment (light green) on top of HP/HC bars
+- Total displayed = HP + HC + autoconso = total house consumption
+- Legend updated with autoconso total
+
+## Acceptance Criteria
+
+- [ ] Poller fetches `sum_energy_resell_to_grid` alongside existing measures
+- [ ] Poller computes production and writes `energy_production` on bridge Device with `sourceTimestamp`
+- [ ] New Equipment type `energy_production_meter` (singleton)
+- [ ] Auto-binding works for `energy_production_meter` (category `energy`)
+- [ ] HistoryWriter writes production `energy` to InfluxDB (no HP/HC classification)
+- [ ] EnergyAggregator computes production cumuls (hour/day/month/year)
+- [ ] Energy API returns production + autoconso + injection data
+- [ ] Production chart: stacked bars autoconso (light green) + injection (dark green)
+- [ ] Production chart hidden when no production Equipment exists
+- [ ] Consumption chart: autoconso segment added (Step B)
+- [ ] Virtual binding proposal at `energy_production_meter` creation (Legrand)
+- [ ] TypeScript compilation — zero errors
+- [ ] i18n: all labels translated (fr + en)
+
+## Edge Cases
+
+- No solar panels → no `energy_production_meter` → production chart hidden, energy API returns only consumption
+- Production Equipment exists but no data yet → production chart shows empty state
+- Production > consumption in a 30-min window → injection > 0, autoconso = consumption
+- Production = 0 (night) → autoconso = 0, injection = 0
+- Legrand integration not active → no virtual binding proposal, user can still bind a physical Device
+- Backfill: existing consumption data has no matching production → autoconso/injection = 0 for those periods
+
+## Backfill Strategy
+
+Production backfill is done incrementally across steps:
+
+### Step A.1: Backfill 1 day
+
+- Script to backfill production data for a single day (today or specified date)
+- Validates the pipeline end-to-end before scaling up
+- Uses same approach as `energy-backfill-today.ts`: query Netatmo API, write to InfluxDB
+
+### Step A.2: Backfill 1 month
+
+- Extend script to backfill a full month
+- Validates aggregation (hourly/daily) over a longer period
+- Compare production totals with Legrand dashboard
+
+### Step C: Full backfill (6 months)
+
+- Backfill up to 6 months of historical production data
+- Same pattern as consumption backfill (`energy-backfill.ts`)
+- Query Netatmo API with `scale=1hour`, write to `sowel-energy-hourly`
+
+## Out of Scope
+
+- Cost calculation from HP/HC prices (IT4)
+- Multiple production meters (only one singleton for now)
+- Per-circuit breakdown

--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -35,8 +35,10 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
   // ============================================================
   app.get("/api/v1/energy/status", async (): Promise<EnergyStatus> => {
     const eqId = findEnergyEquipmentId(equipmentManager);
+    const prodId = findProductionEquipmentId(equipmentManager);
     return {
       available: eqId !== null,
+      hasProduction: prodId !== null,
       sources: eqId ? ["legrand"] : [],
       lastDataAt: null, // TODO: query InfluxDB for latest point
       tariffConfigured: tariffClassifier.getConfig() !== null,
@@ -61,6 +63,8 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
       return reply.status(404).send({ error: "No energy equipment configured" });
     }
 
+    const productionEquipmentId = findProductionEquipmentId(equipmentManager);
+
     const config = influxClient.getConfig();
     const client = influxClient.getClient();
     if (!config || !client) {
@@ -78,8 +82,8 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
         buckets.push(`${config.bucket}-energy-hourly`);
       }
 
-      let hpHcPoints: EnergyPoint[] = [];
-      let legacyPoints: EnergyPoint[] = [];
+      let hpHcPoints: Array<{ time: string; hp: number; hc: number }> = [];
+      let legacyPoints: Array<{ time: string; hp: number; hc: number }> = [];
 
       for (const b of buckets) {
         if (hpHcPoints.length === 0) {
@@ -109,21 +113,57 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
 
       // Merge: HP/HC points take priority; fill gaps with legacy
       const hpHcByTime = new Map(hpHcPoints.map((p) => [p.time, p]));
-      const points: EnergyPoint[] = [];
-      const allTimes = new Set([
+      const consumptionPoints: Array<{ time: string; hp: number; hc: number }> = [];
+      const allConsoTimes = new Set([
         ...hpHcPoints.map((p) => p.time),
         ...legacyPoints.map((p) => p.time),
       ]);
-      for (const time of allTimes) {
+      for (const time of allConsoTimes) {
         const hpHc = hpHcByTime.get(time);
         if (hpHc) {
-          points.push(hpHc);
+          consumptionPoints.push(hpHc);
         } else {
           const legacy = legacyPoints.find((p) => p.time === time);
-          if (legacy) points.push(legacy);
+          if (legacy) consumptionPoints.push(legacy);
         }
       }
-      points.sort((a, b) => a.time.localeCompare(b.time));
+      consumptionPoints.sort((a, b) => a.time.localeCompare(b.time));
+
+      // Query production data if production Equipment exists
+      const prodMap = new Map<string, { prod: number; autoconso: number; injection: number }>();
+      if (productionEquipmentId) {
+        const prodPoints = await queryProductionPoints(
+          client,
+          config.org,
+          bucket,
+          productionEquipmentId,
+          from,
+          to,
+          resolution,
+        );
+        for (const p of prodPoints) {
+          prodMap.set(p.time, p);
+        }
+      }
+
+      // Build final EnergyPoint array
+      const points: EnergyPoint[] = [];
+      const allTimes = new Set([...consumptionPoints.map((p) => p.time), ...prodMap.keys()]);
+      const sortedTimes = [...allTimes].sort();
+
+      for (const time of sortedTimes) {
+        const conso = consumptionPoints.find((p) => p.time === time);
+        const hp = conso?.hp ?? 0;
+        const hc = conso?.hc ?? 0;
+        const prodData = prodMap.get(time);
+        const prod = prodData?.prod ?? 0;
+        const autoconso = prodData?.autoconso ?? 0;
+        const injection = prodData?.injection ?? 0;
+
+        if (hp + hc > 0 || prod > 0) {
+          points.push({ time, hp, hc, prod, autoconso, injection });
+        }
+      }
 
       const totals = computeTotals(points);
 
@@ -204,6 +244,12 @@ function findEnergyEquipmentId(equipmentManager: EquipmentManager): string | nul
   return meter?.id ?? null;
 }
 
+function findProductionEquipmentId(equipmentManager: EquipmentManager): string | null {
+  const equipments = equipmentManager.getAll();
+  const meter = equipments.find((eq) => eq.type === "energy_production_meter");
+  return meter?.id ?? null;
+}
+
 function computeRange(
   period: string,
   dateStr: string,
@@ -264,7 +310,7 @@ async function queryEnergyHpHcPoints(
   from: Date,
   to: Date,
   _resolution: "5min" | "1h" | "1d",
-): Promise<EnergyPoint[]> {
+): Promise<Array<{ time: string; hp: number; hc: number }>> {
   const queryApi = client.getQueryApi(org);
   const needsAggregation = _resolution === "1h" && !bucket.includes("-energy-");
 
@@ -304,9 +350,9 @@ async function queryEnergyHpHcPoints(
     }
   }
 
-  // Merge into EnergyPoint array
+  // Merge into point array
   const allTimes = new Set([...hpMap.keys(), ...hcMap.keys()]);
-  const points: EnergyPoint[] = [];
+  const points: Array<{ time: string; hp: number; hc: number }> = [];
   for (const time of allTimes) {
     const hp = hpMap.get(time) ?? 0;
     const hc = hcMap.get(time) ?? 0;
@@ -331,7 +377,7 @@ async function queryEnergyLegacyPoints(
   from: Date,
   to: Date,
   _resolution: "5min" | "1h" | "1d",
-): Promise<EnergyPoint[]> {
+): Promise<Array<{ time: string; hp: number; hc: number }>> {
   const queryApi = client.getQueryApi(org);
   const needsAggregation = _resolution === "1h" && !bucket.includes("-energy-");
 
@@ -354,7 +400,7 @@ async function queryEnergyLegacyPoints(
   |> filter(fn: (r) => r._field == "value_number")
   |> sort(columns: ["_time"])`;
 
-  const points: EnergyPoint[] = [];
+  const points: Array<{ time: string; hp: number; hc: number }> = [];
   const rows = queryApi.iterateRows(flux);
   for await (const { values, tableMeta } of rows) {
     const row = tableMeta.toObject(values) as { _time: string; _value: number };
@@ -366,16 +412,93 @@ async function queryEnergyLegacyPoints(
   return points;
 }
 
+/**
+ * Query production energy points from InfluxDB.
+ * Production Equipment stores 3 aliases: "energy" (total), "autoconso", "injection".
+ */
+async function queryProductionPoints(
+  client: import("@influxdata/influxdb-client").InfluxDB,
+  org: string,
+  bucket: string,
+  equipmentId: string,
+  from: Date,
+  to: Date,
+  _resolution: "5min" | "1h" | "1d",
+): Promise<Array<{ time: string; prod: number; autoconso: number; injection: number }>> {
+  const queryApi = client.getQueryApi(org);
+  const needsAggregation = _resolution === "1h" && !bucket.includes("-energy-");
+
+  const aliasFilter = `r.alias == "energy" or r.alias == "autoconso" or r.alias == "injection"`;
+  const flux = needsAggregation
+    ? `from(bucket: "${bucket}")
+  |> range(start: ${from.toISOString()}, stop: ${to.toISOString()})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => ${aliasFilter})
+  |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> aggregateWindow(every: 1h, fn: sum, createEmpty: false, timeSrc: "_start")
+  |> sort(columns: ["_time"])`
+    : `from(bucket: "${bucket}")
+  |> range(start: ${from.toISOString()}, stop: ${to.toISOString()})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => ${aliasFilter})
+  |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> sort(columns: ["_time"])`;
+
+  const prodMap = new Map<string, number>();
+  const autoMap = new Map<string, number>();
+  const injMap = new Map<string, number>();
+
+  const rows = queryApi.iterateRows(flux);
+  for await (const { values, tableMeta } of rows) {
+    const row = tableMeta.toObject(values) as { _time: string; _value: number; alias: string };
+    if (row._value == null) continue;
+    if (row.alias === "energy") {
+      prodMap.set(row._time, (prodMap.get(row._time) ?? 0) + row._value);
+    } else if (row.alias === "autoconso") {
+      autoMap.set(row._time, (autoMap.get(row._time) ?? 0) + row._value);
+    } else if (row.alias === "injection") {
+      injMap.set(row._time, (injMap.get(row._time) ?? 0) + row._value);
+    }
+  }
+
+  const allTimes = new Set([...prodMap.keys(), ...autoMap.keys(), ...injMap.keys()]);
+  const points: Array<{ time: string; prod: number; autoconso: number; injection: number }> = [];
+  for (const time of allTimes) {
+    const prod = prodMap.get(time) ?? 0;
+    const autoconso = autoMap.get(time) ?? 0;
+    const injection = injMap.get(time) ?? 0;
+    if (prod > 0 || autoconso > 0 || injection > 0) {
+      points.push({ time, prod, autoconso, injection });
+    }
+  }
+
+  points.sort((a, b) => a.time.localeCompare(b.time));
+  return points;
+}
+
 function computeTotals(points: EnergyPoint[]): EnergyTotals {
   let totalHp = 0;
   let totalHc = 0;
+  let totalProduction = 0;
+  let totalAutoconso = 0;
+  let totalInjection = 0;
   for (const p of points) {
     totalHp += p.hp;
     totalHc += p.hc;
+    totalProduction += p.prod;
+    totalAutoconso += p.autoconso;
+    totalInjection += p.injection;
   }
   return {
     total_consumption: totalHp + totalHc,
     total_hp: totalHp,
     total_hc: totalHc,
+    total_production: totalProduction,
+    total_autoconso: totalAutoconso,
+    total_injection: totalInjection,
   };
 }

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -39,6 +39,7 @@ const VALID_EQUIPMENT_TYPES: Set<string> = new Set([
   "heater",
   "energy_meter",
   "main_energy_meter",
+  "energy_production_meter",
 ]);
 
 // ============================================================
@@ -244,6 +245,14 @@ export class EquipmentManager {
       const existing = this.getAll().find((eq) => eq.type === "main_energy_meter");
       if (existing) {
         throw new EquipmentError("A main energy meter already exists", 409);
+      }
+    }
+
+    // Only one energy_production_meter allowed
+    if (input.type === "energy_production_meter") {
+      const existing = this.getAll().find((eq) => eq.type === "energy_production_meter");
+      if (existing) {
+        throw new EquipmentError("A production energy meter already exists", 409);
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,14 +141,6 @@ async function main() {
   );
   integrationRegistry.register(mczMaestroIntegration);
 
-  const netatmoHCIntegration = new NetatmoHCIntegration(
-    settingsManager,
-    deviceManager,
-    eventBus,
-    logger,
-  );
-  integrationRegistry.register(netatmoHCIntegration);
-
   const lora2mqttIntegration = new Lora2MqttIntegration(
     settingsManager,
     deviceManager,
@@ -169,6 +161,16 @@ async function main() {
     deviceManager,
     logger,
   );
+
+  // Netatmo H+C needs equipmentManager to resolve production meter bindings
+  const netatmoHCIntegration = new NetatmoHCIntegration(
+    settingsManager,
+    deviceManager,
+    equipmentManager,
+    eventBus,
+    logger,
+  );
+  integrationRegistry.register(netatmoHCIntegration);
 
   // 10. Create Zone Aggregator + Sunlight Manager
   const zoneAggregator = new ZoneAggregator(zoneManager, equipmentManager, eventBus, logger);

--- a/src/integrations/netatmo-hc/index.ts
+++ b/src/integrations/netatmo-hc/index.ts
@@ -42,6 +42,7 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
   private eventBus: EventBus;
   private settingsManager: SettingsManager;
   private deviceManager: DeviceManager;
+  private equipmentManager: EquipmentManager;
   private bridge: NetatmoBridge | null = null;
   private poller: NetatmoPoller | null = null;
   private status: IntegrationStatus = "disconnected";
@@ -51,11 +52,13 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
   constructor(
     settingsManager: SettingsManager,
     deviceManager: DeviceManager,
+    equipmentManager: EquipmentManager,
     eventBus: EventBus,
     logger: Logger,
   ) {
     this.settingsManager = settingsManager;
     this.deviceManager = deviceManager;
+    this.equipmentManager = equipmentManager;
     this.eventBus = eventBus;
     this.logger = logger.child({ module: "legrand-hc" });
   }
@@ -189,6 +192,7 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
       this.poller = new NetatmoPoller(
         this.bridge,
         this.deviceManager,
+        this.equipmentManager,
         this.settingsManager,
         this.eventBus,
         homeId,

--- a/src/integrations/netatmo-hc/netatmo-poller.ts
+++ b/src/integrations/netatmo-hc/netatmo-poller.ts
@@ -10,6 +10,7 @@ import type { Logger } from "../../core/logger.js";
 import type { EventBus } from "../../core/event-bus.js";
 import type { SettingsManager } from "../../core/settings-manager.js";
 import type { DeviceManager } from "../../devices/device-manager.js";
+import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import type { NetatmoBridge } from "./netatmo-bridge.js";
 import {
   isSupportedModule,
@@ -32,6 +33,7 @@ const ENERGY_LOOKBACK_S = 6 * 3600;
 export class NetatmoPoller {
   private bridge: NetatmoBridge;
   private deviceManager: DeviceManager;
+  private equipmentManager: EquipmentManager;
   private eventBus: EventBus;
   private logger: Logger;
   private homeId: string;
@@ -67,6 +69,7 @@ export class NetatmoPoller {
   constructor(
     bridge: NetatmoBridge,
     deviceManager: DeviceManager,
+    equipmentManager: EquipmentManager,
     _settingsManager: SettingsManager,
     eventBus: EventBus,
     homeId: string,
@@ -78,6 +81,7 @@ export class NetatmoPoller {
   ) {
     this.bridge = bridge;
     this.deviceManager = deviceManager;
+    this.equipmentManager = equipmentManager;
     this.eventBus = eventBus;
     this.homeId = homeId;
     this.logger = logger.child({ module: "legrand-hc-poller" });
@@ -445,11 +449,16 @@ export class NetatmoPoller {
    * Cumuls (day/hour/month/year) are handled by EnergyAggregator at equipment level.
    */
   /**
-   * Query a 30-min energy window and return total Wh.
+   * Query a 30-min energy window and return consumption + production Wh.
+   * consumption = buy_from_grid$1 + buy_from_grid$2 + self_consumption (total house)
+   * production  = self_consumption + resell_to_grid (total solar)
    */
-  private async queryEnergyWindow(windowStart: number, windowEnd: number): Promise<number> {
+  private async queryEnergyWindow(
+    windowStart: number,
+    windowEnd: number,
+  ): Promise<{ consumption: number; production: number; autoconso: number; injection: number }> {
     const ENERGY_TYPES =
-      "sum_energy_buy_from_grid$1,sum_energy_buy_from_grid$2,sum_energy_self_consumption";
+      "sum_energy_buy_from_grid$1,sum_energy_buy_from_grid$2,sum_energy_self_consumption,sum_energy_resell_to_grid";
 
     const res = await this.bridge.getMeasure(
       this.bridgeId!,
@@ -461,14 +470,38 @@ export class NetatmoPoller {
     );
 
     const timestamps = Object.keys(res.body);
-    if (timestamps.length === 0) return 0;
+    if (timestamps.length === 0)
+      return { consumption: 0, production: 0, autoconso: 0, injection: 0 };
 
-    let windowWh = 0;
+    let consumption = 0;
+    let autoconso = 0;
+    let injection = 0;
     for (const ts of timestamps) {
       const values = res.body[ts];
-      windowWh += (values[0] ?? 0) + (values[1] ?? 0) + (values[2] ?? 0);
+      const hp = values[0] ?? 0;
+      const hc = values[1] ?? 0;
+      const selfConso = values[2] ?? 0;
+      const resellToGrid = values[3] ?? 0;
+      consumption += hp + hc + selfConso;
+      autoconso += selfConso;
+      injection += resellToGrid;
     }
-    return windowWh;
+    const production = autoconso + injection;
+    return { consumption, production, autoconso, injection };
+  }
+
+  /**
+   * Resolve the Device friendlyName bound to the energy_production_meter Equipment.
+   * Returns null if no production Equipment exists or has no energy binding.
+   */
+  private resolveProductionDeviceName(): string | null {
+    const eq = this.equipmentManager.getAll().find((e) => e.type === "energy_production_meter");
+    if (!eq) return null;
+    const binding = this.equipmentManager
+      .getDataBindingsWithValues(eq.id)
+      .find((b) => b.alias === "energy");
+    if (!binding) return null;
+    return binding.deviceName ?? null;
   }
 
   private async pollEnergyMeters(): Promise<void> {
@@ -486,30 +519,48 @@ export class NetatmoPoller {
 
       let newBuckets = 0;
       let lastBucketEnergy = 0;
+      let lastBucketProduction = 0;
 
       for (let windowStart = lookbackStart; windowStart < nowTs; windowStart += HALF_HOUR) {
         const windowEnd = windowStart + HALF_HOUR;
         // Only process windows that have ended
         if (windowEnd > nowTs) break;
 
-        const windowWh = await this.queryEnergyWindow(windowStart, windowEnd);
-        if (windowWh <= 0) continue;
+        const { consumption, production, autoconso, injection } = await this.queryEnergyWindow(
+          windowStart,
+          windowEnd,
+        );
+        if (consumption <= 0 && production <= 0) continue;
 
         // Pass sourceTimestamp = windowStart so HistoryWriter writes at the
         // aligned 30-min boundary, not at "now".
         // InfluxDB overwrites if the point already exists (idempotent).
-        this.deviceManager.updateDeviceData(
-          "netatmo_hc",
-          this.mainMeterName!,
-          {
-            energy: windowWh,
-          },
-          windowStart,
-        );
+        if (consumption > 0) {
+          this.deviceManager.updateDeviceData(
+            "netatmo_hc",
+            this.mainMeterName!,
+            { energy: consumption },
+            windowStart,
+          );
+        }
+
+        // Write production, autoconso, injection on the production Device
+        if (production > 0) {
+          const prodDeviceName = this.resolveProductionDeviceName();
+          if (prodDeviceName) {
+            this.deviceManager.updateDeviceData(
+              "netatmo_hc",
+              prodDeviceName,
+              { energy: production, autoconso, injection },
+              windowStart,
+            );
+          }
+        }
 
         if (windowStart > this.lastEmittedWindowTs) {
           newBuckets++;
-          lastBucketEnergy = windowWh;
+          lastBucketEnergy = consumption;
+          lastBucketProduction = production;
           this.lastEmittedWindowTs = windowStart;
         }
       }
@@ -523,7 +574,11 @@ export class NetatmoPoller {
 
       if (newBuckets > 0) {
         this.logger.debug(
-          { newBuckets, demand30minW: Math.round(lastBucketEnergy * 2) },
+          {
+            newBuckets,
+            demand30minW: Math.round(lastBucketEnergy * 2),
+            lastProdWh: lastBucketProduction,
+          },
           "Energy poll: new 30-min buckets processed",
         );
       }

--- a/src/integrations/netatmo-hc/netatmo-types.ts
+++ b/src/integrations/netatmo-hc/netatmo-types.ts
@@ -252,6 +252,8 @@ export function mapModuleToDiscovered(mod: NetatmoModule, homeId: string): Disco
   } else if (METER_TYPES.has(mod.type)) {
     data.push({ key: "power", type: "number", category: "power", unit: "W" });
     data.push({ key: "energy", type: "number", category: "energy", unit: "Wh" });
+    data.push({ key: "autoconso", type: "number", category: "energy", unit: "Wh" });
+    data.push({ key: "injection", type: "number", category: "energy", unit: "Wh" });
     data.push({ key: "demand_30min", type: "number", category: "power", unit: "W" });
   } else if (GATEWAY_TYPES.has(mod.type)) {
     data.push({ key: "wifi_strength", type: "number", category: "generic" });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -157,7 +157,8 @@ export type EquipmentType =
   | "gate"
   | "heater"
   | "energy_meter"
-  | "main_energy_meter";
+  | "main_energy_meter"
+  | "energy_production_meter";
 
 export interface Equipment {
   id: string;
@@ -806,12 +807,18 @@ export interface EnergyPoint {
   time: string;
   hp: number; // Wh attributed to Heures Pleines
   hc: number; // Wh attributed to Heures Creuses
+  prod: number; // Wh total production
+  autoconso: number; // min(prod, consumption) Wh
+  injection: number; // max(0, prod - consumption) Wh
 }
 
 export interface EnergyTotals {
   total_consumption: number; // hp + hc (Wh)
   total_hp: number; // Wh
   total_hc: number; // Wh
+  total_production: number; // Wh
+  total_autoconso: number; // Wh
+  total_injection: number; // Wh
 }
 
 export interface EnergyHistoryResponse {
@@ -825,6 +832,7 @@ export interface EnergyHistoryResponse {
 
 export interface EnergyStatus {
   available: boolean;
+  hasProduction: boolean;
   sources: string[];
   lastDataAt: string | null;
   tariffConfigured: boolean;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -24,6 +24,7 @@ import { NotificationPublishersPage } from "./pages/NotificationPublishersPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { QrLoginPage } from "./pages/QrLoginPage";
 import { EnergyPage } from "./components/energy/EnergyPage";
+import { ProductionPage } from "./components/energy/ProductionPage";
 
 export default function App() {
   return (
@@ -62,6 +63,7 @@ export default function App() {
           <Route path="/calendar" element={<CalendarPage />} />
           <Route path="/energy" element={<Navigate to="/energy/consumption" replace />} />
           <Route path="/energy/consumption" element={<EnergyPage />} />
+          <Route path="/energy/production" element={<ProductionPage />} />
           <Route path="/analyse" element={<AnalysePage />} />
           <Route path="/analyse/:chartId" element={<AnalysePage />} />
           <Route path="/settings" element={<SettingsPage />} />

--- a/ui/src/components/energy/EnergyBarChart.tsx
+++ b/ui/src/components/energy/EnergyBarChart.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ResponsiveContainer,
@@ -21,48 +21,63 @@ interface EnergyBarChartProps {
 
 interface ChartDatum {
   label: string;
-  /** Tooltip label — e.g. "14h00 – 15h00" for day view */
   tooltipLabel?: string;
   hp: number; // kWh
   hc: number; // kWh
+  autoconso: number; // kWh — already included in hp+hc
 }
 
 const HP_COLOR = "#4F7BE8";
 const HC_COLOR = "#93B5F0";
+const AUTOCONSO_COLOR = "#6BCB77";
 
 // ============================================================
 // Aggregation: collapse raw points into period-appropriate bars
 // ============================================================
 
-/** Day view: always 24 bars (00:00–23:00), empty bars for hours without data */
+function toDatum(label: string, tooltipLabel: string, hpWh: number, hcWh: number, autoWh: number): ChartDatum {
+  const hp = hpWh / 1000;
+  const hc = hcWh / 1000;
+  const autoconso = Math.min(autoWh / 1000, hp + hc);
+  return { label, tooltipLabel, hp, hc, autoconso };
+}
+
+/** Day view: always 24 bars (00:00–23:00) */
 function aggregateDay(points: EnergyPoint[]): ChartDatum[] {
   const hpByHour = new Map<number, number>();
   const hcByHour = new Map<number, number>();
+  const autoByHour = new Map<number, number>();
 
   for (const p of points) {
     const d = new Date(p.time);
     const hour = d.getHours();
     hpByHour.set(hour, (hpByHour.get(hour) ?? 0) + p.hp);
     hcByHour.set(hour, (hcByHour.get(hour) ?? 0) + p.hc);
+    autoByHour.set(hour, (autoByHour.get(hour) ?? 0) + p.autoconso);
   }
 
-  return Array.from({ length: 24 }, (_, hour) => ({
-    label: `${String(hour).padStart(2, "0")}h`,
-    tooltipLabel: `${String(hour).padStart(2, "0")}h00 – ${String((hour + 1) % 24).padStart(2, "0")}h00`,
-    hp: (hpByHour.get(hour) ?? 0) / 1000,
-    hc: (hcByHour.get(hour) ?? 0) / 1000,
-  }));
+  return Array.from({ length: 24 }, (_, hour) =>
+    toDatum(
+      `${String(hour).padStart(2, "0")}h`,
+      `${String(hour).padStart(2, "0")}h00 – ${String((hour + 1) % 24).padStart(2, "0")}h00`,
+      hpByHour.get(hour) ?? 0,
+      hcByHour.get(hour) ?? 0,
+      autoByHour.get(hour) ?? 0,
+    ),
+  );
 }
 
-/** Week view: always 7 bars (Mon–Sun), empty bars for days without data */
+/** Week view: always 7 bars (Mon–Sun) */
 function aggregateWeek(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
   const hpByDay = new Map<string, number>();
   const hcByDay = new Map<string, number>();
+  const autoByDay = new Map<string, number>();
   for (const p of points) {
     const d = new Date(p.time);
     const key = localDateKey(d);
     hpByDay.set(key, (hpByDay.get(key) ?? 0) + p.hp);
     hcByDay.set(key, (hcByDay.get(key) ?? 0) + p.hc);
+    autoByDay.set(key, (autoByDay.get(key) ?? 0) + p.autoconso);
   }
 
   const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
@@ -75,30 +90,27 @@ function aggregateWeek(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
     const day = new Date(monday);
     day.setDate(day.getDate() + i);
     const key = localDateKey(day);
-    const label = capitalizeFirst(
-      day.toLocaleDateString("fr-FR", { weekday: "short", day: "numeric" }),
+    return toDatum(
+      capitalizeFirst(day.toLocaleDateString("fr-FR", { weekday: "short", day: "numeric" })),
+      capitalizeFirst(day.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long", year: "numeric" })),
+      hpByDay.get(key) ?? 0,
+      hcByDay.get(key) ?? 0,
+      autoByDay.get(key) ?? 0,
     );
-    const tooltipLabel = capitalizeFirst(
-      day.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long", year: "numeric" }),
-    );
-    return {
-      label,
-      tooltipLabel,
-      hp: (hpByDay.get(key) ?? 0) / 1000,
-      hc: (hcByDay.get(key) ?? 0) / 1000,
-    };
   });
 }
 
-/** Month view: always N bars (1 per day of the month), empty bars for days without data */
+/** Month view: always N bars (1 per day of the month) */
 function aggregateMonth(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
   const hpByDay = new Map<string, number>();
   const hcByDay = new Map<string, number>();
+  const autoByDay = new Map<string, number>();
   for (const p of points) {
     const d = new Date(p.time);
     const key = localDateKey(d);
     hpByDay.set(key, (hpByDay.get(key) ?? 0) + p.hp);
     hcByDay.set(key, (hcByDay.get(key) ?? 0) + p.hc);
+    autoByDay.set(key, (autoByDay.get(key) ?? 0) + p.autoconso);
   }
 
   const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
@@ -109,46 +121,43 @@ function aggregateMonth(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
   return Array.from({ length: daysInMonth }, (_, i) => {
     const day = new Date(year, month, i + 1);
     const key = localDateKey(day);
-    const tooltipLabel = capitalizeFirst(
-      day.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long", year: "numeric" }),
+    return toDatum(
+      String(i + 1),
+      capitalizeFirst(day.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long", year: "numeric" })),
+      hpByDay.get(key) ?? 0,
+      hcByDay.get(key) ?? 0,
+      autoByDay.get(key) ?? 0,
     );
-    return {
-      label: String(i + 1),
-      tooltipLabel,
-      hp: (hpByDay.get(key) ?? 0) / 1000,
-      hc: (hcByDay.get(key) ?? 0) / 1000,
-    };
   });
 }
 
-/** Year view: always 12 bars (Jan–Dec), empty bars for months without data */
+/** Year view: always 12 bars (Jan–Dec) */
 function aggregateYear(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
   const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
   const year = ref.getFullYear();
 
   const hpTotals = new Array<number>(12).fill(0);
   const hcTotals = new Array<number>(12).fill(0);
+  const autoTotals = new Array<number>(12).fill(0);
   for (const p of points) {
     const d = new Date(p.time);
     hpTotals[d.getMonth()] += p.hp;
     hcTotals[d.getMonth()] += p.hc;
+    autoTotals[d.getMonth()] += p.autoconso;
   }
 
   return Array.from({ length: 12 }, (_, i) => {
     const d = new Date(year, i, 1);
-    const tooltipLabel = capitalizeFirst(
-      d.toLocaleDateString("fr-FR", { month: "long", year: "numeric" }),
+    return toDatum(
+      capitalizeFirst(d.toLocaleDateString("fr-FR", { month: "short" })),
+      capitalizeFirst(d.toLocaleDateString("fr-FR", { month: "long", year: "numeric" })),
+      hpTotals[i],
+      hcTotals[i],
+      autoTotals[i],
     );
-    return {
-      label: capitalizeFirst(d.toLocaleDateString("fr-FR", { month: "short" })),
-      tooltipLabel,
-      hp: hpTotals[i] / 1000,
-      hc: hcTotals[i] / 1000,
-    };
   });
 }
 
-/** Local date key to avoid UTC midnight split (e.g., 23:00 UTC = next day in CET). */
 function localDateKey(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
@@ -159,16 +168,11 @@ function capitalizeFirst(s: string): string {
 
 function buildChartData(points: EnergyPoint[], period: string, date?: string): ChartDatum[] {
   switch (period) {
-    case "day":
-      return aggregateDay(points);
-    case "week":
-      return aggregateWeek(points, date);
-    case "month":
-      return aggregateMonth(points, date);
-    case "year":
-      return aggregateYear(points, date);
-    default:
-      return aggregateDay(points);
+    case "day": return aggregateDay(points);
+    case "week": return aggregateWeek(points, date);
+    case "month": return aggregateMonth(points, date);
+    case "year": return aggregateYear(points, date);
+    default: return aggregateDay(points);
   }
 }
 
@@ -190,6 +194,15 @@ function formatYAxis(kwh: number): string {
 }
 
 // ============================================================
+// SVG path helper: rectangle with only top corners rounded
+// ============================================================
+
+function roundedTopRect(x: number, y: number, w: number, h: number, r: number): string {
+  const radius = Math.min(r, h, w / 2);
+  return `M${x},${y + h} L${x},${y + radius} Q${x},${y} ${x + radius},${y} L${x + w - radius},${y} Q${x + w},${y} ${x + w},${y + radius} L${x + w},${y + h}Z`;
+}
+
+// ============================================================
 // Component
 // ============================================================
 
@@ -197,9 +210,7 @@ export function EnergyBarChart({ points, period, date, height = 300 }: EnergyBar
   const { t } = useTranslation();
   const data = useMemo(() => buildChartData(points, period, date), [points, period, date]);
 
-  const hasHpHc = useMemo(() => {
-    return data.some((d) => d.hc > 0);
-  }, [data]);
+  const hasAutoconso = useMemo(() => data.some((d) => d.autoconso > 0), [data]);
 
   // Fixed gridline intervals per period
   const yTicks = useMemo(() => {
@@ -214,6 +225,11 @@ export function EnergyBarChart({ points, period, date, height = 300 }: EnergyBar
     return Array.from({ length: max / step + 1 }, (_, i) => i * step);
   }, [data, period]);
 
+  // Store HC bar baseline positions (bottom y of each HC bar = bottom of full stack)
+  // Populated during HC shape render, consumed during HP shape render for autoconso overlay
+  const hcBaselinesRef = useRef<Array<{ x: number; width: number; baseline: number }>>([]);
+  const hcBaselines = hcBaselinesRef.current;
+
   if (data.length === 0) {
     return (
       <div className="flex items-center justify-center text-text-tertiary text-[13px]" style={{ height }}>
@@ -222,8 +238,8 @@ export function EnergyBarChart({ points, period, date, height = 300 }: EnergyBar
     );
   }
 
-  // Determine tick interval to avoid label overlap on day view
   const tickInterval = period === "day" ? Math.max(1, Math.floor(data.length / 12)) - 1 : 0;
+  const maxBarSize = period === "day" ? 20 : 40;
 
   return (
     <ResponsiveContainer width="100%" height={height}>
@@ -247,62 +263,98 @@ export function EnergyBarChart({ points, period, date, height = 300 }: EnergyBar
         />
         <Tooltip
           cursor={false}
-          contentStyle={{
-            backgroundColor: "var(--color-surface)",
-            border: "1px solid var(--color-border)",
-            borderRadius: "6px",
-            fontSize: "12px",
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null;
+            const datum = payload[0]?.payload as ChartDatum | undefined;
+            if (!datum) return null;
+            const total = datum.hp + datum.hc;
+            return (
+              <div
+                style={{
+                  backgroundColor: "var(--color-surface)",
+                  border: "1px solid var(--color-border)",
+                  borderRadius: "6px",
+                  fontSize: "12px",
+                  padding: "8px 12px",
+                }}
+              >
+                <div style={{ fontWeight: 600, marginBottom: 4 }}>{datum.tooltipLabel}</div>
+                <div style={{ fontWeight: 600, marginBottom: 4 }}>{t("energy.consumption")} : {formatKWh(total)}</div>
+                <div style={{ color: HP_COLOR }}>{t("energy.peakHours")} : {formatKWh(datum.hp)}</div>
+                <div style={{ color: HC_COLOR }}>{t("energy.offPeakHours")} : {formatKWh(datum.hc)}</div>
+                {datum.autoconso > 0 && (
+                  <div style={{ color: AUTOCONSO_COLOR }}>
+                    {t("energy.autoconsumption")} : {formatKWh(datum.autoconso)}
+                  </div>
+                )}
+              </div>
+            );
           }}
-          formatter={(value: number | undefined, name: string | undefined) => {
-            const n = name ?? "";
-            const label = n === "hp" ? t("energy.peakHours") : n === "hc" ? t("energy.offPeakHours") : n;
-            return [formatKWh(value ?? 0), label];
-          }}
-          labelFormatter={(_label: unknown, payload: ReadonlyArray<{ payload?: ChartDatum }>) =>
-            payload[0]?.payload?.tooltipLabel ?? String(_label)
-          }
         />
-        {hasHpHc ? (
-          <>
-            <Bar
-              dataKey="hp"
-              stackId="energy"
-              fill={HP_COLOR}
-              maxBarSize={period === "day" ? 20 : 40}
-              name="hp"
-              shape={(props: unknown) => {
-                const p = props as Record<string, unknown>;
-                const x = p.x as number, y = p.y as number, width = p.width as number, height = p.height as number;
-                const f = p.fill as string, hcVal = p.hc as number;
-                if (!height || height <= 0) return null;
-                const r = hcVal > 0 ? 0 : 4;
-                return (
-                  <path
-                    d={`M${x},${y + height}V${y + r}${r ? `Q${x},${y} ${x + r},${y}` : ""}H${x + width - r}${r ? `Q${x + width},${y} ${x + width},${y + r}` : ""}V${y + height}Z`}
-                    fill={f as string}
-                  />
-                );
-              }}
-            />
-            <Bar
-              dataKey="hc"
-              stackId="energy"
-              fill={HC_COLOR}
-              radius={[4, 4, 0, 0]}
-              maxBarSize={period === "day" ? 20 : 40}
-              name="hc"
-            />
-          </>
-        ) : (
-          <Bar
-            dataKey="hp"
-            fill={HP_COLOR}
-            activeBar={{ fill: "#6B93F0" }}
-            radius={[4, 4, 0, 0]}
-            maxBarSize={period === "day" ? 20 : 40}
-            name="hp"
-          />
-        )}
+        {/* HC (light blue) at bottom — captures baseline for autoconso overlay */}
+        <Bar
+          dataKey="hc"
+          stackId="consumption"
+          fill={HC_COLOR}
+          maxBarSize={maxBarSize}
+          name="hc"
+          shape={(props: { x?: number; y?: number; width?: number; height?: number; index?: number; payload?: ChartDatum }) => {
+            const { x = 0, y = 0, width: w = 0, height: h = 0, index = 0, payload } = props;
+            // Record baseline for autoconso overlay
+            hcBaselines[index] = { x, width: w, baseline: y + h };
+            if (!h || h <= 0) return null;
+            const rounded = !payload || payload.hp <= 0;
+            if (!rounded) return <rect x={x} y={y} width={w} height={h} fill={HC_COLOR} />;
+            return <path d={roundedTopRect(x, y, w, h, 4)} fill={HC_COLOR} />;
+          }}
+        />
+        {/* HP (dark blue) on top — also draws autoconso green overlay */}
+        <Bar
+          dataKey="hp"
+          stackId="consumption"
+          fill={HP_COLOR}
+          radius={[4, 4, 0, 0]}
+          maxBarSize={maxBarSize}
+          name="hp"
+          shape={(props: { x?: number; y?: number; width?: number; height?: number; index?: number; payload?: ChartDatum }) => {
+            const { x = 0, y = 0, width: w = 0, height: h = 0, index = 0, payload } = props;
+            const hpRect = h > 0
+              ? <path d={roundedTopRect(x, y, w, h, 4)} fill={HP_COLOR} />
+              : null;
+
+            // Draw autoconso overlay from baseline upward
+            let autoRect = null;
+            if (hasAutoconso && payload && payload.autoconso > 0) {
+              const total = payload.hp + payload.hc;
+              const geo = hcBaselines[index];
+              if (total > 0 && geo) {
+                // Full stack pixel height: from top of HP (or top of HC if HP=0) to baseline
+                // y = top of HP segment (or top of stack when HP=0, since recharts positions it there)
+                const fullStackH = geo.baseline - y;
+                if (fullStackH > 0) {
+                  const ratio = payload.autoconso / total;
+                  const autoH = fullStackH * ratio;
+                  autoRect = (
+                    <rect
+                      x={geo.x}
+                      y={geo.baseline - autoH}
+                      width={geo.width}
+                      height={autoH}
+                      fill={AUTOCONSO_COLOR}
+                    />
+                  );
+                }
+              }
+            }
+
+            return (
+              <g>
+                {hpRect}
+                {autoRect}
+              </g>
+            );
+          }}
+        />
       </BarChart>
     </ResponsiveContainer>
   );

--- a/ui/src/components/energy/EnergyPage.tsx
+++ b/ui/src/components/energy/EnergyPage.tsx
@@ -70,7 +70,7 @@ export function EnergyPage() {
                     </span>
                   )}
                 </div>
-                <div className="text-[13px] font-semibold text-text tabular-nums">
+                <div className="text-[15px] font-semibold text-text tabular-nums">
                   Total : {formatKWh(history.totals.total_consumption, period)} kWh
                   {hasProduction && history.totals.total_consumption > 0 && history.totals.total_autoconso > 0 && (
                     <span className="ml-2 font-normal text-text-secondary">

--- a/ui/src/components/energy/EnergyPage.tsx
+++ b/ui/src/components/energy/EnergyPage.tsx
@@ -10,12 +10,14 @@ function formatKWh(wh: number, period: string): string {
   return Math.round(kwh).toString();
 }
 
+const AUTOCONSO_COLOR = "#6BCB77";
 export function EnergyPage() {
   const { t } = useTranslation();
   const history = useEnergy((s) => s.history);
   const period = useEnergy((s) => s.period);
   const date = useEnergy((s) => s.date);
   const loading = useEnergy((s) => s.loading);
+  const hasProduction = useEnergy((s) => s.hasProduction);
   const fetchHistory = useEnergy((s) => s.fetchHistory);
 
   useEffect(() => {
@@ -38,36 +40,49 @@ export function EnergyPage() {
           {t("common.loading")}
         </div>
       ) : (
-        <div className="bg-surface border border-border rounded-[10px] p-4 sm:p-6">
-          {/* Chart */}
-          <EnergyBarChart
-            points={history?.points ?? []}
-            period={period}
-            date={date}
-            height={350}
-          />
+        <>
+          {/* Consumption chart */}
+          <div className="bg-surface border border-border rounded-[10px] p-4 sm:p-6">
+            <EnergyBarChart
+              points={history?.points ?? []}
+              period={period}
+              date={date}
+              height={350}
+            />
 
-          {/* Legend below chart */}
-          {history && (
-            <div className="flex flex-col items-center mt-3 gap-1">
-              {hasHpHc && (
-                <div className="flex items-center gap-4 text-[13px] text-text-secondary">
+            {/* Legend below chart */}
+            {history && (
+              <div className="flex flex-col items-center mt-3 gap-1">
+                <div className="flex items-center gap-4 text-[13px] text-text-secondary flex-wrap justify-center">
                   <span className="flex items-center gap-1.5">
                     <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: "#4F7BE8" }} />
-                    {t("energy.peakHours")} : {formatKWh(history.totals.total_hp, period)} kWh
+                    {t("energy.gridConsumption")} : {formatKWh((history.totals.total_consumption ?? 0) - (history.totals.total_autoconso ?? 0), period)} kWh
                   </span>
-                  <span className="flex items-center gap-1.5">
-                    <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: "#93B5F0" }} />
-                    {t("energy.offPeakHours")} : {formatKWh(history.totals.total_hc, period)} kWh
-                  </span>
+                  {hasHpHc && (
+                    <span className="text-text-tertiary">
+                      ({t("energy.peakHours")} : {formatKWh(history.totals.total_hp, period)} — {t("energy.offPeakHours")} : {formatKWh(history.totals.total_hc, period)})
+                    </span>
+                  )}
+                  {hasProduction && history.totals.total_autoconso > 0 && (
+                    <span className="flex items-center gap-1.5">
+                      <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: AUTOCONSO_COLOR }} />
+                      {t("energy.autoconsumption")} : {formatKWh(history.totals.total_autoconso, period)} kWh
+                    </span>
+                  )}
                 </div>
-              )}
-              <div className="text-[13px] font-semibold text-text tabular-nums">
-                Total : {formatKWh(history.totals.total_consumption, period)} kWh
+                <div className="text-[13px] font-semibold text-text tabular-nums">
+                  Total : {formatKWh(history.totals.total_consumption, period)} kWh
+                  {hasProduction && history.totals.total_consumption > 0 && history.totals.total_autoconso > 0 && (
+                    <span className="ml-2 font-normal text-text-secondary">
+                      ({Math.round(history.totals.total_autoconso / history.totals.total_consumption * 100)}% {t("energy.autoconsumption").toLowerCase()})
+                    </span>
+                  )}
+                </div>
               </div>
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+
+        </>
       )}
     </div>
   );

--- a/ui/src/components/energy/EnergyPage.tsx
+++ b/ui/src/components/energy/EnergyPage.tsx
@@ -60,7 +60,7 @@ export function EnergyPage() {
                   </span>
                   {hasHpHc && (
                     <span className="text-text-tertiary">
-                      ({t("energy.peakHours")} : {formatKWh(history.totals.total_hp, period)} — {t("energy.offPeakHours")} : {formatKWh(history.totals.total_hc, period)})
+                      ({t("energy.peakHours")} : {formatKWh(history.totals.total_hp, period)} kWh — {t("energy.offPeakHours")} : {formatKWh(history.totals.total_hc, period)} kWh)
                     </span>
                   )}
                   {hasProduction && history.totals.total_autoconso > 0 && (

--- a/ui/src/components/energy/EnergyPage.tsx
+++ b/ui/src/components/energy/EnergyPage.tsx
@@ -70,7 +70,7 @@ export function EnergyPage() {
                     </span>
                   )}
                 </div>
-                <div className="text-[15px] font-semibold text-text tabular-nums">
+                <div className="text-[15px] font-semibold text-text tabular-nums mt-1">
                   Total : {formatKWh(history.totals.total_consumption, period)} kWh
                   {hasProduction && history.totals.total_consumption > 0 && history.totals.total_autoconso > 0 && (
                     <span className="ml-2 font-normal text-text-secondary">

--- a/ui/src/components/energy/ProductionBarChart.tsx
+++ b/ui/src/components/energy/ProductionBarChart.tsx
@@ -1,0 +1,283 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+import type { EnergyPoint } from "../../types";
+
+interface ProductionBarChartProps {
+  points: EnergyPoint[];
+  period: string;
+  date?: string;
+  height?: number;
+}
+
+interface ChartDatum {
+  label: string;
+  tooltipLabel?: string;
+  autoconso: number; // kWh
+  injection: number; // kWh
+}
+
+const AUTOCONSO_COLOR = "#6BCB77"; // light green
+const INJECTION_COLOR = "#2D8F3E"; // dark green
+
+/** Local date key to avoid UTC midnight split. */
+function localDateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function capitalizeFirst(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function aggregateDay(points: EnergyPoint[]): ChartDatum[] {
+  const autoByHour = new Map<number, number>();
+  const injByHour = new Map<number, number>();
+
+  for (const p of points) {
+    const d = new Date(p.time);
+    const hour = d.getHours();
+    autoByHour.set(hour, (autoByHour.get(hour) ?? 0) + p.autoconso);
+    injByHour.set(hour, (injByHour.get(hour) ?? 0) + p.injection);
+  }
+
+  return Array.from({ length: 24 }, (_, hour) => ({
+    label: `${String(hour).padStart(2, "0")}h`,
+    tooltipLabel: `${String(hour).padStart(2, "0")}h00 – ${String((hour + 1) % 24).padStart(2, "0")}h00`,
+    autoconso: (autoByHour.get(hour) ?? 0) / 1000,
+    injection: (injByHour.get(hour) ?? 0) / 1000,
+  }));
+}
+
+function aggregateWeek(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
+  const autoByDay = new Map<string, number>();
+  const injByDay = new Map<string, number>();
+  for (const p of points) {
+    const d = new Date(p.time);
+    const key = localDateKey(d);
+    autoByDay.set(key, (autoByDay.get(key) ?? 0) + p.autoconso);
+    injByDay.set(key, (injByDay.get(key) ?? 0) + p.injection);
+  }
+
+  const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+  const dayOfWeek = ref.getDay();
+  const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+  const monday = new Date(ref);
+  monday.setDate(monday.getDate() + mondayOffset);
+
+  return Array.from({ length: 7 }, (_, i) => {
+    const day = new Date(monday);
+    day.setDate(day.getDate() + i);
+    const key = localDateKey(day);
+    const label = capitalizeFirst(
+      day.toLocaleDateString("fr-FR", { weekday: "short", day: "numeric" }),
+    );
+    const tooltipLabel = capitalizeFirst(
+      day.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long", year: "numeric" }),
+    );
+    return {
+      label,
+      tooltipLabel,
+      autoconso: (autoByDay.get(key) ?? 0) / 1000,
+      injection: (injByDay.get(key) ?? 0) / 1000,
+    };
+  });
+}
+
+function aggregateMonth(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
+  const autoByDay = new Map<string, number>();
+  const injByDay = new Map<string, number>();
+  for (const p of points) {
+    const d = new Date(p.time);
+    const key = localDateKey(d);
+    autoByDay.set(key, (autoByDay.get(key) ?? 0) + p.autoconso);
+    injByDay.set(key, (injByDay.get(key) ?? 0) + p.injection);
+  }
+
+  const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+  const year = ref.getFullYear();
+  const month = ref.getMonth();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  return Array.from({ length: daysInMonth }, (_, i) => {
+    const day = new Date(year, month, i + 1);
+    const key = localDateKey(day);
+    const tooltipLabel = capitalizeFirst(
+      day.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long", year: "numeric" }),
+    );
+    return {
+      label: String(i + 1),
+      tooltipLabel,
+      autoconso: (autoByDay.get(key) ?? 0) / 1000,
+      injection: (injByDay.get(key) ?? 0) / 1000,
+    };
+  });
+}
+
+function aggregateYear(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
+  const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+  const year = ref.getFullYear();
+
+  const autoTotals = new Array<number>(12).fill(0);
+  const injTotals = new Array<number>(12).fill(0);
+  for (const p of points) {
+    const d = new Date(p.time);
+    autoTotals[d.getMonth()] += p.autoconso;
+    injTotals[d.getMonth()] += p.injection;
+  }
+
+  return Array.from({ length: 12 }, (_, i) => {
+    const d = new Date(year, i, 1);
+    const tooltipLabel = capitalizeFirst(
+      d.toLocaleDateString("fr-FR", { month: "long", year: "numeric" }),
+    );
+    return {
+      label: capitalizeFirst(d.toLocaleDateString("fr-FR", { month: "short" })),
+      tooltipLabel,
+      autoconso: autoTotals[i] / 1000,
+      injection: injTotals[i] / 1000,
+    };
+  });
+}
+
+function buildChartData(points: EnergyPoint[], period: string, date?: string): ChartDatum[] {
+  switch (period) {
+    case "day":
+      return aggregateDay(points);
+    case "week":
+      return aggregateWeek(points, date);
+    case "month":
+      return aggregateMonth(points, date);
+    case "year":
+      return aggregateYear(points, date);
+    default:
+      return aggregateDay(points);
+  }
+}
+
+function formatKWh(kwh: number): string {
+  if (kwh >= 1) return `${kwh.toFixed(2)} kWh`;
+  if (kwh > 0) return `${Math.round(kwh * 1000)} Wh`;
+  return "0 Wh";
+}
+
+function formatYAxis(kwh: number): string {
+  if (kwh >= 100) return `${Math.round(kwh)} kWh`;
+  if (kwh >= 1) return `${kwh.toFixed(1)} kWh`;
+  if (kwh === 0) return "0";
+  return `${kwh.toFixed(2)} kWh`;
+}
+
+export function ProductionBarChart({ points, period, date, height = 300 }: ProductionBarChartProps) {
+  const { t } = useTranslation();
+  const data = useMemo(() => buildChartData(points, period, date), [points, period, date]);
+
+  const yTicks = useMemo(() => {
+    const stepByPeriod: Record<string, number> = {
+      day: 0.5,
+      week: 5,
+      month: 10,
+      year: 200,
+    };
+    const step = stepByPeriod[period] ?? 0.5;
+    const max = Math.ceil(Math.max(...data.map((d) => d.autoconso + d.injection), step) / step) * step;
+    return Array.from({ length: max / step + 1 }, (_, i) => i * step);
+  }, [data, period]);
+
+  const hasData = data.some((d) => d.autoconso > 0 || d.injection > 0);
+  if (!hasData) {
+    return (
+      <div className="flex items-center justify-center text-text-tertiary text-[13px]" style={{ height }}>
+        {t("common.noData")}
+      </div>
+    );
+  }
+
+  const tickInterval = period === "day" ? Math.max(1, Math.floor(data.length / 12)) - 1 : 0;
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light)" vertical={false} />
+        <XAxis
+          dataKey="label"
+          tick={{ fontSize: 11, fill: "var(--color-text-tertiary)" }}
+          interval={tickInterval}
+          tickLine={false}
+          axisLine={{ stroke: "var(--color-border)" }}
+        />
+        <YAxis
+          tick={{ fontSize: 11, fill: "var(--color-text-tertiary)" }}
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={formatYAxis}
+          width={70}
+          domain={[0, yTicks[yTicks.length - 1] ?? "dataMax"]}
+          ticks={yTicks}
+        />
+        <Tooltip
+          cursor={false}
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null;
+            const datum = payload[0]?.payload as ChartDatum | undefined;
+            if (!datum) return null;
+            const total = (datum.autoconso ?? 0) + (datum.injection ?? 0);
+            return (
+              <div
+                style={{
+                  backgroundColor: "var(--color-surface)",
+                  border: "1px solid var(--color-border)",
+                  borderRadius: "6px",
+                  fontSize: "12px",
+                  padding: "8px 12px",
+                }}
+              >
+                <div style={{ fontWeight: 600, marginBottom: 4 }}>{datum.tooltipLabel}</div>
+                <div style={{ fontWeight: 600, marginBottom: 4 }}>{t("energy.production")} : {formatKWh(total)}</div>
+                <div style={{ color: AUTOCONSO_COLOR }}>{t("energy.autoconsumption")} : {formatKWh(datum.autoconso)}</div>
+                {datum.injection > 0 && (
+                  <div style={{ color: INJECTION_COLOR }}>{t("energy.gridInjection")} : {formatKWh(datum.injection)}</div>
+                )}
+              </div>
+            );
+          }}
+        />
+        <Bar
+          dataKey="autoconso"
+          stackId="production"
+          fill={AUTOCONSO_COLOR}
+          maxBarSize={period === "day" ? 20 : 40}
+          name="autoconso"
+          shape={(props: unknown) => {
+            const p = props as Record<string, unknown>;
+            const x = p.x as number, y = p.y as number, width = p.width as number, height = p.height as number;
+            const f = p.fill as string, injVal = p.injection as number;
+            if (!height || height <= 0) return null;
+            const r = injVal > 0 ? 0 : 4;
+            return (
+              <path
+                d={`M${x},${y + height}V${y + r}${r ? `Q${x},${y} ${x + r},${y}` : ""}H${x + width - r}${r ? `Q${x + width},${y} ${x + width},${y + r}` : ""}V${y + height}Z`}
+                fill={f}
+              />
+            );
+          }}
+        />
+        <Bar
+          dataKey="injection"
+          stackId="production"
+          fill={INJECTION_COLOR}
+          radius={[4, 4, 0, 0]}
+          maxBarSize={period === "day" ? 20 : 40}
+          name="injection"
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/ui/src/components/energy/ProductionPage.tsx
+++ b/ui/src/components/energy/ProductionPage.tsx
@@ -62,7 +62,7 @@ export function ProductionPage() {
                   {t("energy.gridInjection")} : {formatKWh(history.totals.total_injection, period)} kWh
                 </span>
               </div>
-              <div className="text-[15px] font-semibold text-text tabular-nums">
+              <div className="text-[15px] font-semibold text-text tabular-nums mt-1">
                 Total : {formatKWh(history.totals.total_production, period)} kWh
               </div>
             </div>

--- a/ui/src/components/energy/ProductionPage.tsx
+++ b/ui/src/components/energy/ProductionPage.tsx
@@ -62,7 +62,7 @@ export function ProductionPage() {
                   {t("energy.gridInjection")} : {formatKWh(history.totals.total_injection, period)} kWh
                 </span>
               </div>
-              <div className="text-[13px] font-semibold text-text tabular-nums">
+              <div className="text-[15px] font-semibold text-text tabular-nums">
                 Total : {formatKWh(history.totals.total_production, period)} kWh
               </div>
             </div>

--- a/ui/src/components/energy/ProductionPage.tsx
+++ b/ui/src/components/energy/ProductionPage.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { useEnergy } from "../../store/useEnergy";
+import { PeriodSelector } from "./PeriodSelector";
+import { ProductionBarChart } from "./ProductionBarChart";
+
+function formatKWh(wh: number, period: string): string {
+  const kwh = wh / 1000;
+  if (period === "day") return kwh.toFixed(2);
+  return Math.round(kwh).toString();
+}
+
+const AUTOCONSO_COLOR = "#6BCB77";
+const INJECTION_COLOR = "#2D8F3E";
+
+export function ProductionPage() {
+  const { t } = useTranslation();
+  const history = useEnergy((s) => s.history);
+  const period = useEnergy((s) => s.period);
+  const date = useEnergy((s) => s.date);
+  const loading = useEnergy((s) => s.loading);
+  const fetchHistory = useEnergy((s) => s.fetchHistory);
+
+  useEffect(() => {
+    fetchHistory();
+  }, [fetchHistory]);
+
+  const hasProdData = history ? history.totals.total_production > 0 : false;
+
+  return (
+    <div className="p-4 sm:p-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4 sm:mb-6">
+        <h1 className="text-[18px] font-semibold text-text">{t("energy.production")}</h1>
+        <PeriodSelector />
+      </div>
+
+      {/* Content */}
+      {loading && !history ? (
+        <div className="flex items-center justify-center h-[300px] text-text-tertiary text-[13px]">
+          {t("common.loading")}
+        </div>
+      ) : (
+        <div className="bg-surface border border-border rounded-[10px] p-4 sm:p-6">
+          <ProductionBarChart
+            points={history?.points ?? []}
+            period={period}
+            date={date}
+            height={350}
+          />
+
+          {/* Production legend */}
+          {history && hasProdData && (
+            <div className="flex flex-col items-center mt-3 gap-1">
+              <div className="flex items-center gap-4 text-[13px] text-text-secondary">
+                <span className="flex items-center gap-1.5">
+                  <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: AUTOCONSO_COLOR }} />
+                  {t("energy.autoconsumption")} : {formatKWh(history.totals.total_autoconso, period)} kWh
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: INJECTION_COLOR }} />
+                  {t("energy.gridInjection")} : {formatKWh(history.totals.total_injection, period)} kWh
+                </span>
+              </div>
+              <div className="text-[13px] font-semibold text-text tabular-nums">
+                Total : {formatKWh(history.totals.total_production, period)} kWh
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -18,6 +18,7 @@ const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> 
   heater: ["generic", "light_state"],
   energy_meter: ["energy"],
   main_energy_meter: ["energy"],
+  energy_production_meter: ["energy", "power"],
 };
 
 /** Maps EquipmentType to required data keys for filtering (when category alone is too broad). */

--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -36,6 +36,7 @@ const TYPE_ICONS: Record<EquipmentType, React.ReactNode> = {
   heater: <Heater size={18} strokeWidth={1.5} />,
   energy_meter: <Zap size={18} strokeWidth={1.5} />,
   main_energy_meter: <Zap size={18} strokeWidth={1.5} />,
+  energy_production_meter: <Zap size={18} strokeWidth={1.5} />,
 };
 
 const TYPE_LABELS: Record<EquipmentType, string> = {
@@ -52,6 +53,7 @@ const TYPE_LABELS: Record<EquipmentType, string> = {
   heater: "equipments.type.heater",
   energy_meter: "equipments.type.energy_meter",
   main_energy_meter: "equipments.type.main_energy_meter",
+  energy_production_meter: "equipments.type.energy_production_meter",
 };
 
 interface EquipmentCardProps {

--- a/ui/src/components/equipments/EquipmentForm.tsx
+++ b/ui/src/components/equipments/EquipmentForm.tsx
@@ -18,6 +18,7 @@ const EQUIPMENT_TYPE_KEYS: { value: EquipmentType; labelKey: string }[] = [
   { value: "heater", labelKey: "equipments.type.heater" },
   { value: "energy_meter", labelKey: "equipments.type.energy_meter" },
   { value: "main_energy_meter", labelKey: "equipments.type.main_energy_meter" },
+  { value: "energy_production_meter", labelKey: "equipments.type.energy_production_meter" },
 ];
 
 interface EquipmentFormProps {

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -22,6 +22,7 @@ const RELEVANT_DATA: Record<string, string[]> = {
   heater: ["generic", "light_state"],
   energy_meter: ["energy", "power"],
   main_energy_meter: ["energy", "power"],
+  energy_production_meter: ["energy", "power"],
 };
 
 /** Maps equipment types to relevant order keys for auto-binding. */
@@ -38,6 +39,7 @@ const RELEVANT_ORDERS: Record<string, string[]> = {
   heater: ["state", "on", "R1", "R2", "R3", "R4"],
   energy_meter: [],
   main_energy_meter: [],
+  energy_production_meter: [],
 };
 
 /**

--- a/ui/src/components/equipments/useEquipmentState.ts
+++ b/ui/src/components/equipments/useEquipmentState.ts
@@ -16,7 +16,7 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
     equipment.type === "light_color";
   const isShutter = equipment.type === "shutter";
   const isSensor = equipment.type === "sensor" || equipment.type === "button" || equipment.type === "weather";
-  const isEnergyMeter = equipment.type === "energy_meter" || equipment.type === "main_energy_meter";
+  const isEnergyMeter = equipment.type === "energy_meter" || equipment.type === "main_energy_meter" || equipment.type === "energy_production_meter";
   const isThermostat = equipment.type === "thermostat";
   const isHeater = equipment.type === "heater";
   const isGate = equipment.type === "gate";

--- a/ui/src/components/home/ZoneEquipmentsView.tsx
+++ b/ui/src/components/home/ZoneEquipmentsView.tsx
@@ -24,7 +24,7 @@ const EQUIPMENT_GROUPS: EquipmentGroup[] = [
   { labelKey: "equipments.group.lights", types: ["light_onoff", "light_dimmable", "light_color"], icon: <Lightbulb size={14} strokeWidth={1.5} />, headerBg: "bg-active/8", iconColor: "text-active-text" },
   { labelKey: "equipments.group.shutters", types: ["shutter"], icon: <ShutterClosedIcon size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
   { labelKey: "equipments.group.climate", types: ["thermostat", "heater"], icon: <Thermometer size={14} strokeWidth={1.5} />, headerBg: "bg-error/6", iconColor: "text-error" },
-  { labelKey: "equipments.group.energy", types: ["energy_meter", "main_energy_meter"], icon: <Zap size={14} strokeWidth={1.5} />, headerBg: "bg-accent/8", iconColor: "text-accent" },
+  { labelKey: "equipments.group.energy", types: ["energy_meter", "main_energy_meter", "energy_production_meter"], icon: <Zap size={14} strokeWidth={1.5} />, headerBg: "bg-accent/8", iconColor: "text-accent" },
   { labelKey: "equipments.group.sensors", types: ["sensor"], icon: <Gauge size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
   { labelKey: "equipments.group.weather", types: ["weather"], icon: <CloudSun size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
   { labelKey: "equipments.group.other", types: ["switch", "button", "gate"], icon: <ToggleRight size={14} strokeWidth={1.5} />, headerBg: "bg-text-tertiary/6", iconColor: "text-text-secondary" },

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -18,6 +18,8 @@ import {
   Bell,
   LayoutDashboard,
   Zap,
+  PlugZap,
+  Sun,
 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -52,6 +54,7 @@ export function Sidebar() {
   const user = useAuth((s) => s.user);
   const isAdmin = user?.role === "admin";
   const energyAvailable = useEnergy((s) => s.available);
+  const hasProduction = useEnergy((s) => s.hasProduction);
   const checkEnergyAvailability = useEnergy((s) => s.checkAvailability);
 
   useEffect(() => {
@@ -255,8 +258,25 @@ export function Sidebar() {
                       }
                     `}
                   >
+                    <PlugZap size={14} strokeWidth={1.5} />
                     {t("nav.energy.consumption")}
                   </NavLink>
+                  {hasProduction && (
+                    <NavLink
+                      to="/energy/production"
+                      className={({ isActive }) => `
+                        flex items-center gap-2 px-3 py-1.5 rounded-[6px] min-w-0
+                        text-[13px] transition-colors duration-150 ease-out
+                        ${isActive
+                          ? "bg-primary-light text-primary font-medium"
+                          : "text-text-secondary hover:bg-border-light hover:text-text"
+                        }
+                      `}
+                    >
+                      <Sun size={14} strokeWidth={1.5} />
+                      {t("nav.energy.production")}
+                    </NavLink>
+                  )}
                 </div>
               </>
             )}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -38,6 +38,7 @@
   "common.create": "Create",
   "common.retry": "Retry",
   "common.loading": "Loading...",
+  "common.noData": "No data",
   "common.saving": "Saving...",
   "common.creating": "Creating...",
   "common.deleting": "Deleting...",
@@ -191,6 +192,7 @@
   "equipments.type.heater": "Electric Heater",
   "equipments.type.energy_meter": "Energy Meter (sub-meter)",
   "equipments.type.main_energy_meter": "Energy Meter (main)",
+  "equipments.type.energy_production_meter": "Energy Meter (production)",
 
   "equipments.group.lights": "Lights",
   "equipments.group.shutters": "Shutters",
@@ -771,6 +773,7 @@
 
   "nav.energy": "Energy",
   "nav.energy.consumption": "Consumption",
+  "nav.energy.production": "Production",
 
   "energy.consumption": "Consumption",
   "energy.today": "Today",
@@ -784,6 +787,11 @@
   "energy.totalConsumption": "Total consumption",
   "energy.peakHours": "Peak hours",
   "energy.offPeakHours": "Off-peak hours",
+  "energy.production": "Solar Production",
+  "energy.totalProduction": "Total production",
+  "energy.autoconsumption": "Self-consumption",
+  "energy.gridInjection": "Grid injection",
+  "energy.gridConsumption": "Grid",
 
   "tariff.title": "Energy tariffs",
   "tariff.priceHp": "Peak price (€/kWh)",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -38,6 +38,7 @@
   "common.create": "Créer",
   "common.retry": "Réessayer",
   "common.loading": "Chargement...",
+  "common.noData": "Aucune donnée",
   "common.saving": "Enregistrement...",
   "common.creating": "Création...",
   "common.deleting": "Suppression...",
@@ -191,6 +192,7 @@
   "equipments.type.heater": "Radiateur électrique",
   "equipments.type.energy_meter": "Compteur d'Énergie (sous-compteur)",
   "equipments.type.main_energy_meter": "Compteur d'Énergie (principal)",
+  "equipments.type.energy_production_meter": "Compteur d'Énergie (production)",
 
   "equipments.group.lights": "Éclairages",
   "equipments.group.shutters": "Volets",
@@ -771,6 +773,7 @@
 
   "nav.energy": "Énergie",
   "nav.energy.consumption": "Consommation",
+  "nav.energy.production": "Production",
 
   "energy.consumption": "Consommation",
   "energy.today": "Aujourd'hui",
@@ -784,6 +787,11 @@
   "energy.totalConsumption": "Consommation totale",
   "energy.peakHours": "H. pleines",
   "energy.offPeakHours": "H. creuses",
+  "energy.production": "Production solaire",
+  "energy.totalProduction": "Production totale",
+  "energy.autoconsumption": "Autoconsommation",
+  "energy.gridInjection": "Injection réseau",
+  "energy.gridConsumption": "Réseau",
 
   "tariff.title": "Tarifs énergie",
   "tariff.priceHp": "Prix HP (€/kWh)",

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -301,7 +301,7 @@ export function EquipmentDetailPage() {
       ) : null}
 
       {/* Energy cumuls */}
-      {equipment.type === "main_energy_meter" && equipment.computedData && (
+      {(equipment.type === "main_energy_meter" || equipment.type === "energy_production_meter") && equipment.computedData && (
         <EnergyDataPanel computedData={equipment.computedData} />
       )}
 

--- a/ui/src/pages/EquipmentsPage.tsx
+++ b/ui/src/pages/EquipmentsPage.tsx
@@ -144,7 +144,7 @@ export function EquipmentsPage() {
 }
 
 /** Singleton equipment types — only one instance allowed. */
-const SINGLETON_TYPES: EquipmentType[] = ["main_energy_meter"];
+const SINGLETON_TYPES: EquipmentType[] = ["main_energy_meter", "energy_production_meter"];
 
 function singletonExcludeTypes(equipments: EquipmentWithDetails[]): Set<EquipmentType> {
   const exclude = new Set<EquipmentType>();

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -265,6 +265,7 @@ export function HomePage() {
           excludeTypes={(() => {
             const exclude = new Set<EquipmentType>();
             if (equipments.some((eq) => eq.type === "main_energy_meter")) exclude.add("main_energy_meter");
+            if (equipments.some((eq) => eq.type === "energy_production_meter")) exclude.add("energy_production_meter");
             return exclude;
           })()}
           boundDeviceIds={new Set(equipments.flatMap((e) => [

--- a/ui/src/store/useEnergy.ts
+++ b/ui/src/store/useEnergy.ts
@@ -9,6 +9,7 @@ interface EnergyState {
   date: string; // YYYY-MM-DD
   history: EnergyHistoryResponse | null;
   available: boolean | null; // null = not checked yet
+  hasProduction: boolean;
   loading: boolean;
   error: string | null;
 
@@ -72,6 +73,7 @@ export const useEnergy = create<EnergyState>((set, get) => ({
   date: todayStr(),
   history: null,
   available: null,
+  hasProduction: false,
   loading: false,
   error: null,
 
@@ -108,9 +110,9 @@ export const useEnergy = create<EnergyState>((set, get) => ({
   checkAvailability: async () => {
     try {
       const status = await getEnergyStatus();
-      set({ available: status.available });
+      set({ available: status.available, hasProduction: status.hasProduction });
     } catch {
-      set({ available: false });
+      set({ available: false, hasProduction: false });
     }
   },
 }));

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -152,7 +152,8 @@ export type EquipmentType =
   | "gate"
   | "heater"
   | "energy_meter"
-  | "main_energy_meter";
+  | "main_energy_meter"
+  | "energy_production_meter";
 
 export interface Equipment {
   id: string;
@@ -689,12 +690,18 @@ export interface EnergyPoint {
   time: string;
   hp: number; // Wh attributed to Heures Pleines
   hc: number; // Wh attributed to Heures Creuses
+  prod: number; // Wh total production
+  autoconso: number; // min(prod, consumption) Wh
+  injection: number; // max(0, prod - consumption) Wh
 }
 
 export interface EnergyTotals {
   total_consumption: number; // hp + hc (Wh)
   total_hp: number; // Wh
   total_hc: number; // Wh
+  total_production: number; // Wh
+  total_autoconso: number; // Wh
+  total_injection: number; // Wh
 }
 
 export interface EnergyHistoryResponse {
@@ -708,6 +715,7 @@ export interface EnergyHistoryResponse {
 
 export interface EnergyStatus {
   available: boolean;
+  hasProduction: boolean;
   sources: string[];
   lastDataAt: string | null;
   tariffConfigured: boolean;


### PR DESCRIPTION
## Summary
- Add solar production tracking with autoconsumption split (self-consumed vs grid injection)
- New Production page (`/energy/production`) with dedicated bar chart and legend
- Autoconsumption overlay on consumption chart: green rect drawn over HP/HC stacked bars
- Sidebar navigation with icons (PlugZap for Consommation, Sun for Production)

## Changes
- **UI**: New `ProductionPage`, `ProductionBarChart`, updated `EnergyBarChart` with autoconso overlay, updated `Sidebar` with icons, new i18n keys
- **Charts**: Custom Recharts shape rendering with cross-bar geometry passing via `useRef` for precise autoconso overlay positioning

## Test plan
- [x] TypeScript compiles (zero errors)
- [x] All 454 tests pass
- [x] ESLint clean
- [x] Manually verified consumption chart with HP/HC + green autoconso overlay
- [x] Manually verified production chart with autoconso + injection split
- [x] Sidebar icons and conditional production link working

🤖 Generated with [Claude Code](https://claude.com/claude-code)