### PR TITLE
docs: refresh documentation for plugin V2 + self-update + deployment

### DIFF
--- a/.claude/skills/debug-bug/reference.md
+++ b/.claude/skills/debug-bug/reference.md
@@ -1,32 +1,45 @@
 # Debug Bug Reference
 
-## Log Modules
+## Log Modules (current, spec 053+)
 
-| Module                         | Domain                       |
-| ------------------------------ | ---------------------------- |
-| `device-manager`               | Device CRUD, data updates    |
-| `equipment-manager`            | Equipment CRUD, bindings     |
-| `zone-aggregator`              | Zone aggregation             |
-| `recipe-manager`               | Recipe instantiation         |
-| `mode-manager`                 | Mode activation/deactivation |
-| `integration-registry`         | Integration lifecycle        |
-| `integration-zigbee2mqtt`      | Z2M MQTT integration         |
-| `legrand-hc`                   | Netatmo/Legrand Home+Control |
-| `legrand-hc-poller`            | Netatmo polling              |
-| `integration-panasonic-cc`     | Panasonic Comfort Cloud      |
-| `integration-mcz-maestro`      | MCZ Maestro stove            |
-| `plugin-manager`               | Plugin lifecycle             |
-| `plugin:smartthings`           | SmartThings plugin           |
-| `weather-forecast`             | Weather forecast plugin      |
-| `history-writer`               | InfluxDB writes              |
-| `energy-aggregator`            | Energy HP/HC classification  |
-| `websocket`                    | WebSocket connections        |
-| `auth-service`                 | Authentication, tokens       |
-| `mqtt`                         | MQTT broker connections      |
-| `mqtt-publish-service`         | MQTT publishers              |
-| `notification-publish-service` | Notifications                |
-| `database`                     | SQLite operations            |
-| `migrations`                   | Schema migrations            |
+| Module                             | Domain                                        |
+| ---------------------------------- | --------------------------------------------- |
+| `device-manager`                   | Device CRUD, data updates                     |
+| `equipment-manager`                | Equipment CRUD, bindings, order dispatch      |
+| `zone-manager` / `zone-aggregator` | Zones, aggregation                            |
+| `sunlight-manager`                 | Sunrise/sunset, isDaylight transitions        |
+| `recipe-manager`                   | Recipe engine (instances, triggers, actions)  |
+| `mode-manager`                     | Mode activation/deactivation                  |
+| `calendar-manager`                 | Croner calendar slots                         |
+| `button-action-manager`            | Physical button actions                       |
+| `integration-registry`             | Integration lifecycle (plugins register here) |
+| `plugin-loader`                    | Plugin loader (integrations)                  |
+| `recipe-loader`                    | Recipe loader (recipe packages)               |
+| `package-manager`                  | Package download, install, update, remove     |
+| `plugin:zigbee2mqtt`               | Zigbee2MQTT plugin                            |
+| `plugin:lora2mqtt`                 | LoRa2MQTT plugin                              |
+| `plugin:panasonic_cc`              | Panasonic Comfort Cloud plugin                |
+| `plugin:mcz_maestro`               | MCZ Maestro plugin                            |
+| `plugin:legrand_control`           | Legrand Home+Control plugin                   |
+| `plugin:legrand_energy`            | Legrand energy monitoring plugin              |
+| `plugin:netatmo_weather`           | Netatmo Weather Station plugin                |
+| `plugin:smartthings`               | Samsung SmartThings plugin                    |
+| `plugin:weather-forecast`          | Open-Meteo weather forecast plugin            |
+| `backup-manager`                   | Backup export/restore                         |
+| `update-manager`                   | Self-update (helper container)                |
+| `version-checker`                  | GitHub releases poll                          |
+| `history-writer`                   | InfluxDB history writes                       |
+| `energy-aggregator`                | Energy HP/HC classification, aggregation      |
+| `websocket`                        | WebSocket connections                         |
+| `auth-service`                     | Authentication, tokens                        |
+| `mqtt-broker-manager`              | Outbound MQTT brokers                         |
+| `mqtt-publish-service`             | MQTT publishers                               |
+| `notification-publish-service`     | Notifications (telegram, ntfy, webhook, FCM)  |
+| `influx-client`                    | InfluxDB connection / queries                 |
+| `database`                         | SQLite operations                             |
+| `migrations`                       | Schema migrations                             |
+
+The plugin modules are always prefixed `plugin:<id>` — the `<id>` matches the `manifest.json` id. Some plugins add a second-level module (e.g. `plugin:zigbee2mqtt > z2m-parser`).
 
 ## Log Retrieval Commands
 
@@ -92,6 +105,26 @@ curl -s http://localhost:3000/api/v1/zones/<id> \
 # SQLite quick query
 sqlite3 data/sowel.db "SELECT key, substr(value, 1, 80) FROM settings;"
 ```
+
+## Production log file access (spec 015, updated spec 060)
+
+The ring buffer is in-memory only and lost on restart. **For post-incident investigation after a container recreation (e.g. after self-update)**, use the persistent log files on the `sowel-data` volume:
+
+```bash
+# SSH to sowelox
+ssh mchacher@192.168.0.230
+
+# List log files (14 days daily rotation)
+docker exec sowel ls -la /app/data/logs/
+
+# View today's log (sowel.6.log is usually the newest — file numbers rotate)
+docker exec sowel cat /app/data/logs/sowel.6.log | tail -100
+
+# Grep a time window (UTC in logs) for error/warn
+docker exec sowel sh -c 'cat /app/data/logs/sowel.6.log | grep -E "2026-04-11T07:" | grep -E "\"level\":\"(error|warn)\""'
+```
+
+⚠️ **Logs are in UTC** (`time` field). To correlate with user timestamps (typically local CEST = UTC+2), convert before filtering.
 
 ## InfluxDB Diagnostics (energy/history bugs)
 

--- a/.claude/skills/plugin-integration/SKILL.md
+++ b/.claude/skills/plugin-integration/SKILL.md
@@ -20,18 +20,24 @@ All conventions are in `CLAUDE.md`. For the full UI touchpoint checklist, see [r
 
 ### 1.1 Read Essential Documentation
 
-| Document                                   | Purpose                                     |
-| ------------------------------------------ | ------------------------------------------- |
-| `src/shared/types.ts`                      | EquipmentType union, IntegrationPlugin, etc |
-| `src/shared/plugin-api.ts`                 | PluginDeps interface, PluginFactory type    |
-| `src/plugins/plugin-manager.ts`            | Plugin lifecycle (load, install, update)    |
-| `src/integrations/integration-registry.ts` | IntegrationPlugin interface                 |
-| `CLAUDE.md`                                | Project conventions and rules               |
+| Document                                   | Purpose                                              |
+| ------------------------------------------ | ---------------------------------------------------- |
+| `CLAUDE.md`                                | Project conventions and rules (entry point)          |
+| `docs/technical/plugin-development.md`     | Full plugin development guide (end-to-end)           |
+| `docs/technical/architecture.md`           | Plugin architecture V2 section                       |
+| `src/shared/types.ts`                      | EquipmentType union, IntegrationPlugin, etc          |
+| `src/shared/plugin-api.ts`                 | PluginDeps interface, PluginFactory type             |
+| `src/packages/package-manager.ts`          | Package lifecycle (install from GitHub, update, etc) |
+| `src/plugins/plugin-loader.ts`             | Integration plugin loader (factory + registration)   |
+| `src/integrations/integration-registry.ts` | IntegrationPlugin interface                          |
 
-Also study an existing plugin for reference:
+Also study an existing plugin repo for reference:
 
-- `sowel-plugin-weather-forecast` — simple polling plugin (read-only)
-- `sowel-plugin-smartthings` — polling + orders plugin (read/write)
+- [`sowel-plugin-weather-forecast`](https://github.com/mchacher/sowel-plugin-weather-forecast) — simple polling plugin (read-only)
+- [`sowel-plugin-smartthings`](https://github.com/mchacher/sowel-plugin-smartthings) — polling + orders (read/write) with OAuth
+- [`sowel-plugin-zigbee2mqtt`](https://github.com/mchacher/sowel-plugin-zigbee2mqtt) — MQTT-based discovery
+
+**Plugins live in separate GitHub repos** — they are NOT in the main Sowel repo.
 
 ### 1.2 Deep-Dive Requirements
 

--- a/.claude/skills/sowel-feature/SKILL.md
+++ b/.claude/skills/sowel-feature/SKILL.md
@@ -24,16 +24,19 @@ All conventions (logging, implementation rules, design system) are in `CLAUDE.md
 
 ### 1.1 Read Essential Documentation
 
-Before starting, read these files:
+Before starting, read these files IN ORDER:
 
-| Document                  | Purpose                              |
-| ------------------------- | ------------------------------------ |
-| `docs/sowel-spec.md`      | Full specification — source of truth |
-| `src/shared/types.ts`     | All TypeScript interfaces            |
-| `src/shared/constants.ts` | DataCategory, EquipmentType, etc.    |
-| `CLAUDE.md`               | Project conventions and rules        |
+| Document                         | Purpose                                                      |
+| -------------------------------- | ------------------------------------------------------------ |
+| `CLAUDE.md`                      | AI agent entry point — conventions, rules, refs              |
+| `docs/technical/architecture.md` | Current architecture (plugin V2, self-update, backup, CI/CD) |
+| `docs/specs-index.md`            | Scan for related specs — there may already be a design       |
+| `src/shared/types.ts`            | All TypeScript interfaces                                    |
+| `src/shared/constants.ts`        | DataCategory, EquipmentType, etc.                            |
 
-If the feature involves a specific domain, also read the relevant source files (see [reference.md](reference.md) for the full list).
+**Do NOT read `docs/sowel-spec.md`** — it's legacy and outdated.
+
+If the feature involves a specific domain, also read the relevant source files (see [reference.md](reference.md) for the full list). When in doubt about history, check the spec files in `specs/XXX-*/` for the relevant feature.
 
 ### 1.2 Deep-Dive Requirements
 

--- a/.claude/skills/sowel-feature/reference.md
+++ b/.claude/skills/sowel-feature/reference.md
@@ -1,62 +1,103 @@
 # Sowel Feature Reference
 
-## Key Files
+Quick reference for the `sowel-feature` skill. For the full workflow, see [SKILL.md](SKILL.md).
 
-| Purpose              | Location                                   |
-| -------------------- | ------------------------------------------ |
-| Full specification   | `docs/sowel-spec.md`                       |
-| Feature specs        | `specs/XXX-feature-name/`                  |
-| TypeScript types     | `src/shared/types.ts`                      |
-| Constants            | `src/shared/constants.ts`                  |
-| Event bus            | `src/core/event-bus.ts`                    |
-| Database             | `src/core/database.ts`                     |
-| Device manager       | `src/devices/device-manager.ts`            |
-| Equipment manager    | `src/equipments/equipment-manager.ts`      |
-| Zone manager         | `src/zones/zone-manager.ts`                |
-| Zone aggregator      | `src/zones/zone-aggregator.ts`             |
-| Recipe engine        | `src/recipes/engine/recipe-manager.ts`     |
-| API server           | `src/api/server.ts`                        |
-| WebSocket            | `src/api/websocket.ts`                     |
-| API routes           | `src/api/routes/`                          |
-| Plugin manager       | `src/plugins/plugin-manager.ts`            |
-| Integration registry | `src/integrations/integration-registry.ts` |
-| AI manager           | `src/ai/ai-manager.ts`                     |
-| UI stores            | `ui/src/store/`                            |
-| UI components        | `ui/src/components/`                       |
-| UI pages             | `ui/src/pages/`                            |
-| Migrations           | `migrations/`                              |
-| Tailwind config      | `ui/tailwind.config.js`                    |
+## Where to find things
 
-## Domain-Specific Files
+| Topic                     | File                              |
+| ------------------------- | --------------------------------- |
+| **AI agent entry point**  | `CLAUDE.md`                       |
+| **Current architecture**  | `docs/technical/architecture.md`  |
+| **Specs index (chrono)**  | `docs/specs-index.md`             |
+| **Production operations** | `docs/technical/deployment.md`    |
+| **Data model**            | `docs/technical/data-model.md`    |
+| **API reference**         | `docs/technical/api-reference.md` |
+| **Feature specs**         | `specs/XXX-feature-name/`         |
+| **TypeScript types**      | `src/shared/types.ts`             |
+| **Constants**             | `src/shared/constants.ts`         |
 
-| Domain       | Files to read                                         |
-| ------------ | ----------------------------------------------------- |
-| Devices      | `src/devices/`                                        |
-| Equipments   | `src/equipments/`, bindings, computed engine          |
-| Zones        | `src/zones/`, zone-aggregator                         |
-| Scenarios    | `src/scenarios/`, trigger/condition/action evaluators |
-| Recipes      | `src/recipes/engine/`, `src/recipes/*.ts`             |
-| AI Assistant | `src/ai/`, prompt templates, providers                |
-| API          | `src/api/routes/`, `src/api/server.ts`                |
-| Auth         | `src/auth/`, middleware                               |
-| Plugins      | `src/plugins/`, `plugins/`                            |
-| UI           | `ui/src/components/`, `ui/src/store/`                 |
-| Database     | `migrations/`, SQLite schema in spec section 8        |
+## Core backend services
+
+| Service                       | File                           |
+| ----------------------------- | ------------------------------ |
+| Event bus                     | `src/core/event-bus.ts`        |
+| Database                      | `src/core/database.ts`         |
+| Settings manager              | `src/core/settings-manager.ts` |
+| Version checker (update poll) | `src/core/version-checker.ts`  |
+| Update manager (self-update)  | `src/core/update-manager.ts`   |
+| Influx client                 | `src/core/influx-client.ts`    |
+| Logger                        | `src/core/logger.ts`           |
+| Backup manager                | `src/backup/backup-manager.ts` |
+
+## Plugin system (spec 053+)
+
+| Service                               | File                                       |
+| ------------------------------------- | ------------------------------------------ |
+| Package manager (GitHub distribution) | `src/packages/package-manager.ts`          |
+| Plugin loader (integrations)          | `src/plugins/plugin-loader.ts`             |
+| Recipe loader (recipes)               | `src/recipes/recipe-loader.ts`             |
+| Integration registry (runtime)        | `src/integrations/integration-registry.ts` |
+| Plugin API types                      | `src/shared/plugin-api.ts`                 |
+| Plugin registry (source of truth)     | `plugins/registry.json`                    |
+
+**Everything is a plugin now**. There are no built-in integrations or recipes in `src/`. See [docs/technical/architecture.md § Plugin Architecture V2](../../../docs/technical/architecture.md#plugin-architecture-v2-current).
+
+## Domain managers
+
+| Manager               | File                                   |
+| --------------------- | -------------------------------------- |
+| Device manager        | `src/devices/device-manager.ts`        |
+| Equipment manager     | `src/equipments/equipment-manager.ts`  |
+| Zone manager          | `src/zones/zone-manager.ts`            |
+| Zone aggregator       | `src/zones/zone-aggregator.ts`         |
+| Sunlight manager      | `src/zones/sunlight-manager.ts`        |
+| Mode manager          | `src/modes/mode-manager.ts`            |
+| Calendar manager      | `src/modes/calendar-manager.ts`        |
+| Recipe engine         | `src/recipes/engine/recipe-manager.ts` |
+| Button action manager | `src/buttons/button-action-manager.ts` |
+| Energy aggregator     | `src/energy/energy-aggregator.ts`      |
+| Tariff classifier     | `src/energy/tariff-classifier.ts`      |
+| History writer        | `src/history/history-writer.ts`        |
+| Auth service          | `src/auth/auth-service.ts`             |
+| User manager          | `src/auth/user-manager.ts`             |
+
+## API
+
+| Part                                | File                          |
+| ----------------------------------- | ----------------------------- |
+| Server setup + route registration   | `src/api/server.ts`           |
+| WebSocket handler + event broadcast | `src/api/websocket.ts`        |
+| Individual routes                   | `src/api/routes/<domain>.ts`  |
+| Auth middleware                     | `src/auth/auth-middleware.ts` |
+
+## Frontend
+
+| Part                 | File                               |
+| -------------------- | ---------------------------------- |
+| Zustand stores       | `ui/src/store/`                    |
+| Components by domain | `ui/src/components/<domain>/`      |
+| Pages                | `ui/src/pages/`                    |
+| API client           | `ui/src/api.ts`                    |
+| Types                | `ui/src/types.ts`                  |
+| i18n locales         | `ui/src/i18n/locales/{en,fr}.json` |
 
 ## Commands
 
-| Action             | Command                               |
-| ------------------ | ------------------------------------- |
-| Start engine       | `npm run dev`                         |
-| Start UI           | `cd ui && npm run dev`                |
-| Type check backend | `npx tsc --noEmit`                    |
-| Type check UI      | `cd ui && npx tsc --noEmit`           |
-| Run tests          | `cd /path/to/Sowel && npx vitest run` |
-| Run single test    | `npx vitest run <file>`               |
-| Lint               | `npx eslint src/ --ext .ts`           |
-| Reset DB           | `rm data/sowel.db && npm run dev`     |
+| Action             | Command                           |
+| ------------------ | --------------------------------- |
+| Start engine (dev) | `npm run dev`                     |
+| Start UI (dev)     | `cd ui && npm run dev`            |
+| Type check backend | `npx tsc --noEmit`                |
+| Type check UI      | `cd ui && npx tsc -b --noEmit`    |
+| Run tests          | `npx vitest run`                  |
+| Run single test    | `npx vitest run <file>`           |
+| Lint backend       | `npx eslint src/ --ext .ts`       |
+| Lint UI            | `cd ui && npx eslint .`           |
+| Full validate      | `npm run validate`                |
+| Reset DB           | `rm data/sowel.db && npm run dev` |
+| Release            | `scripts/release.sh <version>`    |
 
-## Event-Driven Pipeline
+## Reactive pipeline
 
 ```
 Integration message (MQTT, cloud API poll, etc.)
@@ -67,95 +108,102 @@ Integration message (MQTT, cloud API poll, etc.)
           → Event Bus: "equipment.data.changed"
             → Zone Manager (re-evaluates aggregations)
               → Event Bus: "zone.data.changed"
-                → Scenario Engine (evaluates triggers → conditions → actions)
+                → Recipe Engine (evaluates triggers → conditions → actions)
                   → Actions may emit Orders → Integration Plugin → device
             → WebSocket pushes to UI clients
 ```
 
-## Spec Templates
+## Spec templates
 
 ### spec.md
 
 ```markdown
-# Feature Name
+# Spec XXX — Feature Name
 
-## Summary
+## Context
 
-Brief description.
+Why this feature exists, what problem it solves.
 
-## Reference
+## Goals
 
-- Spec sections: §X, §Y (reference sowel-spec.md sections)
+1. Goal 1
+2. Goal 2
+
+## Non-Goals
+
+- What is explicitly NOT included
+
+## Functional Requirements
+
+### FR1 — Name
+
+Description, behavior, data flow.
 
 ## Acceptance Criteria
 
 - [ ] Criterion 1
 - [ ] Criterion 2
 
-## Scope
-
-### In Scope
-
-- Item 1
-
-### Out of Scope
-
-- What is NOT included
-
 ## Edge Cases
 
 - Edge case 1
-- Edge case 2
 ```
 
 ### architecture.md
 
 ```markdown
-# Architecture: Feature Name
+# Architecture — Spec XXX
 
-## Data Model Changes
+## Flow diagram
+```
 
-- New SQLite tables / columns
-- New types in types.ts
+[ascii diagram of the flow]
 
-## Event Bus Events
+```
 
-- New events emitted / consumed
+## Components
 
-## API Changes
+### New: `src/path/to/new-file.ts`
 
-- New / changed endpoints
+Description.
 
-## UI Changes
+## Files changed
 
-- New components / store changes
-
-## File Changes
-
-| File                  | Change      |
-| --------------------- | ----------- |
-| `src/path/to/file.ts` | Description |
+| Domain | File | Change |
+| --- | --- | --- |
+| Core | `src/core/foo.ts` | Added bar |
 ```
 
 ### plan.md
 
 ```markdown
-# Implementation Plan: Feature Name
+# Implementation Plan — Spec XXX
 
-## Tasks
+## Slices
 
-1. [ ] Task 1
-2. [ ] Task 2
+### Slice A — Foundation
 
-## Dependencies
+- A.1 — Create X
+- A.2 — Refactor Y
 
-- Requires spec XXX to be completed first
+### Slice B — Feature
 
-## Testing
+- B.1 — Implement Z
 
-- How to verify manually
+## Validation Plan
+
+- Typecheck, lint, tests
+- Manual tests
 ```
 
-## Commit Scopes
+## Commit scopes
 
-`mqtt`, `devices`, `equipments`, `zones`, `scenarios`, `recipes`, `ai`, `api`, `ws`, `ui`, `auth`, `db`, `core`, `plugins`, `backup`
+`mqtt`, `devices`, `equipments`, `zones`, `recipes`, `modes`, `api`, `ws`, `ui`, `auth`, `db`, `core`, `plugins`, `packages`, `backup`, `self-update`, `energy`, `logging`, `docs`.
+
+## Production deployment
+
+Sowel production runs on Linux VM `sowelox` at `192.168.0.230:3000` (public: `https://app.sowel.org`). See [docs/technical/deployment.md](../../../docs/technical/deployment.md) for full operations guide.
+
+- SSH access: `ssh mchacher@192.168.0.230` (key-based, no password)
+- Log files: `docker exec sowel cat /app/data/logs/sowel.N.log`
+- Credentials: memory file `reference_sowel_access.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,27 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (and any AI agent) working on the Sowel repository. This is the **first file to read** when starting a session. It is intentionally short — deep context lives in `docs/` and `specs/`.
 
-## Project Overview
+## Where to find context
 
-**Sowel** is a home automation engine with a plugin-based integration architecture. It supports multiple device sources (Zigbee2MQTT, Panasonic Comfort Cloud, MCZ Maestro, and more via the IntegrationPlugin interface). It separates physical **Devices** (auto-discovered from integrations) from user-facing **Equipments** (functional units like "Spots Salon"), provides automatic **Zone** aggregation, a **Scenario** engine with reusable **Recipe** templates, and exposes a reactive web UI.
+| You want to know...                                                | Read this                                                                     |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| What Sowel is and how it's architected                             | [docs/technical/architecture.md](docs/technical/architecture.md)              |
+| The full list of features ever shipped, by spec                    | [docs/specs-index.md](docs/specs-index.md)                                    |
+| How to deploy, update, backup, restore, troubleshoot in production | [docs/technical/deployment.md](docs/technical/deployment.md)                  |
+| Data model — tables, types, events                                 | [docs/technical/data-model.md](docs/technical/data-model.md)                  |
+| REST API and WebSocket events                                      | [docs/technical/api-reference.md](docs/technical/api-reference.md)            |
+| How to develop a plugin                                            | [docs/technical/plugin-development.md](docs/technical/plugin-development.md)  |
+| How to develop a recipe                                            | [docs/technical/recipe-development.md](docs/technical/recipe-development.md)  |
+| Specific feature history / design                                  | `specs/XXX-name/{spec,architecture,plan}.md` — index in `docs/specs-index.md` |
 
-The full specification is in [sowel-spec.md](sowel-spec.md) — it is the single source of truth. It is a living document that evolves alongside feature development; always re-read the relevant sections before implementing a milestone.
+**Do not rely on `docs/sowel-spec.md`** — it is a legacy document preserved for history. Use `docs/technical/*` and `specs/*` instead.
 
-## Architecture
+## Project in one paragraph
 
-### Reactive Pipeline (core data flow)
+Sowel is a home automation engine. Physical **Devices** (auto-discovered from integrations like Zigbee2MQTT, Panasonic Comfort Cloud, etc.) are bound to user-facing **Equipments**. Equipments live in **Zones** (nestable tree) that auto-aggregate data (motion=OR, temperature=AVG, etc.). **Recipes** (automation templates) run on top, triggered by events. **Modes** (Day/Night/Away) flip zones between configurations. Everything is event-driven through a typed **EventBus**, and the UI is a reactive React SPA fed by WebSocket. Since spec 053, **everything is a plugin** — integrations and recipes are distributed from GitHub, nothing is built-in.
+
+## Reactive pipeline
 
 ```
 Integration message (MQTT, cloud API poll, etc.)
@@ -21,246 +32,220 @@ Integration message (MQTT, cloud API poll, etc.)
           → Event Bus: "equipment.data.changed"
             → Zone Manager (re-evaluates aggregations)
               → Event Bus: "zone.data.changed"
-                → Scenario Engine (evaluates triggers → conditions → actions)
+                → Recipe Engine (triggers → conditions → actions)
                   → Actions may emit Orders → Integration Plugin → device
             → WebSocket pushes to UI clients
 ```
 
-### Key Domain Concepts
+## Key domain concepts
 
-| Term          | Role                                                                                                            |
-| ------------- | --------------------------------------------------------------------------------------------------------------- |
-| **Device**    | Physical hardware, auto-discovered from integrations. Exposes raw Data and Orders.                              |
-| **Equipment** | User-facing functional unit. Binds to one or more Devices. Can have computed Data and dispatched Orders.        |
-| **Zone**      | Spatial grouping (nestable). Auto-aggregates Equipment Data (motion=OR, temperature=AVG, lightsOn=COUNT, etc.). |
-| **Scenario**  | Automation rule: trigger(s) → condition(s) → action(s).                                                         |
-| **Recipe**    | Reusable Scenario template with typed parameter slots.                                                          |
+| Term          | Role                                                                                   |
+| ------------- | -------------------------------------------------------------------------------------- |
+| **Device**    | Physical hardware, auto-discovered from integrations. Raw data and orders.             |
+| **Equipment** | User-facing functional unit. Binds to one or more Devices. Can have computed data.     |
+| **Zone**      | Spatial grouping (nestable tree). Auto-aggregates equipment data.                      |
+| **Recipe**    | Reusable automation template with typed parameter slots (instance = running scenario). |
+| **Mode**      | Named zone-level state (Day/Night/Away) with impacts on recipes.                       |
+| **Plugin**    | A package (integration or recipe) distributed from GitHub via PackageManager.          |
 
-### Tech Stack
+Guiding principle: **a Device is what's on the network. An Equipment is what's in the room.**
 
-**Backend:** Node.js 20+ / TypeScript (strict) / Fastify / SQLite (better-sqlite3) / InfluxDB 2.x / ws (WebSocket) / mqtt.js (for MQTT integrations)
+## Tech stack
 
-**Frontend:** React 18+ / TypeScript / Vite / Tailwind CSS / Zustand / Lucide React
+- **Backend**: Node.js 20+, TypeScript strict, Fastify, SQLite (better-sqlite3), InfluxDB 2.x, ws, mqtt.js, pino
+- **Frontend**: React 18, TypeScript, Vite, Tailwind CSS, Zustand, Lucide React
+- **Infra**: Docker + docker-compose, GitHub Actions release to ghcr.io
 
-**Infrastructure:** Docker + docker-compose / PM2
-
-### Project Structure
+## Project structure (current, spec 053+)
 
 ```
 sowel/
 ├── src/
 │   ├── index.ts                 # Entry point
 │   ├── config.ts                # Env config loading
-│   ├── core/                    # event-bus, database (SQLite), influx, logger
-│   ├── integrations/            # Integration plugins (zigbee2mqtt, panasonic-cc, mcz-maestro, ...)
-│   ├── devices/                 # Device manager, auto-discovery, category inference
+│   ├── core/                    # event-bus, database, influx-client, logger, settings-manager,
+│   │                            # version-checker, update-manager
+│   ├── backup/                  # BackupManager (export/restore, local backups)
+│   ├── packages/                # PackageManager (GitHub-based plugin distribution)
+│   ├── plugins/                 # PluginLoader (integration plugins lifecycle)
+│   ├── integrations/            # IntegrationRegistry (runtime registry — plugins register here)
+│   ├── recipes/                 # RecipeLoader + engine/recipe-manager.ts
+│   ├── devices/                 # Device manager, category inference
 │   ├── equipments/              # Equipment manager, bindings, computed engine, order dispatcher
-│   ├── energy/                  # Energy aggregator, tariff classifier (HP/HC)
-│   ├── zones/                   # Zone manager, auto-aggregation engine
-│   ├── scenarios/               # Scenario engine, triggers, conditions, actions, recipes
-│   ├── ai/                      # LLM integration (Claude/OpenAI/Ollama) — V1.0+
+│   ├── zones/                   # Zone manager, zone-aggregator, sunlight-manager
+│   ├── modes/                   # Mode manager, calendar manager (croner)
+│   ├── energy/                  # Energy aggregator, HP/HC tariff classifier
+│   ├── buttons/                 # Button action bindings (Zigbee button → mode/order)
+│   ├── charts/                  # Saved chart configurations
+│   ├── history/                 # InfluxDB history writer
+│   ├── mqtt-publishers/         # Outbound MQTT (broker + publisher managers)
+│   ├── notifications/           # Telegram/webhook/FCM/ntfy notification publishers
 │   ├── auth/                    # JWT + API tokens, middleware, first-run setup
 │   ├── users/                   # User CRUD, preferences
-│   ├── notifications/           # Channels: telegram, webhook, FCM, ntfy, email
-│   ├── api/                     # Fastify server, WebSocket handler, route files
-│   └── shared/                  # types.ts (all interfaces), constants.ts
+│   ├── api/                     # Fastify server, WebSocket, route files
+│   └── shared/                  # types.ts (all interfaces), constants.ts, plugin-api.ts
 ├── ui/                          # React frontend (separate Vite project)
-│   └── src/
-│       ├── store/               # Zustand stores (devices, equipments, zones, WebSocket)
-│       ├── components/          # By domain: dashboard/, devices/, equipments/, zones/, scenarios/
-│       └── pages/               # Dashboard, Devices, Equipments, Zones, Scenarios, Settings
-├── recipes/                     # Built-in Recipe JSON templates
-├── migrations/                  # SQLite migration SQL files
-├── specs/                       # Feature specifications (XXX-version-name/)
-└── scripts/                     # Maintenance & diagnostic scripts
-    ├── energy/                  # InfluxDB energy backfill, diagnostic, admin
-    └── logs/                    # Log retrieval via API
+├── plugins/
+│   └── registry.json            # Official plugin registry (fetched remotely with local fallback)
+├── migrations/                  # SQLite migration SQL files (runs on startup)
+├── specs/XXX-name/              # Per-feature specs (spec.md + architecture.md + plan.md)
+├── docs/                        # MkDocs Material — see "Where to find context" above
+└── scripts/
+    ├── release.sh               # Release script (versioning + tag + push)
+    ├── energy/                  # InfluxDB energy backfill, diagnostic
+    └── logs/fetch-logs.py       # Log retrieval helper
 ```
 
-## Build & Run Commands
+**Not in src/ anymore**: no more built-in integrations or recipes. Each has its own GitHub repo (e.g. `sowel-plugin-zigbee2mqtt`). See `plugins/registry.json` for the current list.
+
+## Build & run commands
 
 ```bash
 # Backend
 npm install
-npm run dev          # Development with hot reload
-npm run build        # TypeScript compilation
-npm start            # Production (compiled JS)
+npm run dev                  # Development with tsx watch
+npm run build                # tsc build to dist/
+npm start                    # Production run
 
-# Frontend (from ui/ directory)
+# Frontend
 cd ui && npm install
-cd ui && npm run dev     # Vite dev server
-cd ui && npm run build   # Production build
-
-# Docker
-docker-compose up -d     # Engine + InfluxDB
+cd ui && npm run dev         # Vite dev server
+cd ui && npm run build       # Production build
 
 # Tests
-npm test                 # Run all tests
-npm test -- --grep "pattern"  # Run specific tests
+npx vitest run               # All backend tests
+npx vitest run <file>        # Single test file
+
+# Type checks and lint
+npx tsc --noEmit             # Backend
+cd ui && npx tsc -b --noEmit # UI
+npx eslint src/ --ext .ts
+cd ui && npx eslint .
+
+# Full validate
+npm run validate             # Runs all checks (backend + UI)
+
+# Docker
+docker compose up -d         # Local docker deployment
 ```
 
-## Git Workflow
+## Git workflow
 
-- **Feature branches required**: any non-trivial development (new feature, refactoring, multi-file changes) must be done on a dedicated branch, not directly on `main`. Use descriptive branch names like `feat/gate-abstraction` or `fix/rate-limit`.
-- Small, isolated fixes (typo, single-line config change) may go directly on `main`.
-- **PR merge requires explicit user approval**: never merge a pull request without the user's explicit validation. Create the PR, present it, and wait for approval before merging.
+- **Feature branches required** for any non-trivial change. Prefixes: `feat/`, `fix/`, `refactor/`, `docs/`.
+- Small isolated fixes (typo, single-line) may go on `main` directly.
+- **Never merge a PR without explicit user approval**. Present the PR, wait for "oui" / "merge" / "go".
+- **Never add `Co-Authored-By: Claude` lines** in commit messages or PR bodies.
+- Conventional commits. Scopes: `mqtt`, `devices`, `equipments`, `zones`, `recipes`, `modes`, `api`, `ws`, `ui`, `auth`, `db`, `core`, `plugins`, `packages`, `backup`, `self-update`, `energy`, `logging`.
 
-## Implementation Conventions
+## Implementation conventions
 
-### IDs and Data
+### IDs and data
 
-- UUID v4 for all entity IDs (`crypto.randomUUID()`)
-- All dates in ISO 8601 format
-- All types defined in `src/shared/types.ts`, shared across backend modules
-- Use TypeScript discriminated unions for the typed Event Bus
+- UUID v4 (`crypto.randomUUID()`) for all entity IDs
+- ISO 8601 dates everywhere
+- All types in `src/shared/types.ts`, discriminated unions for EventBus
 
 ### Database
 
-- SQLite via `better-sqlite3` synchronous API — intentionally sync, very fast
-- WAL mode: `PRAGMA journal_mode=WAL`
-- Run migrations on startup
-- Use transactions for batch operations
+- SQLite via `better-sqlite3` (synchronous — fast, no callback overhead)
+- WAL mode (`PRAGMA journal_mode=WAL`)
+- Migrations in `migrations/` run on startup (sequential numbering)
+- Use transactions for batch writes
 
-### Integrations
+### Integrations (plugins)
 
-- Plugin-based architecture: each device source implements `IntegrationPlugin`
-- Plugins register with `IntegrationRegistry` which manages lifecycle (start/stop/reconnect)
-- MQTT-based integrations use `mqtt.js` with `connectAsync` for async/await
-- Cloud-based integrations use polling with configurable intervals
-- All message/event handlers must never throw — wrap in try/catch with logging
-- Settings stored in SQLite `settings` table, configurable from UI
+- Each integration is a **plugin package** distributed from GitHub — see spec 053/054
+- `PackageManager` downloads/installs/updates; `PluginLoader` or `RecipeLoader` handles lifecycle
+- Plugins export `createPlugin(deps)` returning an `IntegrationPlugin` (see `src/shared/plugin-api.ts`)
+- Settings stored in `settings` table under `integration.<id>.<key>`
+- All message/event handlers must never throw — wrap in try/catch with structured log
+- Missing plugins on disk are **auto-downloaded** on startup (spec 058)
 
 ### Event Bus
 
-- Typed EventEmitter with TypeScript discriminated union (`EngineEvent` type)
+- Typed `EventEmitter` with TypeScript discriminated union (`EngineEvent`)
 - All handlers must be non-blocking and never throw
-
-### Expression Engine
-
-- Safe expression parser (NOT `eval`) — consider `expr-eval` or custom
-- References: `binding.<alias>`, `equipment.<id>.<key>`, `zone.<zoneId>.<key>`
-- Operators: OR, AND, NOT, AVG, MIN, MAX, SUM, IF, THRESHOLD
+- High-frequency events are deduplicated per batch before being sent to WebSocket clients
 
 ### Authentication
 
-- bcrypt (cost 12) for passwords, `jsonwebtoken` (HS256) for JWT
-- API tokens: `swl_` prefix (legacy `wch_` and `cbl_` also accepted), SHA-256 hash stored, generated via `crypto.randomBytes(32)`
-- Auth middleware: try JWT decode first, then API token lookup
-- Roles: admin > user > viewer (hierarchical permissions)
+- Passwords: bcrypt cost 12. JWT HS256 via `jsonwebtoken`.
+- Access token TTL 15 min, refresh token TTL 30 days
+- API tokens: `swl_` prefix, SHA-256 hash stored, `crypto.randomBytes(32)`
+- Roles: `admin` > `user` > `viewer`
 
 ### Frontend
 
-- Zustand stores updated by WebSocket events
-- Auto-reconnecting WebSocket with state recovery (incremental or full)
-- Tailwind CSS utility classes only — no custom CSS files
-- Mobile-first responsive design (breakpoints: 640px, 1024px)
+- Zustand stores per domain, updated by WebSocket events
+- Tailwind utility classes only, no custom CSS files
+- Mobile-first responsive (breakpoints: 640px, 1024px)
+- Dark mode via Tailwind `class` strategy
+- Lucide icons, stroke 1.5px
 
 ### Logging
 
-Structured JSON logging via pino (Fastify default) with multistream: ring buffer (UI), pino-pretty (dev), JSON stdout + pino-roll files (prod).
+- **Always** use pino structured logging, **never** `console.*`
+- Child logger per module: `logger.child({ module: "module-name" })`
+- Structured context first, message second: `logger.info({ deviceId, status }, "Device status changed")`
+- Error logs must include `{ err }`: `logger.error({ err }, "Poll failed")`
+- Sensitive fields (password, token, secret, apiKey) are auto-redacted by config
 
-#### Log Level Strategy
+### Log levels
 
-| Level     | Purpose                                             | Production visible | Examples                                                                     |
-| --------- | --------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------- |
-| **fatal** | Process about to crash, unrecoverable               | Yes                | Uncaught exception, database corruption                                      |
-| **error** | Operation failed, engine continues. Needs attention | Yes                | Integration poll failed, order dispatch error, recipe execution error        |
-| **warn**  | Unexpected situation, handled gracefully            | Yes                | MQTT reconnecting, device offline, token refresh retry, stale device cleanup |
-| **info**  | Significant business events — one per operation     | Yes                | Engine start/stop, device discovered/removed, equipment CRUD, mode activated |
-| **debug** | Operational detail for troubleshooting              | No (dev/UI only)   | Binding evaluation, aggregation steps, migration applied, config loaded      |
-| **trace** | High-volume hot-path data, deep debugging only      | No (dev/UI only)   | Every event bus emission, every MQTT message, every data point update        |
+| Level   | When                                                          |
+| ------- | ------------------------------------------------------------- |
+| `fatal` | Process crash imminent                                        |
+| `error` | Operation failed, engine continues                            |
+| `warn`  | Self-recovering degradation (reconnect, retry, stale data)    |
+| `info`  | Significant business events — one per operation, not per item |
+| `debug` | Developer troubleshooting detail                              |
+| `trace` | High-volume hot path (off in production)                      |
 
-#### Level Assignment Rules
+Production logs go to both stdout (captured by Docker) and `data/logs/sowel-N.log` (daily rotation, 14 days kept). **File logs survive container recreation**, crucial for post-incident investigation.
 
-- **info = admin dashboard**: an operator reading info logs should understand _what happened_ without drowning. One log per business operation, not per item processed.
-- **debug = developer session**: detailed enough to trace a specific problem. One human can read these for a module during a debug session.
-- **trace = replay mode**: enables reproducing exact state transitions. High volume, never on in production.
-- **error always includes `{ err }`**: pass the Error object as structured context, e.g. `logger.error({ err }, "Poll failed")`.
-- **warn = self-recovering**: the system handled it, but repeated warnings signal degradation.
-- **Never use `console.log/error/warn`**: always use the structured pino logger. Console calls bypass the ring buffer, file rotation, and redaction.
+## Design system
 
-#### What Goes Where (by domain)
+- **Fonts**: Inter (body), JetBrains Mono (values, logs)
+- **Primary**: `#1A4F6E` (ocean blue), hover `#13405A`, light `#E6F0F6`
+- **Accent**: `#D4963F` (amber), hover `#BB8232`
+- **Spacing**: 4px base, 6px radius (buttons), 10px (cards), 14px (modals)
+- **Font sizes**: 14px body, 28px data values
 
-| Domain           | info                                        | debug                                    | trace                       |
-| ---------------- | ------------------------------------------- | ---------------------------------------- | --------------------------- |
-| **MQTT**         | Connected, disconnected, reconnecting       | Subscribed to topic, publish result      | Every message received      |
-| **Devices**      | Discovered, removed, status changed         | Data auto-created, category inferred     | Every data point update     |
-| **Equipments**   | CRUD, order dispatched                      | Binding evaluation, computed data result | Every binding re-evaluation |
-| **Zones**        | CRUD, aggregation summary                   | Individual aggregation fields computed   | Every aggregation trigger   |
-| **Modes**        | Activated, deactivated, CRUD                | Each impact action executed              | —                           |
-| **Recipes**      | Instance created/deleted, enabled/disabled  | Execution steps, trigger evaluation      | —                           |
-| **Integrations** | Started, stopped, connected, poll completed | Poll cycle details, API call results     | Raw API responses           |
-| **Auth**         | User login, token created, password changed | JWT validation, middleware decisions     | —                           |
-| **API**          | Server listening, route registered          | Request handling details                 | Every request/response      |
-| **WebSocket**    | Client connected/disconnected               | Topic subscription, message sent         | Every frame                 |
-| **Event Bus**    | —                                           | —                                        | Every event emitted         |
-| **Database**     | DB opened, migration applied                | Query execution, schema changes          | —                           |
+## Production context (important for session recovery)
 
-#### Logger Conventions
+- **Production runs on**: Linux VM `sowelox` (Proxmox), x86_64, 8 GB RAM
+- **Path**: `/opt/sowel/`
+- **Access**: LAN `http://192.168.0.230:3000`, public `https://app.sowel.org` (Cloudflare tunnel)
+- **Related services on the same VM**: mosquitto (MQTT broker), zigbee2mqtt, lora2mqtt, cloudflared — **not** managed by Sowel itself
+- **Log files** accessible via `ssh mchacher@192.168.0.230 'docker exec sowel cat /app/data/logs/sowel.N.log'`
+- **SSH / API credentials**: in memory file `reference_sowel_access.md`
+- **Timezone**: `TZ=Europe/Paris` explicitly set in compose (workaround pending spec 061 auto-derivation)
 
-- **Property name**: use `this.logger` in classes, `logger` in standalone functions. Never `this.log`, `log`, or `console`.
-- **Child loggers**: every module creates a child logger with `{ module: "module-name" }` for filtering.
-- **Structured context**: pass data as first argument object, message as second: `logger.info({ deviceId, status }, "Device status changed")`.
-- **Sensitive data**: automatically redacted by pino config (passwords, tokens, secrets, API keys). Never log credentials manually.
-- **No string interpolation in messages**: use `logger.info({ count }, "Devices discovered")` not `logger.info("Discovered ${count} devices")`.
+See [docs/technical/deployment.md](docs/technical/deployment.md) for the full operations guide.
 
-## Design System
+## Skills available
 
-- **Font:** Inter (body), JetBrains Mono (values/logs)
-- **Primary color:** `#1A4F6E` (ocean blue) — hover: `#13405A`, light: `#E6F0F6`
-- **Accent color:** `#D4963F` (amber) — hover: `#BB8232`
-- **Spacing base unit:** 4px
-- **Border radius:** 6px (buttons), 10px (cards), 14px (modals)
-- **Body font size:** 14px (dense dashboard), Data values: 28px (readable at a glance)
-- **Icons:** Lucide React, stroke 1.5px
-- Dark mode via Tailwind `class` strategy — essential for nighttime dashboard use
+The repo ships Claude Code skills under `.claude/skills/`:
 
-## Development Roadmap
+| Skill                | When to use                                                                                                      |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `sowel-feature`      | Implementing a new feature (Phase 1-6 workflow with gates). Drafts spec, creates branch, implements, tests, PRs. |
+| `debug-bug`          | Investigating a bug. Gathers symptoms, pulls logs, traces the pipeline, presents diagnosis before fix.           |
+| `sowel-release`      | Bumping version, tagging, pushing — triggers GitHub Actions build.                                               |
+| `plugin-integration` | Creating a new plugin integration (plugin code, UI touchpoints, manifest).                                       |
+| `update-docs`        | Updating MkDocs pages when features change.                                                                      |
 
-V0.1 Devices → V0.2 Zones → V0.3 Equipments+Bindings → V0.4 UI Home → V0.5 Sensors → V0.6 Zone Aggregation → V0.7 Shutters → V0.8 Recipes → V0.9 Modes+Calendar → V0.10 Integration Plugins (Z2M, Panasonic CC, MCZ Maestro, Netatmo HC) → V0.11 Logging → V0.12 Computed Data → V0.13 History (InfluxDB) → V1.0+ AI Assistant
+## Energy monitoring notes
 
-## Environment Variables
+Energy data flows through 3 InfluxDB buckets: `sowel` (raw, 7d) → `sowel-energy-hourly` (2y) → `sowel-energy-daily` (10y). Downsampling tasks are created automatically on startup. Key gotchas documented in [docs/technical/architecture.md](docs/technical/architecture.md#influxdb):
 
-All settings are optional with sensible defaults — Sowel runs zero-config out of the box. Override via `.env` if needed:
+- `aggregateWindow` must use `timeSrc: "_start"` to avoid a +1h offset
+- Day boundaries use local midnight (assumes correct TZ — see spec 061)
+- HP/HC tariff classifier in `src/energy/tariff-classifier.ts` uses `getHours()` which is TZ-sensitive
 
-| Variable          | Default                 | Notes                                             |
-| ----------------- | ----------------------- | ------------------------------------------------- |
-| `SQLITE_PATH`     | `./data/sowel.db`       | SQLite database path                              |
-| `API_PORT`        | `3000`                  | HTTP server port                                  |
-| `API_HOST`        | `0.0.0.0`               | Bind address                                      |
-| `JWT_SECRET`      | auto-generated          | Persisted in `data/.jwt-secret` on first launch   |
-| `JWT_ACCESS_TTL`  | `900`                   | Access token TTL in seconds (15 min)              |
-| `JWT_REFRESH_TTL` | `2592000`               | Refresh token TTL in seconds (30 days)            |
-| `LOG_LEVEL`       | `info`                  | Pino log level                                    |
-| `CORS_ORIGINS`    | `*`                     | Comma-separated allowed origins                   |
-| `INFLUX_URL`      | `http://localhost:8086` | InfluxDB 2.x URL                                  |
-| `INFLUX_TOKEN`    | auto-generated          | Persisted in `data/.influx-token` on first launch |
-| `INFLUX_ORG`      | `sowel`                 | InfluxDB organization                             |
-| `INFLUX_BUCKET`   | `sowel`                 | InfluxDB primary bucket                           |
+## When in doubt
 
-InfluxDB is mandatory — Sowel connects on startup and auto-creates buckets, downsampling tasks, and energy aggregation tasks. No UI configuration needed.
-
-Integration settings (MQTT, cloud credentials, polling intervals) are configured from the UI (Administration > Integrations), not from `.env`.
-
-## Energy Monitoring (InfluxDB)
-
-### Architecture
-
-Energy data flows through a 3-bucket InfluxDB pipeline:
-
-```
-sowel (raw)              — 7-day retention  — 30-min points from Netatmo poller
-  ↓ task: sowel-energy-sum-hourly (every: 1h, lookback: -7h)
-sowel-energy-hourly      — 2-year retention — hourly sums
-  ↓ task: sowel-energy-sum-daily (every: 1d, lookback: -2d)
-sowel-energy-daily       — 10-year retention — daily sums
-```
-
-### Key Implementation Details
-
-- **`timeSrc: "_start"`**: All `aggregateWindow` calls (queries and tasks) must use `timeSrc: "_start"` to avoid a +1h timestamp offset. InfluxDB defaults to `_stop` (end of window).
-- **Day view query strategy**: For recent days (< 6 days), query raw bucket with `aggregateWindow(every: 1h, fn: sum)` for real-time accuracy. For older days, fall back to `energy-hourly` bucket. If raw returns 0 points, also fall back to hourly.
-- **Netatmo polling**: 30-min energy windows via `getMeasure` API (scale=5min, summed). Only processes completed windows (`windowEnd > nowTs` → skip). Sliding 6h lookback for idempotent overwrites.
-- **Timestamps**: Raw data stored in UTC. Local time (CET/CEST = UTC+1/+2) conversion happens in the UI. Day boundaries use local midnight (`new Date(dateStr + "T00:00:00")`).
-- **Backup**: Exports all 5 InfluxDB buckets (raw, hourly, daily, energy-hourly, energy-daily) as CSV in ZIP. Tasks are recreated automatically on startup via `ensureEnergyBuckets()`.
-- **Maintenance scripts**: See `scripts/energy/README.md` for backfill, diagnostic, and admin tools.
+1. **Read `docs/specs-index.md` first** to see if there's already a spec for what you're about to do
+2. **Read the relevant architecture section** in `docs/technical/architecture.md`
+3. **Grep for similar patterns** in the codebase before inventing
+4. **Ask the user** if requirements are unclear — never assume

--- a/README.md
+++ b/README.md
@@ -2,32 +2,62 @@
 
 Home automation engine with a plugin-based architecture. Separates physical devices from user-facing equipments, provides automatic zone aggregation, a recipe-based automation engine, and a reactive web UI.
 
-**Founded by Marc Chachereau** | AGPL-3.0
+**Founded by Marc Chachereau** · AGPL-3.0 · [app.sowel.org](https://app.sowel.org)
 
-## Quick Start (Docker)
+## Quick Start
 
 ```bash
+mkdir /opt/sowel && cd /opt/sowel
 curl -O https://raw.githubusercontent.com/mchacher/sowel/main/docker-compose.yml
+# Optional: edit docker-compose.yml to set TZ=<Your_Timezone> for correct local time
 docker compose up -d
 ```
 
-Open [http://localhost:3000](http://localhost:3000) and create your admin account.
+Open `http://<host>:3000` and create your admin account on first launch.
 
-## Architecture
+See [docs/technical/deployment.md](docs/technical/deployment.md) for the full deployment guide (self-update, backup, troubleshooting).
 
-- **Devices** -- auto-discovered from integration plugins (Zigbee2MQTT, Panasonic CC, Netatmo, etc.)
-- **Equipments** -- user-facing functional units with data bindings and order dispatch
-- **Zones** -- spatial grouping with automatic aggregation (motion, temperature, etc.)
-- **Recipes** -- automation templates (motion-light, presence-thermostat, state-watch, etc.)
-- **Plugins** -- external packages for integrations and recipes, installed from the built-in store
+## Key concepts
 
-## Tech Stack
+- **Devices** — auto-discovered from integration plugins
+- **Equipments** — user-facing functional units with data bindings and order dispatch
+- **Zones** — nestable spatial grouping with automatic aggregation (motion, temperature, energy…)
+- **Recipes** — automation templates (motion-light, presence-thermostat, state-watch…)
+- **Modes** — named zone-level states (Day/Night/Away) with impacts
+- **Plugins** — integrations and recipes distributed from GitHub, installed from the built-in store
+
+## Features
+
+- 🔌 **Plugin ecosystem**: Zigbee2MQTT, Panasonic CC, MCZ Maestro, Legrand (Control + Energy), Netatmo Weather & Security, SmartThings, LoRa2MQTT, Weather Forecast
+- 🏠 **Zone aggregation**: automatic rollup of equipment data up the zone tree
+- 📅 **Calendar-driven modes**: schedule mode changes via cron slots (day/night/away)
+- 🤖 **Recipe engine**: reusable automation templates with typed parameter slots
+- ⚡ **Energy monitoring**: HP/HC tariff classification, daily/monthly aggregation, InfluxDB history
+- 💾 **Backup & restore**: full system ZIP, auto pre-update backups, one-click restore
+- 🔄 **Self-update**: update from the UI via Docker helper container (no CLI needed)
+- 📱 **PWA**: installable on mobile, offline-aware, responsive
+- 🌍 **i18n**: French and English
+
+## Tech stack
 
 | Layer          | Technology                                                 |
 | -------------- | ---------------------------------------------------------- |
 | Backend        | Node.js 20+ / TypeScript / Fastify / SQLite / InfluxDB 2.x |
 | Frontend       | React 18+ / TypeScript / Vite / Tailwind CSS / Zustand     |
 | Infrastructure | Docker / GitHub Container Registry                         |
+| Logging        | pino (ring buffer + rotating files)                        |
+
+## Documentation
+
+- [Architecture](docs/technical/architecture.md) — system design, plugin system, self-update, backup, logging
+- [Deployment](docs/technical/deployment.md) — install, update, backup/restore, troubleshooting
+- [API Reference](docs/technical/api-reference.md) — REST and WebSocket
+- [Plugin Development](docs/technical/plugin-development.md) — how to build a plugin
+- [Recipe Development](docs/technical/recipe-development.md) — how to build a recipe
+- [Data Model](docs/technical/data-model.md) — SQLite schema and types
+- [Specs Index](docs/specs-index.md) — chronological index of every spec
+
+User guides in [docs/user/](docs/user/).
 
 ## Development
 
@@ -36,11 +66,22 @@ Open [http://localhost:3000](http://localhost:3000) and create your admin accoun
 npm install
 npm run dev
 
-# Frontend
+# Frontend (separate terminal)
 cd ui && npm install && npm run dev
 
-# Docker (local build)
-docker compose -f docker-compose.dev.yml up -d --build
+# Run tests
+npx vitest run
+
+# Full validation (typecheck + lint + tests, backend + UI)
+npm run validate
+```
+
+## Release
+
+Releases are tagged on `main` via `scripts/release.sh <version>`. GitHub Actions builds the Docker image and pushes it to `ghcr.io/mchacher/sowel:<version>`.
+
+```bash
+scripts/release.sh 1.1.0
 ```
 
 ## License

--- a/docs/sowel-spec.md
+++ b/docs/sowel-spec.md
@@ -1,8 +1,26 @@
 # Sowel — Functional Specification
 
+> ⚠️ **LEGACY DOCUMENT — PRESERVED FOR HISTORY** ⚠️
+>
+> This file was the original single-source-of-truth (V0.1 through V0.9 era, ~February 2026).
+> The project has evolved significantly since — **do not rely on it** for current architecture.
+>
+> For current docs, use:
+>
+> - [Architecture](technical/architecture.md) — current architecture (plugin V2, self-update, backup, CI/CD)
+> - [Deployment](technical/deployment.md) — production operations
+> - [Specs index](specs-index.md) — chronological index of every spec with status
+> - `CLAUDE.md` at the repo root — AI agent entry point
+>
+> Keep this file for reference only (design intent, early requirements, domain model motivation).
+
+---
+
+## Original content
+
 > Version: 0.8 — February 2026
 > Author: Marc
-> Purpose: This document is the single source of truth for Claude Code to build the project.
+> Purpose: This document was the original source of truth. See warning above.
 > **Sowel** — the invisible structure of your smart home.
 
 ---

--- a/docs/specs-index.md
+++ b/docs/specs-index.md
@@ -1,0 +1,127 @@
+# Sowel Specs Index
+
+This file is a navigation aid over `specs/`. Every spec under `specs/XXX-name/` typically contains three files: `spec.md` (requirements + acceptance criteria), `architecture.md` (technical design), `plan.md` (implementation steps).
+
+**Use this index to quickly recover context**: scan descriptions, find the relevant spec, then read the full folder for details.
+
+Specs are grouped by theme and annotated with status:
+
+- ✅ **active** — implemented and in production
+- 🔁 **superseded** — replaced by a later spec (follow the arrow)
+- 🟡 **partial** — implemented, but scope has evolved
+
+---
+
+## Foundations (V0.x) — core engine
+
+| #   | Title                                  | Status                    | Summary                                                                        |
+| --- | -------------------------------------- | ------------------------- | ------------------------------------------------------------------------------ |
+| 001 | V0.1 MQTT devices                      | ✅                        | First integration with Zigbee2MQTT bridge. Raw device auto-discovery via MQTT. |
+| 002 | V0.1 UI scaffolding devices            | ✅                        | Initial React frontend with device list.                                       |
+| 003 | V0.2 Zones                             | ✅                        | Hierarchical nestable zones. Parent-child tree structure.                      |
+| 004 | V0.3 Equipments                        | ✅                        | User-facing equipments that bind to devices via data keys.                     |
+| 005 | V0.5 UI restructuring                  | ✅                        | Navigation overhaul (home, zones, equipments, devices, admin).                 |
+| 006 | V0.6 Sensor equipments                 | ✅                        | Temperature, humidity, motion, luminance sensor types.                         |
+| 007 | V0.7 Zone aggregation                  | ✅                        | Auto-compute zone metrics from equipment data (motion=OR, temp=AVG, etc.).     |
+| 008 | Shutter equipments                     | ✅                        | Position + state + cover orders (open/close/stop).                             |
+| 009 | V0.8 Recipes                           | ✅                        | Automation engine with typed slots. First built-in recipes.                    |
+| 010 | V0.9 Modes                             | ✅                        | Named zone-level states (Day/Night/Away) with impacts.                         |
+| 011 | V0.10a Integration plugin architecture | 🔁 superseded by 040, 053 | Initial plugin interface for integrations.                                     |
+
+## V0.10 — built-in integrations (most are now 🔁 externalized as plugins)
+
+| #   | Title                          | Status                | Summary                                                                      |
+| --- | ------------------------------ | --------------------- | ---------------------------------------------------------------------------- |
+| 012 | V0.10b Panasonic Comfort Cloud | 🔁 → 050              | Panasonic AC cloud API polling (now a plugin).                               |
+| 013 | V0.10c MCZ Maestro             | 🔁 → 049              | MCZ pellet stove Socket.IO integration (now a plugin).                       |
+| 014 | V0.10d Netatmo Home+Control    | 🔁 → 048a, 048b, 048c | Netatmo HC integration (now split into 3 plugins: weather, control, energy). |
+
+## V0.11 — logging, backup, shutters UX
+
+| #   | Title                           | Status             | Summary                                                              |
+| --- | ------------------------------- | ------------------ | -------------------------------------------------------------------- |
+| 015 | V0.11 Logging system            | ✅                 | Pino structured logging, ring buffer, module tagging, UI log viewer. |
+| 016 | V0.8b Motion Light enhancements | ✅                 | Motion-light recipe refinements (time slots, override, fallback).    |
+| 017 | V0.11b Backup hardening         | 🔁 → 046, 058, 060 | First backup system (export/import).                                 |
+| 018 | Recipes roadmap                 | ✅ (meta)          | Roadmap document for planned recipes.                                |
+| 019 | V0.8c Switch light              | ✅                 | Switch-light recipe (toggle on button press).                        |
+| 020 | V0.8e Presence thermostat       | ✅                 | Presence-based thermostat setpoint logic with cocoon.                |
+| 021 | V0.8f Zone commands             | ✅                 | Zone-level order batching (allShuttersOpen/Close, allLightsOn/Off).  |
+
+## UX & dashboard
+
+| #   | Title                              | Status   | Summary                                                                 |
+| --- | ---------------------------------- | -------- | ----------------------------------------------------------------------- |
+| 022 | Dark mode                          | ✅       | Tailwind class-based dark mode with user preference.                    |
+| 023 | Sunrise / sunset                   | ✅       | SunCalc-based sunlight manager with offset settings.                    |
+| 024 | Motion light split                 | ✅       | Split motion-light into basic + dimmable variants.                      |
+| 025 | V0.13 History (InfluxDB)           | ✅       | Time-series history for numeric device data.                            |
+| 026 | V0.8 Cocoon thermostat             | ✅       | Bedtime cocoon logic for presence thermostat.                           |
+| 027 | V0.8 Presence heater               | ✅       | Presence-based heater recipe (eco/comfort).                             |
+| 028 | MQTT publishers                    | ✅       | Outbound MQTT publisher manager (mappings from events to topics).       |
+| 029 | MQTT brokers                       | ✅       | Multi-broker support for MQTT publishers.                               |
+| 030 | Logging audit                      | ✅       | Consolidated log level strategy and module taxonomy.                    |
+| 031 | Notification publishers            | ✅       | Telegram / webhook / FCM / ntfy notification channels.                  |
+| 032 | State watch recipe                 | ✅       | Generic data-key watch with alarm recipe.                               |
+| 033 | Dashboard widgets                  | ✅       | Customizable zone widgets on dashboard.                                 |
+| 034 | Progressive Web App                | ✅       | PWA manifest, service worker (`NetworkOnly` for /api/), offline banner. |
+| 035 | Energy dashboard                   | ✅       | Day/week/month/year energy breakdown with HP/HC classification.         |
+| 036 | Order dispatch error handling      | ✅       | Graceful fallback when order publish fails.                             |
+| 037 | Panasonic CC connection resilience | 🔁 → 050 | Reconnect logic for Panasonic Comfort Cloud.                            |
+| 038 | MCZ connection resilience          | 🔁 → 049 | Reconnect logic for MCZ Maestro.                                        |
+| 039 | Integrations page redesign         | ✅       | Unified integrations page (list, configure, status).                    |
+
+## Plugin system V2 (crucial — current architecture)
+
+| #   | Title                      | Status               | Summary                                                       |
+| --- | -------------------------- | -------------------- | ------------------------------------------------------------- |
+| 040 | Plugin engine              | 🟡 superseded by 053 | First generation plugin engine (install from local zip).      |
+| 041 | Weather forecast plugin    | ✅                   | Open-Meteo-based weather forecast plugin (reference example). |
+| 042 | Weather forecast equipment | ✅                   | Equipment type for forecast data display.                     |
+| 043 | Plugin update              | ✅                   | In-place plugin update from GitHub release.                   |
+| 044 | Plugin SmartThings         | ✅                   | Samsung SmartThings plugin (polling + orders).                |
+| 045 | Plugin SmartThings OAuth   | ✅                   | OAuth2 flow for SmartThings authentication.                   |
+| 046 | Backup v2                  | 🔁 → 058, 060        | Revised backup format (includes InfluxDB line protocol).      |
+| 047 | Prebuilt plugins           | ✅                   | Plugin distribution via GitHub releases (tarball).            |
+
+## V1.0 — externalizing all integrations as plugins
+
+| #    | Title                       | Status | Summary                                                                                                                                             |
+| ---- | --------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 048a | Plugin Netatmo Weather      | ✅     | Externalized Netatmo Weather Station integration.                                                                                                   |
+| 048b | Plugin Legrand Control      | ✅     | Externalized Legrand Home+Control (lights/shutters/plugs).                                                                                          |
+| 048c | Plugin Legrand Energy       | ✅     | Externalized Legrand energy monitoring (NLPC meters).                                                                                               |
+| 049  | Plugin MCZ Maestro          | ✅     | Externalized MCZ Maestro integration.                                                                                                               |
+| 050  | Plugin Panasonic CC         | ✅     | Externalized Panasonic Comfort Cloud integration.                                                                                                   |
+| 051  | Plugin LoRa2MQTT            | ✅     | LoRa2MQTT bridge as plugin.                                                                                                                         |
+| 052  | Plugin Zigbee2MQTT          | ✅     | Zigbee2MQTT as plugin (last built-in to be externalized).                                                                                           |
+| 053  | **Package manager**         | ✅     | **Major refactor**: `PackageManager` service manages all packages (integrations + recipes). GitHub-based distribution with `plugins/registry.json`. |
+| 054  | Recipe packages             | ✅     | Recipes externalized as packages (same distribution model as plugins).                                                                              |
+| 055  | Versioning + CI/CD + Docker | ✅     | GitHub Actions release workflow, `scripts/release.sh`, ghcr.io image, semver tags. Introduced v1.0.0.                                               |
+
+## V1.0+ — self-update & deployment
+
+| #   | Title                                           | Status                          | Summary                                                                                                                                                                                                                                                                                   |
+| --- | ----------------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 057 | Self-update UI                                  | 🔁 → 060                        | Initial self-update via UI (had race condition).                                                                                                                                                                                                                                          |
+| 058 | Backup completeness                             | ✅                              | Auto-download missing plugins on startup; dynamic data file scan; FK-safe restore.                                                                                                                                                                                                        |
+| 059 | Remote registry + backup fix                    | ✅                              | Remote `plugins/registry.json` fetch with cache + local fallback. InfluxDB ensureBuckets before restore.                                                                                                                                                                                  |
+| 060 | **Self-update helper + detection improvements** | ✅                              | **Current self-update architecture**: helper container pattern (spawn `docker:25-cli` that survives sowel death), auto pre-update backup in `data/backups/` (rotate keep 3), 1h version poll, WebSocket push of update.available, "Check for updates" button, `composeManaged` detection. |
+| 061 | Timezone from home location                     | 🟡 drafted, not yet implemented | Auto-derive `process.env.TZ` from `home.latitude`/`home.longitude` via `tz-lookup` to fix TZ-sensitive logic (calendar cron, HP/HC tariff, sunrise display). Temporary workaround: `TZ=Europe/Paris` hardcoded on sowelox.                                                                |
+
+---
+
+## How to use this index after context loss
+
+1. **Find the theme** you need via section headers above
+2. **Open `specs/XXX-name/spec.md`** for requirements and acceptance criteria
+3. **Open `specs/XXX-name/architecture.md`** for technical design, data model changes, file-level impact
+4. **Open `specs/XXX-name/plan.md`** for implementation steps
+
+For the current plugin-based architecture, start with **spec 053** (PackageManager) — it's the root of everything plugin-related.
+
+For self-update, start with **spec 060** — it supersedes spec 057 and is the current design.
+
+For the full system overview, see [technical/architecture.md](technical/architecture.md).
+
+For production operations (deploy, backup, self-update, logs), see [technical/deployment.md](technical/deployment.md).

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -147,32 +147,74 @@ sowel/
 
 ---
 
-## Integration Architecture
+## Plugin Architecture V2 (current)
 
-Sowel uses a plugin-based architecture for device integrations. Each device source implements the `IntegrationPlugin` interface and registers with the `IntegrationRegistry`.
+Since spec 053, **all integrations and recipes are plugins** distributed via GitHub. Nothing is built-in anymore — a fresh Sowel install has zero plugins and downloads them on demand from a registry.
 
-### Built-in Integrations
+### Core services
 
-| Integration             | Protocol          | Discovery                        |
-| ----------------------- | ----------------- | -------------------------------- |
-| Zigbee2MQTT             | MQTT              | Automatic (bridge/devices topic) |
-| Panasonic Comfort Cloud | Cloud API polling | Automatic (API device list)      |
-| MCZ Maestro             | Cloud API polling | Automatic (API device list)      |
-| Netatmo Home Coach      | Cloud API polling | Automatic (API device list)      |
+| Service                 | File                                       | Role                                                                                                                                                                                                                   |
+| ----------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PackageManager**      | `src/packages/package-manager.ts`          | Downloads, installs, updates, and removes packages (integrations + recipes). Fetches manifests from GitHub releases. Maintains DB state in `plugins` table.                                                            |
+| **PluginLoader**        | `src/plugins/plugin-loader.ts`             | Integration-specific loader. Imports the plugin JS entry (`dist/index.js`), calls `createPlugin`, registers with `IntegrationRegistry`. Auto-downloads plugin files on startup if missing (e.g. after backup restore). |
+| **RecipeLoader**        | `src/recipes/recipe-loader.ts`             | Recipe-specific loader. Same model as PluginLoader but for recipe packages.                                                                                                                                            |
+| **IntegrationRegistry** | `src/integrations/integration-registry.ts` | Runtime registry of connected integrations. Handles start/stop with staggering (to avoid simultaneous cloud API calls).                                                                                                |
 
-### Third-party Plugins
+### Distribution model
 
-Plugins are ESM Node.js packages installed in the `plugins/` directory. They export a `createPlugin` factory function that receives a `PluginDeps` object. See the [Plugin Development Guide](plugin-development.md) for details.
+Plugins live in separate GitHub repos (e.g. `mchacher/sowel-plugin-zigbee2mqtt`). Each release ships a prebuilt tarball. The **registry** — a list of available packages — is fetched from:
 
-### Integration Lifecycle
+- **Remote**: `https://raw.githubusercontent.com/mchacher/sowel/main/plugins/registry.json` (cache TTL 1h)
+- **Fallback**: local `plugins/registry.json` shipped in the Docker image
 
-1. **Registration**: Plugin registers with `IntegrationRegistry`.
-2. **Configuration check**: `isConfigured()` must return true before starting.
-3. **Start**: `start()` is called -- plugin connects, discovers devices, begins polling.
-4. **Runtime**: Plugin pushes device data via `deviceManager.updateDeviceData()`.
-5. **Stop**: `stop()` is called -- plugin cancels timers, closes connections.
+Installation flow:
 
-Settings for integrations are stored in the SQLite `settings` table under `integration.<id>.<key>` and configurable from the UI (Administration > Integrations).
+1. User clicks "Install" in Admin → Plugins UI
+2. PackageManager calls GitHub releases API for the plugin's repo
+3. Downloads the latest release tarball + manifest
+4. Extracts to `plugins/<id>/` on the `sowel-plugins` volume
+5. Inserts a row in the `plugins` SQLite table
+6. PluginLoader imports the entry and registers the integration
+
+The `plugins/registry.json` on `main` is the source of truth for the official plugin list. Any user can point to their own fork.
+
+### Plugin manifest format
+
+Each plugin ships a `manifest.json` with `id`, `type` (`integration` or `recipe`), `name`, `description`, `icon` (Lucide name), `author`, `repo`, `version`, `tags`. See [plugin-development.md](plugin-development.md) for the full spec.
+
+### Integration lifecycle
+
+1. **Load** — `PluginLoader.loadAll()` scans the `plugins` table, imports each enabled entry, calls `createPlugin(deps)`, registers with `IntegrationRegistry`.
+2. **Start** — `IntegrationRegistry.startAll()` starts plugins sequentially with small delays. Each plugin's `start()` connects, discovers devices, begins polling.
+3. **Runtime** — Plugin pushes data via `deviceManager.updateDeviceData()`. Orders go out via `plugin.executeOrder()`.
+4. **Stop** — `stop()` cancels timers, closes connections.
+5. **Update** — Unload → `PackageManager.updateFiles()` → reload.
+6. **Uninstall** — Unload → `PackageManager.removeFiles()`.
+
+Settings for integrations are stored in SQLite `settings` under `integration.<id>.<key>`, configured from the UI.
+
+### Current official plugin ecosystem
+
+| Plugin                  | Repo                                          | Type        |
+| ----------------------- | --------------------------------------------- | ----------- |
+| `zigbee2mqtt`           | `mchacher/sowel-plugin-zigbee2mqtt`           | integration |
+| `lora2mqtt`             | `mchacher/sowel-plugin-lora2mqtt`             | integration |
+| `panasonic_cc`          | `mchacher/sowel-plugin-panasonic-cc`          | integration |
+| `mcz_maestro`           | `mchacher/sowel-plugin-mcz-maestro`           | integration |
+| `legrand_control`       | `mchacher/sowel-plugin-legrand-control`       | integration |
+| `legrand_energy`        | `mchacher/sowel-plugin-legrand-energy`        | integration |
+| `netatmo_weather`       | `mchacher/sowel-plugin-netatmo-weather`       | integration |
+| `netatmo-security`      | `mchacher/sowel-plugin-netatmo-security`      | integration |
+| `weather-forecast`      | `mchacher/sowel-plugin-weather-forecast`      | integration |
+| `smartthings`           | `mchacher/sowel-plugin-smartthings`           | integration |
+| `motion-light`          | `mchacher/sowel-recipe-motion-light`          | recipe      |
+| `motion-light-dimmable` | `mchacher/sowel-recipe-motion-light-dimmable` | recipe      |
+| `switch-light`          | `mchacher/sowel-recipe-switch-light`          | recipe      |
+| `presence-heater`       | `mchacher/sowel-recipe-presence-heater`       | recipe      |
+| `presence-thermostat`   | `mchacher/sowel-recipe-presence-thermostat`   | recipe      |
+| `state-watch`           | `mchacher/sowel-recipe-state-watch`           | recipe      |
+
+The live list is in `plugins/registry.json` at the repo root.
 
 ---
 
@@ -254,23 +296,207 @@ InfluxDB is mandatory -- Sowel connects on startup and auto-creates buckets, dow
 
 ---
 
+## Backup & Restore
+
+Backups capture the full system state as a single ZIP archive and restore it atomically.
+
+### Service
+
+`BackupManager` in `src/backup/backup-manager.ts` is the central service. It is called by:
+
+- **HTTP routes** `GET/POST /api/v1/backup` (manual export/import)
+- **UpdateManager** (automatic pre-update backup — see self-update section)
+- **Local backup routes** `GET /api/v1/backup/local`, `POST /api/v1/backup/restore-local`
+
+### Archive format
+
+A backup ZIP contains:
+
+| Entry                     | Content                                                                                                          |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `sowel-backup.json`       | SQLite export as JSON, structured per table (version 2 format)                                                   |
+| `influx-raw.lp`           | Raw InfluxDB data as line protocol (last 7 days)                                                                 |
+| `influx-hourly.lp`        | Downsampled hourly data (last 90 days)                                                                           |
+| `influx-daily.lp`         | Downsampled daily data (last 5 years)                                                                            |
+| `influx-energy-hourly.lp` | Energy hourly sums (last 2 years)                                                                                |
+| `influx-energy-daily.lp`  | Energy daily sums (last 10 years)                                                                                |
+| `data/*`                  | All non-DB files from `data/` (token secrets, etc.) — dynamically scanned, excluding `.db`, `.pid`, `.log` files |
+
+The SQLite JSON export covers a curated list of tables (`BACKUP_TABLES` constant in `backup-manager.ts`) in dependency order (parents first for restore).
+
+### Local backups (data/backups/)
+
+Separate from manual export, `BackupManager.exportToFile()` writes backups to `data/backups/sowel-backup-<name>.zip` on the persistent volume. Used by:
+
+- **UpdateManager** before any self-update: `data/backups/sowel-backup-pre-v<version>-<timestamp>.zip`
+- **Rotation** via `rotateLocalBackups(keep)` — keeps only the N most recent files
+
+The UI (Admin → Backup) lists local backups and offers one-click restore via `POST /api/v1/backup/restore-local { filename }`.
+
+### Restore flow
+
+1. Validate ZIP structure and JSON schema
+2. Disable FK constraints (outside transaction — SQLite limitation)
+3. Delete all rows in reverse dependency order (children first)
+4. Insert new rows in parent-first order
+5. Run `PRAGMA foreign_key_check` — abort transaction if violations
+6. Ensure InfluxDB buckets exist (`influxClient.ensureBuckets()` and `ensureEnergyBuckets()`)
+7. POST each `.lp` file to InfluxDB `/api/v2/write` in batches of 5000 lines
+8. Restore dynamic data files
+9. Respond with `restartRequired: true` — user must restart sowel to reload state
+
+See spec 060 for the latest backup design and `src/backup/backup-manager.ts` for the implementation.
+
+---
+
+## Self-Update (spec 060)
+
+Sowel can update itself from the UI when running under `docker compose`. The design survives the "process kills itself" paradox via a helper container pattern (similar to Watchtower).
+
+### Detection
+
+`VersionChecker` in `src/core/version-checker.ts` polls `https://api.github.com/repos/mchacher/sowel/releases/latest` every 1 hour (also at T+10s after boot). When a newer semver is found, it emits `system.update.available` on the EventBus, which is broadcast to UI clients via WebSocket. The UI displays a badge in real time. A manual "Check now" button hits `POST /api/v1/system/version/check` which forces an immediate poll.
+
+`GET /api/v1/system/version` returns `{ current, latest, updateAvailable, releaseUrl, dockerAvailable, composeManaged }`. `composeManaged` is derived from the running container's labels (`com.docker.compose.*`); if absent, self-update is disabled with a tooltip.
+
+### Upgrade flow
+
+`UpdateManager` in `src/core/update-manager.ts` orchestrates the upgrade:
+
+1. **Pre-update backup** via `backupManager.exportToFile()` → `data/backups/sowel-backup-pre-v<X>-<ts>.zip`
+2. **Rotate backups** (keep 3 most recent)
+3. **Detect compose context** from current container labels: `com.docker.compose.project.working_dir`, `com.docker.compose.project`, `com.docker.compose.service`
+4. **Spawn helper container** via dockerode:
+   - Image: `docker:25-cli` (has `docker compose` built-in)
+   - Mounts: `/var/run/docker.sock` + the compose working dir as `/workdir`
+   - Cmd: `sh -c "sleep 5 && docker compose pull <service> && docker compose up -d <service>"`
+   - `AutoRemove: true`
+5. **Return from API immediately** — the helper survives sowel's death
+6. **UI shows overlay** ("Updating...") during the swap, polls `/system/version` every 3s
+7. **On version change** → `window.location.reload()`
+
+Why a helper? Calling `dockerode.stop()` on the current container from within the current process kills the Node runtime via SIGTERM before the remove/create/start sequence can run. The helper is a separate process in a separate container that survives the swap.
+
+**Requirements on the host**:
+
+- `/var/run/docker.sock` mounted into the sowel container
+- The compose working dir must be accessible from the host filesystem (any bind mount path works — Sowel reads it from container labels)
+- `docker compose up` must use a standard `docker-compose.yml` / `compose.yml` filename (non-standard file names need `-f`, not currently handled)
+
+---
+
+## CI/CD & Releases (spec 055)
+
+### GitHub Actions workflow
+
+`.github/workflows/release.yml` triggers on pushed tags matching `v*`. It runs:
+
+1. **ci job** — typecheck, lint, tests (backend + UI)
+2. **docker job** — builds `linux/amd64` image with Buildx, pushes to `ghcr.io/mchacher/sowel:<version>` and `:latest`, then creates a GitHub Release with auto-generated notes
+
+The Docker build is **amd64-only** (spec simplified in April 2026 for ~3x faster builds; arm64 dropped because no users run on Apple Silicon Linux hosts in production).
+
+### Release script
+
+`scripts/release.sh <version>`:
+
+1. Validates semver format and clean working tree
+2. Bumps `package.json` + `ui/package.json` versions
+3. Runs full validation (`npm run validate`)
+4. Commits `release: vX.Y.Z`, tags `vX.Y.Z`, pushes to origin
+5. GitHub Actions takes over from there
+
+A Claude Code skill wraps this at `.claude/skills/sowel-release/SKILL.md`.
+
+### Docker image (`Dockerfile`)
+
+Multi-stage build:
+
+1. **backend-build** — Node 20, `tsc` backend
+2. **ui-build** — Node 20, Vite UI build
+3. **runtime** — Debian Trixie (for Python 3.13), Node 20 installed via NodeSource, Python 3.13 + venv for plugins that need it (e.g. Panasonic CC), `better-sqlite3` rebuilt for the platform
+
+Runtime image is ~950 MB uncompressed (~210 MB content). The Python 3.13 requirement dates from the Panasonic CC plugin needing f-string syntax unavailable in Python 3.11.
+
+---
+
+## Logging
+
+### Strategy
+
+Pino structured JSON logging with multistream output (see `src/core/logger.ts`):
+
+- **Ring buffer** — in-memory circular buffer for UI log viewer (always captures debug level)
+- **stdout** — raw JSON in production (captured by Docker logs), pino-pretty in development
+- **File transport** — in production only, via `pino-roll` to `data/logs/sowel-N.log`, daily rotation, keep 14 files
+
+### Log file location
+
+`/app/data/logs/sowel-<N>.log` inside the container (on the `sowel-data` volume). **Survives container recreation** — essential for post-incident investigation after a self-update.
+
+Example retrieval:
+
+```bash
+docker exec sowel sh -c 'cat /app/data/logs/sowel.6.log | grep -E "2026-04-11T07:" | grep error'
+```
+
+### Log level guidance
+
+| Level   | Purpose                                                    |
+| ------- | ---------------------------------------------------------- |
+| `fatal` | Process crash imminent                                     |
+| `error` | Operation failed, engine continues (always with `{ err }`) |
+| `warn`  | Self-recovering degradation (reconnect, stale data)        |
+| `info`  | Significant business events, one per operation             |
+| `debug` | Developer troubleshooting detail                           |
+| `trace` | High-volume hot path (every event, every MQTT message)     |
+
+Conventions:
+
+- Every module creates a child logger with `{ module: "module-name" }`
+- Structured context as first argument object: `logger.info({ deviceId, status }, "Device status changed")`
+- Passwords/tokens/secrets are auto-redacted by pino config
+- **Never use `console.*`** — bypasses ring buffer, file rotation, and redaction
+
+### Retrieval helpers
+
+- **From UI** — Admin → Logs page (reads the ring buffer)
+- **Via API** — `GET /api/v1/logs?module=X&level=Y&limit=N` (ring buffer only, lost on restart)
+- **From file** — `docker exec` into `/app/data/logs/sowel-*.log` (persistent)
+- **Helper script** — `scripts/logs/fetch-logs.py <module> <level> <limit>` with `SOWEL_URL` + `SOWEL_PASSWORD` env vars
+
+---
+
+## Timezone handling
+
+Sowel backend logic depends heavily on local time: calendar cron slots (`croner`), energy HP/HC tariff classification, energy day boundaries, sunrise/sunset display, notifications. All use native `Date` methods that depend on `process.env.TZ`.
+
+**Current state (2026-04-11)**: set `TZ=Europe/Paris` in `docker-compose.yml` environment for production sowelox. This is a temporary workaround.
+
+**Target state (spec 061, drafted)**: auto-derive the timezone from `home.latitude` / `home.longitude` at startup via `tz-lookup`, with `TZ` env var as override. Node caches TZ on first Date call, so changes require restart.
+
+See spec 061 at [github.com/mchacher/sowel/tree/main/specs/061-timezone-from-home-location](https://github.com/mchacher/sowel/tree/main/specs/061-timezone-from-home-location).
+
+---
+
 ## Environment Variables
 
 All settings are optional with sensible defaults -- Sowel runs zero-config out of the box. Override via `.env` if needed:
 
-| Variable          | Default                 | Notes                                             |
-| ----------------- | ----------------------- | ------------------------------------------------- |
-| `SQLITE_PATH`     | `./data/sowel.db`       | SQLite database path                              |
-| `API_PORT`        | `3000`                  | HTTP server port                                  |
-| `API_HOST`        | `0.0.0.0`               | Bind address                                      |
-| `JWT_SECRET`      | auto-generated          | Persisted in `data/.jwt-secret` on first launch   |
-| `JWT_ACCESS_TTL`  | `900`                   | Access token TTL in seconds (15 min)              |
-| `JWT_REFRESH_TTL` | `2592000`               | Refresh token TTL in seconds (30 days)            |
-| `LOG_LEVEL`       | `info`                  | Pino log level                                    |
-| `CORS_ORIGINS`    | `*`                     | Comma-separated allowed origins                   |
-| `INFLUX_URL`      | `http://localhost:8086` | InfluxDB 2.x URL                                  |
-| `INFLUX_TOKEN`    | auto-generated          | Persisted in `data/.influx-token` on first launch |
-| `INFLUX_ORG`      | `sowel`                 | InfluxDB organization                             |
-| `INFLUX_BUCKET`   | `sowel`                 | InfluxDB primary bucket                           |
+| Variable          | Default                        | Notes                                                                    |
+| ----------------- | ------------------------------ | ------------------------------------------------------------------------ |
+| `SQLITE_PATH`     | `./data/sowel.db`              | SQLite database path                                                     |
+| `API_PORT`        | `3000`                         | HTTP server port                                                         |
+| `API_HOST`        | `0.0.0.0`                      | Bind address                                                             |
+| `JWT_SECRET`      | auto-generated                 | Persisted in `data/.jwt-secret` on first launch                          |
+| `JWT_ACCESS_TTL`  | `900`                          | Access token TTL in seconds (15 min)                                     |
+| `JWT_REFRESH_TTL` | `2592000`                      | Refresh token TTL in seconds (30 days)                                   |
+| `LOG_LEVEL`       | `info`                         | Pino log level                                                           |
+| `CORS_ORIGINS`    | `*`                            | Comma-separated allowed origins                                          |
+| `INFLUX_URL`      | `http://localhost:8086`        | InfluxDB 2.x URL                                                         |
+| `INFLUX_TOKEN`    | auto-generated                 | Persisted in `data/.influx-token` on first launch                        |
+| `INFLUX_ORG`      | `sowel`                        | InfluxDB organization                                                    |
+| `INFLUX_BUCKET`   | `sowel`                        | InfluxDB primary bucket                                                  |
+| `TZ`              | system default (UTC in Docker) | IANA timezone. Set explicitly in docker-compose to fix time-based logic. |
 
 Integration settings (MQTT, cloud credentials, polling intervals) are configured from the UI, not from `.env`.

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -1,0 +1,390 @@
+# Deployment Guide
+
+This guide covers deploying, updating, backing up, and troubleshooting Sowel in production.
+
+---
+
+## Initial deployment
+
+Sowel ships as a Docker image at `ghcr.io/mchacher/sowel:latest`. A production deployment consists of two containers (`sowel` + `sowel-influxdb`) orchestrated by `docker compose`.
+
+### Prerequisites
+
+- Linux host (x86_64) with Docker Engine 20.10+ and `docker compose` v2
+- At least 2 GB RAM, 10 GB disk (InfluxDB data grows over time)
+- Network access to `ghcr.io` for image pulls and `api.github.com` for version checks
+
+### Steps
+
+```bash
+# 1. Pick a deployment directory (convention: /opt/sowel)
+sudo mkdir -p /opt/sowel
+sudo chown $USER:$USER /opt/sowel
+cd /opt/sowel
+
+# 2. Download the reference docker-compose.yml
+curl -O https://raw.githubusercontent.com/mchacher/sowel/main/docker-compose.yml
+
+# 3. Optional: set your timezone (recommended — fixes calendar scheduling,
+#    HP/HC tariff classification, sunrise/sunset display)
+#    Edit docker-compose.yml and uncomment / add:
+#      - TZ=Europe/Paris
+
+# 4. Launch
+docker compose up -d
+
+# 5. Check containers are up
+docker compose ps
+
+# 6. Open the UI and create the first admin
+open http://<host>:3000
+```
+
+On first boot, Sowel:
+
+- Creates its SQLite DB at `/app/data/sowel.db` (on the `sowel-data` volume)
+- Generates a persisted JWT secret (`data/.jwt-secret`) and InfluxDB admin token
+- Waits for you to create the first admin via the UI setup screen
+
+### Volumes
+
+| Volume          | Mount                | Content                                                 |
+| --------------- | -------------------- | ------------------------------------------------------- |
+| `sowel-data`    | `/app/data`          | SQLite DB, logs, secrets, backups, data files           |
+| `sowel-plugins` | `/app/plugins`       | Installed plugin files (`dist/`, `manifest.json`, etc.) |
+| `influxdb-data` | `/var/lib/influxdb2` | Time-series storage                                     |
+
+These are **named Docker volumes**, persistent across container recreation. They are what make self-update and backup/restore work — the stateful data survives.
+
+### Required host binding
+
+For **self-update** (spec 060) to work, the Docker socket must be mounted:
+
+```yaml
+services:
+  sowel:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+Without this, the "Update now" button in the UI is disabled.
+
+---
+
+## Operations
+
+### Checking status
+
+```bash
+docker compose ps
+docker logs -f sowel          # live logs from stdout
+docker logs --tail 100 sowel  # last 100 lines
+```
+
+Or via the API:
+
+```bash
+curl -s http://localhost:3000/api/v1/health | jq
+```
+
+### Restart
+
+```bash
+docker compose restart sowel
+```
+
+The ring buffer is in-memory, so restart clears it. The file log (`data/logs/sowel-N.log`) survives.
+
+### Stop / start
+
+```bash
+docker compose stop
+docker compose start
+```
+
+### Rebuild container (without image change)
+
+```bash
+docker compose up -d --force-recreate sowel
+```
+
+---
+
+## Updates
+
+Sowel supports **two paths**: self-update from the UI (easy) and manual update via compose (fallback).
+
+### Path 1 — Self-update from UI (preferred)
+
+1. Sign in as admin
+2. Open the settings / version badge — if an update is available, a badge shows "vX.Y.Z"
+3. Click the badge → confirm in the modal
+4. Sowel creates an automatic backup, then spawns a helper container that does the swap
+5. The UI shows an "Update in progress" overlay
+6. After ~30-90 seconds, the page reloads on the new version
+
+**Requirements**:
+
+- Running under `docker compose` (Sowel detects this via container labels)
+- `/var/run/docker.sock` mounted in the sowel container
+- `docker-compose.yml` in a bind-mounted or accessible directory on the host
+
+If any requirement is missing, the Update button is disabled with a tooltip explaining what to do.
+
+### Path 2 — Manual update via docker compose (fallback)
+
+```bash
+cd /opt/sowel
+docker compose pull sowel   # fetch the latest image from ghcr.io
+docker compose up -d sowel  # recreate the container
+```
+
+Sowel restarts, migrations run automatically, plugins are auto-downloaded if missing (spec 058), and the UI resumes.
+
+**Use this when**:
+
+- Self-update UI is disabled (no docker socket, non-compose deployment)
+- Upgrading across a version that itself contains a self-update bug (e.g. from v1.0.6, which had the race condition fixed in v1.0.7)
+- You want to pin a specific version — edit `docker-compose.yml` to `ghcr.io/mchacher/sowel:1.0.7` before `pull`
+
+---
+
+## Backup & Restore
+
+Backups capture SQLite, InfluxDB data, and all dynamic `data/*` files into a single ZIP.
+
+### Manual backup (export)
+
+**From the UI**: Admin → Backup → "Download a backup". The browser downloads a `sowel-backup-<date>.zip` file.
+
+**From the API**:
+
+```bash
+TOKEN=$(curl -s http://<host>:3000/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  --data-raw '{"username":"admin","password":"<pwd>"}' | jq -r .accessToken)
+
+curl -s http://<host>:3000/api/v1/backup \
+  -H "Authorization: Bearer $TOKEN" \
+  -o sowel-backup.zip
+```
+
+### Automatic pre-update backups (local)
+
+Before every self-update, Sowel creates a backup in `data/backups/sowel-backup-pre-v<version>-<timestamp>.zip`. The three most recent are kept; older are rotated out.
+
+**Listing local backups**:
+
+- From the UI: Admin → Backup → "Local backups" section
+- Via the API: `GET /api/v1/backup/local`
+
+**Restoring a local backup**:
+
+- From the UI: click "Restore" next to the backup in the list
+- Via the API: `POST /api/v1/backup/restore-local { "filename": "sowel-backup-pre-v1.0.7-2026-04-11T08-28-45.zip" }`
+
+### Manual restore (import)
+
+**From the UI**: Admin → Backup → "Upload a backup".
+
+**From the API**:
+
+```bash
+curl -s -X POST http://<host>:3000/api/v1/backup \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "file=@sowel-backup.zip"
+```
+
+After restore, Sowel reports `{ restartRequired: true }`. You must restart the container for the restored state to take full effect:
+
+```bash
+docker compose restart sowel
+```
+
+### Archive contents
+
+See the "Backup & Restore" section in [architecture.md](architecture.md) for the full format.
+
+---
+
+## Logging access
+
+### Three sources
+
+| Source                                       | Retention                           | Use case                                                                              |
+| -------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------- |
+| **Ring buffer** (memory)                     | Lost on restart                     | Live tail via UI Admin → Logs                                                         |
+| **Docker stdout**                            | Per-container (lost on recreate)    | `docker logs sowel`                                                                   |
+| **`pino-roll` files** on `sowel-data` volume | 14 daily files, survives recreation | **Post-incident investigation** — the only source that survives self-update recreates |
+
+### Accessing the file logs
+
+```bash
+# List files
+docker exec sowel ls -la /app/data/logs/
+
+# View today's log
+docker exec sowel cat /app/data/logs/sowel.6.log
+
+# Grep errors/warns in a time window
+docker exec sowel sh -c 'cat /app/data/logs/sowel.6.log | grep -E "2026-04-11T07:" | grep -E "\"level\":\"(error|warn)\""'
+```
+
+### Via the helper script
+
+From the repo (on your dev machine):
+
+```bash
+SOWEL_URL=http://<host>:3000 SOWEL_PASSWORD='<pwd>' \
+  python3 scripts/logs/fetch-logs.py "" error 100
+
+# Filter by module
+SOWEL_URL=http://<host>:3000 SOWEL_PASSWORD='<pwd>' \
+  python3 scripts/logs/fetch-logs.py recipe-manager debug 50
+```
+
+This queries the **ring buffer** via the API — so only logs since the last restart.
+
+### Temporarily raising the log level
+
+```bash
+curl -s -X PUT http://<host>:3000/api/v1/logs/level \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"level":"debug"}'
+```
+
+This affects the ring buffer only (always at debug by default) — the file transport is at the root level set via `LOG_LEVEL` env var.
+
+---
+
+## Version check
+
+```bash
+TOKEN=$(curl -s -X POST http://<host>:3000/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  --data-raw '{"username":"admin","password":"<pwd>"}' | jq -r .accessToken)
+
+curl -s http://<host>:3000/api/v1/system/version \
+  -H "Authorization: Bearer $TOKEN" | jq
+```
+
+Expected response:
+
+```json
+{
+  "current": "1.0.8",
+  "latest": "1.0.8",
+  "updateAvailable": false,
+  "releaseUrl": "https://github.com/mchacher/sowel/releases/tag/v1.0.8",
+  "dockerAvailable": true,
+  "composeManaged": true
+}
+```
+
+Force a fresh GitHub poll:
+
+```bash
+curl -s -X POST http://<host>:3000/api/v1/system/version/check \
+  -H "Authorization: Bearer $TOKEN" | jq
+```
+
+---
+
+## Troubleshooting
+
+### Container keeps restarting
+
+```bash
+docker logs --tail 50 sowel
+```
+
+Common causes:
+
+- Database migration error — check for `migration failed` in logs
+- Missing `/var/run/docker.sock` but self-update is enabled — should only warn, not crash
+- InfluxDB not reachable — check `sowel-influxdb` is up
+
+### Integration not connecting
+
+1. Check status in UI Admin → Integrations or via `GET /api/v1/integrations`
+2. Check logs for the specific plugin module: `plugin:<id>`
+3. Check settings are configured under `integration.<id>.*` in the `settings` table
+
+### Self-update fails
+
+Symptoms: click "Update", overlay shows, but page never reloads. Container still on old version.
+
+Recovery:
+
+```bash
+cd /opt/sowel
+docker compose up -d  # recreates the current container if helper failed mid-way
+# Or manual upgrade:
+docker compose pull && docker compose up -d
+```
+
+Investigation:
+
+- Helper container logs are **lost** if `AutoRemove: true` (current default, spec 060)
+- Check sowel's own logs right before the helper was spawned: `Update helper spawned` is the last line before the swap
+- If sowel never came back, check `docker ps -a` to see if the container is Exited
+
+### Database corrupted
+
+SQLite is WAL mode — safe for abrupt shutdowns in most cases. If corruption:
+
+```bash
+# Stop sowel
+docker compose stop sowel
+
+# Backup the corrupted DB
+docker run --rm -v /opt/sowel_sowel-data:/data alpine cp /data/sowel.db /data/sowel.db.broken
+
+# Restore from the most recent local backup
+docker run --rm -v /opt/sowel_sowel-data:/data alpine ls /data/backups/
+
+# Then use the restore flow (see above)
+```
+
+### InfluxDB bucket missing after restore
+
+If you restore to a fresh machine, InfluxDB may not have buckets yet. The current restore flow (spec 059) calls `ensureBuckets()` and `ensureEnergyBuckets()` before writing data, so this should be automatic. If not, check `sowel-influxdb` logs.
+
+### Time-based logic broken (shutters at wrong time, HP/HC wrong)
+
+The container defaults to UTC. Set `TZ=Europe/Paris` (or your timezone) in `docker-compose.yml` → restart. See [architecture.md § Timezone handling](architecture.md#timezone-handling) and spec 061 at [github.com/mchacher/sowel/tree/main/specs/061-timezone-from-home-location](https://github.com/mchacher/sowel/tree/main/specs/061-timezone-from-home-location).
+
+---
+
+## Production reference — current deployment
+
+The maintainer's production deployment (as of 2026-04-11):
+
+- **Host**: Proxmox VM `sowelox` (Linux, x86_64, 8 GB RAM)
+- **Path**: `/opt/sowel/`
+- **Access**: LAN `http://192.168.0.230:3000`, public `https://app.sowel.org` via Cloudflare Tunnel
+- **Containers**: `sowel` + `sowel-influxdb`
+- **Timezone**: `TZ=Europe/Paris` explicitly set in compose (workaround pending spec 061)
+- **Current version**: tracked via `git log specs/060-self-update-helper-and-detection/` and `docker logs sowel | grep "Sowel engine started"`
+- **Backups**: local in `data/backups/` (auto), manual downloads on maintainer's Mac
+- **MQTT**: external `mosquitto` running on the same VM (not in compose), used by `zigbee2mqtt` and `lora2mqtt` plugins
+- **Zigbee2MQTT**: external daemon on sowelox, not managed by Sowel itself
+
+The connectivity graph:
+
+```
+         Internet
+            |
+     Cloudflare Tunnel
+            |
+     sowelox (Linux VM)
+     +-- docker: sowel           (port 3000)
+     +-- docker: sowel-influxdb
+     +-- docker: mosquitto       (MQTT broker, 1883)
+     +-- systemd: zigbee2mqtt   (reads Zigbee coordinator USB)
+     +-- systemd: lora2mqtt     (reads LoRa dongle USB)
+     +-- systemd: cloudflared   (tunnel)
+```
+
+See the memory file `reference_sowel_access.md` for SSH / API credentials.

--- a/docs/technical/index.md
+++ b/docs/technical/index.md
@@ -1,6 +1,6 @@
 # Technical Guide
 
-This section covers the architecture, APIs, and development guides for Sowel.
+This section covers the architecture, APIs, development, and operations of Sowel.
 
 ## Overview
 
@@ -15,18 +15,25 @@ Integration message (MQTT, cloud API poll, plugin)
           → Event Bus: "equipment.data.changed"
             → Zone Manager (re-evaluates aggregations)
               → Event Bus: "zone.data.changed"
-                → Scenario Engine (triggers → conditions → actions)
+                → Recipe Engine (triggers → conditions → actions)
                   → Actions may emit Orders → Integration Plugin → device
             → WebSocket pushes to UI clients
 ```
 
+Since spec 053, **everything is a plugin** — integrations and recipes are distributed from GitHub via the `PackageManager` service. There are no built-in integrations in `src/` anymore.
+
 ## Sections
 
-| Section                                     | Description                                       |
-| ------------------------------------------- | ------------------------------------------------- |
-| [Architecture](architecture.md)             | System design, tech stack, project structure      |
-| [API Reference](api-reference.md)           | REST API endpoints and WebSocket events           |
-| [Plugin Development](plugin-development.md) | How to create third-party plugins                 |
-| [Recipe Development](recipe-development.md) | How to create automation recipe templates         |
-| [Data Model](data-model.md)                 | SQLite schema, TypeScript types, event bus events |
-| [Contributing](contributing.md)             | Development setup, conventions, and workflow      |
+| Section                                     | Description                                                     |
+| ------------------------------------------- | --------------------------------------------------------------- |
+| [Architecture](architecture.md)             | System design, plugin V2, self-update, backup, CI/CD, logging   |
+| [Deployment](deployment.md)                 | Production deployment, updates, backup/restore, troubleshooting |
+| [API Reference](api-reference.md)           | REST API endpoints and WebSocket events                         |
+| [Plugin Development](plugin-development.md) | How to create third-party plugin integrations                   |
+| [Recipe Development](recipe-development.md) | How to create automation recipe packages                        |
+| [Data Model](data-model.md)                 | SQLite schema, TypeScript types, event bus events               |
+| [Contributing](contributing.md)             | Development setup, conventions, and workflow                    |
+
+## Specs index
+
+For a chronological list of every spec with one-line summaries and status, see [../specs-index.md](../specs-index.md).

--- a/docs/technical/plugin-development.md
+++ b/docs/technical/plugin-development.md
@@ -945,6 +945,7 @@ To make your plugin appear in the Sowel plugin store, submit a PR to the Sowel r
 ```json
 {
   "id": "my-device",
+  "type": "integration",
   "name": "My Device",
   "description": "Integration with My Device API",
   "icon": "Cpu",
@@ -957,16 +958,25 @@ To make your plugin appear in the Sowel plugin store, submit a PR to the Sowel r
 
 #### Registry Entry Schema
 
-| Field         | Type     | Required | Description                                                   |
-| ------------- | -------- | -------- | ------------------------------------------------------------- |
-| `id`          | string   | Yes      | Must match the plugin's `manifest.json` id                    |
-| `name`        | string   | Yes      | Display name in the store                                     |
-| `description` | string   | Yes      | Short description                                             |
-| `icon`        | string   | Yes      | Lucide icon name                                              |
-| `author`      | string   | Yes      | Author name                                                   |
-| `repo`        | string   | Yes      | GitHub `owner/repo` path (used to fetch releases)             |
-| `version`     | string   | No       | Latest available version (shown in the store "Available" tab) |
-| `tags`        | string[] | Yes      | Searchable tags (e.g. `["camera", "security"]`)               |
+| Field         | Type     | Required | Description                                                                        |
+| ------------- | -------- | -------- | ---------------------------------------------------------------------------------- |
+| `id`          | string   | Yes      | Must match the plugin's `manifest.json` id                                         |
+| `type`        | string   | Yes      | `integration` or `recipe` — routes to PluginLoader or RecipeLoader at install time |
+| `name`        | string   | Yes      | Display name in the store                                                          |
+| `description` | string   | Yes      | Short description                                                                  |
+| `icon`        | string   | Yes      | Lucide icon name                                                                   |
+| `author`      | string   | Yes      | Author name                                                                        |
+| `repo`        | string   | Yes      | GitHub `owner/repo` path (used to fetch releases)                                  |
+| `version`     | string   | No       | Latest available version (shown in the store "Available" tab)                      |
+| `tags`        | string[] | Yes      | Searchable tags (e.g. `["camera", "security"]`)                                    |
+
+#### Remote registry fetch
+
+Since spec 059, Sowel fetches `plugins/registry.json` from `https://raw.githubusercontent.com/mchacher/sowel/main/plugins/registry.json` with a 1-hour cache, falling back to the local file shipped in the Docker image. This means:
+
+- **Publishing a new plugin version** only requires updating `plugins/registry.json` on `main` — no Sowel release needed
+- **Private forks** can point Sowel at their own registry by changing `REGISTRY_URL` in `package-manager.ts`
+- **Plugins are re-downloaded automatically** on container startup if their directory is missing (e.g. after a backup restore — spec 058)
 
 ### Versioning
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,11 +72,13 @@ nav:
   - Technical Guide:
     - technical/index.md
     - Architecture: technical/architecture.md
+    - Deployment: technical/deployment.md
     - API Reference: technical/api-reference.md
     - Plugin Development: technical/plugin-development.md
     - Recipe Development: technical/recipe-development.md
     - Data Model: technical/data-model.md
     - Contributing: technical/contributing.md
+    - Specs Index: specs-index.md
   - User Guide:
     - user/index.md
     - Getting Started: user/getting-started.md

--- a/specs/061-timezone-from-home-location/architecture.md
+++ b/specs/061-timezone-from-home-location/architecture.md
@@ -1,0 +1,179 @@
+# Architecture — Spec 061
+
+## Flow at startup
+
+```
+src/index.ts (entry point)
+  │
+  ├─ 1. Load settings from DB (read-only, before any Date-using module)
+  │
+  ├─ 2. detectTimezone({ latitude, longitude, tzEnv: process.env.TZ, logger })
+  │     │
+  │     ├─ if tzEnv is already set → return tzEnv (no override)
+  │     ├─ if latitude && longitude → tzLookup(lat, lon) → return TZ
+  │     └─ else → return "UTC" + log WARN
+  │
+  ├─ 3. process.env.TZ = detected_tz
+  │     (⚠️ MUST happen before any Date method or cron is used)
+  │
+  ├─ 4. Continue normal startup: create managers, server, etc.
+  │     All Date methods, crons, suncalc, etc. now use the correct TZ
+```
+
+## Key insight
+
+**`process.env.TZ` must be set before the first Date method is called**, otherwise Node.js caches the TZ internally and subsequent changes don't take effect. The `detectTimezone()` function runs at the very start of `main()`, before any manager is instantiated.
+
+## New module: `src/core/timezone.ts`
+
+```typescript
+import tzLookup from "tz-lookup";
+import type { Logger } from "./logger.js";
+
+export interface DetectTimezoneOptions {
+  latitude?: number | null;
+  longitude?: number | null;
+  tzEnv?: string | undefined; // process.env.TZ at startup
+  logger: Logger;
+}
+
+/**
+ * Determines which timezone Sowel should operate in.
+ *
+ * Priority:
+ *   1. TZ env var (if set at startup) — explicit override
+ *   2. Auto-derive from home.latitude/longitude via tz-lookup
+ *   3. Fallback to UTC with a warning
+ *
+ * Returns an IANA timezone name (e.g., "Europe/Paris").
+ */
+export function detectTimezone(opts: DetectTimezoneOptions): string {
+  const { latitude, longitude, tzEnv, logger } = opts;
+  const tzLogger = logger.child({ module: "timezone" });
+
+  // Priority 1: env var
+  if (tzEnv && tzEnv.trim()) {
+    tzLogger.info({ tz: tzEnv }, "Timezone set from TZ env var");
+    return tzEnv.trim();
+  }
+
+  // Priority 2: auto-derive from coordinates
+  if (typeof latitude === "number" && typeof longitude === "number") {
+    try {
+      const tz = tzLookup(latitude, longitude);
+      tzLogger.info({ tz, latitude, longitude }, "Timezone detected from home location");
+      return tz;
+    } catch (err) {
+      tzLogger.warn(
+        { err, latitude, longitude },
+        "Failed to derive timezone from home location, falling back to UTC",
+      );
+    }
+  }
+
+  // Priority 3: fallback
+  tzLogger.warn(
+    "Timezone not configured: using UTC. Set home.latitude/longitude in Settings or TZ env var in docker-compose.yml for correct local time.",
+  );
+  return "UTC";
+}
+```
+
+## Integration in `src/index.ts`
+
+Near the top of `main()`, after opening the database and loading settings:
+
+```typescript
+// Load settings BEFORE creating any manager (for timezone detection)
+const settings = new SettingsManager(db, logger);
+const latStr = settings.get("home.latitude");
+const lonStr = settings.get("home.longitude");
+const latitude = latStr ? parseFloat(latStr) : null;
+const longitude = lonStr ? parseFloat(lonStr) : null;
+
+const detectedTz = detectTimezone({
+  latitude: isNaN(latitude ?? NaN) ? null : latitude,
+  longitude: isNaN(longitude ?? NaN) ? null : longitude,
+  tzEnv: process.env.TZ,
+  logger,
+});
+
+// Set TZ globally — affects all subsequent Date methods
+process.env.TZ = detectedTz;
+
+// Continue normal startup...
+```
+
+⚠️ **Caveat on runtime changes**: Node.js caches the TZ internally on the first Date method call. Changing `process.env.TZ` at runtime does NOT affect already-loaded Date behavior. Hence the FR4 restart requirement.
+
+## Integration with croner
+
+`croner` uses the system TZ by default. Once `process.env.TZ` is set at boot, croner automatically uses it. **No code change in `calendar-manager.ts`**.
+
+## Integration with suncalc
+
+`suncalc` returns Date objects with absolute timestamps (they're always correct). The issue is only in how Sowel **formats** those dates. Once `Date.prototype.getHours()` returns CEST hours, the existing `formatTime()` in `sunlight-manager.ts` works correctly.
+
+**No code change in `sunlight-manager.ts`**.
+
+## Integration with tariff-classifier, energy-aggregator, notifications
+
+Same reasoning — they all use native Date methods. **No code change**.
+
+## Settings change handler
+
+In `SettingsManager` or wherever `home.latitude`/`home.longitude` are updated:
+
+```typescript
+if (keys.includes("home.latitude") || keys.includes("home.longitude")) {
+  this.logger.warn("Home location changed. Restart Sowel for timezone changes to fully apply.");
+  // Optionally: emit an event to the UI
+  this.eventBus.emit({
+    type: "system.restart_required",
+    reason: "timezone_changed",
+  });
+}
+```
+
+UI listens for this event and shows a toast.
+
+## Repo `docker-compose.yml` update
+
+```yaml
+services:
+  sowel:
+    image: ghcr.io/mchacher/sowel:latest
+    container_name: sowel
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      # Timezone: by default, Sowel auto-derives from home.latitude/longitude
+      # in Settings. To override explicitly, uncomment and set:
+      # - TZ=Europe/Paris
+      - INFLUX_URL=http://influxdb:8086
+      # ... rest unchanged
+```
+
+## Files changed
+
+| Domain | File                              | Change                                              |
+| ------ | --------------------------------- | --------------------------------------------------- |
+| Core   | `src/core/timezone.ts` (NEW)      | `detectTimezone()` helper                           |
+| Core   | `src/core/timezone.test.ts` (NEW) | Unit tests for detection logic                      |
+| Core   | `src/index.ts`                    | Call `detectTimezone()` early, set `process.env.TZ` |
+| Core   | `src/core/settings-manager.ts`    | Emit warn/event on home.latitude/longitude change   |
+| Shared | `src/shared/types.ts`             | New event type `system.restart_required` (optional) |
+| UI     | `ui/src/store/useWebSocket.ts`    | Handle `system.restart_required` event              |
+| UI     | `ui/src/pages/SettingsPage.tsx`   | Toast on home location change success               |
+| Infra  | `docker-compose.yml` (repo root)  | Add commented TZ example                            |
+| Docs   | `README.md`                       | Timezone section                                    |
+| Deps   | `package.json`                    | Add `tz-lookup` dependency                          |
+
+## Why this design
+
+- **Minimal code changes**: one new helper + one line in `index.ts`. No refactor of 15+ call sites
+- **Zero-config for 90% of users**: they already set lat/lon for sunlight — timezone is derived for free
+- **Escape hatch**: `TZ` env var remains the ultimate override for unusual deployments
+- **Clear failure mode**: when nothing is configured, loud WARN log tells the user what to do
+- **Respects Node.js limitations**: TZ is set once at boot, documented restart requirement for changes

--- a/specs/061-timezone-from-home-location/plan.md
+++ b/specs/061-timezone-from-home-location/plan.md
@@ -1,0 +1,179 @@
+# Implementation Plan — Spec 061
+
+## Strategy
+
+Tiny surgical change at the startup boundary. No refactor of existing time-using code. Three slices:
+
+1. **A** — Core timezone detection module + integration in `index.ts`
+2. **B** — Settings change notification (UI toast + WS event for restart hint)
+3. **C** — Docker compose + README documentation
+
+All in a single PR.
+
+---
+
+## Slice A — Timezone detection at startup
+
+### A.1 — Add `tz-lookup` dependency
+
+```bash
+npm install tz-lookup
+```
+
+Also add types if needed (tz-lookup ships its own `.d.ts` or a simple ambient declaration may be needed).
+
+### A.2 — Create `src/core/timezone.ts`
+
+Implements `detectTimezone()` as described in architecture.md:
+
+- Priority 1: `tzEnv` (from `process.env.TZ`)
+- Priority 2: `tzLookup(latitude, longitude)`
+- Priority 3: fallback `"UTC"` + warn log
+
+Exports:
+
+```typescript
+export function detectTimezone(opts: DetectTimezoneOptions): string;
+```
+
+### A.3 — Integrate in `src/index.ts`
+
+At the very top of `main()`, right after the database is opened and **before** any other manager is instantiated:
+
+1. Create a temporary `SettingsManager` (already done in existing flow)
+2. Read `home.latitude` and `home.longitude`
+3. Call `detectTimezone({ latitude, longitude, tzEnv: process.env.TZ, logger })`
+4. `process.env.TZ = detected`
+
+### A.4 — Unit tests for `detectTimezone()`
+
+- Test: when `tzEnv` is set → returns that value, doesn't call lookup
+- Test: when `tzEnv` is empty/undefined + valid lat/lon → returns tz-lookup result
+- Test: when lat/lon are both null → returns "UTC" + warn log
+- Test: when lat/lon are out of range → returns "UTC" + warn log
+- Test: when `tzEnv` is whitespace only → treated as unset
+
+---
+
+## Slice B — Settings change notification
+
+### B.1 — Emit warn + event on home location change
+
+In `settings-manager.ts` (or wherever `updateSettings` is handled), after the update transaction:
+
+```typescript
+if (changedKeys.includes("home.latitude") || changedKeys.includes("home.longitude")) {
+  this.logger.warn("Home location changed. Restart Sowel for timezone changes to fully apply.");
+}
+```
+
+### B.2 — UI toast after settings save
+
+In `ui/src/pages/SettingsPage.tsx` `HomeSettingsSection`:
+
+After successful save, if lat/lon changed compared to the initial values, show a toast:
+
+> Home location saved. Restart Sowel for timezone changes to fully apply.
+
+Use existing toast/notification pattern in the app. If no toast system exists, use a simple inline alert banner that disappears after 5s.
+
+### B.3 — No-op for non-location settings
+
+Other home settings (sunriseOffset, sunsetOffset, homeName) don't trigger the restart hint.
+
+---
+
+## Slice C — Documentation
+
+### C.1 — Update repo `docker-compose.yml`
+
+Add commented TZ example at the top of the `environment:` block:
+
+```yaml
+environment:
+  # Timezone: by default, Sowel auto-derives from home.latitude/longitude in Settings.
+  # To override explicitly (e.g., for no-geolocation setups), uncomment:
+  # - TZ=Europe/Paris
+  - INFLUX_URL=http://influxdb:8086
+```
+
+### C.2 — README section on timezone
+
+Add a short section under "Configuration" or similar:
+
+```markdown
+## Timezone
+
+Sowel auto-derives the timezone from the home location you set in Settings
+(latitude/longitude). This affects:
+
+- Sunrise/sunset display
+- Calendar-based mode scheduling (via cron)
+- HP/HC energy tariff classification
+- Daily/monthly energy aggregation boundaries
+- Notification timestamps
+
+If you don't set a home location, or want to override the auto-detection,
+set the `TZ` environment variable in `docker-compose.yml`:
+
+    environment:
+      - TZ=Europe/Paris
+
+Note: changes to home location require a Sowel restart to take effect.
+```
+
+### C.3 — Update `docs/technical/architecture.md`
+
+Add a section "Timezone handling" explaining the priority order (env var → geo → UTC) and the restart-required caveat.
+
+### C.4 — Update CLAUDE.md if relevant
+
+Add a note in the implementation conventions that native `Date` methods are intentionally used throughout the codebase and rely on `process.env.TZ` being set correctly at startup (via the timezone detection module).
+
+---
+
+## Validation Plan
+
+### Phase 4 — automated checks
+
+```bash
+npx tsc --noEmit
+npx eslint src/ --ext .ts
+npx vitest run
+cd ui && npx tsc -b --noEmit && npx eslint .
+```
+
+### Phase 4 — manual test plan
+
+1. **Unit tests** for `detectTimezone()` — as listed in A.4
+2. **Local integration test** on Mac:
+   - Fresh Sowel install, no TZ env var, no lat/lon → verify log says "using UTC" + warning
+   - Set lat/lon to Grenoble (45.19, 5.72) via UI → restart → verify log says "Europe/Paris" and sunrise/sunset are correct (07:xx / 20:xx in April)
+   - Set TZ=America/New_York in docker-compose → restart → verify log says "TZ env var" and sunrise/sunset are in EDT
+3. **Production validation** on sowelox (after release):
+   - Remove the hardcoded `TZ=Europe/Paris` from `/opt/sowel/docker-compose.yml` (the workaround)
+   - Upgrade to the new version via self-update (validates the feature end-to-end)
+   - Verify sunrise/sunset still 07:xx / 20:xx (auto-derived from Grenoble lat/lon)
+   - Verify calendar slots still fire at correct local times
+   - Verify energy HP/HC classification still works
+
+---
+
+## Risks & Mitigations
+
+| Risk                                                                         | Mitigation                                                                                           |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `tz-lookup` returns wrong TZ for edge coordinates                            | Fallback to UTC + warn log. User can override via TZ env var.                                        |
+| Node.js TZ cache prevents runtime changes                                    | Documented restart requirement. UI toast makes it visible.                                           |
+| Other Node versions or Alpine image behave differently                       | Pin Node 20 LTS (already done). Test in Docker during CI.                                            |
+| Settings loaded twice (in `detectTimezone()` and later by `SettingsManager`) | Only reads 2 keys, negligible cost. OR pass the already-loaded settingsManager into the detect call. |
+| Users who relied on the UTC behavior (unlikely but possible)                 | Breaking change noted in release notes. Explicit `TZ=UTC` in docker-compose restores old behavior.   |
+
+---
+
+## Out of Scope
+
+- Historical data re-classification (energy HP/HC in InfluxDB that was computed with wrong hours) — separate investigation
+- Multi-TZ household — not applicable for home automation
+- UI picker for timezone — the detected/env var TZ is displayed as read-only in Settings → Home
+- Migration of existing calendar slots that were time-compensated by users — manual fix by user after spec deployed

--- a/specs/061-timezone-from-home-location/spec.md
+++ b/specs/061-timezone-from-home-location/spec.md
@@ -1,0 +1,115 @@
+# Spec 061 — Timezone auto-derived from home location
+
+## Context
+
+On 2026-04-11, the user reported that sunrise/sunset times displayed on the production UI were wrong (5:00 / 18:17 instead of 7:00 / 20:17 local in Grenoble). Investigation revealed that Docker containers default to UTC timezone, and the Sowel backend relies on native `Date` methods (`getHours()`, `getDate()`, etc.) which return the system-local time.
+
+**This is not just a UI display bug** — it affects core automation logic:
+
+| Affected component                    | Current bug (TZ=UTC)                                                            |
+| ------------------------------------- | ------------------------------------------------------------------------------- |
+| `croner` calendar slots               | Fire at specified time in UTC, not user's local time → modes activated 2h off   |
+| `tariff-classifier.ts` HP/HC          | HP/HC classification uses UTC hours → wrong tariff assignment for 2 windows/day |
+| `energy-aggregator.ts` day boundaries | "Today midnight" is 00:00 UTC (= 02:00 CEST) → day energy totals shifted        |
+| `sunlight-manager.ts` display         | Sunrise/sunset displayed as UTC times                                           |
+| `sunlight-manager.ts` isDaylight      | Based on `now >= sunriseOffset` in UTC → daylight window off                    |
+| Notifications timestamps              | Shows UTC hour in messages                                                      |
+
+A temporary workaround was applied on the user's production box (sowelox) by setting `TZ=Europe/Paris` in the deployment `docker-compose.yml`. This unblocks the immediate issue, but:
+
+- Hardcoded per-deployment — not portable for users in other timezones
+- Requires manual edit of `docker-compose.yml`
+- Users in America/Australia/Asia need to remember to set it
+- Not discoverable — a new user deploying Sowel has no indication of the issue
+
+## Goals
+
+1. Make Sowel **timezone-aware by default**, using the user's home location as the source of truth
+2. **Zero configuration** for users who already set `home.latitude` / `home.longitude` in settings
+3. Allow manual override via `TZ` env var for edge cases (users without geolocation, deployments on machines that already set system TZ)
+4. **Update the shipped `docker-compose.yml`** to document the `TZ` override pattern without hardcoding a specific value
+5. Ensure all time-based backend logic (crons, tariff classifier, energy aggregator, sunlight manager, notifications) uses the right TZ
+
+## Non-Goals
+
+- Per-user timezones (household members in different TZs) — Sowel is single-household
+- Migration of existing InfluxDB historical energy data that may have been classified with wrong HP/HC — tracked separately as needed
+- Changing how dates are stored (SQLite already stores UTC ISO strings, InfluxDB stores UTC nanoseconds — no change)
+- Changing the log timestamps (pino `isoTime` outputs absolute UTC ISO — no change)
+- User-facing TZ selector in the UI — the derived TZ is just displayed, not selected
+
+## Functional Requirements
+
+### FR1 — Auto-derive timezone from home coordinates
+
+- At Sowel startup, read `home.latitude` and `home.longitude` from settings
+- If both are set, call `tz-lookup` (or similar library) to derive the IANA timezone name (e.g., `Europe/Paris`, `America/New_York`)
+- Set `process.env.TZ` to the derived value **before** any module that uses `Date` methods, crons, or suncalc is initialized
+- Log the detected timezone at INFO level: `"Timezone detected from home location: Europe/Paris"`
+
+### FR2 — Manual override via `TZ` env var
+
+- If `TZ` is already set in the environment at startup (e.g., via `docker-compose.yml` or host env), Sowel **respects it** and does NOT override it
+- Log at INFO level: `"Timezone set from TZ env var: Europe/Paris (overriding auto-detection)"`
+
+### FR3 — Fallback to UTC with warning
+
+- If neither `TZ` env var is set NOR `home.latitude`/`home.longitude` are configured, fall back to UTC
+- Log at WARN level with actionable message: `"Timezone not configured: using UTC. Set home.latitude/home.longitude in Settings or TZ env var in docker-compose.yml for correct local time."`
+
+### FR4 — Re-derive on settings change
+
+- If the user updates `home.latitude` / `home.longitude` in the UI while Sowel is running, the new TZ must take effect
+- Since `process.env.TZ` is read by Node at startup and cannot be reliably changed at runtime (Date.prototype.getHours uses the cached TZ), we emit a NOTICE to the user: **restart required after home location change**
+- UI shows a toast after saving: "Home location saved. Restart Sowel for timezone changes to fully apply."
+
+### FR5 — Repo `docker-compose.yml` documentation
+
+- Update the shipped `docker-compose.yml` at the repo root to include a commented-out `TZ` environment variable with an example:
+
+  ```yaml
+  services:
+    sowel:
+      environment:
+        # Optional: override timezone. By default, Sowel auto-derives the
+        # timezone from home.latitude/home.longitude in Settings.
+        # - TZ=Europe/Paris
+  ```
+
+- Add a section in the README about timezone configuration
+
+### FR6 — Existing backend code remains functional
+
+- No changes to `sunlight-manager.ts`, `calendar-manager.ts`, `energy-aggregator.ts`, `tariff-classifier.ts`, etc.
+- These modules continue to use `Date` methods — they now get the right TZ "for free" because `process.env.TZ` was set before they were instantiated
+
+## Acceptance Criteria
+
+- [ ] FR1: On a fresh Sowel deployment with `home.latitude=45.1885, home.longitude=5.7245` (Grenoble) and no `TZ` env var, sunrise/sunset display as CEST (e.g., 07:00 / 20:17 in April), not UTC
+- [ ] FR2: When `TZ=America/New_York` is set in docker-compose, Sowel ignores home.latitude/longitude TZ derivation and uses America/New_York
+- [ ] FR3: When no home location and no TZ env var, backend logs a WARN and uses UTC (status quo for new installations)
+- [ ] FR4: After changing lat/lon in Settings, a toast asks the user to restart. After restart, new TZ is applied.
+- [ ] FR5: Repo `docker-compose.yml` includes commented `TZ` example with explanatory comment
+- [ ] FR6: Calendar cron slots fire at the correct local time (not UTC)
+- [ ] FR6: HP/HC tariff classifier uses local hours
+- [ ] FR6: Energy aggregator day boundaries use local midnight
+- [ ] New tests added for the `detectTimezone()` helper covering: (a) TZ env var priority, (b) lat/lon lookup, (c) fallback to UTC with warning
+- [ ] Documentation updated: `docs/technical/architecture.md` mentions the timezone handling strategy
+
+## Edge Cases
+
+- **Invalid lat/lon** (e.g., `999.0`) → `tz-lookup` throws or returns null → fall back to UTC with warning
+- **Remote/polar coordinates** where tz-lookup has no clear answer → same fallback
+- **User deploys on a server with system TZ already set** (e.g., Raspberry Pi with `timedatectl set-timezone Europe/Paris`) → `process.env.TZ` inherited from system → no override needed, Sowel respects it (FR2 branch)
+- **User updates lat/lon during runtime** → no live effect on `Date` methods (limitation), requires restart (FR4 notice)
+- **Multi-user household with user timezones differing from home** → out of scope, home TZ is used for all automation logic (which is the right behavior for home automation)
+
+## Dependencies
+
+- Add `tz-lookup` or `geo-tz` to backend package.json. Preference: `tz-lookup` — small (~100KB including data), synchronous, zero dependencies.
+
+## Notes
+
+The root cause of this issue is that Docker images use UTC by default and the codebase uses native `Date` methods that depend on `process.env.TZ`. This spec addresses the symptom cleanly at the boundary (one env var set early at boot) without touching the 15+ places in the code that use `getHours()`, `getDate()`, etc. — all of them benefit transparently.
+
+Long-term, if Sowel ever gains multi-location support (e.g., vacation homes), the approach would need to be revisited — but that's beyond the scope of single-household automation.


### PR DESCRIPTION
## Summary

The codebase evolved significantly across specs 053-060 (plugin V2, self-update, backup, CI/CD) without docs catching up. This PR aligns all documentation with the current state so an AI agent (or a human) can recover full context from the files alone.

## New files

- **`docs/specs-index.md`** — chronological index of every spec (001-061) with one-line descriptions and status (active / superseded / partial). Vital navigation aid after context loss.
- **`docs/technical/deployment.md`** — production operations guide: install, self-update, backup/restore, log access, troubleshooting, plus a "Production reference" section documenting the maintainer's sowelox deployment.
- **`specs/061-timezone-from-home-location/`** — spec, architecture, plan for auto-deriving `process.env.TZ` from home coordinates (drafted, not yet implemented — currently worked around on sowelox via `TZ=Europe/Paris` in compose).

## Updated files

### Core docs

- **`docs/technical/architecture.md`** — added five new sections:
  - Plugin Architecture V2 (PackageManager, PluginLoader, RecipeLoader, registry, plugin ecosystem)
  - Backup & Restore (BackupManager, format, local backups, rotation, restore flow)
  - Self-Update (spec 060 helper container pattern)
  - CI/CD & Releases (workflow, script, Dockerfile)
  - Logging (strategy, file location, retrieval helpers)
  - Timezone handling
- **`docs/technical/index.md`** — nav includes Deployment + Specs Index
- **`docs/technical/plugin-development.md`** — registry schema gains `type` field, new "Remote registry fetch" section (spec 059)
- **`docs/sowel-spec.md`** — marked as LEGACY with a prominent redirect banner

### Top-level

- **`CLAUDE.md`** — rewritten as a concise AI agent entry point: "Where to find context" table, project paragraph, current project structure, production context (sowelox), skills list. No longer references the legacy `sowel-spec.md`.
- **`README.md`** — expanded from 48 to ~90 lines with feature list, quickstart, doc links, release workflow
- **`mkdocs.yml`** — nav includes new Deployment + Specs Index pages

### Skills

- **`.claude/skills/sowel-feature/SKILL.md`** — Phase 1 doc reading list no longer points to legacy `sowel-spec.md`
- **`.claude/skills/sowel-feature/reference.md`** — rewritten with current service map (core, plugin system, domain managers, API, frontend), spec templates, production deployment
- **`.claude/skills/plugin-integration/SKILL.md`** — replaces references to `src/plugins/plugin-manager.ts` (no longer exists) with `src/packages/package-manager.ts` + `src/plugins/plugin-loader.ts`
- **`.claude/skills/debug-bug/reference.md`** — log module table refreshed to `plugin:<id>` convention, adds `package-manager`, `plugin-loader`, `update-manager`, `version-checker`, `backup-manager`, `sunlight-manager`, `button-action-manager`. New "Production log file access" section for post-incident investigation after container recreation.

## Validation

- [x] `mkdocs build --strict` passes (zero warnings)
- [x] All links resolve within the docs tree
- [x] No references to obsolete files (`src/plugins/plugin-manager.ts`, `docs/sowel-spec.md`)
- [ ] Manual review of architecture.md for accuracy
- [ ] Manual review of deployment.md for accuracy

## Impact

No code changes. Documentation only. Safe to merge.