### PR TITLE
feat(core): outdoor temperature/humidity categories + netatmo-weather apiVersion 2 (spec 076)

### DIFF
--- a/specs/076-order-dispatch-netatmo-weather/architecture.md
+++ b/specs/076-order-dispatch-netatmo-weather/architecture.md
@@ -1,0 +1,14 @@
+# Spec 076 — Architecture
+
+## File Changes
+
+### sowel-plugin-netatmo-weather/src/index.ts
+
+1. **IntegrationPlugin interface**: add `apiVersion`, update `executeOrder` signature
+2. **DiscoveredDevice interface**: `dispatchConfig` optional in orders
+3. **Plugin class**: add `readonly apiVersion = 2`
+4. **executeOrder**: update signature (still throws "read-only")
+
+### Sowel core
+
+No changes needed.

--- a/specs/076-order-dispatch-netatmo-weather/plan.md
+++ b/specs/076-order-dispatch-netatmo-weather/plan.md
@@ -1,0 +1,25 @@
+# Spec 076 — Implementation Plan
+
+## Tasks
+
+- [ ] 1. Update local interfaces (IntegrationPlugin, DiscoveredDevice)
+- [ ] 2. Add `apiVersion: 2` to plugin class
+- [ ] 3. Update executeOrder signature (still throws)
+- [ ] 4. Build
+- [ ] 5. Release netatmo-weather v2.0.0
+- [ ] 6. Update registry
+
+---
+
+## Test Plan
+
+### Scenarios
+
+| Module       | Scenario                   | Expected                                                   |
+| ------------ | -------------------------- | ---------------------------------------------------------- |
+| executeOrder | Any order                  | Throws "read-only"                                         |
+| discovery    | Weather station discovered | Categories temperature/humidity/pressure/co2/noise correct |
+| discovery    | Modules discovered         | Categories battery/wind/rain correct                       |
+| plugin       | Status reported            | Plugin starts and reports "connected"                      |
+
+Note: read-only plugin — tests are manual.

--- a/specs/076-order-dispatch-netatmo-weather/spec.md
+++ b/specs/076-order-dispatch-netatmo-weather/spec.md
@@ -1,0 +1,38 @@
+# Spec 076 — Order Dispatch: Netatmo Weather Migration
+
+**Depends on**: spec 067 (core refactoring)
+
+## Summary
+
+Migrate the netatmo-weather plugin to apiVersion 2 for interface coherence. Read-only plugin (executeOrder throws) — no functional change.
+
+## Changes
+
+- `apiVersion: 2` on plugin class
+- `executeOrder` signature updated to v2 (still throws)
+- Local interfaces updated (IntegrationPlugin, DiscoveredDevice)
+
+## Categories (verified — all correct)
+
+| Data key                           | Category      | Equipment type |
+| ---------------------------------- | ------------- | -------------- |
+| temperature                        | `temperature` | weather        |
+| humidity                           | `humidity`    | weather        |
+| co2                                | `co2`         | weather        |
+| noise                              | `noise`       | weather        |
+| pressure                           | `pressure`    | weather        |
+| battery                            | `battery`     | weather        |
+| wind*strength, wind_angle, gust*\* | `wind`        | weather        |
+| rain, sum*rain*\*                  | `rain`        | weather        |
+
+## Acceptance Criteria
+
+- [x] Plugin declares `apiVersion: 2`
+- [x] Local interfaces aligned with v2
+- [x] Categories: NAModule1 outdoor → `temperature_outdoor`, `humidity_outdoor`
+- [x] New core categories: `temperature_outdoor`, `humidity_outdoor`
+- [x] weather-forecast: temp_min/max → `temperature_outdoor`
+- [x] panasonic-cc: outsideTemperature → `temperature_outdoor`
+- [x] Build succeeds
+- [ ] Released as netatmo-weather v2.0.0
+- [ ] Registry updated

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -36,6 +36,8 @@ export type DataCategory =
   | "uv"
   | "solar_radiation"
   | "setpoint"
+  | "temperature_outdoor"
+  | "humidity_outdoor"
   | "media_volume"
   | "media_mute"
   | "media_input"

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -36,6 +36,8 @@ export type DataCategory =
   | "uv"
   | "solar_radiation"
   | "setpoint"
+  | "temperature_outdoor"
+  | "humidity_outdoor"
   | "media_volume"
   | "media_mute"
   | "media_input"


### PR DESCRIPTION
## Summary
- New DataCategories: `temperature_outdoor`, `humidity_outdoor`
- netatmo-weather: apiVersion 2, NAModule1 outdoor categories
- weather-forecast: temp_min/max → `temperature_outdoor`
- panasonic-cc: outsideTemperature → `temperature_outdoor`

## Test plan
- [x] TypeScript compiles (backend + frontend)
- [x] 327 tests pass
- [x] Manual: netatmo-weather poll OK, weather-forecast + panasonic-cc connected