### PR TITLE
feat(devices): device data enum values for dynamic button actions

### DIFF
--- a/migrations/005_device_data_enum_values.sql
+++ b/migrations/005_device_data_enum_values.sql
@@ -1,0 +1,3 @@
+-- Add enum_values column to device_data, mirroring device_orders.
+-- Allows storing possible values for enum-type data properties (e.g. button action values).
+ALTER TABLE device_data ADD COLUMN enum_values JSON;

--- a/specs/079-data-enum-values/architecture.md
+++ b/specs/079-data-enum-values/architecture.md
@@ -1,0 +1,71 @@
+# Spec 079 — Architecture
+
+## Data Model Changes
+
+### Migration: `005_device_data_enum_values.sql`
+
+```sql
+ALTER TABLE device_data ADD COLUMN enum_values JSON;
+```
+
+### Types (`src/shared/types.ts`)
+
+Add `enumValues` to `DiscoveredDevice.data` entries:
+
+```typescript
+data: {
+  key: string;
+  type: DataType;
+  category: DataCategory;
+  unit?: string;
+  enumValues?: string[];  // NEW
+}[];
+```
+
+Add `enumValues` to `DataBindingWithValue`:
+
+```typescript
+export interface DataBindingWithValue extends DataBinding {
+  // ... existing fields ...
+  enumValues?: string[]; // NEW
+}
+```
+
+### UI Types (`ui/src/types.ts`)
+
+Mirror the backend change in `DataBindingWithValue`.
+
+## Files to Modify
+
+### Backend
+
+| File                                         | Change                                                                 |
+| -------------------------------------------- | ---------------------------------------------------------------------- |
+| `migrations/005_device_data_enum_values.sql` | Add `enum_values` column                                               |
+| `src/shared/types.ts`                        | Add `enumValues` to `DiscoveredDevice.data` and `DataBindingWithValue` |
+| `src/devices/device-manager.ts`              | Store/read `enum_values` in device_data upsert + DeviceDataRow         |
+| `src/equipments/equipment-manager.ts`        | Include `dd.enum_values` in data binding SQL query + mapper            |
+
+### Z2M Plugin
+
+| File                                         | Change                                                         |
+| -------------------------------------------- | -------------------------------------------------------------- |
+| `sowel-plugin-zigbee2mqtt/src/z2m-parser.ts` | Add `enumValues: expose.values` to data entries for enum types |
+
+### Frontend
+
+| File                                                    | Change                                             |
+| ------------------------------------------------------- | -------------------------------------------------- |
+| `ui/src/types.ts`                                       | Add `enumValues` to `DataBindingWithValue`         |
+| `ui/src/components/equipments/ButtonActionsSection.tsx` | Use enum values from equipment action data binding |
+
+## Data Flow
+
+```
+Z2M expose.values (discovery)
+  → z2m-parser: DiscoveredDevice.data[].enumValues
+    → device-manager: INSERT INTO device_data ... enum_values = JSON
+      → equipment-manager: SELECT ... dd.enum_values FROM data_bindings JOIN device_data
+        → API response: DataBindingWithValue.enumValues
+          → UI ButtonActionsSection: dynamic action value list
+```

--- a/specs/079-data-enum-values/plan.md
+++ b/specs/079-data-enum-values/plan.md
@@ -1,0 +1,52 @@
+# Spec 079 — Implementation Plan
+
+## Task Breakdown
+
+### Phase 1: Types + Migration
+
+- [ ] 1.1 Add `enum_values` column to `device_data` via migration 005
+- [ ] 1.2 Add `enumValues` to `DiscoveredDevice.data` entries in `src/shared/types.ts`
+- [ ] 1.3 Add `enumValues` to `DataBindingWithValue` in `src/shared/types.ts`
+- [ ] 1.4 Mirror in `ui/src/types.ts`
+
+### Phase 2: Backend
+
+- [ ] 2.1 Device Manager: store `enum_values` on INSERT/UPDATE of device_data
+- [ ] 2.2 Device Manager: read `enum_values` in DeviceDataRow + mapper
+- [ ] 2.3 Equipment Manager: include `dd.enum_values` in data binding SQL query
+- [ ] 2.4 Equipment Manager: parse `enum_values` in data binding mapper
+- [ ] 2.5 Write tests
+
+### Phase 3: Z2M Plugin
+
+- [ ] 3.1 z2m-parser: add `enumValues: expose.values` to data entries for enum-type properties
+
+### Phase 4: Frontend
+
+- [ ] 4.1 ButtonActionsSection: read action enum values from equipment data bindings
+- [ ] 4.2 Replace hardcoded BUTTON_ACTIONS with dynamic values (fallback to defaults)
+
+### Phase 5: Validate
+
+- [ ] 5.1 `npx tsc --noEmit` (backend)
+- [ ] 5.2 `cd ui && npx tsc -b --noEmit` (frontend)
+- [ ] 5.3 `npx vitest run` (all tests pass)
+- [ ] 5.4 `npx eslint src/ --ext .ts` (zero errors)
+
+## Test Plan
+
+### Modules to test
+
+- `device-manager` — enum values stored and read for device data
+- `equipment-manager` — enum values included in data binding response
+
+### Scenarios
+
+| Module            | Scenario                                             | Expected                                 |
+| ----------------- | ---------------------------------------------------- | ---------------------------------------- |
+| device-manager    | Discover device with enum data (action)              | enum_values stored in device_data        |
+| device-manager    | Discover device without enum data (temperature)      | enum_values is null                      |
+| device-manager    | Re-discover updates enum_values                      | enum_values updated                      |
+| equipment-manager | Data binding for enum device data                    | DataBindingWithValue includes enumValues |
+| equipment-manager | Data binding for non-enum device data                | enumValues is undefined                  |
+| equipment-manager | Existing bindings without enum_values (retro-compat) | enumValues is undefined, no crash        |

--- a/specs/079-data-enum-values/spec.md
+++ b/specs/079-data-enum-values/spec.md
@@ -1,0 +1,49 @@
+# Spec 079 — Device Data Enum Values
+
+## Summary
+
+Store enum values for device data entries (read-only properties like `action`), the same way they are already stored for device orders (writable properties). This allows the UI to display the actual possible values instead of hardcoding them.
+
+## Problem
+
+The `device_orders` table stores `enum_values` (e.g., `["ON","OFF"]`), and this is exposed through `OrderBindingWithDetails`. But `device_data` does not store enum values. For button/remote equipment, the `action` property is read-only (data, not order), so its possible values (`1_single`, `2_double`, etc.) are lost after discovery. The button action UI hardcodes `["single", "double", "hold"]` which doesn't work for multi-button remotes.
+
+## Requirements
+
+### R1 — Store enum values in device_data
+
+When a plugin discovers a device with enum-type data properties, store the possible values in the `device_data` table.
+
+### R2 — Expose enum values in DataBindingWithValue
+
+The equipment data binding response includes `enumValues` so the UI can use them.
+
+### R3 — Dynamic action values in button action UI
+
+The button action configuration form uses the equipment's `action` data binding enum values instead of a hardcoded list. Fallback to `["single", "double", "hold"]` if no enum values are available.
+
+## Acceptance Criteria
+
+- [x] AC1: `device_data` table has an `enum_values` column (JSON)
+- [x] AC2: `DiscoveredDevice.data` entries support optional `enumValues`
+- [x] AC3: Device manager stores and reads enum values for data entries
+- [x] AC4: `DataBindingWithValue` includes `enumValues?: string[]`
+- [x] AC5: Equipment manager SQL query joins enum values from device_data
+- [x] AC6: Z2M plugin sends enum values for enum-type data properties
+- [x] AC7: Button action UI shows dynamic action values from equipment data
+- [x] AC8: Fallback to `["single", "double", "hold"]` when no enum values
+
+## Scope
+
+### In scope
+
+- Migration to add `enum_values` to `device_data`
+- Backend types, device manager, equipment manager
+- Z2M plugin: include `enumValues` in data entries
+- UI: dynamic action values in ButtonActionsSection
+
+### Out of scope
+
+- Other plugins (they can adopt `enumValues` in data later)
+- Grouping action values by button number (UI shows flat list)
+- New equipment types

--- a/src/api/routes/calendar.test.ts
+++ b/src/api/routes/calendar.test.ts
@@ -19,6 +19,7 @@ function createTestDb(): Database.Database {
     "002_mqtt_publisher_on_change_only.sql",
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../../migrations/${file}`),

--- a/src/api/routes/modes.test.ts
+++ b/src/api/routes/modes.test.ts
@@ -16,6 +16,7 @@ function createTestDb(): Database.Database {
     "002_mqtt_publisher_on_change_only.sql",
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../../migrations/${file}`),

--- a/src/buttons/button-action-manager.test.ts
+++ b/src/buttons/button-action-manager.test.ts
@@ -14,6 +14,7 @@ function createTestDb(): Database.Database {
     "002_mqtt_publisher_on_change_only.sql",
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),

--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -15,6 +15,7 @@ function createTestDb(): Database.Database {
     "002_mqtt_publisher_on_change_only.sql",
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", "../../migrations", file),
@@ -385,6 +386,71 @@ describe("DeviceManager", () => {
       const counts = manager.getStatusCounts();
       expect(counts.online).toBe(1);
       expect(counts.unknown).toBe(1);
+    });
+  });
+
+  describe("data enum values", () => {
+    const sampleButton = {
+      ieeeAddress: "0x00158d0001a2b3c6",
+      friendlyName: "remote_4btn",
+      manufacturer: "LoraTap",
+      model: "SS6400ZB",
+      data: [
+        {
+          key: "action",
+          type: "enum" as const,
+          category: "action" as const,
+          enumValues: ["1_single", "1_double", "1_hold", "2_single"],
+        },
+        { key: "battery", type: "number" as const, category: "battery" as const, unit: "%" },
+      ],
+      orders: [],
+      rawExpose: [],
+    };
+
+    it("stores enum_values for data entries", () => {
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", sampleButton);
+
+      const device = manager.getAll()[0];
+      const row = db
+        .prepare("SELECT enum_values FROM device_data WHERE device_id = ? AND key = 'action'")
+        .get(device.id) as { enum_values: string | null };
+      expect(row.enum_values).not.toBeNull();
+      expect(JSON.parse(row.enum_values!)).toEqual(["1_single", "1_double", "1_hold", "2_single"]);
+    });
+
+    it("stores null enum_values for non-enum data", () => {
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", sampleButton);
+
+      const device = manager.getAll()[0];
+      const row = db
+        .prepare("SELECT enum_values FROM device_data WHERE device_id = ? AND key = 'battery'")
+        .get(device.id) as { enum_values: string | null };
+      expect(row.enum_values).toBeNull();
+    });
+
+    it("updates enum_values on re-discovery", () => {
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", sampleButton);
+      const device = manager.getAll()[0];
+
+      const updated = {
+        ...sampleButton,
+        data: [
+          {
+            key: "action",
+            type: "enum" as const,
+            category: "action" as const,
+            enumValues: ["1_single", "1_double"],
+          },
+          { key: "battery", type: "number" as const, category: "battery" as const, unit: "%" },
+        ],
+      };
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", updated);
+
+      const row = db
+        .prepare("SELECT enum_values FROM device_data WHERE device_id = ? AND key = 'action'")
+        .get(device.id) as { enum_values: string | null };
+      expect(JSON.parse(row.enum_values!)).toEqual(["1_single", "1_double"]);
     });
   });
 });

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -34,6 +34,7 @@ export interface DiscoveredDevice {
     type: DataType;
     category: DataCategory;
     unit?: string;
+    enumValues?: string[];
   }[];
   orders: {
     key: string;
@@ -102,11 +103,11 @@ export class DeviceManager {
         "SELECT * FROM device_data WHERE device_id = ? AND key = ?",
       ),
       insertDeviceData: this.db.prepare(
-        `INSERT INTO device_data (id, device_id, key, type, category, unit)
-         VALUES (@id, @deviceId, @key, @type, @category, @unit)`,
+        `INSERT INTO device_data (id, device_id, key, type, category, unit, enum_values)
+         VALUES (@id, @deviceId, @key, @type, @category, @unit, @enumValues)`,
       ),
       updateDeviceDataDef: this.db.prepare(
-        "UPDATE device_data SET type = ?, category = ?, unit = ? WHERE id = ?",
+        "UPDATE device_data SET type = ?, category = ?, unit = ?, enum_values = ? WHERE id = ?",
       ),
       updateDeviceDataValue: this.db.prepare(
         "UPDATE device_data SET value = ?, last_updated = datetime('now'), last_changed = CASE WHEN value IS NOT ? OR category = 'action' THEN datetime('now') ELSE last_changed END WHERE id = ?",
@@ -181,8 +182,15 @@ export class DeviceManager {
         const existingData = this.stmts.findDeviceDataByDeviceAndKey.get(deviceId, d.key) as
           | { id: string }
           | undefined;
+        const enumJson = d.enumValues ? JSON.stringify(d.enumValues) : null;
         if (existingData) {
-          this.stmts.updateDeviceDataDef.run(d.type, d.category, d.unit ?? null, existingData.id);
+          this.stmts.updateDeviceDataDef.run(
+            d.type,
+            d.category,
+            d.unit ?? null,
+            enumJson,
+            existingData.id,
+          );
         } else {
           this.stmts.insertDeviceData.run({
             id: deterministicId(deviceId, "data", d.key),
@@ -191,6 +199,7 @@ export class DeviceManager {
             type: d.type,
             category: d.category,
             unit: d.unit ?? null,
+            enumValues: enumJson,
           });
         }
       }
@@ -386,6 +395,7 @@ export class DeviceManager {
           type: dataType,
           category,
           unit: unit ?? null,
+          enumValues: null,
         });
         this.logger.info(
           { deviceId: device.id, key, category },
@@ -623,6 +633,7 @@ interface DeviceDataRow {
   category: string;
   value: string | null;
   unit: string | null;
+  enum_values: string | null;
   last_updated: string | null;
 }
 

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -17,6 +17,7 @@ function createTestDb(): Database.Database {
     "002_mqtt_publisher_on_change_only.sql",
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
   ]) {
     db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
   }
@@ -31,7 +32,14 @@ function seedDevice(
   opts: {
     deviceId?: string;
     name?: string;
-    dataKeys?: { id?: string; key: string; type?: string; category?: string; value?: string }[];
+    dataKeys?: {
+      id?: string;
+      key: string;
+      type?: string;
+      category?: string;
+      value?: string;
+      enumValues?: string[];
+    }[];
     orderKeys?: {
       id?: string;
       key: string;
@@ -52,9 +60,17 @@ function seedDevice(
   for (const d of opts.dataKeys ?? []) {
     const id = d.id ?? crypto.randomUUID();
     db.prepare(
-      `INSERT INTO device_data (id, device_id, key, type, category, value)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-    ).run(id, deviceId, d.key, d.type ?? "boolean", d.category ?? "generic", d.value ?? null);
+      `INSERT INTO device_data (id, device_id, key, type, category, value, enum_values)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      id,
+      deviceId,
+      d.key,
+      d.type ?? "boolean",
+      d.category ?? "generic",
+      d.value ?? null,
+      d.enumValues ? JSON.stringify(d.enumValues) : null,
+    );
     dataIds.push(id);
   }
 
@@ -695,6 +711,41 @@ describe("EquipmentManager", () => {
     it("returns 0 for empty zone", () => {
       const zone = zoneManager.create({ name: "Salon" });
       expect(manager.countByZone(zone.id)).toBe(0);
+    });
+  });
+
+  describe("data binding enum values", () => {
+    it("includes enumValues in data binding response", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Remote", type: "button", zoneId: zone.id });
+      const { dataIds } = seedDevice(db, {
+        dataKeys: [
+          {
+            key: "action",
+            type: "enum",
+            category: "action",
+            enumValues: ["1_single", "1_double", "2_single"],
+          },
+        ],
+      });
+      manager.addDataBinding(eq.id, dataIds[0], "action");
+
+      const detail = manager.getByIdWithDetails(eq.id);
+      const actionBinding = detail?.dataBindings.find((b) => b.alias === "action");
+      expect(actionBinding?.enumValues).toEqual(["1_single", "1_double", "2_single"]);
+    });
+
+    it("returns undefined enumValues for non-enum data", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Remote", type: "button", zoneId: zone.id });
+      const { dataIds } = seedDevice(db, {
+        dataKeys: [{ key: "battery", type: "number", category: "battery" }],
+      });
+      manager.addDataBinding(eq.id, dataIds[0], "battery");
+
+      const detail = manager.getByIdWithDetails(eq.id);
+      const batteryBinding = detail?.dataBindings.find((b) => b.alias === "battery");
+      expect(batteryBinding?.enumValues).toBeUndefined();
     });
   });
 });

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -182,7 +182,7 @@ export class EquipmentManager {
       getDataBindingsWithValues: this.db.prepare(
         `SELECT db.id, db.equipment_id, db.device_data_id, db.alias, db.historize,
                 dd.device_id, d.name as device_name, dd.key, dd.type, dd.category,
-                dd.value, dd.unit, dd.last_updated, dd.last_changed
+                dd.value, dd.unit, dd.enum_values, dd.last_updated, dd.last_changed
          FROM data_bindings db
          JOIN device_data dd ON db.device_data_id = dd.id
          JOIN devices d ON dd.device_id = d.id
@@ -1026,6 +1026,7 @@ interface DataBindingJoinRow {
   category: string;
   value: string | null;
   unit: string | null;
+  enum_values: string | null;
   last_updated: string | null;
   last_changed: string | null;
 }
@@ -1069,6 +1070,14 @@ function rowToDataBindingWithValue(row: DataBindingJoinRow): DataBindingWithValu
       value = row.value;
     }
   }
+  let enumValues: string[] | undefined;
+  if (row.enum_values) {
+    try {
+      enumValues = JSON.parse(row.enum_values);
+    } catch {
+      enumValues = undefined;
+    }
+  }
   return {
     id: row.id,
     equipmentId: row.equipment_id,
@@ -1082,6 +1091,7 @@ function rowToDataBindingWithValue(row: DataBindingJoinRow): DataBindingWithValu
     category: row.category as DataCategory,
     value,
     unit: row.unit ?? undefined,
+    enumValues,
     lastUpdated: toISOUtc(row.last_updated),
     lastChanged: toISOUtc(row.last_changed),
   };

--- a/src/modes/calendar-manager.test.ts
+++ b/src/modes/calendar-manager.test.ts
@@ -17,6 +17,7 @@ function createTestDb(): Database.Database {
     "002_mqtt_publisher_on_change_only.sql",
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),

--- a/src/modes/mode-manager.test.ts
+++ b/src/modes/mode-manager.test.ts
@@ -16,6 +16,7 @@ function createTestDb(): Database.Database {
     "002_mqtt_publisher_on_change_only.sql",
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),

--- a/src/recipes/engine/recipe-manager.test.ts
+++ b/src/recipes/engine/recipe-manager.test.ts
@@ -24,6 +24,7 @@ function createTestDb(): Database.Database {
     "002_mqtt_publisher_on_change_only.sql",
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
   ];
   for (const file of migrations) {
     const sql = readFileSync(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -268,6 +268,7 @@ export interface DataBindingWithValue extends DataBinding {
   category: DataCategory;
   value: unknown;
   unit?: string;
+  enumValues?: string[];
   lastUpdated: string | null;
   lastChanged: string | null;
   historize?: number | null;

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -18,6 +18,7 @@ function createTestDb(): Database.Database {
     "002_mqtt_publisher_on_change_only.sql",
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
   ]) {
     db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
   }
@@ -46,9 +47,9 @@ function seedDevice(
   for (const d of opts.dataKeys ?? []) {
     const id = d.id ?? crypto.randomUUID();
     db.prepare(
-      `INSERT INTO device_data (id, device_id, key, type, category, value)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-    ).run(id, deviceId, d.key, d.type ?? "boolean", d.category ?? "generic", d.value ?? null);
+      `INSERT INTO device_data (id, device_id, key, type, category, value, enum_values)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(id, deviceId, d.key, d.type ?? "boolean", d.category ?? "generic", d.value ?? null, null);
     dataIds.push(id);
   }
 

--- a/ui/src/components/equipments/ButtonActionsSection.tsx
+++ b/ui/src/components/equipments/ButtonActionsSection.tsx
@@ -8,7 +8,7 @@ import { useRecipes } from "../../store/useRecipes";
 import { useZones } from "../../store/useZones";
 import type { ButtonActionBinding, ButtonEffectType, ZoneWithChildren } from "../../types";
 
-const BUTTON_ACTIONS = ["single", "double", "hold"] as const;
+const DEFAULT_BUTTON_ACTIONS = ["single", "double", "hold"];
 
 const ZONE_ORDER_OPTIONS: { key: string; group: string; parametric: boolean }[] = [
   { key: "allLightsOn", group: "lights", parametric: false },
@@ -47,6 +47,11 @@ export function ButtonActionsSection({ equipmentId }: ButtonActionsSectionProps)
   // Flatten zone tree for name lookup
   const zones = flattenZones(zoneTree);
   const instances = useRecipes((s) => s.instances);
+
+  // Derive action values from the equipment's "action" data binding enum values
+  const currentEquipment = equipments.find((e) => e.id === equipmentId);
+  const actionBinding = currentEquipment?.dataBindings.find((b) => b.alias === "action" || b.category === "action");
+  const actionValues = actionBinding?.enumValues ?? DEFAULT_BUTTON_ACTIONS;
 
   const [bindings, setBindings] = useState<ButtonActionBinding[]>([]);
   const [showAddForm, setShowAddForm] = useState(false);
@@ -158,10 +163,7 @@ export function ButtonActionsSection({ equipmentId }: ButtonActionsSectionProps)
         <p className="text-[13px] text-text-tertiary">{t("buttonActions.noEffects")}</p>
       )}
 
-      {BUTTON_ACTIONS.map((actionValue) => {
-        const actionBindings = grouped.get(actionValue);
-        if (!actionBindings) return null;
-        return (
+      {[...grouped.entries()].map(([actionValue, actionBindings]) => (
           <div key={actionValue} className="mb-3">
             <div className="text-[11px] font-medium text-text-tertiary uppercase tracking-wider mb-1.5">
               {getActionLabel(actionValue)}
@@ -175,56 +177,7 @@ export function ButtonActionsSection({ equipmentId }: ButtonActionsSectionProps)
                     equipments={equipments}
                     zones={zones}
                     instances={instances}
-                    initial={binding}
-                    onSubmit={async (data) => handleEdit(binding.id, data)}
-                    onCancel={() => setEditingId(null)}
-                  />
-                ) : (
-                  <div
-                    key={binding.id}
-                    className="flex items-center gap-2 px-3 py-2 bg-background rounded-[6px] border border-border-light"
-                  >
-                    <Zap size={12} strokeWidth={1.5} className="text-accent flex-shrink-0" />
-                    <span className="text-[12px] text-text flex-1 truncate">
-                      {getEffectLabel(binding)}
-                    </span>
-                    <button
-                      onClick={() => setEditingId(binding.id)}
-                      className="p-1 text-text-tertiary hover:text-primary transition-colors"
-                    >
-                      <Pencil size={12} strokeWidth={1.5} />
-                    </button>
-                    <button
-                      onClick={() => handleRemove(binding.id)}
-                      className="p-1 text-text-tertiary hover:text-error transition-colors"
-                    >
-                      <Trash2 size={12} strokeWidth={1.5} />
-                    </button>
-                  </div>
-                ),
-              )}
-            </div>
-          </div>
-        );
-      })}
-
-      {/* Show bindings with non-standard action values */}
-      {[...grouped.entries()]
-        .filter(([key]) => !BUTTON_ACTIONS.includes(key as typeof BUTTON_ACTIONS[number]))
-        .map(([actionValue, actionBindings]) => (
-          <div key={actionValue} className="mb-3">
-            <div className="text-[11px] font-medium text-text-tertiary uppercase tracking-wider mb-1.5">
-              {actionValue}
-            </div>
-            <div className="space-y-1.5">
-              {actionBindings.map((binding) =>
-                editingId === binding.id ? (
-                  <AddEffectForm
-                    key={binding.id}
-                    modes={modes}
-                    equipments={equipments}
-                    zones={zones}
-                    instances={instances}
+                    actionValues={actionValues}
                     initial={binding}
                     onSubmit={async (data) => handleEdit(binding.id, data)}
                     onCancel={() => setEditingId(null)}
@@ -263,6 +216,7 @@ export function ButtonActionsSection({ equipmentId }: ButtonActionsSectionProps)
           equipments={equipments}
           zones={zones}
           instances={instances}
+          actionValues={actionValues}
           onSubmit={handleAdd}
           onCancel={() => setShowAddForm(false)}
         />
@@ -276,6 +230,7 @@ function AddEffectForm({
   equipments,
   zones,
   instances,
+  actionValues,
   initial,
   onSubmit,
   onCancel,
@@ -284,14 +239,21 @@ function AddEffectForm({
   equipments: { id: string; name: string; type: string; zoneId: string; orderBindings: { alias: string; type?: string; enumValues?: string[]; min?: number; max?: number }[] }[];
   zones: { id: string; name: string }[];
   instances: { id: string; recipeId: string }[];
+  actionValues: string[];
   initial?: ButtonActionBinding;
   onSubmit: (data: { actionValue: string; effectType: ButtonEffectType; config: Record<string, unknown> }) => Promise<void>;
   onCancel: () => void;
 }) {
   const { t } = useTranslation();
-  const [actionValue, setActionValue] = useState(initial?.actionValue ?? "single");
+  const [actionValue, setActionValue] = useState(initial?.actionValue ?? actionValues[0] ?? "single");
   const [effectType, setEffectType] = useState<ButtonEffectType>(initial?.effectType ?? "mode_activate");
   const [saving, setSaving] = useState(false);
+
+  const getActionLabel = (val: string): string => {
+    const key = `buttonActions.action.${val}`;
+    const translated = t(key);
+    return translated !== key ? translated : val;
+  };
 
   // mode_activate
   const [modeId, setModeId] = useState(
@@ -412,22 +374,34 @@ function AddEffectForm({
 
   return (
     <div className="bg-border-light/20 border border-border-light rounded-[6px] p-3 space-y-3 mt-3">
-      {/* Action value (single / double / hold) */}
+      {/* Action value */}
       <div>
         <label className="block text-[11px] text-text-tertiary uppercase tracking-wider mb-1">
           {t("buttonActions.actionType")}
         </label>
-        <div className="inline-flex">
-          {BUTTON_ACTIONS.map((action, i) => (
-            <button
-              key={action}
-              onClick={() => setActionValue(action)}
-              className={seg(actionValue === action, i === 0 ? "first" : i === BUTTON_ACTIONS.length - 1 ? "last" : "mid")}
-            >
-              {t(`buttonActions.action.${action}`)}
-            </button>
-          ))}
-        </div>
+        {actionValues.length <= 4 ? (
+          <div className="inline-flex flex-wrap gap-y-1">
+            {actionValues.map((action, i) => (
+              <button
+                key={action}
+                onClick={() => setActionValue(action)}
+                className={seg(actionValue === action, i === 0 ? "first" : i === actionValues.length - 1 ? "last" : "mid")}
+              >
+                {getActionLabel(action)}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <select
+            value={actionValue}
+            onChange={(e) => setActionValue(e.target.value)}
+            className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+          >
+            {actionValues.map((action) => (
+              <option key={action} value={action}>{getActionLabel(action)}</option>
+            ))}
+          </select>
+        )}
       </div>
 
       {/* Effect type selector */}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -222,6 +222,7 @@ export interface DataBindingWithValue extends DataBinding {
   category: DataCategory;
   value: unknown;
   unit?: string;
+  enumValues?: string[];
   lastUpdated: string | null;
   lastChanged: string | null;
   historize?: number | null;


### PR DESCRIPTION
## Summary

- Store `enum_values` in `device_data` table (mirroring `device_orders`)
- Z2M plugin sends enum values for data properties (e.g. action on multi-button remotes)
- Equipment data bindings expose `enumValues` to the frontend
- Button action UI displays dynamic action values from the equipment instead of hardcoded `single/double/hold`

## Changes

- **Migration 005**: `ALTER TABLE device_data ADD COLUMN enum_values JSON`
- **Backend types**: `enumValues` added to `DiscoveredDevice.data` entries and `DataBindingWithValue`
- **Device Manager**: stores/reads enum_values on INSERT/UPDATE of device_data
- **Equipment Manager**: SQL query includes `dd.enum_values`, mapper parses JSON
- **Z2M Plugin**: `z2m-parser.ts` passes `expose.values` to data entries
- **UI**: `ButtonActionsSection` reads action enum values from equipment data bindings, uses dropdown for >4 values
- **Tests**: 5 new scenarios (device-manager + equipment-manager)
- **Spec**: 079-data-enum-values

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `cd ui && npx tsc -b --noEmit` — zero errors
- [x] `npx vitest run` — 336 tests pass
- [x] `npx eslint src/ --ext .ts` — zero errors
- [ ] Manual: verify multi-button remote (SS6400ZB) shows 12 action values after re-discovery
- [ ] Manual: verify single-button (Aqara) still shows single/double/hold