### PR TITLE
fix(recipes): skip state-watch processing when value unchanged

### DIFF
--- a/src/recipes/state-watch.ts
+++ b/src/recipes/state-watch.ts
@@ -310,7 +310,11 @@ export class StateWatchRecipe extends Recipe {
   // ============================================================
 
   private onValueChanged(value: unknown): void {
+    const previousValue = this.ctx.state.get("currentValue");
     this.ctx.state.set("currentValue", value);
+
+    // Skip processing if value hasn't actually changed
+    if (String(value) === String(previousValue)) return;
 
     if (this.matchesWatchValue(value)) {
       if (!this.ctx.state.get("watchStartedAt")) {


### PR DESCRIPTION
## Summary
- State-watch recipe now skips processing when the equipment value hasn't actually changed
- Eliminates log spam (`state=closed` every ~10s) and notification burst dedup warnings

## Root cause
Contact sensors (gate/garage) report the same value on every Z2M update cycle. The state-watch recipe was processing every event, logging and calling `notifyStateChanged()` even when the value was identical — triggering notification publisher dedup warnings (burst < 1s).

## Test plan
- [x] TypeScript compiles (zero errors)
- [x] All 454 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)