### PR TITLE
feat: registry independence + sowelVersion compatibility (spec 066)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -8,7 +8,8 @@
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-zigbee2mqtt",
     "version": "1.2.0",
-    "tags": ["zigbee", "mqtt", "z2m", "sensors", "lights", "switches"]
+    "tags": ["zigbee", "mqtt", "z2m", "sensors", "lights", "switches"],
+    "sowelVersion": ">=1.1.0"
   },
   {
     "id": "lora2mqtt",
@@ -19,7 +20,8 @@
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-lora2mqtt",
     "version": "1.1.0",
-    "tags": ["lora", "mqtt", "iot", "sensors"]
+    "tags": ["lora", "mqtt", "iot", "sensors"],
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "panasonic_cc",
@@ -30,7 +32,8 @@
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-panasonic-cc",
     "version": "1.2.1",
-    "tags": ["panasonic", "ac", "heating", "cooling", "comfort-cloud"]
+    "tags": ["panasonic", "ac", "heating", "cooling", "comfort-cloud"],
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "mcz_maestro",
@@ -41,51 +44,56 @@
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-mcz-maestro",
     "version": "1.1.0",
-    "tags": ["mcz", "pellet", "stove", "heating"]
+    "tags": ["mcz", "pellet", "stove", "heating"],
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "legrand_energy",
     "type": "integration",
     "name": "Legrand Energy",
-    "description": "Legrand energy monitoring \u2014 NLPC meters, consumption + solar production",
+    "description": "Legrand energy monitoring — NLPC meters, consumption + solar production",
     "icon": "Zap",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-legrand-energy",
     "version": "1.1.0",
-    "tags": ["legrand", "energy", "consumption", "solar", "production"]
+    "tags": ["legrand", "energy", "consumption", "solar", "production"],
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "legrand_control",
     "type": "integration",
     "name": "Legrand Control",
-    "description": "Legrand Home+Control \u2014 lights, shutters, plugs, contactors",
+    "description": "Legrand Home+Control — lights, shutters, plugs, contactors",
     "icon": "PlugZap",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-legrand-control",
     "version": "1.1.0",
-    "tags": ["legrand", "netatmo", "light", "shutter", "plug"]
+    "tags": ["legrand", "netatmo", "light", "shutter", "plug"],
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "netatmo_weather",
     "type": "integration",
     "name": "Netatmo Weather",
-    "description": "Netatmo Weather Station \u2014 temperature, humidity, pressure, CO2, wind, rain",
+    "description": "Netatmo Weather Station — temperature, humidity, pressure, CO2, wind, rain",
     "icon": "CloudSun",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-netatmo-weather",
     "version": "1.1.0",
-    "tags": ["weather", "netatmo", "temperature", "humidity", "rain", "wind"]
+    "tags": ["weather", "netatmo", "temperature", "humidity", "rain", "wind"],
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "netatmo-security",
     "type": "integration",
     "name": "Netatmo Security",
-    "description": "Netatmo cameras (Welcome, Presence, Doorbell) \u2014 monitoring on/off",
+    "description": "Netatmo cameras (Welcome, Presence, Doorbell) — monitoring on/off",
     "icon": "Camera",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-netatmo-security",
     "version": "0.5.0",
-    "tags": ["camera", "netatmo", "security"]
+    "tags": ["camera", "netatmo", "security"],
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "weather-forecast",
@@ -96,7 +104,8 @@
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-weather-forecast",
     "version": "0.5.0",
-    "tags": ["weather", "forecast", "open-meteo"]
+    "tags": ["weather", "forecast", "open-meteo"],
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "smartthings",
@@ -107,13 +116,14 @@
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-smartthings",
     "version": "0.8.0",
-    "tags": ["samsung", "smartthings", "tv", "washer", "appliance"]
+    "tags": ["samsung", "smartthings", "tv", "washer", "appliance"],
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "switch-light",
     "type": "recipe",
     "name": "Switch Light",
-    "description": "Lights follow manual commands \u2014 any button press toggles lights on/off",
+    "description": "Lights follow manual commands — any button press toggles lights on/off",
     "icon": "ToggleRight",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-switch-light",
@@ -121,10 +131,11 @@
     "tags": ["automation", "button", "light", "toggle"],
     "i18n": {
       "fr": {
-        "name": "Lumi\u00e8re sur interrupteur",
-        "description": "Allume ou \u00e9teint les lumi\u00e8res d'une pi\u00e8ce via un interrupteur ou une t\u00e9l\u00e9commande Zigbee."
+        "name": "Lumière sur interrupteur",
+        "description": "Allume ou éteint les lumières d'une pièce via un interrupteur ou une télécommande Zigbee."
       }
-    }
+    },
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "state-watch",
@@ -138,10 +149,11 @@
     "tags": ["automation", "monitoring", "alarm", "state"],
     "i18n": {
       "fr": {
-        "name": "Surveillance d'\u00e9tat",
-        "description": "Surveille une donn\u00e9e d'\u00e9quipement et d\u00e9clenche une alarme si la valeur reste dans un \u00e9tat donn\u00e9."
+        "name": "Surveillance d'état",
+        "description": "Surveille une donnée d'équipement et déclenche une alarme si la valeur reste dans un état donné."
       }
-    }
+    },
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "presence-heater",
@@ -155,10 +167,11 @@
     "tags": ["automation", "heating", "presence", "heater"],
     "i18n": {
       "fr": {
-        "name": "Chauffage pr\u00e9sence",
-        "description": "Passe les radiateurs en confort sur d\u00e9tection de mouvement, \u00e9co apr\u00e8s un d\u00e9lai sans pr\u00e9sence."
+        "name": "Chauffage présence",
+        "description": "Passe les radiateurs en confort sur détection de mouvement, éco après un délai sans présence."
       }
-    }
+    },
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "presence-thermostat",
@@ -172,10 +185,11 @@
     "tags": ["automation", "heating", "thermostat", "presence"],
     "i18n": {
       "fr": {
-        "name": "Thermostat pr\u00e9sence",
-        "description": "Ajuste la consigne du thermostat selon la pr\u00e9sence dans la zone, avec mode nuit, pr\u00e9chauffe et cocoon."
+        "name": "Thermostat présence",
+        "description": "Ajuste la consigne du thermostat selon la présence dans la zone, avec mode nuit, préchauffe et cocoon."
       }
-    }
+    },
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "motion-light",
@@ -189,10 +203,11 @@
     "tags": ["automation", "motion", "light"],
     "i18n": {
       "fr": {
-        "name": "Lumi\u00e8re sur mouvement",
-        "description": "Allume les lumi\u00e8res sur d\u00e9tection de mouvement, \u00e9teint apr\u00e8s un d\u00e9lai sans mouvement."
+        "name": "Lumière sur mouvement",
+        "description": "Allume les lumières sur détection de mouvement, éteint après un délai sans mouvement."
       }
-    }
+    },
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "motion-light-dimmable",
@@ -206,10 +221,11 @@
     "tags": ["automation", "motion", "light", "dimmable", "brightness"],
     "i18n": {
       "fr": {
-        "name": "Lumi\u00e8re dimmable sur mouvement",
-        "description": "Allume les lumi\u00e8res dimmables sur mouvement avec contr\u00f4le de luminosit\u00e9 et plages horaires."
+        "name": "Lumière dimmable sur mouvement",
+        "description": "Allume les lumières dimmables sur mouvement avec contrôle de luminosité et plages horaires."
       }
-    }
+    },
+    "sowelVersion": ">=0.10.0"
   },
   {
     "id": "auto-watering",
@@ -226,7 +242,8 @@
         "name": "Arrosage Auto",
         "description": "Arrosage programmé avec créneaux horaires, durées par vanne et gestion intelligente de la pluie."
       }
-    }
+    },
+    "sowelVersion": ">=1.1.0"
   },
   {
     "id": "freecooling",
@@ -243,6 +260,7 @@
         "name": "Freecooling",
         "description": "Ferme automatiquement les volets avant le lever du soleil."
       }
-    }
+    },
+    "sowelVersion": ">=1.1.0"
   }
 ]

--- a/specs/066-registry-independence/architecture.md
+++ b/specs/066-registry-independence/architecture.md
@@ -1,0 +1,100 @@
+# Architecture — Spec 066
+
+## Overview
+
+Three changes to make the registry independent of Sowel releases:
+
+1. **Warm registry at boot** — `await` the remote fetch before serving any store/update data
+2. **sowelVersion compatibility check** — store API + install guard
+3. **Documentation** of the new workflow
+
+## Backend changes
+
+### Modified: `src/packages/package-manager.ts`
+
+**Registry warm-up (new):**
+
+```typescript
+async warmRegistryCache(): Promise<void>
+```
+
+Called once at boot (before plugin/recipe loading). Fetches the remote registry synchronously (with 10s timeout). Falls back to local bundled file if remote is unreachable. After this call, `getRegistryEntries()` is guaranteed to have fresh data.
+
+The existing `getRegistryEntries()` keeps its background-refresh-on-stale behavior for subsequent calls (>1h TTL).
+
+**Compatibility check (new):**
+
+```typescript
+getCurrentVersion(): string
+```
+
+Reads `version` from `/app/package.json` (or `process.cwd()/package.json`). Cached after first call.
+
+**Store API enrichment:**
+
+`getStore()` returns entries with a `compatible` field:
+
+```typescript
+interface StoreEntry extends PluginManifest {
+  compatible: boolean;
+  compatReason?: string; // "Requires Sowel >= X.Y.Z"
+}
+```
+
+Compatibility is checked by parsing the `sowelVersion` field from the registry entry (e.g., `">=1.1.0"`) against the current Sowel version. Simple semver `>=` comparison — no dependency.
+
+### Modified: `src/api/routes/plugins.ts`
+
+**Install guard:**
+
+Before installing, check sowelVersion from the registry entry:
+
+```typescript
+const entry = packageManager.getStore().find((m) => m.repo === repo);
+if (entry && !entry.compatible) {
+  return reply.code(400).send({ error: `Requires Sowel >= ${entry.sowelVersion}` });
+}
+```
+
+### Modified: `src/index.ts`
+
+Add `await packageManager.warmRegistryCache()` before plugin/recipe loading.
+
+## UI changes
+
+### Modified: `ui/src/pages/PluginsPage.tsx`
+
+For incompatible store entries:
+
+- Disable "Install" button
+- Show tooltip/text: "Nécessite Sowel >= X.Y.Z"
+
+## Registry entries
+
+### Modified: all plugin/recipe manifests
+
+Add/update `sowelVersion` constraint:
+
+| Plugin        | sowelVersion                                   |
+| ------------- | ---------------------------------------------- |
+| zigbee2mqtt   | `>=1.1.0` (uses composite payload from v1.1.0) |
+| auto-watering | `>=1.1.0` (needs water_valve type + rain_24h)  |
+| freecooling   | `>=1.1.0` (needs sunlight data)                |
+| All others    | `>=0.10.0` (legacy compat)                     |
+
+## Files changed
+
+| File                               | Change                                                                            |
+| ---------------------------------- | --------------------------------------------------------------------------------- |
+| `src/packages/package-manager.ts`  | `warmRegistryCache()`, `getCurrentVersion()`, compatibility check in `getStore()` |
+| `src/index.ts`                     | Call `warmRegistryCache()` at boot                                                |
+| `src/api/routes/plugins.ts`        | Install guard for sowelVersion                                                    |
+| `ui/src/pages/PluginsPage.tsx`     | Disable install for incompatible packages                                         |
+| `plugins/registry.json`            | Add `sowelVersion` to all entries                                                 |
+| `specs/066-registry-independence/` | Spec + architecture docs                                                          |
+
+## No changes needed
+
+- No SQLite migration
+- No new API endpoints (existing store endpoint enriched)
+- No new events

--- a/src/api/routes/plugins.ts
+++ b/src/api/routes/plugins.ts
@@ -80,9 +80,17 @@ export function registerPluginRoutes(app: FastifyInstance, deps: PluginsDeps): v
     }
 
     try {
-      // Peek at the registry to determine package type before install
-      const registryType =
-        packageManager.getStore().find((m) => m.repo === repo)?.type ?? "integration";
+      // Peek at the registry to determine package type + compatibility
+      const entry = packageManager.getStore().find((m) => m.repo === repo);
+      const registryType = entry?.type ?? "integration";
+
+      if (entry && !entry.compatible) {
+        return reply.code(400).send({
+          error:
+            entry.compatReason ??
+            `Incompatible with current Sowel version (${packageManager.getCurrentVersion()})`,
+        });
+      }
 
       if (registryType === "recipe") {
         await recipeLoader.install(repo);

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,8 +253,10 @@ async function main() {
   const userManager = new UserManager(db, logger);
   const authService = new AuthService(db, userManager, config.jwt, logger);
 
-  // 14. Create Package Manager + Plugin Loader and load plugins
+  // 14. Create Package Manager + warm registry cache (await remote fetch before loading plugins)
   const packageManager = new PackageManager(db, logger);
+  await packageManager.warmRegistryCache();
+
   const pluginLoader = new PluginLoader(
     packageManager,
     integrationRegistry,

--- a/src/packages/package-manager.ts
+++ b/src/packages/package-manager.ts
@@ -32,6 +32,23 @@ interface RegistryEntry {
   version?: string;
   type?: string;
   tags: string[];
+  sowelVersion?: string; // e.g. ">=1.1.0"
+}
+
+/** Simple semver ">=" check: returns true if current >= required. */
+function semverSatisfiesGte(current: string, required: string): boolean {
+  const parse = (v: string) =>
+    v
+      .replace(/^[>=<^~\s]+/, "")
+      .split(".")
+      .map(Number);
+  const c = parse(current);
+  const r = parse(required);
+  for (let i = 0; i < 3; i++) {
+    if ((c[i] ?? 0) > (r[i] ?? 0)) return true;
+    if ((c[i] ?? 0) < (r[i] ?? 0)) return false;
+  }
+  return true; // equal
 }
 
 /**
@@ -46,6 +63,7 @@ export class PackageManager {
   private stmts: ReturnType<typeof this.prepareStatements>;
   private registryCache: RegistryEntry[] | null = null;
   private registryCacheTime = 0;
+  private sowelVersionCache: string | null = null;
 
   constructor(db: Database.Database, logger: Logger) {
     this.db = db;
@@ -67,6 +85,25 @@ export class PackageManager {
       updateManifest: this.db.prepare("UPDATE plugins SET version = ?, manifest = ? WHERE id = ?"),
       remove: this.db.prepare<[string]>("DELETE FROM plugins WHERE id = ?"),
     };
+  }
+
+  /** Get the current Sowel version from package.json (cached). */
+  getCurrentVersion(): string {
+    if (this.sowelVersionCache) return this.sowelVersionCache;
+    try {
+      const pkgPath = resolve(process.cwd(), "package.json");
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version: string };
+      this.sowelVersionCache = pkg.version;
+      return pkg.version;
+    } catch {
+      return "0.0.0";
+    }
+  }
+
+  /** Check if a sowelVersion constraint is compatible with the current version. */
+  isCompatible(sowelVersion?: string): boolean {
+    if (!sowelVersion) return true; // No constraint = compatible
+    return semverSatisfiesGte(this.getCurrentVersion(), sowelVersion);
   }
 
   /** Ensure plugins directory exists */
@@ -107,14 +144,15 @@ export class PackageManager {
   /**
    * Get available packages from registry (not yet installed).
    */
-  getStore(): PluginManifest[] {
+  getStore(): (PluginManifest & { compatible: boolean; compatReason?: string })[] {
     const entries = this.getRegistryEntries();
     const installedIds = new Set((this.stmts.getAll.all() as PackageRow[]).map((r) => r.id));
 
     return entries
       .filter((e) => !installedIds.has(e.id))
-      .map(
-        (e): PluginManifest => ({
+      .map((e) => {
+        const compatible = this.isCompatible(e.sowelVersion);
+        return {
           id: e.id,
           name: e.name,
           version: e.version ?? "",
@@ -123,8 +161,11 @@ export class PackageManager {
           author: e.author,
           repo: e.repo,
           type: (e.type as PackageType) ?? "integration",
-        }),
-      );
+          sowelVersion: e.sowelVersion,
+          compatible,
+          ...(!compatible ? { compatReason: `Requires Sowel >= ${e.sowelVersion}` } : {}),
+        };
+      });
   }
 
   /** Get available packages from registry filtered by type */
@@ -318,18 +359,44 @@ export class PackageManager {
   }
 
   /**
-   * Fetch registry entries — remote first (cached 1h), fallback to local file.
-   * Uses synchronous cache to avoid async in getStore()/getLatestVersions().
-   * Remote fetch runs in background to refresh cache.
+   * Warm the registry cache by fetching the remote registry.
+   * Must be called once at startup before any getStore()/getLatestVersions() calls.
+   * Falls back to local file if remote is unreachable.
+   */
+  async warmRegistryCache(): Promise<void> {
+    try {
+      const res = await fetch(REGISTRY_URL, {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (res.ok) {
+        const entries = (await res.json()) as RegistryEntry[];
+        if (Array.isArray(entries) && entries.length > 0) {
+          this.registryCache = entries;
+          this.registryCacheTime = Date.now();
+          this.logger.info({ count: entries.length }, "Remote registry loaded");
+          return;
+        }
+      }
+    } catch {
+      // Remote unreachable — fall back to local
+    }
+    // Fallback to bundled local file
+    this.readLocalRegistry();
+    this.logger.info({ count: this.registryCache?.length ?? 0 }, "Using local registry fallback");
+  }
+
+  /**
+   * Get registry entries from cache.
+   * If cache is stale (>1h), trigger a background refresh and return stale data.
    */
   private getRegistryEntries(): RegistryEntry[] {
-    // Return cache if fresh
     if (this.registryCache && Date.now() - this.registryCacheTime < REGISTRY_CACHE_TTL_MS) {
       return this.registryCache;
     }
 
-    // Trigger background refresh
-    this.fetchRemoteRegistry();
+    // Trigger background refresh for next call
+    this.refreshRegistryInBackground();
 
     // Return stale cache or local fallback
     if (this.registryCache) return this.registryCache;
@@ -349,7 +416,7 @@ export class PackageManager {
     }
   }
 
-  private fetchRemoteRegistry(): void {
+  private refreshRegistryInBackground(): void {
     fetch(REGISTRY_URL, { headers: { Accept: "application/json" } })
       .then(async (res) => {
         if (!res.ok) return;

--- a/ui/src/pages/PluginsPage.tsx
+++ b/ui/src/pages/PluginsPage.tsx
@@ -478,13 +478,14 @@ function StoreRow({
   lang,
   onRefresh,
 }: {
-  manifest: PluginManifest;
+  manifest: PluginManifest & { compatible?: boolean; compatReason?: string };
   installed: boolean;
   lang: string;
   onRefresh: () => void;
 }) {
   const { t } = useTranslation();
   const [installing, setInstalling] = useState(false);
+  const compatible = manifest.compatible !== false;
 
   const IconComponent =
     (LucideIcons as unknown as Record<string, LucideIcons.LucideIcon>)[manifest.icon] ?? Cpu;
@@ -536,7 +537,7 @@ function StoreRow({
           <span className="px-3 py-1.5 text-[12px] font-medium text-success bg-success/10 rounded-[6px]">
             {t("plugins.installed_badge")}
           </span>
-        ) : (
+        ) : compatible ? (
           <button
             onClick={handleInstall}
             disabled={installing}
@@ -554,6 +555,10 @@ function StoreRow({
               </>
             )}
           </button>
+        ) : (
+          <span className="px-3 py-1.5 text-[11px] font-medium text-text-tertiary bg-border-light rounded-[6px]" title={manifest.compatReason}>
+            {manifest.compatReason ?? t("plugins.incompatible")}
+          </span>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Warm registry at boot**: `await` remote fetch before serving store data (10s timeout, local fallback). Fixes the bug where first store call returned stale bundled data.
- **sowelVersion compatibility**: store API returns `compatible` + `compatReason` per package. Install API rejects incompatible packages.
- **UI**: incompatible packages shown grayed out with reason text instead of install button.
- **Registry entries**: all 18 entries now have `sowelVersion` constraints.

This means plugin/recipe registry updates only require a `git push` to `main` — no Sowel Docker release needed.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `cd ui && npx tsc -b --noEmit` — clean
- [x] `npx vitest run` — 319 passed
- [x] `npx eslint src/` — clean
- [ ] Manual: store shows fresh remote data at boot (no stale local)
- [ ] Manual: incompatible packages grayed out
- [ ] Manual: install of incompatible package rejected