### PR TITLE
feat(backup): auto-download missing plugins + dynamic data files (spec 058)

### DIFF
--- a/specs/058-backup-completeness/spec.md
+++ b/specs/058-backup-completeness/spec.md
@@ -1,0 +1,64 @@
+# 058 — Backup Completeness & Plugin Auto-Download
+
+## Summary
+
+Ensure backup/restore cycle is complete for deployment to a new machine. Two changes:
+
+1. **Plugin auto-download**: At startup, if a plugin exists in the `plugins` DB table but its directory is missing on disk, automatically download it from GitHub using the repo field in the stored manifest.
+
+2. **Data files**: Backup all token files and secrets from `data/` directory dynamically, instead of a hardcoded list that misses new plugins' token files.
+
+## Plugin Auto-Download
+
+### Flow
+
+```
+Startup:
+  PluginLoader.loadAll()
+    → for each enabled integration plugin in DB:
+      → if plugins/<id>/dist/index.js missing:
+        → log warn "Plugin <id> missing on disk, downloading..."
+        → PackageManager.installFromGitHub(manifest.repo)  // already exists
+        → loadPlugin(id)
+      → else: loadPlugin(id) as usual
+
+  RecipeLoader.loadAll()
+    → same logic for recipe packages
+```
+
+### Edge cases
+
+- No internet → download fails, plugin stays unloaded, error logged
+- Manifest in DB has no repo → skip, warn log
+- Plugin already on disk → no download, normal flow
+
+## Data Files
+
+### Current (hardcoded, incomplete)
+
+```typescript
+const DATA_FILES = [".jwt-secret", "panasonic-tokens.json", "netatmo-tokens.json"];
+```
+
+### After (dynamic scan)
+
+Export: scan `data/` for `*.json` and `.*` files (excluding `sowel.db`, `sowel.pid`, logs).
+Restore: extract all files from `data/` directory in the ZIP.
+
+This automatically covers any future plugin token files without code changes.
+
+## Files Changed
+
+| File                           | Change                                               |
+| ------------------------------ | ---------------------------------------------------- |
+| `src/plugins/plugin-loader.ts` | Auto-download missing plugins before loading         |
+| `src/recipes/recipe-loader.ts` | Auto-download missing recipes before loading         |
+| `src/api/routes/backup.ts`     | Dynamic data file scanning instead of hardcoded list |
+
+## Acceptance Criteria
+
+- [ ] Missing integration plugins auto-downloaded at startup
+- [ ] Missing recipe packages auto-downloaded at startup
+- [ ] Backup exports all `data/*.json` + `data/.*` files (not hardcoded)
+- [ ] Restore recreates all data files from ZIP
+- [ ] TypeScript compiles, all tests pass, lint clean

--- a/src/api/routes/backup.ts
+++ b/src/api/routes/backup.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import archiver from "archiver";
 import AdmZip from "adm-zip";
@@ -46,8 +46,23 @@ const BACKUP_TABLES = [
 // Reverse order for deletion (children first)
 const DELETE_ORDER = [...BACKUP_TABLES].reverse();
 
-// Data files to include in backup (relative to dataDir)
-const DATA_FILES = [".jwt-secret", "panasonic-tokens.json", "netatmo-tokens.json"];
+// Exclude these files from data/ backup (managed separately or transient)
+const DATA_FILES_EXCLUDE = new Set(["sowel.db", "sowel.db-wal", "sowel.db-shm", "sowel.pid"]);
+const DATA_FILES_EXCLUDE_EXT = new Set([".db", ".pid", ".log"]);
+
+/** Scan data/ directory for files to include in backup (tokens, secrets, etc.) */
+function scanDataFiles(dataDir: string): string[] {
+  if (!existsSync(dataDir)) return [];
+  const files: string[] = [];
+  for (const entry of readdirSync(dataDir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    if (DATA_FILES_EXCLUDE.has(entry.name)) continue;
+    const ext = entry.name.includes(".") ? entry.name.slice(entry.name.lastIndexOf(".")) : "";
+    if (DATA_FILES_EXCLUDE_EXT.has(ext)) continue;
+    files.push(entry.name);
+  }
+  return files;
+}
 
 interface BackupPayload {
   version: 2;
@@ -199,8 +214,9 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupDeps): vo
       }
     }
 
-    // 4. Append data files (tokens, JWT secret)
-    for (const filename of DATA_FILES) {
+    // 4. Append data files (tokens, JWT secret — dynamically scanned)
+    const dataFiles = scanDataFiles(dataDir);
+    for (const filename of dataFiles) {
       const filePath = resolve(dataDir, filename);
       if (existsSync(filePath)) {
         try {
@@ -380,11 +396,12 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupDeps): vo
       logger.warn("InfluxDB not connected — skipping time-series restore");
     }
 
-    // 4. Restore data files
+    // 4. Restore data files (extract all data/* entries from ZIP)
     let filesRestored = 0;
-    for (const filename of DATA_FILES) {
-      const entry = zip.getEntry(`data/${filename}`);
-      if (!entry) continue;
+    for (const entry of zip.getEntries()) {
+      if (!entry.entryName.startsWith("data/") || entry.isDirectory) continue;
+      const filename = entry.entryName.slice("data/".length);
+      if (!filename || DATA_FILES_EXCLUDE.has(filename)) continue;
 
       try {
         const filePath = resolve(dataDir, filename);

--- a/src/packages/package-manager.ts
+++ b/src/packages/package-manager.ts
@@ -194,6 +194,41 @@ export class PackageManager {
   }
 
   /**
+   * Download files for a package that exists in DB but is missing on disk.
+   * Used after backup restore — downloads tarball without modifying DB.
+   */
+  async downloadMissing(repo: string): Promise<void> {
+    const tmpDir = resolve(this.pluginsDir, ".tmp");
+    try {
+      const extractDir = await this.downloadPrebuiltAsset(repo, tmpDir);
+
+      const manifestPath = resolve(extractDir, "manifest.json");
+      if (!existsSync(manifestPath)) {
+        throw new Error("Package archive does not contain manifest.json");
+      }
+
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as PluginManifest;
+
+      const pkgDir = resolve(this.pluginsDir, manifest.id);
+      if (existsSync(pkgDir)) {
+        rmSync(pkgDir, { recursive: true });
+      }
+      await rename(extractDir, pkgDir);
+
+      this.logger.info(
+        { packageId: manifest.id, version: manifest.version },
+        "Missing package downloaded",
+      );
+    } finally {
+      try {
+        if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+
+  /**
    * Update — download new version, replace files, update DB.
    * Caller must stop/unload before calling and reload after.
    */

--- a/src/plugins/plugin-loader.ts
+++ b/src/plugins/plugin-loader.ts
@@ -49,6 +49,33 @@ export class PluginLoader {
         continue;
       }
 
+      // Auto-download if plugin directory is missing (e.g. after backup restore)
+      const entryPath = resolve(
+        this.packageManager.getPackageDir(pkg.manifest.id),
+        "dist/index.js",
+      );
+      if (!existsSync(entryPath)) {
+        const repo = pkg.manifest.repo;
+        if (repo) {
+          this.logger.warn(
+            { pluginId: pkg.manifest.id, repo },
+            "Plugin missing on disk, downloading",
+          );
+          try {
+            await this.packageManager.downloadMissing(repo);
+          } catch (err) {
+            this.logger.error({ err, pluginId: pkg.manifest.id }, "Failed to auto-download plugin");
+            continue;
+          }
+        } else {
+          this.logger.warn(
+            { pluginId: pkg.manifest.id },
+            "Plugin missing on disk and no repo in manifest, skipping",
+          );
+          continue;
+        }
+      }
+
       try {
         await this.loadPlugin(pkg.manifest.id);
         loaded++;

--- a/src/recipes/recipe-loader.ts
+++ b/src/recipes/recipe-loader.ts
@@ -36,6 +36,33 @@ export class RecipeLoader {
         continue;
       }
 
+      // Auto-download if recipe directory is missing (e.g. after backup restore)
+      const entryPath = resolve(
+        this.packageManager.getPackageDir(pkg.manifest.id),
+        "dist/index.js",
+      );
+      if (!existsSync(entryPath)) {
+        const repo = pkg.manifest.repo;
+        if (repo) {
+          this.logger.warn(
+            { recipeId: pkg.manifest.id, repo },
+            "Recipe missing on disk, downloading",
+          );
+          try {
+            await this.packageManager.downloadMissing(repo);
+          } catch (err) {
+            this.logger.error({ err, recipeId: pkg.manifest.id }, "Failed to auto-download recipe");
+            continue;
+          }
+        } else {
+          this.logger.warn(
+            { recipeId: pkg.manifest.id },
+            "Recipe missing on disk and no repo in manifest, skipping",
+          );
+          continue;
+        }
+      }
+
       try {
         await this.loadRecipe(pkg.manifest.id);
         loaded++;


### PR DESCRIPTION
## Summary

- **Plugin auto-download**: PluginLoader + RecipeLoader detect missing plugin directories at startup and auto-download from GitHub using the repo field in the DB manifest. Enables seamless backup/restore to a new machine.
- **Dynamic data files**: Backup export scans `data/` directory dynamically instead of a hardcoded list. Automatically includes all token files (legrand, netatmo, panasonic, etc.) and secrets.

## Changes

| File | Change |
|------|--------|
| `src/plugins/plugin-loader.ts` | Auto-download missing integration plugins |
| `src/recipes/recipe-loader.ts` | Auto-download missing recipe packages |
| `src/api/routes/backup.ts` | Dynamic data file scan + restore all data/* from ZIP |

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 267 tests pass
- [x] `npx eslint src/` — 0 errors
- [ ] Manual: backup ZIP includes all token files
- [ ] Manual: restore on fresh instance → plugins auto-download