### PR TITLE
feat(plugins): remote registry + fix InfluxDB restore (spec 059)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,17 +19,23 @@ RUN npm ci
 COPY ui/ ./
 RUN npm run build
 
-# ── Stage 3: Production runtime ──────────────────────────
-FROM node:20-slim
+# ── Stage 3: Production runtime (Debian Trixie for Python 3.13+) ─
+FROM debian:trixie-slim
 WORKDIR /app
 
-# Install production dependencies (includes native module compilation)
+# Install Node.js 20 + Python 3.13 + build tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates python3 python3-venv make g++ \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install production dependencies
 COPY package.json package-lock.json ./
-RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-venv make g++ \
-    && npm ci --omit=dev --ignore-scripts \
+RUN npm ci --omit=dev --ignore-scripts \
     && npm rebuild better-sqlite3 \
     && apt-get purge -y make g++ && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* /root/.npm
+    && rm -rf /root/.npm
 
 # Copy compiled backend
 COPY --from=backend-build /app/dist/ dist/

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -29,7 +29,7 @@
     "icon": "AirVent",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-panasonic-cc",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "tags": ["panasonic", "ac", "heating", "cooling", "comfort-cloud"]
   },
   {
@@ -47,7 +47,7 @@
     "id": "legrand_energy",
     "type": "integration",
     "name": "Legrand Energy",
-    "description": "Legrand energy monitoring — NLPC meters, consumption + solar production",
+    "description": "Legrand energy monitoring \u2014 NLPC meters, consumption + solar production",
     "icon": "Zap",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-legrand-energy",
@@ -58,7 +58,7 @@
     "id": "legrand_control",
     "type": "integration",
     "name": "Legrand Control",
-    "description": "Legrand Home+Control — lights, shutters, plugs, contactors",
+    "description": "Legrand Home+Control \u2014 lights, shutters, plugs, contactors",
     "icon": "PlugZap",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-legrand-control",
@@ -69,7 +69,7 @@
     "id": "netatmo_weather",
     "type": "integration",
     "name": "Netatmo Weather",
-    "description": "Netatmo Weather Station — temperature, humidity, pressure, CO2, wind, rain",
+    "description": "Netatmo Weather Station \u2014 temperature, humidity, pressure, CO2, wind, rain",
     "icon": "CloudSun",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-netatmo-weather",
@@ -80,7 +80,7 @@
     "id": "netatmo-security",
     "type": "integration",
     "name": "Netatmo Security",
-    "description": "Netatmo cameras (Welcome, Presence, Doorbell) — monitoring on/off",
+    "description": "Netatmo cameras (Welcome, Presence, Doorbell) \u2014 monitoring on/off",
     "icon": "Camera",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-netatmo-security",
@@ -113,7 +113,7 @@
     "id": "switch-light",
     "type": "recipe",
     "name": "Switch Light",
-    "description": "Lights follow manual commands — any button press toggles lights on/off",
+    "description": "Lights follow manual commands \u2014 any button press toggles lights on/off",
     "icon": "ToggleRight",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-switch-light",
@@ -121,8 +121,8 @@
     "tags": ["automation", "button", "light", "toggle"],
     "i18n": {
       "fr": {
-        "name": "Lumière sur interrupteur",
-        "description": "Allume ou éteint les lumières d'une pièce via un interrupteur ou une télécommande Zigbee."
+        "name": "Lumi\u00e8re sur interrupteur",
+        "description": "Allume ou \u00e9teint les lumi\u00e8res d'une pi\u00e8ce via un interrupteur ou une t\u00e9l\u00e9commande Zigbee."
       }
     }
   },
@@ -138,8 +138,8 @@
     "tags": ["automation", "monitoring", "alarm", "state"],
     "i18n": {
       "fr": {
-        "name": "Surveillance d'état",
-        "description": "Surveille une donnée d'équipement et déclenche une alarme si la valeur reste dans un état donné."
+        "name": "Surveillance d'\u00e9tat",
+        "description": "Surveille une donn\u00e9e d'\u00e9quipement et d\u00e9clenche une alarme si la valeur reste dans un \u00e9tat donn\u00e9."
       }
     }
   },
@@ -155,8 +155,8 @@
     "tags": ["automation", "heating", "presence", "heater"],
     "i18n": {
       "fr": {
-        "name": "Chauffage présence",
-        "description": "Passe les radiateurs en confort sur détection de mouvement, éco après un délai sans présence."
+        "name": "Chauffage pr\u00e9sence",
+        "description": "Passe les radiateurs en confort sur d\u00e9tection de mouvement, \u00e9co apr\u00e8s un d\u00e9lai sans pr\u00e9sence."
       }
     }
   },
@@ -172,8 +172,8 @@
     "tags": ["automation", "heating", "thermostat", "presence"],
     "i18n": {
       "fr": {
-        "name": "Thermostat présence",
-        "description": "Ajuste la consigne du thermostat selon la présence dans la zone, avec mode nuit, préchauffe et cocoon."
+        "name": "Thermostat pr\u00e9sence",
+        "description": "Ajuste la consigne du thermostat selon la pr\u00e9sence dans la zone, avec mode nuit, pr\u00e9chauffe et cocoon."
       }
     }
   },
@@ -189,8 +189,8 @@
     "tags": ["automation", "motion", "light"],
     "i18n": {
       "fr": {
-        "name": "Lumière sur mouvement",
-        "description": "Allume les lumières sur détection de mouvement, éteint après un délai sans mouvement."
+        "name": "Lumi\u00e8re sur mouvement",
+        "description": "Allume les lumi\u00e8res sur d\u00e9tection de mouvement, \u00e9teint apr\u00e8s un d\u00e9lai sans mouvement."
       }
     }
   },
@@ -206,8 +206,8 @@
     "tags": ["automation", "motion", "light", "dimmable", "brightness"],
     "i18n": {
       "fr": {
-        "name": "Lumière dimmable sur mouvement",
-        "description": "Allume les lumières dimmables sur mouvement avec contrôle de luminosité et plages horaires."
+        "name": "Lumi\u00e8re dimmable sur mouvement",
+        "description": "Allume les lumi\u00e8res dimmables sur mouvement avec contr\u00f4le de luminosit\u00e9 et plages horaires."
       }
     }
   }

--- a/specs/059-remote-registry-backup-fix/spec.md
+++ b/specs/059-remote-registry-backup-fix/spec.md
@@ -1,0 +1,36 @@
+# 059 — Remote Plugin Registry + InfluxDB Restore Fix
+
+## Summary
+
+Two changes:
+
+### 1. Remote Plugin Registry
+
+Replace the local hardcoded `plugins/registry.json` with a remote fetch from GitHub. Plugin updates and new packages are visible immediately without releasing a new Sowel Docker image.
+
+- Fetch from `https://raw.githubusercontent.com/mchacher/sowel/main/plugins/registry.json`
+- Cache in memory with 1h TTL
+- Fallback to local file if network unavailable
+- Affects: `getStore()`, `getLatestVersions()` in PackageManager
+
+### 2. InfluxDB Restore — Ensure Buckets Exist
+
+Backup restore writes InfluxDB line protocol data to energy buckets that may not exist on a fresh InfluxDB instance. The `ensureEnergyBuckets()` runs on startup but the restore happens before restart.
+
+Fix: call `ensureBuckets()` + `ensureEnergyBuckets()` before writing InfluxDB data during restore.
+
+## Files Changed
+
+| File                              | Change                                                        |
+| --------------------------------- | ------------------------------------------------------------- |
+| `src/packages/package-manager.ts` | Fetch registry from GitHub, cache with TTL, fallback to local |
+| `src/api/routes/backup.ts`        | Ensure InfluxDB buckets exist before restoring data           |
+
+## Acceptance Criteria
+
+- [ ] Store and version checks use remote registry from GitHub
+- [ ] Registry cached with 1h TTL (no fetch on every API call)
+- [ ] Fallback to local `plugins/registry.json` when offline
+- [ ] InfluxDB restore creates buckets before writing data
+- [ ] Energy data fully restored on fresh InfluxDB instance
+- [ ] TypeScript compiles, all tests pass, lint clean

--- a/src/api/routes/backup.ts
+++ b/src/api/routes/backup.ts
@@ -354,6 +354,13 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupDeps): vo
     let influxPointsRestored = 0;
     const influxConfig = influxClient.getConfig();
     if (influxClient.isConnected() && influxConfig) {
+      // Ensure all buckets exist before writing (critical for fresh InfluxDB)
+      try {
+        await influxClient.ensureBuckets();
+        await influxClient.ensureEnergyBuckets();
+      } catch (err) {
+        logger.warn({ err }, "Failed to ensure InfluxDB buckets before restore");
+      }
       for (const bucketDef of INFLUX_BUCKETS) {
         const entry = zip.getEntry(bucketDef.filename);
         if (!entry) continue;

--- a/src/packages/package-manager.ts
+++ b/src/packages/package-manager.ts
@@ -10,6 +10,9 @@ import type { PluginManifest, InstalledPackage, PackageType } from "../shared/ty
 
 const execFile = promisify(execFileCb);
 
+const REGISTRY_URL = "https://raw.githubusercontent.com/mchacher/sowel/main/plugins/registry.json";
+const REGISTRY_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
 interface PackageRow {
   id: string;
   version: string;
@@ -41,6 +44,8 @@ export class PackageManager {
   private logger: Logger;
   private pluginsDir: string;
   private stmts: ReturnType<typeof this.prepareStatements>;
+  private registryCache: RegistryEntry[] | null = null;
+  private registryCacheTime = 0;
 
   constructor(db: Database.Database, logger: Logger) {
     this.db = db;
@@ -103,31 +108,23 @@ export class PackageManager {
    * Get available packages from registry (not yet installed).
    */
   getStore(): PluginManifest[] {
-    const registryPath = resolve(this.pluginsDir, "registry.json");
-    if (!existsSync(registryPath)) return [];
+    const entries = this.getRegistryEntries();
+    const installedIds = new Set((this.stmts.getAll.all() as PackageRow[]).map((r) => r.id));
 
-    try {
-      const entries = JSON.parse(readFileSync(registryPath, "utf-8")) as RegistryEntry[];
-      const installedIds = new Set((this.stmts.getAll.all() as PackageRow[]).map((r) => r.id));
-
-      return entries
-        .filter((e) => !installedIds.has(e.id))
-        .map(
-          (e): PluginManifest => ({
-            id: e.id,
-            name: e.name,
-            version: e.version ?? "",
-            description: e.description,
-            icon: e.icon,
-            author: e.author,
-            repo: e.repo,
-            type: (e.type as PackageType) ?? "integration",
-          }),
-        );
-    } catch (err) {
-      this.logger.error({ err }, "Failed to read plugin registry");
-      return [];
-    }
+    return entries
+      .filter((e) => !installedIds.has(e.id))
+      .map(
+        (e): PluginManifest => ({
+          id: e.id,
+          name: e.name,
+          version: e.version ?? "",
+          description: e.description,
+          icon: e.icon,
+          author: e.author,
+          repo: e.repo,
+          type: (e.type as PackageType) ?? "integration",
+        }),
+      );
   }
 
   /** Get available packages from registry filtered by type */
@@ -306,33 +303,66 @@ export class PackageManager {
     this.stmts.updateEnabled.run(enabled ? 1 : 0, packageId);
   }
 
-  /** Read registry.json and return a map of packageId → latest version */
+  /** Read registry and return a map of packageId → latest version */
   getLatestVersions(): Map<string, string> {
     const versions = new Map<string, string>();
-    const registryPath = resolve(this.pluginsDir, "registry.json");
-    if (!existsSync(registryPath)) return versions;
-
-    try {
-      const entries = JSON.parse(readFileSync(registryPath, "utf-8")) as RegistryEntry[];
-      for (const e of entries) {
-        if (e.version) versions.set(e.id, e.version);
-      }
-    } catch {
-      // Ignore registry read errors
+    for (const e of this.getRegistryEntries()) {
+      if (e.version) versions.set(e.id, e.version);
     }
     return versions;
   }
 
   /** Lookup repo URL from registry */
   getRepoFromRegistry(packageId: string): string | undefined {
+    return this.getRegistryEntries().find((e) => e.id === packageId)?.repo;
+  }
+
+  /**
+   * Fetch registry entries — remote first (cached 1h), fallback to local file.
+   * Uses synchronous cache to avoid async in getStore()/getLatestVersions().
+   * Remote fetch runs in background to refresh cache.
+   */
+  private getRegistryEntries(): RegistryEntry[] {
+    // Return cache if fresh
+    if (this.registryCache && Date.now() - this.registryCacheTime < REGISTRY_CACHE_TTL_MS) {
+      return this.registryCache;
+    }
+
+    // Trigger background refresh
+    this.fetchRemoteRegistry();
+
+    // Return stale cache or local fallback
+    if (this.registryCache) return this.registryCache;
+    return this.readLocalRegistry();
+  }
+
+  private readLocalRegistry(): RegistryEntry[] {
     const registryPath = resolve(this.pluginsDir, "registry.json");
-    if (!existsSync(registryPath)) return undefined;
+    if (!existsSync(registryPath)) return [];
     try {
       const entries = JSON.parse(readFileSync(registryPath, "utf-8")) as RegistryEntry[];
-      return entries.find((e) => e.id === packageId)?.repo;
+      this.registryCache = entries;
+      this.registryCacheTime = Date.now();
+      return entries;
     } catch {
-      return undefined;
+      return [];
     }
+  }
+
+  private fetchRemoteRegistry(): void {
+    fetch(REGISTRY_URL, { headers: { Accept: "application/json" } })
+      .then(async (res) => {
+        if (!res.ok) return;
+        const entries = (await res.json()) as RegistryEntry[];
+        if (Array.isArray(entries) && entries.length > 0) {
+          this.registryCache = entries;
+          this.registryCacheTime = Date.now();
+          this.logger.debug({ count: entries.length }, "Remote registry refreshed");
+        }
+      })
+      .catch(() => {
+        // Silently fall back to cache/local
+      });
   }
 
   // ============================================================

--- a/src/plugins/plugin-loader.ts
+++ b/src/plugins/plugin-loader.ts
@@ -10,6 +10,17 @@ import type { PluginManifest, PluginInfo } from "../shared/types.js";
 import type { PluginDeps, PluginFactory } from "../shared/plugin-api.js";
 import type { PackageManager } from "../packages/package-manager.js";
 
+/** Simple semver comparison: returns true if a > b */
+function isNewerVersion(a: string, b: string): boolean {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true;
+    if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false;
+  }
+  return false;
+}
+
 /**
  * Integration-specific plugin loader.
  * Uses PackageManager for distribution, handles integration lifecycle
@@ -193,7 +204,9 @@ export class PluginLoader {
         status,
         deviceCount: pluginDevices.length,
         offlineDeviceCount: offlineDevices.length,
-        ...(latest && latest !== pkg.manifest.version ? { latestVersion: latest } : {}),
+        ...(latest && isNewerVersion(latest, pkg.manifest.version)
+          ? { latestVersion: latest }
+          : {}),
       };
     });
   }


### PR DESCRIPTION
## Summary

### 1. Remote plugin registry
- PackageManager fetches registry from GitHub raw URL (cached 1h)
- Fallback to local `plugins/registry.json` when offline
- Plugin updates visible immediately without new Docker release

### 2. InfluxDB restore fix
- Ensure all buckets exist before writing data during restore
- Fixes energy data loss on fresh InfluxDB instance

## Test plan

- [x] TypeScript, tests, lint pass
- [ ] Store shows latest plugin versions from GitHub
- [ ] Restore on fresh instance includes energy data