### PR TITLE
feat(equipments): order dispatch v2 — orderKey instead of dispatchConfig (spec 067)

### DIFF
--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -37,7 +37,7 @@ export interface DiscoveredDevice {
   orders: {
     key: string;
     type: DataType;
-    dispatchConfig: Record<string, unknown>;
+    dispatchConfig?: Record<string, unknown>;
     min?: number;
     max?: number;
     enumValues?: string[];
@@ -213,7 +213,7 @@ export class DeviceManager {
         if (existingOrder) {
           this.stmts.updateDeviceOrderDef.run(
             o.type,
-            JSON.stringify(o.dispatchConfig),
+            o.dispatchConfig ? JSON.stringify(o.dispatchConfig) : null,
             o.min ?? null,
             o.max ?? null,
             o.enumValues ? JSON.stringify(o.enumValues) : null,
@@ -226,7 +226,7 @@ export class DeviceManager {
             deviceId,
             key: o.key,
             type: o.type,
-            dispatchConfig: JSON.stringify(o.dispatchConfig),
+            dispatchConfig: o.dispatchConfig ? JSON.stringify(o.dispatchConfig) : null,
             min: o.min ?? null,
             max: o.max ?? null,
             enumValues: o.enumValues ? JSON.stringify(o.enumValues) : null,

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -27,7 +27,13 @@ function seedDevice(
     deviceId?: string;
     name?: string;
     dataKeys?: { id?: string; key: string; type?: string; category?: string; value?: string }[];
-    orderKeys?: { id?: string; key: string; type?: string; payloadKey?: string }[];
+    orderKeys?: {
+      id?: string;
+      key: string;
+      type?: string;
+      payloadKey?: string;
+      enumValues?: string[];
+    }[];
   } = {},
 ) {
   const deviceId = opts.deviceId ?? crypto.randomUUID();
@@ -51,8 +57,8 @@ function seedDevice(
   for (const o of opts.orderKeys ?? []) {
     const id = o.id ?? crypto.randomUUID();
     db.prepare(
-      `INSERT INTO device_orders (id, device_id, key, type, mqtt_set_topic, payload_key, dispatch_config)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO device_orders (id, device_id, key, type, mqtt_set_topic, payload_key, dispatch_config, enum_values)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       id,
       deviceId,
@@ -61,6 +67,7 @@ function seedDevice(
       `z2m/${name}/set`,
       o.payloadKey ?? o.key,
       JSON.stringify({ topic: `z2m/${name}/set`, payloadKey: o.payloadKey ?? o.key }),
+      o.enumValues ? JSON.stringify(o.enumValues) : null,
     );
     orderIds.push(id);
   }
@@ -83,20 +90,38 @@ describe("EquipmentManager", () => {
     zoneManager = new ZoneManager(db, eventBus, logger);
     mockPublished = [];
     deviceManager = new DeviceManager(db, eventBus, logger);
-    const mockIntegrationRegistry = {
-      getById: (id: string) => ({
-        id,
-        getStatus: () => "connected" as const,
-        executeOrder: async (
-          _device: any,
-          dispatchConfig: Record<string, unknown>,
-          value: unknown,
-        ) => {
-          const topic = dispatchConfig.topic as string;
-          const payloadKey = dispatchConfig.payloadKey as string;
+    const mockPlugin = {
+      id: "zigbee2mqtt",
+      getStatus: () => "connected" as const,
+      executeOrder: async (
+        _device: any,
+        dispatchConfigOrOrderKey: Record<string, unknown> | string,
+        value: unknown,
+      ) => {
+        if (typeof dispatchConfigOrOrderKey === "string") {
+          mockPublished.push({
+            topic: `z2m/${_device.name}/set`,
+            payload: JSON.stringify({ [dispatchConfigOrOrderKey]: value }),
+          });
+        } else {
+          const topic = dispatchConfigOrOrderKey.topic as string;
+          const payloadKey = dispatchConfigOrOrderKey.payloadKey as string;
           mockPublished.push({ topic, payload: JSON.stringify({ [payloadKey]: value }) });
-        },
-      }),
+        }
+      },
+    };
+    const mockIntegrationRegistry = {
+      getById: () => mockPlugin,
+      dispatchOrder: async (
+        _integrationId: string,
+        device: any,
+        _orderKey: string,
+        dispatchConfig: Record<string, unknown>,
+        value: unknown,
+      ) => {
+        // v1 behavior (default): pass dispatchConfig
+        await mockPlugin.executeOrder(device, dispatchConfig, value);
+      },
     };
     manager = new EquipmentManager(
       db,
@@ -499,6 +524,99 @@ describe("EquipmentManager", () => {
       await expect(noIntegrationManager.executeOrder(eq.id, "state", "ON")).rejects.toThrow(
         /integration/i,
       );
+    });
+
+    it("dispatches via dispatchOrder with orderKey for v2 plugin", async () => {
+      const dispatched: { orderKey: string; value: unknown }[] = [];
+      const v2Plugin = {
+        id: "lora2mqtt",
+        apiVersion: 2,
+        getStatus: () => "connected" as const,
+        executeOrder: async (_device: any, orderKey: string, value: unknown) => {
+          dispatched.push({ orderKey: orderKey as string, value });
+        },
+      };
+      const v2Registry = {
+        getById: () => v2Plugin,
+        dispatchOrder: async (
+          _iid: string,
+          device: any,
+          orderKey: string,
+          _dc: Record<string, unknown>,
+          value: unknown,
+        ) => {
+          // Simulate real dispatchOrder: v2 passes orderKey
+          if ((v2Plugin.apiVersion ?? 1) >= 2) {
+            await v2Plugin.executeOrder(device, orderKey, value);
+          }
+        },
+      };
+      const v2Manager = new EquipmentManager(
+        db,
+        eventBus,
+        v2Registry as any,
+        deviceManager,
+        logger,
+      );
+      const zone = zoneManager.create({ name: "Garage" });
+      const eq = v2Manager.create({ name: "Gate", type: "gate", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, { name: "garage", orderKeys: [{ key: "R1" }] });
+      v2Manager.addOrderBinding(eq.id, orderIds[0], "command");
+
+      await v2Manager.executeOrder(eq.id, "command", "latch");
+
+      expect(dispatched).toHaveLength(1);
+      expect(dispatched[0].orderKey).toBe("R1");
+      expect(dispatched[0].value).toBe("latch");
+    });
+
+    it("resolves enum value case-insensitively", async () => {
+      const zone = zoneManager.create({ name: "Garage" });
+      const eq = manager.create({ name: "Light", type: "light_onoff", zoneId: zone.id });
+      // Device has lowercase enum values ["on", "off"]
+      const { orderIds } = seedDevice(db, {
+        name: "LoraLight",
+        orderKeys: [{ key: "state", payloadKey: "state", enumValues: ["on", "off"] }],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      await manager.executeOrder(eq.id, "state", "ON"); // uppercase from zone order
+
+      expect(mockPublished).toHaveLength(1);
+      // Should resolve "ON" → "on" (matching device's enum)
+      expect(JSON.parse(mockPublished[0].payload)).toEqual({ state: "on" });
+    });
+
+    it("dispatches via dispatchOrder with dispatchConfig for v1 plugin", async () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Lamp", type: "light_onoff", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        name: "ZigbeeLamp",
+        orderKeys: [{ key: "state", payloadKey: "state" }],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      await manager.executeOrder(eq.id, "state", "ON");
+
+      // v1 mock dispatches via dispatchConfig → mockPublished captures topic + payload
+      expect(mockPublished).toHaveLength(1);
+      expect(mockPublished[0].topic).toBe("z2m/ZigbeeLamp/set");
+      expect(JSON.parse(mockPublished[0].payload)).toEqual({ state: "ON" });
+    });
+
+    it("dispatches with null dispatchConfig for v1 plugin gracefully", async () => {
+      const zone = zoneManager.create({ name: "Test" });
+      const eq = manager.create({ name: "Dev", type: "sensor", zoneId: zone.id });
+      // Seed device with no dispatchConfig (null in DB)
+      const { orderIds } = seedDevice(db, {
+        name: "NullDevice",
+        orderKeys: [{ key: "state" }],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      // Should not throw — dispatchConfig defaults to {}
+      await manager.executeOrder(eq.id, "state", "ON");
+      expect(mockPublished).toHaveLength(1);
     });
   });
 

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -539,19 +539,28 @@ export class EquipmentManager {
       throw new EquipmentError(`Order alias not found: ${alias}`, 404);
     }
 
-    // Resolve value: if null/undefined/empty, use the first enum value from the order binding
+    // Resolve value against the binding's enumValues:
+    // - null/undefined/empty → use first enum value
+    // - string → match case-insensitively against enum values (e.g. "ON" matches "on")
     let resolvedValue = value;
-    if (resolvedValue === null || resolvedValue === undefined || resolvedValue === "") {
-      const firstBinding = bindings[0];
-      if (firstBinding.enum_values) {
-        try {
-          const enumVals = JSON.parse(firstBinding.enum_values);
-          if (Array.isArray(enumVals) && enumVals.length > 0) {
+    const firstBinding = bindings[0];
+    if (firstBinding.enum_values) {
+      try {
+        const enumVals = JSON.parse(firstBinding.enum_values) as unknown[];
+        if (Array.isArray(enumVals) && enumVals.length > 0) {
+          if (resolvedValue === null || resolvedValue === undefined || resolvedValue === "") {
             resolvedValue = enumVals[0];
+          } else if (typeof resolvedValue === "string") {
+            const match = enumVals.find(
+              (v) =>
+                typeof v === "string" &&
+                v.toLowerCase() === (resolvedValue as string).toLowerCase(),
+            );
+            if (match !== undefined) resolvedValue = match;
           }
-        } catch {
-          // ignore parse errors
         }
+      } catch {
+        // ignore parse errors
       }
     }
 
@@ -575,6 +584,7 @@ export class EquipmentManager {
         throw new EquipmentError(`Integration ${device.integrationId} not connected`, 503);
       }
 
+      const orderKey = binding.key;
       let dispatchConfig: Record<string, unknown> = {};
       if (binding.dispatch_config) {
         try {
@@ -588,7 +598,13 @@ export class EquipmentManager {
       let dispatched = false;
       for (let attempt = 1; attempt <= 2; attempt++) {
         try {
-          await integration.executeOrder(device, dispatchConfig, resolvedValue);
+          await this.integrationRegistry.dispatchOrder(
+            device.integrationId,
+            device,
+            orderKey,
+            dispatchConfig,
+            resolvedValue,
+          );
           dispatched = true;
           break;
         } catch (err) {

--- a/src/integrations/integration-registry.test.ts
+++ b/src/integrations/integration-registry.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { IntegrationRegistry } from "./integration-registry.js";
+import type { IntegrationPlugin } from "./integration-registry.js";
+import { createLogger } from "../core/logger.js";
+
+const logger = createLogger("silent").logger;
+
+function createMockPlugin(overrides: Partial<IntegrationPlugin> = {}): IntegrationPlugin {
+  return {
+    id: "test-plugin",
+    name: "Test",
+    description: "Test plugin",
+    icon: "Plug",
+    getStatus: () => "connected",
+    isConfigured: () => true,
+    getSettingsSchema: () => [],
+    start: async () => {},
+    stop: async () => {},
+    executeOrder: async () => {},
+    ...overrides,
+  };
+}
+
+describe("IntegrationRegistry", () => {
+  describe("dispatchOrder", () => {
+    it("passes dispatchConfig to v1 plugin (no apiVersion)", async () => {
+      const registry = new IntegrationRegistry(logger);
+      const calls: unknown[] = [];
+      const plugin = createMockPlugin({
+        id: "v1-plugin",
+        executeOrder: async (_device, dispatchConfigOrKey, value) => {
+          calls.push({ arg: dispatchConfigOrKey, value });
+        },
+      });
+      registry.register(plugin);
+
+      const device = {
+        id: "d1",
+        integrationId: "v1-plugin",
+        sourceDeviceId: "dev1",
+        name: "Dev1",
+      } as any;
+      const dispatchConfig = { topic: "z2m/dev1/set", payloadKey: "state" };
+      await registry.dispatchOrder("v1-plugin", device, "state", dispatchConfig, "ON");
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual({ arg: dispatchConfig, value: "ON" });
+    });
+
+    it("passes orderKey string to v2 plugin", async () => {
+      const registry = new IntegrationRegistry(logger);
+      const calls: unknown[] = [];
+      const plugin = createMockPlugin({
+        id: "v2-plugin",
+        apiVersion: 2,
+        executeOrder: async (_device, orderKeyOrDc, value) => {
+          calls.push({ arg: orderKeyOrDc, value });
+        },
+      });
+      registry.register(plugin);
+
+      const device = {
+        id: "d1",
+        integrationId: "v2-plugin",
+        sourceDeviceId: "dev1",
+        name: "Dev1",
+      } as any;
+      const dispatchConfig = { topic: "old/topic", payloadKey: "state" };
+      await registry.dispatchOrder("v2-plugin", device, "state", dispatchConfig, "OPEN");
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual({ arg: "state", value: "OPEN" });
+    });
+
+    it("throws for unknown integration", async () => {
+      const registry = new IntegrationRegistry(logger);
+
+      const device = { id: "d1", integrationId: "unknown" } as any;
+      await expect(registry.dispatchOrder("unknown", device, "state", {}, "ON")).rejects.toThrow(
+        /not found/i,
+      );
+    });
+
+    it("treats apiVersion 1 as v1", async () => {
+      const registry = new IntegrationRegistry(logger);
+      const calls: unknown[] = [];
+      const plugin = createMockPlugin({
+        id: "explicit-v1",
+        apiVersion: 1,
+        executeOrder: async (_device, arg, value) => {
+          calls.push({ arg, value });
+        },
+      });
+      registry.register(plugin);
+
+      const device = { id: "d1" } as any;
+      const dc = { topic: "test" };
+      await registry.dispatchOrder("explicit-v1", device, "state", dc, "OFF");
+
+      expect(calls[0]).toEqual({ arg: dc, value: "OFF" });
+    });
+  });
+});

--- a/src/integrations/integration-registry.ts
+++ b/src/integrations/integration-registry.ts
@@ -19,6 +19,8 @@ export interface IntegrationPlugin {
   readonly description: string;
   /** Lucide icon name */
   readonly icon: string;
+  /** Plugin API version: 1 = dispatchConfig (default), 2 = orderKey */
+  readonly apiVersion?: number;
 
   /** Current connection/health status */
   getStatus(): IntegrationStatus;
@@ -37,13 +39,13 @@ export interface IntegrationPlugin {
 
   /**
    * Execute an order on a device managed by this integration.
-   * @param device The target device
-   * @param dispatchConfig Integration-specific order config
-   * @param value The value to set
+   *
+   * API v1 (default): executeOrder(device, dispatchConfig, value)
+   * API v2: executeOrder(device, orderKey, value)
    */
   executeOrder(
     device: Device,
-    dispatchConfig: Record<string, unknown>,
+    orderKeyOrDispatchConfig: string | Record<string, unknown>,
     value: unknown,
   ): Promise<void>;
 
@@ -124,6 +126,29 @@ export class IntegrationRegistry {
         supportsOAuth: typeof plugin.getOAuthUrl === "function",
       };
     });
+  }
+
+  /**
+   * Dispatch an order to a plugin, routing based on apiVersion.
+   * v1: passes dispatchConfig (Record). v2: passes orderKey (string).
+   */
+  async dispatchOrder(
+    integrationId: string,
+    device: Device,
+    orderKey: string,
+    dispatchConfig: Record<string, unknown>,
+    value: unknown,
+  ): Promise<void> {
+    const plugin = this.plugins.get(integrationId);
+    if (!plugin) {
+      throw new Error(`Integration not found: ${integrationId}`);
+    }
+
+    if ((plugin.apiVersion ?? 1) >= 2) {
+      await plugin.executeOrder(device, orderKey, value);
+    } else {
+      await plugin.executeOrder(device, dispatchConfig, value);
+    }
   }
 
   async startAll(): Promise<void> {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -87,7 +87,7 @@ export interface DeviceOrder {
   deviceId: string;
   key: string;
   type: DataType;
-  dispatchConfig: Record<string, unknown>;
+  dispatchConfig?: Record<string, unknown>;
   min?: number;
   max?: number;
   enumValues?: string[];
@@ -256,7 +256,7 @@ export interface OrderBindingWithDetails extends OrderBinding {
   deviceName: string;
   key: string;
   type: DataType;
-  dispatchConfig: Record<string, unknown>;
+  dispatchConfig?: Record<string, unknown>;
   min?: number;
   max?: number;
   enumValues?: string[];
@@ -706,6 +706,7 @@ export interface PluginManifest {
   author?: string;
   sowelVersion?: string;
   settings?: IntegrationSettingDef[];
+  apiVersion?: number; // 1 (default) = dispatchConfig, 2 = orderKey
 }
 
 /** Raw package data from DB — no runtime info */


### PR DESCRIPTION
## Summary
- New `executeOrder(device, orderKey, value)` signature for v2 plugins
- `IntegrationRegistry.dispatchOrder` routes based on `plugin.apiVersion` (v1 retro-compat)
- Equipment manager delegates dispatch to registry
- Enum values resolved case-insensitively (fixes zone order "ON" vs "on" mismatch)
- `dispatchConfig` becomes optional in types and DB

## Changes
- `integration-registry.ts`: added `dispatchOrder` method + `apiVersion` on plugin interface
- `equipment-manager.ts`: uses `dispatchOrder`, enum case resolution
- `device-manager.ts`: handles null `dispatchConfig` in upsert
- `types.ts`: `dispatchConfig` optional, `apiVersion` on `PluginManifest`
- 8 new tests (integration-registry + equipment-manager)

## Test plan
- [x] TypeScript compiles
- [x] 327 tests pass (8 new)
- [x] Lint clean
- [x] Manual: lora2mqtt orders work with v2 plugin (portail, garage, lumière)
- [x] Manual: z2m orders work with v1 retro-compat (volets)
- [x] Manual: zone allLightsOn resolves "ON" → "on" for lora2mqtt lights