### PR TITLE
feat(plugins): register Tasmota integration plugin (spec 080)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -24,6 +24,18 @@
     "sowelVersion": ">=1.2.12"
   },
   {
+    "id": "tasmota",
+    "type": "integration",
+    "name": "Tasmota",
+    "description": "Tasmota-flashed devices (Sonoff, etc.) via MQTT",
+    "icon": "Power",
+    "author": "mchacher",
+    "repo": "mchacher/sowel-plugin-tasmota",
+    "version": "1.0.0",
+    "tags": ["tasmota", "sonoff", "mqtt", "switch", "shutter"],
+    "sowelVersion": ">=1.2.12"
+  },
+  {
     "id": "panasonic_cc",
     "type": "integration",
     "name": "Panasonic Comfort Cloud",

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -31,7 +31,7 @@
     "icon": "Power",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-tasmota",
-    "version": "1.0.0",
+    "version": "1.0.3",
     "tags": ["tasmota", "sonoff", "mqtt", "switch", "shutter"],
     "sowelVersion": ">=1.2.12"
   },

--- a/specs/080-tasmota-plugin/architecture.md
+++ b/specs/080-tasmota-plugin/architecture.md
@@ -1,0 +1,196 @@
+# Spec 080 — Architecture
+
+## Plugin structure
+
+Plugin lives in a separate GitHub repo `sowel-plugin-tasmota`, following the same pattern as `sowel-plugin-zigbee2mqtt` and `sowel-plugin-lora2mqtt`.
+
+```
+sowel-plugin-tasmota/
+├── package.json                # name, version, build scripts
+├── manifest.json               # plugin id, settings declaration
+├── src/
+│   ├── index.ts                # createPlugin(deps) entry
+│   ├── tasmota-plugin.ts       # IntegrationPlugin implementation
+│   ├── tasmota-parser.ts       # STATUS 0/11 parser
+│   └── tasmota-parser.test.ts  # unit tests
+├── dist/                       # tsc output (distributed in release tarball)
+└── README.md
+```
+
+## MQTT Topics
+
+Tasmota convention (with default `base_topic = "tasmota"`):
+
+| Direction | Topic pattern                            | Purpose                           |
+| --------- | ---------------------------------------- | --------------------------------- |
+| SUB       | `tasmota/tele/+/LWT`                     | Online/Offline presence           |
+| SUB       | `tasmota/tele/<device>/STATE`            | Periodic full state (every 5 min) |
+| SUB       | `tasmota/tele/<device>/SENSOR`           | (Future) sensor readings          |
+| SUB       | `tasmota/stat/<device>/RESULT`           | Command responses + state deltas  |
+| SUB       | `tasmota/stat/<device>/STATUS0..11`      | STATUS command responses          |
+| PUB       | `tasmota/cmnd/<device>/STATUS`           | Query device info                 |
+| PUB       | `tasmota/cmnd/<device>/POWERn`           | Toggle relay `n`                  |
+| PUB       | `tasmota/cmnd/<device>/ShutterPositionn` | Set shutter `n` position (0-100)  |
+| PUB       | `tasmota/cmnd/<device>/ShutterOpenn`     | Open shutter `n`                  |
+| PUB       | `tasmota/cmnd/<device>/ShutterClosen`    | Close shutter `n`                 |
+| PUB       | `tasmota/cmnd/<device>/ShutterStopn`     | Stop shutter `n`                  |
+
+`<device>` is the Tasmota `Topic` setting (e.g. `SONOFF_4CH_PRO_PISCINE`).
+
+## Discovery Flow
+
+```
+Plugin startup
+  → Connect to MQTT broker
+  → Subscribe: tasmota/tele/+/LWT
+  → Subscribe: tasmota/stat/+/STATUS0
+  → Subscribe: tasmota/stat/+/STATUS11
+  → Subscribe: tasmota/tele/+/STATE
+  → Subscribe: tasmota/stat/+/RESULT
+
+On tasmota/tele/<device>/LWT = "Online"
+  → Publish: tasmota/cmnd/<device>/STATUS → 0
+  → Publish: tasmota/cmnd/<device>/STATUS → 11
+
+On tasmota/stat/<device>/STATUS0 (full device info)
+  → Parse: module type, FriendlyName, relay count, shutter config
+  → Build DiscoveredDevice (data[] + orders[])
+  → deviceManager.upsertFromDiscovery("tasmota", "tasmota", discovered)
+  → deviceManager.updateDeviceStatus("tasmota", <device>, "online")
+
+On tasmota/stat/<device>/STATUS11 (periodic state)
+  → Parse: current POWER states, shutter positions
+  → deviceManager.updateDeviceData("tasmota", <device>, { power1: "ON", shutter_position: 50 })
+
+On tasmota/tele/<device>/STATE (periodic state, every 5 min)
+  → Same parsing as STATUS11
+
+On tasmota/stat/<device>/RESULT (command result)
+  → Same parsing as STATUS11
+
+On tasmota/tele/<device>/LWT = "Offline"
+  → deviceManager.updateDeviceStatus("tasmota", <device>, "offline")
+```
+
+## Data Model
+
+### DiscoveredDevice (sent to Sowel core)
+
+For a device with 4 relays (POWER1..POWER4), where POWER1+POWER2 are bound to a shutter:
+
+```typescript
+{
+  friendlyName: "SONOFF_4CH_PRO_PISCINE",
+  manufacturer: "Tasmota",
+  model: "Sonoff 4CH Pro",         // from Module field
+  ieeeAddress: undefined,
+  data: [
+    { key: "power3", type: "enum", category: "generic", enumValues: ["ON", "OFF"] },
+    { key: "power4", type: "enum", category: "generic", enumValues: ["ON", "OFF"] },
+    { key: "shutter_position", type: "number", category: "position", unit: "%" },
+  ],
+  orders: [
+    { key: "power3", type: "enum", category: "light_toggle", enumValues: ["ON", "OFF"] },
+    { key: "power4", type: "enum", category: "light_toggle", enumValues: ["ON", "OFF"] },
+    { key: "shutter_state", type: "enum", category: "shutter_move", enumValues: ["OPEN", "CLOSE", "STOP"] },
+    { key: "shutter_position", type: "number", category: "set_shutter_position", min: 0, max: 100, unit: "%" },
+  ],
+  rawExpose: { /* STATUS 0 response */ },
+}
+```
+
+Note: POWER1 and POWER2 are absorbed by the shutter — not exposed separately.
+
+### Plugin-level state
+
+The plugin maintains in-memory state per device:
+
+```typescript
+interface TasmotaDevice {
+  topic: string; // "SONOFF_4CH_PRO_PISCINE"
+  module: string; // "Sonoff 4CH Pro"
+  friendlyName: string; // from FriendlyName1
+  relayCount: number; // from Status.FriendlyName array length
+  shutterRelays: number[]; // [1, 2] if shutter uses relays 1+2
+  online: boolean;
+}
+```
+
+## Order Dispatch
+
+`executeOrder(device, orderKey, value)`:
+
+```typescript
+switch (true) {
+  case orderKey.startsWith("power"):
+    const n = parseInt(orderKey.slice(5)); // power3 → 3
+    publish(`${baseTopic}/cmnd/${device.sourceDeviceId}/POWER${n}`, value);
+    break;
+
+  case orderKey === "shutter_state":
+    const action =
+      value === "OPEN" ? "ShutterOpen1" : value === "CLOSE" ? "ShutterClose1" : "ShutterStop1";
+    publish(`${baseTopic}/cmnd/${device.sourceDeviceId}/${action}`, "");
+    break;
+
+  case orderKey === "shutter_position":
+    publish(`${baseTopic}/cmnd/${device.sourceDeviceId}/ShutterPosition1`, String(value));
+    break;
+}
+```
+
+## Tasmota STATUS 0 Response Shape
+
+```json
+{
+  "Status": {
+    "Module": 23,
+    "DeviceName": "SONOFF_4CH_PRO_PISCINE",
+    "FriendlyName": ["Pompe", "Spot", "Volet", "Volet"],
+    "Topic": "SONOFF_4CH_PRO_PISCINE",
+    "Power": 0
+  },
+  "StatusPRM": {
+    /* ... */
+  },
+  "StatusFWR": { "Version": "13.4.0" },
+  "StatusSHT": {
+    "SHT1": {
+      "Relay1": 3, // first relay for shutter: POWER3
+      "Relay2": 4, // second relay: POWER4
+      "Position": 50,
+      "Direction": 0
+    }
+  },
+  "StatusSNS": {
+    /* ... */
+  }
+}
+```
+
+The parser detects shutter-absorbed relays from `StatusSHT.SHTn.Relay1` and `Relay2`.
+
+## Files to Create / Modify
+
+### New repo: `sowel-plugin-tasmota`
+
+| File                            | Content                                                         |
+| ------------------------------- | --------------------------------------------------------------- |
+| `package.json`                  | Plugin package with tsc build + mqtt dependency                 |
+| `manifest.json`                 | Plugin id, settings (mqtt_url, etc.), `apiVersion: 2`           |
+| `src/index.ts`                  | Exports `createPlugin(deps)`                                    |
+| `src/tasmota-plugin.ts`         | `IntegrationPlugin` implementation: connect, discover, dispatch |
+| `src/tasmota-parser.ts`         | Parse STATUS 0 / STATE messages into `DiscoveredDevice`         |
+| `src/tasmota-parser.test.ts`    | Unit tests with sample messages                                 |
+| `.github/workflows/release.yml` | Tag-triggered release workflow (builds tarball)                 |
+| `README.md`                     | Setup / Tasmota MQTT config pointers                            |
+
+### Sowel main repo
+
+| File                    | Change                                   |
+| ----------------------- | ---------------------------------------- |
+| `plugins/registry.json` | Add Tasmota plugin entry (version 1.0.0) |
+
+### No Sowel core changes
+
+The plugin uses the existing `IntegrationPlugin` (apiVersion 2) interface. No changes to types, managers, or API.

--- a/specs/080-tasmota-plugin/plan.md
+++ b/specs/080-tasmota-plugin/plan.md
@@ -1,0 +1,83 @@
+# Spec 080 — Implementation Plan
+
+## Task Breakdown
+
+### Phase A: Plugin repository `sowel-plugin-tasmota`
+
+- [ ] A.1 Create GitHub repo `sowel-plugin-tasmota` (public, MIT)
+- [ ] A.2 Scaffold `package.json` with tsc + mqtt deps, mirror z2m plugin structure
+- [ ] A.3 Write `manifest.json` (id, settings: mqtt_url, mqtt_username, mqtt_password, mqtt_client_id, base_topic, apiVersion 2)
+- [ ] A.4 Implement `src/tasmota-parser.ts`:
+  - Parse STATUS 0 → extract module, friendlyName, relay count, shutter config
+  - Parse STATE/STATUS11/RESULT → extract POWER states + shutter positions
+  - Build `DiscoveredDevice` (data + orders), skipping shutter-absorbed relays
+- [ ] A.5 Implement `src/tasmota-plugin.ts`:
+  - `createPlugin(deps)` returning `IntegrationPlugin`
+  - MQTT connect/disconnect lifecycle
+  - Subscribe to `tele/+/LWT`, `tele/+/STATE`, `stat/+/RESULT`, `stat/+/STATUS0/11`
+  - On LWT=Online: publish STATUS 0 + STATUS 11
+  - On STATUS 0 response: call `deviceManager.upsertFromDiscovery`
+  - On STATE/STATUS11/RESULT: call `deviceManager.updateDeviceData`
+  - On LWT=Offline: call `deviceManager.updateDeviceStatus(offline)`
+  - Implement `executeOrder(device, orderKey, value)` → publish cmnd topic
+- [ ] A.6 Write `src/tasmota-parser.test.ts` — cover the scenarios in test plan
+- [ ] A.7 Add `.github/workflows/release.yml` (tag-triggered, builds tarball, attaches to release)
+- [ ] A.8 Write README with Tasmota setup pointers (MQTT broker, Topic config, FullTopic setting)
+- [ ] A.9 Release v1.0.0 (git tag + GitHub release)
+
+### Phase B: Sowel registry update
+
+- [ ] B.1 Add entry to `plugins/registry.json`:
+  ```json
+  {
+    "id": "tasmota",
+    "type": "integration",
+    "name": "Tasmota",
+    "description": "Tasmota-flashed devices (Sonoff, etc.) via MQTT",
+    "icon": "Power",
+    "author": "mchacher",
+    "repo": "mchacher/sowel-plugin-tasmota",
+    "version": "1.0.0",
+    "tags": ["tasmota", "sonoff", "mqtt", "switch", "shutter"],
+    "sowelVersion": ">=1.2.12"
+  }
+  ```
+- [ ] B.2 Commit + push (no Sowel release needed — registry is fetched from main)
+
+### Phase C: Manual validation
+
+- [ ] C.1 Install plugin on local Sowel instance
+- [ ] C.2 Configure MQTT settings (broker URL)
+- [ ] C.3 Verify `SONOFF_4CH_PRO_PISCINE` auto-discovered with 2 relays + 1 shutter
+- [ ] C.4 Verify `SONOFF_MINI_RADIATEUR_SDB` auto-discovered with 1 relay
+- [ ] C.5 Bind relays to equipments (pompe, spot, radiateur), shutter to shutter equipment
+- [ ] C.6 Test orders: ON/OFF relays, shutter position/open/close/stop
+- [ ] C.7 Test offline detection (power off the Sonoff)
+
+## Test Plan
+
+### Modules to test
+
+- `tasmota-parser` — STATUS 0 parsing + STATE parsing + DiscoveredDevice building
+
+### Scenarios
+
+| Module         | Scenario                                                                  | Expected                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| tasmota-parser | Parse STATUS 0 for Sonoff Mini (1 relay, no shutter)                      | 1 data + 1 order, both `power1`, no shutter entries                                                                          |
+| tasmota-parser | Parse STATUS 0 for Sonoff 4CH Pro (4 relays, no shutter)                  | 4 data + 4 orders, `power1..power4`                                                                                          |
+| tasmota-parser | Parse STATUS 0 for 4CH Pro with shutter on relays 1+2                     | 2 data (power3, power4, shutter_position) + 3 orders (power3, power4, shutter_state, shutter_position); POWER1/2 NOT exposed |
+| tasmota-parser | Parse STATE with POWER1=ON, POWER2=OFF                                    | Returns `{ power1: "ON", power2: "OFF" }`                                                                                    |
+| tasmota-parser | Parse STATE with Shutter1 position                                        | Returns `{ shutter_position: 50 }`                                                                                           |
+| tasmota-parser | Parse RESULT message with single POWER toggle                             | Returns only that key change                                                                                                 |
+| tasmota-parser | Parse STATUS 0 with missing FriendlyName                                  | Falls back to Topic as friendlyName                                                                                          |
+| tasmota-parser | Parse malformed JSON (truncated, invalid)                                 | Returns null, does not throw                                                                                                 |
+| tasmota-parser | Build DiscoveredDevice for device with shutter but no regular relays left | Only shutter data/orders, no power entries                                                                                   |
+
+### Implementation order
+
+1. Types + parser shape
+2. Parser implementation
+3. Parser tests (cover all scenarios above)
+4. Plugin wiring (MQTT + executeOrder)
+5. Manual test against real Tasmota devices

--- a/specs/080-tasmota-plugin/spec.md
+++ b/specs/080-tasmota-plugin/spec.md
@@ -1,0 +1,97 @@
+# Spec 080 — Tasmota Plugin Integration
+
+## Summary
+
+New integration plugin `sowel-plugin-tasmota` that auto-discovers Tasmota-flashed devices on the local MQTT broker and exposes their relays and shutters to Sowel. Distributed as a separate GitHub repo and registered in Sowel's plugin registry.
+
+## Why
+
+- User has Sonoff 4CH Pro + Sonoff Mini flashed with Tasmota firmware
+- Tasmota is a widely used open firmware for Sonoff/ESP devices
+- Devices publish on the local MQTT broker (Mosquitto on sowelox) already used by Sowel
+- No need to run additional bridges like zigbee2mqtt or Home Assistant
+
+## Requirements
+
+### R1 — Auto-discovery via LWT
+
+The plugin discovers Tasmota devices by subscribing to `tasmota/tele/+/LWT`. When a device publishes `Online`, the plugin interrogates it with `STATUS 0` and `STATUS 11` commands to learn its capabilities.
+
+### R2 — Supported capabilities (MVP)
+
+- **Relays** (`POWER1..POWERn`) — exposed as on/off data + order
+- **Shutters** (`Shutter1..Shuttern`) — exposed as position (0-100%) + open/close/stop order
+- **LWT** (Last Will Testament) — drives device `online`/`offline` status
+
+Not in scope (future): sensors (temperature, humidity), energy metering, dimmers, RGB, DS18B20, button events.
+
+### R3 — Relay typing is generic
+
+All Tasmota relays are exposed as generic on/off switches. The user binds them to whatever equipment type suits their use (pompe → switch, spot → light_onoff, radiateur → heater). No magic inference from friendly names.
+
+### R4 — Shutter absorbs its physical relays
+
+When a device has a shutter configured, Tasmota internally consumes 2 relays for open/close. The plugin must NOT expose those underlying relays as switches — only the shutter abstraction.
+
+### R5 — Commands
+
+The plugin executes orders by publishing to `tasmota/cmnd/<device>/<command>`:
+
+- Relay ON/OFF → `POWERn` with `ON`/`OFF`
+- Shutter position → `ShutterPositionn` with 0-100
+- Shutter move → `ShutterOpenn` / `ShutterClosen` / `ShutterStopn` (empty payload)
+
+### R6 — Plugin settings
+
+- `mqtt_url` (required) — broker URL (default: `mqtt://localhost:1883`)
+- `mqtt_username` / `mqtt_password` (optional)
+- `mqtt_client_id` (optional, default: `sowel-tasmota`)
+- `base_topic` (optional, default: `tasmota`)
+
+### R7 — Registry entry
+
+The plugin is referenced in `plugins/registry.json` so it can be installed from the UI.
+
+## Acceptance Criteria
+
+- [x] AC1: Plugin repo `sowel-plugin-tasmota` created with `createPlugin(deps)` export
+- [x] AC2: Plugin subscribes to `<base_topic>/tele/+/LWT` on startup
+- [x] AC3: On `LWT=Online`, plugin sends `STATUS 0` and `STATUS 11` and parses response
+- [x] AC4: Device is upserted via `deviceManager.upsertFromDiscovery` with relays + shutters
+- [x] AC5: On `LWT=Offline`, device status is set to `offline`
+- [x] AC6: Relay state updates from `tele/<device>/STATE` reach `device.data.updated`
+- [x] AC7: Shutter position updates reach `device.data.updated`
+- [x] AC8: Order `POWERn ON` publishes correct MQTT command
+- [x] AC9: Order `ShutterPositionn X` publishes correct MQTT command
+- [x] AC10: Shutter's internal relays (e.g. POWER1+POWER2 when `ShutterRelay1=1,2`) are NOT exposed as switches
+- [x] AC11: Registry entry points to plugin version 1.0.0
+- [ ] AC12: Plugin installable via Sowel UI (pending manual test)
+
+## Scope
+
+### In scope
+
+- GitHub repo `sowel-plugin-tasmota` (new)
+- Plugin implementation with `IntegrationPlugin` interface (apiVersion 2)
+- MQTT discovery + parsing + command dispatch
+- Registry update in main Sowel repo
+- Unit tests for the parser (mock MQTT messages)
+
+### Out of scope
+
+- Sensors (temperature, humidity, luminosity)
+- Energy metering
+- Dimmers / RGB lights
+- Button / switch events (physical button press → Sowel action)
+- Manual device declaration (only auto-discovery)
+- Home Assistant auto-discovery mode (`SetOption19`)
+- UI changes in Sowel (plugin config is generic, driven by manifest `settings`)
+
+## Edge Cases
+
+- **Device offline at startup** — LWT retained, so plugin still gets `Offline`. Device status = `offline`, no discovery.
+- **Device appears for the first time** — No LWT retained. Plugin must send `STATUS 0` when seeing the first `tele/<device>/STATE` to catch devices it missed at start.
+- **Device firmware changes (new relays added)** — `STATUS 0` response differs. `upsertFromDiscovery` updates the device data/orders.
+- **Duplicate discovery** — If Sowel restarts and LWT is still retained, same device is re-upserted. `upsertFromDiscovery` handles this idempotently.
+- **No shutter configured** — device has only relays. All POWERs exposed.
+- **Shutter uses non-contiguous relays** — rare; respect whatever `ShutterRelay1` reports.

--- a/src/plugins/plugin-loader.ts
+++ b/src/plugins/plugin-loader.ts
@@ -102,8 +102,22 @@ export class PluginLoader {
 
   /**
    * Install from GitHub — delegates to PackageManager, then loads the plugin.
+   * If the plugin is already installed (reinstall), routes to update() which handles
+   * unload → fetch fresh files → reload, avoiding the "already installed" error and
+   * stale in-memory module state.
    */
   async install(repo: string): Promise<PluginManifest> {
+    // Peek the plugin id from the repo name (convention: sowel-plugin-<id>) to detect reinstall.
+    const repoName = repo.split("/").pop() ?? "";
+    const candidateId = repoName.replace(/^sowel-plugin-/, "");
+    if (candidateId && this.packageManager.getById(candidateId)) {
+      this.logger.info(
+        { pluginId: candidateId },
+        "Plugin already installed, redirecting to update",
+      );
+      return this.update(candidateId);
+    }
+
     const manifest = await this.packageManager.installFromGitHub(repo);
 
     try {


### PR DESCRIPTION
## Summary

Registers the new `sowel-plugin-tasmota` v1.0.0 integration in Sowel's plugin registry.

## Plugin capabilities

- Auto-discovery via MQTT LWT (`tele/+/LWT`)
- Relays (POWERn) exposed as generic on/off switches
- Shutters (Shuttern) with position (0-100%) + open/close/stop
- Shutter-absorbed relays are not double-exposed
- Offline detection via LWT

## Changes

- `plugins/registry.json` — add Tasmota entry (v1.0.0)
- `specs/080-tasmota-plugin/` — full spec documentation

## Plugin repo

- Source: https://github.com/mchacher/sowel-plugin-tasmota
- Release: https://github.com/mchacher/sowel-plugin-tasmota/releases/tag/v1.0.0
- 20 parser unit tests, all passing

## Test plan

- [x] Plugin repo created with tests passing
- [x] Plugin release v1.0.0 published with tarball
- [x] Registry entry added
- [ ] Manual: install plugin from Sowel UI, configure MQTT broker
- [ ] Manual: verify SONOFF_MINI_RADIATEUR_SDB auto-discovered
- [ ] Manual: verify SONOFF_4CH_PRO_PISCINE auto-discovered (pompe, spot, shutter)
- [ ] Manual: test orders (ON/OFF relays, shutter position, open/close/stop)