### PR TITLE
fix: hot-install/update for recipe packages

### DIFF
--- a/src/api/routes/plugins.ts
+++ b/src/api/routes/plugins.ts
@@ -2,17 +2,25 @@ import type { FastifyInstance } from "fastify";
 import type { Logger } from "../../core/logger.js";
 import type { PackageManager } from "../../packages/package-manager.js";
 import type { PluginLoader } from "../../plugins/plugin-loader.js";
+import type { RecipeLoader } from "../../recipes/recipe-loader.js";
 import type { IntegrationRegistry } from "../../integrations/integration-registry.js";
 
 interface PluginsDeps {
   packageManager: PackageManager;
   pluginLoader: PluginLoader;
+  recipeLoader: RecipeLoader;
   integrationRegistry: IntegrationRegistry;
   logger: Logger;
 }
 
 export function registerPluginRoutes(app: FastifyInstance, deps: PluginsDeps): void {
-  const { packageManager, pluginLoader, integrationRegistry, logger: parentLogger } = deps;
+  const {
+    packageManager,
+    pluginLoader,
+    recipeLoader,
+    integrationRegistry,
+    logger: parentLogger,
+  } = deps;
   const logger = parentLogger.child({ module: "plugin-routes" });
 
   // GET /api/v1/plugins — list installed
@@ -72,11 +80,21 @@ export function registerPluginRoutes(app: FastifyInstance, deps: PluginsDeps): v
     }
 
     try {
-      const manifest = await pluginLoader.install(repo);
-      logger.info({ pluginId: manifest.id, repo }, "Plugin installed via API");
-      return { success: true, manifest };
+      // Peek at the registry to determine package type before install
+      const registryType =
+        packageManager.getStore().find((m) => m.repo === repo)?.type ?? "integration";
+
+      if (registryType === "recipe") {
+        await recipeLoader.install(repo);
+        logger.info({ repo, type: "recipe" }, "Recipe installed via API");
+        return { success: true };
+      } else {
+        const manifest = await pluginLoader.install(repo);
+        logger.info({ pluginId: manifest.id, repo }, "Plugin installed via API");
+        return { success: true, manifest };
+      }
     } catch (err) {
-      logger.error({ err, repo }, "Failed to install plugin");
+      logger.error({ err, repo }, "Failed to install package");
       return reply.code(500).send({
         error: err instanceof Error ? err.message : "Install failed",
       });
@@ -108,14 +126,23 @@ export function registerPluginRoutes(app: FastifyInstance, deps: PluginsDeps): v
     }
 
     try {
-      const manifest = await pluginLoader.update(request.params.id);
-      logger.info(
-        { pluginId: request.params.id, version: manifest.version },
-        "Plugin updated via API",
-      );
-      return { success: true, manifest };
+      const pkg = packageManager.getById(request.params.id);
+      const pkgType = pkg?.type ?? "integration";
+
+      if (pkgType === "recipe") {
+        await recipeLoader.update(request.params.id);
+        logger.info({ pluginId: request.params.id, type: "recipe" }, "Recipe updated via API");
+        return { success: true };
+      } else {
+        const manifest = await pluginLoader.update(request.params.id);
+        logger.info(
+          { pluginId: request.params.id, version: manifest.version },
+          "Plugin updated via API",
+        );
+        return { success: true, manifest };
+      }
     } catch (err) {
-      logger.error({ err, pluginId: request.params.id }, "Failed to update plugin");
+      logger.error({ err, pluginId: request.params.id }, "Failed to update package");
       return reply.code(500).send({
         error: err instanceof Error ? err.message : "Update failed",
       });

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -84,6 +84,7 @@ interface ServerDeps {
   notificationPublishService: NotificationPublishService;
   packageManager: PackageManager;
   pluginLoader: PluginLoader;
+  recipeLoader: import("../recipes/recipe-loader.js").RecipeLoader;
   backupManager: BackupManager;
   versionChecker: import("../core/version-checker.js").VersionChecker;
   updateManager: import("../core/update-manager.js").UpdateManager;
@@ -123,6 +124,7 @@ export async function createServer(deps: ServerDeps) {
     notificationPublishService,
     packageManager,
     pluginLoader,
+    recipeLoader,
     backupManager,
     versionChecker,
     updateManager,
@@ -211,7 +213,13 @@ export async function createServer(deps: ServerDeps) {
     logger,
   });
   registerDashboardRoutes(app, { db });
-  registerPluginRoutes(app, { packageManager, pluginLoader, integrationRegistry, logger });
+  registerPluginRoutes(app, {
+    packageManager,
+    pluginLoader,
+    recipeLoader,
+    integrationRegistry,
+    logger,
+  });
   registerSystemRoutes(app, { versionChecker, updateManager, tzInfo, logger });
   registerLogRoutes(app, { logBuffer, logger });
   registerWebSocket(app, { eventBus, authService, logBuffer, logger });

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,6 +306,7 @@ async function main() {
     notificationPublishService,
     packageManager,
     pluginLoader,
+    recipeLoader,
     backupManager,
     versionChecker,
     updateManager,

--- a/src/recipes/recipe-loader.ts
+++ b/src/recipes/recipe-loader.ts
@@ -23,6 +23,35 @@ export class RecipeLoader {
   }
 
   /**
+   * Install a recipe from GitHub — download, register, and load immediately.
+   */
+  async install(repo: string): Promise<void> {
+    const manifest = await this.packageManager.installFromGitHub(repo);
+    if (manifest.type !== "recipe") {
+      throw new Error(`Package "${manifest.id}" is not a recipe (type: ${manifest.type})`);
+    }
+    try {
+      await this.loadRecipe(manifest.id);
+      this.logger.info({ recipeId: manifest.id }, "Recipe installed and loaded");
+    } catch (err) {
+      this.logger.error({ err, recipeId: manifest.id }, "Recipe installed but failed to load");
+    }
+  }
+
+  /**
+   * Update a recipe — download new version and reload.
+   */
+  async update(recipeId: string): Promise<void> {
+    const newManifest = await this.packageManager.updateFiles(recipeId);
+    try {
+      await this.loadRecipe(recipeId);
+      this.logger.info({ recipeId, version: newManifest.version }, "Recipe updated and reloaded");
+    } catch (err) {
+      this.logger.error({ err, recipeId }, "Recipe updated but failed to reload");
+    }
+  }
+
+  /**
    * Load all installed recipe packages and register with RecipeManager.
    * Must be called after PackageManager is ready, before recipeManager.init().
    */


### PR DESCRIPTION
## Summary

Recipe packages installed/updated via the UI required a restart to be available. The API routes dispatched everything to `PluginLoader` which only handles integration plugins.

Now the routes detect the package type and dispatch to `RecipeLoader` for recipes. `RecipeLoader` gains `install()` and `update()` methods that download and immediately register the recipe — no restart needed.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 319 passed
- [ ] Manual: install a recipe via Settings → available immediately without restart