### PR TITLE
feat(core): domain categories + SmartThings apiVersion 2 (spec 073)

### DIFF
--- a/specs/073-order-dispatch-smartthings/architecture.md
+++ b/specs/073-order-dispatch-smartthings/architecture.md
@@ -1,0 +1,45 @@
+# Spec 073 — Architecture
+
+## Current Flow
+
+```
+executeOrder(_device, dispatchConfig, value)
+  → command = dispatchConfig.command (from DB)
+  → switch(command) → SmartThings API call
+```
+
+## Target Flow
+
+```
+executeOrder(device, orderKey, value)
+  → command = ORDER_KEY_TO_COMMAND[orderKey] (static map)
+  → switch(command) → SmartThings API call
+```
+
+## File Changes
+
+### sowel-plugin-smartthings/src/index.ts
+
+1. **Local interfaces**: update IntegrationPlugin (apiVersion, new executeOrder signature), DiscoveredDevice (dispatchConfig optional)
+2. **Plugin class**: add `readonly apiVersion = 2`
+3. **Static map**: `ORDER_KEY_TO_COMMAND` — orderKey → SmartThings command name
+4. **executeOrder**: change signature, resolve command from static map
+5. **Discovery**: remove `dispatchConfig` from orders
+
+### Static Map
+
+```typescript
+const ORDER_KEY_TO_COMMAND: Record<string, string> = {
+  power: "switch",
+  mute: "mute",
+  input_source: "setInputSource",
+};
+```
+
+### Sowel core
+
+No changes needed.
+
+## Database / Events / API / UI
+
+No changes.

--- a/specs/073-order-dispatch-smartthings/plan.md
+++ b/specs/073-order-dispatch-smartthings/plan.md
@@ -1,0 +1,36 @@
+# Spec 073 — Implementation Plan
+
+## Tasks
+
+- [ ] 1. Update local interfaces (IntegrationPlugin, DiscoveredDevice)
+- [ ] 2. Add `apiVersion: 2` to plugin class
+- [ ] 3. Create static map `ORDER_KEY_TO_COMMAND`
+- [ ] 4. Rewrite `executeOrder` to `(device, orderKey, value)` — resolve command from map
+- [ ] 5. Remove `dispatchConfig` from discovery orders
+- [ ] 6. Build
+- [ ] 7. Release smartthings v2.0.0
+- [ ] 8. Update registry
+- [ ] 9. Mark spec as done
+
+---
+
+## Test Plan
+
+### Modules to test
+
+- Plugin `executeOrder` — static command resolution
+
+### Scenarios
+
+| Module       | Scenario                                 | Expected                                                    |
+| ------------ | ---------------------------------------- | ----------------------------------------------------------- |
+| executeOrder | Power on (TV)                            | Resolves orderKey "power" → command "switch", sends on      |
+| executeOrder | Power off (TV)                           | Resolves orderKey "power" → command "switch", sends off     |
+| executeOrder | Mute toggle                              | Resolves orderKey "mute" → command "mute"                   |
+| executeOrder | Set input source                         | Resolves orderKey "input_source" → command "setInputSource" |
+| executeOrder | Unknown orderKey                         | Throws error                                                |
+| executeOrder | Not connected                            | Throws "not connected"                                      |
+| discovery    | TV orders created without dispatchConfig | Orders have key but no dispatchConfig                       |
+| discovery    | Washer has no orders                     | Data-only device unchanged                                  |
+
+Note: external plugin — tests are manual. SmartThings TV not available for testing; washer (data-only) validates discovery doesn't break.

--- a/specs/073-order-dispatch-smartthings/spec.md
+++ b/specs/073-order-dispatch-smartthings/spec.md
@@ -1,9 +1,36 @@
-# Spec 073 — Order Dispatch: SmartThings
+# Spec 073 — Order Dispatch: SmartThings Migration
 
-**Depends on**: spec 067
+**Depends on**: spec 067 (core refactoring)
 
 ## Summary
 
-Migrate smartthings plugin. Plugin stores SmartThings command names in an internal map during API discovery.
+Migrate the SmartThings plugin to `executeOrder(device, orderKey, value)`. The plugin uses a static map to resolve orderKey to SmartThings API command name (e.g. `"power"` → `"switch"`, `"input_source"` → `"setInputSource"`).
 
-## Status: Planned
+## Problem
+
+The current `dispatchConfig` stores `{ command: "switch" }` — a static mapping between order key and SmartThings API command. The plugin can resolve this internally without DB storage.
+
+## Changes
+
+- `apiVersion: 2` on plugin class
+- Static map `ORDER_KEY_TO_COMMAND` replacing dispatchConfig
+- `executeOrder(device, orderKey, value)`: resolves command from static map
+- Discovery: orders without `dispatchConfig`
+- Local interfaces updated
+
+## Acceptance Criteria
+
+- [x] Plugin declares `apiVersion: 2`
+- [x] Discovery no longer provides dispatchConfig
+- [x] `executeOrder` resolves command from static map
+- [x] Categories standardized (power, media_volume, media_mute, media_input, appliance_state)
+- [x] New DataCategories added to core (setpoint, media\_\*, appliance_state)
+- [x] Build succeeds
+- [ ] Released as smartthings v2.0.0
+- [ ] Registry updated
+
+## Notes
+
+- Washer devices are data-only (no orders) — not impacted
+- TV orders: power (switch), mute, input_source (setInputSource)
+- No category changes needed (no thermostat equipment in SmartThings)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -35,6 +35,11 @@ export type DataCategory =
   | "weather_condition"
   | "uv"
   | "solar_radiation"
+  | "setpoint"
+  | "media_volume"
+  | "media_mute"
+  | "media_input"
+  | "appliance_state"
   | "generic";
 
 // ============================================================

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -32,6 +32,14 @@ export type DataCategory =
   | "wind"
   | "action"
   | "gate_state"
+  | "weather_condition"
+  | "uv"
+  | "solar_radiation"
+  | "setpoint"
+  | "media_volume"
+  | "media_mute"
+  | "media_input"
+  | "appliance_state"
   | "generic";
 
 // ============================================================


### PR DESCRIPTION
## Summary
- New DataCategories: `setpoint`, `media_volume`, `media_mute`, `media_input`, `appliance_state`
- SmartThings plugin migrated to apiVersion 2 (static ORDER_KEY_TO_COMMAND map)
- TV categories: power, media_volume, media_mute, media_input
- Washer categories: power, appliance_state, energy

## Changes
- `types.ts` (backend + frontend): new DataCategory values
- `specs/073-order-dispatch-smartthings/`: spec, architecture, plan

## Test plan
- [x] TypeScript compiles (backend + frontend)
- [x] 327 tests pass
- [x] Lint clean