### PR TITLE
fix(mcz): improve connection resilience with reconnect-aware polling

### DIFF
--- a/specs/038-mcz-connection-resilience/spec.md
+++ b/specs/038-mcz-connection-resilience/spec.md
@@ -1,0 +1,21 @@
+# Fix: MCZ Maestro Connection Resilience
+
+## Summary
+
+The MCZ cloud server (app.mcz.it:9000) drops Socket.IO connections via ping timeout every ~10-20 minutes. Socket.IO reconnects successfully in ~5s, but during that window polls fail with "MCZ bridge not connected". Additionally, `emitJoin()` fires twice on every reconnect (both `reconnect` and `connect` events), and the integration has no retry logic if the initial connection fails.
+
+## Acceptance Criteria
+
+- [x] No double `emitJoin()` on reconnection
+- [x] `getStatus()` waits for reconnection instead of throwing immediately
+- [x] Automatic recovery poll triggered after reconnection
+- [x] `scheduleRetry()` with exponential backoff on initial start failure
+- [x] No data model, API, or UI changes
+
+## File Changes
+
+| File            | Change                                                                    |
+| --------------- | ------------------------------------------------------------------------- |
+| `mcz-bridge.ts` | Fix double join, add `waitForConnection()`, expose `onReconnect` callback |
+| `mcz-poller.ts` | Listen for reconnection → trigger recovery poll                           |
+| `index.ts`      | Add `scheduleRetry()` with exponential backoff                            |

--- a/src/integrations/mcz-maestro/index.ts
+++ b/src/integrations/mcz-maestro/index.ts
@@ -29,6 +29,8 @@ export class MczMaestroIntegration implements IntegrationPlugin {
   private bridge: MczBridge | null = null;
   private poller: MczPoller | null = null;
   private status: IntegrationStatus = "disconnected";
+  private retryTimeout: ReturnType<typeof setTimeout> | null = null;
+  private retryCount = 0;
 
   constructor(
     settingsManager: SettingsManager,
@@ -123,15 +125,37 @@ export class MczMaestroIntegration implements IntegrationPlugin {
       await this.poller.start(options?.pollOffset ?? 0);
 
       this.status = "connected";
+      this.retryCount = 0;
       this.eventBus.emit({ type: "system.integration.connected", integrationId: this.id });
       this.logger.info({ pollingIntervalMs }, "MCZ Maestro integration started");
     } catch (err) {
       this.status = "error";
       this.logger.error({ err }, "Failed to start MCZ Maestro integration");
+      this.scheduleRetry();
+    }
+  }
+
+  /** Schedule an automatic retry with exponential backoff (30s, 60s, 120s, ... max 10min). */
+  private scheduleRetry(): void {
+    this.cancelRetry();
+    this.retryCount++;
+    const delaySec = Math.min(30 * Math.pow(2, this.retryCount - 1), 600);
+    this.logger.warn({ retryCount: this.retryCount, delaySec }, "Scheduling automatic retry");
+    this.retryTimeout = setTimeout(() => {
+      this.retryTimeout = null;
+      this.start().catch((err) => this.logger.error({ err }, "Retry start failed"));
+    }, delaySec * 1000);
+  }
+
+  private cancelRetry(): void {
+    if (this.retryTimeout) {
+      clearTimeout(this.retryTimeout);
+      this.retryTimeout = null;
     }
   }
 
   async stop(): Promise<void> {
+    this.cancelRetry();
     if (this.poller) {
       this.poller.stop();
       this.poller = null;

--- a/src/integrations/mcz-maestro/mcz-bridge.ts
+++ b/src/integrations/mcz-maestro/mcz-bridge.ts
@@ -17,6 +17,7 @@ import {
 
 const MCZ_CLOUD_URL = "http://app.mcz.it:9000";
 const REQUEST_TIMEOUT_MS = 15_000;
+const RECONNECT_WAIT_TIMEOUT_MS = 20_000;
 
 export class MczBridge {
   private socket: Socket | null = null;
@@ -24,6 +25,10 @@ export class MczBridge {
   private serialNumber = "";
   private macAddress = "";
   private connected = false;
+  private initialConnectDone = false;
+
+  /** Called after a successful reconnection (join completed). */
+  onReconnect: (() => void) | null = null;
 
   constructor(logger: Logger) {
     this.logger = logger.child({ module: "mcz-bridge" });
@@ -35,6 +40,7 @@ export class MczBridge {
   async connect(serialNumber: string, macAddress: string): Promise<void> {
     this.serialNumber = serialNumber;
     this.macAddress = macAddress;
+    this.initialConnectDone = false;
 
     return new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
@@ -54,18 +60,26 @@ export class MczBridge {
       });
 
       this.socket.on("connect", () => {
-        this.logger.info({ socketId: this.socket?.id }, "Connected to MCZ cloud, joining...");
-        this.emitJoin();
-        this.connected = true;
-        clearTimeout(timeout);
-        resolve();
+        if (!this.initialConnectDone) {
+          // First connection — join and resolve the connect() promise
+          this.logger.info({ socketId: this.socket?.id }, "Connected to MCZ cloud, joining...");
+          this.emitJoin();
+          this.connected = true;
+          this.initialConnectDone = true;
+          clearTimeout(timeout);
+          resolve();
+        }
+        // Reconnections are handled by io.on("reconnect") below — do NOT
+        // emit a second join here, as both events fire on reconnect.
       });
 
       this.socket.on("connect_error", (err) => {
         this.logger.error({ err: err.message }, "MCZ cloud connection error");
         this.connected = false;
-        clearTimeout(timeout);
-        reject(new Error(`MCZ cloud connection failed: ${err.message}`));
+        if (!this.initialConnectDone) {
+          clearTimeout(timeout);
+          reject(new Error(`MCZ cloud connection failed: ${err.message}`));
+        }
       });
 
       this.socket.on("disconnect", (reason) => {
@@ -78,6 +92,9 @@ export class MczBridge {
         this.logger.info("Reconnected to MCZ cloud, re-joining...");
         this.emitJoin();
         this.connected = true;
+        if (this.onReconnect) {
+          this.onReconnect();
+        }
       });
 
       // Log incoming events at debug level
@@ -103,16 +120,49 @@ export class MczBridge {
       this.socket = null;
     }
     this.connected = false;
+    this.onReconnect = null;
     this.logger.info("Disconnected from MCZ cloud");
+  }
+
+  /**
+   * Wait for the socket to be connected, with a timeout.
+   * If already connected, resolves immediately.
+   * If disconnected but Socket.IO is reconnecting, waits for reconnection.
+   */
+  private waitForConnection(): Promise<void> {
+    if (this.connected && this.socket?.connected) {
+      return Promise.resolve();
+    }
+    if (!this.socket) {
+      return Promise.reject(new Error("MCZ bridge not initialized"));
+    }
+
+    this.logger.debug("Waiting for MCZ reconnection...");
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(new Error("MCZ bridge reconnection timeout"));
+      }, RECONNECT_WAIT_TIMEOUT_MS);
+
+      const onReconnect = () => {
+        cleanup();
+        resolve();
+      };
+
+      const cleanup = () => {
+        clearTimeout(timeout);
+        this.socket?.io.off("reconnect", onReconnect);
+      };
+
+      this.socket!.io.on("reconnect", onReconnect);
+    });
   }
 
   /**
    * Request the full stove status via RecuperoInfo.
    */
   async getStatus(): Promise<MczStatusFrame> {
-    if (!this.socket || !this.connected || !this.socket.connected) {
-      throw new Error("MCZ bridge not connected");
-    }
+    await this.waitForConnection();
 
     return new Promise<MczStatusFrame>((resolve, reject) => {
       const timeout = setTimeout(() => {
@@ -167,9 +217,7 @@ export class MczBridge {
    * Send a control command to the stove.
    */
   async sendCommand(commandId: number, value: number): Promise<void> {
-    if (!this.socket || !this.connected || !this.socket.connected) {
-      throw new Error("MCZ bridge not connected");
-    }
+    await this.waitForConnection();
 
     const message =
       commandId === COMMAND_ID.RESET_ALARM

--- a/src/integrations/mcz-maestro/mcz-poller.ts
+++ b/src/integrations/mcz-maestro/mcz-poller.ts
@@ -62,6 +62,13 @@ export class MczPoller {
 
   async start(pollOffset = 0): Promise<void> {
     this.logger.info({ intervalMs: this.pollIntervalMs, pollOffset }, "Starting MCZ poller");
+
+    // Schedule a recovery poll after each reconnection
+    this.bridge.onReconnect = () => {
+      this.logger.info("MCZ reconnected, scheduling recovery poll");
+      this.scheduleOnDemandPoll(2_000);
+    };
+
     // Immediate first poll — awaited so data is available at startup
     await this.poll();
     // Stagger recurring polls by pollOffset


### PR DESCRIPTION
## Summary
- Fix double `emitJoin()` on reconnection (both `connect` and `reconnect` events fired)
- `getStatus()`/`sendCommand()` now wait for Socket.IO reconnection (~5s) instead of throwing immediately
- Automatic recovery poll 2s after reconnection to avoid stale data
- Add `scheduleRetry()` with exponential backoff (30s→10min) on initial start failure

## Root cause
MCZ cloud (app.mcz.it:9000) drops Socket.IO via ping timeout every ~15min. Reconnection takes ~5s but polls hitting that window failed with "MCZ bridge not connected" — 26 failures observed today.

## Test plan
- [x] TypeScript compiles (zero errors)
- [x] All 454 tests pass
- [x] Lint passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)