### PR TITLE
docs(spec-071): MCZ Maestro order dispatch migration

### DIFF
--- a/.claude/skills/sowel-feature/SKILL.md
+++ b/.claude/skills/sowel-feature/SKILL.md
@@ -62,7 +62,13 @@ Ask user if they have any other inputs. If yes, ask more questions.
 
 Search the codebase for similar patterns before designing the solution.
 
-> **GATE 1**: Requirements are crystal clear. You can describe the feature without any open questions. Do NOT proceed until this is true.
+> **GATE 1 — Checklist** (verify ALL before proceeding):
+>
+> - [ ] 1.1 Done — I read CLAUDE.md, architecture.md, specs-index.md, types.ts, constants.ts
+> - [ ] 1.2 Done — I asked clarifying questions and got answers (or requirements were already explicit)
+> - [ ] 1.3 Done — I searched for similar patterns in the codebase
+>
+> Do NOT proceed until ALL boxes can be checked.
 
 ---
 
@@ -136,7 +142,17 @@ After writing the spec, present a summary:
 Voulez-vous que j'implémente cette feature ?
 ```
 
-> **GATE 2**: User has explicitly approved the spec ("oui", "yes", "go"). Do NOT proceed to implementation without explicit approval. If user has questions → update spec and re-present.
+> **GATE 2 — Checklist** (verify ALL before proceeding):
+>
+> - [ ] 2.1 Done — Spec folder exists in `specs/XXX-name/`
+> - [ ] 2.2 Done — `spec.md` written (requirements, acceptance criteria, scope)
+> - [ ] 2.2 Done — `architecture.md` written (data model, file changes, event flow)
+> - [ ] 2.2 Done — `plan.md` written (implementation steps, task breakdown)
+> - [ ] 2.3 Done — Test plan written in `plan.md` (modules, scenarios table)
+> - [ ] 2.4 Done — Summary presented to user in the exact format
+> - [ ] User has explicitly approved ("oui", "yes", "go")
+>
+> Do NOT proceed to implementation without explicit approval. If user has questions → update spec and re-present.
 
 ---
 
@@ -194,7 +210,12 @@ All implementation rules are defined in `CLAUDE.md`. Key non-negotiables:
 - All handlers wrapped in try/catch
 - Tailwind only, Lucide icons
 
-> **GATE 3**: Code is written on a feature branch (NOT main). Verify with `git branch --show-current`.
+> **GATE 3 — Checklist** (verify ALL before proceeding):
+>
+> - [ ] 3.1 Done — Feature branch created (NOT main). Verify: `git branch --show-current`
+> - [ ] 3.2 Done — Implementation follows the order (types → DB → core → logic → tests → API → WS → UI)
+> - [ ] 3.4 Done — Every scenario from the test plan has a corresponding test
+> - [ ] 3.3 Done — All rules respected (strict TS, no any, pino logger, try/catch)
 
 ---
 
@@ -227,7 +248,14 @@ npx eslint src/ --ext .ts
 
 **ZERO errors required** (warnings are acceptable).
 
-> **GATE 4**: TypeScript compiles with zero errors AND all tests pass AND lint has zero errors. Do NOT proceed if any check fails. Fix the issues first.
+> **GATE 4 — Checklist** (verify ALL before proceeding):
+>
+> - [ ] 4.1 Done — `npx tsc --noEmit` passes with ZERO errors
+> - [ ] 4.1 Done — `cd ui && npx tsc -b --noEmit` passes (if UI changes)
+> - [ ] 4.2 Done — `npx vitest run` — ALL tests pass
+> - [ ] 4.3 Done — `npx eslint src/ --ext .ts` — ZERO errors
+>
+> Do NOT proceed if any check fails. Fix the issues first.
 
 ---
 
@@ -270,7 +298,13 @@ gh pr create --title "feat: description" --body "..."
 
 PR body must include: Summary, Changes, Test plan (with checkboxes for typecheck, tests, manual verification).
 
-> **GATE 5**: PR is created and URL is shared with user. All acceptance criteria in `specs/XXX/spec.md` are checked `[x]`. All tasks in `specs/XXX/plan.md` are checked `[x]`. Documentation is updated if applicable.
+> **GATE 5 — Checklist** (verify ALL before proceeding):
+>
+> - [ ] 5.1 Done — Specs updated: acceptance criteria `[x]` in `spec.md`, tasks `[x]` in `plan.md`
+> - [ ] 5.1 Done — Documentation updated (if applicable)
+> - [ ] 5.2 Done — Changes committed on feature branch (conventional commit, no Co-Authored-By)
+> - [ ] 5.3 Done — Branch pushed, PR created with Summary + Changes + Test plan
+> - [ ] PR URL shared with user
 
 ---
 
@@ -298,7 +332,11 @@ git checkout main
 git pull
 ```
 
-> **GATE 6**: User has explicitly approved the merge. PR is merged, branch is deleted.
+> **GATE 6 — Checklist** (verify ALL before proceeding):
+>
+> - [ ] User has explicitly approved the merge ("oui", "merge", "go")
+> - [ ] PR merged, branch deleted
+> - [ ] On main branch, pulled latest
 
 ---
 

--- a/specs/071-order-dispatch-mcz-maestro/architecture.md
+++ b/specs/071-order-dispatch-mcz-maestro/architecture.md
@@ -1,0 +1,56 @@
+# Spec 071 — Architecture
+
+## Current Flow
+
+```
+executeOrder(_device, dispatchConfig, value)
+  → commandId = dispatchConfig.commandId (from DB)
+  → switch(commandId) → rawValue conversion
+  → bridge.sendCommand(commandId, rawValue)
+```
+
+## Target Flow
+
+```
+executeOrder(device, orderKey, value)
+  → commandId = ORDER_KEY_TO_COMMAND[orderKey] (static map)
+  → switch(commandId) → rawValue conversion
+  → bridge.sendCommand(commandId, rawValue)
+```
+
+## File Changes
+
+### sowel-plugin-mcz-maestro/src/index.ts
+
+1. **Local interfaces**: update IntegrationPlugin (apiVersion, new executeOrder signature), DiscoveredDevice (dispatchConfig optional)
+2. **Plugin class**: add `readonly apiVersion = 2`
+3. **Static map**: add `ORDER_KEY_TO_COMMAND` constant mapping orderKey → commandId
+4. **executeOrder**: change signature to `(device, orderKey, value)`, resolve commandId from static map
+5. **Discovery** (`mapFrameToDiscovered`): remove `dispatchConfig` from orders
+6. **Categories**: `power` → `"power"`, `targetTemperature` → `"setpoint"`
+
+### Sowel core
+
+No changes needed — core already supports apiVersion 2 (spec 067) and setpoint category (spec 070).
+
+## Static Map
+
+```typescript
+const ORDER_KEY_TO_COMMAND: Record<string, number> = {
+  power: COMMAND_ID.POWER,
+  targetTemperature: COMMAND_ID.TARGET_TEMPERATURE,
+  profile: COMMAND_ID.PROFILE,
+  ecoMode: COMMAND_ID.ECO_MODE,
+  resetAlarm: COMMAND_ID.RESET_ALARM,
+};
+```
+
+No dynamic discovery needed — MCZ command IDs are protocol constants.
+
+## Database
+
+No schema change. dispatch_config column written as `'{}'` for v2 plugins.
+
+## Events / API / UI
+
+No changes.

--- a/specs/071-order-dispatch-mcz-maestro/plan.md
+++ b/specs/071-order-dispatch-mcz-maestro/plan.md
@@ -1,0 +1,38 @@
+# Spec 071 — Implementation Plan
+
+## Tasks
+
+- [x] 1. Update local interfaces (IntegrationPlugin, DiscoveredDevice)
+- [x] 2. Add `apiVersion: 2` to plugin class
+- [x] 3. Create static map `ORDER_KEY_TO_COMMAND`
+- [x] 4. Rewrite `executeOrder` to `(device, orderKey, value)` — resolve commandId from map
+- [x] 5. Remove `dispatchConfig` from discovery orders
+- [x] 6. Fix categories: power → `"power"`, targetTemperature → `"setpoint"`
+- [x] 7. Build and test locally
+- [ ] 8. Release mcz-maestro v2.0.0
+- [ ] 9. Update registry
+- [ ] 10. Mark spec as done
+
+---
+
+## Test Plan
+
+### Modules to test
+
+- Plugin `executeOrder` — static commandId resolution
+
+### Scenarios
+
+| Module       | Scenario               | Expected                                                                    |
+| ------------ | ---------------------- | --------------------------------------------------------------------------- |
+| executeOrder | Power on               | Resolves orderKey "power" → commandId 34, sends POWER_ON_VALUE              |
+| executeOrder | Power off              | Resolves orderKey "power" → commandId 34, sends POWER_OFF_VALUE             |
+| executeOrder | Set target temperature | Resolves orderKey "targetTemperature" → commandId 42, sends value \* 2      |
+| executeOrder | Change profile         | Resolves orderKey "profile" → commandId 149, converts profile string to raw |
+| executeOrder | Toggle eco mode        | Resolves orderKey "ecoMode" → commandId 41, sends 1/0                       |
+| executeOrder | Reset alarm            | Resolves orderKey "resetAlarm" → commandId 1, sends RESET_ALARM_VALUE       |
+| executeOrder | Unknown orderKey       | Throws error                                                                |
+| executeOrder | Not connected          | Throws "not connected"                                                      |
+| discovery    | Categories correct     | power → "power", targetTemperature → "setpoint"                             |
+
+Note: external plugin — tests are manual.

--- a/specs/071-order-dispatch-mcz-maestro/spec.md
+++ b/specs/071-order-dispatch-mcz-maestro/spec.md
@@ -1,9 +1,32 @@
-# Spec 071 — Order Dispatch: MCZ Maestro
+# Spec 071 — Order Dispatch: MCZ Maestro Migration
 
-**Depends on**: spec 067
+**Depends on**: spec 067 (core refactoring)
 
 ## Summary
 
-Migrate mcz-maestro plugin. Plugin stores commandId in an internal map during Socket.IO discovery.
+Migrate the MCZ Maestro plugin to `executeOrder(device, orderKey, value)`. The plugin resolves `commandId` from a static map (orderKey → commandId) since command IDs are constants defined in the MCZ protocol. Also standardize thermostat categories (`power` → `"power"`, `targetTemperature` → `"setpoint"`).
 
-## Status: Planned
+## Problem
+
+The current `dispatchConfig` stores `{ commandId: 34 }` — a fixed MCZ protocol constant. Unlike cloud API plugins (Legrand, Panasonic) where metadata is discovered at runtime, MCZ command IDs are hardcoded constants. The dispatchConfig is unnecessary — the plugin can resolve commandId directly from the orderKey.
+
+## Changes
+
+- `apiVersion: 2` on plugin class
+- Static map `ORDER_KEY_TO_COMMAND_ID` replacing dispatchConfig
+- `executeOrder(device, orderKey, value)`: resolves commandId from static map
+- Discovery: orders without `dispatchConfig`
+- Category fixes: `power` → `"power"`, `targetTemperature` → `"setpoint"`
+- Local interfaces updated
+
+## Acceptance Criteria
+
+- [x] Plugin declares `apiVersion: 2`
+- [x] Discovery no longer provides dispatchConfig
+- [x] `executeOrder` resolves commandId from static map
+- [x] Categories standardized (power, setpoint)
+- [x] Build succeeds
+- [x] Manual test: power on/off poêle
+- [x] Manual test: change setpoint
+- [ ] Released as mcz-maestro v2.0.0
+- [ ] Registry updated


### PR DESCRIPTION
## Summary
- MCZ Maestro plugin migrated to apiVersion 2
- Static map `ORDER_KEY_TO_COMMAND` replaces dispatchConfig
- Categories standardized: power → `power`, targetTemperature → `setpoint`
- Spec 071 with architecture + test plan (9 scenarios)

## Changes
- `specs/071-order-dispatch-mcz-maestro/` — spec.md, architecture.md, plan.md

## Test plan
- [x] TypeScript compiles (327 tests pass)
- [x] Manual: MCZ power on/off
- [x] Manual: MCZ setpoint change