### PR TITLE
fix(zones): exclude setpoint from temperature aggregation

### DIFF
--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -458,7 +458,9 @@ export class ZoneAggregator {
 
       switch (category) {
         case "temperature":
-          if (typeof value === "number") {
+          // Only aggregate actual temperature readings (alias "temperature"),
+          // not setpoints or outside temperatures from thermostats
+          if (typeof value === "number" && binding.alias === "temperature") {
             acc.temperatureSum += value;
             acc.temperatureCount += 1;
           }


### PR DESCRIPTION
## Problem

Zone temperature averaging included thermostat setpoints and outside temperatures, causing incorrect values (e.g., RDC showed 20°C by averaging setpoint 20 + measured 18.5 + Bureau 21.4 = 19.97).

## Fix

Only aggregate bindings with `alias === "temperature"` for the temperature category. Excludes `setpoint` and `outsideTemperature`.

## Test plan

- [x] TypeScript, tests, lint pass
- [ ] RDC temperature should now reflect only actual measured temperatures