### PR TITLE
docs(spec-075): Legrand Energy apiVersion 2 — interface alignment

### DIFF
--- a/specs/075-order-dispatch-legrand-energy/architecture.md
+++ b/specs/075-order-dispatch-legrand-energy/architecture.md
@@ -1,0 +1,26 @@
+# Spec 075 — Architecture
+
+## File Changes
+
+### sowel-plugin-legrand-energy/src/index.ts
+
+1. **IntegrationPlugin interface**: add `apiVersion`, update `executeOrder` signature
+2. **DiscoveredDevice interface**: `dispatchConfig` optional in orders
+3. **Plugin class**: add `readonly apiVersion = 2`
+4. **executeOrder**: update signature (still throws "not supported")
+
+### Sowel core
+
+No changes needed.
+
+## Categories (verified)
+
+| Data key     | Current category | Correct |
+| ------------ | ---------------- | ------- |
+| power        | `power`          | ✓       |
+| energy       | `energy`         | ✓       |
+| autoconso    | `energy`         | ✓       |
+| injection    | `energy`         | ✓       |
+| demand_30min | `power`          | ✓       |
+
+All categories already correct.

--- a/specs/075-order-dispatch-legrand-energy/plan.md
+++ b/specs/075-order-dispatch-legrand-energy/plan.md
@@ -1,0 +1,28 @@
+# Spec 075 — Implementation Plan
+
+## Tasks
+
+- [ ] 1. Update local interfaces (IntegrationPlugin, DiscoveredDevice)
+- [ ] 2. Add `apiVersion: 2` to plugin class
+- [ ] 3. Update executeOrder signature (still throws)
+- [ ] 4. Build
+- [ ] 5. Release legrand-energy v2.0.0
+- [ ] 6. Update registry
+
+---
+
+## Test Plan
+
+### Modules to test
+
+- Plugin interface coherence (no logic change)
+
+### Scenarios
+
+| Module       | Scenario                  | Expected                              |
+| ------------ | ------------------------- | ------------------------------------- |
+| executeOrder | Any order                 | Throws "does not support orders"      |
+| discovery    | Energy devices discovered | Categories power/energy correct       |
+| plugin       | Status reported           | Plugin starts and reports "connected" |
+
+Note: read-only plugin — tests are manual (verify energy data still flows).

--- a/specs/075-order-dispatch-legrand-energy/spec.md
+++ b/specs/075-order-dispatch-legrand-energy/spec.md
@@ -1,0 +1,23 @@
+# Spec 075 — Order Dispatch: Legrand Energy Migration
+
+**Depends on**: spec 067 (core refactoring)
+
+## Summary
+
+Migrate the legrand-energy plugin to apiVersion 2 for interface coherence. This is a read-only plugin (executeOrder throws) — no functional change, only interface alignment.
+
+## Changes
+
+- `apiVersion: 2` on plugin class
+- `executeOrder` signature updated to `(device, orderKey, value)` (still throws)
+- Local interfaces updated (IntegrationPlugin, DiscoveredDevice)
+- Verify energy categories are correct (already `power` and `energy`)
+
+## Acceptance Criteria
+
+- [x] Plugin declares `apiVersion: 2`
+- [x] Local interfaces aligned with v2
+- [x] Categories verified correct (power, energy)
+- [x] Build succeeds
+- [ ] Released as legrand-energy v2.0.0
+- [ ] Registry updated


### PR DESCRIPTION
## Summary
- Legrand Energy plugin migrated to apiVersion 2 (interface only, read-only plugin)
- No functional change — executeOrder still throws
- Categories verified correct (power, energy)

## Test plan
- [x] TypeScript compiles, 327 tests pass
- [x] Lint clean