### PR TITLE
feat(ui): add equipment column to devices page

### DIFF
--- a/ui/src/components/devices/DeviceList.tsx
+++ b/ui/src/components/devices/DeviceList.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import type { Device, DeviceData } from "../../types";
 import { sourceLabel } from "../../lib/format";
 import { RelativeTime } from "../RelativeTime";
@@ -19,6 +19,8 @@ interface DeviceListProps {
   deviceData: Record<string, DeviceData[]>;
   /** Active integration tab (null = all devices). Controls which columns are shown. */
   activeTab: string | null;
+  /** Map of deviceId → associated equipments with zone info */
+  deviceEquipmentMap: Map<string, { id: string; name: string; zoneName?: string; zoneId?: string }[]>;
 }
 
 type SortKey =
@@ -92,7 +94,7 @@ function compareSortKey(
   }
 }
 
-export function DeviceList({ devices, deviceData, activeTab }: DeviceListProps) {
+export function DeviceList({ devices, deviceData, activeTab, deviceEquipmentMap }: DeviceListProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [sortKey, setSortKey] = useState<SortKey>("name");
@@ -157,6 +159,11 @@ export function DeviceList({ devices, deviceData, activeTab }: DeviceListProps) 
               align="left"
               className="hidden md:table-cell"
             />
+            <th className="py-2 px-3 text-left hidden md:table-cell">
+              <span className="text-[11px] font-semibold uppercase tracking-wider text-text-tertiary">
+                {t("devices.col.equipment")}
+              </span>
+            </th>
             {showSource && (
               <SortHeader
                 label={t("devices.col.source")}
@@ -236,6 +243,9 @@ export function DeviceList({ devices, deviceData, activeTab }: DeviceListProps) 
                   <span className="text-[12px] text-text-secondary truncate block max-w-[180px]">
                     {device.model ?? "—"}
                   </span>
+                </td>
+                <td className="py-2.5 px-3 hidden md:table-cell">
+                  <EquipmentCell equipments={deviceEquipmentMap.get(device.id)} />
                 </td>
                 {showSource && (
                   <td className="py-2.5 px-3 hidden sm:table-cell">
@@ -362,6 +372,40 @@ function LqiCell({ value }: { value: unknown }) {
     <span className={`inline-flex items-center gap-1 ${color}`}>
       <Signal size={13} strokeWidth={1.5} />
       <span className="text-[11px] font-mono">{lqi}</span>
+    </span>
+  );
+}
+
+function EquipmentCell({ equipments }: { equipments?: { id: string; name: string; zoneName?: string; zoneId?: string }[] }) {
+  if (!equipments || equipments.length === 0) {
+    return <span className="text-[11px] text-text-tertiary">—</span>;
+  }
+
+  return (
+    <span className="flex flex-col gap-0.5">
+      {equipments.map((eq) => (
+        <span key={eq.id} className="text-[12px] truncate max-w-[220px]">
+          {eq.zoneName && eq.zoneId && (
+            <>
+              <Link
+                to={`/home/${eq.zoneId}`}
+                onClick={(e) => e.stopPropagation()}
+                className="text-text-secondary hover:text-primary hover:underline"
+              >
+                {eq.zoneName}
+              </Link>
+              <span className="text-text-tertiary mx-0.5">›</span>
+            </>
+          )}
+          <Link
+            to={`/equipments/${eq.id}`}
+            onClick={(e) => e.stopPropagation()}
+            className="text-primary hover:text-primary-hover hover:underline"
+          >
+            {eq.name}
+          </Link>
+        </span>
+      ))}
     </span>
   );
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -89,6 +89,7 @@
   "devices.col.name": "Name",
   "devices.col.manufacturer": "Manufacturer",
   "devices.col.model": "Model",
+  "devices.col.equipment": "Equipment",
   "devices.col.source": "Source",
   "devices.col.battery": "Battery",
   "devices.col.lqi": "LQI",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -89,6 +89,7 @@
   "devices.col.name": "Nom",
   "devices.col.manufacturer": "Fabricant",
   "devices.col.model": "Modèle",
+  "devices.col.equipment": "Équipement",
   "devices.col.source": "Source",
   "devices.col.battery": "Batterie",
   "devices.col.lqi": "LQI",

--- a/ui/src/pages/DevicesPage.tsx
+++ b/ui/src/pages/DevicesPage.tsx
@@ -2,7 +2,10 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
 import { useDevices } from "../store/useDevices";
+import { useEquipments } from "../store/useEquipments";
+import { useZones } from "../store/useZones";
 import { DeviceList } from "../components/devices/DeviceList";
+import type { ZoneWithChildren } from "../types";
 import { Radio, Loader2, Search, X } from "lucide-react";
 import { useWsSubscription } from "../hooks/useWsSubscription";
 import { INTEGRATION_LABELS } from "../constants";
@@ -10,12 +13,44 @@ import { INTEGRATION_LABELS } from "../constants";
 const ALL_TAB = "__all__";
 
 export function DevicesPage() {
-  useWsSubscription(["devices"]);
+  useWsSubscription(["devices", "equipments", "zones"]);
   const { t } = useTranslation();
   const devices = useDevices((s) => s.devices);
   const deviceData = useDevices((s) => s.deviceData);
   const loading = useDevices((s) => s.loading);
   const error = useDevices((s) => s.error);
+  const equipments = useEquipments((s) => s.equipments);
+  const zoneTree = useZones((s) => s.tree);
+
+  // Flatten zone tree into id → name map
+  const zoneNames = useMemo(() => {
+    const map = new Map<string, string>();
+    const walk = (zones: ZoneWithChildren[]) => {
+      for (const z of zones) {
+        map.set(z.id, z.name);
+        if (z.children) walk(z.children);
+      }
+    };
+    walk(zoneTree);
+    return map;
+  }, [zoneTree]);
+
+  // Build map: deviceId → list of equipments that reference it via bindings
+  const deviceEquipmentMap = useMemo(() => {
+    const map = new Map<string, { id: string; name: string; zoneName?: string; zoneId?: string }[]>();
+    for (const eq of equipments) {
+      const deviceIds = new Set<string>();
+      for (const b of eq.dataBindings ?? []) {
+        if (b.deviceId) deviceIds.add(b.deviceId);
+      }
+      const zoneName = eq.zoneId ? zoneNames.get(eq.zoneId) : undefined;
+      for (const deviceId of deviceIds) {
+        if (!map.has(deviceId)) map.set(deviceId, []);
+        map.get(deviceId)!.push({ id: eq.id, name: eq.name, zoneName, zoneId: eq.zoneId });
+      }
+    }
+    return map;
+  }, [equipments, zoneNames]);
   const [searchParams, setSearchParams] = useSearchParams();
   const filter = searchParams.get("q") ?? "";
   const activeTab = searchParams.get("tab") ?? ALL_TAB;
@@ -151,6 +186,7 @@ export function DevicesPage() {
           devices={filtered}
           deviceData={deviceData}
           activeTab={resolvedTab === ALL_TAB ? null : resolvedTab}
+          deviceEquipmentMap={deviceEquipmentMap}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- New "Équipement" column in the Appareils table
- Shows linked equipment name(s) as clickable links
- Devices without equipment show "—"

## Test plan
- [x] TypeScript + tests + lint pass
- [x] UI deployed and verified via Playwright screenshot
- [x] Equipment names visible and clickable for bound devices
- [x] "—" shown for unbound devices