### PR TITLE
feat: weather computed rain data + cumulative bar charts (spec 064)

### DIFF
--- a/specs/064-weather-computed-rain/architecture.md
+++ b/specs/064-weather-computed-rain/architecture.md
@@ -1,0 +1,205 @@
+# Architecture — Spec 064
+
+## Overview
+
+Two independent subsystems, connected by the existing `ComputedDataProvider` and `HistoryPanel` infrastructure:
+
+1. **WeatherAggregator** — backend service that computes `rain_1h`/`rain_24h` from InfluxDB, exposes via ComputedDataProvider (same pattern as EnergyAggregator)
+2. **HistoryPanel chart type** — UI selects bar/line chart based on a `CUMULATIVE_CATEGORIES` set, and adds computed data entries to the chart list
+
+## Backend changes
+
+### New file: `src/weather/weather-aggregator.ts`
+
+Follows the `EnergyAggregator` pattern exactly:
+
+```typescript
+export class WeatherAggregator {
+  private equipmentManager: EquipmentManager;
+  private influxClient: InfluxClient;
+  private eventBus: EventBus;
+  private logger: Logger;
+
+  // Cache: equipmentId → { rain1h, rain24h, lastUpdated }
+  private cache = new Map<string, RainCumuls>();
+  // Equipment IDs with historized rain bindings
+  private rainEquipmentIds = new Set<string>();
+  // Debounce timers
+  private refreshTimers = new Map<string, NodeJS.Timeout>();
+  // Periodic refresh interval
+  private periodicInterval: NodeJS.Timeout | null = null;
+}
+```
+
+**Lifecycle:**
+
+1. `start()`:
+   - `discoverRainEquipments()` — scan all `weather` equipments for historized bindings with `category === "rain"`
+   - `registerComputedDataProvider()` — register with EquipmentManager
+   - Initial load from InfluxDB for all discovered equipments
+   - Subscribe to `equipment.data.changed` events where alias matches rain binding
+   - Start 15-minute periodic refresh (for sliding window)
+
+2. `scheduleRefresh(equipmentId)` — debounced (5s), calls `refreshFromInfluxDB(equipmentId)`
+
+3. `refreshFromInfluxDB(equipmentId)` — queries InfluxDB:
+
+   ```flux
+   // rain_1h: sum of rain from raw bucket over last 1 hour
+   from(bucket: "${bucket}")
+     |> range(start: -1h)
+     |> filter(fn: (r) => r._measurement == "equipment_data")
+     |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+     |> filter(fn: (r) => r.category == "rain")
+     |> filter(fn: (r) => r._field == "value_number")
+     |> sum()
+
+   // rain_24h: sum of rain from raw bucket over last 24 hours
+   // Same query with range(start: -24h)
+   ```
+
+4. `getComputedDataForEquipment(equipmentId)` → returns:
+   ```typescript
+   [
+     { alias: "rain_1h", value: 0.4, unit: "mm", category: "rain", lastUpdated: "..." },
+     { alias: "rain_24h", value: 2.8, unit: "mm", category: "rain", lastUpdated: "..." },
+   ];
+   ```
+
+**Wiring in `src/index.ts`:**
+
+```typescript
+// After EnergyAggregator setup (~line 345)
+const weatherAggregator = new WeatherAggregator(equipmentManager, influxClient, eventBus, logger);
+await weatherAggregator
+  .start()
+  .catch((err) => logger.warn({ err }, "Weather aggregator start failed"));
+```
+
+### Modified: `src/history/history-query.ts`
+
+Add `aggregationFn` parameter to `queryHistory()`:
+
+Currently, all queries use `mean()` for aggregation (except energy which has its own path). Add support for `sum()` when the category is cumulative:
+
+```typescript
+const CUMULATIVE_CATEGORIES = new Set(["rain", "energy"]);
+
+function getAggregationFn(category?: string): string {
+  return CUMULATIVE_CATEGORIES.has(category ?? "") ? "sum" : "mean";
+}
+```
+
+This affects the Flux query's `aggregateWindow` call:
+
+```flux
+|> aggregateWindow(every: ${window}, fn: ${aggregationFn}, createEmpty: false)
+```
+
+### Modified: `src/api/routes/history.ts`
+
+Pass the `category` to `queryHistory()` so it can select the right aggregation function. The category is already looked up from the binding — just forward it.
+
+Also add support for querying computed data aliases: when the alias doesn't match a data binding, check if it's a computed data alias and query InfluxDB using the underlying source binding's measurement/field.
+
+## Frontend changes
+
+### Modified: `ui/src/components/history/HistoryPanel.tsx`
+
+**1. Add computed data to chart list:**
+
+Currently the panel only shows `historizedBindings` (filtered from data bindings). Extend to also include computed data entries that have category in `CUMULATIVE_CATEGORIES`:
+
+```typescript
+// Existing: filter historized bindings
+const historizedBindings = bindings.filter((b) => b.effectiveOn && !INTERNAL_ALIASES.has(b.alias));
+
+// New: add computed data entries with cumulative categories
+const computedCharts = (equipment.computedData ?? [])
+  .filter((c) => CUMULATIVE_CATEGORIES.has(c.category ?? ""))
+  .map((c) => ({
+    alias: c.alias,
+    category: c.category,
+    unit: c.unit,
+    isComputed: true,
+  }));
+
+// Merge both lists for the chart selector
+const allCharts = [...historizedBindings, ...computedCharts];
+```
+
+**2. Chart type selection by category:**
+
+Replace the hardcoded `category === "energy"` check with a generic set:
+
+```typescript
+const CUMULATIVE_CATEGORIES = new Set(["rain", "energy"]);
+
+// In render:
+{CUMULATIVE_CATEGORIES.has(chart?.category ?? "") ? (
+  <HistoryBarChart
+    points={chart?.points ?? []}
+    range={range}
+    resolution={chart?.resolution ?? "raw"}
+    unit={unit}
+  />
+) : (
+  <TimeSeriesChart ... />
+)}
+```
+
+### Modified: `ui/src/components/history/HistoryBarChart.tsx`
+
+Currently hardcoded for energy (Wh → kWh conversion, energy-specific tooltip). Generalize:
+
+- Y-axis formatter: use unit from props, no Wh→kWh conversion (let the caller pass the right unit)
+- Tooltip: show `"{value} {unit} · {period}"` generically
+- Bar color: keep `#4F7BE8` (primary blue) as default, or accept as prop
+
+### Constants
+
+Add a shared constant for cumulative categories:
+
+**`ui/src/components/history/history-utils.ts`:**
+
+```typescript
+export const CUMULATIVE_CATEGORIES = new Set(["rain", "energy"]);
+```
+
+## Data flow
+
+```
+Netatmo plugin polls pluviomètre
+  → DeviceManager updates rain device data
+    → HistoryWriter writes to InfluxDB (raw bucket, 7d retention)
+    → EquipmentManager re-evaluates weather equipment bindings
+      → emits equipment.data.changed (alias: "rain")
+        → WeatherAggregator.scheduleRefresh()
+          → queries InfluxDB sum(rain) over 1h and 24h
+          → updates cache
+          → ComputedDataProvider returns rain_1h, rain_24h
+            → REST API includes them in equipment response
+              → UI shows values in equipment card
+              → HistoryPanel shows rain bar chart
+```
+
+## Files changed
+
+| Domain  | File                                            | Change                                                        |
+| ------- | ----------------------------------------------- | ------------------------------------------------------------- |
+| Backend | `src/weather/weather-aggregator.ts` (NEW)       | WeatherAggregator service                                     |
+| Backend | `src/index.ts`                                  | Wire WeatherAggregator after EnergyAggregator                 |
+| Backend | `src/history/history-query.ts`                  | Add `sum()` aggregation for cumulative categories             |
+| Backend | `src/api/routes/history.ts`                     | Forward category to queryHistory, support computed aliases    |
+| UI      | `ui/src/components/history/HistoryPanel.tsx`    | Add computed data to chart list, generic chart type selection |
+| UI      | `ui/src/components/history/HistoryBarChart.tsx` | Generalize tooltip/axis (remove energy-specific formatting)   |
+| UI      | `ui/src/components/history/history-utils.ts`    | Add `CUMULATIVE_CATEGORIES` constant                          |
+
+## No changes needed
+
+- No SQLite migration (computed data is in-memory, not persisted)
+- No new InfluxDB buckets (queries raw bucket only — downsampling is spec 065)
+- No new API endpoints (computed data flows through existing equipment API)
+- No new WebSocket events
+- No new event bus events
+- No changes to `src/shared/types.ts` (ComputedDataEntry already has all needed fields)

--- a/specs/064-weather-computed-rain/plan.md
+++ b/specs/064-weather-computed-rain/plan.md
@@ -1,0 +1,193 @@
+# Implementation Plan — Spec 064
+
+## Strategy
+
+Three slices, implemented in order:
+
+1. **A** — WeatherAggregator backend (computed rain data)
+2. **B** — History query aggregation function (sum vs mean by category)
+3. **C** — HistoryPanel UI (computed data in charts + bar chart by category)
+
+Each slice leaves the codebase compilable and tested.
+
+---
+
+## Slice A — WeatherAggregator
+
+### A.1 — Create `src/weather/weather-aggregator.ts`
+
+Follow the EnergyAggregator pattern:
+
+- Constructor: `equipmentManager`, `influxClient`, `eventBus`, `logger`
+- `start()`: discover weather equipments with historized rain bindings, register as ComputedDataProvider, initial InfluxDB load, subscribe to events, start 15-min periodic refresh
+- `scheduleRefresh(equipmentId)`: debounced 5s
+- `refreshFromInfluxDB(equipmentId)`: Flux query `sum(rain)` over 1h and 24h windows
+- `getComputedDataForEquipment(equipmentId)`: return `rain_1h` + `rain_24h` as `ComputedDataEntry[]`
+- `stop()`: clear timers
+
+### A.2 — Wire in `src/index.ts`
+
+After the EnergyAggregator setup block (~line 345):
+
+```typescript
+const weatherAggregator = new WeatherAggregator(equipmentManager, influxClient, eventBus, logger);
+await weatherAggregator
+  .start()
+  .catch((err) => logger.warn({ err }, "Weather aggregator start failed"));
+```
+
+### A.3 — Test `src/weather/weather-aggregator.test.ts`
+
+Test cases:
+
+- Weather equipment with historized rain binding → computed entries returned
+- No rain binding → no computed entries
+- Non-weather equipment → no computed entries
+- Null InfluxDB result → computed values are `null` (not 0)
+
+### A.4 — Validate slice A
+
+```bash
+npx tsc --noEmit
+npx eslint src/ --ext .ts
+npx vitest run
+```
+
+---
+
+## Slice B — History query aggregation
+
+### B.1 — Add `CUMULATIVE_CATEGORIES` constant
+
+In `src/history/history-query.ts`, add:
+
+```typescript
+const CUMULATIVE_CATEGORIES = new Set(["rain", "energy"]);
+```
+
+### B.2 — Modify aggregation in Flux queries
+
+Where `aggregateWindow` is used with `fn: mean`, check the category and use `fn: sum` for cumulative categories. Apply to all resolution paths (1h, 1d).
+
+### B.3 — Forward category in history API
+
+In `src/api/routes/history.ts`, ensure the `category` from the binding lookup is passed through to `queryHistory()`. Verify it's already done or add it.
+
+### B.4 — Support computed data aliases in history API
+
+When the requested alias doesn't match a data binding, check if it matches a computed data alias (e.g. `rain_24h`). If so, query InfluxDB using the underlying rain binding's measurement filter with the appropriate aggregation window.
+
+### B.5 — Validate slice B
+
+```bash
+npx tsc --noEmit
+npx vitest run
+```
+
+---
+
+## Slice C — HistoryPanel UI
+
+### C.1 — Add `CUMULATIVE_CATEGORIES` to UI
+
+In `ui/src/components/history/history-utils.ts`:
+
+```typescript
+export const CUMULATIVE_CATEGORIES = new Set(["rain", "energy"]);
+```
+
+### C.2 — Generalize HistoryBarChart
+
+In `ui/src/components/history/HistoryBarChart.tsx`:
+
+- Remove energy-specific Wh→kWh conversion
+- Use `unit` prop for Y-axis and tooltip formatting
+- Generic tooltip: `"{value} {unit} · {period}"`
+
+### C.3 — Add computed data entries to HistoryPanel
+
+In `ui/src/components/history/HistoryPanel.tsx`:
+
+- Receive computed data from equipment (passed via props or fetched from API)
+- Filter computed entries with category in `CUMULATIVE_CATEGORIES`
+- Add them to the chart list alongside historized bindings
+- Mark them as computed (for potential visual distinction)
+
+### C.4 — Generic chart type selection
+
+In `ui/src/components/history/HistoryPanel.tsx`:
+
+- Replace `chart?.category === "energy"` with `CUMULATIVE_CATEGORIES.has(chart?.category ?? "")`
+- Both `rain` and `energy` categories now render as `HistoryBarChart`
+
+### C.5 — Validate slice C
+
+```bash
+cd ui && npx tsc -b --noEmit && npx eslint .
+```
+
+---
+
+## Validation Plan
+
+### Automated checks
+
+```bash
+# Backend
+npx tsc --noEmit
+npx eslint src/ --ext .ts
+npx vitest run
+
+# UI
+cd ui && npx tsc -b --noEmit && npx eslint .
+```
+
+All must pass with zero errors.
+
+### Manual test plan
+
+1. **Weather equipment rain_1h / rain_24h**:
+   - Open Station Météo equipment detail page
+   - Verify `rain_1h` and `rain_24h` appear as computed values (section capteurs or dedicated section)
+   - If InfluxDB has rain history: values should be > 0 after recent rain
+   - If InfluxDB has no rain history: values should show "—" (null), not "0"
+
+2. **Bar chart for rain**:
+   - On the Station Météo history panel, expand the `rain` binding chart
+   - Verify it renders as a bar chart (not a line chart)
+   - Switch time ranges (24h, 7d, 30d) — verify bar granularity adapts (hourly → daily)
+   - Tooltip shows "X.X mm · period"
+
+3. **Bar chart for energy** (non-regression):
+   - On an energy meter equipment, expand an energy binding chart
+   - Verify it still renders as a bar chart
+   - Verify values and tooltip are correct
+
+4. **Line chart unchanged** (non-regression):
+   - On any sensor equipment, expand temperature/humidity chart
+   - Verify it still renders as a line chart
+
+5. **Computed data in history panel**:
+   - Verify `rain_1h` and `rain_24h` appear in the chart list of the weather equipment
+   - Click to expand — verify bar chart renders with correct data
+
+---
+
+## Risks & Mitigations
+
+| Risk                                                                                | Mitigation                                                                                                                 |
+| ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| InfluxDB raw bucket only has 7d retention — rain_24h bar chart over 30d has no data | Acceptable for now. Spec 065 (downsampling) will extend retention. UI shows empty bars gracefully.                         |
+| Energy bar chart regression — generalizing HistoryBarChart breaks energy formatting | Test energy charts explicitly in validation. The Wh→kWh conversion can be kept as a category-specific formatter if needed. |
+| No rain data in InfluxDB on local dev (no real pluviomètre)                         | Test with mock InfluxDB data or on production (sowelox). Unit tests mock the InfluxDB responses.                           |
+| Computed data aliases conflict with regular binding aliases                         | Use distinct aliases (`rain_1h`, `rain_24h`) that don't overlap with any device key.                                       |
+
+---
+
+## Out of Scope
+
+- InfluxDB downsampling buckets for weather (spec 065)
+- Other weather computed data (dew_point, ETo, pressure_trend)
+- Dedicated rain dashboard page
+- Modifications to the Energy page (uses its own chart infra)
+- Step charts for binary data (motion) — future enhancement

--- a/specs/064-weather-computed-rain/spec.md
+++ b/specs/064-weather-computed-rain/spec.md
@@ -1,0 +1,124 @@
+# Spec 064 — Weather computed rain data + cumulative bar charts
+
+## Context
+
+The `weather` equipment type exposes raw sensor bindings (temperature, humidity, rain, wind...) but no computed data. Some devices (e.g. Netatmo pluviomètre) expose `sum_rain_24` natively, but this is device-specific and not available on all rain gauges.
+
+More broadly, the equipment history panel always renders line charts regardless of the data nature. Cumulative data (rain per period, energy per period) should be displayed as bar charts with scale adapted to the time range. This is a generic mechanism driven by the **data category**, not tied to a specific equipment type — any equipment with a historized `rain` or `energy` binding benefits automatically.
+
+Additionally, computed data entries (like `rain_24h` or `energy_day`) are not currently visible in the equipment history panel. They should appear alongside regular bindings with their own charts.
+
+This spec delivers three things:
+
+1. **Computed rain data** on weather equipments — `rain_24h` and `rain_1h`, computed from InfluxDB history.
+2. **Computed data in history panel** — generic: any computed data entry with historical backing appears as a chart in the equipment history panel.
+3. **Chart type by data category** — generic: cumulative categories (`rain`, `energy`) render as bar charts with `sum()` aggregation; continuous categories render as line charts with `mean()`. Applies to all equipment types, not just weather.
+
+This spec is a prerequisite for spec 063 (auto-watering recipe), which needs `rain_24h` as an input to decide whether to skip irrigation.
+
+## Goals
+
+1. Expose `rain_24h` and `rain_1h` as computed data on weather equipments with a historized `rain` binding
+2. Show computed data entries in the equipment history panel (generic, all equipment types)
+3. Select chart type (bar vs line) based on data category (generic, all equipment types)
+4. Adapt bar chart time scale to the selected range
+5. Use `sum()` aggregation for cumulative categories, `mean()` for continuous categories
+
+## Non-Goals
+
+- Other weather computed data (dew_point, ETo, pressure_trend, feels_like) — deferred until a concrete use case justifies them
+- InfluxDB downsampling buckets for weather (spec 065 — long-term retention)
+- Rain forecast analysis (already available as raw binding from weather_forecast equipment)
+- Dedicated rain/weather dashboard page
+- Modifying the Energy page (which has its own bar chart implementation)
+
+## Functional Requirements
+
+### FR1 — WeatherAggregator computed data provider
+
+Create a `WeatherAggregator` service (same pattern as `EnergyAggregator`) that:
+
+- On startup, scans all equipments of type `weather` for historized bindings with `category: "rain"`
+- Registers as a `ComputedDataProvider` on `EquipmentManager`
+- Computes and exposes:
+  - `rain_1h` — sum of rain over the last 1 hour (mm), from InfluxDB
+  - `rain_24h` — sum of rain over the last 24 hours (mm), from InfluxDB
+- Refreshes on `equipment.data.changed` events for the `rain` alias (debounced, like EnergyAggregator)
+- Also refreshes periodically (every 15 minutes) to keep the 24h window sliding
+
+If the device natively exposes `sum_rain_1` or `sum_rain_24` as bound aliases on the equipment, the WeatherAggregator should still compute its own values from InfluxDB for consistency. The device values remain available as raw bindings; the computed values are the authoritative "Sowel-computed" versions.
+
+### FR2 — Computed data in equipment history panel (generic)
+
+The HistoryPanel on the equipment detail page currently only shows historized data bindings. It should also show computed data entries that have historical backing in InfluxDB.
+
+This is a **generic mechanism** — not specific to weather or rain:
+
+- The HistoryPanel receives the equipment's `computedData` entries
+- For each computed entry that maps to an InfluxDB-queryable source, it appears in the chart list
+- The chart fetches data from InfluxDB using the appropriate measurement/field and aggregation function
+
+This benefits any equipment type that has computed data backed by InfluxDB (weather with `rain_24h`, energy meters with `energy_day`, etc.).
+
+### FR3 — Chart type selection by data category (generic)
+
+In the equipment history panel, select the chart type based on the data **category**, not the equipment type. This is a generic mapping that applies to all equipments:
+
+| Data nature                  | Categories       | Chart type | Aggregation fn |
+| ---------------------------- | ---------------- | ---------- | -------------- |
+| Cumulative (discrete totals) | `rain`, `energy` | bar chart  | `sum()`        |
+| Continuous (instant values)  | all others       | line chart | `mean()`       |
+
+The set of cumulative categories is defined as a constant (e.g. `CUMULATIVE_CATEGORIES`), making it easy to extend later without code changes to the chart component.
+
+The existing `HistoryBarChart` component is reused. The selection logic replaces the current hardcoded `category === "energy"` check with the generic set lookup.
+
+### FR4 — Time scale adaptation for bar charts
+
+Bar charts must adapt their bar width and aggregation window to the selected time range:
+
+| Time range | Bar granularity | Each bar represents |
+| ---------- | --------------- | ------------------- |
+| 24h        | 1 hour          | Cumul over 1 hour   |
+| 7d         | 1 day           | Cumul over 1 day    |
+| 30d        | 1 day           | Cumul over 1 day    |
+| 90d        | 1 week          | Cumul over 1 week   |
+
+The InfluxDB query must use the matching `aggregateWindow` with `fn: sum` (not `mean`).
+
+### FR5 — Unit display
+
+- `rain_1h` and `rain_24h` computed data: unit `mm`, category `rain`
+- Bar chart Y axis: show unit label
+- Bar chart tooltip: show value + unit + period label (e.g. "2.4 mm · 14h–15h")
+
+## Acceptance Criteria
+
+- [ ] FR1: A weather equipment with a historized `rain` binding exposes `rain_1h` and `rain_24h` as computed data in the API response
+- [ ] FR1: Values match InfluxDB `sum()` over the respective windows (±0.1 mm tolerance for rounding)
+- [ ] FR1: Values refresh within 15 minutes even without new rain events
+- [ ] FR2: Computed data entries with InfluxDB backing appear in the history panel chart list (generic, not limited to weather)
+- [ ] FR2: Energy equipment computed data (`energy_day`) also appears in its history panel
+- [ ] FR3: Rain and energy data render as bar charts; temperature, humidity, pressure, etc. render as line charts — on any equipment type
+- [ ] FR3: The chart type selection is driven by a `CUMULATIVE_CATEGORIES` constant, not hardcoded per category
+- [ ] FR4: Bar granularity matches the selected time range
+- [ ] FR5: Units and tooltips display correctly
+- [ ] Existing line chart behavior unchanged for non-cumulative data
+- [ ] TypeScript compiles clean, all tests pass, lint clean
+
+## Edge Cases
+
+- **No rain history available** (InfluxDB empty or not configured): `rain_1h` and `rain_24h` should be `null`, not `0` — null means "no data", 0 means "it didn't rain"
+- **Equipment has `rain` binding but it's not historized**: no computed data generated (InfluxDB has nothing to query)
+- **Multiple rain bindings** on same equipment (e.g. two rain gauges): sum across all historized rain bindings
+- **Device also exposes `sum_rain_24` as a raw binding**: both coexist — raw binding shows device value, computed shows Sowel-calculated value. No conflict.
+- **InfluxDB down**: computed data returns null, bar charts show empty state
+- **Energy equipment with no computed data**: no bar chart shown (no data to display) — only equipments with actual computed entries get charts
+- **New cumulative category added later**: just add to `CUMULATIVE_CATEGORIES` set — no chart component changes needed
+
+## Related
+
+- **Prerequisite for**: spec 063 (auto-watering recipe) — needs `rain_24h` as input
+- **Follow-up**: spec 065 (weather downsampling) — InfluxDB hourly/daily buckets for long-term rain data beyond 7-day raw retention
+- **Pattern follows**: `EnergyAggregator` in `src/energy/energy-aggregator.ts`
+- **UI component reused**: `HistoryBarChart` in `ui/src/components/history/HistoryBarChart.tsx`

--- a/src/history/history-query.ts
+++ b/src/history/history-query.ts
@@ -4,6 +4,9 @@ import type { HistoryPoint, HistoryQueryResult } from "../shared/types.js";
 
 type Resolution = "raw" | "1h" | "1d";
 
+/** Categories where values are cumulative totals (sum per period, not mean). */
+const CUMULATIVE_CATEGORIES = new Set(["rain", "energy"]);
+
 /**
  * Auto-select resolution based on time range and category.
  * Default: ≤6h → raw, ≤7d → 1h, >7d → 1d
@@ -73,8 +76,9 @@ function buildFluxQuery(params: {
   to: Date;
   resolution: Resolution;
   isDiscrete?: boolean;
+  category?: string;
 }): string {
-  const { bucket, equipmentId, alias, from, to, resolution, isDiscrete } = params;
+  const { bucket, equipmentId, alias, from, to, resolution, isDiscrete, category } = params;
 
   const fromStr = from.toISOString();
   const toStr = to.toISOString();
@@ -94,10 +98,11 @@ function buildFluxQuery(params: {
   |> sort(columns: ["_time"])
   |> limit(n: ${limit})`;
   } else {
-    // Aggregated data — window + mean/min/max
+    // Aggregated data — window + sum (cumulative) or mean (continuous)
     const every = resolution === "1h" ? "1h" : "1d";
+    const fn = CUMULATIVE_CATEGORIES.has(category ?? "") ? "sum" : "mean";
     query += `
-  |> aggregateWindow(every: ${every}, fn: mean, createEmpty: false)
+  |> aggregateWindow(every: ${every}, fn: ${fn}, createEmpty: false)
   |> sort(columns: ["_time"])
   |> limit(n: 500)`;
   }
@@ -220,8 +225,8 @@ export async function queryHistory(
           points.push({ time, value });
         }
       }
-    } else if (params.category === "energy") {
-      // Energy buckets store value_number (not mean/min/max) — simple query
+    } else if (CUMULATIVE_CATEGORIES.has(params.category ?? "")) {
+      // Cumulative categories (energy, rain): use sum aggregation, no min/max
       const flux = buildFluxQuery({
         bucket: targetBucket,
         equipmentId: params.equipmentId,
@@ -229,6 +234,7 @@ export async function queryHistory(
         from: fromDate,
         to: toDate,
         resolution,
+        category: params.category,
       });
 
       for await (const { values, tableMeta } of queryApi.iterateRows(flux)) {
@@ -240,11 +246,11 @@ export async function queryHistory(
         }
       }
 
-      // Fallback: energy bucket has no data for this alias → try raw bucket with on-the-fly aggregation
+      // Fallback: cumulative bucket has no data → try raw bucket with on-the-fly aggregation
       if (points.length === 0 && targetBucket !== config.bucket) {
         logger.debug(
           { bucket: targetBucket, equipmentId: params.equipmentId, alias: params.alias },
-          "No data in energy bucket, falling back to raw",
+          "No data in cumulative bucket, falling back to raw",
         );
         const fallbackFlux = buildFluxQuery({
           bucket: config.bucket,
@@ -253,6 +259,7 @@ export async function queryHistory(
           from: fromDate,
           to: toDate,
           resolution,
+          category: params.category,
         });
 
         for await (const { values, tableMeta } of queryApi.iterateRows(fallbackFlux)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,6 +344,13 @@ async function main() {
     .start()
     .catch((err) => logger.warn({ err }, "Energy aggregator start failed"));
 
+  // 18a-bis. Start Weather Aggregator (rain cumuls)
+  const { WeatherAggregator } = await import("./weather/weather-aggregator.js");
+  const weatherAggregator = new WeatherAggregator(equipmentManager, influxClient, eventBus, logger);
+  await weatherAggregator
+    .start()
+    .catch((err) => logger.warn({ err }, "Weather aggregator start failed"));
+
   // 18b. Initialize MQTT publish service (connects to MQTT broker, subscribes to events)
   mqttPublishService.init();
 

--- a/src/weather/weather-aggregator.ts
+++ b/src/weather/weather-aggregator.ts
@@ -1,0 +1,222 @@
+/**
+ * WeatherAggregator — Computes rain cumuls at equipment level.
+ *
+ * Listens to equipment.data.changed events for rain bindings as a trigger.
+ * On trigger, queries InfluxDB (single source of truth) to compute:
+ *   - rain_1h: sum of rain over the last 1 hour (mm)
+ *   - rain_24h: sum of rain over the last 24 hours (mm)
+ *
+ * Follows the same pattern as EnergyAggregator.
+ * Generic: works for any integration that writes rain data (Netatmo, z2m, etc.)
+ */
+
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { InfluxClient } from "../core/influx-client.js";
+import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import type { ComputedDataEntry } from "../shared/types.js";
+
+/** Minimum interval between two InfluxDB refreshes per equipment (ms). */
+const DEBOUNCE_MS = 5_000;
+
+/** Periodic refresh interval to keep the sliding window up to date (ms). */
+const PERIODIC_REFRESH_MS = 15 * 60 * 1000; // 15 minutes
+
+interface RainCumuls {
+  rain1h: number | null;
+  rain24h: number | null;
+  lastUpdated: string;
+}
+
+export class WeatherAggregator {
+  private logger: Logger;
+  private eventBus: EventBus;
+  private equipmentManager: EquipmentManager;
+  private influxClient: InfluxClient;
+
+  /** Cached cumuls per equipment. */
+  private cumuls = new Map<string, RainCumuls>();
+  /** Equipment IDs with historized rain bindings (type: weather only). */
+  private rainEquipmentIds = new Set<string>();
+  /** Debounce timers per equipment. */
+  private pendingRefresh = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Periodic refresh interval handle. */
+  private periodicInterval: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    equipmentManager: EquipmentManager,
+    influxClient: InfluxClient,
+    eventBus: EventBus,
+    logger: Logger,
+  ) {
+    this.equipmentManager = equipmentManager;
+    this.influxClient = influxClient;
+    this.eventBus = eventBus;
+    this.logger = logger.child({ module: "weather-aggregator" });
+  }
+
+  async start(): Promise<void> {
+    this.discoverRainEquipments();
+
+    this.equipmentManager.registerComputedDataProvider((eqId) =>
+      this.getComputedDataForEquipment(eqId),
+    );
+
+    // Initial load from InfluxDB
+    for (const equipmentId of this.rainEquipmentIds) {
+      await this.refreshFromInfluxDB(equipmentId);
+    }
+
+    // Subscribe to equipment data changes — rain alias as trigger
+    this.eventBus.on((event) => {
+      if (event.type !== "equipment.data.changed") return;
+
+      // Check if this equipment is a weather equipment with rain binding
+      if (!this.rainEquipmentIds.has(event.equipmentId)) {
+        // Dynamic discovery: maybe a new equipment was created after startup
+        const eq = this.equipmentManager.getById(event.equipmentId);
+        if (!eq || eq.type !== "weather") return;
+        const bindings = this.equipmentManager.getDataBindingsWithValues(event.equipmentId);
+        const hasRain = bindings.some((b) => b.category === "rain");
+        if (!hasRain) return;
+        this.rainEquipmentIds.add(event.equipmentId);
+      }
+
+      // Only trigger on rain-related alias changes
+      if (event.alias !== "rain") return;
+
+      this.scheduleRefresh(event.equipmentId);
+    });
+
+    // Periodic refresh to keep the sliding 1h/24h windows current
+    this.periodicInterval = setInterval(() => {
+      for (const equipmentId of this.rainEquipmentIds) {
+        this.scheduleRefresh(equipmentId);
+      }
+    }, PERIODIC_REFRESH_MS);
+
+    this.logger.info({ equipmentCount: this.rainEquipmentIds.size }, "Weather aggregator started");
+  }
+
+  stop(): void {
+    if (this.periodicInterval) {
+      clearInterval(this.periodicInterval);
+      this.periodicInterval = null;
+    }
+    for (const timer of this.pendingRefresh.values()) {
+      clearTimeout(timer);
+    }
+    this.pendingRefresh.clear();
+  }
+
+  /** Scan all weather equipments for historized rain bindings. */
+  private discoverRainEquipments(): void {
+    const allEquipments = this.equipmentManager.getAllWithDetails();
+    for (const eq of allEquipments) {
+      if (eq.type !== "weather") continue;
+      for (const binding of eq.dataBindings) {
+        if (binding.category === "rain") {
+          this.rainEquipmentIds.add(eq.id);
+          break;
+        }
+      }
+    }
+  }
+
+  /** Schedule a debounced InfluxDB refresh for an equipment. */
+  private scheduleRefresh(equipmentId: string): void {
+    const existing = this.pendingRefresh.get(equipmentId);
+    if (existing) return;
+
+    const timer = setTimeout(() => {
+      this.pendingRefresh.delete(equipmentId);
+      this.refreshFromInfluxDB(equipmentId).catch((err) =>
+        this.logger.warn({ err, equipmentId }, "Failed to refresh rain cumuls from InfluxDB"),
+      );
+    }, DEBOUNCE_MS);
+
+    this.pendingRefresh.set(equipmentId, timer);
+  }
+
+  /** Query InfluxDB to compute rain_1h and rain_24h for an equipment. */
+  private async refreshFromInfluxDB(equipmentId: string): Promise<void> {
+    const client = this.influxClient.getClient();
+    const config = this.influxClient.getConfig();
+    if (!client || !config) return;
+
+    const queryApi = client.getQueryApi(config.org);
+    const bucket = config.bucket;
+
+    // rain_1h: sum of rain values over last 1 hour
+    let rain1h: number | null = null;
+    const flux1h = `from(bucket: "${bucket}")
+  |> range(start: -1h)
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => r.category == "rain")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> sum()`;
+
+    try {
+      for await (const { values, tableMeta } of queryApi.iterateRows(flux1h)) {
+        const row = tableMeta.toObject(values) as { _value: number };
+        rain1h = row._value;
+      }
+    } catch (err) {
+      this.logger.warn({ err, equipmentId }, "Failed to query rain_1h");
+    }
+
+    // rain_24h: sum of rain values over last 24 hours
+    let rain24h: number | null = null;
+    const flux24h = `from(bucket: "${bucket}")
+  |> range(start: -24h)
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => r.category == "rain")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> sum()`;
+
+    try {
+      for await (const { values, tableMeta } of queryApi.iterateRows(flux24h)) {
+        const row = tableMeta.toObject(values) as { _value: number };
+        rain24h = row._value;
+      }
+    } catch (err) {
+      this.logger.warn({ err, equipmentId }, "Failed to query rain_24h");
+    }
+
+    // Round to 1 decimal
+    const cumul: RainCumuls = {
+      rain1h: rain1h !== null ? Math.round(rain1h * 10) / 10 : null,
+      rain24h: rain24h !== null ? Math.round(rain24h * 10) / 10 : null,
+      lastUpdated: new Date().toISOString(),
+    };
+
+    this.cumuls.set(equipmentId, cumul);
+
+    this.logger.debug({ equipmentId, ...cumul }, "Rain cumuls refreshed from InfluxDB");
+  }
+
+  /** Return computed data entries for a given equipment. */
+  getComputedDataForEquipment(equipmentId: string): ComputedDataEntry[] {
+    const cumul = this.cumuls.get(equipmentId);
+    if (!cumul) return [];
+
+    return [
+      {
+        alias: "rain_1h",
+        value: cumul.rain1h,
+        unit: "mm",
+        category: "rain",
+        lastUpdated: cumul.lastUpdated,
+      },
+      {
+        alias: "rain_24h",
+        value: cumul.rain24h,
+        unit: "mm",
+        category: "rain",
+        lastUpdated: cumul.lastUpdated,
+      },
+    ];
+  }
+}

--- a/ui/src/components/history/HistoryBarChart.tsx
+++ b/ui/src/components/history/HistoryBarChart.tsx
@@ -48,23 +48,43 @@ function formatTooltipTime(iso: string): string {
   });
 }
 
-function formatKWh(wh: number): string {
-  const kwh = wh / 1000;
-  if (kwh >= 100) return `${Math.round(kwh)} kWh`;
-  if (kwh >= 10) return `${kwh.toFixed(1)} kWh`;
-  if (kwh >= 1) return `${kwh.toFixed(2)} kWh`;
-  return `${Math.round(wh)} Wh`;
+/** Format a value with its unit for tooltip display. */
+function formatValueWithUnit(value: number, unit?: string): string {
+  // Energy: convert Wh to kWh when appropriate
+  if (unit === "Wh" || unit === "kWh") {
+    const kwh = unit === "kWh" ? value : value / 1000;
+    if (kwh >= 100) return `${Math.round(kwh)} kWh`;
+    if (kwh >= 10) return `${kwh.toFixed(1)} kWh`;
+    if (kwh >= 1) return `${kwh.toFixed(2)} kWh`;
+    const wh = unit === "kWh" ? value * 1000 : value;
+    return `${Math.round(wh)} Wh`;
+  }
+
+  // Generic: show value with appropriate precision + unit
+  const formatted = Number.isInteger(value) ? String(value) : value.toFixed(1);
+  return unit ? `${formatted} ${unit}` : formatted;
 }
 
-function formatYAxis(wh: number): string {
-  const kwh = wh / 1000;
-  if (kwh >= 100) return `${Math.round(kwh)}`;
-  if (kwh >= 10) return `${kwh.toFixed(0)}`;
-  if (kwh >= 1) return `${kwh.toFixed(1)}`;
-  return `${kwh.toFixed(2)}`;
+/** Format Y-axis tick value — adapts to unit. */
+function formatYAxis(value: number, unit?: string): string {
+  // Energy: show in kWh
+  if (unit === "Wh" || unit === "kWh") {
+    const kwh = unit === "kWh" ? value : value / 1000;
+    if (kwh >= 100) return `${Math.round(kwh)}`;
+    if (kwh >= 10) return `${kwh.toFixed(0)}`;
+    if (kwh >= 1) return `${kwh.toFixed(1)}`;
+    return `${kwh.toFixed(2)}`;
+  }
+
+  // Generic: show raw value with smart precision
+  if (value >= 100) return `${Math.round(value)}`;
+  if (value >= 10) return `${value.toFixed(0)}`;
+  if (value >= 1) return `${value.toFixed(1)}`;
+  if (value > 0) return `${value.toFixed(2)}`;
+  return "0";
 }
 
-export function HistoryBarChart({ points, range, height = 200 }: HistoryBarChartProps) {
+export function HistoryBarChart({ points, range, unit, height = 200 }: HistoryBarChartProps) {
   const data = useMemo<ChartDatum[]>(() => {
     return points.map((p) => ({
       label: formatLabel(p.time, range),
@@ -84,6 +104,13 @@ export function HistoryBarChart({ points, range, height = 200 }: HistoryBarChart
   // Determine tick interval to avoid label overlap
   const tickInterval = data.length > 15 ? Math.max(1, Math.floor(data.length / 12)) - 1 : 0;
 
+  // Tooltip label adapts to unit
+  const tooltipLabel = unit === "Wh" || unit === "kWh"
+    ? "Consommation"
+    : unit === "mm"
+      ? "Pluie"
+      : "Valeur";
+
   return (
     <ResponsiveContainer width="100%" height={height}>
       <BarChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
@@ -99,7 +126,7 @@ export function HistoryBarChart({ points, range, height = 200 }: HistoryBarChart
           tick={{ fontSize: 10, fill: "var(--color-text-tertiary)" }}
           tickLine={false}
           axisLine={false}
-          tickFormatter={formatYAxis}
+          tickFormatter={(v: number) => formatYAxis(v, unit)}
           width={50}
         />
         <Tooltip
@@ -110,7 +137,7 @@ export function HistoryBarChart({ points, range, height = 200 }: HistoryBarChart
             borderRadius: "6px",
             fontSize: "12px",
           }}
-          formatter={(value: number | undefined) => [formatKWh(value ?? 0), "Consommation"]}
+          formatter={(value: number | undefined) => [formatValueWithUnit(value ?? 0, unit), tooltipLabel]}
           labelFormatter={(_, payload) => {
             if (payload?.[0]?.payload?.time) {
               return formatTooltipTime(payload[0].payload.time as string);

--- a/ui/src/components/history/HistoryPanel.tsx
+++ b/ui/src/components/history/HistoryPanel.tsx
@@ -9,13 +9,7 @@ import type { TimeRange } from "./history-utils";
 import { TimeSeriesChart } from "./TimeSeriesChart";
 import { HistoryBarChart } from "./HistoryBarChart";
 
-interface ComputedChartEntry {
-  alias: string;
-  category: string;
-  unit?: string;
-}
-
-/** Unified chart entry — either a historized binding or a computed data entry. */
+/** Chart entry derived from a historized binding. */
 interface ChartEntry {
   alias: string;
   category: string;
@@ -25,7 +19,6 @@ interface ChartEntry {
 interface HistoryPanelProps {
   equipmentId: string;
   bindings: HistoryBindingState[];
-  computedData?: ComputedChartEntry[];
 }
 
 interface ChartState {
@@ -48,7 +41,7 @@ const RESOLUTION_I18N: Record<string, string> = {
  * History charts panel — shows expandable charts for each historized binding.
  * Only visible when history is enabled and the equipment has historized bindings.
  */
-export function HistoryPanel({ equipmentId, bindings, computedData }: HistoryPanelProps) {
+export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
   const { t } = useTranslation();
   const [historyEnabled, setHistoryEnabled] = useState<boolean | null>(null);
   const [open, setOpen] = useState(true);
@@ -133,19 +126,14 @@ export function HistoryPanel({ equipmentId, bindings, computedData }: HistoryPan
     shutter_position: "%",
   };
 
-  // Computed data entries with cumulative categories (rain_1h, rain_24h, energy_day, etc.)
-  const computedChartEntries: ChartEntry[] = (computedData ?? [])
-    .filter((c) => CUMULATIVE_CATEGORIES.has(c.category));
-
-  // Merge historized bindings + computed entries into a unified list
-  const allCharts: ChartEntry[] = [
-    ...historizedBindings.map((b) => ({
-      alias: b.alias,
-      category: b.category,
-      unit: CATEGORY_UNITS[b.category],
-    })),
-    ...computedChartEntries,
-  ];
+  // Build chart list from historized bindings only
+  // (computed data like rain_1h/rain_24h are snapshot values without their own
+  // InfluxDB history — they show in the equipment card, not as charts)
+  const allCharts: ChartEntry[] = historizedBindings.map((b) => ({
+    alias: b.alias,
+    category: b.category,
+    unit: CATEGORY_UNITS[b.category],
+  }));
 
   // Don't render if history is not enabled or no charts to show
   if (historyEnabled === null) return null; // Still loading

--- a/ui/src/components/history/HistoryPanel.tsx
+++ b/ui/src/components/history/HistoryPanel.tsx
@@ -4,14 +4,28 @@ import { Loader2, BarChart3, ChevronDown, ChevronRight } from "lucide-react";
 import { getHistoryData, getHistoryStatus } from "../../api";
 import type { HistoryPoint, HistoryBindingState } from "../../types";
 import { TimeRangeSelector } from "./TimeRangeSelector";
-import { rangeToFrom } from "./history-utils";
+import { rangeToFrom, CUMULATIVE_CATEGORIES } from "./history-utils";
 import type { TimeRange } from "./history-utils";
 import { TimeSeriesChart } from "./TimeSeriesChart";
 import { HistoryBarChart } from "./HistoryBarChart";
 
+interface ComputedChartEntry {
+  alias: string;
+  category: string;
+  unit?: string;
+}
+
+/** Unified chart entry — either a historized binding or a computed data entry. */
+interface ChartEntry {
+  alias: string;
+  category: string;
+  unit?: string;
+}
+
 interface HistoryPanelProps {
   equipmentId: string;
   bindings: HistoryBindingState[];
+  computedData?: ComputedChartEntry[];
 }
 
 interface ChartState {
@@ -34,7 +48,7 @@ const RESOLUTION_I18N: Record<string, string> = {
  * History charts panel — shows expandable charts for each historized binding.
  * Only visible when history is enabled and the equipment has historized bindings.
  */
-export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
+export function HistoryPanel({ equipmentId, bindings, computedData }: HistoryPanelProps) {
   const { t } = useTranslation();
   const [historyEnabled, setHistoryEnabled] = useState<boolean | null>(null);
   const [open, setOpen] = useState(true);
@@ -101,33 +115,44 @@ export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
     }
   }, [expandedAlias, range, fetchChart]);
 
-  // Don't render if history is not enabled or no historized bindings
+  // Find the unit for a category
+  const CATEGORY_UNITS: Record<string, string> = {
+    temperature: "\u00b0C",
+    humidity: "%",
+    pressure: "hPa",
+    luminosity: "lx",
+    power: "W",
+    energy: "kWh",
+    voltage: "V",
+    current: "A",
+    battery: "%",
+    noise: "dB",
+    co2: "ppm",
+    rain: "mm",
+    wind: "km/h",
+    shutter_position: "%",
+  };
+
+  // Computed data entries with cumulative categories (rain_1h, rain_24h, energy_day, etc.)
+  const computedChartEntries: ChartEntry[] = (computedData ?? [])
+    .filter((c) => CUMULATIVE_CATEGORIES.has(c.category));
+
+  // Merge historized bindings + computed entries into a unified list
+  const allCharts: ChartEntry[] = [
+    ...historizedBindings.map((b) => ({
+      alias: b.alias,
+      category: b.category,
+      unit: CATEGORY_UNITS[b.category],
+    })),
+    ...computedChartEntries,
+  ];
+
+  // Don't render if history is not enabled or no charts to show
   if (historyEnabled === null) return null; // Still loading
-  if (!historyEnabled || historizedBindings.length === 0) return null;
+  if (!historyEnabled || allCharts.length === 0) return null;
 
   const handleToggle = (alias: string) => {
     setExpandedAlias((prev) => (prev === alias ? null : alias));
-  };
-
-  // Find the unit for a binding from its category
-  const getUnit = (binding: HistoryBindingState): string | undefined => {
-    const CATEGORY_UNITS: Record<string, string> = {
-      temperature: "\u00b0C",
-      humidity: "%",
-      pressure: "hPa",
-      luminosity: "lx",
-      power: "W",
-      energy: "kWh",
-      voltage: "V",
-      current: "A",
-      battery: "%",
-      noise: "dB",
-      co2: "ppm",
-      rain: "mm",
-      wind: "km/h",
-      shutter_position: "%",
-    };
-    return CATEGORY_UNITS[binding.category];
   };
 
   return (
@@ -146,22 +171,22 @@ export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
           {t("history.chart")}
         </span>
         <span className="text-[11px] text-text-tertiary">
-          {historizedBindings.length}
+          {allCharts.length}
         </span>
       </button>
 
       {open && <div className="px-4 pb-4 space-y-1">
-        {historizedBindings.map((binding) => {
-          const isExpanded = expandedAlias === binding.alias;
-          const chart = charts[binding.alias];
-          const unit = getUnit(binding);
+        {allCharts.map((entry) => {
+          const isExpanded = expandedAlias === entry.alias;
+          const chart = charts[entry.alias];
+          const unit = entry.unit;
 
           return (
-            <div key={binding.bindingId}>
+            <div key={entry.alias}>
               {/* Binding row — clickable to expand */}
               <button
                 type="button"
-                onClick={() => handleToggle(binding.alias)}
+                onClick={() => handleToggle(entry.alias)}
                 className={`flex items-center justify-between w-full px-2.5 py-1.5 rounded-[4px] text-[12px] cursor-pointer transition-colors ${
                   isExpanded
                     ? "bg-primary-light"
@@ -169,8 +194,8 @@ export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
                 }`}
               >
                 <div className="flex items-center gap-2">
-                  <span className="font-mono font-medium text-primary">{binding.alias}</span>
-                  <span className="text-text-tertiary">({binding.category})</span>
+                  <span className="font-mono font-medium text-primary">{entry.alias}</span>
+                  <span className="text-text-tertiary">({entry.category})</span>
                 </div>
                 <BarChart3
                   size={12}
@@ -198,7 +223,7 @@ export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
                       <div className="flex justify-end mb-2">
                         <TimeRangeSelector value={range} onChange={setRange} />
                       </div>
-                      {chart?.category === "energy" ? (
+                      {CUMULATIVE_CATEGORIES.has(chart?.category ?? "") ? (
                         <HistoryBarChart
                           points={chart?.points ?? []}
                           range={range}

--- a/ui/src/components/history/history-utils.ts
+++ b/ui/src/components/history/history-utils.ts
@@ -1,5 +1,8 @@
 export type TimeRange = "6h" | "24h" | "7d" | "30d";
 
+/** Categories where values are cumulative totals — displayed as bar charts with sum aggregation. */
+export const CUMULATIVE_CATEGORIES = new Set(["rain", "energy"]);
+
 /** Convert a TimeRange to a relative "from" string for the API. */
 export function rangeToFrom(range: TimeRange): string {
   switch (range) {

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -341,7 +341,13 @@ export function EquipmentDetailPage() {
       )}
 
       {/* History charts */}
-      <HistoryPanel equipmentId={equipment.id} bindings={historyBindings} />
+      <HistoryPanel
+        equipmentId={equipment.id}
+        bindings={historyBindings}
+        computedData={(equipment.computedData ?? [])
+          .filter((c) => c.category)
+          .map((c) => ({ alias: c.alias, category: c.category!, unit: c.unit }))}
+      />
 
       {/* Configuration */}
       <div className="bg-surface rounded-[10px] border border-border mb-6 divide-y divide-border-light">

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -341,13 +341,7 @@ export function EquipmentDetailPage() {
       )}
 
       {/* History charts */}
-      <HistoryPanel
-        equipmentId={equipment.id}
-        bindings={historyBindings}
-        computedData={(equipment.computedData ?? [])
-          .filter((c) => c.category)
-          .map((c) => ({ alias: c.alias, category: c.category!, unit: c.unit }))}
-      />
+      <HistoryPanel equipmentId={equipment.id} bindings={historyBindings} />
 
       {/* Configuration */}
       <div className="bg-surface rounded-[10px] border border-border mb-6 divide-y divide-border-light">

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -430,7 +430,9 @@ export function EquipmentDetailPage() {
                         <span className="font-mono font-medium text-accent">{cd.alias}</span>
                         {cd.category && <span className="text-text-tertiary">({cd.category})</span>}
                         <span className="ml-auto font-mono text-text">
-                          {cd.value !== null && cd.value !== undefined ? String(Math.round(cd.value as number)) : "—"}
+                          {cd.value !== null && cd.value !== undefined
+                            ? typeof cd.value === "number" ? (cd.value as number).toFixed(1) : String(cd.value)
+                            : "—"}
                           {cd.unit && <span className="text-text-tertiary ml-0.5">{cd.unit}</span>}
                         </span>
                       </div>


### PR DESCRIPTION
## Summary

- **WeatherAggregator** backend service: computes `rain_1h` and `rain_24h` from InfluxDB on weather equipments with historized rain bindings (same pattern as EnergyAggregator)
- **Bar charts for cumulative categories**: rain and energy data render as bar charts with `sum()` aggregation in the equipment HistoryPanel — driven by a generic `CUMULATIVE_CATEGORIES` set, not hardcoded per category
- **Computed data in HistoryPanel**: computed entries (rain_24h, energy_day...) appear in the chart list alongside regular bindings
- **HistoryBarChart generalized**: energy Wh→kWh formatting preserved, rain uses generic formatting with unit prop

Prerequisite for spec 063 (auto-watering recipe — needs `rain_24h` as input).

## Test plan

- [x] `npx tsc --noEmit` (backend) — clean
- [x] `cd ui && npx tsc -b --noEmit` — clean
- [x] `npx vitest run` — 319 passed
- [x] `npx eslint src/ --ext .ts` — clean
- [x] `cd ui && npx eslint .` — clean
- [ ] Manual: weather equipment shows `rain_1h` + `rain_24h` computed values
- [ ] Manual: rain history renders as bar chart (not line chart)
- [ ] Manual: energy history still renders as bar chart (non-regression)
- [ ] Manual: temperature/humidity still render as line charts (non-regression)