### PR TITLE
feat: weather forecast plugin (Open-Meteo) + new DataCategory values

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -8,5 +8,15 @@
     "repo": "mchacher/sowel-plugin-netatmo-security",
     "version": "0.2.0",
     "tags": ["camera", "netatmo", "security"]
+  },
+  {
+    "id": "weather-forecast",
+    "name": "Weather Forecast",
+    "description": "Weather forecast via Open-Meteo API (free, no API key)",
+    "icon": "CloudSun",
+    "author": "mchacher",
+    "repo": "mchacher/sowel-plugin-weather-forecast",
+    "version": "0.1.0",
+    "tags": ["weather", "forecast", "open-meteo"]
   }
 ]

--- a/specs/041-weather-forecast-plugin/architecture.md
+++ b/specs/041-weather-forecast-plugin/architecture.md
@@ -1,0 +1,110 @@
+# Architecture: Weather Forecast Plugin
+
+## Two Deliverables
+
+### 1. Sowel Core Changes (branch feat/weather-forecast-plugin)
+
+Minimal changes to support the plugin.
+
+#### types.ts — New DataCategory values
+
+```typescript
+export type DataCategory =
+  // ... existing values ...
+  | "weather_condition" // NEW — weather state (sunny, cloudy, rainy, etc.)
+  | "uv" // NEW — UV index
+  | "solar_radiation" // NEW — solar radiation (W/m²)
+  | "generic";
+```
+
+#### plugins/registry.json — New entry
+
+```json
+{
+  "id": "weather-forecast",
+  "name": "Weather Forecast",
+  "description": "Weather forecast via Open-Meteo API (free, no API key)",
+  "icon": "CloudSun",
+  "author": "mchacher",
+  "repo": "mchacher/sowel-plugin-weather-forecast",
+  "version": "0.1.0",
+  "tags": ["weather", "forecast", "open-meteo"]
+}
+```
+
+### 2. Plugin (separate GitHub repo: mchacher/sowel-plugin-weather-forecast)
+
+#### Plugin Structure
+
+```
+sowel-plugin-weather-forecast/
+  manifest.json        ← plugin metadata + settings schema
+  package.json         ← npm config (no external deps)
+  tsconfig.json        ← TypeScript config
+  src/index.ts         ← plugin implementation
+  dist/index.js        ← compiled output (included in release)
+  README.md            ← installation & usage guide
+  .gitignore
+```
+
+#### manifest.json
+
+```json
+{
+  "id": "weather-forecast",
+  "name": "Weather Forecast",
+  "version": "0.1.0",
+  "description": "Weather forecast via Open-Meteo API (free, no API key)",
+  "icon": "CloudSun",
+  "author": "mchacher",
+  "sowelVersion": ">=0.10.0",
+  "settings": [
+    {
+      "key": "polling_interval",
+      "label": "Polling interval (minutes)",
+      "type": "number",
+      "required": false,
+      "defaultValue": "30",
+      "placeholder": "Min 15, default 30"
+    }
+  ]
+}
+```
+
+#### Configuration
+
+- **Lat/lon**: read from Sowel settings `home.latitude` and `home.longitude`
+- **Polling interval**: from plugin settings, in minutes (default 30, minimum 15)
+- **No API key needed**: Open-Meteo is fully free
+
+#### Data Flow
+
+```
+Open-Meteo API (every 30 min)
+  → Plugin polls /v1/forecast
+    → deviceManager.upsertFromDiscovery("weather-forecast", "open-meteo", {...})
+    → deviceManager.updateDeviceData("weather-forecast", "open-meteo", {...})
+      → EventBus: "device.data.updated"
+        → Equipment bindings evaluate
+          → Zone aggregation (temperature, humidity)
+            → Scenarios can trigger on forecast data
+```
+
+## File Changes
+
+### Sowel Core
+
+| File                    | Change                     |
+| ----------------------- | -------------------------- |
+| `src/shared/types.ts`   | Add 3 DataCategory values  |
+| `plugins/registry.json` | Add weather-forecast entry |
+
+### Plugin (separate repo)
+
+| File            | Description                |
+| --------------- | -------------------------- |
+| `manifest.json` | Plugin metadata            |
+| `package.json`  | npm config                 |
+| `tsconfig.json` | TypeScript config          |
+| `src/index.ts`  | Full plugin implementation |
+| `README.md`     | Documentation              |

--- a/specs/041-weather-forecast-plugin/plan.md
+++ b/specs/041-weather-forecast-plugin/plan.md
@@ -1,0 +1,44 @@
+# Implementation Plan: Weather Forecast Plugin
+
+## Tasks
+
+### Sowel Core
+
+1. [ ] Add DataCategory values (weather_condition, uv, solar_radiation) to types.ts
+2. [ ] Add weather-forecast entry to plugins/registry.json
+3. [ ] TypeScript compile + tests pass
+4. [ ] Commit and push branch
+
+### Plugin (separate repo)
+
+5. [ ] Create GitHub repo mchacher/sowel-plugin-weather-forecast
+6. [ ] Create manifest.json, package.json, tsconfig.json
+7. [ ] Implement src/index.ts (Open-Meteo polling, device creation, data updates)
+8. [ ] Build and verify dist/index.js
+9. [ ] Create README.md
+10. [ ] Commit, push, create GitHub release with dist/
+
+### End-to-End Testing
+
+11. [ ] Install plugin from Sowel store
+12. [ ] Verify device "Weather Forecast" appears in Appareils
+13. [ ] Verify data points update every 30 minutes
+14. [ ] Create Equipment bound to forecast device
+15. [ ] Verify data flows to equipment and zone
+
+### Finalize
+
+16. [ ] Create PR for Sowel core changes
+17. [ ] Merge after validation
+
+## Dependencies
+
+- Plugin engine (specs/040-plugin-engine/) must be merged — DONE
+
+## Testing
+
+- Install plugin via store UI or API
+- Check device in GET /api/v1/devices — should have 14 data points
+- Check data values are reasonable (temperature, humidity, etc.)
+- Uninstall and reinstall — verify clean cycle
+- Verify polling interval respects configured value

--- a/specs/041-weather-forecast-plugin/spec.md
+++ b/specs/041-weather-forecast-plugin/spec.md
@@ -1,0 +1,91 @@
+# Weather Forecast Plugin (Open-Meteo)
+
+## Summary
+
+A Sowel plugin that provides weather forecast data using the Open-Meteo API (free, no API key, no account required). Creates a single device with current conditions and daily forecast data. Uses the home's latitude/longitude from Sowel settings — zero configuration needed.
+
+## Reference
+
+- Plugin engine: specs/040-plugin-engine/
+- Open-Meteo API: https://open-meteo.com/en/docs
+
+## Acceptance Criteria
+
+- [ ] Plugin installs from the Sowel plugin store
+- [ ] Plugin starts automatically when lat/lon are available in Sowel settings
+- [ ] 1 device "Weather Forecast" created with 14 data points
+- [ ] Data updates every 30 minutes (configurable, min 15 min)
+- [ ] New DataCategory values (weather_condition, uv, solar_radiation) added to Sowel core
+- [ ] Device visible in Appareils page
+- [ ] Equipment can be created and bound to the forecast device
+- [ ] Data flows through the full pipeline: device → equipment → zone → WebSocket
+
+## Scope
+
+### In Scope
+
+- Current weather conditions (temperature, humidity, wind, precipitation, UV, cloud cover, solar radiation)
+- Daily forecast summary (temp min/max, rain total for today)
+- Weather condition code mapping (WMO codes → human-readable enum)
+- Configurable polling interval in minutes (default 30, minimum 15)
+- Auto-detection of lat/lon from Sowel home settings
+
+### Out of Scope
+
+- Hourly forecast detail (deferred)
+- Multi-day forecast (deferred)
+- Weather alerts/warnings
+- Historical weather data
+- UI weather widget (use standard equipment card)
+
+## Device Data Points
+
+| Data key                  | Type   | Category          | Unit | Description                                         |
+| ------------------------- | ------ | ----------------- | ---- | --------------------------------------------------- |
+| condition                 | enum   | weather_condition | —    | sunny/cloudy/partly_cloudy/rainy/snowy/stormy/foggy |
+| temperature               | number | temperature       | °C   | Current temperature                                 |
+| feels_like                | number | temperature       | °C   | Apparent temperature                                |
+| humidity                  | number | humidity          | %    | Relative humidity                                   |
+| precipitation             | number | rain              | mm   | Current precipitation                               |
+| precipitation_probability | number | rain              | %    | Probability of rain                                 |
+| wind_speed                | number | wind              | km/h | Wind speed at 10m                                   |
+| wind_gusts                | number | wind              | km/h | Wind gusts                                          |
+| uv_index                  | number | uv                | —    | UV index (0-11+)                                    |
+| cloud_cover               | number | generic           | %    | Cloud coverage                                      |
+| solar_radiation           | number | solar_radiation   | W/m² | Global solar radiation                              |
+| forecast_temp_min         | number | temperature       | °C   | Today's minimum temperature                         |
+| forecast_temp_max         | number | temperature       | °C   | Today's maximum temperature                         |
+| forecast_rain_today       | number | rain              | mm   | Today's total precipitation forecast                |
+
+## Open-Meteo API
+
+### Endpoint
+
+```
+GET https://api.open-meteo.com/v1/forecast
+  ?latitude={lat}
+  &longitude={lon}
+  &current=temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,weather_code,cloud_cover,wind_speed_10m,wind_gusts_10m,uv_index,direct_radiation
+  &daily=temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max
+  &timezone=auto
+  &forecast_days=1
+```
+
+### WMO Weather Code Mapping
+
+| Code         | Condition     |
+| ------------ | ------------- |
+| 0            | sunny         |
+| 1, 2         | partly_cloudy |
+| 3            | cloudy        |
+| 45, 48       | foggy         |
+| 51-67, 80-82 | rainy         |
+| 71-77, 85-86 | snowy         |
+| 95-99        | stormy        |
+
+## Edge Cases
+
+- Lat/lon not configured → status "not_configured", no polling
+- Open-Meteo API down → status "error", retry with backoff
+- Invalid API response → log error, keep last known data
+- Plugin installed but Sowel has no home settings → prompt user to set home location

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,6 +32,9 @@ export type DataCategory =
   | "wind"
   | "action"
   | "gate_state"
+  | "weather_condition"
+  | "uv"
+  | "solar_radiation"
   | "generic";
 
 // ============================================================


### PR DESCRIPTION
## Summary
- Add 3 new DataCategory values: `weather_condition`, `uv`, `solar_radiation`
- Add weather-forecast plugin to registry
- Plugin repo: https://github.com/mchacher/sowel-plugin-weather-forecast

## Plugin details
- Open-Meteo API (free, no API key, no account)
- 14 data points: current conditions + daily forecast
- Polling every 30 min (configurable, min 15 min)
- Auto-detects lat/lon from Sowel home settings

## Test plan
- [x] TypeScript compiles (zero errors)
- [x] All 454 tests pass
- [x] Plugin builds and GitHub release created

🤖 Generated with [Claude Code](https://claude.com/claude-code)