### PR TITLE
feat: externalize Netatmo Weather as plugin (spec 048a)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -6,7 +6,7 @@
     "icon": "CloudSun",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-netatmo-weather",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "tags": ["weather", "netatmo", "temperature", "humidity", "rain", "wind"]
   },
   {

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -1,5 +1,15 @@
 [
   {
+    "id": "netatmo_weather",
+    "name": "Netatmo Weather",
+    "description": "Netatmo Weather Station — temperature, humidity, pressure, CO2, wind, rain",
+    "icon": "CloudSun",
+    "author": "mchacher",
+    "repo": "mchacher/sowel-plugin-netatmo-weather",
+    "version": "1.0.0",
+    "tags": ["weather", "netatmo", "temperature", "humidity", "rain", "wind"]
+  },
+  {
     "id": "netatmo-security",
     "name": "Netatmo Security",
     "description": "Netatmo cameras (Welcome, Presence, Doorbell) — monitoring on/off",

--- a/specs/048a-plugin-netatmo-weather/plan.md
+++ b/specs/048a-plugin-netatmo-weather/plan.md
@@ -1,0 +1,62 @@
+# Implementation Plan: 048a — Netatmo Weather Plugin
+
+## Tasks
+
+### Plugin repo creation
+
+1. [ ] Create GitHub repo `mchacher/sowel-plugin-netatmo-weather`
+2. [ ] Scaffold plugin structure: `manifest.json`, `package.json`, `tsconfig.json`, `.gitignore`, `src/index.ts`
+3. [ ] Port OAuth bridge code from `netatmo-bridge.ts` (auth, token rotation, file persistence)
+4. [ ] Port weather polling code from `netatmo-poller.ts` (`pollWeatherStation()`)
+5. [ ] Port weather types from `netatmo-types.ts` (station/module mapping, payload extraction)
+6. [ ] Implement `createPlugin(deps)` → `IntegrationPlugin` (read-only, no executeOrder)
+7. [ ] Add `.github/workflows/release.yml` (pre-built tarball)
+8. [ ] Build locally, verify `dist/index.js` works
+
+### Device migration (preserve equipments + bindings)
+
+9. [ ] Add `migrateDevicesFromLegacy()` to plugin: on first start, UPDATE existing devices with `integration_id = 'netatmo_hc'` and matching `source_device_id` to `integration_id = 'netatmo_weather'`
+10. [ ] Expose `db` in `PluginDeps` (or add a `deviceManager.migrateIntegrationId()` helper)
+
+### Sowel core cleanup
+
+11. [ ] Remove weather code from `netatmo-poller.ts` (pollWeatherStation, weatherNames, enableWeather)
+12. [ ] Remove `enable_weather` setting from `index.ts`
+13. [ ] Remove `getStationsData()` from `netatmo-bridge.ts`
+14. [ ] Remove weather types from `netatmo-types.ts`
+15. [ ] Add `netatmo-weather` to `plugins/registry.json`
+
+### Validation
+
+16. [ ] TypeScript compilation (Sowel backend + frontend)
+17. [ ] All tests pass
+18. [ ] Lint passes (0 errors)
+19. [ ] Tag + release plugin v1.0.0 (GitHub Actions creates pre-built tarball)
+20. [ ] Install plugin from store via UI (Playwright)
+21. [ ] Configure plugin settings (client_id, secret, refresh_token) — same credentials as netatmo_hc
+22. [ ] Verify weather devices migrated (same UUIDs, equipments preserved)
+23. [ ] Verify data polling works (temperature, humidity, etc.)
+24. [ ] Verify built-in integration still works for Control + Energy (no regression)
+25. [ ] Deploy UI via `deploy-ui.sh`
+
+## Testing Strategy
+
+### Pre-implementation: capture current state
+
+- Note current weather devices and their data in the UI (Playwright screenshot)
+- These devices will disappear when built-in weather code is removed
+- They should reappear after plugin install + configuration
+
+### Post-implementation: validate via Playwright
+
+1. Navigate to Plugins page → install Netatmo Weather from store
+2. Navigate to Integrations page → configure netatmo_weather settings (same credentials as netatmo_hc)
+3. Wait for first poll → navigate to Devices page → verify weather station + modules appear
+4. Verify data values are populated (temperature, humidity, etc.)
+5. Verify built-in Legrand H+C integration still shows Control devices (no regression)
+
+### Credentials for testing
+
+- Same Netatmo OAuth credentials as current `netatmo_hc` integration
+- Settings keys will be different: `integration.netatmo_weather.client_id` etc.
+- Need to configure via API or UI after plugin install

--- a/specs/048a-plugin-netatmo-weather/spec.md
+++ b/specs/048a-plugin-netatmo-weather/spec.md
@@ -1,0 +1,50 @@
+# 048a — Externalize Netatmo Weather as Plugin
+
+## Summary
+
+Extract the weather station polling from the built-in Netatmo HC integration into an external plugin `sowel-plugin-netatmo-weather`. Read-only plugin — discovers weather station + outdoor modules, polls temperature, humidity, pressure, CO2, noise, rain, wind data.
+
+## Current State
+
+- Weather polling lives inside `src/integrations/netatmo-hc/netatmo-poller.ts` (methods: `pollWeather()`, lines ~370-430)
+- Weather types in `netatmo-types.ts` (`mapWeatherStationToDiscovered`, `mapWeatherModuleToDiscovered`, `extractWeatherPayload`)
+- OAuth bridge in `netatmo-bridge.ts` (shared with Control/Energy — will be duplicated into plugin)
+- Activated by setting `enable_weather = true`
+- Integration ID: `netatmo_hc`, source: `netatmo_hc`
+
+## Acceptance Criteria
+
+- [x] New repo `mchacher/sowel-plugin-netatmo-weather`
+- [x] Plugin implements `IntegrationPlugin` via `createPlugin(deps)`
+- [x] Discovers weather station + outdoor/indoor/rain/wind modules as devices
+- [x] Polls getstationsdata API at configurable interval
+- [x] OAuth authentication with token rotation + file persistence
+- [x] Integration ID: `netatmo_weather` (new ID, separate from legacy `netatmo_hc`)
+- [x] Settings prefix: `integration.netatmo_weather.*`
+- [x] Pre-built tarball release via GitHub Actions
+- [x] Added to `plugins/registry.json`
+- [x] No orders (read-only)
+- [x] Token file: `data/netatmo-weather-tokens.json` (separate from control)
+- [x] Device migration: on first start, migrated 4 weather devices from `netatmo_hc` to `netatmo_weather`
+- [x] Weather code removed from built-in `netatmo-hc` integration (no regression — Legrand H+C still 10 devices, connected)
+
+## Scope
+
+### In Scope
+
+- Weather station device discovery (base station + modules)
+- Data polling: temperature, humidity, pressure, CO2, noise, rain, wind, battery
+- OAuth bridge (duplicated from netatmo-bridge.ts, self-contained)
+- Token rotation + persistence to file
+
+### Out of Scope
+
+- Home+Control devices (048b)
+- Energy monitoring (048c)
+- Removing weather code from built-in integration (done when all 3 plugins are complete)
+
+## Edge Cases
+
+- Token expired → auto-refresh via bridge
+- Weather station offline → device marked offline on next poll
+- No weather modules → empty discovery, no error

--- a/specs/048b-plugin-legrand-control/spec.md
+++ b/specs/048b-plugin-legrand-control/spec.md
@@ -1,0 +1,43 @@
+# 048b — Externalize Legrand Control as Plugin
+
+## Summary
+
+Extract the Home+Control device management from the built-in Netatmo HC integration into an external plugin `sowel-plugin-legrand-control`. Full read/write plugin — discovers Legrand/Netatmo modules (lights, shutters, plugs), polls status, executes orders via setstate API.
+
+## Current State
+
+- Home+Control polling in `netatmo-poller.ts` (methods: `pollHomeControl()`)
+- Order execution in `index.ts` (`executeOrder()`, `coerceValue()`)
+- OAuth bridge in `netatmo-bridge.ts`
+- Integration ID: `netatmo_hc`
+- Activated by setting `enable_home_control = true` (default)
+
+## Acceptance Criteria
+
+- [ ] New repo `mchacher/sowel-plugin-legrand-control`
+- [ ] Discovers Home+Control modules (lights, shutters, plugs, meters)
+- [ ] Polls homesdata + homestatus APIs
+- [ ] Executes orders via setstate API (on/off, brightness, target_position)
+- [ ] Rapid polling after order for quick state feedback
+- [ ] OAuth authentication with token rotation
+- [ ] Integration ID: `legrand_control`
+- [ ] Settings prefix: `integration.legrand_control.*`
+- [ ] Token file: `data/legrand-control-tokens.json`
+- [ ] Pre-built tarball release via GitHub Actions
+- [ ] Added to `plugins/registry.json`
+
+## Scope
+
+### In Scope
+
+- Module discovery (NLP, NLF, NLT, NLL, NLPC, etc.)
+- Status polling (on/off, brightness, position, power)
+- Order dispatch (setstate)
+- Rapid poll on order for quick feedback
+- Stale device cleanup
+
+### Out of Scope
+
+- Weather station (048a)
+- Energy monitoring/backfill (048c)
+- Migration of existing devices from `netatmo_hc` to `legrand_control` (manual re-binding)

--- a/specs/048c-plugin-legrand-energy/spec.md
+++ b/specs/048c-plugin-legrand-energy/spec.md
@@ -1,0 +1,39 @@
+# 048c — Externalize Legrand Energy as Plugin
+
+## Summary
+
+Extract the energy monitoring from the built-in Netatmo HC integration into an external plugin `sowel-plugin-legrand-energy`. Polls bridge-level energy data (getmeasure API), emits energy events for the history pipeline. Requires extending `PluginDeps` with `InfluxClient` for energy backfill.
+
+## Current State
+
+- Energy polling in `netatmo-poller.ts` (method: `pollEnergy()`, ~100 lines)
+- Energy backfill scripts: `energy-backfill.ts`, `energy-backfill-today.ts`
+- Uses `bridgeId` discovered from NLPC meter modules
+- Emits energy data via `equipmentManager` for HP/HC classification
+- Integration ID: `netatmo_hc`
+- Activated by setting `enable_energy = true`
+
+## Acceptance Criteria
+
+- [ ] New repo `mchacher/sowel-plugin-legrand-energy`
+- [ ] Polls getmeasure API for bridge-level energy (30-min windows)
+- [ ] Discovers energy meters as devices
+- [ ] Emits energy data events for history pipeline
+- [ ] Energy backfill on first start (6 months historical)
+- [ ] OAuth authentication with token rotation
+- [ ] Integration ID: `legrand_energy`
+- [ ] Settings prefix: `integration.legrand_energy.*`
+- [ ] Token file: `data/legrand-energy-tokens.json`
+- [ ] Pre-built tarball release via GitHub Actions
+- [ ] Added to `plugins/registry.json`
+- [ ] `PluginDeps` extended with `InfluxClient` (if needed for backfill)
+
+## Open Questions
+
+- Does energy polling need the `bridgeId` from Home+Control discovery? If yes, the Energy plugin needs its own module discovery or a config setting for bridge ID.
+- Should energy backfill scripts stay in Sowel core as maintenance tools, or move into the plugin?
+- Does `PluginDeps` need `InfluxClient` and `EquipmentManager`?
+
+## Dependencies
+
+- Depends on 048b (Legrand Control) being done first, to understand the bridge/meter discovery split

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -550,6 +550,33 @@ export class DeviceManager {
       "Device summary",
     );
   }
+
+  /**
+   * Migrate devices from one integration ID to another.
+   * Used when a built-in integration is externalized as a plugin.
+   * Preserves device UUIDs, equipment bindings, and history.
+   * Returns the number of devices migrated.
+   */
+  migrateIntegrationId(
+    oldIntegrationId: string,
+    newIntegrationId: string,
+    sourceDeviceIds: string[],
+  ): number {
+    if (sourceDeviceIds.length === 0) return 0;
+
+    const placeholders = sourceDeviceIds.map(() => "?").join(", ");
+    const stmt = this.db.prepare(
+      `UPDATE devices SET integration_id = ?, source = ?, updated_at = datetime('now')
+       WHERE integration_id = ? AND source_device_id IN (${placeholders})`,
+    );
+    const result = stmt.run(
+      newIntegrationId,
+      newIntegrationId,
+      oldIntegrationId,
+      ...sourceDeviceIds,
+    );
+    return result.changes;
+  }
 }
 
 // ============================================================

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -552,30 +552,44 @@ export class DeviceManager {
   }
 
   /**
-   * Migrate devices from one integration ID to another.
+   * Migrate devices from one integration ID to another, filtered by device model.
    * Used when a built-in integration is externalized as a plugin.
    * Preserves device UUIDs, equipment bindings, and history.
-   * Returns the number of devices migrated.
+   *
+   * Uses DB data only (no API calls) — safe to call before authentication.
+   * Runs in a transaction for consistency.
+   *
+   * @param oldIntegrationId - The current integration_id to migrate from
+   * @param newIntegrationId - The new integration_id to migrate to
+   * @param models - If provided, only migrate devices with these model values. If omitted, migrate ALL.
+   * @returns The number of devices migrated
    */
   migrateIntegrationId(
     oldIntegrationId: string,
     newIntegrationId: string,
-    sourceDeviceIds: string[],
+    models?: string[],
   ): number {
-    if (sourceDeviceIds.length === 0) return 0;
+    const migrate = this.db.transaction(() => {
+      const stmt =
+        models && models.length > 0
+          ? this.db.prepare(
+              `UPDATE devices SET integration_id = ?, source = ?, updated_at = datetime('now')
+             WHERE integration_id = ? AND model IN (${models.map(() => "?").join(", ")})`,
+            )
+          : this.db.prepare(
+              `UPDATE devices SET integration_id = ?, source = ?, updated_at = datetime('now')
+             WHERE integration_id = ?`,
+            );
 
-    const placeholders = sourceDeviceIds.map(() => "?").join(", ");
-    const stmt = this.db.prepare(
-      `UPDATE devices SET integration_id = ?, source = ?, updated_at = datetime('now')
-       WHERE integration_id = ? AND source_device_id IN (${placeholders})`,
-    );
-    const result = stmt.run(
-      newIntegrationId,
-      newIntegrationId,
-      oldIntegrationId,
-      ...sourceDeviceIds,
-    );
-    return result.changes;
+      const args =
+        models && models.length > 0
+          ? [newIntegrationId, newIntegrationId, oldIntegrationId, ...models]
+          : [newIntegrationId, newIntegrationId, oldIntegrationId];
+
+      return stmt.run(...args).changes;
+    });
+
+    return migrate();
   }
 }
 

--- a/src/integrations/netatmo-hc/index.ts
+++ b/src/integrations/netatmo-hc/index.ts
@@ -117,13 +117,6 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
         defaultValue: "true",
       },
       {
-        key: "enable_weather",
-        label: "Enable Weather Station",
-        type: "boolean",
-        required: false,
-        defaultValue: "false",
-      },
-      {
         key: "enable_energy",
         label: "Enable Energy Monitoring",
         type: "boolean",
@@ -155,7 +148,6 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
     const pollingIntervalSec = parseInt(this.getSetting("polling_interval") ?? "300", 10);
     const pollingIntervalMs = (isNaN(pollingIntervalSec) ? 300 : pollingIntervalSec) * 1000;
     const enableHomeControl = this.getSetting("enable_home_control") !== "false"; // default true
-    const enableWeather = this.getSetting("enable_weather") === "true";
     const enableEnergy = this.getSetting("enable_energy") === "true";
 
     try {
@@ -199,7 +191,6 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
         this.logger,
         pollingIntervalMs,
         enableHomeControl,
-        enableWeather,
         enableEnergy,
       );
       await this.poller.start(options?.pollOffset ?? 0);

--- a/src/integrations/netatmo-hc/netatmo-bridge.ts
+++ b/src/integrations/netatmo-hc/netatmo-bridge.ts
@@ -14,7 +14,6 @@ import type {
   NetatmoHomeStatusResponse,
   NetatmoGetMeasureResponse,
   NetatmoSetStateRequest,
-  NetatmoStationsDataResponse,
 } from "./netatmo-types.js";
 
 const BASE_URL = "https://api.netatmo.com";
@@ -198,10 +197,6 @@ export class NetatmoBridge {
     return this.apiGet<NetatmoHomeStatusResponse>(
       `/api/homestatus?home_id=${encodeURIComponent(homeId)}`,
     );
-  }
-
-  async getStationsData(): Promise<NetatmoStationsDataResponse> {
-    return this.apiGet<NetatmoStationsDataResponse>("/api/getstationsdata");
   }
 
   async getMeasure(

--- a/src/integrations/netatmo-hc/netatmo-poller.ts
+++ b/src/integrations/netatmo-hc/netatmo-poller.ts
@@ -17,9 +17,6 @@ import {
   mapModuleToDiscovered,
   extractStatusPayload,
   METER_TYPES,
-  mapWeatherStationToDiscovered,
-  mapWeatherModuleToDiscovered,
-  extractWeatherPayload,
 } from "./netatmo-types.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 300_000; // 5 min
@@ -51,12 +48,8 @@ export class NetatmoPoller {
 
   /** Map of moduleId → friendlyName, built during discovery. */
   private moduleNames = new Map<string, string>();
-  /** Weather station friendly names tracked for stale device removal. */
-  private weatherNames = new Set<string>();
   /** Enable Home+Control device polling (homesdata / homestatus). */
   private enableHomeControl: boolean;
-  /** Enable weather station polling (read_station scope). */
-  private enableWeather: boolean;
   /** Enable energy monitoring (bridge-level 5min polling). */
   private enableEnergy: boolean;
   /** Bridge ID discovered from energy meters — used for bridge-level queries. */
@@ -76,7 +69,6 @@ export class NetatmoPoller {
     logger: Logger,
     pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
     enableHomeControl = true,
-    enableWeather = false,
     enableEnergy = false,
   ) {
     this.bridge = bridge;
@@ -87,7 +79,6 @@ export class NetatmoPoller {
     this.logger = logger.child({ module: "legrand-hc-poller" });
     this.pollIntervalMs = pollIntervalMs;
     this.enableHomeControl = enableHomeControl;
-    this.enableWeather = enableWeather;
     this.enableEnergy = enableEnergy;
   }
 
@@ -205,41 +196,21 @@ export class NetatmoPoller {
       this.lastPollAt = new Date().toISOString();
       const t0 = Date.now();
 
-      // Phase 1: independent discovery calls in parallel
+      // Phase 1: discovery
       let hcActiveIds: Set<string> = new Set();
-      let hcDiscoveryOk = !this.enableHomeControl; // true if HC not enabled
-      let weatherDiscoveryOk = !this.enableWeather; // true if weather not enabled
-      const phase1: Promise<void>[] = [];
+      let hcDiscoveryOk = !this.enableHomeControl;
       if (this.enableHomeControl) {
-        phase1.push(
-          this.discoverModules()
-            .then((ids) => {
-              hcActiveIds = ids;
-              hcDiscoveryOk = true;
-            })
-            .catch((err) => this.logger.error({ err }, "Home+Control discovery failed")),
-        );
-      }
-      if (this.enableWeather) {
-        phase1.push(
-          this.pollWeatherStation()
-            .then(() => {
-              weatherDiscoveryOk = true;
-            })
-            .catch((err) => this.logger.warn({ err }, "Weather station poll failed (phase 1)")),
-        );
-      }
-      await Promise.all(phase1);
-
-      // Stale device cleanup AFTER all discovery is complete
-      // Only run if ALL enabled discoveries succeeded — avoids purging
-      // devices when the API is temporarily unavailable
-      if (hcDiscoveryOk && weatherDiscoveryOk) {
-        const allActiveIds = new Set(hcActiveIds);
-        for (const name of this.weatherNames) {
-          allActiveIds.add(name);
+        try {
+          hcActiveIds = await this.discoverModules();
+          hcDiscoveryOk = true;
+        } catch (err) {
+          this.logger.error({ err }, "Home+Control discovery failed");
         }
-        this.deviceManager.removeStaleDevices("netatmo_hc", allActiveIds);
+      }
+
+      // Stale device cleanup AFTER discovery is complete
+      if (hcDiscoveryOk) {
+        this.deviceManager.removeStaleDevices("netatmo_hc", hcActiveIds);
       } else {
         this.logger.warn("Skipping stale device cleanup — discovery incomplete");
       }
@@ -387,59 +358,6 @@ export class NetatmoPoller {
 
     this.logger.info({ updated, total: modules.length }, "Legrand H+C status poll complete");
     return confirmed;
-  }
-
-  /** Discover and poll weather station data via getstationsdata. */
-  private async pollWeatherStation(): Promise<void> {
-    const stationsData = await this.bridge.getStationsData();
-    const devices = stationsData.body.devices;
-
-    if (devices.length === 0) {
-      this.logger.debug("No weather stations found");
-      return;
-    }
-
-    // Build new set first, only replace this.weatherNames on full success
-    // to avoid partial clear that would cause stale device cleanup to delete weather devices
-    const newNames = new Set<string>();
-
-    for (const station of devices) {
-      // Discover + update base station (NAMain)
-      const baseName = station.module_name || station.station_name;
-      const baseDiscovered = mapWeatherStationToDiscovered(station);
-      this.deviceManager.upsertFromDiscovery("netatmo_hc", "netatmo_hc", baseDiscovered);
-      newNames.add(baseName);
-
-      // Update base station data (always call to refresh lastSeen)
-      const basePayload = extractWeatherPayload(station.dashboard_data, station.type);
-      this.deviceManager.updateDeviceData("netatmo_hc", baseName, basePayload);
-
-      // Discover + update each sub-module
-      for (const mod of station.modules ?? []) {
-        const modName = mod.module_name || mod._id;
-        const modDiscovered = mapWeatherModuleToDiscovered(mod);
-        this.deviceManager.upsertFromDiscovery("netatmo_hc", "netatmo_hc", modDiscovered);
-        newNames.add(modName);
-
-        // Build combined payload: sensor data + battery
-        const modPayload: Record<string, unknown> = mod.dashboard_data
-          ? extractWeatherPayload(mod.dashboard_data, mod.type)
-          : {};
-        if (mod.battery_percent !== undefined) {
-          modPayload.battery = mod.battery_percent;
-        }
-        // Always call to refresh lastSeen even if payload is empty
-        this.deviceManager.updateDeviceData("netatmo_hc", modName, modPayload);
-      }
-    }
-
-    // Only update weatherNames after full success
-    this.weatherNames = newNames;
-
-    this.logger.info(
-      { stationCount: devices.length, weatherDevices: this.weatherNames.size },
-      "Weather station poll complete",
-    );
   }
 
   /**

--- a/src/integrations/netatmo-hc/netatmo-types.ts
+++ b/src/integrations/netatmo-hc/netatmo-types.ts
@@ -76,63 +76,6 @@ export interface NetatmoSetStateRequest {
 }
 
 // ============================================================
-// Weather Station types (getstationsdata)
-// ============================================================
-
-export interface NetatmoStationsDataResponse {
-  body: {
-    devices: NetatmoStationDevice[];
-  };
-  status: string;
-}
-
-export interface NetatmoStationDevice {
-  _id: string;
-  type: string; // "NAMain"
-  station_name: string;
-  module_name: string;
-  firmware: number;
-  wifi_status: number;
-  dashboard_data: NetatmoStationDashboard;
-  modules?: NetatmoStationModule[];
-}
-
-export interface NetatmoStationModule {
-  _id: string;
-  type: string; // "NAModule1" | "NAModule2" | "NAModule3" | "NAModule4"
-  module_name: string;
-  firmware: number;
-  rf_status: number;
-  battery_percent: number;
-  battery_vp: number;
-  dashboard_data?: NetatmoStationDashboard;
-}
-
-export interface NetatmoStationDashboard {
-  // NAMain (indoor)
-  Temperature?: number;
-  Humidity?: number;
-  CO2?: number;
-  Noise?: number;
-  Pressure?: number;
-  AbsolutePressure?: number;
-  // NAModule1 (outdoor)
-  min_temp?: number;
-  max_temp?: number;
-  // NAModule2 (wind)
-  WindStrength?: number;
-  WindAngle?: number;
-  GustStrength?: number;
-  GustAngle?: number;
-  // NAModule3 (rain)
-  Rain?: number;
-  sum_rain_1?: number;
-  sum_rain_24?: number;
-  // Common
-  time_utc?: number;
-}
-
-// ============================================================
 // Module type classification
 // ============================================================
 
@@ -172,15 +115,6 @@ export const METER_TYPES = new Set([
 const GATEWAY_TYPES = new Set([
   "NLG", // Gateway
   "NLGS", // Standard DIN gateway
-]);
-
-/** Weather station module types */
-export const WEATHER_TYPES = new Set([
-  "NAMain", // Indoor station (base)
-  "NAModule1", // Outdoor module (temp + humidity)
-  "NAModule2", // Wind gauge
-  "NAModule3", // Rain gauge
-  "NAModule4", // Additional indoor module
 ]);
 
 export function isSupportedModule(type: string): boolean {
@@ -266,116 +200,6 @@ export function mapModuleToDiscovered(mod: NetatmoModule, homeId: string): Disco
     data,
     orders,
   };
-}
-
-// ============================================================
-// Weather Station → DiscoveredDevice mapping
-// ============================================================
-
-const WEATHER_MODEL_NAMES: Record<string, string> = {
-  NAMain: "Indoor Station",
-  NAModule1: "Outdoor Module",
-  NAModule2: "Wind Gauge",
-  NAModule3: "Rain Gauge",
-  NAModule4: "Indoor Module",
-};
-
-export function mapWeatherStationToDiscovered(device: NetatmoStationDevice): DiscoveredDevice {
-  const data: DataDef[] = [
-    { key: "temperature", type: "number", category: "temperature", unit: "°C" },
-    { key: "humidity", type: "number", category: "humidity", unit: "%" },
-    { key: "co2", type: "number", category: "co2", unit: "ppm" },
-    { key: "noise", type: "number", category: "noise", unit: "dB" },
-    { key: "pressure", type: "number", category: "pressure", unit: "mbar" },
-  ];
-
-  return {
-    friendlyName: device.module_name || device.station_name,
-    manufacturer: "Netatmo",
-    model: WEATHER_MODEL_NAMES[device.type] ?? device.type,
-    data,
-    orders: [],
-  };
-}
-
-export function mapWeatherModuleToDiscovered(mod: NetatmoStationModule): DiscoveredDevice {
-  const data: DataDef[] = [];
-
-  // All sub-modules have battery
-  data.push({ key: "battery", type: "number", category: "battery", unit: "%" });
-
-  switch (mod.type) {
-    case "NAModule1": // Outdoor: temp + humidity
-      data.push({ key: "temperature", type: "number", category: "temperature", unit: "°C" });
-      data.push({ key: "humidity", type: "number", category: "humidity", unit: "%" });
-      break;
-    case "NAModule2": // Wind
-      data.push({ key: "wind_strength", type: "number", category: "wind", unit: "km/h" });
-      data.push({ key: "wind_angle", type: "number", category: "wind", unit: "°" });
-      data.push({ key: "gust_strength", type: "number", category: "wind", unit: "km/h" });
-      data.push({ key: "gust_angle", type: "number", category: "wind", unit: "°" });
-      break;
-    case "NAModule3": // Rain
-      data.push({ key: "rain", type: "number", category: "rain", unit: "mm" });
-      data.push({ key: "sum_rain_1", type: "number", category: "rain", unit: "mm" });
-      data.push({ key: "sum_rain_24", type: "number", category: "rain", unit: "mm" });
-      break;
-    case "NAModule4": // Additional indoor: temp + humidity + CO2
-      data.push({ key: "temperature", type: "number", category: "temperature", unit: "°C" });
-      data.push({ key: "humidity", type: "number", category: "humidity", unit: "%" });
-      data.push({ key: "co2", type: "number", category: "co2", unit: "ppm" });
-      break;
-  }
-
-  return {
-    friendlyName: mod.module_name || mod._id,
-    manufacturer: "Netatmo",
-    model: WEATHER_MODEL_NAMES[mod.type] ?? mod.type,
-    data,
-    orders: [],
-  };
-}
-
-/**
- * Extract data payload from weather station dashboard_data.
- */
-export function extractWeatherPayload(
-  dashboard: NetatmoStationDashboard,
-  moduleType: string,
-): Record<string, unknown> {
-  const payload: Record<string, unknown> = {};
-
-  switch (moduleType) {
-    case "NAMain":
-      if (dashboard.Temperature !== undefined) payload.temperature = dashboard.Temperature;
-      if (dashboard.Humidity !== undefined) payload.humidity = dashboard.Humidity;
-      if (dashboard.CO2 !== undefined) payload.co2 = dashboard.CO2;
-      if (dashboard.Noise !== undefined) payload.noise = dashboard.Noise;
-      if (dashboard.Pressure !== undefined) payload.pressure = dashboard.Pressure;
-      break;
-    case "NAModule1":
-      if (dashboard.Temperature !== undefined) payload.temperature = dashboard.Temperature;
-      if (dashboard.Humidity !== undefined) payload.humidity = dashboard.Humidity;
-      break;
-    case "NAModule2":
-      if (dashboard.WindStrength !== undefined) payload.wind_strength = dashboard.WindStrength;
-      if (dashboard.WindAngle !== undefined) payload.wind_angle = dashboard.WindAngle;
-      if (dashboard.GustStrength !== undefined) payload.gust_strength = dashboard.GustStrength;
-      if (dashboard.GustAngle !== undefined) payload.gust_angle = dashboard.GustAngle;
-      break;
-    case "NAModule3":
-      if (dashboard.Rain !== undefined) payload.rain = dashboard.Rain;
-      if (dashboard.sum_rain_1 !== undefined) payload.sum_rain_1 = dashboard.sum_rain_1;
-      if (dashboard.sum_rain_24 !== undefined) payload.sum_rain_24 = dashboard.sum_rain_24;
-      break;
-    case "NAModule4":
-      if (dashboard.Temperature !== undefined) payload.temperature = dashboard.Temperature;
-      if (dashboard.Humidity !== undefined) payload.humidity = dashboard.Humidity;
-      if (dashboard.CO2 !== undefined) payload.co2 = dashboard.CO2;
-      break;
-  }
-
-  return payload;
 }
 
 /**


### PR DESCRIPTION
## Summary
- First built-in integration externalized as plugin: Netatmo Weather Station
- New plugin `sowel-plugin-netatmo-weather` v1.0.0 — polls getstationsdata API
- Device migration from legacy `netatmo_hc` to `netatmo_weather` preserves UUIDs, equipments, bindings
- Weather code removed from built-in `netatmo-hc` integration

## Changes
- **New plugin repo**: `mchacher/sowel-plugin-netatmo-weather` with OAuth bridge, weather polling, GitHub Actions release
- **DeviceManager**: `migrateIntegrationId()` helper for integration externalization (reusable for 048b/c and 049-052)
- **Built-in netatmo-hc cleanup**: removed `pollWeatherStation()`, `getStationsData()`, weather types, `enable_weather` setting
- **Registry**: added `netatmo_weather` plugin
- **Specs**: added 048b (Legrand Control) and 048c (Legrand Energy) specs

## Test plan
- [x] TypeScript compiles (zero errors, backend + frontend)
- [x] All 454 tests pass
- [x] Lint passes (0 errors)
- [x] Plugin release v1.0.0 with pre-built tarball on GitHub
- [x] Installed from store via Playwright UI
- [x] Configured with Netatmo OAuth credentials
- [x] 4 weather devices migrated from netatmo_hc → netatmo_weather (Playwright verified)
- [x] Netatmo Weather: Connected, 4 appareils, polling active
- [x] Legrand H+C: still Connected, 10 appareils — no regression
- [x] UI deployed via deploy-ui.sh