### PR TITLE
feat(equipments): thermostat setpoint category (spec 070)

### DIFF
--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -752,7 +752,7 @@ export class EquipmentManager {
     allShuttersClose: { types: ["shutter"], category: "shutter_position", value: "CLOSE" },
     allThermostatsPowerOn: { types: ["thermostat"], category: "power", value: true },
     allThermostatsPowerOff: { types: ["thermostat"], category: "power", value: false },
-    allThermostatsSetpoint: { types: ["thermostat"], category: "temperature", value: "FROM_BODY" },
+    allThermostatsSetpoint: { types: ["thermostat"], category: "setpoint", value: "FROM_BODY" },
   };
 
   static readonly VALID_ZONE_ORDER_KEYS = Object.keys(EquipmentManager.ZONE_ORDERS);


### PR DESCRIPTION
## Summary
- `allThermostatsSetpoint` zone order uses category `setpoint` instead of `temperature`
- Panasonic CC v2.1.0: `power` → category `power`, `targetTemperature` → category `setpoint`

## Test plan
- [x] TypeScript compiles, 327 tests pass
- [x] Manual: PAC setpoint/power orders work