### PR TITLE
feat(equipments): order dispatch legrand-control + zone orders by category (spec 069)

### DIFF
--- a/specs/069-order-dispatch-legrand-control/plan.md
+++ b/specs/069-order-dispatch-legrand-control/plan.md
@@ -1,0 +1,36 @@
+# Spec 069 — Implementation Plan
+
+## Tasks
+
+- [ ] 1. Add `apiVersion: 2` to plugin class
+- [ ] 2. Add `orderMeta` Map to plugin class
+- [ ] 3. Populate Map during `parseModule` discovery (sourceDeviceId:orderKey → metadata)
+- [ ] 4. Rewrite `executeOrder` to `(device, orderKey, value)` — lookup metadata from Map
+- [ ] 5. Remove `dispatchConfig` from discovery orders
+- [ ] 6. Update local interfaces (IntegrationPlugin, DiscoveredDevice)
+- [ ] 7. Build and test locally
+- [ ] 8. Release legrand-control v2.0.0
+- [ ] 9. Update registry
+- [ ] 10. Update spec (acceptance criteria)
+
+---
+
+## Test Plan
+
+### Modules to test
+
+- Plugin `executeOrder` — order dispatch via internal Map lookup
+
+### Scenarios
+
+| Module       | Scenario                                    | Expected                                                                                |
+| ------------ | ------------------------------------------- | --------------------------------------------------------------------------------------- |
+| executeOrder | Light toggle (param: "on")                  | Looks up meta for sourceDeviceId:on, calls bridge.setState with correct homeId/moduleId |
+| executeOrder | Brightness set (param: "brightness")        | Looks up meta for sourceDeviceId:brightness                                             |
+| executeOrder | Shutter position (param: "target_position") | Looks up meta for sourceDeviceId:target_position                                        |
+| executeOrder | Unknown device/orderKey                     | Throws "Order metadata not found"                                                       |
+| executeOrder | Not connected                               | Throws "not connected"                                                                  |
+| discovery    | parseModule populates orderMeta Map         | Map contains entries for each order key                                                 |
+| discovery    | Re-discovery refreshes Map                  | Old entries replaced with new ones                                                      |
+
+Note: this is an external plugin — tests are manual (no Vitest in plugin repos).

--- a/specs/069-order-dispatch-legrand-control/spec.md
+++ b/specs/069-order-dispatch-legrand-control/spec.md
@@ -1,9 +1,41 @@
-# Spec 069 — Order Dispatch: Legrand Control
+# Spec 069 — Order Dispatch: Legrand Control Migration
 
-**Depends on**: spec 067
+**Depends on**: spec 067 (core refactoring)
 
 ## Summary
 
-Migrate legrand-control plugin. Plugin stores homeId/moduleId/param in an internal map during cloud API discovery.
+Migrate the legrand-control plugin to `executeOrder(device, orderKey, value)`. The plugin stores cloud API metadata (`homeId`, `moduleId`, `param`, `bridge`) in an in-memory Map during discovery, and looks it up by `sourceDeviceId + orderKey` at execution time.
 
-## Status: Planned
+## Problem
+
+The current `dispatchConfig` stores Legrand cloud API identifiers:
+
+```json
+{ "homeId": "abc", "moduleId": "xyz", "param": "on", "bridge": "gw1" }
+```
+
+These are baked into `device_orders` at discovery time. The plugin should own this data internally.
+
+## Changes
+
+- `apiVersion: 2` on plugin class
+- New `orderMeta` Map populated during discovery: `sourceDeviceId:orderKey → {homeId, moduleId, param, bridge?}`
+- `executeOrder(device, orderKey, value)`: looks up metadata from Map
+- Discovery: orders without `dispatchConfig`
+- Local interfaces updated
+
+## Acceptance Criteria
+
+- [ ] Plugin declares `apiVersion: 2`
+- [ ] Discovery no longer provides dispatchConfig
+- [ ] `executeOrder` uses internal Map to resolve cloud API IDs
+- [ ] Map is populated on every discovery poll
+- [ ] Build succeeds
+- [ ] Manual test: toggle Legrand light on/off
+- [ ] Manual test: set Legrand shutter position
+- [ ] Released as legrand-control v2.0.0
+- [ ] Registry updated
+
+## Out of scope
+
+- legrand-energy (read-only, no executeOrder)

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -213,7 +213,7 @@ export class DeviceManager {
         if (existingOrder) {
           this.stmts.updateDeviceOrderDef.run(
             o.type,
-            o.dispatchConfig ? JSON.stringify(o.dispatchConfig) : null,
+            o.dispatchConfig ? JSON.stringify(o.dispatchConfig) : "{}",
             o.min ?? null,
             o.max ?? null,
             o.enumValues ? JSON.stringify(o.enumValues) : null,
@@ -226,7 +226,7 @@ export class DeviceManager {
             deviceId,
             key: o.key,
             type: o.type,
-            dispatchConfig: o.dispatchConfig ? JSON.stringify(o.dispatchConfig) : null,
+            dispatchConfig: o.dispatchConfig ? JSON.stringify(o.dispatchConfig) : "{}",
             min: o.min ?? null,
             max: o.max ?? null,
             enumValues: o.enumValues ? JSON.stringify(o.enumValues) : null,

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -722,32 +722,37 @@ export class EquipmentManager {
   // Zone-level order execution
   // ============================================================
 
-  /** Valid zone order keys and their mapping to equipment types + order alias + value. */
+  /**
+   * Zone order definitions.
+   * `category` is used to find the correct order binding on each equipment
+   * by matching the data binding with that category → using its alias.
+   * This is integration-agnostic: works for "state" (z2m), "on" (Legrand), etc.
+   */
   private static readonly ZONE_ORDERS: Record<
     string,
-    { types: string[]; alias: string; value: unknown | "FROM_BODY" }
+    { types: string[]; category: string; value: unknown | "FROM_BODY" }
   > = {
     allLightsOn: {
       types: ["light_onoff", "light_dimmable", "light_color"],
-      alias: "state",
+      category: "light_state",
       value: "ON",
     },
     allLightsOff: {
       types: ["light_onoff", "light_dimmable", "light_color"],
-      alias: "state",
+      category: "light_state",
       value: "OFF",
     },
     allLightsBrightness: {
       types: ["light_dimmable", "light_color"],
-      alias: "brightness",
+      category: "light_brightness",
       value: "FROM_BODY",
     },
-    allShuttersOpen: { types: ["shutter"], alias: "state", value: "OPEN" },
-    allShuttersStop: { types: ["shutter"], alias: "state", value: "STOP" },
-    allShuttersClose: { types: ["shutter"], alias: "state", value: "CLOSE" },
-    allThermostatsPowerOn: { types: ["thermostat"], alias: "power", value: true },
-    allThermostatsPowerOff: { types: ["thermostat"], alias: "power", value: false },
-    allThermostatsSetpoint: { types: ["thermostat"], alias: "setpoint", value: "FROM_BODY" },
+    allShuttersOpen: { types: ["shutter"], category: "shutter_position", value: "OPEN" },
+    allShuttersStop: { types: ["shutter"], category: "shutter_position", value: "STOP" },
+    allShuttersClose: { types: ["shutter"], category: "shutter_position", value: "CLOSE" },
+    allThermostatsPowerOn: { types: ["thermostat"], category: "power", value: true },
+    allThermostatsPowerOff: { types: ["thermostat"], category: "power", value: false },
+    allThermostatsSetpoint: { types: ["thermostat"], category: "temperature", value: "FROM_BODY" },
   };
 
   static readonly VALID_ZONE_ORDER_KEYS = Object.keys(EquipmentManager.ZONE_ORDERS);
@@ -784,21 +789,33 @@ export class EquipmentManager {
         if (!eq.enabled) continue;
         if (!mapping.types.includes(eq.type)) continue;
 
+        // Resolve the order alias from the equipment's data bindings by category
+        const details = this.getByIdWithDetails(eq.id);
+        const dataBinding = details?.dataBindings.find((b) => b.category === mapping.category);
+        if (!dataBinding) {
+          this.logger.debug(
+            { equipmentId: eq.id, equipmentName: eq.name, category: mapping.category },
+            "Zone order skipped — no data binding with matching category",
+          );
+          continue;
+        }
+        const alias = dataBinding.alias;
+
         try {
-          const result = await this.executeOrder(eq.id, mapping.alias, resolvedValue);
+          const result = await this.executeOrder(eq.id, alias, resolvedValue);
           if (result.success) {
             executed++;
           } else {
             errors++;
             this.logger.warn(
-              { equipmentId: eq.id, equipmentName: eq.name, orderKey, error: result.error },
+              { equipmentId: eq.id, equipmentName: eq.name, orderKey, alias, error: result.error },
               "Zone order dispatch failed for equipment",
             );
           }
         } catch (err) {
           errors++;
           this.logger.warn(
-            { err, equipmentId: eq.id, equipmentName: eq.name, orderKey },
+            { err, equipmentId: eq.id, equipmentName: eq.name, orderKey, alias },
             "Zone order failed for equipment",
           );
         }


### PR DESCRIPTION
## Summary
- Legrand-control plugin migrated to apiVersion 2 (orderMeta Map)
- Zone orders now resolve alias by data binding **category** instead of hardcoded name
- Fixes zone orders for all integrations regardless of alias naming (z2m "state", Legrand "on")
- Fixes NOT NULL constraint on dispatch_config for v2 plugins

## Changes
- `equipment-manager.ts`: ZONE_ORDERS uses `category` field, executeZoneOrder resolves alias dynamically
- `device-manager.ts`: uses `'{}'` instead of null for empty dispatchConfig
- legrand-control plugin: apiVersion 2, orderMeta Map, no dispatchConfig in discovery

## Test plan
- [x] TypeScript compiles
- [x] 327 tests pass
- [x] Manual: Legrand light toggle (individual) — works
- [x] Manual: zone allLightsOn/Off for zone with Legrand lights — works
- [x] Manual: z2m shutter zone commands still work
- [x] Manual: lora2mqtt orders still work