### PR TITLE
feat(equipments): order categories for zone orders (spec 077)

### DIFF
--- a/migrations/003_device_order_category.sql
+++ b/migrations/003_device_order_category.sql
@@ -1,0 +1,1 @@
+ALTER TABLE device_orders ADD COLUMN category TEXT;

--- a/specs/077-order-category/architecture.md
+++ b/specs/077-order-category/architecture.md
@@ -1,0 +1,114 @@
+# Spec 077 — Architecture
+
+## Type Changes
+
+### New type: OrderCategory
+
+```typescript
+export type OrderCategory =
+  | "light_toggle"
+  | "set_brightness"
+  | "set_color_temp"
+  | "set_color"
+  | "shutter_move"
+  | "set_shutter_position"
+  | "toggle_power"
+  | "set_setpoint"
+  | "gate_trigger"
+  | "valve_toggle"
+  | "toggle_mute"
+  | "set_input";
+```
+
+### Updated interfaces
+
+- `DiscoveredDevice.orders[].category?: OrderCategory` — plugin provides during discovery
+- `DeviceOrder.category?: OrderCategory` — stored in DB
+- `OrderBindingWithDetails.category?: OrderCategory` — returned by equipment queries
+- `OrderBindingJoinRow.category: string | null` — raw SQL row
+
+## Database Migration
+
+```sql
+ALTER TABLE device_orders ADD COLUMN category TEXT;
+```
+
+Nullable — backward compatible with existing data.
+
+## File Changes
+
+### 1. `src/shared/types.ts`
+
+- Add `OrderCategory` type
+- Add `category?: OrderCategory` to `DeviceOrder` and `OrderBindingWithDetails`
+
+### 2. `ui/src/types.ts`
+
+- Mirror `OrderCategory` type and updated interfaces
+
+### 3. `migrations/003_device_order_category.sql`
+
+- ALTER TABLE device_orders ADD COLUMN category TEXT
+
+### 4. `src/devices/device-manager.ts`
+
+- Add `category?` to `DiscoveredDevice.orders`
+- Update SQL INSERT/UPDATE statements to include category
+- Handle null category for backward compat
+
+### 5. `src/equipments/equipment-manager.ts`
+
+- Update `OrderBindingJoinRow` — add `category: string | null`
+- Update SQL queries to SELECT category from device_orders
+- Update `rowToOrderBindingWithDetails` to include category
+- Replace ZONE_ORDERS `category` field with `orderCategory` (uses OrderCategory, not DataCategory)
+- Replace brute-force loop in `executeZoneOrder` with category-based lookup:
+
+```typescript
+const orderBinding = details.orderBindings.find((ob) => ob.category === mapping.orderCategory);
+```
+
+### 6. All plugins with orders
+
+Each plugin adds `category` to its discovered orders:
+
+**zigbee2mqtt** (z2m-parser.ts):
+
+- Light state orders → `light_toggle`
+- Light brightness → `set_brightness`
+- Shutter state (OPEN/CLOSE/STOP) → `shutter_move`
+- Shutter position (0-100) → `set_shutter_position`
+- Color temp → `set_color_temp`
+
+**lora2mqtt**:
+
+- Light R1 (on/off) → `light_toggle`
+- Gate R1 (latch) → `gate_trigger`
+
+**legrand-control**:
+
+- Light on → `light_toggle`
+- Brightness → `set_brightness`
+- Shutter target_position → `set_shutter_position`
+
+**panasonic-cc**:
+
+- Power → `toggle_power`
+- Target temperature → `set_setpoint`
+- Other orders (mode, fan, swing) → no category (null)
+
+**mcz-maestro**:
+
+- Power → `toggle_power`
+- Target temperature → `set_setpoint`
+- Other orders (profile, eco, alarm) → no category (null)
+
+**smartthings**:
+
+- Power → `toggle_power`
+- Mute → `toggle_mute`
+- Input source → `set_input`
+
+## Events / API / WebSocket
+
+No changes.

--- a/specs/077-order-category/plan.md
+++ b/specs/077-order-category/plan.md
@@ -1,0 +1,58 @@
+# Spec 077 — Implementation Plan
+
+## Phase 1: Core (Sowel)
+
+- [ ] 1.1 Add `OrderCategory` type to `src/shared/types.ts`
+- [ ] 1.2 Add `category?: OrderCategory` to `DeviceOrder` and `OrderBindingWithDetails`
+- [ ] 1.3 Mirror types in `ui/src/types.ts`
+- [ ] 1.4 Create migration `003_device_order_category.sql`
+- [ ] 1.5 Update `device-manager.ts` — DiscoveredDevice, upsert SQL
+- [ ] 1.6 Update `equipment-manager.ts` — OrderBindingJoinRow, SQL queries, row mapper
+- [ ] 1.7 Update `equipment-manager.ts` — ZONE_ORDERS with `orderCategory`, category-based resolution
+- [ ] 1.8 Write tests
+- [ ] 1.9 TypeScript compiles, all tests pass, lint clean
+
+## Phase 2: Plugins
+
+- [ ] 2.1 zigbee2mqtt — add order categories in z2m-parser discovery
+- [ ] 2.2 lora2mqtt — add order categories in parseNode
+- [ ] 2.3 legrand-control — add order categories in mapModuleToDiscovered
+- [ ] 2.4 panasonic-cc — add order categories in mapDeviceToDiscovered
+- [ ] 2.5 mcz-maestro — add order categories in mapFrameToDiscovered
+- [ ] 2.6 smartthings — add order categories in buildDiscoveredDevice
+- [ ] 2.7 Build all plugins
+
+## Phase 3: Validation
+
+- [ ] 3.1 Test local: zone allLightsOn/Off (z2m + Legrand + lora)
+- [ ] 3.2 Test local: zone allShuttersOpen/Close (z2m + Legrand)
+- [ ] 3.3 Test local: zone allThermostatsPowerOn/Off (Panasonic + MCZ)
+- [ ] 3.4 Test local: individual orders still work
+- [ ] 3.5 Release core + all plugins
+
+---
+
+## Test Plan
+
+### Modules to test
+
+- `equipment-manager` — zone order dispatch via order category
+- `device-manager` — upsert with order category
+- `integration-registry` — unchanged (apiVersion routing already tested)
+
+### Scenarios
+
+| Module                | Scenario                                                              | Expected                                             |
+| --------------------- | --------------------------------------------------------------------- | ---------------------------------------------------- |
+| **equipment-manager** | Zone allLightsOn — light with category `light_toggle`                 | Finds order by category, executes with ON            |
+| **equipment-manager** | Zone allLightsOff — light with category `light_toggle`                | Finds order by category, executes with OFF           |
+| **equipment-manager** | Zone allShuttersOpen — shutter with category `shutter_move`           | Finds order by category, executes with OPEN          |
+| **equipment-manager** | Zone allShuttersClose — shutter with category `shutter_move`          | Finds order by category, executes with CLOSE         |
+| **equipment-manager** | Zone allThermostatsPowerOn — thermostat with category `toggle_power`  | Finds order by category, executes with true          |
+| **equipment-manager** | Zone allThermostatsSetpoint — thermostat with category `set_setpoint` | Finds order by category, executes with numeric value |
+| **equipment-manager** | Zone order on equipment without matching order category               | Skipped with debug log                               |
+| **equipment-manager** | Zone order with brute-force fallback (no category on old orders)      | Falls back to trying each binding                    |
+| **equipment-manager** | Enum case-insensitive resolution still works                          | ON → on when device has enum ["on","off"]            |
+| **device-manager**    | upsertFromDiscovery with order category                               | category stored in device_orders                     |
+| **device-manager**    | upsertFromDiscovery without order category                            | category stored as null                              |
+| **device-manager**    | upsertFromDiscovery updates existing order category                   | category updated                                     |

--- a/specs/077-order-category/spec.md
+++ b/specs/077-order-category/spec.md
@@ -1,0 +1,92 @@
+# Spec 077 — Order Categories
+
+**Depends on**: spec 067 (apiVersion 2 deployed)
+
+## Summary
+
+Add a `category` field to device orders, mirroring the existing `category` on device data. Plugins declare the semantic role of each order during discovery. Zone orders use this category to find the right order binding on each equipment, eliminating alias guessing.
+
+## Problem
+
+Today, device orders have no semantic metadata. The zone order "allLightsOn" must guess which order binding to use (alias "state"? "on"? try all?). This is fragile and breaks across integrations.
+
+Device DATA already has `category` (e.g., `light_state`, `shutter_position`). Device ORDERS should have the same, so the system knows: "this order controls the light state" vs "this order sets the brightness."
+
+## Design
+
+### Plugin discovery
+
+Orders gain an optional `category` field:
+
+```typescript
+orders: [
+  { key: "state", type: "enum", category: "light_state", enumValues: ["ON", "OFF"] },
+  { key: "brightness", type: "number", category: "light_brightness", min: 0, max: 254 },
+];
+```
+
+### Database
+
+Add `category` column to `device_orders` table (nullable, for backward compat).
+
+### Zone orders
+
+Zone order finds the ORDER binding by category:
+
+```typescript
+const orderBinding = details.orderBindings.find((ob) => ob.category === mapping.category);
+```
+
+No more alias guessing, enum scanning, or brute-force trying.
+
+### Automatic flow
+
+```
+Plugin discovery → device order with category
+  → device_orders table (category stored)
+  → equipment order binding (category inherited)
+  → zone order finds by category
+```
+
+No user intervention — fully automatic.
+
+## Categories for orders
+
+| Equipment type | Order category     | Meaning                |
+| -------------- | ------------------ | ---------------------- |
+| light_onoff    | `light_state`      | Toggle on/off          |
+| light_dimmable | `light_state`      | Toggle on/off          |
+| light_dimmable | `light_brightness` | Set brightness level   |
+| shutter        | `shutter_state`    | Open/close/stop        |
+| shutter        | `shutter_position` | Set position 0-100     |
+| thermostat     | `power`            | Power on/off           |
+| thermostat     | `setpoint`         | Set target temperature |
+| gate           | `gate_state`       | Latch/toggle gate      |
+| water_valve    | `valve_state`      | Open/close valve       |
+| media_player   | `power`            | Power on/off           |
+
+Note: new category `shutter_state` needed (distinct from `shutter_position` which is numeric).
+
+## Acceptance Criteria
+
+- [ ] `category` field added to `DiscoveredDevice.orders`
+- [ ] `category` column added to `device_orders` table (migration)
+- [ ] `OrderBindingWithDetails` includes `category`
+- [ ] Zone orders resolve by order category
+- [ ] All plugins updated to declare order categories
+- [ ] Zone orders work for lights, shutters, thermostats across all integrations
+- [ ] Existing tests pass + new tests for category-based zone order dispatch
+
+## Plugins to update
+
+- zigbee2mqtt
+- lora2mqtt
+- legrand-control
+- panasonic-cc
+- mcz-maestro
+- smartthings
+
+## Out of scope
+
+- Removal of dispatch_config (spec 074, separate)
+- UI changes (order categories are backend only)

--- a/specs/077-order-category/spec.md
+++ b/specs/077-order-category/spec.md
@@ -10,7 +10,7 @@ Add a `category` field to device orders, mirroring the existing `category` on de
 
 Today, device orders have no semantic metadata. The zone order "allLightsOn" must guess which order binding to use (alias "state"? "on"? try all?). This is fragile and breaks across integrations.
 
-Device DATA already has `category` (e.g., `light_state`, `shutter_position`). Device ORDERS should have the same, so the system knows: "this order controls the light state" vs "this order sets the brightness."
+Device DATA already has `category` (e.g., `light_state`, `shutter_position`). Device ORDERS should have a similar concept, but with distinct names: data describes **what it is** (state), orders describe **what to do** (action).
 
 ## Design
 
@@ -20,8 +20,8 @@ Orders gain an optional `category` field:
 
 ```typescript
 orders: [
-  { key: "state", type: "enum", category: "light_state", enumValues: ["ON", "OFF"] },
-  { key: "brightness", type: "number", category: "light_brightness", min: 0, max: 254 },
+  { key: "state", type: "enum", category: "light_toggle", enumValues: ["ON", "OFF"] },
+  { key: "brightness", type: "number", category: "set_brightness", min: 0, max: 254 },
 ];
 ```
 
@@ -34,7 +34,7 @@ Add `category` column to `device_orders` table (nullable, for backward compat).
 Zone order finds the ORDER binding by category:
 
 ```typescript
-const orderBinding = details.orderBindings.find((ob) => ob.category === mapping.category);
+const orderBinding = details.orderBindings.find((ob) => ob.category === mapping.orderCategory);
 ```
 
 No more alias guessing, enum scanning, or brute-force trying.
@@ -50,22 +50,91 @@ Plugin discovery → device order with category
 
 No user intervention — fully automatic.
 
-## Categories for orders
+---
 
-| Equipment type | Order category     | Meaning                |
-| -------------- | ------------------ | ---------------------- |
-| light_onoff    | `light_state`      | Toggle on/off          |
-| light_dimmable | `light_state`      | Toggle on/off          |
-| light_dimmable | `light_brightness` | Set brightness level   |
-| shutter        | `shutter_state`    | Open/close/stop        |
-| shutter        | `shutter_position` | Set position 0-100     |
-| thermostat     | `power`            | Power on/off           |
-| thermostat     | `setpoint`         | Set target temperature |
-| gate           | `gate_state`       | Latch/toggle gate      |
-| water_valve    | `valve_state`      | Open/close valve       |
-| media_player   | `power`            | Power on/off           |
+## Data Categories (exhaustive — état, lecture)
 
-Note: new category `shutter_state` needed (distinct from `shutter_position` which is numeric).
+Describe what the data IS.
+
+| Category              | Description                                  | Unit    | Used by                                  |
+| --------------------- | -------------------------------------------- | ------- | ---------------------------------------- |
+| `motion`              | Mouvement détecté                            | —       | sensor                                   |
+| `temperature`         | Température intérieure                       | °C      | sensor, thermostat                       |
+| `temperature_outdoor` | Température extérieure                       | °C      | weather, weather_forecast                |
+| `humidity`            | Humidité intérieure                          | %       | sensor                                   |
+| `humidity_outdoor`    | Humidité extérieure                          | %       | weather                                  |
+| `pressure`            | Pression atmosphérique                       | mbar    | weather                                  |
+| `luminosity`          | Luminosité                                   | lx      | sensor                                   |
+| `contact_door`        | Contact porte (ouvert/fermé)                 | —       | sensor                                   |
+| `contact_window`      | Contact fenêtre (ouvert/fermé)               | —       | sensor                                   |
+| `light_state`         | État lumière (on/off)                        | —       | light_onoff, light_dimmable, light_color |
+| `light_brightness`    | Niveau luminosité                            | 0-254   | light_dimmable, light_color              |
+| `light_color_temp`    | Température couleur                          | mireds  | light_color                              |
+| `light_color`         | Couleur (xy/hs)                              | —       | light_color                              |
+| `shutter_position`    | Position volet                               | %       | shutter                                  |
+| `lock_state`          | État serrure                                 | —       | lock                                     |
+| `battery`             | Niveau batterie                              | %       | sensor, weather                          |
+| `power`               | État marche/arrêt                            | —       | thermostat, media_player, appliance      |
+| `energy`              | Consommation énergie                         | Wh/kWh  | energy_meter, appliance                  |
+| `voltage`             | Tension                                      | V       | energy_meter                             |
+| `current`             | Intensité                                    | A       | energy_meter                             |
+| `water_leak`          | Fuite d'eau                                  | —       | sensor                                   |
+| `smoke`               | Détection fumée                              | —       | sensor                                   |
+| `co2`                 | Taux CO2                                     | ppm     | sensor, weather                          |
+| `voc`                 | Composés organiques volatils                 | ppb     | sensor                                   |
+| `noise`               | Niveau sonore                                | dB      | sensor, weather                          |
+| `rain`                | Précipitations                               | mm      | weather                                  |
+| `wind`                | Vent (vitesse/direction)                     | km/h, ° | weather                                  |
+| `action`              | Action bouton (single, double, hold)         | —       | button                                   |
+| `gate_state`          | État portail/garage (ouvert/fermé/mouvement) | —       | gate                                     |
+| `weather_condition`   | Condition météo (sunny, rainy...)            | —       | weather_forecast                         |
+| `uv`                  | Index UV                                     | —       | weather                                  |
+| `solar_radiation`     | Radiation solaire                            | W/m²    | weather                                  |
+| `setpoint`            | Consigne température                         | °C      | thermostat                               |
+| `media_volume`        | Volume audio                                 | 0-100   | media_player                             |
+| `media_mute`          | Sourdine                                     | —       | media_player                             |
+| `media_input`         | Source d'entrée                              | —       | media_player                             |
+| `appliance_state`     | État appareil (running/stopped...)           | —       | appliance                                |
+| `generic`             | Donnée sans catégorie standardisée           | —       | tout                                     |
+
+---
+
+## Order Categories (exhaustive — action, écriture)
+
+Describe what the order DOES. Distinct names from data categories.
+
+| Category               | Description                 | Value type      | Used by                                  |
+| ---------------------- | --------------------------- | --------------- | ---------------------------------------- |
+| `light_toggle`         | Allumer/éteindre            | ON/OFF          | light_onoff, light_dimmable, light_color |
+| `set_brightness`       | Régler luminosité           | 0-254           | light_dimmable, light_color              |
+| `set_color_temp`       | Régler température couleur  | mireds          | light_color                              |
+| `set_color`            | Régler couleur              | xy/hs           | light_color                              |
+| `shutter_move`         | Ouvrir/fermer/stop volet    | OPEN/CLOSE/STOP | shutter                                  |
+| `set_shutter_position` | Régler position volet       | 0-100           | shutter                                  |
+| `toggle_power`         | Allumer/éteindre appareil   | true/false      | thermostat, media_player                 |
+| `set_setpoint`         | Régler consigne température | °C              | thermostat                               |
+| `gate_trigger`         | Actionner portail/garage    | latch           | gate                                     |
+| `valve_toggle`         | Ouvrir/fermer vanne         | ON/OFF          | water_valve                              |
+| `toggle_mute`          | Activer/désactiver sourdine | true/false      | media_player                             |
+| `set_input`            | Changer source d'entrée     | string          | media_player                             |
+
+---
+
+## Zone Orders mapping
+
+| Zone order               | Equipment types             | Order category                      |
+| ------------------------ | --------------------------- | ----------------------------------- |
+| `allLightsOn`            | light\_\*                   | `light_toggle` (value: ON)          |
+| `allLightsOff`           | light\_\*                   | `light_toggle` (value: OFF)         |
+| `allLightsBrightness`    | light_dimmable, light_color | `set_brightness` (value: FROM_BODY) |
+| `allShuttersOpen`        | shutter                     | `shutter_move` (value: OPEN)        |
+| `allShuttersClose`       | shutter                     | `shutter_move` (value: CLOSE)       |
+| `allShuttersStop`        | shutter                     | `shutter_move` (value: STOP)        |
+| `allThermostatsPowerOn`  | thermostat                  | `toggle_power` (value: true)        |
+| `allThermostatsPowerOff` | thermostat                  | `toggle_power` (value: false)       |
+| `allThermostatsSetpoint` | thermostat                  | `set_setpoint` (value: FROM_BODY)   |
+
+---
 
 ## Acceptance Criteria
 

--- a/src/api/routes/calendar.test.ts
+++ b/src/api/routes/calendar.test.ts
@@ -14,7 +14,11 @@ import type { CalendarModeAction } from "../../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of ["001_initial.sql"]) {
+  for (const file of [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+  ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../../migrations/${file}`),
       "utf-8",

--- a/src/api/routes/modes.test.ts
+++ b/src/api/routes/modes.test.ts
@@ -11,7 +11,11 @@ import { registerModeRoutes } from "./modes.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of ["001_initial.sql"]) {
+  for (const file of [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+  ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../../migrations/${file}`),
       "utf-8",

--- a/src/buttons/button-action-manager.test.ts
+++ b/src/buttons/button-action-manager.test.ts
@@ -9,7 +9,11 @@ import { createLogger } from "../core/logger.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of ["001_initial.sql"]) {
+  for (const file of [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+  ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),
       "utf-8",

--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -10,7 +10,11 @@ import type { EngineEvent } from "../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of ["001_initial.sql"]) {
+  for (const file of [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+  ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", "../../migrations", file),
       "utf-8",

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -37,6 +37,7 @@ export interface DiscoveredDevice {
   orders: {
     key: string;
     type: DataType;
+    category?: string;
     dispatchConfig?: Record<string, unknown>;
     min?: number;
     max?: number;
@@ -116,11 +117,11 @@ export class DeviceManager {
         "SELECT * FROM device_orders WHERE device_id = ? AND key = ?",
       ),
       insertDeviceOrder: this.db.prepare(
-        `INSERT INTO device_orders (id, device_id, key, type, dispatch_config, min_value, max_value, enum_values, unit)
-         VALUES (@id, @deviceId, @key, @type, @dispatchConfig, @min, @max, @enumValues, @unit)`,
+        `INSERT INTO device_orders (id, device_id, key, type, category, dispatch_config, min_value, max_value, enum_values, unit)
+         VALUES (@id, @deviceId, @key, @type, @category, @dispatchConfig, @min, @max, @enumValues, @unit)`,
       ),
       updateDeviceOrderDef: this.db.prepare(
-        "UPDATE device_orders SET type = ?, dispatch_config = ?, min_value = ?, max_value = ?, enum_values = ?, unit = ? WHERE id = ?",
+        "UPDATE device_orders SET type = ?, category = ?, dispatch_config = ?, min_value = ?, max_value = ?, enum_values = ?, unit = ? WHERE id = ?",
       ),
       deleteDeviceOrderById: this.db.prepare("DELETE FROM device_orders WHERE id = ?"),
       getDeviceOrderIds: this.db.prepare("SELECT id, key FROM device_orders WHERE device_id = ?"),
@@ -213,6 +214,7 @@ export class DeviceManager {
         if (existingOrder) {
           this.stmts.updateDeviceOrderDef.run(
             o.type,
+            o.category ?? null,
             o.dispatchConfig ? JSON.stringify(o.dispatchConfig) : "{}",
             o.min ?? null,
             o.max ?? null,
@@ -226,6 +228,7 @@ export class DeviceManager {
             deviceId,
             key: o.key,
             type: o.type,
+            category: o.category ?? null,
             dispatchConfig: o.dispatchConfig ? JSON.stringify(o.dispatchConfig) : "{}",
             min: o.min ?? null,
             max: o.max ?? null,

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -12,9 +12,13 @@ import type { EngineEvent } from "../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  db.exec(
-    readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations/001_initial.sql"), "utf-8"),
-  );
+  for (const file of [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+  ]) {
+    db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
+  }
   return db;
 }
 
@@ -31,6 +35,7 @@ function seedDevice(
       id?: string;
       key: string;
       type?: string;
+      category?: string;
       payloadKey?: string;
       enumValues?: string[];
     }[];
@@ -57,13 +62,14 @@ function seedDevice(
   for (const o of opts.orderKeys ?? []) {
     const id = o.id ?? crypto.randomUUID();
     db.prepare(
-      `INSERT INTO device_orders (id, device_id, key, type, mqtt_set_topic, payload_key, dispatch_config, enum_values)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO device_orders (id, device_id, key, type, category, mqtt_set_topic, payload_key, dispatch_config, enum_values)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       id,
       deviceId,
       o.key,
       o.type ?? "boolean",
+      o.category ?? null,
       `z2m/${name}/set`,
       o.payloadKey ?? o.key,
       JSON.stringify({ topic: `z2m/${name}/set`, payloadKey: o.payloadKey ?? o.key }),
@@ -617,6 +623,68 @@ describe("EquipmentManager", () => {
       // Should not throw — dispatchConfig defaults to {}
       await manager.executeOrder(eq.id, "state", "ON");
       expect(mockPublished).toHaveLength(1);
+    });
+  });
+
+  // ============================================================
+  // Zone orders with order categories
+  // ============================================================
+
+  describe("zone orders with order categories", () => {
+    it("finds order binding by order category (light_toggle)", async () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Spots", type: "light_onoff", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        name: "ZLight",
+        orderKeys: [{ key: "state", category: "light_toggle", enumValues: ["ON", "OFF"] }],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      const result = await manager.executeZoneOrder([zone.id], "allLightsOn");
+      expect(result.executed).toBe(1);
+      expect(result.errors).toBe(0);
+      expect(mockPublished).toHaveLength(1);
+    });
+
+    it("finds order binding by order category (shutter_move)", async () => {
+      const zone = zoneManager.create({ name: "Bureau" });
+      const eq = manager.create({ name: "Volet", type: "shutter", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        name: "ZShutter",
+        orderKeys: [
+          { key: "position", category: "set_shutter_position" },
+          { key: "state", category: "shutter_move", enumValues: ["OPEN", "CLOSE", "STOP"] },
+        ],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "position");
+      manager.addOrderBinding(eq.id, orderIds[1], "state");
+
+      const result = await manager.executeZoneOrder([zone.id], "allShuttersOpen");
+      expect(result.executed).toBe(1);
+      expect(mockPublished).toHaveLength(1);
+      expect(JSON.parse(mockPublished[0].payload)).toEqual({ state: "OPEN" });
+    });
+
+    it("falls back to brute-force when no order category", async () => {
+      const zone = zoneManager.create({ name: "Old" });
+      const eq = manager.create({ name: "Light", type: "light_onoff", zoneId: zone.id });
+      // No category on order — old plugin style
+      const { orderIds } = seedDevice(db, {
+        name: "OldLight",
+        orderKeys: [{ key: "state" }],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      const result = await manager.executeZoneOrder([zone.id], "allLightsOn");
+      expect(result.executed).toBe(1);
+    });
+
+    it("skips equipment without matching order category or binding", async () => {
+      const zone = zoneManager.create({ name: "Empty" });
+      manager.create({ name: "Sensor", type: "light_onoff", zoneId: zone.id });
+      // No order bindings at all
+      const result = await manager.executeZoneOrder([zone.id], "allLightsOn");
+      expect(result.executed).toBe(0);
     });
   });
 

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -16,6 +16,7 @@ import type {
   OrderBindingWithDetails,
   DataType,
   DataCategory,
+  OrderCategory,
 } from "../shared/types.js";
 
 /** A function that returns computed data entries for a given equipment. */
@@ -202,7 +203,7 @@ export class EquipmentManager {
       getOrderBindingsWithDetails: this.db.prepare(
         `SELECT ob.id, ob.equipment_id, ob.device_order_id, ob.alias,
                 do2.device_id, d.name as device_name, do2.key, do2.type,
-                do2.dispatch_config, do2.min_value, do2.max_value,
+                do2.category, do2.dispatch_config, do2.min_value, do2.max_value,
                 do2.enum_values, do2.unit
          FROM order_bindings ob
          JOIN device_orders do2 ON ob.device_order_id = do2.id
@@ -212,7 +213,7 @@ export class EquipmentManager {
       getOrderBindingsByAlias: this.db.prepare(
         `SELECT ob.id, ob.equipment_id, ob.device_order_id, ob.alias,
                 do2.device_id, d.name as device_name, do2.key, do2.type,
-                do2.dispatch_config, do2.min_value, do2.max_value,
+                do2.category, do2.dispatch_config, do2.min_value, do2.max_value,
                 do2.enum_values, do2.unit
          FROM order_bindings ob
          JOIN device_orders do2 ON ob.device_order_id = do2.id
@@ -724,35 +725,38 @@ export class EquipmentManager {
 
   /**
    * Zone order definitions.
-   * `category` is used to find the correct order binding on each equipment
-   * by matching the data binding with that category → using its alias.
-   * This is integration-agnostic: works for "state" (z2m), "on" (Legrand), etc.
+   * `orderCategory` matches the ORDER binding category (not data binding).
+   * Each plugin declares order categories during discovery.
    */
   private static readonly ZONE_ORDERS: Record<
     string,
-    { types: string[]; category: string; value: unknown | "FROM_BODY" }
+    { types: string[]; orderCategory: OrderCategory; value: unknown | "FROM_BODY" }
   > = {
     allLightsOn: {
       types: ["light_onoff", "light_dimmable", "light_color"],
-      category: "light_state",
+      orderCategory: "light_toggle",
       value: "ON",
     },
     allLightsOff: {
       types: ["light_onoff", "light_dimmable", "light_color"],
-      category: "light_state",
+      orderCategory: "light_toggle",
       value: "OFF",
     },
     allLightsBrightness: {
       types: ["light_dimmable", "light_color"],
-      category: "light_brightness",
+      orderCategory: "set_brightness",
       value: "FROM_BODY",
     },
-    allShuttersOpen: { types: ["shutter"], category: "shutter_position", value: "OPEN" },
-    allShuttersStop: { types: ["shutter"], category: "shutter_position", value: "STOP" },
-    allShuttersClose: { types: ["shutter"], category: "shutter_position", value: "CLOSE" },
-    allThermostatsPowerOn: { types: ["thermostat"], category: "power", value: true },
-    allThermostatsPowerOff: { types: ["thermostat"], category: "power", value: false },
-    allThermostatsSetpoint: { types: ["thermostat"], category: "setpoint", value: "FROM_BODY" },
+    allShuttersOpen: { types: ["shutter"], orderCategory: "shutter_move", value: "OPEN" },
+    allShuttersStop: { types: ["shutter"], orderCategory: "shutter_move", value: "STOP" },
+    allShuttersClose: { types: ["shutter"], orderCategory: "shutter_move", value: "CLOSE" },
+    allThermostatsPowerOn: { types: ["thermostat"], orderCategory: "toggle_power", value: true },
+    allThermostatsPowerOff: { types: ["thermostat"], orderCategory: "toggle_power", value: false },
+    allThermostatsSetpoint: {
+      types: ["thermostat"],
+      orderCategory: "set_setpoint",
+      value: "FROM_BODY",
+    },
   };
 
   static readonly VALID_ZONE_ORDER_KEYS = Object.keys(EquipmentManager.ZONE_ORDERS);
@@ -789,35 +793,51 @@ export class EquipmentManager {
         if (!eq.enabled) continue;
         if (!mapping.types.includes(eq.type)) continue;
 
-        // Resolve the order alias from the equipment's data bindings by category
+        // Find the order binding by category
         const details = this.getByIdWithDetails(eq.id);
-        const dataBinding = details?.dataBindings.find((b) => b.category === mapping.category);
-        if (!dataBinding) {
-          this.logger.debug(
-            { equipmentId: eq.id, equipmentName: eq.name, category: mapping.category },
-            "Zone order skipped — no data binding with matching category",
-          );
-          continue;
-        }
-        const alias = dataBinding.alias;
+        if (!details || details.orderBindings.length === 0) continue;
 
-        try {
-          const result = await this.executeOrder(eq.id, alias, resolvedValue);
-          if (result.success) {
-            executed++;
-          } else {
+        const orderBinding = details.orderBindings.find(
+          (ob) => ob.category === mapping.orderCategory,
+        );
+
+        if (!orderBinding) {
+          // Fallback: try each binding (for plugins not yet declaring order categories)
+          let dispatched = false;
+          for (const ob of details.orderBindings) {
+            try {
+              const result = await this.executeOrder(eq.id, ob.alias, resolvedValue);
+              if (result.success) {
+                executed++;
+                dispatched = true;
+                break;
+              }
+            } catch {
+              /* try next */
+            }
+          }
+          if (!dispatched) {
             errors++;
             this.logger.warn(
-              { equipmentId: eq.id, equipmentName: eq.name, orderKey, alias, error: result.error },
-              "Zone order dispatch failed for equipment",
+              { equipmentId: eq.id, equipmentName: eq.name, orderKey },
+              "Zone order failed — no matching order category or binding",
             );
           }
-        } catch (err) {
-          errors++;
-          this.logger.warn(
-            { err, equipmentId: eq.id, equipmentName: eq.name, orderKey, alias },
-            "Zone order failed for equipment",
-          );
+        } else {
+          try {
+            const result = await this.executeOrder(eq.id, orderBinding.alias, resolvedValue);
+            if (result.success) {
+              executed++;
+            } else {
+              errors++;
+            }
+          } catch (err) {
+            errors++;
+            this.logger.warn(
+              { err, equipmentId: eq.id, equipmentName: eq.name, orderKey },
+              "Zone order failed for equipment",
+            );
+          }
         }
       }
     }
@@ -1039,6 +1059,7 @@ interface OrderBindingJoinRow {
   device_name: string;
   key: string;
   type: string;
+  category: string | null;
   dispatch_config: string;
   min_value: number | null;
   max_value: number | null;
@@ -1113,6 +1134,7 @@ function rowToOrderBindingWithDetails(row: OrderBindingJoinRow): OrderBindingWit
     deviceName: row.device_name,
     key: row.key,
     type: row.type as DataType,
+    category: (row.category as OrderCategory) ?? undefined,
     dispatchConfig,
     min: row.min_value ?? undefined,
     max: row.max_value ?? undefined,

--- a/src/modes/calendar-manager.test.ts
+++ b/src/modes/calendar-manager.test.ts
@@ -12,7 +12,11 @@ import type { CalendarModeAction, EngineEvent } from "../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of ["001_initial.sql"]) {
+  for (const file of [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+  ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),
       "utf-8",

--- a/src/modes/mode-manager.test.ts
+++ b/src/modes/mode-manager.test.ts
@@ -11,7 +11,11 @@ function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
   // Load required migrations
-  for (const file of ["001_initial.sql"]) {
+  for (const file of [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+  ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),
       "utf-8",

--- a/src/recipes/engine/recipe-manager.test.ts
+++ b/src/recipes/engine/recipe-manager.test.ts
@@ -19,7 +19,11 @@ import type { RecipeSlotDef, EngineEvent } from "../../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  const migrations = ["001_initial.sql"];
+  const migrations = [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+  ];
   for (const file of migrations) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", "../../../migrations", file),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -44,6 +44,20 @@ export type DataCategory =
   | "appliance_state"
   | "generic";
 
+export type OrderCategory =
+  | "light_toggle"
+  | "set_brightness"
+  | "set_color_temp"
+  | "set_color"
+  | "shutter_move"
+  | "set_shutter_position"
+  | "toggle_power"
+  | "set_setpoint"
+  | "gate_trigger"
+  | "valve_toggle"
+  | "toggle_mute"
+  | "set_input";
+
 // ============================================================
 // Device
 // ============================================================
@@ -94,6 +108,7 @@ export interface DeviceOrder {
   deviceId: string;
   key: string;
   type: DataType;
+  category?: OrderCategory;
   dispatchConfig?: Record<string, unknown>;
   min?: number;
   max?: number;
@@ -263,6 +278,7 @@ export interface OrderBindingWithDetails extends OrderBinding {
   deviceName: string;
   key: string;
   type: DataType;
+  category?: OrderCategory;
   dispatchConfig?: Record<string, unknown>;
   min?: number;
   max?: number;

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -13,9 +13,13 @@ import type { EngineEvent } from "../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  db.exec(
-    readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations/001_initial.sql"), "utf-8"),
-  );
+  for (const file of [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+  ]) {
+    db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
+  }
   return db;
 }
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -44,6 +44,20 @@ export type DataCategory =
   | "appliance_state"
   | "generic";
 
+export type OrderCategory =
+  | "light_toggle"
+  | "set_brightness"
+  | "set_color_temp"
+  | "set_color"
+  | "shutter_move"
+  | "set_shutter_position"
+  | "toggle_power"
+  | "set_setpoint"
+  | "gate_trigger"
+  | "valve_toggle"
+  | "toggle_mute"
+  | "set_input";
+
 // ============================================================
 // Device
 // ============================================================
@@ -93,6 +107,7 @@ export interface DeviceOrder {
   deviceId: string;
   key: string;
   type: DataType;
+  category?: OrderCategory;
   dispatchConfig: Record<string, unknown>;
   min?: number;
   max?: number;
@@ -217,6 +232,7 @@ export interface OrderBindingWithDetails extends OrderBinding {
   deviceName: string;
   key: string;
   type: DataType;
+  category?: OrderCategory;
   dispatchConfig: Record<string, unknown>;
   min?: number;
   max?: number;


### PR DESCRIPTION
## Summary
- New `OrderCategory` type (12 action categories: light_toggle, shutter_move, toggle_power...)
- Device orders carry a `category` field set by plugins during discovery
- Zone orders resolve by order category — no more alias guessing
- Fallback brute-force for plugins without categories
- Migration 003: `category` column on `device_orders`

## Plugins updated
- zigbee2mqtt: light_toggle, set_brightness, shutter_move, set_shutter_position, set_color_temp
- lora2mqtt: light_toggle, gate_trigger (from bridge order_category or data→order mapping)
- legrand-control: light_toggle, set_brightness, set_shutter_position
- panasonic-cc: toggle_power, set_setpoint
- mcz-maestro: toggle_power, set_setpoint
- smartthings: toggle_power, toggle_mute, set_input

## Test plan
- [x] TypeScript compiles (backend + frontend)
- [x] 331 tests pass (4 new zone order category tests)
- [x] Lint clean
- [x] Manual: z2m lights + shutters zone orders
- [x] Manual: lora2mqtt light + gate
- [x] Manual: legrand lights + shutters
- [x] Manual: PAC + poêle power/setpoint