### PR TITLE
feat: externalize Legrand Control as plugin (spec 048b)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -1,5 +1,15 @@
 [
   {
+    "id": "legrand_control",
+    "name": "Legrand Control",
+    "description": "Legrand Home+Control — lights, shutters, plugs, contactors",
+    "icon": "PlugZap",
+    "author": "mchacher",
+    "repo": "mchacher/sowel-plugin-legrand-control",
+    "version": "1.0.0",
+    "tags": ["legrand", "netatmo", "light", "shutter", "plug"]
+  },
+  {
     "id": "netatmo_weather",
     "name": "Netatmo Weather",
     "description": "Netatmo Weather Station — temperature, humidity, pressure, CO2, wind, rain",

--- a/specs/048b-plugin-legrand-control/plan.md
+++ b/specs/048b-plugin-legrand-control/plan.md
@@ -1,0 +1,44 @@
+# Implementation Plan: 048b — Legrand Control Plugin
+
+## Tasks
+
+### Plugin repo creation
+
+1. [ ] Create GitHub repo `mchacher/sowel-plugin-legrand-control`
+2. [ ] Scaffold plugin: manifest.json, package.json, tsconfig.json, .gitignore, .github/workflows/release.yml
+3. [ ] Port OAuth bridge from netatmo-bridge.ts (auth, token rotation, file persistence, homesdata, homestatus, setstate)
+4. [ ] Port module discovery from netatmo-poller.ts (discoverModules, isSupportedModule — exclude NLPC)
+5. [ ] Port status polling from netatmo-poller.ts (pollStatus, extractStatusPayload)
+6. [ ] Port order execution from index.ts (executeOrder, coerceValue, setstate)
+7. [ ] Port rapid polling (scheduleOnDemandPoll, stopRapidPoll)
+8. [ ] Port types from netatmo-types.ts (module classification, mapModuleToDiscovered, extractStatusPayload — exclude NLPC mapping)
+9. [ ] Add device migration from netatmo_hc by model (all models except NLPC), DB-only, before auth
+10. [ ] Implement createPlugin(deps) → IntegrationPlugin
+11. [ ] Build + verify dist/index.js
+
+### Sowel core cleanup
+
+12. [ ] Remove control code from netatmo-poller.ts (discoverModules, pollStatus, rapid poll — keep only energy)
+13. [ ] Remove control code from index.ts (executeOrder, coerceValue, enable_home_control)
+14. [ ] Remove control types from netatmo-types.ts (keep only NLPC/METER_TYPES + energy-related)
+15. [ ] Remove getHomesData, getHomeStatus, setState from netatmo-bridge.ts (keep only getMeasure + auth)
+16. [ ] Add legrand_control to plugins/registry.json
+
+### Validation
+
+17. [ ] TypeScript compilation (Sowel backend + frontend)
+18. [ ] All tests pass
+19. [ ] Lint (0 errors)
+20. [ ] Tag + release plugin v1.0.0
+21. [ ] Configure plugin settings (copy from netatmo_hc credentials)
+22. [ ] Verify control devices migrated (same UUIDs, bindings preserved)
+23. [ ] Verify orders work (light on/off, shutter control)
+24. [ ] Verify energy devices (NLPC) still under netatmo_hc (no regression)
+25. [ ] Deploy UI via deploy-ui.sh
+
+## Testing Strategy
+
+- Migration: verify Lumière 1-5, CT Green Up, Legrand Gateway moved to legrand_control
+- Orders: test light toggle via Playwright
+- Energy: verify PAC, Piscine, Solaire, Total remain under netatmo_hc
+- No regression on existing equipment bindings

--- a/specs/048b-plugin-legrand-control/spec.md
+++ b/specs/048b-plugin-legrand-control/spec.md
@@ -14,30 +14,44 @@ Extract the Home+Control device management from the built-in Netatmo HC integrat
 
 ## Acceptance Criteria
 
-- [ ] New repo `mchacher/sowel-plugin-legrand-control`
-- [ ] Discovers Home+Control modules (lights, shutters, plugs, meters)
-- [ ] Polls homesdata + homestatus APIs
-- [ ] Executes orders via setstate API (on/off, brightness, target_position)
-- [ ] Rapid polling after order for quick state feedback
-- [ ] OAuth authentication with token rotation
-- [ ] Integration ID: `legrand_control`
-- [ ] Settings prefix: `integration.legrand_control.*`
-- [ ] Token file: `data/legrand-control-tokens.json`
-- [ ] Pre-built tarball release via GitHub Actions
-- [ ] Added to `plugins/registry.json`
+- [x] New repo `mchacher/sowel-plugin-legrand-control`
+- [x] Discovers Home+Control modules (lights, shutters, plugs, gateway — all models EXCEPT NLPC)
+- [x] Polls homesdata + homestatus APIs
+- [x] Executes orders via setstate API (on/off, brightness, target_position)
+- [x] Rapid polling after order for quick state feedback
+- [x] OAuth authentication with token rotation
+- [x] Integration ID: `legrand_control`
+- [x] Settings prefix: `integration.legrand_control.*`
+- [x] Token file: `data/legrand-control-tokens.json`
+- [x] Pre-built tarball release via GitHub Actions
+- [x] Added to `plugins/registry.json`
+- [x] Device migration: 6 non-NLPC devices migrated from netatmo_hc to legrand_control
+- [x] Control code removed from built-in netatmo-hc (only energy/NLPC code remains)
+- [x] No user-facing regression: energy bindings intact (Total, Solaire), control devices had no equipment bindings
+
+## Module Models
+
+| Category      | Models                                      | Plugin                       |
+| ------------- | ------------------------------------------- | ---------------------------- |
+| Switches      | NLPT, NLPO, NLL, NLIS, NLP, NLPM, NLPD, NLC | legrand_control              |
+| Dimmers       | NLF, NLFE, NLFN                             | legrand_control              |
+| Shutters      | NLV, NLLV, NLIV                             | legrand_control              |
+| Gateway       | NLG, NLGS                                   | legrand_control              |
+| Energy meters | NLPC                                        | stays in netatmo_hc (→ 048c) |
 
 ## Scope
 
 ### In Scope
 
-- Module discovery (NLP, NLF, NLT, NLL, NLPC, etc.)
-- Status polling (on/off, brightness, position, power)
+- Module discovery (all models except NLPC)
+- Status polling (on/off, brightness, position, wifi_strength)
 - Order dispatch (setstate)
 - Rapid poll on order for quick feedback
 - Stale device cleanup
+- Device migration from netatmo_hc by model
 
 ### Out of Scope
 
-- Weather station (048a)
-- Energy monitoring/backfill (048c)
-- Migration of existing devices from `netatmo_hc` to `legrand_control` (manual re-binding)
+- Weather station (done in 048a)
+- Energy meters NLPC (048c)
+- Energy monitoring / getmeasure / backfill (048c)

--- a/src/integrations/netatmo-hc/index.ts
+++ b/src/integrations/netatmo-hc/index.ts
@@ -14,29 +14,16 @@ import { backfillEnergyIfNeeded } from "./energy-backfill.js";
 const SETTINGS_PREFIX = "integration.netatmo_hc.";
 const DEFAULT_DATA_DIR = resolve(process.cwd(), "data");
 
-/** Boolean params expected by Netatmo setstate API. */
-const BOOLEAN_PARAMS = new Set(["on"]);
-/** Numeric params expected by Netatmo setstate API. */
-const NUMERIC_PARAMS = new Set(["brightness", "target_position"]);
-
-/** Coerce Sowel order value to the type Netatmo API expects. */
-function coerceValue(param: string, value: unknown): unknown {
-  if (BOOLEAN_PARAMS.has(param)) {
-    if (typeof value === "boolean") return value;
-    if (typeof value === "string") return value.toUpperCase() === "ON" || value === "true";
-    return Boolean(value);
-  }
-  if (NUMERIC_PARAMS.has(param)) {
-    return typeof value === "number" ? value : Number(value);
-  }
-  return value;
-}
-
+/**
+ * Netatmo HC integration — now only handles energy monitoring (NLPC meters).
+ * Home+Control devices are handled by the legrand_control plugin.
+ * Weather data is handled by the netatmo_weather plugin.
+ */
 export class NetatmoHCIntegration implements IntegrationPlugin {
   readonly id = "netatmo_hc";
-  readonly name = "Legrand Home+Control";
-  readonly description = "Netatmo Connect API integration";
-  readonly icon = "PlugZap";
+  readonly name = "Legrand Energy";
+  readonly description = "Legrand energy monitoring (NLPC meters)";
+  readonly icon = "Zap";
 
   private logger: Logger;
   private eventBus: EventBus;
@@ -72,7 +59,9 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
   }
 
   isConfigured(): boolean {
+    const enableEnergy = this.getSetting("enable_energy") === "true";
     return (
+      enableEnergy &&
       this.getSetting("client_id") !== undefined &&
       this.getSetting("client_secret") !== undefined &&
       this.getSetting("refresh_token") !== undefined
@@ -88,12 +77,7 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
         required: true,
         placeholder: "From dev.netatmo.com",
       },
-      {
-        key: "client_secret",
-        label: "Client Secret",
-        type: "password",
-        required: true,
-      },
+      { key: "client_secret", label: "Client Secret", type: "password", required: true },
       {
         key: "refresh_token",
         label: "Refresh Token",
@@ -110,13 +94,6 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
         placeholder: "300",
       },
       {
-        key: "enable_home_control",
-        label: "Enable Home+Control devices",
-        type: "boolean",
-        required: false,
-        defaultValue: "true",
-      },
-      {
         key: "enable_energy",
         label: "Enable Energy Monitoring",
         type: "boolean",
@@ -127,7 +104,6 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
   }
 
   async start(options?: { pollOffset?: number }): Promise<void> {
-    // Clean up previous state before (re)starting
     if (this.poller) {
       this.poller.stop();
       this.poller = null;
@@ -147,11 +123,8 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
     const refreshToken = this.getSetting("refresh_token")!;
     const pollingIntervalSec = parseInt(this.getSetting("polling_interval") ?? "300", 10);
     const pollingIntervalMs = (isNaN(pollingIntervalSec) ? 300 : pollingIntervalSec) * 1000;
-    const enableHomeControl = this.getSetting("enable_home_control") !== "false"; // default true
-    const enableEnergy = this.getSetting("enable_energy") === "true";
 
     try {
-      // Create bridge with token rotation callback
       this.bridge = new NetatmoBridge(
         clientId,
         clientSecret,
@@ -159,28 +132,20 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
         this.logger,
         DEFAULT_DATA_DIR,
         (newToken) => {
-          // Persist the rotated refresh_token to settings
           this.settingsManager.set(`${SETTINGS_PREFIX}refresh_token`, newToken);
         },
       );
 
-      // Authenticate (refresh token → get access token)
       await this.bridge.authenticate();
-      this.logger.info("Legrand H+C authentication successful");
+      this.logger.info("Legrand Energy authentication successful");
 
-      // Discover home ID (use first home) — needed for Home+Control
-      let homeId = "";
-      if (enableHomeControl) {
-        const homesData = await this.bridge.getHomesData();
-        const homes = homesData.body.homes;
-        if (homes.length === 0) {
-          throw new Error("No homes found in Legrand H+C account");
-        }
-        homeId = homes[0].id;
-        this.logger.info({ homeId, homeName: homes[0].name }, "Using Legrand H+C home");
-      }
+      // Discover home ID for energy polling
+      const homesData = await this.bridge.getHomesData();
+      const homes = homesData.body.homes;
+      if (homes.length === 0) throw new Error("No homes found");
+      const homeId = homes[0].id;
 
-      // Start polling
+      // Start energy-only poller
       this.poller = new NetatmoPoller(
         this.bridge,
         this.deviceManager,
@@ -190,18 +155,16 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
         homeId,
         this.logger,
         pollingIntervalMs,
-        enableHomeControl,
-        enableEnergy,
       );
       await this.poller.start(options?.pollOffset ?? 0);
 
       this.status = "connected";
       this.retryCount = 0;
       this.eventBus.emit({ type: "system.integration.connected", integrationId: this.id });
-      this.logger.info({ pollingIntervalMs }, "Legrand H+C integration started");
+      this.logger.info({ pollingIntervalMs }, "Legrand Energy started");
     } catch (err) {
       this.status = "error";
-      this.logger.error({ err }, "Failed to start Legrand H+C integration");
+      this.logger.error({ err }, "Failed to start Legrand Energy");
       this.scheduleRetry();
     }
   }
@@ -218,18 +181,17 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
     }
     this.status = "disconnected";
     this.eventBus.emit({ type: "system.integration.disconnected", integrationId: this.id });
-    this.logger.info("Legrand H+C integration stopped");
+    this.logger.info("Legrand Energy stopped");
   }
 
-  /** Schedule an automatic retry with exponential backoff (30s, 60s, 120s, ... max 10min). */
   private scheduleRetry(): void {
     this.cancelRetry();
     this.retryCount++;
     const delaySec = Math.min(30 * Math.pow(2, this.retryCount - 1), 600);
-    this.logger.warn({ retryCount: this.retryCount, delaySec }, "Scheduling automatic retry");
+    this.logger.warn({ retryCount: this.retryCount, delaySec }, "Scheduling retry");
     this.retryTimeout = setTimeout(() => {
       this.retryTimeout = null;
-      this.start().catch((err) => this.logger.error({ err }, "Retry start failed"));
+      this.start().catch((err) => this.logger.error({ err }, "Retry failed"));
     }, delaySec * 1000);
   }
 
@@ -242,59 +204,21 @@ export class NetatmoHCIntegration implements IntegrationPlugin {
 
   async executeOrder(
     _device: Device,
-    dispatchConfig: Record<string, unknown>,
-    value: unknown,
+    _dispatchConfig: Record<string, unknown>,
+    _value: unknown,
   ): Promise<void> {
-    if (!this.bridge || this.status !== "connected") {
-      throw new Error("Legrand H+C integration not connected");
-    }
-
-    const homeId = dispatchConfig.homeId as string;
-    const moduleId = dispatchConfig.moduleId as string;
-    const param = dispatchConfig.param as string;
-    const bridge = dispatchConfig.bridge as string | undefined;
-
-    if (!homeId || !moduleId || !param) {
-      throw new Error("Invalid dispatch config: missing homeId, moduleId, or param");
-    }
-
-    // Coerce value to the type expected by Netatmo API
-    const apiValue = coerceValue(param, value);
-
-    const modulePayload: Record<string, unknown> = { id: moduleId, [param]: apiValue };
-    if (bridge) modulePayload.bridge = bridge;
-
-    await this.bridge.setState({
-      home: {
-        id: homeId,
-        modules: [modulePayload],
-      },
-    });
-
-    this.logger.info({ moduleId, param, value }, "Legrand H+C order executed");
-
-    // Rapid-poll status until the expected state is confirmed (or 10s timeout)
-    if (this.poller) {
-      this.poller.scheduleOnDemandPoll({ moduleId, param, value: apiValue });
-    }
+    throw new Error("Legrand Energy does not support orders");
   }
 
   async refresh(): Promise<void> {
-    if (!this.poller || this.status !== "connected") {
-      throw new Error("Legrand H+C integration not connected");
-    }
+    if (!this.poller || this.status !== "connected") throw new Error("Not connected");
     await this.poller.refresh();
-    this.logger.info("Legrand H+C manual refresh completed");
   }
 
   getPollingInfo(): { lastPollAt: string; intervalMs: number } | null {
     return this.poller?.getPollingInfo() ?? null;
   }
 
-  /**
-   * Run energy backfill if needed (first run only).
-   * Must be called after integrations start and Equipment bindings are set up.
-   */
   async runEnergyBackfillIfNeeded(
     equipmentManager: EquipmentManager,
     influxClient: InfluxClient,

--- a/src/integrations/netatmo-hc/netatmo-bridge.ts
+++ b/src/integrations/netatmo-hc/netatmo-bridge.ts
@@ -13,7 +13,6 @@ import type {
   NetatmoHomesDataResponse,
   NetatmoHomeStatusResponse,
   NetatmoGetMeasureResponse,
-  NetatmoSetStateRequest,
 } from "./netatmo-types.js";
 
 const BASE_URL = "https://api.netatmo.com";
@@ -221,22 +220,6 @@ export class NetatmoBridge {
       params.set("date_end", String(dateEnd));
     }
     return this.apiGet<NetatmoGetMeasureResponse>(`/api/getmeasure?${params.toString()}`);
-  }
-
-  async setState(request: NetatmoSetStateRequest): Promise<void> {
-    const res = await this.apiFetch(`${BASE_URL}/api/setstate`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${this.accessToken}`,
-      },
-      body: JSON.stringify(request),
-    });
-
-    if (!res.ok) {
-      const text = await res.text();
-      throw new Error(`setstate failed (${res.status}): ${text}`);
-    }
   }
 
   // ============================================================

--- a/src/integrations/netatmo-hc/netatmo-poller.ts
+++ b/src/integrations/netatmo-hc/netatmo-poller.ts
@@ -1,9 +1,9 @@
 /**
- * NetatmoPoller — Periodic polling of Netatmo Home+Control API.
+ * NetatmoPoller — Energy-only polling (NLPC meters).
  *
  * On each poll:
- * 1. GET /api/homesdata → discover modules → upsertFromDiscovery
- * 2. GET /api/homestatus → read live values → updateDeviceData
+ * 1. GET /api/homesdata → discover NLPC meters → capture bridgeId
+ * 2. GET /api/getmeasure → fetch 30-min energy windows
  */
 
 import type { Logger } from "../../core/logger.js";
@@ -12,19 +12,9 @@ import type { SettingsManager } from "../../core/settings-manager.js";
 import type { DeviceManager } from "../../devices/device-manager.js";
 import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import type { NetatmoBridge } from "./netatmo-bridge.js";
-import {
-  isSupportedModule,
-  mapModuleToDiscovered,
-  extractStatusPayload,
-  METER_TYPES,
-} from "./netatmo-types.js";
+import { METER_TYPES, mapModuleToDiscovered, extractStatusPayload } from "./netatmo-types.js";
 
-const DEFAULT_POLL_INTERVAL_MS = 300_000; // 5 min
-const RAPID_POLL_FIRST_MS = 1_000; // first rapid poll 1s after order
-const RAPID_POLL_INTERVAL_MS = 1_000; // then every 1s
-const RAPID_POLL_DURATION_MS = 10_000; // stop after 10s
-
-/** Sliding window: query last 6h of energy data on each poll cycle. */
+const DEFAULT_POLL_INTERVAL_MS = 300_000;
 const ENERGY_LOOKBACK_S = 6 * 3600;
 
 export class NetatmoPoller {
@@ -37,26 +27,18 @@ export class NetatmoPoller {
   private pollIntervalMs: number;
 
   private interval: ReturnType<typeof setInterval> | null = null;
-  private rapidInterval: ReturnType<typeof setInterval> | null = null;
-  private rapidTimeout: ReturnType<typeof setTimeout> | null = null;
-  private rapidStopTimeout: ReturnType<typeof setTimeout> | null = null;
+  private staggerTimeout: ReturnType<typeof setTimeout> | null = null;
   private polling = false;
   private pollFailed = false;
-  private rapidPolling = false;
   private lastPollAt: string | null = null;
-  private staggerTimeout: ReturnType<typeof setTimeout> | null = null;
 
-  /** Map of moduleId → friendlyName, built during discovery. */
+  /** Map of moduleId → friendlyName for NLPC meters. */
   private moduleNames = new Map<string, string>();
-  /** Enable Home+Control device polling (homesdata / homestatus). */
-  private enableHomeControl: boolean;
-  /** Enable energy monitoring (bridge-level 5min polling). */
-  private enableEnergy: boolean;
-  /** Bridge ID discovered from energy meters — used for bridge-level queries. */
+  /** Bridge ID discovered from NLPC meters. */
   private bridgeId: string | null = null;
-  /** Friendly name of the NLPC module that receives bridge-level energy data. */
+  /** Friendly name of the main NLPC meter (receives bridge-level energy). */
   private mainMeterName: string | null = null;
-  /** High-water mark: highest window timestamp emitted to EnergyAggregator this session. */
+  /** High-water mark for energy window timestamps. */
   private lastEmittedWindowTs = 0;
 
   constructor(
@@ -68,8 +50,6 @@ export class NetatmoPoller {
     homeId: string,
     logger: Logger,
     pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
-    enableHomeControl = true,
-    enableEnergy = false,
   ) {
     this.bridge = bridge;
     this.deviceManager = deviceManager;
@@ -78,21 +58,17 @@ export class NetatmoPoller {
     this.homeId = homeId;
     this.logger = logger.child({ module: "legrand-hc-poller" });
     this.pollIntervalMs = pollIntervalMs;
-    this.enableHomeControl = enableHomeControl;
-    this.enableEnergy = enableEnergy;
   }
 
   async start(pollOffset = 0): Promise<void> {
     this.logger.info(
       { homeId: this.homeId, intervalMs: this.pollIntervalMs, pollOffset },
-      "Starting Legrand H+C poller",
+      "Starting Legrand Energy poller",
     );
-    // Immediate first poll (awaited — data available at startup)
     await this.poll();
-    // Stagger recurring polls by pollOffset so integrations don't all fire at once
     const startInterval = () => {
       this.interval = setInterval(() => {
-        this.poll().catch((err) => this.logger.error({ err }, "Legrand H+C poll failed"));
+        this.poll().catch((err) => this.logger.error({ err }, "Energy poll failed"));
       }, this.pollIntervalMs);
     };
     if (pollOffset > 0) {
@@ -111,8 +87,7 @@ export class NetatmoPoller {
       clearTimeout(this.staggerTimeout);
       this.staggerTimeout = null;
     }
-    this.stopRapidPoll();
-    this.logger.info("Legrand H+C poller stopped");
+    this.logger.info("Legrand Energy poller stopped");
   }
 
   async refresh(): Promise<void> {
@@ -132,108 +107,24 @@ export class NetatmoPoller {
     return this.bridgeId;
   }
 
-  /** Rapid status polling after an order: first at 1s, then every 1s, stops on confirmation or 10s timeout. */
-  scheduleOnDemandPoll(expected?: { moduleId: string; param: string; value: unknown }): void {
-    this.stopRapidPoll();
-    this.logger.debug({ expected }, "Starting rapid status polling after order");
-
-    const doRapidPoll = () => {
-      if (this.rapidPolling || this.polling) return;
-      this.rapidPolling = true;
-      this.pollStatus(expected)
-        .then((confirmed) => {
-          if (confirmed) {
-            this.logger.debug("Order confirmed by status poll, stopping rapid poll");
-            this.stopRapidPoll();
-          }
-        })
-        .catch((err) => {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (msg.includes("429")) {
-            this.logger.debug("Legrand H+C rapid poll skipped (rate-limited)");
-          } else {
-            this.logger.error({ err }, "Legrand H+C rapid poll failed");
-          }
-        })
-        .finally(() => {
-          this.rapidPolling = false;
-        });
-    };
-
-    // First poll at 1s, then every 1s
-    this.rapidTimeout = setTimeout(() => {
-      doRapidPoll();
-      this.rapidInterval = setInterval(doRapidPoll, RAPID_POLL_INTERVAL_MS);
-    }, RAPID_POLL_FIRST_MS);
-
-    // Hard stop after 10s
-    this.rapidStopTimeout = setTimeout(() => {
-      this.stopRapidPoll();
-      this.logger.debug("Rapid status polling timed out");
-    }, RAPID_POLL_DURATION_MS);
-  }
-
-  private stopRapidPoll(): void {
-    if (this.rapidInterval) {
-      clearInterval(this.rapidInterval);
-      this.rapidInterval = null;
-    }
-    if (this.rapidTimeout) {
-      clearTimeout(this.rapidTimeout);
-      this.rapidTimeout = null;
-    }
-    if (this.rapidStopTimeout) {
-      clearTimeout(this.rapidStopTimeout);
-      this.rapidStopTimeout = null;
-    }
-  }
-
   private async poll(): Promise<void> {
     if (this.polling) return;
     this.polling = true;
 
     try {
       this.lastPollAt = new Date().toISOString();
-      const t0 = Date.now();
 
-      // Phase 1: discovery
-      let hcActiveIds: Set<string> = new Set();
-      let hcDiscoveryOk = !this.enableHomeControl;
-      if (this.enableHomeControl) {
-        try {
-          hcActiveIds = await this.discoverModules();
-          hcDiscoveryOk = true;
-        } catch (err) {
-          this.logger.error({ err }, "Home+Control discovery failed");
-        }
-      }
+      // Phase 1: discover NLPC meters + capture bridgeId
+      await this.discoverMeters();
 
-      // Stale device cleanup AFTER discovery is complete
-      if (hcDiscoveryOk) {
-        this.deviceManager.removeStaleDevices("netatmo_hc", hcActiveIds);
-      } else {
-        this.logger.warn("Skipping stale device cleanup — discovery incomplete");
-      }
+      // Phase 2: poll status for NLPC meters (power readings)
+      await this.pollMeterStatus().catch((err) =>
+        this.logger.warn({ err }, "Meter status poll failed"),
+      );
 
-      const t1 = Date.now();
-
-      // Phase 2: status + energy (depend on discovery results)
-      if (this.enableHomeControl) {
-        const phase2: Promise<unknown>[] = [
-          this.pollStatus().catch((err) =>
-            this.logger.error({ err }, "Home+Control status poll failed"),
-          ),
-          this.pollEnergyMeters().catch((err) =>
-            this.logger.warn({ err }, "Energy meters poll failed"),
-          ),
-        ];
-        await Promise.all(phase2);
-      }
-      const t2 = Date.now();
-
-      this.logger.debug(
-        { phase1Ms: t1 - t0, phase2Ms: t2 - t1, totalMs: t2 - t0 },
-        "Legrand H+C poll timing",
+      // Phase 3: poll bridge-level energy data
+      await this.pollEnergyMeters().catch((err) =>
+        this.logger.warn({ err }, "Energy meters poll failed"),
       );
 
       if (this.pollFailed) {
@@ -241,19 +132,19 @@ export class NetatmoPoller {
         this.eventBus.emit({
           type: "system.alarm.resolved",
           alarmId: "poll-fail:netatmo_hc",
-          source: "Legrand Home+Control",
+          source: "Legrand Energy",
           message: "Communication rétablie",
         });
       }
     } catch (err) {
-      this.logger.error({ err }, "Legrand H+C poll cycle failed");
+      this.logger.error({ err }, "Energy poll cycle failed");
       if (!this.pollFailed) {
         this.pollFailed = true;
         this.eventBus.emit({
           type: "system.alarm.raised",
           alarmId: "poll-fail:netatmo_hc",
           level: "error",
-          source: "Legrand Home+Control",
+          source: "Legrand Energy",
           message: `Poll en échec : ${err instanceof Error ? err.message : String(err)}`,
         });
       }
@@ -262,115 +153,128 @@ export class NetatmoPoller {
     }
   }
 
-  /** Returns the set of active HC module friendly names discovered. */
-  private async discoverModules(): Promise<Set<string>> {
+  /** Discover NLPC meters from homesdata and capture bridgeId. */
+  private async discoverMeters(): Promise<void> {
     const homesData = await this.bridge.getHomesData();
     const home = homesData.body.homes.find((h) => h.id === this.homeId);
-    if (!home) {
-      throw new Error(`Home ${this.homeId} not found in homesdata response`);
-    }
+    if (!home) throw new Error(`Home ${this.homeId} not found`);
 
     const modules = home.modules ?? [];
-    this.logger.info(
-      { homeId: this.homeId, homeName: home.name, moduleCount: modules.length },
-      "Legrand H+C discovery: scanning home",
-    );
-
-    if (modules.length === 0) {
-      throw new Error("Legrand H+C discovery returned 0 modules — API response may be incomplete");
-    }
-
     const activeIds = new Set<string>();
-    let supported = 0;
 
     for (const mod of modules) {
-      if (!isSupportedModule(mod.type)) {
-        this.logger.info(
-          { type: mod.type, name: mod.name, id: mod.id },
-          "Skipping unsupported module type",
-        );
-        continue;
+      if (!METER_TYPES.has(mod.type)) continue;
+
+      // Capture bridge ID from first NLPC with a bridge
+      if (mod.bridge && !this.bridgeId) {
+        this.bridgeId = mod.bridge;
+        this.logger.info({ moduleId: mod.id, bridge: mod.bridge }, "Bridge ID captured");
       }
 
-      // Energy meters: capture bridgeId + identify main meter for bridge-level energy injection
-      if (METER_TYPES.has(mod.type)) {
-        if (mod.bridge && !this.bridgeId) {
-          this.bridgeId = mod.bridge;
-          this.logger.info(
-            { moduleId: mod.id, bridge: mod.bridge, type: mod.type },
-            "Energy meter detected — bridge ID captured",
-          );
-        }
-        // First NLPC with a bridge becomes the main meter (receives bridge-level energy)
-        if (this.enableEnergy && !this.mainMeterName && mod.bridge) {
-          this.mainMeterName = mod.name || mod.id;
-          this.logger.info(
-            { moduleId: mod.id, name: this.mainMeterName },
-            "Main energy meter identified for bridge-level data",
-          );
-        }
+      // First NLPC with a bridge = main meter
+      if (!this.mainMeterName && mod.bridge) {
+        this.mainMeterName = mod.name || mod.id;
+        this.logger.info({ name: this.mainMeterName }, "Main energy meter identified");
       }
 
       const discovered = mapModuleToDiscovered(mod, this.homeId);
       this.deviceManager.upsertFromDiscovery("netatmo_hc", "netatmo_hc", discovered);
 
-      supported++;
-
-      // Track moduleId → friendlyName for status updates
       const name = mod.name || mod.id;
       this.moduleNames.set(mod.id, name);
-      activeIds.add(name); // sourceDeviceId = friendlyName
+      activeIds.add(name);
     }
 
-    this.logger.info(
-      { total: modules.length, supported, skipped: modules.length - supported },
-      "Legrand H+C discovery complete",
-    );
-
-    // Weather names are merged and stale cleanup is done in poll()
-    // after all Phase 1 discovery is complete (avoids race condition).
-    return activeIds;
+    // Only remove stale NLPC devices (not control devices which are now managed by legrand_control plugin)
+    this.deviceManager.removeStaleDevices("netatmo_hc", activeIds);
   }
 
-  private async pollStatus(expected?: {
-    moduleId: string;
-    param: string;
-    value: unknown;
-  }): Promise<boolean> {
+  /** Poll homestatus for NLPC power readings. */
+  private async pollMeterStatus(): Promise<void> {
     const status = await this.bridge.getHomeStatus(this.homeId);
     const modules = status.body.home.modules;
-    let updated = 0;
-    let confirmed = false;
 
     for (const mod of modules) {
       const friendlyName = this.moduleNames.get(mod.id);
-      if (!friendlyName) continue; // Not a supported/discovered module
-
+      if (!friendlyName) continue;
       const payload = extractStatusPayload(mod);
-      // Always call to refresh lastSeen even if payload is empty
       this.deviceManager.updateDeviceData("netatmo_hc", friendlyName, payload);
-      updated++;
-
-      if (expected && mod.id === expected.moduleId && payload[expected.param] === expected.value) {
-        confirmed = true;
-      }
     }
-
-    this.logger.info({ updated, total: modules.length }, "Legrand H+C status poll complete");
-    return confirmed;
   }
 
-  /**
-   * Poll bridge-level energy data (30-min granularity).
-   * Queries aligned 30-min windows after lastEnergyTimestamp.
-   * Writes raw energy (Wh) and demand_30min (W) to device data.
-   * Cumuls (day/hour/month/year) are handled by EnergyAggregator at equipment level.
-   */
-  /**
-   * Query a 30-min energy window and return consumption + production Wh.
-   * consumption = buy_from_grid$1 + buy_from_grid$2 + self_consumption (total house)
-   * production  = self_consumption + resell_to_grid (total solar)
-   */
+  /** Poll bridge-level energy data (30-min granularity). */
+  private async pollEnergyMeters(): Promise<void> {
+    if (!this.bridgeId || !this.mainMeterName) return;
+
+    try {
+      const nowTs = Math.floor(Date.now() / 1000);
+      const HALF_HOUR = 1800;
+      const lookbackStart = Math.floor((nowTs - ENERGY_LOOKBACK_S) / HALF_HOUR) * HALF_HOUR;
+
+      let newBuckets = 0;
+      let lastBucketEnergy = 0;
+      let lastBucketProduction = 0;
+
+      for (let windowStart = lookbackStart; windowStart < nowTs; windowStart += HALF_HOUR) {
+        const windowEnd = windowStart + HALF_HOUR;
+        if (windowEnd > nowTs) break;
+
+        const { consumption, production, autoconso, injection } = await this.queryEnergyWindow(
+          windowStart,
+          windowEnd,
+        );
+        if (consumption <= 0 && production <= 0) continue;
+
+        if (consumption > 0) {
+          this.deviceManager.updateDeviceData(
+            "netatmo_hc",
+            this.mainMeterName!,
+            { energy: consumption },
+            windowStart,
+          );
+        }
+
+        if (production > 0) {
+          const prodDeviceName = this.resolveProductionDeviceName();
+          if (prodDeviceName) {
+            this.deviceManager.updateDeviceData(
+              "netatmo_hc",
+              prodDeviceName,
+              { energy: production, autoconso, injection },
+              windowStart,
+            );
+          }
+        }
+
+        if (windowStart > this.lastEmittedWindowTs) {
+          newBuckets++;
+          lastBucketEnergy = consumption;
+          lastBucketProduction = production;
+          this.lastEmittedWindowTs = windowStart;
+        }
+      }
+
+      if (lastBucketEnergy > 0) {
+        this.deviceManager.updateDeviceData("netatmo_hc", this.mainMeterName!, {
+          demand_30min: Math.round(lastBucketEnergy * 2),
+        });
+      }
+
+      if (newBuckets > 0) {
+        this.logger.debug(
+          {
+            newBuckets,
+            demand30minW: Math.round(lastBucketEnergy * 2),
+            lastProdWh: lastBucketProduction,
+          },
+          "Energy poll: new 30-min buckets processed",
+        );
+      }
+    } catch (err) {
+      this.logger.warn({ err }, "Failed to poll bridge-level energy data");
+    }
+  }
+
   private async queryEnergyWindow(
     windowStart: number,
     windowEnd: number,
@@ -404,104 +308,15 @@ export class NetatmoPoller {
       autoconso += selfConso;
       injection += resellToGrid;
     }
-    const production = autoconso + injection;
-    return { consumption, production, autoconso, injection };
+    return { consumption, production: autoconso + injection, autoconso, injection };
   }
 
-  /**
-   * Resolve the Device friendlyName bound to the energy_production_meter Equipment.
-   * Returns null if no production Equipment exists or has no energy binding.
-   */
   private resolveProductionDeviceName(): string | null {
     const eq = this.equipmentManager.getAll().find((e) => e.type === "energy_production_meter");
     if (!eq) return null;
     const binding = this.equipmentManager
       .getDataBindingsWithValues(eq.id)
       .find((b) => b.alias === "energy");
-    if (!binding) return null;
-    return binding.deviceName ?? null;
-  }
-
-  private async pollEnergyMeters(): Promise<void> {
-    if (!this.enableEnergy || !this.bridgeId || !this.mainMeterName) return;
-
-    try {
-      const nowTs = Math.floor(Date.now() / 1000);
-      const HALF_HOUR = 1800;
-
-      // Sliding window: always query last 6h of aligned 30-min windows.
-      // InfluxDB overwrites existing points (same tags + timestamp = idempotent).
-      // No data lag guard needed: if Netatmo returns partial data for the latest
-      // window, the next poll cycle will overwrite it with the final value.
-      const lookbackStart = Math.floor((nowTs - ENERGY_LOOKBACK_S) / HALF_HOUR) * HALF_HOUR;
-
-      let newBuckets = 0;
-      let lastBucketEnergy = 0;
-      let lastBucketProduction = 0;
-
-      for (let windowStart = lookbackStart; windowStart < nowTs; windowStart += HALF_HOUR) {
-        const windowEnd = windowStart + HALF_HOUR;
-        // Only process windows that have ended
-        if (windowEnd > nowTs) break;
-
-        const { consumption, production, autoconso, injection } = await this.queryEnergyWindow(
-          windowStart,
-          windowEnd,
-        );
-        if (consumption <= 0 && production <= 0) continue;
-
-        // Pass sourceTimestamp = windowStart so HistoryWriter writes at the
-        // aligned 30-min boundary, not at "now".
-        // InfluxDB overwrites if the point already exists (idempotent).
-        if (consumption > 0) {
-          this.deviceManager.updateDeviceData(
-            "netatmo_hc",
-            this.mainMeterName!,
-            { energy: consumption },
-            windowStart,
-          );
-        }
-
-        // Write production, autoconso, injection on the production Device
-        if (production > 0) {
-          const prodDeviceName = this.resolveProductionDeviceName();
-          if (prodDeviceName) {
-            this.deviceManager.updateDeviceData(
-              "netatmo_hc",
-              prodDeviceName,
-              { energy: production, autoconso, injection },
-              windowStart,
-            );
-          }
-        }
-
-        if (windowStart > this.lastEmittedWindowTs) {
-          newBuckets++;
-          lastBucketEnergy = consumption;
-          lastBucketProduction = production;
-          this.lastEmittedWindowTs = windowStart;
-        }
-      }
-
-      // Write demand_30min (instantaneous power from last bucket)
-      if (lastBucketEnergy > 0) {
-        this.deviceManager.updateDeviceData("netatmo_hc", this.mainMeterName!, {
-          demand_30min: Math.round(lastBucketEnergy * 2), // Wh/30min → W
-        });
-      }
-
-      if (newBuckets > 0) {
-        this.logger.debug(
-          {
-            newBuckets,
-            demand30minW: Math.round(lastBucketEnergy * 2),
-            lastProdWh: lastBucketProduction,
-          },
-          "Energy poll: new 30-min buckets processed",
-        );
-      }
-    } catch (err) {
-      this.logger.warn({ err }, "Failed to poll bridge-level energy data");
-    }
+    return binding?.deviceName ?? null;
   }
 }

--- a/src/integrations/netatmo-hc/netatmo-types.ts
+++ b/src/integrations/netatmo-hc/netatmo-types.ts
@@ -29,8 +29,7 @@ export interface NetatmoModule {
   id: string;
   type: string;
   name: string;
-  bridge?: string; // gateway module ID
-  room_id?: string;
+  bridge?: string;
 }
 
 export interface NetatmoHomeStatusResponse {
@@ -46,21 +45,9 @@ export interface NetatmoHomeStatusResponse {
 export interface NetatmoModuleStatus {
   id: string;
   type: string;
-  // Switch / contactor / teleruptor
-  on?: boolean;
-  // Dimmer
-  brightness?: number;
-  // Shutter
-  current_position?: number;
-  target_position?: number;
-  // Energy meter
   power?: number;
   sum_energy_elec?: number;
-  // Gateway
-  wifi_strength?: number;
-  // Common
   reachable?: boolean;
-  firmware_revision?: number;
 }
 
 export interface NetatmoGetMeasureResponse {
@@ -68,67 +55,17 @@ export interface NetatmoGetMeasureResponse {
   status: string;
 }
 
-export interface NetatmoSetStateRequest {
-  home: {
-    id: string;
-    modules: Array<Record<string, unknown>>;
-  };
-}
-
 // ============================================================
-// Module type classification
+// Module type classification (energy meters only)
 // ============================================================
 
-/** Module types that support on/off commands */
-const SWITCHABLE_TYPES = new Set([
-  "NLPT", // Teleruptor
-  "NLPO", // Contactor
-  "NLL", // Light switch with neutral
-  "NLIS", // Double switch with neutral
-  "NLP", // Power outlet
-  "NLPM", // Mobile socket
-  "NLPD", // Dry contact
-  "NLC", // Cable outlet
-]);
-
-/** Module types that are dimmers */
-const DIMMER_TYPES = new Set([
-  "NLF", // Dimmer switch
-  "NLFE", // Dimmer switch evolution
-  "NLFN", // Dimmer with neutral
-]);
-
-/** Module types that are shutters */
-const SHUTTER_TYPES = new Set([
-  "NLV", // Roller shutter switch
-  "NLLV", // Roller shutter with level
-  "NLIV", // 1/2 gangs shutter
-]);
-
-/** Module types that are energy meters */
+/** Energy meter module types */
 export const METER_TYPES = new Set([
   "NLPC", // DIN energy meter
-  "NLE", // Ecometer
 ]);
-
-/** Module types that are gateways (data only) */
-const GATEWAY_TYPES = new Set([
-  "NLG", // Gateway
-  "NLGS", // Standard DIN gateway
-]);
-
-export function isSupportedModule(type: string): boolean {
-  return (
-    SWITCHABLE_TYPES.has(type) ||
-    DIMMER_TYPES.has(type) ||
-    SHUTTER_TYPES.has(type) ||
-    METER_TYPES.has(type) ||
-    GATEWAY_TYPES.has(type)
-  );
-}
 
 // ============================================================
-// Module → DiscoveredDevice mapping
+// Module → DiscoveredDevice mapping (NLPC only)
 // ============================================================
 
 interface DataDef {
@@ -138,83 +75,30 @@ interface DataDef {
   unit?: string;
 }
 
-interface OrderDef {
-  key: string;
-  type: DataType;
-  dispatchConfig: Record<string, unknown>;
-  min?: number;
-  max?: number;
-  enumValues?: string[];
-  unit?: string;
-}
-
-export function mapModuleToDiscovered(mod: NetatmoModule, homeId: string): DiscoveredDevice {
-  const data: DataDef[] = [];
-  const orders: OrderDef[] = [];
-  const dc = (param: string) => ({
-    homeId,
-    moduleId: mod.id,
-    param,
-    ...(mod.bridge ? { bridge: mod.bridge } : {}),
-  });
-
-  if (SWITCHABLE_TYPES.has(mod.type)) {
-    data.push({ key: "on", type: "boolean", category: "light_state" });
-    orders.push({ key: "on", type: "boolean", dispatchConfig: dc("on") });
-  } else if (DIMMER_TYPES.has(mod.type)) {
-    data.push({ key: "on", type: "boolean", category: "light_state" });
-    data.push({ key: "brightness", type: "number", category: "light_brightness", unit: "%" });
-    orders.push({ key: "on", type: "boolean", dispatchConfig: dc("on") });
-    orders.push({
-      key: "brightness",
-      type: "number",
-      dispatchConfig: dc("brightness"),
-      min: 0,
-      max: 100,
-      unit: "%",
-    });
-  } else if (SHUTTER_TYPES.has(mod.type)) {
-    data.push({ key: "current_position", type: "number", category: "shutter_position", unit: "%" });
-    orders.push({
-      key: "target_position",
-      type: "number",
-      dispatchConfig: dc("target_position"),
-      min: 0,
-      max: 100,
-      unit: "%",
-    });
-  } else if (METER_TYPES.has(mod.type)) {
-    data.push({ key: "power", type: "number", category: "power", unit: "W" });
-    data.push({ key: "energy", type: "number", category: "energy", unit: "Wh" });
-    data.push({ key: "autoconso", type: "number", category: "energy", unit: "Wh" });
-    data.push({ key: "injection", type: "number", category: "energy", unit: "Wh" });
-    data.push({ key: "demand_30min", type: "number", category: "power", unit: "W" });
-  } else if (GATEWAY_TYPES.has(mod.type)) {
-    data.push({ key: "wifi_strength", type: "number", category: "generic" });
-  }
+export function mapModuleToDiscovered(mod: NetatmoModule, _homeId: string): DiscoveredDevice {
+  const data: DataDef[] = [
+    { key: "power", type: "number", category: "power", unit: "W" },
+    { key: "energy", type: "number", category: "energy", unit: "Wh" },
+    { key: "autoconso", type: "number", category: "energy", unit: "Wh" },
+    { key: "injection", type: "number", category: "energy", unit: "Wh" },
+    { key: "demand_30min", type: "number", category: "power", unit: "W" },
+  ];
 
   return {
     friendlyName: mod.name || mod.id,
     manufacturer: "Legrand",
     model: mod.type,
     data,
-    orders,
+    orders: [],
   };
 }
 
 /**
- * Extract data payload from a module status response.
- * Returns a Record<string, unknown> suitable for DeviceManager.updateDeviceData().
+ * Extract data payload from a module status response (NLPC meters).
  */
 export function extractStatusPayload(mod: NetatmoModuleStatus): Record<string, unknown> {
   const payload: Record<string, unknown> = {};
-
-  if (mod.on !== undefined) payload.on = mod.on;
-  if (mod.brightness !== undefined) payload.brightness = mod.brightness;
-  if (mod.current_position !== undefined) payload.current_position = mod.current_position;
   if (mod.power !== undefined) payload.power = mod.power;
   if (mod.sum_energy_elec !== undefined) payload.sum_energy_elec = mod.sum_energy_elec;
-  if (mod.wifi_strength !== undefined) payload.wifi_strength = mod.wifi_strength;
-
   return payload;
 }


### PR DESCRIPTION
## Summary
- New plugin `sowel-plugin-legrand-control` v1.0.0 — Home+Control lights, shutters, plugs
- Built-in `netatmo_hc` stripped to energy-only (NLPC meters + getMeasure)
- Device migration by model: 6 control devices migrated, 4 energy devices preserved

## Changes
- **New plugin repo**: `mchacher/sowel-plugin-legrand-control` with full H+C support (discovery, status, orders, rapid poll, OAuth)
- **Built-in cleanup**: `netatmo_hc` renamed to "Legrand Energy", only handles NLPC meters + energy polling
- **Registry**: added `legrand_control` plugin

## Test plan
- [x] TypeScript compiles (zero errors)
- [x] All 454 tests pass
- [x] Lint passes (0 errors)
- [x] Plugin release v1.0.0 with pre-built tarball
- [x] Plugin installed + configured + started → Connected, 6 devices
- [x] Device migration: 6 control devices (NLPT/NLPO/NLG) → legrand_control
- [x] Energy devices (4 NLPC) remain under netatmo_hc with intact bindings
- [x] UI deployed