### PR TITLE
feat: backup v2 — full system backup with InfluxDB restore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cors": "^10.0.2",
+        "@fastify/multipart": "^9.4.0",
         "@fastify/rate-limit": "^10.3.0",
         "@fastify/static": "^9.0.0",
         "@fastify/websocket": "^11.0.1",
         "@influxdata/influxdb-client": "^1.35.0",
         "@types/archiver": "^7.0.0",
+        "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
         "bcrypt": "^6.0.0",
         "better-sqlite3": "^11.7.0",
@@ -31,6 +33,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/adm-zip": "^0.5.8",
         "@types/bcrypt": "^6.0.0",
         "@types/better-sqlite3": "^7.6.12",
         "@types/jsonwebtoken": "^9.0.10",
@@ -738,6 +741,12 @@
         "fast-uri": "^3.0.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
     "node_modules/@fastify/cors": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-10.1.0.tgz",
@@ -757,6 +766,22 @@
         "fastify-plugin": "^5.0.0",
         "mnemonist": "0.40.0"
       }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
@@ -826,6 +851,29 @@
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/multipart": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-9.4.0.tgz",
+      "integrity": "sha512-Z404bzZeLSXTBmp/trCBuoVFX28pM7rhv849Q5TsbTFZHuk1lc4QjQITTPK92DKVpXmNtJXeHSSc7GYvqFpxAQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@fastify/deepmerge": "^3.0.0",
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0",
+        "secure-json-parse": "^4.0.0"
       }
     },
     "node_modules/@fastify/proxy-addr": {
@@ -1482,6 +1530,16 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/archiver": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
@@ -2024,6 +2082,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
   },
   "dependencies": {
     "@fastify/cors": "^10.0.2",
+    "@fastify/multipart": "^9.4.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",
     "@fastify/websocket": "^11.0.1",
     "@influxdata/influxdb-client": "^1.35.0",
     "@types/archiver": "^7.0.0",
+    "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^11.7.0",
@@ -45,6 +47,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/adm-zip": "^0.5.8",
     "@types/bcrypt": "^6.0.0",
     "@types/better-sqlite3": "^7.6.12",
     "@types/jsonwebtoken": "^9.0.10",

--- a/specs/046-backup-v2/architecture.md
+++ b/specs/046-backup-v2/architecture.md
@@ -1,0 +1,91 @@
+# Architecture: Backup V2
+
+## ZIP Structure
+
+```
+sowel-backup-2026-03-28.zip
+├── sowel-backup.json              # SQLite data (version: 2)
+├── influx-raw.lp                  # Line protocol — sowel bucket (7d)
+├── influx-hourly.lp               # Line protocol — sowel-hourly bucket (90d)
+├── influx-daily.lp                # Line protocol — sowel-daily bucket (5y)
+├── influx-energy-hourly.lp        # Line protocol — sowel-energy-hourly bucket (2y)
+├── influx-energy-daily.lp         # Line protocol — sowel-energy-daily bucket (10y)
+└── data/
+    ├── .jwt-secret                # JWT signing secret
+    ├── panasonic-tokens.json      # Panasonic CC OAuth tokens (if exists)
+    └── netatmo-tokens.json        # Netatmo HC OAuth tokens (if exists)
+```
+
+## Data Model Changes
+
+- `BackupPayload.version` changes from `1` to `2`
+- No new SQLite tables or columns
+- No new types in types.ts
+
+## API Changes
+
+### `GET /api/v1/backup` (Export)
+
+**Response**: Always ZIP (no JSON fallback)
+
+Changes:
+
+- InfluxDB query uses `toLineProtocol()` flux function instead of `queryRaw()` CSV
+- Remove `equipment_data` measurement filter
+- Add `data/` folder to ZIP with token files and JWT secret
+- Content-Type always `application/zip`
+
+### `POST /api/v1/backup` (Restore)
+
+**Request**: Changes from `application/json` body to `multipart/form-data` with ZIP file
+
+Changes:
+
+- Parse ZIP file (using `unzipper` or `yauzl` or manual ZIP parsing)
+- Extract `sowel-backup.json` → restore SQLite (existing logic)
+- Extract `influx-*.lp` files → write to InfluxDB via `writeApi.writeLines()`
+- Extract `data/*` files → write to filesystem
+
+## InfluxDB Export Strategy
+
+### Current (V1): Annotated CSV via queryRaw
+
+```flux
+from(bucket: "sowel")
+  |> range(start: -7d)
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+```
+
+→ Returns CSV with `#group`, `#datatype` headers. Not writable back.
+
+### New (V2): Line Protocol
+
+Two approaches available:
+
+**Option A — Server-side conversion**: Query with Flux, iterate rows, build line protocol strings manually.
+
+**Option B — Flux `experimental/csv.from` + raw export**: Not applicable since we need line protocol output.
+
+**Chosen: Option A** — Query normally via `collectRows()`, convert each row to line protocol format:
+
+```
+measurement,tag1=val1,tag2=val2 field1=value1,field2=value2 timestamp_ns
+```
+
+## InfluxDB Restore Strategy
+
+Use `writeApi.writeLines()` method which accepts line protocol strings directly.
+
+- Create a WriteApi per bucket with large batch size (5000)
+- Split .lp file content by newlines
+- Write in batches of 5000 lines
+- Call `writeApi.close()` to flush after each bucket
+
+## File Changes
+
+| File                          | Change                                                                                                |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `src/api/routes/backup.ts`    | Rewrite export (line protocol + data files) and restore (ZIP parsing + InfluxDB write + file restore) |
+| `ui/src/api.ts`               | `importBackup()` sends ZIP as FormData binary instead of JSON                                         |
+| `ui/src/pages/BackupPage.tsx` | No changes needed (already accepts .zip)                                                              |
+| `package.json`                | Add `adm-zip` dependency for ZIP reading on restore                                                   |

--- a/specs/046-backup-v2/plan.md
+++ b/specs/046-backup-v2/plan.md
@@ -1,0 +1,43 @@
+# Implementation Plan: Backup V2
+
+## Tasks
+
+### Backend — Export
+
+1. [ ] Add `adm-zip` dependency (for restore ZIP reading — archiver already handles export)
+2. [ ] Rewrite InfluxDB export: query with `collectRows()`, convert to line protocol strings, write as `.lp` files
+3. [ ] Remove `equipment_data` measurement filter from InfluxDB export
+4. [ ] Add `data/` folder to ZIP: `.jwt-secret`, `panasonic-tokens.json`, `netatmo-tokens.json` (skip if absent)
+5. [ ] Remove JSON-only fallback — always produce ZIP
+6. [ ] Bump backup version to `2`
+
+### Backend — Restore
+
+7. [ ] Change POST endpoint to accept `multipart/form-data` (ZIP file upload)
+8. [ ] Parse ZIP: extract `sowel-backup.json`, validate version 2
+9. [ ] Restore SQLite tables (existing logic, unchanged)
+10. [ ] Extract and restore `influx-*.lp` files: write to correct buckets via `writeApi.writeLines()`
+11. [ ] Extract and restore `data/*` files: write to filesystem
+12. [ ] Log summary: tables restored, InfluxDB points written, files restored
+
+### Frontend
+
+13. [ ] Update `importBackup()` in `api.ts` to send ZIP as `FormData` binary instead of JSON
+
+### Validation
+
+14. [ ] TypeScript compilation (backend + frontend)
+15. [ ] All tests pass
+16. [ ] Manual test: export backup, inspect ZIP contents
+17. [ ] Manual test: restore backup on running instance
+
+## Dependencies
+
+- `archiver` (already installed) — ZIP creation
+- `adm-zip` (to install) — ZIP reading on restore
+
+## Testing
+
+- Export: download ZIP, verify it contains `.json`, `.lp` files, and `data/` folder
+- Restore: upload the exported ZIP, verify SQLite data restored, InfluxDB data present, token files written
+- Edge case: export/restore with InfluxDB disconnected (should still work for SQLite + files)

--- a/specs/046-backup-v2/spec.md
+++ b/specs/046-backup-v2/spec.md
@@ -1,0 +1,49 @@
+# Backup V2 — Full System Backup & Restore
+
+## Summary
+
+Overhaul the backup system to provide a complete, restorable backup of all Sowel state: SQLite configuration, InfluxDB time-series history, and persistent file-based state (OAuth tokens, JWT secret). The export format changes from version 1 (JSON + annotated CSV) to version 2 (ZIP with line protocol). No backward compatibility with V1.
+
+## Reference
+
+- Audit findings from 2026-03-28 conversation
+- CLAUDE.md § Energy Monitoring (InfluxDB)
+
+## Acceptance Criteria
+
+- [ ] Export always produces a ZIP file (no JSON-only fallback)
+- [ ] ZIP contains: `sowel-backup.json` (v2), InfluxDB `.lp` files, `data/` folder with token files
+- [ ] InfluxDB exported as line protocol (no annotated CSV, no measurement filter)
+- [ ] Restore accepts a ZIP file via `POST /api/v1/backup` (multipart/form-data)
+- [ ] Restore re-inserts SQLite data with FK integrity check
+- [ ] Restore writes InfluxDB line protocol back to correct buckets
+- [ ] Restore writes OAuth token files and JWT secret back to `data/`
+- [ ] UI sends ZIP as binary (not JSON-parsed)
+- [ ] TypeScript compiles with zero errors
+- [ ] All existing tests pass
+
+## Scope
+
+### In Scope
+
+- Backup format V2 (breaking change, no V1 compat)
+- InfluxDB export as line protocol, restore via writeApi
+- OAuth token files (panasonic-tokens.json, netatmo-tokens.json) in ZIP
+- JWT secret (.jwt-secret) in ZIP
+- UI update to send ZIP binary on import
+- Backend accepts multipart/form-data ZIP on restore
+
+### Out of Scope
+
+- Selective backup (choose what to include)
+- Scheduled/automatic backups
+- Hot reload of managers post-restore (manual server restart required)
+- Plugin source code in ZIP (reinstall from GitHub via repo field)
+
+## Edge Cases
+
+- InfluxDB not connected at export time: export ZIP without .lp files (SQLite + data files only)
+- InfluxDB not connected at restore time: restore SQLite + data files, skip InfluxDB, log warning
+- Token files don't exist at export time: skip them (no error)
+- Bucket doesn't exist at restore time: create it or skip with warning
+- Empty .lp file: skip writing to that bucket

--- a/src/api/routes/backup.ts
+++ b/src/api/routes/backup.ts
@@ -1,4 +1,7 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
 import archiver from "archiver";
+import AdmZip from "adm-zip";
 import type { FastifyInstance } from "fastify";
 import type Database from "better-sqlite3";
 import type { Logger } from "../../core/logger.js";
@@ -8,6 +11,7 @@ interface BackupDeps {
   db: Database.Database;
   influxClient: InfluxClient;
   logger: Logger;
+  dataDir: string; // path to data/ directory
 }
 
 // Tables to export, in dependency order (parents first)
@@ -42,134 +46,217 @@ const BACKUP_TABLES = [
 // Reverse order for deletion (children first)
 const DELETE_ORDER = [...BACKUP_TABLES].reverse();
 
+// Data files to include in backup (relative to dataDir)
+const DATA_FILES = [".jwt-secret", "panasonic-tokens.json", "netatmo-tokens.json"];
+
 interface BackupPayload {
-  version: 1;
+  version: 2;
   exportedAt: string;
   tables: Record<string, unknown[]>;
 }
 
+// InfluxDB bucket definitions for export/restore
+interface InfluxBucketDef {
+  filename: string;
+  bucketSuffix: string; // "" for raw, "-hourly", "-daily", etc.
+  range: string;
+}
+
+const INFLUX_BUCKETS: InfluxBucketDef[] = [
+  { filename: "influx-raw.lp", bucketSuffix: "", range: "-7d" },
+  { filename: "influx-hourly.lp", bucketSuffix: "-hourly", range: "-90d" },
+  { filename: "influx-daily.lp", bucketSuffix: "-daily", range: "-5y" },
+  { filename: "influx-energy-hourly.lp", bucketSuffix: "-energy-hourly", range: "-2y" },
+  { filename: "influx-energy-daily.lp", bucketSuffix: "-energy-daily", range: "-10y" },
+];
+
+/**
+ * Convert a Flux query result row to InfluxDB line protocol.
+ * Format: measurement,tag1=val1,tag2=val2 field1=value1,field2="str" timestamp_ns
+ */
+function rowToLineProtocol(row: Record<string, string>): string | null {
+  const measurement = row["_measurement"];
+  const field = row["_field"];
+  const value = row["_value"];
+  const time = row["_time"];
+
+  if (!measurement || !field || value === undefined || value === "" || !time) return null;
+
+  // Collect tags (skip internal Flux columns)
+  const skipKeys = new Set([
+    "_measurement",
+    "_field",
+    "_value",
+    "_time",
+    "_start",
+    "_stop",
+    "result",
+    "table",
+    "",
+  ]);
+  const tags: string[] = [];
+  for (const [k, v] of Object.entries(row)) {
+    if (skipKeys.has(k) || v === undefined || v === "") continue;
+    tags.push(`${escapeTag(k)}=${escapeTag(v)}`);
+  }
+
+  // Build tag set
+  const tagSet = tags.length > 0 ? `,${tags.join(",")}` : "";
+
+  // Build field value: try number first, then string
+  const numVal = Number(value);
+  const fieldValue =
+    !isNaN(numVal) && value.trim() !== "" ? `${numVal}` : `"${escapeFieldString(value)}"`;
+
+  // Convert ISO timestamp to nanoseconds
+  const tsNs = new Date(time).getTime() * 1_000_000;
+
+  return `${escapeTag(measurement)}${tagSet} ${escapeTag(field)}=${fieldValue} ${tsNs}`;
+}
+
+function escapeTag(s: string): string {
+  return s.replace(/,/g, "\\,").replace(/ /g, "\\ ").replace(/=/g, "\\=");
+}
+
+function escapeFieldString(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
 export function registerBackupRoutes(app: FastifyInstance, deps: BackupDeps): void {
-  const { db, influxClient, logger: parentLogger } = deps;
+  const { db, influxClient, logger: parentLogger, dataDir } = deps;
   const logger = parentLogger.child({ module: "backup" });
 
-  // GET /api/v1/backup — Export full configuration as ZIP (SQLite JSON + InfluxDB CSV)
+  // ============================================================
+  // GET /api/v1/backup — Export full system as ZIP
+  // ============================================================
   app.get("/api/v1/backup", async (request, reply) => {
     if (!request.auth || request.auth.role !== "admin") {
       return reply.code(403).send({ error: "Admin access required" });
     }
 
-    // Build SQLite JSON payload
+    // 1. Collect SQLite data
     const tables: Record<string, unknown[]> = {};
     let totalRows = 0;
     for (const table of BACKUP_TABLES) {
       tables[table] = db.prepare(`SELECT * FROM ${table}`).all();
       totalRows += tables[table].length;
     }
+
+    const sqlitePayload: BackupPayload = {
+      version: 2,
+      exportedAt: new Date().toISOString(),
+      tables,
+    };
+
     logger.info(
       { tables: BACKUP_TABLES.length, totalRows },
       "Backup export — SQLite data collected",
     );
 
-    const sqlitePayload: BackupPayload = {
-      version: 1,
-      exportedAt: new Date().toISOString(),
-      tables,
-    };
-
-    // Export InfluxDB data if connected
-    const influxConfig = influxClient.getConfig();
-    const influxConnected = influxClient.isConnected() && influxConfig;
-
-    const influxCsvs: { name: string; csv: string }[] = [];
-    if (influxConnected) {
-      const client = influxClient.getClient();
-      if (client) {
-        const queryApi = client.getQueryApi(influxConfig.org);
-        const buckets = [
-          { name: "influx-raw.csv", bucket: influxConfig.bucket, range: "-7d" },
-          { name: "influx-hourly.csv", bucket: `${influxConfig.bucket}-hourly`, range: "-90d" },
-          { name: "influx-daily.csv", bucket: `${influxConfig.bucket}-daily`, range: "-5y" },
-          {
-            name: "influx-energy-hourly.csv",
-            bucket: `${influxConfig.bucket}-energy-hourly`,
-            range: "-2y",
-          },
-          {
-            name: "influx-energy-daily.csv",
-            bucket: `${influxConfig.bucket}-energy-daily`,
-            range: "-10y",
-          },
-        ];
-
-        for (const b of buckets) {
-          try {
-            const flux = `from(bucket: "${b.bucket}")
-  |> range(start: ${b.range})
-  |> filter(fn: (r) => r._measurement == "equipment_data")`;
-
-            const csv = await queryApi.queryRaw(flux);
-
-            if (csv.trim().length > 0) {
-              influxCsvs.push({ name: b.name, csv });
-            }
-          } catch (err) {
-            logger.warn({ err, bucket: b.bucket }, "Failed to export InfluxDB bucket");
-          }
-        }
-      }
-    }
-
-    const dateStr = new Date().toISOString().slice(0, 10);
-
-    // If no InfluxDB data, return JSON directly (backward compatible)
-    if (influxCsvs.length === 0) {
-      logger.info("Configuration exported (JSON only, no InfluxDB data)");
-      return reply
-        .header("Content-Disposition", `attachment; filename="sowel-backup-${dateStr}.json"`)
-        .send(sqlitePayload);
-    }
-
-    // Build ZIP archive with SQLite JSON + InfluxDB CSVs
-    logger.info(
-      { influxFiles: influxCsvs.map((f) => f.name) },
-      "Configuration exported (ZIP with InfluxDB data)",
-    );
-
+    // 2. Build ZIP
     const archive = archiver("zip", { zlib: { level: 6 } });
+    const dateStr = new Date().toISOString().slice(0, 10);
 
     reply
       .header("Content-Type", "application/zip")
       .header("Content-Disposition", `attachment; filename="sowel-backup-${dateStr}.zip"`);
 
     // Append SQLite JSON
-    archive.append(JSON.stringify(sqlitePayload, null, 2), {
-      name: "sowel-backup.json",
-    });
+    archive.append(JSON.stringify(sqlitePayload, null, 2), { name: "sowel-backup.json" });
 
-    // Append InfluxDB CSVs
-    for (const f of influxCsvs) {
-      archive.append(f.csv, { name: f.name });
+    // 3. Export InfluxDB buckets as line protocol
+    const influxConfig = influxClient.getConfig();
+    if (influxClient.isConnected() && influxConfig) {
+      const client = influxClient.getClient();
+      if (client) {
+        const queryApi = client.getQueryApi(influxConfig.org);
+
+        for (const bucketDef of INFLUX_BUCKETS) {
+          try {
+            const bucket = `${influxConfig.bucket}${bucketDef.bucketSuffix}`;
+            const flux = `from(bucket: "${bucket}") |> range(start: ${bucketDef.range})`;
+
+            const rows = await queryApi.collectRows<Record<string, string>>(flux);
+            if (rows.length === 0) continue;
+
+            const lines: string[] = [];
+            for (const row of rows) {
+              const line = rowToLineProtocol(row);
+              if (line) lines.push(line);
+            }
+
+            if (lines.length > 0) {
+              archive.append(lines.join("\n"), { name: bucketDef.filename });
+              logger.debug(
+                { bucket, lines: lines.length },
+                "InfluxDB bucket exported as line protocol",
+              );
+            }
+          } catch (err) {
+            logger.warn({ err, filename: bucketDef.filename }, "Failed to export InfluxDB bucket");
+          }
+        }
+      }
     }
 
+    // 4. Append data files (tokens, JWT secret)
+    for (const filename of DATA_FILES) {
+      const filePath = resolve(dataDir, filename);
+      if (existsSync(filePath)) {
+        try {
+          archive.append(readFileSync(filePath), { name: `data/${filename}` });
+        } catch (err) {
+          logger.warn({ err, filename }, "Failed to include data file in backup");
+        }
+      }
+    }
+
+    logger.info("Backup export completed — ZIP archive ready");
     archive.finalize();
 
     return reply.send(archive);
   });
 
-  // POST /api/v1/backup — Restore configuration from JSON
-  app.post<{ Body: BackupPayload }>("/api/v1/backup", async (request, reply) => {
+  // ============================================================
+  // POST /api/v1/backup — Restore from ZIP
+  // ============================================================
+  app.post("/api/v1/backup", async (request, reply) => {
     if (!request.auth || request.auth.role !== "admin") {
       return reply.code(403).send({ error: "Admin access required" });
     }
 
-    const payload = request.body;
-
-    // Validate structure
-    if (!payload || payload.version !== 1 || !payload.tables) {
-      return reply.code(400).send({ error: "Invalid backup format" });
+    // Accept multipart/form-data with a ZIP file
+    const data = await request.file();
+    if (!data) {
+      return reply.code(400).send({ error: "No file uploaded" });
     }
 
-    // Validate that all tables in the payload are known
+    const buffer = await data.toBuffer();
+    let zip: AdmZip;
+    try {
+      zip = new AdmZip(buffer);
+    } catch {
+      return reply.code(400).send({ error: "Invalid ZIP file" });
+    }
+
+    // 1. Extract and validate SQLite payload
+    const jsonEntry = zip.getEntry("sowel-backup.json");
+    if (!jsonEntry) {
+      return reply.code(400).send({ error: "ZIP missing sowel-backup.json" });
+    }
+
+    let payload: BackupPayload;
+    try {
+      payload = JSON.parse(jsonEntry.getData().toString("utf-8")) as BackupPayload;
+    } catch {
+      return reply.code(400).send({ error: "Invalid JSON in sowel-backup.json" });
+    }
+
+    if (!payload || payload.version !== 2 || !payload.tables) {
+      return reply.code(400).send({ error: "Invalid backup format (expected version 2)" });
+    }
+
+    // Validate table names
     for (const tableName of Object.keys(payload.tables)) {
       if (!(BACKUP_TABLES as readonly string[]).includes(tableName)) {
         return reply.code(400).send({ error: `Unknown table: ${tableName}` });
@@ -179,22 +266,19 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupDeps): vo
       }
     }
 
+    // 2. Restore SQLite
     try {
       const restore = db.transaction(() => {
-        // Disable foreign keys during restore
         db.pragma("foreign_keys = OFF");
 
-        // Delete all data in reverse dependency order
         for (const table of DELETE_ORDER) {
           db.prepare(`DELETE FROM ${table}`).run();
         }
 
-        // Insert data in dependency order
         for (const table of BACKUP_TABLES) {
           const rows = payload.tables[table];
           if (!rows || rows.length === 0) continue;
 
-          // Get column names from the first row
           const firstRow = rows[0] as Record<string, unknown>;
           const columns = Object.keys(firstRow);
           const placeholders = columns.map(() => "?").join(", ");
@@ -208,7 +292,6 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupDeps): vo
           }
         }
 
-        // Re-enable foreign keys and verify integrity
         db.pragma("foreign_keys = ON");
 
         const violations = db.pragma("foreign_key_check") as {
@@ -235,22 +318,100 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupDeps): vo
         0,
       );
       logger.info(
-        {
-          tables: Object.keys(payload.tables).length,
-          totalRows: totalRestoredRows,
-          exportedAt: payload.exportedAt,
-        },
-        "Configuration restored from backup",
+        { tables: Object.keys(payload.tables).length, totalRows: totalRestoredRows },
+        "SQLite data restored",
       );
-
-      return { success: true, restoredAt: new Date().toISOString() };
     } catch (err) {
-      logger.error({ err }, "Backup restore failed");
-      // Re-enable foreign keys even on error
+      logger.error({ err }, "SQLite restore failed");
       db.pragma("foreign_keys = ON");
       return reply.code(500).send({
-        error: err instanceof Error ? err.message : "Restore failed",
+        error: err instanceof Error ? err.message : "SQLite restore failed",
       });
     }
+
+    // 3. Restore InfluxDB line protocol files
+    let influxPointsRestored = 0;
+    const influxConfig = influxClient.getConfig();
+    if (influxClient.isConnected() && influxConfig) {
+      for (const bucketDef of INFLUX_BUCKETS) {
+        const entry = zip.getEntry(bucketDef.filename);
+        if (!entry) continue;
+
+        const lp = entry.getData().toString("utf-8").trim();
+        if (!lp) continue;
+
+        const bucket = `${influxConfig.bucket}${bucketDef.bucketSuffix}`;
+        try {
+          const lines = lp.split("\n");
+          // Write in batches of 5000 lines via HTTP API
+          const batchSize = 5000;
+          for (let i = 0; i < lines.length; i += batchSize) {
+            const batch = lines.slice(i, i + batchSize).join("\n");
+            const resp = await fetch(
+              `${influxConfig.url}/api/v2/write?org=${encodeURIComponent(influxConfig.org)}&bucket=${encodeURIComponent(bucket)}&precision=ns`,
+              {
+                method: "POST",
+                headers: {
+                  Authorization: `Token ${influxConfig.token}`,
+                  "Content-Type": "text/plain",
+                },
+                body: batch,
+              },
+            );
+            if (!resp.ok) {
+              const text = await resp.text();
+              logger.warn(
+                { bucket, status: resp.status, body: text.slice(0, 200) },
+                "InfluxDB write batch failed",
+              );
+            }
+          }
+          influxPointsRestored += lines.length;
+          logger.debug({ bucket, lines: lines.length }, "InfluxDB bucket restored");
+        } catch (err) {
+          logger.warn({ err, bucket }, "Failed to restore InfluxDB bucket");
+        }
+      }
+
+      if (influxPointsRestored > 0) {
+        logger.info({ points: influxPointsRestored }, "InfluxDB data restored");
+      }
+    } else {
+      logger.warn("InfluxDB not connected — skipping time-series restore");
+    }
+
+    // 4. Restore data files
+    let filesRestored = 0;
+    for (const filename of DATA_FILES) {
+      const entry = zip.getEntry(`data/${filename}`);
+      if (!entry) continue;
+
+      try {
+        const filePath = resolve(dataDir, filename);
+        mkdirSync(dirname(filePath), { recursive: true });
+        writeFileSync(filePath, entry.getData());
+        filesRestored++;
+        logger.debug({ filename }, "Data file restored");
+      } catch (err) {
+        logger.warn({ err, filename }, "Failed to restore data file");
+      }
+    }
+
+    if (filesRestored > 0) {
+      logger.info({ filesRestored }, "Data files restored");
+    }
+
+    logger.info(
+      { exportedAt: payload.exportedAt, influxPointsRestored, filesRestored },
+      "Backup restore completed — restart server to reload",
+    );
+
+    return {
+      success: true,
+      restoredAt: new Date().toISOString(),
+      influxPointsRestored,
+      filesRestored,
+      restartRequired: true,
+    };
   });
 }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -3,6 +3,7 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import multipart from "@fastify/multipart";
 import rateLimit from "@fastify/rate-limit";
 import fastifyStatic from "@fastify/static";
 import websocket from "@fastify/websocket";
@@ -84,6 +85,7 @@ interface ServerDeps {
   logBuffer: LogRingBuffer;
   logger: Logger;
   corsOrigins: string[];
+  dataDir: string;
 }
 
 export async function createServer(deps: ServerDeps) {
@@ -114,6 +116,7 @@ export async function createServer(deps: ServerDeps) {
     logBuffer,
     logger,
     corsOrigins,
+    dataDir,
   } = deps;
 
   const app = Fastify({
@@ -131,6 +134,9 @@ export async function createServer(deps: ServerDeps) {
     max: 300,
     timeWindow: "1 minute",
   });
+
+  // Multipart file uploads (for backup restore)
+  await app.register(multipart, { limits: { fileSize: 500 * 1024 * 1024 } }); // 500 MB
 
   // WebSocket
   await app.register(websocket);
@@ -158,7 +164,7 @@ export async function createServer(deps: ServerDeps) {
   registerRecipeRoutes(app, { recipeManager, logger });
   registerModeRoutes(app, { modeManager, buttonActionManager, logger });
   registerCalendarRoutes(app, { calendarManager, logger });
-  registerBackupRoutes(app, { db, influxClient, logger });
+  registerBackupRoutes(app, { db, influxClient, logger, dataDir });
   registerSettingsRoutes(app, { settingsManager, eventBus, logger });
   registerIntegrationRoutes(app, {
     integrationRegistry,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { resolve } from "node:path";
+import { resolve, dirname } from "node:path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { loadConfig } from "./config.js";
 import { createLogger } from "./core/logger.js";
@@ -305,6 +305,7 @@ async function main() {
     logBuffer,
     logger,
     corsOrigins: config.cors.origins,
+    dataDir: dirname(resolve(config.sqlite.path)),
   });
 
   await server.listen({ port: config.api.port, host: config.api.host });

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -555,7 +555,7 @@ export async function updatePlugin(id: string): Promise<{ success: boolean; mani
 // Backup (admin)
 // ============================================================
 
-export async function exportBackup(): Promise<{ blob: Blob; isZip: boolean }> {
+export async function exportBackup(): Promise<{ blob: Blob }> {
   const headers: Record<string, string> = {};
   if (_accessToken) {
     headers["Authorization"] = `Bearer ${_accessToken}`;
@@ -564,18 +564,27 @@ export async function exportBackup(): Promise<{ blob: Blob; isZip: boolean }> {
   if (!response.ok) {
     throw new Error(`Export failed: ${response.statusText}`);
   }
-  const contentType = response.headers.get("Content-Type") ?? "";
   const blob = await response.blob();
-  return { blob, isZip: contentType.includes("zip") };
+  return { blob };
 }
 
 export async function importBackup(file: File): Promise<{ success: boolean }> {
-  const text = await file.text();
-  const payload = JSON.parse(text);
-  return fetchJSON(`${API_BASE}/backup`, {
+  const formData = new FormData();
+  formData.append("file", file);
+  const headers: Record<string, string> = {};
+  if (_accessToken) {
+    headers["Authorization"] = `Bearer ${_accessToken}`;
+  }
+  const response = await fetch(`${API_BASE}/backup`, {
     method: "POST",
-    body: JSON.stringify(payload),
+    headers,
+    body: formData,
   });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error((body as { error?: string }).error ?? response.statusText);
+  }
+  return response.json() as Promise<{ success: boolean }>;
 }
 
 // ============================================================

--- a/ui/src/pages/BackupPage.tsx
+++ b/ui/src/pages/BackupPage.tsx
@@ -21,7 +21,7 @@ export function BackupPage() {
       const a = document.createElement("a");
       a.href = url;
       const dateStr = new Date().toISOString().slice(0, 10);
-      a.download = `sowel-backup-${dateStr}.${resp.isZip ? "zip" : "json"}`;
+      a.download = `sowel-backup-${dateStr}.zip`;
       a.click();
       URL.revokeObjectURL(url);
       setSuccess(t("backup.exported"));
@@ -113,7 +113,7 @@ export function BackupPage() {
             <input
               ref={fileInputRef}
               type="file"
-              accept=".json,.zip"
+              accept=".zip"
               onChange={handleImport}
               className="hidden"
             />


### PR DESCRIPTION
## Summary
- Complete overhaul of backup/restore system (v1 → v2, breaking change)
- InfluxDB data now exported as line protocol (.lp) and fully restorable
- Persistent data files (.jwt-secret, OAuth tokens) included in ZIP
- Restore accepts ZIP via multipart upload (was JSON body)

## Changes
- **Backend**: Rewrite `backup.ts` — export line protocol, restore via HTTP write API, include data files
- **Backend**: Add `@fastify/multipart` for ZIP upload, `adm-zip` for ZIP reading
- **Backend**: Pass `dataDir` through server deps for file operations
- **API**: `GET /backup` always returns ZIP, `POST /backup` accepts multipart/form-data
- **UI**: `importBackup()` sends ZIP as FormData binary, export always `.zip`
- **Spec**: `specs/046-backup-v2/` with full spec, architecture, and plan

## What's now backed up
| Category | Items | Format |
|----------|-------|--------|
| SQLite | 25 tables (config, devices, equipments, zones, modes, recipes, plugins, etc.) | JSON |
| InfluxDB | 5 buckets (raw, hourly, daily, energy-hourly, energy-daily) | Line protocol |
| Files | .jwt-secret, panasonic-tokens.json, netatmo-tokens.json | Binary |

## Test plan
- [x] TypeScript compiles (zero errors, backend + frontend)
- [x] All 454 tests pass
- [x] Lint + format pass
- [ ] Manual: export backup, verify ZIP contents
- [ ] Manual: restore backup, verify SQLite + InfluxDB + files