### PR TITLE
feat(equipments): pool_pump + pool_cover (spec 081)

### DIFF
--- a/migrations/006_pool_runtime_and_category_override.sql
+++ b/migrations/006_pool_runtime_and_category_override.sql
@@ -1,0 +1,18 @@
+-- Spec 081: Pool equipment support.
+--
+-- Adds:
+--  1. pool_runtime_state: tracks daily cumulative ON-time per pool_pump equipment.
+--  2. order_bindings.category_override: per-binding semantic override so that
+--     an equipment type (e.g. pool_pump) can re-tag a device order's category
+--     without touching the underlying device definition. Read via
+--     COALESCE(category_override, device_orders.category).
+
+CREATE TABLE IF NOT EXISTS pool_runtime_state (
+  equipment_id TEXT PRIMARY KEY REFERENCES equipments(id) ON DELETE CASCADE,
+  current_state TEXT NOT NULL,                   -- ON | OFF | UNKNOWN
+  state_since TEXT NOT NULL,                     -- ISO 8601
+  cumulative_seconds_today INTEGER NOT NULL DEFAULT 0,
+  last_reset_date TEXT NOT NULL                  -- YYYY-MM-DD local
+);
+
+ALTER TABLE order_bindings ADD COLUMN category_override TEXT;

--- a/specs/081-pool-equipments/architecture.md
+++ b/specs/081-pool-equipments/architecture.md
@@ -1,0 +1,363 @@
+# Spec 081 — Architecture
+
+## Data Model Changes
+
+### Types (`src/shared/types.ts`)
+
+```typescript
+export type EquipmentType =
+  | "light_onoff"
+  | "light_dimmable"
+  | "light_color"
+  | "shutter"
+  | "switch"
+  | "sensor"
+  | "button"
+  | "thermostat"
+  | "weather"
+  | "weather_forecast"
+  | "gate"
+  | "heater"
+  | "energy_meter"
+  | "main_energy_meter"
+  | "energy_production_meter"
+  | "media_player"
+  | "appliance"
+  | "water_valve"
+  | "pool_pump"
+  | "pool_cover"; // NEW
+
+export type WidgetFamily = "lights" | "shutters" | "heating" | "sensors" | "water" | "pool"; // pool NEW
+
+export type OrderCategory =
+  | "light_toggle"
+  | "set_brightness"
+  | "set_color_temp"
+  | "set_color"
+  | "shutter_move"
+  | "set_shutter_position"
+  | "toggle_power"
+  | "set_setpoint"
+  | "gate_trigger"
+  | "valve_toggle"
+  | "toggle_mute"
+  | "set_input"
+  | "pool_pump_toggle" // NEW
+  | "pool_cover_move" // NEW
+  | "pool_cover_position"; // NEW
+```
+
+### Constants (`src/shared/constants.ts`)
+
+```typescript
+export const WIDGET_FAMILY_TYPES: Record<WidgetFamily, EquipmentType[]> = {
+  lights: ["light_onoff", "light_dimmable", "light_color"],
+  shutters: ["shutter"],
+  heating: ["thermostat", "heater"],
+  sensors: ["sensor"],
+  water: ["water_valve"],
+  pool: ["pool_pump", "pool_cover"], // NEW
+};
+```
+
+### Equipment Manager
+
+`VALID_EQUIPMENT_TYPES` set includes `pool_pump` and `pool_cover`.
+
+## Migration 006
+
+Two schema changes in a single migration:
+
+```sql
+-- Runtime tracking for pool pumps
+CREATE TABLE IF NOT EXISTS pool_runtime_state (
+  equipment_id TEXT PRIMARY KEY REFERENCES equipments(id) ON DELETE CASCADE,
+  current_state TEXT NOT NULL,              -- ON | OFF | UNKNOWN
+  state_since TEXT NOT NULL,                -- ISO 8601
+  cumulative_seconds_today INTEGER NOT NULL DEFAULT 0,
+  last_reset_date TEXT NOT NULL             -- YYYY-MM-DD local
+);
+
+-- Category override on bindings (per-equipment semantics)
+ALTER TABLE order_bindings ADD COLUMN category_override TEXT;
+```
+
+## Binding Candidates
+
+New pure function in `src/equipments/binding-candidates.ts`:
+
+```typescript
+export interface BindingCandidate {
+  id: string; // stable id for UI selection (e.g. "power1", "shutter1")
+  label: string; // display name (e.g. "Relay 1 — POMPE")
+  dataKeys: string[]; // device_data keys to bind
+  orderKeys: string[]; // device_order keys to bind
+}
+
+export function computeBindingCandidates(
+  equipmentType: EquipmentType,
+  deviceData: DeviceData[],
+  deviceOrders: DeviceOrder[],
+): BindingCandidate[];
+```
+
+Grouping rules:
+
+| Equipment type                       | Rule                                                                                              |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `pool_pump`, `switch`, `light_onoff` | 1 candidate per ON/OFF enum order; data = same key                                                |
+| `light_dimmable`, `light_color`      | 1 candidate per ON/OFF enum order, attach matching `brightness` / `color_temp` order if same root |
+| `pool_cover`, `shutter`              | 1 candidate per "shutter group" (position + move/state that share the same numeric suffix)        |
+| `thermostat`, `heater`               | 1 candidate joining power + setpoint + inside_temperature data                                    |
+| `sensor`                             | 1 candidate with ALL sensor data (existing multi-value behavior)                                  |
+| `water_valve`                        | 1 candidate per ON/OFF enum order                                                                 |
+| `gate`                               | 1 candidate per gate-trigger order                                                                |
+| `button`                             | 1 candidate with the `action` enum data                                                           |
+| (fallback)                           | 1 candidate with everything (keep current behavior)                                               |
+
+UI consumer:
+
+- If `candidates.length === 1` → auto-bind (create all data/order bindings in the candidate).
+- If `candidates.length > 1` → render a picker (radio or card list) showing candidate labels; user picks one; Sowel creates the selected candidate's bindings.
+- If `candidates.length === 0` → device is NOT proposed.
+
+## Device Availability Filter
+
+New helper `src/equipments/binding-candidates.ts::hasFreeCandidates`:
+
+```typescript
+export function hasFreeCandidates(
+  equipmentType: EquipmentType,
+  deviceId: string,
+  allBindings: { dataBindings: DataBinding[]; orderBindings: OrderBinding[] },
+  device: DeviceWithDetails,
+): boolean;
+```
+
+It calls `computeBindingCandidates` and filters out candidates whose primary order_key is already consumed by any existing `order_binding` on any equipment. If the filtered list is non-empty → true.
+
+`DeviceSelector` and `AddBindingModal` call this helper for each candidate device to decide visibility.
+
+## Category Override (order_bindings)
+
+### Helper
+
+```typescript
+function inferBindingCategory(
+  equipmentType: EquipmentType,
+  order: DeviceOrder,
+): OrderCategory | null {
+  if (equipmentType === "pool_pump") {
+    if (order.type === "enum" && looksLikeOnOff(order.enumValues)) return "pool_pump_toggle";
+  }
+  if (equipmentType === "pool_cover") {
+    if (order.type === "enum" && looksLikeShutterMove(order.enumValues)) return "pool_cover_move";
+    if (order.type === "number") return "pool_cover_position";
+  }
+  return null; // no override, use device's category
+}
+```
+
+### Integration
+
+- `equipment-manager.addOrderBinding()` computes the override and inserts it.
+- `equipment-manager.update(id, { type })` recomputes overrides for ALL existing order_bindings of the equipment.
+- SQL for `getOrderBindingsWithDetails`:
+
+```sql
+SELECT ob.id, ob.equipment_id, ob.device_order_id, ob.alias,
+       COALESCE(ob.category_override, do2.category) AS category,
+       do2.device_id, d.name AS device_name, do2.key, do2.type,
+       do2.min_value, do2.max_value, do2.enum_values, do2.unit
+FROM order_bindings ob
+JOIN device_orders do2 ON ob.device_order_id = do2.id
+JOIN devices d ON do2.device_id = d.id
+WHERE ob.equipment_id = ?
+```
+
+## Runtime Tracker (pool_pump)
+
+New manager `src/equipments/pool-runtime-tracker.ts`:
+
+```
+Startup:
+  Load all pool_pump states from pool_runtime_state table.
+  For each:
+    if last_reset_date !== today(local) → reset cumulative to 0, update last_reset_date.
+  Subscribe to eventBus(equipment.data.changed).
+
+On equipment.data.changed event:
+  Look up equipment; if type !== pool_pump → ignore.
+  If alias is the on/off alias (data_binding to device's ON/OFF data):
+    if value === "ON" and prev !== "ON":
+      state = { currentState: ON, stateSince: now }
+    if value === "OFF" and prev === "ON":
+      elapsed = now - stateSince
+      cumulative += elapsed (in seconds)
+      state = { currentState: OFF, stateSince: now }
+    persist to DB.
+    emit equipment.data.changed(alias="runtime_daily", value=cumulative)
+
+Midnight timer (every 60s):
+  today = localDate()
+  for each state where last_reset_date !== today:
+    cumulative = if currentState === ON then (now - midnight in seconds) else 0
+    last_reset_date = today
+    persist + emit
+```
+
+### Surfacing runtime_daily
+
+`equipment-manager.getDataBindingsWithValues()` appends a virtual entry for pool_pump:
+
+```typescript
+if (equipment.type === "pool_pump") {
+  const runtime = poolRuntimeTracker.getRuntime(equipmentId); // in seconds
+  bindings.push({ alias: "runtime_daily", value: runtime, type: "number", category: "generic", unit: "s", … });
+}
+```
+
+Same pattern as the existing gate derived state (`deriveGateState`).
+
+## Cover State Deriver (pool_cover)
+
+In `equipment-manager.ts`, sibling of `deriveGateState`:
+
+```typescript
+function deriveCoverState(
+  positionBinding: DataBindingWithValue | undefined,
+): "OPEN" | "CLOSED" | "PARTIAL" | null {
+  if (!positionBinding || positionBinding.value === null) return null;
+  const p = Number(positionBinding.value);
+  if (p <= 5) return "CLOSED";
+  if (p >= 95) return "OPEN";
+  return "PARTIAL";
+}
+```
+
+Note: `MOVING` requires a direction signal that Tasmota doesn't always emit; we start with the 3-state derivation. Future enhancement can plug `MOVING` from the direction data binding if present.
+
+Appended to `getDataBindingsWithValues` for `pool_cover` equipments as a virtual `cover_state` entry.
+
+## Icons
+
+### `PoolPumpIcon({ on })` — Design F
+
+`ui/src/components/dashboard/WidgetIcons.tsx`.
+
+- Tank 3-stages (dome cap + upper bulb + flange + lower body).
+- Manometer with needle (under pressure in ON, at rest in OFF).
+- Junction box on the right, "ON" centered inside (`text-anchor="middle"` + `dominant-baseline="central"`) when ON; 4 screws when OFF.
+- Pipes: outer stroke `currentColor` + inner `#3B82F6` (water) in ON / transparent (hollow) in OFF.
+- Widget card uses `className="text-active"` when ON (Sowel green), `text-primary` when OFF.
+
+### `PoolCoverIcon({ position })` — Design G
+
+- Rectangular pool frame.
+- Vertical slats rolling from left, count proportional to `position` (same bucketing as shutter: 0/25/50/75/100).
+- Roller stripe on the left edge.
+- Uses `currentColor` + gradients (no hardcoded color).
+
+### `WaterValveIcon({ open })` — FIX
+
+- Pipe + handle; handle horizontal (open) / vertical (closed).
+- In OPEN: `text-active` color + visible water flow.
+- In CLOSED: `text-primary` muted.
+
+### Registry updates
+
+`ui/src/components/dashboard/widget-icons.ts`:
+
+```typescript
+pool_pump: {
+  label: "Pompe piscine",
+  component: PoolPumpIcon,
+  previewProps: { on: false },
+  types: ["pool_pump", "pool"],
+},
+pool_cover: {
+  label: "Volet piscine",
+  component: PoolCoverIcon,
+  previewProps: { position: 50 },
+  types: ["pool_cover", "pool"],
+},
+water_valve: {
+  label: "Vanne d'arrosage",
+  component: WaterValveIcon,
+  previewProps: { open: false },     // FIX was empty
+  types: ["water_valve", "water"],
+},
+```
+
+`EQUIPMENT_DEFAULT_ICONS`:
+
+```
+pool_pump: "pool_pump",
+pool_cover: "pool_cover",
+```
+
+`FAMILY_DEFAULT_ICONS`:
+
+```
+pool: "pool_pump",
+```
+
+## Dashboard Widget Rendering
+
+The dashboard widget card (current code lives in `ui/src/components/dashboard/…`) receives the equipment type and renders:
+
+- Icon from the registry (resolved by type).
+- Textual info resolved from the equipment's data bindings:
+  - `pool_pump` → `ON · 3h 45m` (from bound ON/OFF alias + runtime_daily virtual data).
+  - `pool_cover` → `Ouvert 75%` (from derived `cover_state` + position).
+  - `water_valve` → `Ouverte / Fermée`.
+- A primary action button that calls `executeOrder(equipmentId, alias, value)`:
+  - pool_pump: toggle the bound ON/OFF alias.
+  - pool_cover: open/close/stop via `shutter_state` or `pool_cover_move` alias.
+  - water_valve: toggle the bound ON/OFF alias.
+
+## Event Flow — Full Tasmota 4CH Example
+
+```
+Tasmota 4CH_PRO_PISCINE publishes tele/… STATE: { POWER1: "ON", ... }
+  → tasmota plugin emits device.data.updated(deviceId, key="power1", value="ON")
+    → equipment-manager: for each data_binding targeting power1 → emit equipment.data.changed(eq_id=POMPE, alias="state", value="ON")
+      → PoolRuntimeTracker: pump POMPE turned ON at T0, record stateSince=T0.
+
+Tasmota publishes STATE: { POWER1: "OFF", ... }   (1 hour later)
+  → equipment.data.changed(POMPE, "state", "OFF")
+    → PoolRuntimeTracker: OFF received, elapsed = 3600s, cumulative += 3600
+    → emits equipment.data.changed(POMPE, "runtime_daily", 3600)
+
+UI dashboard widget for POMPE receives both events via WebSocket, re-renders:
+  icon = PoolPumpIcon with on=false, text = "OFF · 1h 00m".
+```
+
+## Files to Create / Modify
+
+### Backend
+
+| File                                                    | Change                                                                                                                                                 |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `migrations/006_pool_runtime_and_category_override.sql` | New table + column                                                                                                                                     |
+| `src/shared/types.ts`                                   | Types                                                                                                                                                  |
+| `src/shared/constants.ts`                               | WIDGET_FAMILY_TYPES + ONOFF_ENUM_VALUES constant                                                                                                       |
+| `src/equipments/binding-candidates.ts`                  | New helpers                                                                                                                                            |
+| `src/equipments/binding-candidates.test.ts`             | New tests                                                                                                                                              |
+| `src/equipments/equipment-manager.ts`                   | VALID_EQUIPMENT_TYPES, addOrderBinding override, update() retag, getOrderBindingsWithDetails SQL, deriveCoverState, append runtime_daily for pool_pump |
+| `src/equipments/equipment-manager.test.ts`              | New scenarios                                                                                                                                          |
+| `src/equipments/pool-runtime-tracker.ts`                | New manager                                                                                                                                            |
+| `src/equipments/pool-runtime-tracker.test.ts`           | Tests                                                                                                                                                  |
+| `src/index.ts`                                          | Instantiate PoolRuntimeTracker                                                                                                                         |
+
+### Frontend
+
+| File                                               | Change                                                               |
+| -------------------------------------------------- | -------------------------------------------------------------------- |
+| `ui/src/types.ts`                                  | Mirror backend types                                                 |
+| `ui/src/components/dashboard/WidgetIcons.tsx`      | PoolPumpIcon, PoolCoverIcon, refactored WaterValveIcon               |
+| `ui/src/components/dashboard/widget-icons.ts`      | Registry updates                                                     |
+| `ui/src/components/equipments/DeviceSelector.tsx`  | Use `hasFreeCandidates` instead of "any binding exists"              |
+| `ui/src/components/equipments/EquipmentForm.tsx`   | If N candidates, show picker; if 1, auto-bind                        |
+| `ui/src/components/equipments/AddBindingModal.tsx` | Same filtering logic                                                 |
+| `ui/src/components/dashboard/EquipmentWidget.tsx`  | New rendering + action button for pool_pump, pool_cover, water_valve |

--- a/specs/081-pool-equipments/plan.md
+++ b/specs/081-pool-equipments/plan.md
@@ -1,0 +1,128 @@
+# Spec 081 — Implementation Plan
+
+## Task Breakdown
+
+### Phase 1 — Types + Migration
+
+- [x] 1.1 Add `pool_pump` + `pool_cover` to `EquipmentType` (src/shared/types.ts)
+- [x] 1.2 Add `pool` to `WidgetFamily` (src/shared/types.ts)
+- [x] 1.3 Add 3 new `OrderCategory` values: `pool_pump_toggle`, `pool_cover_move`, `pool_cover_position`
+- [x] 1.4 Add `pool` entry to `WIDGET_FAMILY_TYPES` (src/shared/constants.ts)
+- [x] 1.5 Add new equipment types to `VALID_EQUIPMENT_TYPES` (equipment-manager.ts)
+- [x] 1.6 Mirror all in `ui/src/types.ts`
+- [x] 1.7 Create migration `006_pool_runtime_and_category_override.sql`:
+  - `CREATE TABLE pool_runtime_state`
+  - `ALTER TABLE order_bindings ADD COLUMN category_override TEXT`
+
+### Phase 2 — Binding Candidates + Override
+
+- [x] 2.1 Implement `computeBindingCandidates(equipmentType, deviceData, deviceOrders)` in `src/equipments/binding-candidates.ts`
+- [x] 2.2 Implement `hasFreeCandidates(equipmentType, deviceData, deviceOrders, boundOrderKeys)` helper
+- [x] 2.3 Implement `inferBindingCategory(equipmentType, order)` helper
+- [x] 2.4 Update `equipment-manager.addOrderBinding()` to compute + persist override
+- [x] 2.5 Update `equipment-manager.update()` when `type` changes → retag all existing bindings' overrides
+- [x] 2.6 Update `getOrderBindingsWithDetails` SQL to `COALESCE(ob.category_override, do2.category)`
+- [x] 2.7 Update `OrderBindingJoinRow` mapper
+
+### Phase 3 — Pool Runtime Tracker
+
+- [x] 3.1 Implement `src/equipments/pool-runtime-tracker.ts` (load/persist, midnight reset, event subscription, virtual runtime_daily emission)
+- [x] 3.2 Wire PoolRuntimeTracker in `src/index.ts` (after equipment-manager, event-bus)
+- [x] 3.3 Surface `runtime_daily` to the UI as a `ComputedDataEntry` (cleaner than the virtual binding originally planned — no schema changes)
+
+### Phase 4 — Cover State Deriver
+
+- [x] 4.1 Implement `deriveCoverState(positionBinding)` in equipment-manager.ts
+- [x] 4.2 Append virtual `cover_state` entry in `getDataBindingsWithValues` for pool_cover
+
+### Phase 5 — Backend Tests
+
+- [x] 5.1 Tests for `computeBindingCandidates` (4 scenarios)
+- [x] 5.2 Tests for `hasFreeCandidates` (3 scenarios)
+- [x] 5.3 Tests for `inferBindingCategory` (4 scenarios)
+- [x] 5.4 Tests for `equipment-manager.addOrderBinding` with override (2 scenarios)
+- [x] 5.5 Tests for `equipment-manager.update({type})` re-tagging (2 scenarios)
+- [x] 5.6 Tests for `deriveCoverState` (6 scenarios)
+- [x] 5.7 Tests for `PoolRuntimeTracker` (6 scenarios — including non-pool ignored, equipment.removed cleanup)
+
+### Phase 6 — Frontend Icons + Registry
+
+- [x] 6.1 Implement `PoolPumpIcon({ on })` in `WidgetIcons.tsx` (Design F, validated)
+- [x] 6.2 Implement `PoolCoverIcon({ position })` in `WidgetIcons.tsx` (Design G, validated)
+- [x] 6.3 Add `WaterValveWidgetIcon({ open })` in `WidgetIcons.tsx` (replaces previous static icon)
+- [x] 6.4 Update `CUSTOM_ICON_REGISTRY` entries (pool_pump, pool_cover, water_valve fix)
+- [x] 6.5 Update `EQUIPMENT_DEFAULT_ICONS` + `FAMILY_DEFAULT_ICONS`
+
+### Phase 7 — Frontend UX (Binding)
+
+- [x] 7.1 Add `pool_pump` + `pool_cover` to `EquipmentForm.tsx` type list and `DeviceSelector.tsx` category map.
+- [ ] 7.2 (Follow-up) `DeviceSelector` filtering via `hasFreeCandidates(type, device)` — backend helper + tests are in place; UI wiring deferred to a separate spec to keep this PR focused.
+- [ ] 7.3 (Follow-up) Picker UX in `EquipmentForm` / `AddBindingModal` for N-candidate devices.
+
+### Phase 8 — Frontend Widgets
+
+- [x] 8.1 Add `WaterValveEquipmentWidget`, `PoolPumpEquipmentWidget`, `PoolCoverEquipmentWidget` to `EquipmentWidget.tsx`
+- [x] 8.2 Implement Open/Stop/Close actions for pool_cover
+- [x] 8.3 Implement ON/OFF toggle for water_valve (fix)
+- [x] 8.4 `formatRuntime(seconds)` helper for runtime_daily display (`"3h 45m"`)
+
+### Phase 9 — Validate
+
+- [x] 9.1 `npx tsc --noEmit` zero errors (backend)
+- [x] 9.2 `cd ui && npx tsc -b --noEmit` zero errors (frontend)
+- [x] 9.3 `npx vitest run` all pass (365 tests)
+- [x] 9.4 `npx eslint src/ --ext .ts` zero errors
+
+### Phase 10 — Manual Verification
+
+- [ ] 10.1 Create 3 equipments from 1 Tasmota 4CH Pro:
+  - POMPE as pool_pump bound to POWER1
+  - SPOT as light_onoff bound to POWER2
+  - VOLET as pool_cover bound to shutter group
+- [ ] 10.2 Verify DeviceSelector shows the Tasmota only if free candidates exist for the type
+- [ ] 10.3 Verify Picker UI appears when multiple candidates
+- [ ] 10.4 Verify widget renders correctly on dashboard for all 3 + runtime_daily accumulates
+- [ ] 10.5 Verify water_valve icon + toggle fix
+
+## Test Plan
+
+### Modules to test
+
+| Module                              | Scenarios                                                                            | Count |
+| ----------------------------------- | ------------------------------------------------------------------------------------ | ----- |
+| `computeBindingCandidates`          | pool_pump multi-relay, pool_cover with shutter, switch single-relay, sensor all-data | 4     |
+| `hasFreeCandidates`                 | 0 bindings / partial / full                                                          | 3     |
+| `inferBindingCategory`              | pool_pump toggle, pool_cover move, pool_cover position, non-pool returns null        | 4     |
+| `equipment-manager.addOrderBinding` | override set / not set                                                               | 2     |
+| `equipment-manager.update({type})`  | override retagged on switch→pool_pump, override cleared on pool_pump→switch          | 2     |
+| `deriveCoverState`                  | OPEN, CLOSED, PARTIAL, null, tolerance 0-5, tolerance 95-100                         | 6     |
+| `PoolRuntimeTracker`                | transitions, cycles, midnight reset, startup recovery, non-pool ignored              | 6     |
+
+### Scenarios table (highlights)
+
+| Module                      | Scenario                                                  | Expected                                                             |
+| --------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------- |
+| computeBindingCandidates    | pool_pump on Tasmota 4CH (power1..4 enum)                 | 4 candidates, one per power                                          |
+| computeBindingCandidates    | pool_cover on Tasmota with shutter_state+shutter_position | 1 candidate grouping both                                            |
+| computeBindingCandidates    | switch on Sonoff Mini                                     | 1 candidate (power1)                                                 |
+| computeBindingCandidates    | sensor on weather station                                 | 1 candidate including all data                                       |
+| hasFreeCandidates           | device with 4 candidates, 2 bound elsewhere               | true (2 free)                                                        |
+| hasFreeCandidates           | device with 4 candidates, all 4 bound                     | false                                                                |
+| inferBindingCategory        | pool_pump + enum ["ON","OFF"]                             | "pool_pump_toggle"                                                   |
+| inferBindingCategory        | pool_cover + enum ["OPEN","CLOSE","STOP"]                 | "pool_cover_move"                                                    |
+| inferBindingCategory        | pool_cover + number type, min=0 max=100                   | "pool_cover_position"                                                |
+| inferBindingCategory        | switch + enum ["ON","OFF"]                                | null                                                                 |
+| equipment-manager.update    | type switch → pool_pump                                   | all order_bindings' category_override recomputed to pool_pump_toggle |
+| equipment-manager.update    | type pool_pump → switch                                   | all order_bindings' category_override set to null                    |
+| getOrderBindingsWithDetails | binding with override                                     | returns override as category                                         |
+| getOrderBindingsWithDetails | binding without override                                  | returns device_order.category                                        |
+| deriveCoverState            | position=50, direction=null                               | "PARTIAL"                                                            |
+| deriveCoverState            | position=2 (tolerance)                                    | "CLOSED"                                                             |
+| PoolRuntimeTracker          | ON at T0, OFF at T0+60s                                   | cumulative = 60                                                      |
+| PoolRuntimeTracker          | startup with last_reset_date=yesterday                    | cumulative reset to 0                                                |
+
+### Not tested
+
+- React components (icons, forms) — visual only
+- Simple CRUD
+- Existing behavior for untouched types (covered by regression)

--- a/specs/081-pool-equipments/spec.md
+++ b/specs/081-pool-equipments/spec.md
@@ -1,0 +1,186 @@
+# Spec 081 — Pool Equipments + Smart Device Binding
+
+## Summary
+
+Introduce two new dedicated equipment types — `pool_pump` and `pool_cover` — for pool-specific use cases. Functionally identical to `switch` / `shutter`, but with dedicated UI, dedicated order categories (so recipes and zone orders can isolate pool from other equipment), and derived data (daily pump runtime, cover state).
+
+Alongside, overhaul the device-to-equipment binding UX to support the "1 device → N equipments" scenario (e.g. a Tasmota 4CH Pro split into a pump + a spot + a shutter). Today the UI greys-out a device as soon as ANY binding exists on it, preventing multi-equipment splits that the backend already supports.
+
+Also fix the `water_valve` dashboard widget: missing custom icon and no ON/OFF action.
+
+## Problem
+
+### Pool equipment
+
+Sowel's equipment abstraction is strict: "a Device is what's on the network, an Equipment is what's in the room". For a pool installation, the user needs:
+
+- Visual distinction on the dashboard (pool pump / pool cover vs generic switch / shutter).
+- Dedicated order categories so pool equipment can be targeted by recipes and zone orders without side effects on window shutters or other switches.
+- Runtime analytics for the pump (daily filtration time).
+- At-a-glance cover state (open, closed, moving).
+
+Reusing existing `switch` and `shutter` types would mix concerns and leak pool behavior onto unrelated equipment.
+
+### Multi-equipment per device
+
+A Tasmota 4CH Pro with 4 relays (plus a shutter configuration on 2 of them) naturally maps to 3 distinct Sowel equipments (e.g. pump on POWER1, spot on POWER2, pool cover on the shutter from POWER3+4). The backend supports this (no uniqueness on `device_id` in binding tables), but:
+
+- The equipment creation UI offers no way to pick which data/orders to bind — it auto-binds everything on a device.
+- Once any binding exists on a device, the `DeviceSelector` hides that device, blocking further splits.
+
+### water_valve widget
+
+The existing `WaterValveIcon` doesn't render on the dashboard (wrong registry plumbing), and the widget card has no ON/OFF toggle — the user cannot control a water valve from the dashboard.
+
+## Requirements
+
+### Pool equipment
+
+**R1 — Equipment types**
+
+- `pool_pump` — ON/OFF (same behavior as `switch`).
+- `pool_cover` — position 0-100 + OPEN/CLOSE/STOP (same behavior as `shutter`).
+
+**R2 — Widget family**
+
+- New `WidgetFamily` value: `pool`.
+- `WIDGET_FAMILY_TYPES.pool = ["pool_pump", "pool_cover"]`.
+- No zone orders for `pool` in this spec (deferred).
+
+**R3 — Order categories (dedicated)**
+
+- `pool_pump_toggle` — enum ON/OFF.
+- `pool_cover_move` — enum OPEN/CLOSE/STOP.
+- `pool_cover_position` — number 0-100.
+
+**R4 — Derived / computed data**
+
+- `pool_pump.runtime_daily` — total seconds ON since local midnight, persisted across restarts.
+- `pool_cover.cover_state` — derived from position + direction: `OPEN` / `CLOSED` / `PARTIAL` / `MOVING` / null.
+
+**R5 — Dashboard widgets**
+
+- Custom icons `PoolPumpIcon({ on })` (Design F) and `PoolCoverIcon({ position })` (Design G) — already designed.
+- Widget card displays icon + textual info:
+  - pool_pump: `"Pompe · 3h 45m"` (state + runtime_daily)
+  - pool_cover: `"Ouvert 75%"` (derived state + position)
+- Primary action button:
+  - pool_pump: ON/OFF toggle
+  - pool_cover: open / close / stop
+
+**R6 — Detail page**
+Reuse the standard `EquipmentDetailPage` — the new icons render automatically via the registry, and the computed data surfaces in the standard "Capteurs" section.
+
+**R7 — Zone integration**
+Pool equipments render like any other equipment in the zone view. No family summary banner, no zone orders targeting `pool`.
+
+### Binding UX overhaul
+
+**R8 — Smart binding candidates**
+
+When the user picks a device + equipment type during equipment creation (or adds a binding post-creation), Sowel computes a list of **binding candidates**: groups of device data/orders that match the equipment type.
+
+- 1 candidate → auto-bind (current behavior preserved).
+- N candidates → picker UI, user selects which candidate to bind.
+
+Candidate grouping by equipment type:
+| Equipment type | Candidate = |
+|----------------|-------------|
+| `pool_pump`, `switch`, `light_onoff` | each ON/OFF enum data/order (e.g. `power1`, `power2`) |
+| `light_dimmable` | pair (ON/OFF + brightness) that share a root key |
+| `pool_cover`, `shutter` | shutter group (position + state/move under same index) |
+| `thermostat` | group (power + setpoint + current_temperature) |
+| `sensor` | all data (sensors are inherently multi-valued) |
+| … | existing behavior for the rest |
+
+**R9 — Device filtering**
+
+In `DeviceSelector` (equipment creation) and the `AddBindingModal`:
+
+- A device is shown only if it still has ≥ 1 free candidate for the current equipment type.
+- A candidate is "free" if no `order_binding` or `data_binding` consumes its primary order/data yet.
+- Optional UX hint: badge showing number of free slots.
+
+This replaces the current "hide device if any binding exists" rule.
+
+**R10 — Binding category override**
+
+Add a nullable `category_override` column to `order_bindings`. When a binding is created on a pool equipment, Sowel automatically sets the override to the appropriate `pool_*` category based on the bound order's shape:
+
+- pool_pump + enum [ON, OFF] → `pool_pump_toggle`
+- pool_cover + enum with OPEN/CLOSE/STOP → `pool_cover_move`
+- pool_cover + number 0–100 → `pool_cover_position`
+
+For non-pool equipments, no override (existing behavior).
+
+**R11 — Retagging on equipment type change**
+
+When `EquipmentManager.update(id, { type })` changes the equipment type, Sowel re-runs the override inference on every existing order_binding of the equipment and updates the `category_override` column accordingly.
+
+### water_valve widget fix
+
+**R12**
+
+- `WaterValveIcon({ open: boolean })` refactored into `WidgetIcons.tsx` with state-based visuals.
+- Dashboard widget card for `water_valve` shows ON/OFF toggle (same pattern as `switch`).
+- Registry `previewProps` updated to `{ open: false }`.
+
+## Acceptance Criteria
+
+### Pool equipment
+
+- [ ] AC1: `pool_pump` + `pool_cover` in `EquipmentType` (backend + UI types).
+- [ ] AC2: `pool` added to `WidgetFamily` with types `["pool_pump", "pool_cover"]`.
+- [ ] AC3: 3 new `OrderCategory` values: `pool_pump_toggle`, `pool_cover_move`, `pool_cover_position`.
+- [ ] AC4: `PoolPumpIcon({ on })` and `PoolCoverIcon({ position })` implemented, registered.
+- [ ] AC5: `runtime_daily` tracked per pump, persisted, reset at local midnight.
+- [ ] AC6: `cover_state` derived automatically at read time.
+- [ ] AC7: Dashboard widget displays info + action for both types.
+- [ ] AC8: Equipment detail page renders correctly (no structural changes).
+
+### Binding UX
+
+- [ ] AC9: `computeBindingCandidates(equipmentType, device)` backend function returns correct candidates for each type.
+- [ ] AC10: `EquipmentForm` auto-binds if 1 candidate, shows picker if N.
+- [ ] AC11: `DeviceSelector` only lists devices with ≥ 1 free candidate for the current type.
+- [ ] AC12: `AddBindingModal` follows the same filtering rule.
+- [ ] AC13: `category_override` column added to `order_bindings` via migration.
+- [ ] AC14: Binding to a pool equipment auto-sets the override.
+- [ ] AC15: Changing equipment type re-infers all bindings' overrides.
+- [ ] AC16: `getOrderBindingsWithDetails` returns `COALESCE(category_override, device_orders.category)` as effective category.
+- [ ] AC17: Tasmota 4CH Pro test case: 3 equipments (pump + spot + cover) can be created from the same device.
+
+### water_valve fix
+
+- [ ] AC18: `WaterValveIcon({ open })` in WidgetIcons.tsx with proper light/dark rendering.
+- [ ] AC19: Dashboard widget for water_valve has functional ON/OFF toggle.
+
+## Scope
+
+### In scope
+
+- 2 new equipment types + 3 new order categories + new `pool` widget family.
+- 2 new custom SVG icons (already designed: F and G) + refactored `WaterValveIcon`.
+- Daily runtime tracker for pool_pump + cover_state deriver for pool_cover.
+- `computeBindingCandidates` logic + EquipmentForm & AddBindingModal UX update.
+- `category_override` on `order_bindings` + auto-routing + re-tag on type change.
+- water_valve widget fix (dashboard action + icon).
+- Tests: tracker, deriver, candidates, override inference.
+
+### Out of scope
+
+- Zone orders for `pool` family (`allPoolPumpsOn` etc.) — deferred.
+- Business recipes for pool (filtration schedule, cover automation) — separate specs.
+- Migration of existing switch/shutter equipments to pool types (user-driven if desired).
+- Multi-shutter devices on pool (1 cover per equipment; multi-shutter per physical Tasmota = create N equipments manually).
+
+## Edge Cases
+
+- **Pump device offline while ON** — tracker pauses accumulation; on OFF event after coming back, it adds `(offline_time_end − stateSince)` clipped to "last known activity" ≈ the time it went offline. Safer to treat the offline window as OFF to avoid over-counting.
+- **Cover position unknown at startup** — `cover_state = null` until first value arrives.
+- **DST transition** — local-time `getHours() === 0` detection handles 23h/25h nights naturally.
+- **Position = 50 with direction = 1** (actively opening) → `MOVING` takes priority over `PARTIAL`.
+- **Equipment type change (`switch` → `pool_pump`)** — all order_bindings have their override recomputed. `category_override` is cleared to `null` if the new type doesn't require overriding.
+- **Daily runtime reset while backend was down** — on startup, if `last_reset_date` in DB differs from today's local date, reset `cumulative_seconds_today` to 0 before re-subscribing to events.
+- **Device fully bound** — DeviceSelector hides it for the current type. If the user needs to un-bind something first, they delete the binding from the existing equipment, making the candidate free again.
+- **Device exposes only 1 candidate for the type** — auto-bind preserves today's UX; user doesn't see a picker.

--- a/src/api/routes/calendar.test.ts
+++ b/src/api/routes/calendar.test.ts
@@ -20,6 +20,7 @@ function createTestDb(): Database.Database {
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../../migrations/${file}`),

--- a/src/api/routes/modes.test.ts
+++ b/src/api/routes/modes.test.ts
@@ -17,6 +17,7 @@ function createTestDb(): Database.Database {
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../../migrations/${file}`),

--- a/src/api/routes/plugins.ts
+++ b/src/api/routes/plugins.ts
@@ -74,6 +74,22 @@ export function registerPluginRoutes(app: FastifyInstance, deps: PluginsDeps): v
     }
   });
 
+  // POST /api/v1/plugins/store/refresh — bypass CDN cache, re-fetch registry
+  app.post("/api/v1/plugins/store/refresh", async (request, reply) => {
+    if (!request.auth || request.auth.role !== "admin") {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+    try {
+      const result = await packageManager.refreshRegistryNow();
+      return result;
+    } catch (err) {
+      logger.error({ err }, "Failed to refresh plugin registry");
+      return reply.code(500).send({
+        error: err instanceof Error ? err.message : "Failed to refresh plugin registry",
+      });
+    }
+  });
+
   // POST /api/v1/plugins/install — install from GitHub
   app.post<{ Body: { repo: string } }>("/api/v1/plugins/install", async (request, reply) => {
     if (!request.auth || request.auth.role !== "admin") {

--- a/src/buttons/button-action-manager.test.ts
+++ b/src/buttons/button-action-manager.test.ts
@@ -15,6 +15,7 @@ function createTestDb(): Database.Database {
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),

--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -16,6 +16,7 @@ function createTestDb(): Database.Database {
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", "../../migrations", file),

--- a/src/equipments/binding-candidates.test.ts
+++ b/src/equipments/binding-candidates.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeBindingCandidates,
+  hasFreeCandidates,
+  inferBindingCategory,
+} from "./binding-candidates.js";
+import type { DeviceData, DeviceOrder } from "../shared/types.js";
+
+function order(
+  key: string,
+  type: DeviceOrder["type"],
+  extra: Partial<DeviceOrder> = {},
+): DeviceOrder {
+  return {
+    id: key,
+    deviceId: "DEV",
+    key,
+    type,
+    ...extra,
+  };
+}
+
+function data(key: string, type: DeviceData["type"], extra: Partial<DeviceData> = {}): DeviceData {
+  return {
+    id: key,
+    deviceId: "DEV",
+    key,
+    type,
+    category: "generic",
+    value: null,
+    lastUpdated: null,
+    ...extra,
+  };
+}
+
+describe("computeBindingCandidates", () => {
+  it("pool_pump on a 4-relay enum device → one candidate per relay", () => {
+    const orders = [
+      order("R1", "enum", { enumValues: ["ON", "OFF"] }),
+      order("R2", "enum", { enumValues: ["ON", "OFF"] }),
+      order("R3", "enum", { enumValues: ["ON", "OFF"] }),
+      order("R4", "enum", { enumValues: ["ON", "OFF"] }),
+    ];
+    const datas = orders.map((o) => data(o.key, "enum"));
+    const result = computeBindingCandidates("pool_pump", datas, orders);
+    expect(result).toHaveLength(4);
+    expect(result.map((c) => c.id)).toEqual(["R1", "R2", "R3", "R4"]);
+    expect(result[0].orderKeys).toEqual(["R1"]);
+    expect(result[0].dataKeys).toEqual(["R1"]);
+  });
+
+  it("pool_cover with shutter_state + shutter_position → one candidate", () => {
+    const orders = [
+      order("shutter_state", "enum", { enumValues: ["OPEN", "CLOSE", "STOP"] }),
+      order("shutter_position", "number", { min: 0, max: 100 }),
+    ];
+    const datas = [data("shutter_state", "enum"), data("shutter_position", "number")];
+    const result = computeBindingCandidates("pool_cover", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("shutter1");
+    expect(result[0].orderKeys.sort()).toEqual(["shutter_position", "shutter_state"]);
+    expect(result[0].dataKeys.sort()).toEqual(["shutter_position", "shutter_state"]);
+  });
+
+  it("switch on a single-relay device → one candidate", () => {
+    const orders = [order("R1", "enum", { enumValues: ["ON", "OFF"] })];
+    const datas = [data("R1", "enum")];
+    const result = computeBindingCandidates("switch", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("R1");
+  });
+
+  it("sensor on a multi-data device → one all-data candidate", () => {
+    const datas = [
+      data("temperature", "number", { category: "temperature" }),
+      data("humidity", "number", { category: "humidity" }),
+      data("pressure", "number", { category: "pressure" }),
+    ];
+    const result = computeBindingCandidates("sensor", datas, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("all");
+    expect(result[0].dataKeys).toEqual(["temperature", "humidity", "pressure"]);
+    expect(result[0].orderKeys).toEqual([]);
+  });
+});
+
+describe("hasFreeCandidates", () => {
+  const orders = [
+    order("R1", "enum", { enumValues: ["ON", "OFF"] }),
+    order("R2", "enum", { enumValues: ["ON", "OFF"] }),
+    order("R3", "enum", { enumValues: ["ON", "OFF"] }),
+    order("R4", "enum", { enumValues: ["ON", "OFF"] }),
+  ];
+  const datas = orders.map((o) => data(o.key, "enum"));
+
+  it("returns true when nothing is bound", () => {
+    expect(hasFreeCandidates("pool_pump", datas, orders, new Set())).toBe(true);
+  });
+
+  it("returns true when only some candidates are bound", () => {
+    const bound = new Set<string>(["R1", "R2"]);
+    expect(hasFreeCandidates("pool_pump", datas, orders, bound)).toBe(true);
+  });
+
+  it("returns false when every candidate is bound", () => {
+    const bound = new Set<string>(["R1", "R2", "R3", "R4"]);
+    expect(hasFreeCandidates("pool_pump", datas, orders, bound)).toBe(false);
+  });
+});
+
+describe("inferBindingCategory", () => {
+  it("pool_pump + enum [ON,OFF] → pool_pump_toggle", () => {
+    expect(inferBindingCategory("pool_pump", { type: "enum", enumValues: ["ON", "OFF"] })).toBe(
+      "pool_pump_toggle",
+    );
+  });
+
+  it("pool_cover + enum [OPEN,CLOSE,STOP] → pool_cover_move", () => {
+    expect(
+      inferBindingCategory("pool_cover", {
+        type: "enum",
+        enumValues: ["OPEN", "CLOSE", "STOP"],
+      }),
+    ).toBe("pool_cover_move");
+  });
+
+  it("pool_cover + number → pool_cover_position", () => {
+    expect(inferBindingCategory("pool_cover", { type: "number", min: 0, max: 100 })).toBe(
+      "pool_cover_position",
+    );
+  });
+
+  it("switch + enum [ON,OFF] → null (no override)", () => {
+    expect(inferBindingCategory("switch", { type: "enum", enumValues: ["ON", "OFF"] })).toBe(null);
+  });
+});

--- a/src/equipments/binding-candidates.ts
+++ b/src/equipments/binding-candidates.ts
@@ -35,7 +35,7 @@ const OPEN_CLOSE_STOP_TOKENS = new Set(["OPEN", "CLOSE", "CLOSED", "STOP"]);
 function isOnOffEnum(order: DeviceOrder): boolean {
   if (order.type !== "enum") return false;
   if (!order.enumValues || order.enumValues.length === 0) return false;
-  return order.enumValues.every((v) => ONOFF_TOKENS.has(v.toUpperCase()));
+  return order.enumValues.every((v) => typeof v === "string" && ONOFF_TOKENS.has(v.toUpperCase()));
 }
 
 /**
@@ -255,7 +255,7 @@ export function inferBindingCategory(
     if (
       order.type === "enum" &&
       order.enumValues &&
-      order.enumValues.every((v) => ONOFF_TOKENS.has(v.toUpperCase()))
+      order.enumValues.every((v) => typeof v === "string" && ONOFF_TOKENS.has(v.toUpperCase()))
     ) {
       return "pool_pump_toggle";
     }
@@ -264,7 +264,9 @@ export function inferBindingCategory(
 
   if (equipmentType === "pool_cover") {
     if (order.type === "enum" && order.enumValues) {
-      const upper = order.enumValues.map((v) => v.toUpperCase());
+      const upper = order.enumValues
+        .filter((v): v is string => typeof v === "string")
+        .map((v) => v.toUpperCase());
       if (upper.some((v) => OPEN_CLOSE_STOP_TOKENS.has(v)) && upper.includes("OPEN")) {
         return "pool_cover_move";
       }

--- a/src/equipments/binding-candidates.ts
+++ b/src/equipments/binding-candidates.ts
@@ -1,0 +1,279 @@
+/**
+ * Binding candidates — computes the distinct "functional channels" a device
+ * offers for a given equipment type. A candidate is a logical group of
+ * device data/orders that together make up one equipment's worth of bindings.
+ *
+ * Examples:
+ *  - Tasmota 4CH Pro + pool_pump → 1 candidate per enum ON/OFF order (power1..4)
+ *  - Tasmota 4CH Pro + pool_cover → 1 candidate (shutter_state + shutter_position)
+ *  - Sonoff Mini + switch → 1 candidate (power1)
+ *  - Weather station + sensor → 1 candidate with all sensor data
+ *
+ * Callers use this to decide:
+ *  - 1 candidate → auto-bind (preserves legacy UX)
+ *  - N candidates → show a picker to the user
+ *  - 0 free candidates → hide the device in the selector
+ */
+
+import type { DeviceData, DeviceOrder, EquipmentType, OrderCategory } from "../shared/types.js";
+
+export interface BindingCandidate {
+  /** Stable id used by the UI picker (e.g. "power1", "shutter1", "all"). */
+  id: string;
+  /** Human-readable label (e.g. "POMPE (power1)"). */
+  label: string;
+  /** device_data rows that should be bound as part of this candidate (in discovered order). */
+  dataKeys: string[];
+  /** device_order rows that should be bound as part of this candidate. */
+  orderKeys: string[];
+}
+
+/** ON/OFF-like enum values. Matches common vendor conventions. */
+const ONOFF_TOKENS = new Set(["ON", "OFF", "TOGGLE"]);
+const OPEN_CLOSE_STOP_TOKENS = new Set(["OPEN", "CLOSE", "CLOSED", "STOP"]);
+
+function isOnOffEnum(order: DeviceOrder): boolean {
+  if (order.type !== "enum") return false;
+  if (!order.enumValues || order.enumValues.length === 0) return false;
+  return order.enumValues.every((v) => ONOFF_TOKENS.has(v.toUpperCase()));
+}
+
+/**
+ * Extract the numeric suffix from a key like "power1" → 1, "shutter_state" → null.
+ * Used to group shutter orders that share an index.
+ */
+function extractShutterGroupKey(key: string): string | null {
+  // "shutter_state" and "shutter_position" (single shutter) → group "1"
+  // "shutter1_state" and "shutter1_position" → group "1"
+  // "shutter2_state" etc. → group "2"
+  const indexedMatch = /^shutter(\d+)_(state|position|move)$/.exec(key);
+  if (indexedMatch) return indexedMatch[1];
+  const unindexedMatch = /^shutter_(state|position|move)$/.exec(key);
+  if (unindexedMatch) return "1";
+  return null;
+}
+
+/**
+ * Build binding candidates for an equipment type against a device's data/orders.
+ */
+export function computeBindingCandidates(
+  equipmentType: EquipmentType,
+  deviceData: readonly DeviceData[],
+  deviceOrders: readonly DeviceOrder[],
+): BindingCandidate[] {
+  switch (equipmentType) {
+    case "pool_pump":
+    case "switch":
+    case "light_onoff":
+    case "water_valve": {
+      // One candidate per ON/OFF enum order; attach matching data if same key.
+      const candidates: BindingCandidate[] = [];
+      for (const o of deviceOrders) {
+        if (!isOnOffEnum(o)) continue;
+        const matchingData = deviceData.find((d) => d.key === o.key);
+        candidates.push({
+          id: o.key,
+          label: o.key,
+          dataKeys: matchingData ? [matchingData.key] : [],
+          orderKeys: [o.key],
+        });
+      }
+      return candidates;
+    }
+
+    case "pool_cover":
+    case "shutter": {
+      // Group orders by shutter index (e.g. shutter_state + shutter_position).
+      const byGroup = new Map<string, { dataKeys: string[]; orderKeys: string[] }>();
+      for (const o of deviceOrders) {
+        const g = extractShutterGroupKey(o.key);
+        if (!g) continue;
+        const entry = byGroup.get(g) ?? { dataKeys: [], orderKeys: [] };
+        entry.orderKeys.push(o.key);
+        byGroup.set(g, entry);
+      }
+      for (const d of deviceData) {
+        const g = extractShutterGroupKey(d.key);
+        if (!g) continue;
+        const entry = byGroup.get(g) ?? { dataKeys: [], orderKeys: [] };
+        entry.dataKeys.push(d.key);
+        byGroup.set(g, entry);
+      }
+      const candidates: BindingCandidate[] = [];
+      for (const [g, entry] of byGroup) {
+        if (entry.orderKeys.length === 0) continue;
+        candidates.push({
+          id: `shutter${g}`,
+          label: g === "1" ? "Shutter" : `Shutter ${g}`,
+          dataKeys: entry.dataKeys,
+          orderKeys: entry.orderKeys,
+        });
+      }
+      return candidates;
+    }
+
+    case "light_dimmable":
+    case "light_color": {
+      // A dimmable/color light candidate = ON/OFF order + attached brightness (and optionally color temp/color).
+      const candidates: BindingCandidate[] = [];
+      const brightnessOrders = deviceOrders.filter((o) => o.key.includes("brightness"));
+      const colorTempOrders = deviceOrders.filter(
+        (o) => o.key.includes("color_temp") || o.key.includes("color_temperature"),
+      );
+      const colorOrders = deviceOrders.filter(
+        (o) => o.key === "color" || (o.key.includes("color_") && !colorTempOrders.includes(o)),
+      );
+      for (const o of deviceOrders) {
+        if (!isOnOffEnum(o)) continue;
+        const dataKeys: string[] = [];
+        const orderKeys = [o.key];
+        const matchingData = deviceData.find((d) => d.key === o.key);
+        if (matchingData) dataKeys.push(matchingData.key);
+        for (const b of brightnessOrders) {
+          orderKeys.push(b.key);
+          const bd = deviceData.find((d) => d.key === b.key);
+          if (bd) dataKeys.push(bd.key);
+        }
+        if (equipmentType === "light_color") {
+          for (const ct of colorTempOrders) orderKeys.push(ct.key);
+          for (const c of colorOrders) orderKeys.push(c.key);
+        }
+        candidates.push({ id: o.key, label: o.key, dataKeys, orderKeys });
+      }
+      return candidates;
+    }
+
+    case "sensor":
+    case "weather":
+    case "weather_forecast":
+    case "energy_meter":
+    case "main_energy_meter":
+    case "energy_production_meter":
+    case "button":
+    case "appliance":
+    case "media_player": {
+      // Multi-value equipment: single candidate that groups everything.
+      if (deviceData.length === 0 && deviceOrders.length === 0) return [];
+      return [
+        {
+          id: "all",
+          label: "All data/orders",
+          dataKeys: deviceData.map((d) => d.key),
+          orderKeys: deviceOrders.map((o) => o.key),
+        },
+      ];
+    }
+
+    case "thermostat":
+    case "heater": {
+      // Single candidate grouping everything (power/setpoint/temperature).
+      if (deviceData.length === 0 && deviceOrders.length === 0) return [];
+      return [
+        {
+          id: "all",
+          label: "All thermostat data/orders",
+          dataKeys: deviceData.map((d) => d.key),
+          orderKeys: deviceOrders.map((o) => o.key),
+        },
+      ];
+    }
+
+    case "gate": {
+      // One candidate per gate-trigger-like order.
+      const candidates: BindingCandidate[] = [];
+      for (const o of deviceOrders) {
+        candidates.push({
+          id: o.key,
+          label: o.key,
+          dataKeys: deviceData.filter((d) => d.key === o.key).map((d) => d.key),
+          orderKeys: [o.key],
+        });
+      }
+      if (candidates.length === 0 && deviceData.length > 0) {
+        candidates.push({
+          id: "all",
+          label: "All gate data",
+          dataKeys: deviceData.map((d) => d.key),
+          orderKeys: [],
+        });
+      }
+      return candidates;
+    }
+
+    default: {
+      // Fallback: single "all" candidate.
+      if (deviceData.length === 0 && deviceOrders.length === 0) return [];
+      return [
+        {
+          id: "all",
+          label: "All data/orders",
+          dataKeys: deviceData.map((d) => d.key),
+          orderKeys: deviceOrders.map((o) => o.key),
+        },
+      ];
+    }
+  }
+}
+
+/**
+ * Returns true when the given device exposes at least one binding candidate
+ * for the equipment type whose order keys are not yet consumed by an existing
+ * binding. Used by the UI to hide devices that have nothing left to offer.
+ *
+ * `boundOrderKeysOnDevice` is the set of device_order keys (NOT ids) currently
+ * bound on the device — typically derived from joining `order_bindings` with
+ * `device_orders` by deviceId.
+ */
+export function hasFreeCandidates(
+  equipmentType: EquipmentType,
+  deviceData: readonly DeviceData[],
+  deviceOrders: readonly DeviceOrder[],
+  boundOrderKeysOnDevice: ReadonlySet<string>,
+): boolean {
+  const candidates = computeBindingCandidates(equipmentType, deviceData, deviceOrders);
+  if (candidates.length === 0) return false;
+  return candidates.some((c) => {
+    if (c.orderKeys.length === 0) {
+      // Pure-data candidate (e.g. sensor): treat as free unless every dataKey is
+      // implicitly already used. We don't track data-bound state here because
+      // re-binding the same data alias is allowed for sensors. Return true.
+      return true;
+    }
+    return c.orderKeys.some((k) => !boundOrderKeysOnDevice.has(k));
+  });
+}
+
+/**
+ * Infer a per-binding category override for an order bound to a given equipment type.
+ * Returns null when no override should be applied (the device_order.category is used as-is).
+ */
+export function inferBindingCategory(
+  equipmentType: EquipmentType,
+  order: Pick<DeviceOrder, "type" | "enumValues" | "min" | "max">,
+): OrderCategory | null {
+  if (equipmentType === "pool_pump") {
+    if (
+      order.type === "enum" &&
+      order.enumValues &&
+      order.enumValues.every((v) => ONOFF_TOKENS.has(v.toUpperCase()))
+    ) {
+      return "pool_pump_toggle";
+    }
+    return null;
+  }
+
+  if (equipmentType === "pool_cover") {
+    if (order.type === "enum" && order.enumValues) {
+      const upper = order.enumValues.map((v) => v.toUpperCase());
+      if (upper.some((v) => OPEN_CLOSE_STOP_TOKENS.has(v)) && upper.includes("OPEN")) {
+        return "pool_cover_move";
+      }
+    }
+    if (order.type === "number") {
+      return "pool_cover_position";
+    }
+    return null;
+  }
+
+  return null;
+}

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -18,6 +18,7 @@ function createTestDb(): Database.Database {
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
   ]) {
     db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
   }
@@ -747,5 +748,168 @@ describe("EquipmentManager", () => {
       const batteryBinding = detail?.dataBindings.find((b) => b.alias === "battery");
       expect(batteryBinding?.enumValues).toBeUndefined();
     });
+  });
+
+  // ============================================================
+  // Pool equipments — category override + virtual cover_state
+  // ============================================================
+
+  describe("pool category overrides", () => {
+    it("addOrderBinding on pool_pump persists pool_pump_toggle override", () => {
+      const zone = zoneManager.create({ name: "Piscine" });
+      const eq = manager.create({ name: "Pompe", type: "pool_pump", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        orderKeys: [{ key: "R1", type: "enum", enumValues: ["ON", "OFF"] }],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      const details = manager.getByIdWithDetails(eq.id);
+      expect(details!.orderBindings[0].category).toBe("pool_pump_toggle");
+    });
+
+    it("addOrderBinding on plain switch keeps device order category (no override)", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Lampe", type: "switch", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        orderKeys: [
+          { key: "R1", type: "enum", category: "toggle_power", enumValues: ["ON", "OFF"] },
+        ],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      const details = manager.getByIdWithDetails(eq.id);
+      expect(details!.orderBindings[0].category).toBe("toggle_power");
+    });
+
+    it("update({type: pool_pump}) re-tags existing binding to pool_pump_toggle", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Relais", type: "switch", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        orderKeys: [
+          { key: "R1", type: "enum", category: "toggle_power", enumValues: ["ON", "OFF"] },
+        ],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      manager.update(eq.id, { type: "pool_pump" });
+      const details = manager.getByIdWithDetails(eq.id);
+      expect(details!.orderBindings[0].category).toBe("pool_pump_toggle");
+    });
+
+    it("update({type: switch}) clears pool_pump override (back to device order category)", () => {
+      const zone = zoneManager.create({ name: "Piscine" });
+      const eq = manager.create({ name: "Pompe", type: "pool_pump", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        orderKeys: [
+          { key: "R1", type: "enum", category: "toggle_power", enumValues: ["ON", "OFF"] },
+        ],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      manager.update(eq.id, { type: "switch" });
+      const details = manager.getByIdWithDetails(eq.id);
+      expect(details!.orderBindings[0].category).toBe("toggle_power");
+    });
+  });
+
+  describe("pool_cover virtual cover_state binding", () => {
+    function setupCover(positionValue: string | null) {
+      const zone = zoneManager.create({ name: "Piscine" });
+      const eq = manager.create({ name: "Volet", type: "pool_cover", zoneId: zone.id });
+      const { dataIds } = seedDevice(db, {
+        dataKeys: [
+          {
+            key: "shutter_position",
+            type: "number",
+            category: "shutter_position",
+            value: positionValue,
+          },
+        ],
+      });
+      manager.addDataBinding(eq.id, dataIds[0], "position");
+      return eq;
+    }
+
+    it("position=2 → CLOSED", () => {
+      const eq = setupCover("2");
+      const bindings = manager.getDataBindingsWithValues(eq.id);
+      const cover = bindings.find((b) => b.alias === "cover_state");
+      expect(cover?.value).toBe("CLOSED");
+    });
+
+    it("position=50 → PARTIAL", () => {
+      const eq = setupCover("50");
+      const bindings = manager.getDataBindingsWithValues(eq.id);
+      const cover = bindings.find((b) => b.alias === "cover_state");
+      expect(cover?.value).toBe("PARTIAL");
+    });
+
+    it("position=98 → OPEN", () => {
+      const eq = setupCover("98");
+      const bindings = manager.getDataBindingsWithValues(eq.id);
+      const cover = bindings.find((b) => b.alias === "cover_state");
+      expect(cover?.value).toBe("OPEN");
+    });
+
+    it("position=null → null", () => {
+      const eq = setupCover(null);
+      const bindings = manager.getDataBindingsWithValues(eq.id);
+      const cover = bindings.find((b) => b.alias === "cover_state");
+      expect(cover?.value).toBe(null);
+    });
+  });
+});
+
+// ============================================================
+// deriveCoverState (pure helper)
+// ============================================================
+
+describe("deriveCoverState", () => {
+  function pos(value: unknown) {
+    return {
+      id: "x",
+      equipmentId: "x",
+      deviceDataId: "x",
+      alias: "position",
+      deviceId: "x",
+      deviceName: "x",
+      key: "x",
+      type: "number" as const,
+      category: "shutter_position" as const,
+      value,
+      lastUpdated: null,
+      lastChanged: null,
+    };
+  }
+
+  it("position 0 → CLOSED", async () => {
+    const { deriveCoverState } = await import("./equipment-manager.js");
+    expect(deriveCoverState(pos(0))).toBe("CLOSED");
+  });
+
+  it("position 100 → OPEN", async () => {
+    const { deriveCoverState } = await import("./equipment-manager.js");
+    expect(deriveCoverState(pos(100))).toBe("OPEN");
+  });
+
+  it("position 50 → PARTIAL", async () => {
+    const { deriveCoverState } = await import("./equipment-manager.js");
+    expect(deriveCoverState(pos(50))).toBe("PARTIAL");
+  });
+
+  it("position 3 (tolerance) → CLOSED", async () => {
+    const { deriveCoverState } = await import("./equipment-manager.js");
+    expect(deriveCoverState(pos(3))).toBe("CLOSED");
+  });
+
+  it("position 97 (tolerance) → OPEN", async () => {
+    const { deriveCoverState } = await import("./equipment-manager.js");
+    expect(deriveCoverState(pos(97))).toBe("OPEN");
+  });
+
+  it("undefined / null position → null", async () => {
+    const { deriveCoverState } = await import("./equipment-manager.js");
+    expect(deriveCoverState(undefined)).toBe(null);
+    expect(deriveCoverState(pos(null))).toBe(null);
   });
 });

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -18,6 +18,7 @@ import type {
   DataCategory,
   OrderCategory,
 } from "../shared/types.js";
+import { inferBindingCategory } from "./binding-candidates.js";
 
 /** A function that returns computed data entries for a given equipment. */
 export type ComputedDataProvider = (equipmentId: string) => ComputedDataEntry[];
@@ -45,6 +46,8 @@ const VALID_EQUIPMENT_TYPES: Set<string> = new Set([
   "media_player",
   "appliance",
   "water_valve",
+  "pool_pump",
+  "pool_cover",
 ]);
 
 // ============================================================
@@ -192,8 +195,18 @@ export class EquipmentManager {
 
       // OrderBinding
       insertOrderBinding: this.db.prepare(
-        `INSERT INTO order_bindings (id, equipment_id, device_order_id, alias)
-         VALUES (@id, @equipmentId, @deviceOrderId, @alias)`,
+        `INSERT INTO order_bindings (id, equipment_id, device_order_id, alias, category_override)
+         VALUES (@id, @equipmentId, @deviceOrderId, @alias, @categoryOverride)`,
+      ),
+      updateOrderBindingCategoryOverride: this.db.prepare(
+        `UPDATE order_bindings SET category_override = ? WHERE id = ?`,
+      ),
+      getOrderBindingsByEquipmentWithOrder: this.db.prepare(
+        `SELECT ob.id, ob.equipment_id, ob.device_order_id, ob.alias,
+                do2.type, do2.enum_values, do2.min_value, do2.max_value
+         FROM order_bindings ob
+         JOIN device_orders do2 ON ob.device_order_id = do2.id
+         WHERE ob.equipment_id = ?`,
       ),
       deleteOrderBinding: this.db.prepare("DELETE FROM order_bindings WHERE id = ?"),
       getOrderBindingById: this.db.prepare("SELECT * FROM order_bindings WHERE id = ?"),
@@ -203,7 +216,8 @@ export class EquipmentManager {
       getOrderBindingsWithDetails: this.db.prepare(
         `SELECT ob.id, ob.equipment_id, ob.device_order_id, ob.alias,
                 do2.device_id, d.name as device_name, do2.key, do2.type,
-                do2.category, do2.min_value, do2.max_value,
+                COALESCE(ob.category_override, do2.category) as category,
+                do2.min_value, do2.max_value,
                 do2.enum_values, do2.unit
          FROM order_bindings ob
          JOIN device_orders do2 ON ob.device_order_id = do2.id
@@ -213,7 +227,8 @@ export class EquipmentManager {
       getOrderBindingsByAlias: this.db.prepare(
         `SELECT ob.id, ob.equipment_id, ob.device_order_id, ob.alias,
                 do2.device_id, d.name as device_name, do2.key, do2.type,
-                do2.category, do2.min_value, do2.max_value,
+                COALESCE(ob.category_override, do2.category) as category,
+                do2.min_value, do2.max_value,
                 do2.enum_values, do2.unit
          FROM order_bindings ob
          JOIN device_orders do2 ON ob.device_order_id = do2.id
@@ -233,6 +248,9 @@ export class EquipmentManager {
       checkZoneExists: this.db.prepare("SELECT id FROM zones WHERE id = ?"),
       checkDeviceDataExists: this.db.prepare("SELECT id FROM device_data WHERE id = ?"),
       checkDeviceOrderExists: this.db.prepare("SELECT id FROM device_orders WHERE id = ?"),
+      getDeviceOrderById: this.db.prepare(
+        "SELECT id, device_id, key, type, category, min_value, max_value, enum_values, unit FROM device_orders WHERE id = ?",
+      ),
     };
   }
 
@@ -388,9 +406,39 @@ export class EquipmentManager {
     });
 
     const equipment = this.getById(id)!;
+
+    // If the equipment type changed, re-infer category overrides on all order bindings
+    // so that recipes / zone orders targeting pool-specific categories stay consistent.
+    if (input.type !== undefined && input.type !== existing.type) {
+      this.retagOrderBindingOverrides(id, equipment.type);
+    }
+
     this.logger.info({ equipmentId: id, name: equipment.name }, "Equipment updated");
     this.eventBus.emit({ type: "equipment.updated", equipment });
     return equipment;
+  }
+
+  /**
+   * Recompute `category_override` for all order bindings of an equipment based on its
+   * current type. Called when the equipment type changes.
+   */
+  private retagOrderBindingOverrides(equipmentId: string, equipmentType: EquipmentType): void {
+    const rows = this.stmts.getOrderBindingsByEquipmentWithOrder.all(equipmentId) as Array<{
+      id: string;
+      type: string;
+      enum_values: string | null;
+      min_value: number | null;
+      max_value: number | null;
+    }>;
+    for (const row of rows) {
+      const override = inferBindingCategory(equipmentType, {
+        type: row.type as DataType,
+        enumValues: row.enum_values ? (JSON.parse(row.enum_values) as string[]) : undefined,
+        min: row.min_value ?? undefined,
+        max: row.max_value ?? undefined,
+      });
+      this.stmts.updateOrderBindingCategoryOverride.run(override, row.id);
+    }
   }
 
   delete(id: string): void {
@@ -461,6 +509,13 @@ export class EquipmentManager {
       bindings.unshift(this.buildGateStateBinding(equipmentId, state));
     }
 
+    // Inject virtual cover state binding for pool_cover.
+    if (equipment?.type === "pool_cover") {
+      const positionBinding = bindings.find((b) => b.category === "shutter_position");
+      const state = deriveCoverState(positionBinding);
+      bindings.unshift(this.buildCoverStateBinding(equipmentId, state));
+    }
+
     return bindings;
   }
 
@@ -475,16 +530,36 @@ export class EquipmentManager {
   // ============================================================
 
   addOrderBinding(equipmentId: string, deviceOrderId: string, alias: string): OrderBinding {
-    if (!this.getById(equipmentId)) {
+    const equipment = this.getById(equipmentId);
+    if (!equipment) {
       throw new EquipmentError("Equipment not found", 404);
     }
     if (!this.stmts.checkDeviceOrderExists.get(deviceOrderId)) {
       throw new EquipmentError(`DeviceOrder not found: ${deviceOrderId}`, 404);
     }
 
+    // Compute category override based on equipment type + device order shape.
+    const orderRow = this.stmts.getDeviceOrderById.get(deviceOrderId) as DeviceOrderRow | undefined;
+    const categoryOverride = orderRow
+      ? inferBindingCategory(equipment.type, {
+          type: orderRow.type as DataType,
+          enumValues: orderRow.enum_values
+            ? (JSON.parse(orderRow.enum_values) as string[])
+            : undefined,
+          min: orderRow.min_value ?? undefined,
+          max: orderRow.max_value ?? undefined,
+        })
+      : null;
+
     const id = randomUUID();
     try {
-      this.stmts.insertOrderBinding.run({ id, equipmentId, deviceOrderId, alias });
+      this.stmts.insertOrderBinding.run({
+        id,
+        equipmentId,
+        deviceOrderId,
+        alias,
+        categoryOverride,
+      });
     } catch (err) {
       if (err instanceof Error && err.message.includes("UNIQUE constraint")) {
         throw new EquipmentError(
@@ -495,7 +570,7 @@ export class EquipmentManager {
       throw err;
     }
 
-    this.logger.info({ equipmentId, alias, deviceOrderId }, "OrderBinding added");
+    this.logger.info({ equipmentId, alias, deviceOrderId, categoryOverride }, "OrderBinding added");
     return { id, equipmentId, deviceOrderId, alias };
   }
 
@@ -910,6 +985,28 @@ export class EquipmentManager {
     };
   }
 
+  /** Build a virtual DataBindingWithValue for pool cover state. */
+  private buildCoverStateBinding(
+    equipmentId: string,
+    state: "OPEN" | "CLOSED" | "PARTIAL" | null,
+  ): DataBindingWithValue {
+    return {
+      id: `virtual:cover_state:${equipmentId}`,
+      equipmentId,
+      deviceDataId: "",
+      alias: "cover_state",
+      deviceId: "",
+      deviceName: "",
+      key: "cover_state",
+      type: "enum" as DataType,
+      category: "cover_state" as DataCategory,
+      value: state,
+      unit: undefined,
+      lastUpdated: new Date().toISOString(),
+      lastChanged: new Date().toISOString(),
+    };
+  }
+
   // ============================================================
   // Reactive pipeline: device.data.updated -> equipment.data.changed
   // ============================================================
@@ -968,6 +1065,31 @@ export class EquipmentManager {
       }
     }
   }
+}
+
+// ============================================================
+// Pool cover state derivation
+// ============================================================
+
+/**
+ * Derive a discrete cover state from the position binding (0..100 %).
+ * Returns null when the position is unknown.
+ *
+ * Bucketing follows the shutter convention: ≤5 % → CLOSED, ≥95 % → OPEN,
+ * anything in between → PARTIAL. We don't model MOVING here because Tasmota
+ * doesn't always emit a direction signal.
+ */
+export function deriveCoverState(
+  positionBinding: DataBindingWithValue | undefined,
+): "OPEN" | "CLOSED" | "PARTIAL" | null {
+  if (!positionBinding || positionBinding.value === null || positionBinding.value === undefined) {
+    return null;
+  }
+  const p = Number(positionBinding.value);
+  if (Number.isNaN(p)) return null;
+  if (p <= 5) return "CLOSED";
+  if (p >= 95) return "OPEN";
+  return "PARTIAL";
 }
 
 // ============================================================
@@ -1038,6 +1160,18 @@ interface OrderBindingJoinRow {
   alias: string;
   device_id: string;
   device_name: string;
+  key: string;
+  type: string;
+  category: string | null;
+  min_value: number | null;
+  max_value: number | null;
+  enum_values: string | null;
+  unit: string | null;
+}
+
+interface DeviceOrderRow {
+  id: string;
+  device_id: string;
   key: string;
   type: string;
   category: string | null;

--- a/src/equipments/pool-runtime-tracker.test.ts
+++ b/src/equipments/pool-runtime-tracker.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { EquipmentManager } from "./equipment-manager.js";
+import { PoolRuntimeTracker } from "./pool-runtime-tracker.js";
+import { DeviceManager } from "../devices/device-manager.js";
+import { ZoneManager } from "../zones/zone-manager.js";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  for (const file of [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+    "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
+  ]) {
+    db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
+  }
+  return db;
+}
+
+const logger = createLogger("silent").logger;
+
+function todayLocalString(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+describe("PoolRuntimeTracker", () => {
+  let db: Database.Database;
+  let eventBus: EventBus;
+  let zoneManager: ZoneManager;
+  let equipmentManager: EquipmentManager;
+  let tracker: PoolRuntimeTracker;
+  let deviceManager: DeviceManager;
+
+  beforeEach(() => {
+    db = createTestDb();
+    eventBus = new EventBus(logger);
+    zoneManager = new ZoneManager(db, eventBus, logger);
+    deviceManager = new DeviceManager(db, eventBus, logger);
+    equipmentManager = new EquipmentManager(
+      db,
+      eventBus,
+      { getById: () => null, dispatchOrder: async () => {} } as any,
+      deviceManager,
+      logger,
+    );
+  });
+
+  afterEach(() => {
+    tracker?.stop();
+    db.close();
+    vi.useRealTimers();
+  });
+
+  function createPump(): string {
+    const zone = zoneManager.create({ name: "Piscine" });
+    return equipmentManager.create({ name: "Pompe", type: "pool_pump", zoneId: zone.id }).id;
+  }
+
+  function startTracker(): void {
+    tracker = new PoolRuntimeTracker(db, eventBus, equipmentManager, logger);
+    tracker.start();
+  }
+
+  it("OFF → ON records stateSince but adds no time yet", () => {
+    const eqId = createPump();
+    startTracker();
+
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eqId,
+      alias: "state",
+      value: "OFF",
+      previous: null,
+    });
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eqId,
+      alias: "state",
+      value: "ON",
+      previous: "OFF",
+    });
+
+    expect(tracker.getRuntime(eqId)).toBeGreaterThanOrEqual(0);
+    expect(tracker.getRuntime(eqId)).toBeLessThan(2); // basically 0
+  });
+
+  it("ON → OFF after 60s accumulates ~60s", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-19T12:00:00"));
+    const eqId = createPump();
+    startTracker();
+
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eqId,
+      alias: "state",
+      value: "OFF",
+      previous: null,
+    });
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eqId,
+      alias: "state",
+      value: "ON",
+      previous: "OFF",
+    });
+
+    vi.setSystemTime(new Date("2026-04-19T12:01:00")); // +60s
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eqId,
+      alias: "state",
+      value: "OFF",
+      previous: "ON",
+    });
+
+    expect(tracker.getRuntime(eqId)).toBe(60);
+  });
+
+  it("multiple ON/OFF cycles accumulate correctly", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-19T08:00:00"));
+    const eqId = createPump();
+    startTracker();
+
+    // Initial OFF state
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eqId,
+      alias: "state",
+      value: "OFF",
+      previous: null,
+    });
+
+    // Cycle 1: ON for 30s
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eqId,
+      alias: "state",
+      value: "ON",
+      previous: "OFF",
+    });
+    vi.setSystemTime(new Date("2026-04-19T08:00:30"));
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eqId,
+      alias: "state",
+      value: "OFF",
+      previous: "ON",
+    });
+
+    // Cycle 2: ON for 90s
+    vi.setSystemTime(new Date("2026-04-19T08:01:00"));
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eqId,
+      alias: "state",
+      value: "ON",
+      previous: "OFF",
+    });
+    vi.setSystemTime(new Date("2026-04-19T08:02:30"));
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eqId,
+      alias: "state",
+      value: "OFF",
+      previous: "ON",
+    });
+
+    expect(tracker.getRuntime(eqId)).toBe(120);
+  });
+
+  it("startup with stale last_reset_date resets cumulative", () => {
+    const eqId = createPump();
+    // Pre-seed a state with yesterday's date
+    db.prepare(
+      `INSERT INTO pool_runtime_state (equipment_id, current_state, state_since, cumulative_seconds_today, last_reset_date)
+       VALUES (?, 'OFF', ?, 5000, '2025-01-01')`,
+    ).run(eqId, new Date().toISOString());
+
+    startTracker();
+    expect(tracker.getRuntime(eqId)).toBe(0);
+
+    const row = db
+      .prepare(
+        "SELECT cumulative_seconds_today, last_reset_date FROM pool_runtime_state WHERE equipment_id = ?",
+      )
+      .get(eqId) as { cumulative_seconds_today: number; last_reset_date: string };
+    expect(row.cumulative_seconds_today).toBe(0);
+    expect(row.last_reset_date).toBe(todayLocalString());
+  });
+
+  it("ignores events for non-pool_pump equipments", () => {
+    const zone = zoneManager.create({ name: "Salon" });
+    const eq = equipmentManager.create({
+      name: "Switch",
+      type: "switch",
+      zoneId: zone.id,
+    });
+    startTracker();
+
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eq.id,
+      alias: "state",
+      value: "ON",
+      previous: "OFF",
+    });
+
+    expect(tracker.getRuntime(eq.id)).toBe(0);
+  });
+
+  it("equipment.removed deletes the runtime state row", () => {
+    const eqId = createPump();
+    startTracker();
+
+    // Seed an ON event so a state row is created
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eqId,
+      alias: "state",
+      value: "OFF",
+      previous: null,
+    });
+
+    eventBus.emit({
+      type: "equipment.removed",
+      equipmentId: eqId,
+      equipmentName: "Pompe",
+      zoneId: null,
+    });
+
+    const row = db.prepare("SELECT * FROM pool_runtime_state WHERE equipment_id = ?").get(eqId);
+    expect(row).toBeUndefined();
+  });
+});

--- a/src/equipments/pool-runtime-tracker.ts
+++ b/src/equipments/pool-runtime-tracker.ts
@@ -1,0 +1,285 @@
+/**
+ * Pool runtime tracker — accumulates daily ON-time for every pool_pump equipment.
+ *
+ * Listens to `equipment.data.changed` events. When a pool_pump's ON/OFF data
+ * transitions from OFF→ON, records the timestamp. From ON→OFF, adds the elapsed
+ * time to `cumulative_seconds_today`. Persists state in SQLite so the counter
+ * survives restarts. Resets at local midnight via a 60s tick.
+ */
+
+import type Database from "better-sqlite3";
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { ComputedDataEntry } from "../shared/types.js";
+import type { EquipmentManager } from "./equipment-manager.js";
+
+interface PoolRuntimeRow {
+  equipment_id: string;
+  current_state: string;
+  state_since: string;
+  cumulative_seconds_today: number;
+  last_reset_date: string;
+}
+
+interface InMemoryState {
+  equipmentId: string;
+  currentState: "ON" | "OFF" | "UNKNOWN";
+  stateSince: number; // epoch ms
+  cumulativeSecondsToday: number;
+  lastResetDate: string; // YYYY-MM-DD
+}
+
+export class PoolRuntimeTracker {
+  private readonly db: Database.Database;
+  private readonly eventBus: EventBus;
+  private readonly equipmentManager: EquipmentManager;
+  private readonly logger: Logger;
+
+  private readonly state = new Map<string, InMemoryState>();
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private unsubscribeData: (() => void) | null = null;
+  private unsubscribeEqRemoved: (() => void) | null = null;
+  private readonly stmts;
+
+  constructor(
+    db: Database.Database,
+    eventBus: EventBus,
+    equipmentManager: EquipmentManager,
+    logger: Logger,
+  ) {
+    this.db = db;
+    this.eventBus = eventBus;
+    this.equipmentManager = equipmentManager;
+    this.logger = logger.child({ module: "pool-runtime-tracker" });
+    this.stmts = this.prepareStatements();
+  }
+
+  private prepareStatements() {
+    return {
+      upsert: this.db.prepare(
+        `INSERT INTO pool_runtime_state (equipment_id, current_state, state_since, cumulative_seconds_today, last_reset_date)
+         VALUES (@equipmentId, @currentState, @stateSince, @cumulativeSecondsToday, @lastResetDate)
+         ON CONFLICT(equipment_id) DO UPDATE SET
+           current_state = excluded.current_state,
+           state_since = excluded.state_since,
+           cumulative_seconds_today = excluded.cumulative_seconds_today,
+           last_reset_date = excluded.last_reset_date`,
+      ),
+      selectAll: this.db.prepare(`SELECT * FROM pool_runtime_state`),
+      deleteOne: this.db.prepare(`DELETE FROM pool_runtime_state WHERE equipment_id = ?`),
+    };
+  }
+
+  start(): void {
+    this.loadFromDb();
+
+    // Apply a startup reset if any state's lastResetDate is stale.
+    const today = this.localDateString();
+    for (const s of this.state.values()) {
+      if (s.lastResetDate !== today) {
+        s.cumulativeSecondsToday = 0;
+        s.lastResetDate = today;
+        this.persist(s);
+      }
+    }
+
+    // Subscribe to equipment data changes.
+    this.unsubscribeData = this.eventBus.on((event) => {
+      if (event.type !== "equipment.data.changed") return;
+      try {
+        this.handleEquipmentDataChanged(event.equipmentId, event.alias, event.value);
+      } catch (err) {
+        this.logger.error({ err, equipmentId: event.equipmentId }, "pool-runtime: handler error");
+      }
+    });
+
+    this.unsubscribeEqRemoved = this.eventBus.on((event) => {
+      if (event.type !== "equipment.removed") return;
+      this.state.delete(event.equipmentId);
+      this.stmts.deleteOne.run(event.equipmentId);
+    });
+
+    this.intervalId = setInterval(() => this.tick(), 60_000);
+    this.logger.info({ tracked: this.state.size }, "Pool runtime tracker started");
+  }
+
+  stop(): void {
+    if (this.intervalId) clearInterval(this.intervalId);
+    this.intervalId = null;
+    this.unsubscribeData?.();
+    this.unsubscribeEqRemoved?.();
+  }
+
+  /**
+   * Return the cumulative seconds today for the given equipment, including any
+   * currently running ON interval (live value).
+   */
+  getRuntime(equipmentId: string): number {
+    const s = this.state.get(equipmentId);
+    if (!s) return 0;
+    return this.liveCumulative(s);
+  }
+
+  /**
+   * ComputedDataProvider entry: surfaces `runtime_daily` (in seconds) on every
+   * pool_pump equipment, so the UI can display it like any other data binding.
+   * Returns an empty array for any equipment we have no state for.
+   */
+  getComputedDataForEquipment(equipmentId: string): ComputedDataEntry[] {
+    const eq = this.equipmentManager.getById(equipmentId);
+    if (!eq || eq.type !== "pool_pump") return [];
+    const s = this.state.get(equipmentId);
+    const value = s ? this.liveCumulative(s) : 0;
+    return [
+      {
+        alias: "runtime_daily",
+        value,
+        unit: "s",
+        category: "runtime_daily",
+        lastUpdated: new Date().toISOString(),
+      },
+    ];
+  }
+
+  // ────────────────────────────────────────────────────────────────
+
+  private handleEquipmentDataChanged(equipmentId: string, alias: string, value: unknown): void {
+    // Skip our own derived alias to avoid re-entry loops (runtime_daily values
+    // like 0 would otherwise look like an OFF transition and corrupt state).
+    if (alias === "runtime_daily") return;
+
+    const eq = this.equipmentManager.getById(equipmentId);
+    if (!eq || eq.type !== "pool_pump") return;
+
+    // We track the first ON/OFF-like alias of the equipment.
+    if (!this.isOnOffAlias(alias, value)) return;
+
+    const upper = String(value).toUpperCase();
+    const isOn = upper === "ON" || upper === "TRUE" || upper === "1";
+    const isOff = upper === "OFF" || upper === "FALSE" || upper === "0";
+    if (!isOn && !isOff) return;
+
+    let s = this.state.get(equipmentId);
+    if (!s) {
+      s = {
+        equipmentId,
+        currentState: "UNKNOWN",
+        stateSince: Date.now(),
+        cumulativeSecondsToday: 0,
+        lastResetDate: this.localDateString(),
+      };
+      this.state.set(equipmentId, s);
+    }
+
+    const now = Date.now();
+    const nextState = isOn ? "ON" : "OFF";
+
+    // First transition from UNKNOWN — just record the state, no elapsed time counted.
+    if (s.currentState === "UNKNOWN") {
+      s.currentState = nextState;
+      s.stateSince = now;
+      this.persist(s);
+      return;
+    }
+
+    // No change — just refresh timestamp (keep counting smoothly).
+    if (s.currentState === nextState) return;
+
+    if (s.currentState === "ON" && nextState === "OFF") {
+      // Close the ON interval.
+      const elapsedMs = Math.max(0, now - s.stateSince);
+      s.cumulativeSecondsToday += Math.floor(elapsedMs / 1000);
+    }
+
+    s.currentState = nextState;
+    s.stateSince = now;
+    this.persist(s);
+
+    // Emit the updated runtime_daily to keep UI in sync.
+    this.eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId,
+      alias: "runtime_daily",
+      value: this.liveCumulative(s),
+      previous: null,
+    });
+  }
+
+  private isOnOffAlias(_alias: string, value: unknown): boolean {
+    // We accept any alias whose value is an ON/OFF-like string or boolean.
+    if (typeof value === "boolean") return true;
+    if (typeof value === "number") return value === 0 || value === 1;
+    if (typeof value !== "string") return false;
+    const u = value.toUpperCase();
+    return u === "ON" || u === "OFF" || u === "TRUE" || u === "FALSE";
+  }
+
+  private tick(): void {
+    const today = this.localDateString();
+    for (const s of this.state.values()) {
+      if (s.lastResetDate === today) continue;
+
+      // Close any open ON interval (count until end of previous day = start of today at 00:00).
+      if (s.currentState === "ON") {
+        const midnight = this.startOfLocalDayMs(today);
+        const elapsedMs = Math.max(0, midnight - s.stateSince);
+        s.cumulativeSecondsToday += Math.floor(elapsedMs / 1000);
+        // If still ON, resume accounting from midnight.
+        s.stateSince = midnight;
+      }
+      s.cumulativeSecondsToday = 0;
+      s.lastResetDate = today;
+      this.persist(s);
+
+      this.eventBus.emit({
+        type: "equipment.data.changed",
+        equipmentId: s.equipmentId,
+        alias: "runtime_daily",
+        value: 0,
+        previous: null,
+      });
+    }
+  }
+
+  private liveCumulative(s: InMemoryState): number {
+    if (s.currentState !== "ON") return s.cumulativeSecondsToday;
+    const elapsedMs = Math.max(0, Date.now() - s.stateSince);
+    return s.cumulativeSecondsToday + Math.floor(elapsedMs / 1000);
+  }
+
+  private persist(s: InMemoryState): void {
+    this.stmts.upsert.run({
+      equipmentId: s.equipmentId,
+      currentState: s.currentState,
+      stateSince: new Date(s.stateSince).toISOString(),
+      cumulativeSecondsToday: s.cumulativeSecondsToday,
+      lastResetDate: s.lastResetDate,
+    });
+  }
+
+  private loadFromDb(): void {
+    const rows = this.stmts.selectAll.all() as PoolRuntimeRow[];
+    for (const r of rows) {
+      this.state.set(r.equipment_id, {
+        equipmentId: r.equipment_id,
+        currentState: (r.current_state as InMemoryState["currentState"]) ?? "UNKNOWN",
+        stateSince: new Date(r.state_since).getTime(),
+        cumulativeSecondsToday: r.cumulative_seconds_today,
+        lastResetDate: r.last_reset_date,
+      });
+    }
+  }
+
+  private localDateString(d: Date = new Date()): string {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${y}-${m}-${day}`;
+  }
+
+  private startOfLocalDayMs(dateStr: string): number {
+    // dateStr = YYYY-MM-DD local
+    const [y, m, d] = dateStr.split("-").map(Number);
+    return new Date(y, m - 1, d, 0, 0, 0, 0).getTime();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { EventBus } from "./core/event-bus.js";
 import { DeviceManager } from "./devices/device-manager.js";
 import { ZoneManager } from "./zones/zone-manager.js";
 import { EquipmentManager } from "./equipments/equipment-manager.js";
+import { PoolRuntimeTracker } from "./equipments/pool-runtime-tracker.js";
 import { ZoneAggregator } from "./zones/zone-aggregator.js";
 import { SunlightManager } from "./zones/sunlight-manager.js";
 import { RecipeManager } from "./recipes/engine/recipe-manager.js";
@@ -145,6 +146,12 @@ async function main() {
     integrationRegistry,
     deviceManager,
     logger,
+  );
+
+  // 9b. Create Pool Runtime Tracker (accumulates daily ON-time per pool_pump)
+  const poolRuntimeTracker = new PoolRuntimeTracker(db, eventBus, equipmentManager, logger);
+  equipmentManager.registerComputedDataProvider((eqId) =>
+    poolRuntimeTracker.getComputedDataForEquipment(eqId),
   );
 
   // 10. Create Zone Aggregator + Sunlight Manager
@@ -319,6 +326,9 @@ async function main() {
   // 17. Initialize recipe manager (restore persisted instances — after aggregation is ready)
   recipeManager.init();
 
+  // 17b. Start pool runtime tracker (subscribes to equipment.data.changed)
+  poolRuntimeTracker.start();
+
   // 18. Initialize history writer (connects to InfluxDB if configured, subscribes to events)
   historyWriter.init();
 
@@ -380,6 +390,11 @@ async function main() {
       recipeManager.stopAll();
     } catch (err) {
       logger.error({ err }, "Error stopping recipe manager");
+    }
+    try {
+      poolRuntimeTracker.stop();
+    } catch (err) {
+      logger.error({ err }, "Error stopping pool runtime tracker");
     }
     try {
       notificationPublishService.destroy();

--- a/src/modes/calendar-manager.test.ts
+++ b/src/modes/calendar-manager.test.ts
@@ -18,6 +18,7 @@ function createTestDb(): Database.Database {
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),

--- a/src/modes/mode-manager.test.ts
+++ b/src/modes/mode-manager.test.ts
@@ -17,6 +17,7 @@ function createTestDb(): Database.Database {
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),

--- a/src/packages/package-manager.ts
+++ b/src/packages/package-manager.ts
@@ -364,9 +364,30 @@ export class PackageManager {
    * Falls back to local file if remote is unreachable.
    */
   async warmRegistryCache(): Promise<void> {
+    await this.fetchRemoteRegistry(false);
+  }
+
+  /**
+   * Force refresh the remote registry, bypassing the CDN cache. Used by the
+   * "Refresh" button on the Plugins page.
+   */
+  async refreshRegistryNow(): Promise<{ count: number; source: "remote" | "local" }> {
+    const fetched = await this.fetchRemoteRegistry(true);
+    return {
+      count: this.registryCache?.length ?? 0,
+      source: fetched ? "remote" : "local",
+    };
+  }
+
+  /**
+   * Internal: fetch registry.json from GitHub raw. When `force` is true, append
+   * a cache-busting query string so we bypass the raw CDN's 5-min cache.
+   */
+  private async fetchRemoteRegistry(force: boolean): Promise<boolean> {
+    const url = force ? `${REGISTRY_URL}?t=${Date.now()}` : REGISTRY_URL;
     try {
-      const res = await fetch(REGISTRY_URL, {
-        headers: { Accept: "application/json" },
+      const res = await fetch(url, {
+        headers: { Accept: "application/json", ...(force ? { "Cache-Control": "no-cache" } : {}) },
         signal: AbortSignal.timeout(10_000),
       });
       if (res.ok) {
@@ -374,16 +395,16 @@ export class PackageManager {
         if (Array.isArray(entries) && entries.length > 0) {
           this.registryCache = entries;
           this.registryCacheTime = Date.now();
-          this.logger.info({ count: entries.length }, "Remote registry loaded");
-          return;
+          this.logger.info({ count: entries.length, force }, "Remote registry loaded");
+          return true;
         }
       }
     } catch {
       // Remote unreachable — fall back to local
     }
-    // Fallback to bundled local file
     this.readLocalRegistry();
     this.logger.info({ count: this.registryCache?.length ?? 0 }, "Using local registry fallback");
+    return false;
   }
 
   /**

--- a/src/recipes/engine/recipe-manager.test.ts
+++ b/src/recipes/engine/recipe-manager.test.ts
@@ -25,6 +25,7 @@ function createTestDb(): Database.Database {
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
   ];
   for (const file of migrations) {
     const sql = readFileSync(

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -171,4 +171,5 @@ export const WIDGET_FAMILY_TYPES: Record<WidgetFamily, EquipmentType[]> = {
   heating: ["thermostat", "heater"],
   sensors: ["sensor"],
   water: ["water_valve"],
+  pool: ["pool_pump", "pool_cover"],
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,6 +32,8 @@ export type DataCategory =
   | "wind"
   | "action"
   | "gate_state"
+  | "cover_state"
+  | "runtime_daily"
   | "weather_condition"
   | "uv"
   | "solar_radiation"
@@ -56,7 +58,10 @@ export type OrderCategory =
   | "gate_trigger"
   | "valve_toggle"
   | "toggle_mute"
-  | "set_input";
+  | "set_input"
+  | "pool_pump_toggle"
+  | "pool_cover_move"
+  | "pool_cover_position";
 
 // ============================================================
 // Device
@@ -190,7 +195,9 @@ export type EquipmentType =
   | "energy_production_meter"
   | "media_player"
   | "appliance"
-  | "water_valve";
+  | "water_valve"
+  | "pool_pump"
+  | "pool_cover";
 
 export interface Equipment {
   id: string;
@@ -869,7 +876,7 @@ export interface NotificationPublisherWithMappings extends NotificationPublisher
 // Dashboard Widget
 // ============================================================
 
-export type WidgetFamily = "lights" | "shutters" | "heating" | "sensors" | "water";
+export type WidgetFamily = "lights" | "shutters" | "heating" | "sensors" | "water" | "pool";
 
 export interface WidgetConfig {
   /** Sensor widget: list of binding aliases to display (undefined = show all) */

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -19,6 +19,7 @@ function createTestDb(): Database.Database {
     "003_device_order_category.sql",
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
   ]) {
     db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
   }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,5 +1,5 @@
 import type {
-  Device, DeviceData, DeviceWithDetails,
+  Device, DeviceData, DeviceOrder, DeviceWithDetails,
   ZoneWithChildren, Zone, ZoneAggregatedData,
   Equipment, EquipmentType, EquipmentWithDetails,
   DataBinding, OrderBinding,
@@ -281,6 +281,9 @@ export async function deleteUser(id: string): Promise<void> {
 
 export interface DeviceWithData extends Device {
   data: DeviceData[];
+  /** Orders are always returned by the list endpoint — keep backward-compat
+   * with callers that only read `data`. */
+  orders?: DeviceOrder[];
 }
 
 export async function getDevices(): Promise<DeviceWithData[]> {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -594,6 +594,13 @@ export async function getPluginStore(): Promise<PluginManifest[]> {
   return fetchJSON<PluginManifest[]>(`${API_BASE}/plugins/store`);
 }
 
+export async function refreshPluginStore(): Promise<{ count: number; source: "remote" | "local" }> {
+  return fetchJSON<{ count: number; source: "remote" | "local" }>(
+    `${API_BASE}/plugins/store/refresh`,
+    { method: "POST" },
+  );
+}
+
 export async function installPlugin(repo: string): Promise<PluginManifest> {
   return fetchJSON<PluginManifest>(`${API_BASE}/plugins/install`, {
     method: "POST",

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -5,6 +5,8 @@ import {
   Loader2,
   ChevronUp,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
   Square,
   Minus,
   Plus,
@@ -1042,7 +1044,7 @@ function PoolCoverEquipmentWidget({
             className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
             title={t("controls.open")}
           >
-            {executing ? <Loader2 size={16} className="animate-spin" /> : <ChevronUp size={16} strokeWidth={2} />}
+            {executing ? <Loader2 size={16} className="animate-spin" /> : <ChevronLeft size={16} strokeWidth={2} />}
           </button>
           <button
             onClick={() => handleCommand("STOP")}
@@ -1058,7 +1060,7 @@ function PoolCoverEquipmentWidget({
             className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
             title={t("controls.close")}
           >
-            <ChevronDown size={16} strokeWidth={2} />
+            <ChevronRight size={16} strokeWidth={2} />
           </button>
         </div>
       )}

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -959,10 +959,14 @@ function PoolCoverEquipmentWidget({
   const [executing, setExecuting] = useState(false);
   const slider = useSliderOverride();
 
-  // Mirrors ShutterEquipmentWidget — same position display + OPEN/STOP/CLOSE
-  // buttons — but renders the pool-specific PoolCoverIcon.
+  // Lookup by binding category (not by alias) so we work regardless of
+  // whether the binding alias was rewritten to "state"/"position" or kept
+  // the raw plugin key (e.g. shutter_state on legacy Tasmota).
   const positionBinding = equipment.dataBindings.find(
-    (db) => db.category === "shutter_position" || db.alias === "position",
+    (db) =>
+      db.category === "shutter_position" ||
+      db.category === ("position" as never) ||
+      db.alias === "position",
   );
   const devicePosition =
     positionBinding && typeof positionBinding.value === "number"
@@ -970,19 +974,22 @@ function PoolCoverEquipmentWidget({
       : null;
   const position = slider.displayValue(devicePosition);
 
-  const hasState = equipment.orderBindings.some(
-    (ob) => ob.alias === "state" || ob.category === "pool_cover_move",
+  const moveBinding = equipment.orderBindings.find(
+    (ob) => ob.category === "pool_cover_move" || ob.category === "shutter_move",
   );
 
   const handleCommand = async (command: "OPEN" | "STOP" | "CLOSE") => {
-    if (executing || !hasState) return;
+    if (executing || !moveBinding) return;
     setExecuting(true);
     try {
-      await onExecuteOrder("state", command);
+      const enumMatch = moveBinding.enumValues?.find((v) => v.toUpperCase() === command);
+      await onExecuteOrder(moveBinding.alias, enumMatch ?? command);
     } finally {
       setExecuting(false);
     }
   };
+
+  const hasState = !!moveBinding;
 
   return (
     <WidgetCard label={label}>

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -974,9 +974,25 @@ function PoolCoverEquipmentWidget({
       : null;
   const position = slider.displayValue(devicePosition);
 
+  // Find the move-style order binding by, in order:
+  //   1. binding category (pool_cover_move override, or shutter_move legacy)
+  //   2. binding alias (state / shutter_state / shutter1_state / …)
+  //   3. enum values that look like OPEN/CLOSE/STOP
+  // This covers freshly auto-bound pool covers as well as bindings created
+  // before the category-aware aliasing landed.
   const moveBinding = equipment.orderBindings.find(
     (ob) => ob.category === "pool_cover_move" || ob.category === "shutter_move",
-  );
+  )
+    ?? equipment.orderBindings.find(
+      (ob) => ob.alias === "state" || /shutter\d*_state/.test(ob.alias),
+    )
+    ?? equipment.orderBindings.find((ob) => {
+      if (ob.type !== "enum" || !ob.enumValues) return false;
+      const upper = ob.enumValues.map((v) =>
+        typeof v === "string" ? v.toUpperCase() : "",
+      );
+      return upper.includes("OPEN") && upper.includes("CLOSE");
+    });
 
   const handleCommand = async (command: "OPEN" | "STOP" | "CLOSE") => {
     if (executing || !moveBinding) return;

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -956,30 +956,31 @@ function PoolCoverEquipmentWidget({
   onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
 }) {
   const { t } = useTranslation();
-  const [executing, setExecuting] = useState<string | null>(null);
+  const [executing, setExecuting] = useState(false);
+  const slider = useSliderOverride();
 
-  const positionBinding = equipment.dataBindings.find((db) => db.category === "shutter_position");
-  const position = positionBinding && typeof positionBinding.value === "number" ? positionBinding.value : null;
+  // Mirrors ShutterEquipmentWidget — same position display + OPEN/STOP/CLOSE
+  // buttons — but renders the pool-specific PoolCoverIcon.
+  const positionBinding = equipment.dataBindings.find(
+    (db) => db.category === "shutter_position" || db.alias === "position",
+  );
+  const devicePosition =
+    positionBinding && typeof positionBinding.value === "number"
+      ? positionBinding.value
+      : null;
+  const position = slider.displayValue(devicePosition);
 
-  const coverState = equipment.dataBindings.find((db) => db.alias === "cover_state");
-  const stateLabel = coverState?.value === "OPEN"
-    ? t("controls.opened")
-    : coverState?.value === "CLOSED"
-      ? t("controls.closed")
-      : coverState?.value === "PARTIAL" && position !== null
-        ? `${position}%`
-        : "\u2014";
+  const hasState = equipment.orderBindings.some(
+    (ob) => ob.alias === "state" || ob.category === "pool_cover_move",
+  );
 
-  const moveBinding = equipment.orderBindings.find((ob) => ob.category === "pool_cover_move" || ob.alias === "state");
-
-  const handleMove = async (action: "OPEN" | "STOP" | "CLOSE") => {
-    if (!moveBinding || executing) return;
-    setExecuting(action);
+  const handleCommand = async (command: "OPEN" | "STOP" | "CLOSE") => {
+    if (executing || !hasState) return;
+    setExecuting(true);
     try {
-      const enumMatch = moveBinding.enumValues?.find((v) => v.toUpperCase() === action);
-      await onExecuteOrder(moveBinding.alias, enumMatch ?? action);
+      await onExecuteOrder("state", command);
     } finally {
-      setExecuting(null);
+      setExecuting(false);
     }
   };
 
@@ -989,37 +990,52 @@ function PoolCoverEquipmentWidget({
         <div />
         <PoolCoverIcon position={position} />
         <div className="pl-2">
-          <span className="text-[13px] font-medium text-text-secondary px-2 py-0.5 rounded bg-border-light tabular-nums">
-            {stateLabel}
-          </span>
+          {position === null ? (
+            <span className="text-[16px] text-text-tertiary">{"\u2014"}</span>
+          ) : position === 100 ? (
+            <span className="text-[13px] font-medium text-success px-2 py-0.5 rounded bg-success/10">
+              {t("controls.opened")}
+            </span>
+          ) : position === 0 ? (
+            <span className="text-[13px] font-medium text-text-secondary px-2 py-0.5 rounded bg-border-light">
+              {t("controls.closed")}
+            </span>
+          ) : (
+            <div className="flex items-baseline gap-0.5">
+              <span className="text-[16px] font-semibold text-text tabular-nums leading-none">
+                {position}
+              </span>
+              <span className="text-[12px] font-medium text-text-tertiary">%</span>
+            </div>
+          )}
         </div>
       </div>
 
-      {moveBinding && equipment.enabled && (
+      {hasState && equipment.enabled && (
         <div className="flex justify-center gap-3 mt-auto pt-1">
           <button
-            onClick={() => handleMove("OPEN")}
-            disabled={executing !== null}
+            onClick={() => handleCommand("OPEN")}
+            disabled={executing}
             className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
-            title={t("controls.opened")}
+            title={t("controls.open")}
           >
-            {executing === "OPEN" ? <Loader2 size={16} className="animate-spin" /> : <ChevronUp size={16} strokeWidth={2} />}
+            {executing ? <Loader2 size={16} className="animate-spin" /> : <ChevronUp size={16} strokeWidth={2} />}
           </button>
           <button
-            onClick={() => handleMove("STOP")}
-            disabled={executing !== null}
+            onClick={() => handleCommand("STOP")}
+            disabled={executing}
             className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-text-tertiary hover:text-text hover:bg-border-light active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
-            title="Stop"
+            title={t("controls.stop")}
           >
-            {executing === "STOP" ? <Loader2 size={16} className="animate-spin" /> : <Square size={11} strokeWidth={2.5} />}
+            <Square size={11} strokeWidth={2.5} />
           </button>
           <button
-            onClick={() => handleMove("CLOSE")}
-            disabled={executing !== null}
+            onClick={() => handleCommand("CLOSE")}
+            disabled={executing}
             className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
-            title={t("controls.closed")}
+            title={t("controls.close")}
           >
-            {executing === "CLOSE" ? <Loader2 size={16} className="animate-spin" /> : <ChevronDown size={16} strokeWidth={2} />}
+            <ChevronDown size={16} strokeWidth={2} />
           </button>
         </div>
       )}

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -1013,7 +1013,12 @@ function PoolCoverEquipmentWidget({
     <WidgetCard label={label}>
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
-        <PoolCoverIcon position={position} />
+        {/* Nudge up only here — the icon is intrinsically centered in its
+         * viewBox and the dashboard slot reads it slightly low. Mobile
+         * containers center it correctly without this offset. */}
+        <div className="-mt-3">
+          <PoolCoverIcon position={position} />
+        </div>
         <div className="pl-2">
           {position === null ? (
             <span className="text-[16px] text-text-tertiary">{"\u2014"}</span>

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -29,6 +29,9 @@ import {
   SlidingGateIcon,
   GarageDoorIcon,
   EnergyMeterIcon,
+  PoolPumpIcon,
+  PoolCoverIcon,
+  WaterValveWidgetIcon,
 } from "./WidgetIcons";
 import { WeatherForecastWidget } from "./WeatherForecastWidget";
 import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
@@ -51,6 +54,9 @@ export function EquipmentWidget({ widget, equipment, onExecuteOrder }: Equipment
     isHeater,
     isGate,
     isAppliance,
+    isWaterValve,
+    isPoolPump,
+    isPoolCover,
   } = useEquipmentState(equipment);
 
   const label = widget.label || equipment.name;
@@ -64,6 +70,9 @@ export function EquipmentWidget({ widget, equipment, onExecuteOrder }: Equipment
   if (isEnergyMeter) return <EnergyMeterEquipmentWidget label={label} equipment={equipment} />;
   if (isWeatherForecast) return <WeatherForecastWidget label={label} equipment={equipment} />;
   if (isAppliance) return <ApplianceEquipmentWidget label={label} equipment={equipment} />;
+  if (isWaterValve) return <WaterValveEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
+  if (isPoolPump) return <PoolPumpEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
+  if (isPoolCover) return <PoolCoverEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
   if (isSensor) return <SensorEquipmentWidget label={label} equipment={equipment} iconKey={widget.icon} visibleBindings={widget.config?.visibleBindings} />;
 
   return <GenericEquipmentWidget label={label} equipment={equipment} />;
@@ -761,6 +770,259 @@ function ApplianceEquipmentWidget({
           </span>
         )}
       </div>
+    </WidgetCard>
+  );
+}
+
+// ============================================================
+// Water valve equipment widget — pipe icon + ON/OFF toggle
+// ============================================================
+
+function WaterValveEquipmentWidget({
+  label,
+  equipment,
+  onExecuteOrder,
+}: {
+  label: string;
+  equipment: EquipmentWithDetails;
+  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+}) {
+  const { t } = useTranslation();
+  const [executing, setExecuting] = useState(false);
+
+  const stateBinding = equipment.dataBindings.find(
+    (db) => db.alias === "state" || db.category === "light_state",
+  );
+  const isOpen = stateBinding
+    ? stateBinding.value === true || String(stateBinding.value).toUpperCase() === "ON"
+    : false;
+
+  const toggleBinding = equipment.orderBindings.find(
+    (ob) => ob.type === "boolean" || (ob.alias === "state" && ob.type === "enum"),
+  );
+  const hasToggle = !!toggleBinding;
+
+  const handleToggle = async () => {
+    if (executing || !toggleBinding) return;
+    setExecuting(true);
+    try {
+      const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
+      const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
+      const value = toggleBinding.type === "boolean"
+        ? !isOpen
+        : isOpen ? offVal : onVal;
+      await onExecuteOrder(toggleBinding.alias, value);
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  return (
+    <WidgetCard label={label}>
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
+        <div />
+        <WaterValveWidgetIcon open={isOpen} />
+        <div className="flex items-center gap-2 pl-2">
+          <span
+            className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
+              isOpen ? "bg-active/10 text-active" : "bg-border-light text-text-tertiary"
+            }`}
+          >
+            {isOpen ? t("water.open") : t("water.closed")}
+          </span>
+        </div>
+      </div>
+
+      {hasToggle && equipment.enabled && (
+        <div className="flex justify-center gap-3 mt-auto pt-1">
+          <button
+            onClick={handleToggle}
+            disabled={executing}
+            className={`w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed ${
+              isOpen ? "!border-active/40 !text-active !bg-active/5" : ""
+            }`}
+            title={isOpen ? t("controls.turnOff") : t("controls.turnOn")}
+          >
+            {executing ? <Loader2 size={16} className="animate-spin" /> : <Power size={16} strokeWidth={1.5} />}
+          </button>
+        </div>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ============================================================
+// Pool pump equipment widget — ON/OFF toggle + daily runtime
+// ============================================================
+
+function formatRuntime(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${h}h ${String(m).padStart(2, "0")}m`;
+}
+
+function PoolPumpEquipmentWidget({
+  label,
+  equipment,
+  onExecuteOrder,
+}: {
+  label: string;
+  equipment: EquipmentWithDetails;
+  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+}) {
+  const { t } = useTranslation();
+  const [executing, setExecuting] = useState(false);
+
+  const stateBinding = equipment.dataBindings.find(
+    (db) => db.alias === "state" || db.category === "light_state",
+  );
+  const isOn = stateBinding
+    ? stateBinding.value === true || String(stateBinding.value).toUpperCase() === "ON"
+    : false;
+
+  const runtime = equipment.computedData?.find((c) => c.alias === "runtime_daily");
+  const runtimeSeconds = typeof runtime?.value === "number" ? runtime.value : 0;
+
+  const toggleBinding = equipment.orderBindings.find(
+    (ob) => ob.type === "boolean" || (ob.alias === "state" && ob.type === "enum") || ob.category === "pool_pump_toggle",
+  );
+  const hasToggle = !!toggleBinding;
+
+  const handleToggle = async () => {
+    if (executing || !toggleBinding) return;
+    setExecuting(true);
+    try {
+      const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
+      const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
+      const value = toggleBinding.type === "boolean"
+        ? !isOn
+        : isOn ? offVal : onVal;
+      await onExecuteOrder(toggleBinding.alias, value);
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  return (
+    <WidgetCard label={label}>
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
+        <div />
+        <PoolPumpIcon on={isOn} />
+        <div className="flex flex-col items-start gap-1 pl-2">
+          <span
+            className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
+              isOn ? "bg-active/10 text-active" : "bg-border-light text-text-tertiary"
+            }`}
+          >
+            {isOn ? "ON" : "OFF"}
+          </span>
+          <span className="text-[11px] text-text-tertiary tabular-nums font-mono">
+            {formatRuntime(runtimeSeconds)}
+          </span>
+        </div>
+      </div>
+
+      {hasToggle && equipment.enabled && (
+        <div className="flex justify-center gap-3 mt-auto pt-1">
+          <button
+            onClick={handleToggle}
+            disabled={executing}
+            className={`w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed ${
+              isOn ? "!border-active/40 !text-active !bg-active/5" : ""
+            }`}
+            title={isOn ? t("controls.turnOff") : t("controls.turnOn")}
+          >
+            {executing ? <Loader2 size={16} className="animate-spin" /> : <Power size={16} strokeWidth={1.5} />}
+          </button>
+        </div>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ============================================================
+// Pool cover equipment widget — Open/Stop/Close + position
+// ============================================================
+
+function PoolCoverEquipmentWidget({
+  label,
+  equipment,
+  onExecuteOrder,
+}: {
+  label: string;
+  equipment: EquipmentWithDetails;
+  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+}) {
+  const { t } = useTranslation();
+  const [executing, setExecuting] = useState<string | null>(null);
+
+  const positionBinding = equipment.dataBindings.find((db) => db.category === "shutter_position");
+  const position = positionBinding && typeof positionBinding.value === "number" ? positionBinding.value : null;
+
+  const coverState = equipment.dataBindings.find((db) => db.alias === "cover_state");
+  const stateLabel = coverState?.value === "OPEN"
+    ? t("controls.opened")
+    : coverState?.value === "CLOSED"
+      ? t("controls.closed")
+      : coverState?.value === "PARTIAL" && position !== null
+        ? `${position}%`
+        : "\u2014";
+
+  const moveBinding = equipment.orderBindings.find((ob) => ob.category === "pool_cover_move" || ob.alias === "state");
+
+  const handleMove = async (action: "OPEN" | "STOP" | "CLOSE") => {
+    if (!moveBinding || executing) return;
+    setExecuting(action);
+    try {
+      const enumMatch = moveBinding.enumValues?.find((v) => v.toUpperCase() === action);
+      await onExecuteOrder(moveBinding.alias, enumMatch ?? action);
+    } finally {
+      setExecuting(null);
+    }
+  };
+
+  return (
+    <WidgetCard label={label}>
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
+        <div />
+        <PoolCoverIcon position={position} />
+        <div className="pl-2">
+          <span className="text-[13px] font-medium text-text-secondary px-2 py-0.5 rounded bg-border-light tabular-nums">
+            {stateLabel}
+          </span>
+        </div>
+      </div>
+
+      {moveBinding && equipment.enabled && (
+        <div className="flex justify-center gap-3 mt-auto pt-1">
+          <button
+            onClick={() => handleMove("OPEN")}
+            disabled={executing !== null}
+            className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
+            title={t("controls.opened")}
+          >
+            {executing === "OPEN" ? <Loader2 size={16} className="animate-spin" /> : <ChevronUp size={16} strokeWidth={2} />}
+          </button>
+          <button
+            onClick={() => handleMove("STOP")}
+            disabled={executing !== null}
+            className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-text-tertiary hover:text-text hover:bg-border-light active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
+            title="Stop"
+          >
+            {executing === "STOP" ? <Loader2 size={16} className="animate-spin" /> : <Square size={11} strokeWidth={2.5} />}
+          </button>
+          <button
+            onClick={() => handleMove("CLOSE")}
+            disabled={executing !== null}
+            className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
+            title={t("controls.closed")}
+          >
+            {executing === "CLOSE" ? <Loader2 size={16} className="animate-spin" /> : <ChevronDown size={16} strokeWidth={2} />}
+          </button>
+        </div>
+      )}
     </WidgetCard>
   );
 }

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -13,6 +13,9 @@ import {
   SlidingGateIcon,
   GarageDoorIcon,
   PlugWidgetIcon,
+  PoolPumpIcon,
+  PoolCoverIcon,
+  WaterValveWidgetIcon,
 } from "./WidgetIcons";
 import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
 import { parseForecastDays, CONDITION_ICONS, CONDITION_COLORS } from "../equipments/weatherForecastUtils";
@@ -74,6 +77,9 @@ function useMobileState(
     isWeatherForecast,
     isMediaPlayer,
     isAppliance,
+    isWaterValve,
+    isPoolPump,
+    isPoolCover,
     isOn,
   } = useEquipmentState(equipment);
 
@@ -247,6 +253,38 @@ function useMobileState(
         ? createElement(customEntry.component, customEntry.previewProps)
         : <PlugWidgetIcon on={isOn} />,
       stateLines: [isOn ? "ON" : "OFF"],
+    };
+  }
+
+  if (isWaterValve) {
+    return {
+      icon: <WaterValveWidgetIcon open={isOn} />,
+      stateLines: [isOn ? t("water.open") : t("water.closed")],
+    };
+  }
+
+  if (isPoolPump) {
+    return {
+      icon: <PoolPumpIcon on={isOn} />,
+      stateLines: [isOn ? "ON" : "OFF"],
+    };
+  }
+
+  if (isPoolCover) {
+    const pos = equipment.dataBindings.find(
+      (b) => b.category === "shutter_position" || b.alias === "position",
+    );
+    const position = pos && typeof pos.value === "number" ? pos.value : null;
+    const text = position === 100
+      ? t("controls.opened")
+      : position === 0
+        ? t("controls.closed")
+        : position !== null
+          ? `${position}%`
+          : null;
+    return {
+      icon: <PoolCoverIcon position={position} />,
+      stateLines: text ? [text] : [],
     };
   }
 

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -60,7 +60,7 @@ export function EquipmentDetailSheet({ widget, equipment, onExecuteOrder, onClos
     );
   }
 
-  if (isShutter) {
+  if (isShutter || equipment.type === "pool_cover") {
     return (
       <BottomSheet open onClose={onClose} title={label}
         icon={customEntry ? <div className="scale-[0.35]">{createElement(customEntry.component, customEntry.previewProps)}</div> : undefined}
@@ -123,6 +123,7 @@ const WIDGET_FAMILY_TYPES: Record<string, string[]> = {
   heating: ["thermostat", "heater"],
   sensors: ["sensor"],
   water: ["water_valve"],
+  pool: ["pool_pump", "pool_cover"],
 };
 
 function getDescendantZoneIds(zone: ZoneWithChildren): string[] {

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -361,25 +361,26 @@ function ZoneShuttersDetail({
         <button
           onClick={() => onCommand("allShuttersOpen")}
           disabled={commandLoading !== null}
-          className="flex-1 h-12 flex items-center justify-center gap-2 rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
+          className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
+          title={t("zones.commands.allShuttersOpen")}
         >
           {commandLoading === "allShuttersOpen" ? <Loader2 size={18} className="animate-spin" /> : <ChevronUp size={20} strokeWidth={2} />}
-          {t("zones.commands.allShuttersOpen")}
         </button>
         <button
           onClick={() => onCommand("allShuttersStop")}
           disabled={commandLoading !== null}
           className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
+          title={t("zones.commands.allShuttersStop")}
         >
           {commandLoading === "allShuttersStop" ? <Loader2 size={18} className="animate-spin" /> : <Square size={14} strokeWidth={2.5} />}
         </button>
         <button
           onClick={() => onCommand("allShuttersClose")}
           disabled={commandLoading !== null}
-          className="flex-1 h-12 flex items-center justify-center gap-2 rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
+          className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
+          title={t("zones.commands.allShuttersClose")}
         >
           {commandLoading === "allShuttersClose" ? <Loader2 size={18} className="animate-spin" /> : <ChevronDown size={20} strokeWidth={2} />}
-          {t("zones.commands.allShuttersClose")}
         </button>
       </div>
     </div>

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -5,6 +5,8 @@ import {
   Loader2,
   ChevronUp,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
   Square,
   Minus,
   Plus,
@@ -27,6 +29,7 @@ import {
   GateWidgetIcon,
   SlidingGateIcon,
   GarageDoorIcon,
+  PoolCoverIcon,
 } from "./WidgetIcons";
 import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
 import { BottomSheet } from "./BottomSheet";
@@ -687,9 +690,13 @@ function ShutterDetailContent({
 
   return (
     <div className="flex flex-col gap-6">
-      {/* Icon centered */}
+      {/* Icon centered — pool covers get the pool-specific picto */}
       <div className="flex justify-center">
-        <ShutterWidgetIcon level={level} />
+        {equipment.type === "pool_cover" ? (
+          <PoolCoverIcon position={position} />
+        ) : (
+          <ShutterWidgetIcon level={level} />
+        )}
       </div>
 
       {/* Position slider — full width horizontal */}
@@ -712,32 +719,38 @@ function ShutterDetailContent({
         </div>
       )}
 
-      {/* Action buttons — full width */}
-      {hasState && equipment.enabled && (
-        <div className="flex gap-3">
-          <button
-            onClick={() => handleCommand("OPEN")}
-            disabled={executing}
-            className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
-          >
-            <ChevronUp size={20} strokeWidth={2} />
-          </button>
-          <button
-            onClick={() => handleCommand("STOP")}
-            disabled={executing}
-            className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
-          >
-            <Square size={14} strokeWidth={2.5} />
-          </button>
-          <button
-            onClick={() => handleCommand("CLOSE")}
-            disabled={executing}
-            className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
-          >
-            <ChevronDown size={20} strokeWidth={2} />
-          </button>
-        </div>
-      )}
+      {/* Action buttons — full width. Pool covers slide horizontally so we
+       * use ←/→ arrows; window shutters stay with up/down. */}
+      {hasState && equipment.enabled && (() => {
+        const isHorizontal = equipment.type === "pool_cover";
+        const OpenIcon = isHorizontal ? ChevronLeft : ChevronUp;
+        const CloseIcon = isHorizontal ? ChevronRight : ChevronDown;
+        return (
+          <div className="flex gap-3">
+            <button
+              onClick={() => handleCommand("OPEN")}
+              disabled={executing}
+              className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
+            >
+              <OpenIcon size={20} strokeWidth={2} />
+            </button>
+            <button
+              onClick={() => handleCommand("STOP")}
+              disabled={executing}
+              className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
+            >
+              <Square size={14} strokeWidth={2.5} />
+            </button>
+            <button
+              onClick={() => handleCommand("CLOSE")}
+              disabled={executing}
+              className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
+            >
+              <CloseIcon size={20} strokeWidth={2} />
+            </button>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/ui/src/components/dashboard/WidgetGrid.tsx
+++ b/ui/src/components/dashboard/WidgetGrid.tsx
@@ -543,8 +543,13 @@ function getMobileClickAction(
     return onOpenDetail;
   }
 
-  // Simple on/off (light_onoff, switch) → direct toggle
-  if (type === "light_onoff" || type === "switch") {
+  // Simple on/off (light_onoff, switch, pool_pump, water_valve) → direct toggle
+  if (
+    type === "light_onoff" ||
+    type === "switch" ||
+    type === "pool_pump" ||
+    type === "water_valve"
+  ) {
     const stateBinding = equipment.orderBindings.find(
       (ob) => ob.alias === "state" && (ob.type === "enum" || ob.type === "boolean"),
     );

--- a/ui/src/components/dashboard/WidgetGrid.tsx
+++ b/ui/src/components/dashboard/WidgetGrid.tsx
@@ -404,6 +404,7 @@ const ZONE_FAMILY_TYPES: Record<string, string[]> = {
   heating: ["thermostat", "heater"],
   sensors: ["sensor"],
   water: ["water_valve"],
+  pool: ["pool_pump", "pool_cover"],
 };
 
 function getDescendantZoneIds(zone: ZoneWithChildren): string[] {

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -884,15 +884,12 @@ export function PoolCoverIcon({ position }: { position: number | null }) {
               ? 75
               : 100;
 
-  // Layout — pool basin spans x=4..52 horizontally and y=10..46 vertically
-  // inside a 56×56 viewBox, so the icon fills the canvas vertically (no more
-  // empty bands top and bottom) and reads bigger in the dashboard.
-  // Pool is an immersed cover (volet immergé) — no visible roller box on the
-  // side. Slightly elongated landscape shape (less square than before).
-  const POOL_X = 6;
-  const POOL_W = 46;
-  const POOL_Y = 14;
-  const POOL_H = 28;
+  // Layout — pool basin spans almost the whole 56×56 viewBox (immersed cover,
+  // no visible roller). Landscape ratio ~1.6:1.
+  const POOL_X = 3;
+  const POOL_W = 50;
+  const POOL_Y = 12;
+  const POOL_H = 32;
   const SLAT_Y = POOL_Y + 2;
   const SLAT_H = POOL_H - 4;
   const SLAT_X_START = POOL_X + 0.5;
@@ -947,22 +944,42 @@ export function PoolCoverIcon({ position }: { position: number | null }) {
       />
       <line x1={POOL_X} y1={POOL_Y + POOL_H / 2} x2={POOL_X + POOL_W} y2={POOL_Y + POOL_H / 2} stroke="currentColor" strokeWidth="0.6" opacity="0.1" />
 
-      {/* Water waves only past the last slat */}
-      {slatCount < MAX_SLATS && Array.from({ length: 3 }).map((_, i) => {
-        const y = POOL_Y + 6 + i * 8;
-        if (waveStartX > POOL_X + POOL_W - 6) return null;
-        return (
-          <path
-            key={i}
-            d={`M${waveStartX} ${y} Q${waveStartX + 2} ${y - 1} ${waveStartX + 4} ${y} T${waveStartX + 8} ${y} T${waveStartX + 12} ${y} T${waveStartX + 16} ${y}`}
-            stroke="currentColor"
-            strokeWidth="0.8"
-            strokeOpacity="0.35"
-            fill="none"
-            strokeLinecap="round"
-          />
-        );
-      })}
+      {/* Water waves on the uncovered area — extend across the full width
+       * and height of the pool when slats don't cover. */}
+      {slatCount < MAX_SLATS && (() => {
+        const waveEndX = POOL_X + POOL_W - 1.5;
+        const waveAvail = waveEndX - waveStartX;
+        if (waveAvail < 4) return null;
+        const WAVE_PITCH_X = 4; // crest period
+        const WAVE_ROW_PITCH = 5; // vertical spacing
+        const wavesTopY = POOL_Y + 4;
+        const wavesBottomY = POOL_Y + POOL_H - 4;
+        const rows: number[] = [];
+        for (let y = wavesTopY; y <= wavesBottomY; y += WAVE_ROW_PITCH) rows.push(y);
+        const crestCount = Math.floor(waveAvail / WAVE_PITCH_X);
+        return rows.map((y, rowIdx) => {
+          // Phase shift per row for a more natural look
+          const phase = rowIdx * 2;
+          let d = `M${waveStartX} ${y}`;
+          for (let i = 1; i <= crestCount; i++) {
+            const cx = waveStartX + (i - 0.5) * WAVE_PITCH_X;
+            const ex = waveStartX + i * WAVE_PITCH_X;
+            const cy = y + (i % 2 === 0 ? -1 : 1) * (1 - (phase % 2));
+            d += ` Q${cx} ${cy} ${ex} ${y}`;
+          }
+          return (
+            <path
+              key={rowIdx}
+              d={d}
+              stroke="currentColor"
+              strokeWidth="0.7"
+              strokeOpacity="0.35"
+              fill="none"
+              strokeLinecap="round"
+            />
+          );
+        });
+      })()}
 
       {/* Cover slats — vertical, rolling out from the roller. */}
       {Array.from({ length: slatCount }).map((_, i) => (

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -869,7 +869,7 @@ export function PoolPumpIcon({ on }: { on: boolean }) {
 // ============================================================
 
 export function PoolCoverIcon({ position }: { position: number | null }) {
-  // position 0..100, null = unknown.
+  // position 0..100 (% open). null = unknown.
   // Bucketing mirrors the shutter widget: 0/25/50/75/100.
   const bucket =
     position === null
@@ -883,15 +883,41 @@ export function PoolCoverIcon({ position }: { position: number | null }) {
             : position <= 87
               ? 75
               : 100;
-  // Higher position = more cover rolled out = MORE slats visible.
-  // We assume position = % open. So 100% open → no slats; 0% → all slats.
-  // Here we keep the design semantics: slatCount drops with openness.
+
+  // Layout — pool basin spans x=4..52 horizontally and y=10..46 vertically
+  // inside a 56×56 viewBox, so the icon fills the canvas vertically (no more
+  // empty bands top and bottom) and reads bigger in the dashboard.
+  const POOL_X = 10;
+  const POOL_W = 42;
+  const POOL_Y = 10;
+  const POOL_H = 36;
+  const SLAT_Y = POOL_Y + 2;
+  const SLAT_H = POOL_H - 4;
+  const SLAT_X_START = POOL_X + 0.5;
+  const SLAT_X_END = POOL_X + POOL_W - 0.5;
+  const SLAT_PITCH = 3.5;
+  const SLAT_W = 3;
+  const MAX_SLATS = Math.floor((SLAT_X_END - SLAT_X_START - SLAT_W) / SLAT_PITCH) + 1;
+  // OPEN (100%) → no slat ; CLOSED (0%) → enough slats to cover the basin edge
+  // to edge (so no water peeks out past the last slat).
   const slatCount =
-    bucket === 0 ? 9 : bucket === 25 ? 7 : bucket === 50 ? 5 : bucket === 75 ? 3 : 1;
+    bucket === 100
+      ? 0
+      : bucket === 75
+        ? Math.max(1, Math.round(MAX_SLATS * 0.25))
+        : bucket === 50
+          ? Math.round(MAX_SLATS * 0.5)
+          : bucket === 25
+            ? Math.round(MAX_SLATS * 0.75)
+            : MAX_SLATS;
 
   const id = useId();
   const waterGrad = `pool-water-${id}`;
   const slatGrad = `pool-slat-${id}`;
+
+  // Water waves only on the uncovered area (right of the last slat)
+  const lastSlatRight = SLAT_X_START + (slatCount > 0 ? slatCount * SLAT_PITCH : 0);
+  const waveStartX = Math.max(POOL_X + 2, lastSlatRight + 1);
 
   return (
     <svg width="120" height="120" viewBox="0 0 56 56" fill="none" className="text-primary">
@@ -907,30 +933,29 @@ export function PoolCoverIcon({ position }: { position: number | null }) {
       </defs>
 
       {/* Roller housing on the left */}
-      <rect x="3" y="14" width="6" height="28" rx="3" fill="currentColor" opacity="0.2" />
+      <rect x={POOL_X - 6} y={POOL_Y} width="6" height={POOL_H} rx="3" fill="currentColor" opacity="0.2" />
 
       {/* Pool basin */}
       <rect
-        x="9"
-        y="14"
-        width="44"
-        height="28"
+        x={POOL_X}
+        y={POOL_Y}
+        width={POOL_W}
+        height={POOL_H}
         rx="2"
         stroke="currentColor"
         strokeWidth="1.2"
         fill={`url(#${waterGrad})`}
       />
-      <line x1="9" y1="28" x2="53" y2="28" stroke="currentColor" strokeWidth="0.6" opacity="0.1" />
+      <line x1={POOL_X} y1={POOL_Y + POOL_H / 2} x2={POOL_X + POOL_W} y2={POOL_Y + POOL_H / 2} stroke="currentColor" strokeWidth="0.6" opacity="0.1" />
 
-      {/* Water waves on the uncovered area (right of last slat) */}
-      {Array.from({ length: 3 }).map((_, i) => {
-        const y = 21 + i * 7;
-        const startX = 11 + slatCount * 4;
-        if (startX > 50) return null;
+      {/* Water waves only past the last slat */}
+      {slatCount < MAX_SLATS && Array.from({ length: 3 }).map((_, i) => {
+        const y = POOL_Y + 6 + i * 8;
+        if (waveStartX > POOL_X + POOL_W - 6) return null;
         return (
           <path
             key={i}
-            d={`M${startX} ${y} Q${startX + 2} ${y - 1} ${startX + 4} ${y} T${startX + 8} ${y} T${startX + 12} ${y} T${startX + 16} ${y}`}
+            d={`M${waveStartX} ${y} Q${waveStartX + 2} ${y - 1} ${waveStartX + 4} ${y} T${waveStartX + 8} ${y} T${waveStartX + 12} ${y} T${waveStartX + 16} ${y}`}
             stroke="currentColor"
             strokeWidth="0.8"
             strokeOpacity="0.35"
@@ -940,14 +965,14 @@ export function PoolCoverIcon({ position }: { position: number | null }) {
         );
       })}
 
-      {/* Cover slats (vertical, rolling out from the roller) */}
+      {/* Cover slats — vertical, rolling out from the roller. */}
       {Array.from({ length: slatCount }).map((_, i) => (
         <rect
           key={i}
-          x={11 + i * 4}
-          y="16"
-          width="3.5"
-          height="24"
+          x={SLAT_X_START + i * SLAT_PITCH}
+          y={SLAT_Y}
+          width={SLAT_W}
+          height={SLAT_H}
           rx="0.8"
           fill={`url(#${slatGrad})`}
         />

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -796,7 +796,8 @@ export function PoolPumpIcon({ on }: { on: boolean }) {
   // (blue ON, muted grey OFF). Water is only drawn when ON: light-blue inside
   // the pipes + a subtle tint at the bottom of the tank. The ON badge lives
   // in the widget, not here.
-  const waterPipe = on ? "#93C5FD" : "transparent";
+  // OFF: white inner stroke = visually hollow tube on the white card.
+  const waterPipe = on ? "#93C5FD" : "white";
   const waterTank = on ? "#DBEAFE" : "white";
   return (
     <svg

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -890,7 +890,7 @@ export function PoolCoverIcon({ position }: { position: number | null }) {
   // low otherwise).
   const POOL_X = 3;
   const POOL_W = 50;
-  const POOL_Y = 5;
+  const POOL_Y = 12;
   const POOL_H = 32;
   const SLAT_Y = POOL_Y + 2;
   const SLAT_H = POOL_H - 4;

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -887,10 +887,12 @@ export function PoolCoverIcon({ position }: { position: number | null }) {
   // Layout — pool basin spans x=4..52 horizontally and y=10..46 vertically
   // inside a 56×56 viewBox, so the icon fills the canvas vertically (no more
   // empty bands top and bottom) and reads bigger in the dashboard.
-  const POOL_X = 10;
-  const POOL_W = 42;
-  const POOL_Y = 10;
-  const POOL_H = 36;
+  // Pool is an immersed cover (volet immergé) — no visible roller box on the
+  // side. Slightly elongated landscape shape (less square than before).
+  const POOL_X = 6;
+  const POOL_W = 46;
+  const POOL_Y = 14;
+  const POOL_H = 28;
   const SLAT_Y = POOL_Y + 2;
   const SLAT_H = POOL_H - 4;
   const SLAT_X_START = POOL_X + 0.5;
@@ -931,9 +933,6 @@ export function PoolCoverIcon({ position }: { position: number | null }) {
           <stop offset="100%" stopColor="currentColor" stopOpacity="0.65" />
         </linearGradient>
       </defs>
-
-      {/* Roller housing on the left */}
-      <rect x={POOL_X - 6} y={POOL_Y} width="6" height={POOL_H} rx="3" fill="currentColor" opacity="0.2" />
 
       {/* Pool basin */}
       <rect

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -919,7 +919,7 @@ export function PoolCoverIcon({ position }: { position: number | null }) {
   const waveStartX = Math.max(POOL_X + 2, lastSlatRight + 1);
 
   return (
-    <svg width="120" height="120" viewBox="0 0 56 56" fill="none" className="text-primary">
+    <svg width="138" height="138" viewBox="0 0 56 56" fill="none" className="text-primary">
       <defs>
         <linearGradient id={waterGrad} x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor="currentColor" stopOpacity="0.04" />

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -788,6 +788,233 @@ export function EnergyMeterIcon() {
 }
 
 // ============================================================
+// Pool filter pump (Design F) — tank + manometer + junction box
+// ============================================================
+
+export function PoolPumpIcon({ on }: { on: boolean }) {
+  // Pipes flow water (blue) when ON, are hollow (white) when OFF.
+  // Junction box shows "ON" centered when ON, 4 screws when OFF.
+  // Manometer needle pressurized when ON, at rest when OFF.
+  const waterStroke = on ? "#3B82F6" : "white";
+  return (
+    <svg width="120" height="120" viewBox="0 0 56 56" fill="none" className={on ? "text-active" : "text-primary"}>
+      {/* PIPES — outer stroke + inner water/hollow */}
+      <path d="M14 11 L42 11" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+      <path d="M14 11 L42 11" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M14 16 L14 11" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+      <path d="M14 16 L14 11" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M42 11 L42 20" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+      <path d="M42 11 L42 20" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M42 36 L42 49" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+      <path d="M42 36 L42 49" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M3 49 L42 49" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+      <path d="M3 49 L42 49" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M14 45 L14 49" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+      <path d="M14 45 L14 49" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />
+
+      {/* MANOMETER */}
+      <circle cx="28" cy="10" r="5" stroke="currentColor" strokeWidth="1.6" fill="white" />
+      {on ? (
+        <line x1="28" y1="10" x2="30.5" y2="7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      ) : (
+        <line x1="28" y1="10" x2="25" y2="11.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      )}
+      <circle cx="28" cy="10" r="0.9" fill="currentColor" />
+
+      {/* TANK (3-stages, left side) */}
+      <path
+        d="M8 16 Q8 14 10 14 L18 14 Q20 14 20 16 L20 18 L8 18 Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="white"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M8 18 Q5 21 5 25 L5 28 L23 28 L23 25 Q23 21 20 18 Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="white"
+        strokeLinejoin="round"
+      />
+      <rect x="4" y="28" width="20" height="3" rx="0.5" stroke="currentColor" strokeWidth="1.5" fill="white" />
+      <path
+        d="M5 31 L5 41 Q5 45 10 45 L18 45 Q23 45 23 41 L23 31 Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="white"
+        strokeLinejoin="round"
+      />
+      <path d="M9 21 L9 25" stroke="currentColor" strokeWidth="0.6" strokeLinecap="round" opacity="0.5" />
+
+      {/* JUNCTION BOX */}
+      <rect x="34" y="20" width="16" height="16" rx="1" stroke="currentColor" strokeWidth="1.6" fill="white" />
+      {on ? (
+        <text
+          x="42"
+          y="28"
+          fontFamily="-apple-system, sans-serif"
+          fontWeight="800"
+          fontSize="7"
+          textAnchor="middle"
+          dominantBaseline="central"
+          fill="currentColor"
+        >
+          ON
+        </text>
+      ) : (
+        <>
+          <circle cx="37" cy="23" r="0.9" fill="currentColor" />
+          <circle cx="47" cy="23" r="0.9" fill="currentColor" />
+          <circle cx="37" cy="33" r="0.9" fill="currentColor" />
+          <circle cx="47" cy="33" r="0.9" fill="currentColor" />
+        </>
+      )}
+    </svg>
+  );
+}
+
+// ============================================================
+// Pool cover (Design G) — landscape pool + roller + vertical slats
+// ============================================================
+
+export function PoolCoverIcon({ position }: { position: number | null }) {
+  // position 0..100, null = unknown.
+  // Bucketing mirrors the shutter widget: 0/25/50/75/100.
+  const bucket =
+    position === null
+      ? 50
+      : position <= 12
+        ? 0
+        : position <= 37
+          ? 25
+          : position <= 62
+            ? 50
+            : position <= 87
+              ? 75
+              : 100;
+  // Higher position = more cover rolled out = MORE slats visible.
+  // We assume position = % open. So 100% open → no slats; 0% → all slats.
+  // Here we keep the design semantics: slatCount drops with openness.
+  const slatCount =
+    bucket === 0 ? 9 : bucket === 25 ? 7 : bucket === 50 ? 5 : bucket === 75 ? 3 : 1;
+
+  const id = useId();
+  const waterGrad = `pool-water-${id}`;
+  const slatGrad = `pool-slat-${id}`;
+
+  return (
+    <svg width="120" height="120" viewBox="0 0 56 56" fill="none" className="text-primary">
+      <defs>
+        <linearGradient id={waterGrad} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.04" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0.08" />
+        </linearGradient>
+        <linearGradient id={slatGrad} x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.45" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0.65" />
+        </linearGradient>
+      </defs>
+
+      {/* Roller housing on the left */}
+      <rect x="3" y="14" width="6" height="28" rx="3" fill="currentColor" opacity="0.2" />
+
+      {/* Pool basin */}
+      <rect
+        x="9"
+        y="14"
+        width="44"
+        height="28"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        fill={`url(#${waterGrad})`}
+      />
+      <line x1="9" y1="28" x2="53" y2="28" stroke="currentColor" strokeWidth="0.6" opacity="0.1" />
+
+      {/* Water waves on the uncovered area (right of last slat) */}
+      {Array.from({ length: 3 }).map((_, i) => {
+        const y = 21 + i * 7;
+        const startX = 11 + slatCount * 4;
+        if (startX > 50) return null;
+        return (
+          <path
+            key={i}
+            d={`M${startX} ${y} Q${startX + 2} ${y - 1} ${startX + 4} ${y} T${startX + 8} ${y} T${startX + 12} ${y} T${startX + 16} ${y}`}
+            stroke="currentColor"
+            strokeWidth="0.8"
+            strokeOpacity="0.35"
+            fill="none"
+            strokeLinecap="round"
+          />
+        );
+      })}
+
+      {/* Cover slats (vertical, rolling out from the roller) */}
+      {Array.from({ length: slatCount }).map((_, i) => (
+        <rect
+          key={i}
+          x={11 + i * 4}
+          y="16"
+          width="3.5"
+          height="24"
+          rx="0.8"
+          fill={`url(#${slatGrad})`}
+        />
+      ))}
+    </svg>
+  );
+}
+
+// ============================================================
+// Water valve (widget) — gate valve with handle position + flow
+// ============================================================
+
+export function WaterValveWidgetIcon({ open }: { open: boolean }) {
+  // Pipe horizontal across the bottom; valve body in the center; handle
+  // horizontal when OPEN, vertical when CLOSED. Water flow visible only
+  // when OPEN.
+  return (
+    <svg width="120" height="120" viewBox="0 0 56 56" fill="none" className={open ? "text-active" : "text-primary"}>
+      {/* Pipe (horizontal) */}
+      <rect
+        x="4"
+        y="32"
+        width="48"
+        height="10"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        fill="white"
+      />
+      {/* Flanges */}
+      <line x1="9" y1="32" x2="9" y2="42" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+      <line x1="47" y1="32" x2="47" y2="42" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+
+      {/* Water flow inside the pipe (only when open) */}
+      {open && (
+        <>
+          <path d="M12 37 Q16 35 20 37 T28 37 T36 37 T44 37" stroke="#3B82F6" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+          <path d="M12 39.5 Q16 37.5 20 39.5 T28 39.5 T36 39.5 T44 39.5" stroke="#3B82F6" strokeWidth="1.0" fill="none" strokeLinecap="round" strokeOpacity="0.5" />
+        </>
+      )}
+
+      {/* Valve body (vertical extension) */}
+      <rect x="22" y="20" width="12" height="14" rx="1" stroke="currentColor" strokeWidth="1.6" fill="white" />
+
+      {/* Stem */}
+      <line x1="28" y1="10" x2="28" y2="22" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+
+      {/* Handle: horizontal (open) / vertical (closed) */}
+      {open ? (
+        <rect x="14" y="8" width="28" height="4" rx="2" stroke="currentColor" strokeWidth="1.6" fill="currentColor" fillOpacity="0.18" />
+      ) : (
+        <rect x="26" y="2" width="4" height="16" rx="2" stroke="currentColor" strokeWidth="1.6" fill="currentColor" fillOpacity="0.18" />
+      )}
+    </svg>
+  );
+}
+
+// ============================================================
 // Contact sensor icon — capteur d'ouverture porte/fenêtre
 // ============================================================
 

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -792,36 +792,37 @@ export function EnergyMeterIcon() {
 // ============================================================
 
 export function PoolPumpIcon({ on }: { on: boolean }) {
-  // Pipes flow water (blue) when ON, are hollow (white) when OFF.
-  // Junction box shows "ON" centered when ON, 4 screws when OFF.
-  // Manometer needle pressurized when ON, at rest when OFF.
-  const waterStroke = on ? "#3B82F6" : "white";
+  // Single static SVG — same geometry in both states. The stroke colour
+  // reflects the state (blue ON, muted grey OFF); the light-blue water inside
+  // the pipes is always visible. The ON badge lives in the widget, not here.
   return (
-    <svg width="120" height="120" viewBox="0 0 56 56" fill="none" className={on ? "text-active" : "text-text-tertiary"}>
-      {/* PIPES — outer stroke + inner water/hollow */}
+    <svg
+      width="120"
+      height="120"
+      viewBox="0 0 56 56"
+      fill="none"
+      className={on ? "text-primary" : "text-text-tertiary"}
+    >
+      {/* PIPES — outer stroke + light-blue water core */}
       <path d="M14 11 L42 11" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M14 11 L42 11" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M14 11 L42 11" stroke="#93C5FD" strokeWidth="1.5" strokeLinecap="round" />
       <path d="M14 16 L14 11" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M14 16 L14 11" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M14 16 L14 11" stroke="#93C5FD" strokeWidth="1.5" strokeLinecap="round" />
       <path d="M42 11 L42 20" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M42 11 L42 20" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M42 11 L42 20" stroke="#93C5FD" strokeWidth="1.5" strokeLinecap="round" />
       <path d="M42 36 L42 49" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M42 36 L42 49" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M42 36 L42 49" stroke="#93C5FD" strokeWidth="1.5" strokeLinecap="round" />
       <path d="M3 49 L42 49" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M3 49 L42 49" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M3 49 L42 49" stroke="#93C5FD" strokeWidth="1.5" strokeLinecap="round" />
       <path d="M14 45 L14 49" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M14 45 L14 49" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M14 45 L14 49" stroke="#93C5FD" strokeWidth="1.5" strokeLinecap="round" />
 
-      {/* MANOMETER */}
+      {/* MANOMETER — needle kept at one static angle */}
       <circle cx="28" cy="10" r="5" stroke="currentColor" strokeWidth="1.6" fill="white" />
-      {on ? (
-        <line x1="28" y1="10" x2="30.5" y2="7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-      ) : (
-        <line x1="28" y1="10" x2="25" y2="11.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-      )}
+      <line x1="28" y1="10" x2="30.5" y2="7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
       <circle cx="28" cy="10" r="0.9" fill="currentColor" />
 
-      {/* TANK (3-stages, left side) */}
+      {/* TANK (3-stages) */}
       <path
         d="M8 16 Q8 14 10 14 L18 14 Q20 14 20 16 L20 18 L8 18 Z"
         stroke="currentColor"
@@ -846,29 +847,12 @@ export function PoolPumpIcon({ on }: { on: boolean }) {
       />
       <path d="M9 21 L9 25" stroke="currentColor" strokeWidth="0.6" strokeLinecap="round" opacity="0.5" />
 
-      {/* JUNCTION BOX */}
+      {/* JUNCTION BOX — always shown with 4 screws */}
       <rect x="34" y="20" width="16" height="16" rx="1" stroke="currentColor" strokeWidth="1.6" fill="white" />
-      {on ? (
-        <text
-          x="42"
-          y="28"
-          fontFamily="-apple-system, sans-serif"
-          fontWeight="800"
-          fontSize="7"
-          textAnchor="middle"
-          dominantBaseline="central"
-          fill="currentColor"
-        >
-          ON
-        </text>
-      ) : (
-        <>
-          <circle cx="37" cy="23" r="0.9" fill="currentColor" />
-          <circle cx="47" cy="23" r="0.9" fill="currentColor" />
-          <circle cx="37" cy="33" r="0.9" fill="currentColor" />
-          <circle cx="47" cy="33" r="0.9" fill="currentColor" />
-        </>
-      )}
+      <circle cx="37" cy="23" r="0.9" fill="currentColor" />
+      <circle cx="47" cy="23" r="0.9" fill="currentColor" />
+      <circle cx="37" cy="33" r="0.9" fill="currentColor" />
+      <circle cx="47" cy="33" r="0.9" fill="currentColor" />
     </svg>
   );
 }

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -885,10 +885,12 @@ export function PoolCoverIcon({ position }: { position: number | null }) {
               : 100;
 
   // Layout — pool basin spans almost the whole 56×56 viewBox (immersed cover,
-  // no visible roller). Landscape ratio ~1.6:1.
+  // no visible roller). Landscape ratio ~1.6:1. Shifted up a few units so
+  // the picto sits visually centered (the dashboard layout was reading too
+  // low otherwise).
   const POOL_X = 3;
   const POOL_W = 50;
-  const POOL_Y = 12;
+  const POOL_Y = 8;
   const POOL_H = 32;
   const SLAT_Y = POOL_Y + 2;
   const SLAT_H = POOL_H - 4;

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -792,9 +792,12 @@ export function EnergyMeterIcon() {
 // ============================================================
 
 export function PoolPumpIcon({ on }: { on: boolean }) {
-  // Single static SVG — same geometry in both states. The stroke colour
-  // reflects the state (blue ON, muted grey OFF); the light-blue water inside
-  // the pipes is always visible. The ON badge lives in the widget, not here.
+  // Single static SVG — same geometry in both states. Stroke reflects state
+  // (blue ON, muted grey OFF). Water is only drawn when ON: light-blue inside
+  // the pipes + a subtle tint at the bottom of the tank. The ON badge lives
+  // in the widget, not here.
+  const waterPipe = on ? "#93C5FD" : "transparent";
+  const waterTank = on ? "#DBEAFE" : "white";
   return (
     <svg
       width="120"
@@ -803,26 +806,26 @@ export function PoolPumpIcon({ on }: { on: boolean }) {
       fill="none"
       className={on ? "text-primary" : "text-text-tertiary"}
     >
-      {/* PIPES — outer stroke + light-blue water core */}
+      {/* PIPES — outer stroke + inner water core (visible only when ON) */}
       <path d="M14 11 L42 11" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M14 11 L42 11" stroke="#93C5FD" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M14 11 L42 11" stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" />
       <path d="M14 16 L14 11" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M14 16 L14 11" stroke="#93C5FD" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M14 16 L14 11" stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" />
       <path d="M42 11 L42 20" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M42 11 L42 20" stroke="#93C5FD" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M42 11 L42 20" stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" />
       <path d="M42 36 L42 49" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M42 36 L42 49" stroke="#93C5FD" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M42 36 L42 49" stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" />
       <path d="M3 49 L42 49" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M3 49 L42 49" stroke="#93C5FD" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M3 49 L42 49" stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" />
       <path d="M14 45 L14 49" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M14 45 L14 49" stroke="#93C5FD" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M14 45 L14 49" stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" />
 
       {/* MANOMETER — needle kept at one static angle */}
       <circle cx="28" cy="10" r="5" stroke="currentColor" strokeWidth="1.6" fill="white" />
       <line x1="28" y1="10" x2="30.5" y2="7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
       <circle cx="28" cy="10" r="0.9" fill="currentColor" />
 
-      {/* TANK (3-stages) */}
+      {/* TANK (3-stages) — lower body gets a faint blue tint when ON */}
       <path
         d="M8 16 Q8 14 10 14 L18 14 Q20 14 20 16 L20 18 L8 18 Z"
         stroke="currentColor"
@@ -842,7 +845,7 @@ export function PoolPumpIcon({ on }: { on: boolean }) {
         d="M5 31 L5 41 Q5 45 10 45 L18 45 Q23 45 23 41 L23 31 Z"
         stroke="currentColor"
         strokeWidth="1.5"
-        fill="white"
+        fill={waterTank}
         strokeLinejoin="round"
       />
       <path d="M9 21 L9 25" stroke="currentColor" strokeWidth="0.6" strokeLinecap="round" opacity="0.5" />

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -953,7 +953,9 @@ export function PoolCoverIcon({ position }: { position: number | null }) {
         const WAVE_PITCH_X = 4; // crest period
         const WAVE_ROW_PITCH = 5; // vertical spacing
         const wavesTopY = POOL_Y + 4;
-        const wavesBottomY = POOL_Y + POOL_H - 4;
+        // Push the bottom row closer to the basin floor so a wave sits at the
+        // very bottom of the water area.
+        const wavesBottomY = POOL_Y + POOL_H - 2;
         const rows: number[] = [];
         for (let y = wavesTopY; y <= wavesBottomY; y += WAVE_ROW_PITCH) rows.push(y);
         const crestCount = Math.floor(waveAvail / WAVE_PITCH_X);

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -797,7 +797,7 @@ export function PoolPumpIcon({ on }: { on: boolean }) {
   // Manometer needle pressurized when ON, at rest when OFF.
   const waterStroke = on ? "#3B82F6" : "white";
   return (
-    <svg width="120" height="120" viewBox="0 0 56 56" fill="none" className={on ? "text-active" : "text-primary"}>
+    <svg width="120" height="120" viewBox="0 0 56 56" fill="none" className={on ? "text-active" : "text-text-tertiary"}>
       {/* PIPES — outer stroke + inner water/hollow */}
       <path d="M14 11 L42 11" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
       <path d="M14 11 L42 11" stroke={waterStroke} strokeWidth="1.5" strokeLinecap="round" />

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -890,7 +890,7 @@ export function PoolCoverIcon({ position }: { position: number | null }) {
   // low otherwise).
   const POOL_X = 3;
   const POOL_W = 50;
-  const POOL_Y = 8;
+  const POOL_Y = 5;
   const POOL_H = 32;
   const SLAT_Y = POOL_Y + 2;
   const SLAT_H = POOL_H - 4;

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -807,19 +807,22 @@ export function PoolPumpIcon({ on }: { on: boolean }) {
       fill="none"
       className={on ? "text-primary" : "text-text-tertiary"}
     >
-      {/* PIPES — outer stroke + inner water core (visible only when ON) */}
-      <path d="M14 11 L42 11" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M14 11 L42 11" stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" />
-      <path d="M14 16 L14 11" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M14 16 L14 11" stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" />
-      <path d="M42 11 L42 20" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M42 11 L42 20" stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" />
-      <path d="M42 36 L42 49" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M42 36 L42 49" stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" />
-      <path d="M3 49 L42 49" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M3 49 L42 49" stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" />
-      <path d="M14 45 L14 49" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M14 45 L14 49" stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" />
+      {/* PIPES — single continuous outline with smoothed joints, then an
+       * inner water core on top (visible only when ON). Three disjoint
+       * sub-paths: top loop (tank → manometer line → junction box top),
+       * bottom rail (junction box bottom → ground), tank-bottom drop. */}
+      {(() => {
+        const d =
+          "M14 16 L14 11 L42 11 L42 20 " +
+          "M42 36 L42 49 L3 49 " +
+          "M14 45 L14 49";
+        return (
+          <>
+            <path d={d} stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+            <path d={d} stroke={waterPipe} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+          </>
+        );
+      })()}
 
       {/* MANOMETER — needle kept at one static angle */}
       <circle cx="28" cy="10" r="5" stroke="currentColor" strokeWidth="1.6" fill="white" />

--- a/ui/src/components/dashboard/ZoneWidget.tsx
+++ b/ui/src/components/dashboard/ZoneWidget.tsx
@@ -30,6 +30,7 @@ const WIDGET_FAMILY_TYPES: Record<WidgetFamily, string[]> = {
   heating: ["thermostat", "heater"],
   sensors: ["sensor"],
   water: ["water_valve"],
+  pool: ["pool_pump", "pool_cover"],
 };
 
 interface ZoneWidgetProps {

--- a/ui/src/components/dashboard/widget-icons.ts
+++ b/ui/src/components/dashboard/widget-icons.ts
@@ -67,8 +67,10 @@ import {
   PlugWidgetIcon,
   MotionSensorIcon,
   ContactSensorIcon,
+  PoolPumpIcon,
+  PoolCoverIcon,
+  WaterValveWidgetIcon,
 } from "./WidgetIcons";
-import { WaterValveIcon } from "../icons/WaterValveIcon";
 
 // ============================================================
 // Utility — shutter level bucket (moved from WidgetIcons.tsx to avoid react-refresh lint)
@@ -201,9 +203,21 @@ export const CUSTOM_ICON_REGISTRY: Record<string, CustomIconEntry> = {
   },
   water_valve: {
     label: "Vanne d'arrosage",
-    component: WaterValveIcon as ComponentType<Record<string, unknown>>,
-    previewProps: {},
+    component: WaterValveWidgetIcon as ComponentType<Record<string, unknown>>,
+    previewProps: { open: false },
     types: ["water_valve", "water"],
+  },
+  pool_pump: {
+    label: "Pompe piscine",
+    component: PoolPumpIcon as ComponentType<Record<string, unknown>>,
+    previewProps: { on: false },
+    types: ["pool_pump", "pool"],
+  },
+  pool_cover: {
+    label: "Volet piscine",
+    component: PoolCoverIcon as ComponentType<Record<string, unknown>>,
+    previewProps: { position: 50 },
+    types: ["pool_cover", "pool"],
   },
 };
 
@@ -282,6 +296,8 @@ const EQUIPMENT_DEFAULT_ICONS: Partial<Record<EquipmentType, string>> = {
   switch: "ToggleLeft",
   button: "CircleDot",
   water_valve: "Droplets",
+  pool_pump: "Droplets",
+  pool_cover: "ArrowUpDown",
 };
 
 const FAMILY_DEFAULT_ICONS: Record<WidgetFamily, string> = {
@@ -290,6 +306,7 @@ const FAMILY_DEFAULT_ICONS: Record<WidgetFamily, string> = {
   heating: "Flame",
   sensors: "Gauge",
   water: "Droplets",
+  pool: "Droplets",
 };
 
 export function getWidgetIcon(

--- a/ui/src/components/dashboard/widget-utils.ts
+++ b/ui/src/components/dashboard/widget-utils.ts
@@ -4,6 +4,7 @@ export function needsDetailSheet(equipmentType: string): boolean {
     "light_dimmable",
     "light_color",
     "shutter",
+    "pool_cover",
     "thermostat",
     "heater",
   ].includes(equipmentType);

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -78,6 +78,9 @@ interface DeviceSelectorProps {
   onCandidateChange?: (candidateByDevice: Record<string, string>) => void;
   /** Device IDs already bound to other equipments — excluded from the list. */
   boundDeviceIds?: Set<string>;
+  /** Per-device set of device_order keys already bound on other equipments.
+   * Used to hide candidates whose order keys are all consumed. */
+  boundOrderKeysByDevice?: Record<string, Set<string>>;
 }
 
 export function DeviceSelector({
@@ -86,6 +89,7 @@ export function DeviceSelector({
   onSelectionChange,
   onCandidateChange,
   boundDeviceIds,
+  boundOrderKeysByDevice,
 }: DeviceSelectorProps) {
   const { t } = useTranslation();
   const [allDevices, setAllDevices] = useState<DeviceWithData[]>([]);
@@ -116,16 +120,26 @@ export function DeviceSelector({
   const isCandidateBased = CANDIDATE_BASED_TYPES.has(equipmentType);
 
   /** Per-device candidate list for the current equipment type (candidate-based
-   * types only). Used for visibility + picker. Empty map for legacy types. */
+   * types only). Candidates whose order keys are ALL already bound on this
+   * device (consumed by another equipment) are filtered out. */
   const candidatesByDevice = useMemo(() => {
     if (!isCandidateBased) return new Map<string, BindingCandidate[]>();
     const map = new Map<string, BindingCandidate[]>();
     for (const d of availableDevices) {
-      const cs = computeBindingCandidates(equipmentType, d.data, d.orders ?? []);
-      map.set(d.id, cs);
+      const all = computeBindingCandidates(equipmentType, d.data, d.orders ?? []);
+      const bound = boundOrderKeysByDevice?.[d.id];
+      const free = bound
+        ? all.filter((c) =>
+            // Keep the candidate if at least one of its order keys is not yet
+            // bound on this device. Pure-data candidates (orderKeys=[]) always
+            // stay — re-binding data is allowed.
+            c.orderKeys.length === 0 || c.orderKeys.some((k) => !bound.has(k)),
+          )
+        : all;
+      map.set(d.id, free);
     }
     return map;
-  }, [availableDevices, equipmentType, isCandidateBased]);
+  }, [availableDevices, equipmentType, isCandidateBased, boundOrderKeysByDevice]);
 
   const categories = EQUIPMENT_TYPE_CATEGORIES[equipmentType];
   const requiredKeys = EQUIPMENT_TYPE_DATA_KEYS[equipmentType];

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -19,6 +19,10 @@ const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> 
   energy_meter: ["energy"],
   main_energy_meter: ["energy"],
   energy_production_meter: ["energy", "power"],
+  // Pool equipments accept the same data shapes as switch / shutter at the device level.
+  // The dedicated equipment type adds semantic categorisation (override) + custom UI.
+  pool_pump: ["light_state"],
+  pool_cover: ["shutter_position"],
 };
 
 /** Maps EquipmentType to required data keys for filtering (when category alone is too broad). */

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -19,10 +19,6 @@ const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> 
   energy_meter: ["energy"],
   main_energy_meter: ["energy"],
   energy_production_meter: ["energy", "power"],
-  // Pool equipments accept the same data shapes as switch / shutter at the device level.
-  // The dedicated equipment type adds semantic categorisation (override) + custom UI.
-  pool_pump: ["light_state"],
-  pool_cover: ["shutter_position"],
 };
 
 /** Maps EquipmentType to required data keys for filtering (when category alone is too broad). */
@@ -32,6 +28,18 @@ const EQUIPMENT_TYPE_DATA_KEYS: Partial<Record<EquipmentType, string[]>> = {
   media_player: ["volume", "input_source"],
   appliance: ["state", "remaining_time"],
   water_valve: ["flow", "irrigation_capacity", "irrigation_duration", "irrigation_interval"],
+  // Pool equipments are key-driven because vendor data categories are noisy
+  // (Tasmota emits category="generic" for relays and "position" for shutters).
+  // Match on common relay / shutter keys so multi-channel devices appear.
+  pool_pump: ["power1", "power2", "power3", "power4", "POWER", "state"],
+  pool_cover: [
+    "shutter_position",
+    "shutter1_position",
+    "shutter2_position",
+    "shutter_state",
+    "shutter1_state",
+    "shutter2_state",
+  ],
 };
 
 /** Data keys that strongly indicate a smart water valve (used to exclude from light/switch lists). */

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Radio, Check, ChevronDown, ChevronUp, Search } from "lucide-react";
 import type { DataCategory, EquipmentType } from "../../types";
 import { getDevices, type DeviceWithData } from "../../api";
+import { computeBindingCandidates, type BindingCandidate } from "../../lib/binding-candidates";
 
 /** Maps EquipmentType to required DataCategories for filtering. */
 const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> = {
@@ -54,10 +55,27 @@ function looksLikeWaterValve(device: DeviceWithData): boolean {
   return device.data.some((d) => WATER_VALVE_MARKERS.has(d.key));
 }
 
+/** Equipment types for which binding is driven by computeBindingCandidates
+ * (mirrors the backend). For these types the device is considered compatible
+ * iff it exposes ≥1 candidate, and a channel picker appears when N>1. */
+const CANDIDATE_BASED_TYPES: ReadonlySet<EquipmentType> = new Set<EquipmentType>([
+  "pool_pump",
+  "pool_cover",
+  "light_onoff",
+  "light_dimmable",
+  "light_color",
+  "switch",
+  "shutter",
+  "water_valve",
+]);
+
 interface DeviceSelectorProps {
   equipmentType: EquipmentType;
   selectedDeviceIds: string[];
   onSelectionChange: (deviceIds: string[]) => void;
+  /** Called when the user picks a channel for a multi-channel device.
+   * Maps deviceId → candidate.id. Absent = use the first candidate. */
+  onCandidateChange?: (candidateByDevice: Record<string, string>) => void;
   /** Device IDs already bound to other equipments — excluded from the list. */
   boundDeviceIds?: Set<string>;
 }
@@ -66,6 +84,7 @@ export function DeviceSelector({
   equipmentType,
   selectedDeviceIds,
   onSelectionChange,
+  onCandidateChange,
   boundDeviceIds,
 }: DeviceSelectorProps) {
   const { t } = useTranslation();
@@ -74,6 +93,8 @@ export function DeviceSelector({
   const [expandedDevice, setExpandedDevice] = useState<string | null>(null);
   const [showAll, setShowAll] = useState(false);
   const [filter, setFilter] = useState("");
+  /** deviceId → chosen candidate.id (only for devices with N>1 candidates). */
+  const [candidateByDevice, setCandidateByDevice] = useState<Record<string, string>>({});
 
   useEffect(() => {
     setLoading(true); // eslint-disable-line react-hooks/set-state-in-effect -- loading state before async fetch
@@ -92,17 +113,33 @@ export function DeviceSelector({
     ? allDevices.filter((d) => !boundDeviceIds.has(d.id))
     : allDevices;
 
+  const isCandidateBased = CANDIDATE_BASED_TYPES.has(equipmentType);
+
+  /** Per-device candidate list for the current equipment type (candidate-based
+   * types only). Used for visibility + picker. Empty map for legacy types. */
+  const candidatesByDevice = useMemo(() => {
+    if (!isCandidateBased) return new Map<string, BindingCandidate[]>();
+    const map = new Map<string, BindingCandidate[]>();
+    for (const d of availableDevices) {
+      const cs = computeBindingCandidates(equipmentType, d.data, d.orders ?? []);
+      map.set(d.id, cs);
+    }
+    return map;
+  }, [availableDevices, equipmentType, isCandidateBased]);
+
   const categories = EQUIPMENT_TYPE_CATEGORIES[equipmentType];
   const requiredKeys = EQUIPMENT_TYPE_DATA_KEYS[equipmentType];
-  let compatible = requiredKeys
-    ? availableDevices.filter((device) =>
-        device.data.some((d) => requiredKeys.includes(d.key))
-      )
-    : categories && categories.length > 0
+  let compatible: DeviceWithData[] = isCandidateBased
+    ? availableDevices.filter((d) => (candidatesByDevice.get(d.id)?.length ?? 0) > 0)
+    : requiredKeys
       ? availableDevices.filter((device) =>
-          device.data.some((d) => categories.includes(d.category))
+          device.data.some((d) => requiredKeys.includes(d.key)),
         )
-      : availableDevices;
+      : categories && categories.length > 0
+        ? availableDevices.filter((device) =>
+            device.data.some((d) => categories.includes(d.category)),
+          )
+        : availableDevices;
 
   // Exclude smart water valves from light/switch creation flows so they don't
   // pollute the list (their `state` is misclassified as `light_state`).
@@ -116,12 +153,32 @@ export function DeviceSelector({
     ? baseDevices.filter((d) => d.name.toLowerCase().includes(filterLower))
     : baseDevices;
 
+  const emitCandidates = (next: Record<string, string>) => {
+    setCandidateByDevice(next);
+    onCandidateChange?.(next);
+  };
+
   const toggleDevice = (deviceId: string) => {
     if (selectedDeviceIds.includes(deviceId)) {
       onSelectionChange(selectedDeviceIds.filter((id) => id !== deviceId));
+      if (candidateByDevice[deviceId]) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { [deviceId]: _, ...rest } = candidateByDevice;
+        emitCandidates(rest);
+      }
     } else {
       onSelectionChange([...selectedDeviceIds, deviceId]);
+      // Auto-pick the only candidate if there's just one — callers don't need
+      // to know about candidates when there's no choice to make.
+      const cs = candidatesByDevice.get(deviceId);
+      if (cs && cs.length === 1 && !candidateByDevice[deviceId]) {
+        emitCandidates({ ...candidateByDevice, [deviceId]: cs[0].id });
+      }
     }
+  };
+
+  const pickCandidate = (deviceId: string, candidateId: string) => {
+    emitCandidates({ ...candidateByDevice, [deviceId]: candidateId });
   };
 
   if (loading) {
@@ -222,6 +279,48 @@ export function DeviceSelector({
                     {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
                   </button>
                 </div>
+
+                {/* Candidate picker — only when selected and the device
+                 * exposes multiple functional channels for this type. */}
+                {isSelected && (() => {
+                  const cs = candidatesByDevice.get(device.id) ?? [];
+                  if (cs.length <= 1) return null;
+                  const picked = candidateByDevice[device.id];
+                  return (
+                    <div className="ml-11 mt-1 mb-2 space-y-1">
+                      <div className="text-[11px] font-medium text-text-secondary uppercase tracking-wider mb-1">
+                        {t("deviceSelector.pickChannel")}
+                      </div>
+                      {cs.map((c) => {
+                        const isPicked = picked === c.id;
+                        return (
+                          <label
+                            key={c.id}
+                            className={`flex items-center gap-2 px-2 py-1.5 rounded-[5px] cursor-pointer text-[12px] ${
+                              isPicked
+                                ? "bg-primary/10 text-text"
+                                : "hover:bg-border-light/40 text-text-secondary"
+                            }`}
+                          >
+                            <input
+                              type="radio"
+                              name={`candidate-${device.id}`}
+                              checked={isPicked}
+                              onChange={() => pickCandidate(device.id, c.id)}
+                              className="accent-primary"
+                            />
+                            <span className="font-mono">{c.label}</span>
+                            {(c.dataKeys.length + c.orderKeys.length) > 0 && (
+                              <span className="text-text-tertiary text-[11px]">
+                                ({[...new Set([...c.dataKeys, ...c.orderKeys])].join(", ")})
+                              </span>
+                            )}
+                          </label>
+                        );
+                      })}
+                    </div>
+                  );
+                })()}
 
                 {/* Device data details */}
                 {isExpanded && (

--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -14,6 +14,7 @@ import {
   Zap,
   Tv,
   WashingMachine,
+  Waves,
 } from "lucide-react";
 import { ShutterClosedIcon } from "../icons/ShutterIcons";
 import { WaterValveIcon } from "../icons/WaterValveIcon";
@@ -45,6 +46,8 @@ const TYPE_ICONS: Record<EquipmentType, React.ReactNode> = {
   media_player: <Tv size={18} strokeWidth={1.5} />,
   appliance: <WashingMachine size={18} strokeWidth={1.5} />,
   water_valve: <WaterValveIcon size={18} strokeWidth={1.5} />,
+  pool_pump: <Waves size={18} strokeWidth={1.5} />,
+  pool_cover: <ShutterClosedIcon size={18} strokeWidth={1.5} />,
 };
 
 const TYPE_LABELS: Record<EquipmentType, string> = {
@@ -66,6 +69,8 @@ const TYPE_LABELS: Record<EquipmentType, string> = {
   media_player: "equipments.type.media_player",
   appliance: "equipments.type.appliance",
   water_valve: "equipments.type.water_valve",
+  pool_pump: "equipments.type.pool_pump",
+  pool_cover: "equipments.type.pool_cover",
 };
 
 interface EquipmentCardProps {

--- a/ui/src/components/equipments/EquipmentForm.tsx
+++ b/ui/src/components/equipments/EquipmentForm.tsx
@@ -46,11 +46,13 @@ interface EquipmentFormProps {
   }) => Promise<void>;
   onClose: () => void;
   boundDeviceIds?: Set<string>;
+  /** Per-device set of device_order keys already bound on other equipments. */
+  boundOrderKeysByDevice?: Record<string, Set<string>>;
   /** Equipment types to exclude from the type selector (e.g. singleton types already created). */
   excludeTypes?: Set<EquipmentType>;
 }
 
-export function EquipmentForm({ title, initial, defaultZoneId, zones, onSubmit, onClose, boundDeviceIds, excludeTypes }: EquipmentFormProps) {
+export function EquipmentForm({ title, initial, defaultZoneId, zones, onSubmit, onClose, boundDeviceIds, boundOrderKeysByDevice, excludeTypes }: EquipmentFormProps) {
   const { t } = useTranslation();
   const [step, setStep] = useState<"info" | "devices">("info");
   const [name, setName] = useState(initial?.name ?? "");
@@ -183,6 +185,7 @@ export function EquipmentForm({ title, initial, defaultZoneId, zones, onSubmit, 
                   onSelectionChange={setSelectedDeviceIds}
                   onCandidateChange={setCandidateByDevice}
                   boundDeviceIds={boundDeviceIds}
+                  boundOrderKeysByDevice={boundOrderKeysByDevice}
                 />
               </>
             )}

--- a/ui/src/components/equipments/EquipmentForm.tsx
+++ b/ui/src/components/equipments/EquipmentForm.tsx
@@ -23,6 +23,8 @@ const EQUIPMENT_TYPE_KEYS: { value: EquipmentType; labelKey: string }[] = [
   { value: "media_player", labelKey: "equipments.type.media_player" },
   { value: "appliance", labelKey: "equipments.type.appliance" },
   { value: "water_valve", labelKey: "equipments.type.water_valve" },
+  { value: "pool_pump", labelKey: "equipments.type.pool_pump" },
+  { value: "pool_cover", labelKey: "equipments.type.pool_cover" },
 ];
 
 interface EquipmentFormProps {

--- a/ui/src/components/equipments/EquipmentForm.tsx
+++ b/ui/src/components/equipments/EquipmentForm.tsx
@@ -41,6 +41,8 @@ interface EquipmentFormProps {
     type: EquipmentType;
     zoneId: string;
     selectedDeviceIds: string[];
+    /** For candidate-based types: deviceId → chosen candidate.id. */
+    candidateByDevice?: Record<string, string>;
   }) => Promise<void>;
   onClose: () => void;
   boundDeviceIds?: Set<string>;
@@ -55,6 +57,7 @@ export function EquipmentForm({ title, initial, defaultZoneId, zones, onSubmit, 
   const [type, setType] = useState<EquipmentType>(initial?.type ?? "light_onoff");
   const [zoneId, setZoneId] = useState(initial?.zoneId ?? defaultZoneId ?? "");
   const [selectedDeviceIds, setSelectedDeviceIds] = useState<string[]>([]);
+  const [candidateByDevice, setCandidateByDevice] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -77,6 +80,7 @@ export function EquipmentForm({ title, initial, defaultZoneId, zones, onSubmit, 
         type,
         zoneId,
         selectedDeviceIds,
+        candidateByDevice,
       });
       onClose();
     } catch (err) {
@@ -177,6 +181,7 @@ export function EquipmentForm({ title, initial, defaultZoneId, zones, onSubmit, 
                   equipmentType={type}
                   selectedDeviceIds={selectedDeviceIds}
                   onSelectionChange={setSelectedDeviceIds}
+                  onCandidateChange={setCandidateByDevice}
                   boundDeviceIds={boundDeviceIds}
                 />
               </>

--- a/ui/src/components/equipments/ShutterControl.tsx
+++ b/ui/src/components/equipments/ShutterControl.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronUp, Square, ChevronDown } from "lucide-react";
+import { ChevronUp, ChevronDown, ChevronLeft, ChevronRight, Square } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
 
@@ -26,6 +26,11 @@ export function ShutterControl({ equipment, onExecuteOrder, compact }: ShutterCo
 
   const hasState = equipment.orderBindings.some((ob) => ob.alias === "state");
   const hasPositionOrder = equipment.orderBindings.some((ob) => ob.alias === "position");
+
+  // Pool covers slide horizontally → ←/→ arrows. Window shutters keep ↑/↓.
+  const isHorizontal = equipment.type === "pool_cover";
+  const OpenIcon = isHorizontal ? ChevronLeft : ChevronUp;
+  const CloseIcon = isHorizontal ? ChevronRight : ChevronDown;
 
   const handleCommand = async (command: "OPEN" | "STOP" | "CLOSE", e?: React.MouseEvent) => {
     e?.preventDefault();
@@ -85,7 +90,7 @@ export function ShutterControl({ equipment, onExecuteOrder, compact }: ShutterCo
               className="p-1.5 rounded-[5px] transition-colors duration-150 cursor-pointer bg-border-light text-text-tertiary hover:bg-border hover:text-text-secondary disabled:opacity-50 disabled:cursor-not-allowed"
               title={t("controls.open")}
             >
-              <ChevronUp size={14} strokeWidth={1.5} />
+              <OpenIcon size={14} strokeWidth={1.5} />
             </button>
             <button
               onClick={(e) => handleCommand("STOP", e)}
@@ -101,7 +106,7 @@ export function ShutterControl({ equipment, onExecuteOrder, compact }: ShutterCo
               className="p-1.5 rounded-[5px] transition-colors duration-150 cursor-pointer bg-border-light text-text-tertiary hover:bg-border hover:text-text-secondary disabled:opacity-50 disabled:cursor-not-allowed"
               title={t("controls.close")}
             >
-              <ChevronDown size={14} strokeWidth={1.5} />
+              <CloseIcon size={14} strokeWidth={1.5} />
             </button>
           </>
         )}
@@ -149,7 +154,7 @@ export function ShutterControl({ equipment, onExecuteOrder, compact }: ShutterCo
             disabled={executing}
             className="flex items-center gap-2 px-4 py-2 rounded-[6px] text-[13px] font-medium transition-colors duration-150 bg-border-light text-text-secondary hover:bg-border hover:text-text disabled:opacity-50"
           >
-            <ChevronUp size={16} strokeWidth={1.5} />
+            <OpenIcon size={16} strokeWidth={1.5} />
             {t("controls.open")}
           </button>
           <button
@@ -165,7 +170,7 @@ export function ShutterControl({ equipment, onExecuteOrder, compact }: ShutterCo
             disabled={executing}
             className="flex items-center gap-2 px-4 py-2 rounded-[6px] text-[13px] font-medium transition-colors duration-150 bg-border-light text-text-secondary hover:bg-border hover:text-text disabled:opacity-50"
           >
-            <ChevronDown size={16} strokeWidth={1.5} />
+            <CloseIcon size={16} strokeWidth={1.5} />
             {t("controls.close")}
           </button>
         </div>

--- a/ui/src/components/equipments/ShutterControl.tsx
+++ b/ui/src/components/equipments/ShutterControl.tsx
@@ -16,7 +16,7 @@ export function ShutterControl({ equipment, onExecuteOrder, compact }: ShutterCo
   const slider = useSliderOverride();
 
   const positionBinding = equipment.dataBindings.find(
-    (db) => db.category === "shutter_position"
+    (db) => db.category === "shutter_position" || db.alias === "position",
   );
   const devicePosition = positionBinding && typeof positionBinding.value === "number"
     ? positionBinding.value

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -26,6 +26,11 @@ const RELEVANT_DATA: Record<string, string[]> = {
   media_player: ["generic"],
   appliance: ["generic", "energy"],
   water_valve: ["light_state", "battery", "generic"],
+  // Accept both the spec-correct Sowel categories and the legacy Tasmota
+  // categories (generic for relays, position for shutter) so users on older
+  // plugin versions still get auto-bindings.
+  pool_pump: ["light_state", "generic"],
+  pool_cover: ["shutter_position", "position", "generic"],
 };
 
 /** Maps equipment types to relevant order keys for auto-binding. */
@@ -52,6 +57,29 @@ const RELEVANT_ORDERS: Record<string, string[]> = {
     "irrigation_capacity",
     "total_number",
     "auto_close_when_water_shortage",
+  ],
+  pool_pump: [
+    "state",
+    "on",
+    "R1",
+    "R2",
+    "R3",
+    "R4",
+    "power1",
+    "power2",
+    "power3",
+    "power4",
+  ],
+  pool_cover: [
+    "state",
+    "position",
+    "target_position",
+    "shutter_state",
+    "shutter_position",
+    "shutter1_state",
+    "shutter1_position",
+    "shutter2_state",
+    "shutter2_position",
   ],
 };
 
@@ -111,6 +139,25 @@ const STANDARD_ALIASES: Record<string, Record<string, string>> = {
     irrigation_capacity: "capacity",
     total_number: "cycles",
     auto_close_when_water_shortage: "autoCloseOnShortage",
+  },
+  pool_pump: {
+    power1: "state",
+    power2: "state",
+    power3: "state",
+    power4: "state",
+    R1: "state",
+    R2: "state",
+    R3: "state",
+    R4: "state",
+  },
+  pool_cover: {
+    shutter_state: "state",
+    shutter1_state: "state",
+    shutter2_state: "state",
+    shutter_position: "position",
+    shutter1_position: "position",
+    shutter2_position: "position",
+    target_position: "position",
   },
 };
 

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -105,36 +105,11 @@ const STANDARD_ALIASES: Record<string, Record<string, string>> = {
     R3: "command",
     R4: "command",
   },
-  light_onoff: {
-    R1: "state",
-    R2: "state",
-    R3: "state",
-    R4: "state",
-  },
-  light_dimmable: {
-    R1: "state",
-    R2: "state",
-    R3: "state",
-    R4: "state",
-  },
-  light_color: {
-    R1: "state",
-    R2: "state",
-    R3: "state",
-    R4: "state",
-  },
-  switch: {
-    R1: "state",
-    R2: "state",
-    R3: "state",
-    R4: "state",
-  },
-  heater: {
-    R1: "state",
-    R2: "state",
-    R3: "state",
-    R4: "state",
-  },
+  light_onoff: { R1: "state", R2: "state", R3: "state", R4: "state" },
+  light_dimmable: { R1: "state", R2: "state", R3: "state", R4: "state" },
+  light_color: { R1: "state", R2: "state", R3: "state", R4: "state" },
+  switch: { R1: "state", R2: "state", R3: "state", R4: "state" },
+  heater: { R1: "state", R2: "state", R3: "state", R4: "state" },
   water_valve: {
     // Data keys → standard aliases
     current_device_status: "status",
@@ -145,29 +120,55 @@ const STANDARD_ALIASES: Record<string, Record<string, string>> = {
     total_number: "cycles",
     auto_close_when_water_shortage: "autoCloseOnShortage",
   },
-  pool_pump: {
-    power1: "state",
-    power2: "state",
-    power3: "state",
-    power4: "state",
-    R1: "state",
-    R2: "state",
-    R3: "state",
-    R4: "state",
-  },
-  pool_cover: {
-    shutter_state: "state",
-    shutter1_state: "state",
-    shutter2_state: "state",
-    shutter_position: "position",
-    shutter1_position: "position",
-    shutter2_position: "position",
-    target_position: "position",
-  },
 };
 
-/** Resolve a device key to the standardized equipment alias for the given type. */
-export function resolveAlias(key: string, equipmentType: string): string {
+/**
+ * Category-based aliasing — plugin-agnostic. Whenever an order/data has a
+ * well-known semantic category, the alias is derived from the category, not
+ * from the (plugin-specific) key name. Checked first; falls back to the
+ * per-type key map above, then to the raw key.
+ */
+const ORDER_CATEGORY_ALIASES: Record<string, string> = {
+  light_toggle: "state",
+  toggle_power: "state",
+  valve_toggle: "state",
+  pool_pump_toggle: "state",
+  shutter_move: "state",
+  pool_cover_move: "state",
+  set_shutter_position: "position",
+  pool_cover_position: "position",
+  set_brightness: "brightness",
+  set_color_temp: "color_temp",
+  set_color: "color",
+  set_setpoint: "setpoint",
+  gate_trigger: "command",
+};
+
+const DATA_CATEGORY_ALIASES: Record<string, string> = {
+  light_state: "state",
+  shutter_position: "position",
+  light_brightness: "brightness",
+  light_color_temp: "color_temp",
+  light_color: "color",
+  setpoint: "setpoint",
+  battery: "battery",
+  cover_state: "state",
+};
+
+/**
+ * Resolve a device key to the standardized equipment alias for the given type.
+ * Priority:
+ *   1. Order / data category (plugin-agnostic)
+ *   2. Per-type key map (legacy conventions like lora2mqtt R1..R4)
+ *   3. Raw key
+ */
+export function resolveAlias(
+  key: string,
+  equipmentType: string,
+  categoryMap?: Record<string, string>,
+  category?: string,
+): string {
+  if (category && categoryMap && categoryMap[category]) return categoryMap[category];
   return STANDARD_ALIASES[equipmentType]?.[key] ?? key;
 }
 
@@ -180,11 +181,19 @@ export function isRelevantOrder(key: string, equipmentType: string): boolean {
 }
 
 /** Equipment types whose bindings are spec'd as structured candidates
- * (see src/equipments/binding-candidates.ts). For these, we pick the first
- * candidate and bind exactly its data/order keys — no more, no less. */
+ * (see src/equipments/binding-candidates.ts). For these, we honour the
+ * candidate chosen in DeviceSelector (or pick the first) and bind exactly
+ * its data/order keys — no more, no less. Must stay in sync with the
+ * DeviceSelector's own CANDIDATE_BASED_TYPES. */
 const CANDIDATE_BASED_TYPES: ReadonlySet<EquipmentType> = new Set<EquipmentType>([
   "pool_pump",
   "pool_cover",
+  "light_onoff",
+  "light_dimmable",
+  "light_color",
+  "switch",
+  "shutter",
+  "water_valve",
 ]);
 
 /** Auto-create DataBindings and OrderBindings for selected devices. */
@@ -227,7 +236,10 @@ export async function autoCreateBindings(
 
         for (const data of device.data) {
           if (!allowedData.has(data.key)) continue;
-          const alias = uniqueAlias(resolveAlias(data.key, equipmentType), usedDataAliases);
+          const alias = uniqueAlias(
+            resolveAlias(data.key, equipmentType, DATA_CATEGORY_ALIASES, data.category),
+            usedDataAliases,
+          );
           try {
             await addDataBinding(equipmentId, { deviceDataId: data.id, alias });
             usedDataAliases.add(alias);
@@ -237,7 +249,10 @@ export async function autoCreateBindings(
         }
         for (const order of device.orders) {
           if (!allowedOrders.has(order.key)) continue;
-          const alias = uniqueAlias(resolveAlias(order.key, equipmentType), usedOrderAliases);
+          const alias = uniqueAlias(
+            resolveAlias(order.key, equipmentType, ORDER_CATEGORY_ALIASES, order.category),
+            usedOrderAliases,
+          );
           try {
             await addOrderBinding(equipmentId, { deviceOrderId: order.id, alias });
             usedOrderAliases.add(alias);
@@ -252,7 +267,10 @@ export async function autoCreateBindings(
       // matches the RELEVANT_DATA / RELEVANT_ORDERS whitelists.
       for (const data of device.data) {
         if (isRelevantData(data.category, equipmentType)) {
-          const alias = uniqueAlias(resolveAlias(data.key, equipmentType), usedDataAliases);
+          const alias = uniqueAlias(
+            resolveAlias(data.key, equipmentType, DATA_CATEGORY_ALIASES, data.category),
+            usedDataAliases,
+          );
           try {
             await addDataBinding(equipmentId, { deviceDataId: data.id, alias });
             usedDataAliases.add(alias);
@@ -264,7 +282,10 @@ export async function autoCreateBindings(
 
       for (const order of device.orders) {
         if (isRelevantOrder(order.key, equipmentType)) {
-          const alias = uniqueAlias(resolveAlias(order.key, equipmentType), usedOrderAliases);
+          const alias = uniqueAlias(
+            resolveAlias(order.key, equipmentType, ORDER_CATEGORY_ALIASES, order.category),
+            usedOrderAliases,
+          );
           try {
             await addOrderBinding(equipmentId, { deviceOrderId: order.id, alias });
             usedOrderAliases.add(alias);

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -5,7 +5,12 @@ import {
   removeDataBinding,
   removeOrderBinding,
 } from "../../api";
-import type { DataBindingWithValue, OrderBindingWithDetails } from "../../types";
+import type {
+  DataBindingWithValue,
+  EquipmentType,
+  OrderBindingWithDetails,
+} from "../../types";
+import { computeBindingCandidates } from "../../lib/binding-candidates";
 
 /** Maps equipment types to relevant data categories for auto-binding. */
 const RELEVANT_DATA: Record<string, string[]> = {
@@ -174,6 +179,14 @@ export function isRelevantOrder(key: string, equipmentType: string): boolean {
   return RELEVANT_ORDERS[equipmentType]?.includes(key) ?? false;
 }
 
+/** Equipment types whose bindings are spec'd as structured candidates
+ * (see src/equipments/binding-candidates.ts). For these, we pick the first
+ * candidate and bind exactly its data/order keys — no more, no less. */
+const CANDIDATE_BASED_TYPES: ReadonlySet<EquipmentType> = new Set<EquipmentType>([
+  "pool_pump",
+  "pool_cover",
+]);
+
 /** Auto-create DataBindings and OrderBindings for selected devices. */
 export async function autoCreateBindings(
   equipmentId: string,
@@ -182,11 +195,57 @@ export async function autoCreateBindings(
 ): Promise<void> {
   const usedDataAliases = new Set<string>();
   const usedOrderAliases = new Set<string>();
+  const useCandidates = CANDIDATE_BASED_TYPES.has(equipmentType as EquipmentType);
 
   for (const deviceId of deviceIds) {
     try {
       const device = await getDevice(deviceId);
 
+      // Candidate-based binding: compute the functional channels the device
+      // offers for this equipment type and bind only the first candidate's
+      // data/orders. Guarantees spec-conformant bindings (no cross-channel
+      // pollution on multi-relay devices like Tasmota 4CH Pro).
+      if (useCandidates) {
+        const candidates = computeBindingCandidates(
+          equipmentType as EquipmentType,
+          device.data,
+          device.orders,
+        );
+        if (candidates.length === 0) {
+          // No matching channel on this device — skip silently
+          continue;
+        }
+        // Pick the first candidate deterministically. Multi-candidate picker
+        // UX is a follow-up; users can edit bindings afterwards.
+        const chosen = candidates[0];
+        const allowedData = new Set(chosen.dataKeys);
+        const allowedOrders = new Set(chosen.orderKeys);
+
+        for (const data of device.data) {
+          if (!allowedData.has(data.key)) continue;
+          const alias = uniqueAlias(resolveAlias(data.key, equipmentType), usedDataAliases);
+          try {
+            await addDataBinding(equipmentId, { deviceDataId: data.id, alias });
+            usedDataAliases.add(alias);
+          } catch {
+            // Alias conflict — skip
+          }
+        }
+        for (const order of device.orders) {
+          if (!allowedOrders.has(order.key)) continue;
+          const alias = uniqueAlias(resolveAlias(order.key, equipmentType), usedOrderAliases);
+          try {
+            await addOrderBinding(equipmentId, { deviceOrderId: order.id, alias });
+            usedOrderAliases.add(alias);
+          } catch {
+            // Already bound — skip
+          }
+        }
+        continue;
+      }
+
+      // Legacy path for all other equipment types — bind everything that
+      // matches the RELEVANT_DATA / RELEVANT_ORDERS whitelists.
       for (const data of device.data) {
         if (isRelevantData(data.category, equipmentType)) {
           const alias = uniqueAlias(resolveAlias(data.key, equipmentType), usedDataAliases);

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -192,6 +192,9 @@ export async function autoCreateBindings(
   equipmentId: string,
   deviceIds: string[],
   equipmentType: string,
+  /** deviceId → chosen candidate.id (from DeviceSelector picker). Optional:
+   * when missing, falls back to the first candidate. */
+  candidateByDevice?: Record<string, string>,
 ): Promise<void> {
   const usedDataAliases = new Set<string>();
   const usedOrderAliases = new Set<string>();
@@ -202,7 +205,7 @@ export async function autoCreateBindings(
       const device = await getDevice(deviceId);
 
       // Candidate-based binding: compute the functional channels the device
-      // offers for this equipment type and bind only the first candidate's
+      // offers for this equipment type and bind only the selected candidate's
       // data/orders. Guarantees spec-conformant bindings (no cross-channel
       // pollution on multi-relay devices like Tasmota 4CH Pro).
       if (useCandidates) {
@@ -215,9 +218,10 @@ export async function autoCreateBindings(
           // No matching channel on this device — skip silently
           continue;
         }
-        // Pick the first candidate deterministically. Multi-candidate picker
-        // UX is a follow-up; users can edit bindings afterwards.
-        const chosen = candidates[0];
+        // Honour the explicit pick when present; otherwise default to the
+        // first candidate (deterministic).
+        const chosenId = candidateByDevice?.[deviceId];
+        const chosen = candidates.find((c) => c.id === chosenId) ?? candidates[0];
         const allowedData = new Set(chosen.dataKeys);
         const allowedOrders = new Set(chosen.orderKeys);
 

--- a/ui/src/components/equipments/useEquipmentState.ts
+++ b/ui/src/components/equipments/useEquipmentState.ts
@@ -23,6 +23,9 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
   const isGate = equipment.type === "gate";
   const isMediaPlayer = equipment.type === "media_player";
   const isAppliance = equipment.type === "appliance";
+  const isWaterValve = equipment.type === "water_valve";
+  const isPoolPump = equipment.type === "pool_pump";
+  const isPoolCover = equipment.type === "pool_cover";
 
   // State binding
   const stateBinding = equipment.dataBindings.find(
@@ -124,6 +127,9 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
     isGate,
     isMediaPlayer,
     isAppliance,
+    isWaterValve,
+    isPoolPump,
+    isPoolCover,
     stateBinding,
     isOn,
     shutterPosition,

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -168,14 +168,27 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
         />
       )}
 
-      {/* Pool pump compact: ON/OFF badge + runtime */}
+      {/* Pool pump: runtime badge + ON/OFF toggle (reuse LightControl compact) */}
       {isPoolPump && (
-        <PoolPumpCompact equipment={equipment} />
+        <>
+          <PoolPumpRuntime equipment={equipment} />
+          {equipment.enabled && (
+            <LightControl
+              equipment={equipment}
+              onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
+              compact
+            />
+          )}
+        </>
       )}
 
-      {/* Pool cover compact: cover state + position */}
-      {isPoolCover && (
-        <PoolCoverCompact equipment={equipment} />
+      {/* Pool cover: OPEN/STOP/CLOSE buttons + position slider (reuse ShutterControl compact) */}
+      {isPoolCover && equipment.enabled && (
+        <ShutterControl
+          equipment={equipment}
+          onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
+          compact
+        />
       )}
 
       {/* Boolean state badge for generic equipments */}
@@ -269,62 +282,18 @@ function CompactMediaPlayer({ equipment }: { equipment: EquipmentWithDetails }) 
   );
 }
 
-function PoolPumpCompact({ equipment }: { equipment: EquipmentWithDetails }) {
-  // Find ON/OFF state from the bound pump_toggle order's matching data binding.
-  // We do not assume an alias name — match on enum value shape instead.
-  const stateBinding = equipment.dataBindings.find((b) => {
-    const v = b.value;
-    if (v === true || v === false) return true;
-    if (typeof v === "string") {
-      const u = v.toUpperCase();
-      return u === "ON" || u === "OFF";
-    }
-    return false;
-  });
-  const isOn = stateBinding
-    ? stateBinding.value === true || String(stateBinding.value).toUpperCase() === "ON"
-    : false;
-
+function PoolPumpRuntime({ equipment }: { equipment: EquipmentWithDetails }) {
   const runtime = equipment.computedData?.find((c) => c.alias === "runtime_daily");
   const seconds = typeof runtime?.value === "number" ? runtime.value : 0;
+  if (seconds === 0) return null;
   const runtimeStr = seconds < 60
     ? `${seconds}s`
     : seconds < 3600
       ? `${Math.floor(seconds / 60)}m`
       : `${Math.floor(seconds / 3600)}h${String(Math.floor((seconds % 3600) / 60)).padStart(2, "0")}`;
-
   return (
-    <div className="flex items-center gap-2 flex-shrink-0">
-      <span
-        className={`text-[11px] font-medium px-2 py-0.5 rounded-full ${
-          isOn ? "bg-active/10 text-active" : "bg-border-light text-text-tertiary"
-        }`}
-      >
-        {isOn ? "ON" : "OFF"}
-      </span>
-      <span className="text-[11px] text-text-tertiary tabular-nums font-mono">{runtimeStr}</span>
-    </div>
-  );
-}
-
-function PoolCoverCompact({ equipment }: { equipment: EquipmentWithDetails }) {
-  const coverState = equipment.dataBindings.find((b) => b.alias === "cover_state");
-  const positionBinding = equipment.dataBindings.find(
-    (b) => b.category === "shutter_position" || b.key.includes("shutter") && b.key.includes("position"),
-  );
-  const position = typeof positionBinding?.value === "number" ? positionBinding.value : null;
-
-  const label = coverState?.value === "OPEN"
-    ? "Ouvert"
-    : coverState?.value === "CLOSED"
-      ? "Fermé"
-      : position !== null
-        ? `${position}%`
-        : "—";
-
-  return (
-    <span className="text-[11px] font-medium px-2 py-0.5 rounded-full bg-border-light text-text-secondary tabular-nums flex-shrink-0">
-      {label}
+    <span className="text-[11px] text-text-tertiary tabular-nums font-mono flex-shrink-0">
+      {runtimeStr}
     </span>
   );
 }

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -41,9 +41,11 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
   } = useEquipmentState(equipment);
 
   const isWaterValve = equipment.type === "water_valve";
+  const isPoolPump = equipment.type === "pool_pump";
+  const isPoolCover = equipment.type === "pool_cover";
 
   // Find primary data value for generic equipments
-  const isKnownType = isLight || isSensor || isShutter || isThermostat || isHeater || isGate || isEnergyMeter || isWeatherForecast || isMediaPlayer || isAppliance || isWaterValve;
+  const isKnownType = isLight || isSensor || isShutter || isThermostat || isHeater || isGate || isEnergyMeter || isWeatherForecast || isMediaPlayer || isAppliance || isWaterValve || isPoolPump || isPoolCover;
   const primaryBinding = !isKnownType
     ? equipment.dataBindings[0] ?? null
     : null;
@@ -166,6 +168,16 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
         />
       )}
 
+      {/* Pool pump compact: ON/OFF badge + runtime */}
+      {isPoolPump && (
+        <PoolPumpCompact equipment={equipment} />
+      )}
+
+      {/* Pool cover compact: cover state + position */}
+      {isPoolCover && (
+        <PoolCoverCompact equipment={equipment} />
+      )}
+
       {/* Boolean state badge for generic equipments */}
       {!isKnownType && stateBinding && (
         <span
@@ -254,6 +266,66 @@ function CompactMediaPlayer({ equipment }: { equipment: EquipmentWithDetails }) 
         <span className="text-[12px] text-text-secondary font-medium">{source}</span>
       )}
     </div>
+  );
+}
+
+function PoolPumpCompact({ equipment }: { equipment: EquipmentWithDetails }) {
+  // Find ON/OFF state from the bound pump_toggle order's matching data binding.
+  // We do not assume an alias name — match on enum value shape instead.
+  const stateBinding = equipment.dataBindings.find((b) => {
+    const v = b.value;
+    if (v === true || v === false) return true;
+    if (typeof v === "string") {
+      const u = v.toUpperCase();
+      return u === "ON" || u === "OFF";
+    }
+    return false;
+  });
+  const isOn = stateBinding
+    ? stateBinding.value === true || String(stateBinding.value).toUpperCase() === "ON"
+    : false;
+
+  const runtime = equipment.computedData?.find((c) => c.alias === "runtime_daily");
+  const seconds = typeof runtime?.value === "number" ? runtime.value : 0;
+  const runtimeStr = seconds < 60
+    ? `${seconds}s`
+    : seconds < 3600
+      ? `${Math.floor(seconds / 60)}m`
+      : `${Math.floor(seconds / 3600)}h${String(Math.floor((seconds % 3600) / 60)).padStart(2, "0")}`;
+
+  return (
+    <div className="flex items-center gap-2 flex-shrink-0">
+      <span
+        className={`text-[11px] font-medium px-2 py-0.5 rounded-full ${
+          isOn ? "bg-active/10 text-active" : "bg-border-light text-text-tertiary"
+        }`}
+      >
+        {isOn ? "ON" : "OFF"}
+      </span>
+      <span className="text-[11px] text-text-tertiary tabular-nums font-mono">{runtimeStr}</span>
+    </div>
+  );
+}
+
+function PoolCoverCompact({ equipment }: { equipment: EquipmentWithDetails }) {
+  const coverState = equipment.dataBindings.find((b) => b.alias === "cover_state");
+  const positionBinding = equipment.dataBindings.find(
+    (b) => b.category === "shutter_position" || b.key.includes("shutter") && b.key.includes("position"),
+  );
+  const position = typeof positionBinding?.value === "number" ? positionBinding.value : null;
+
+  const label = coverState?.value === "OPEN"
+    ? "Ouvert"
+    : coverState?.value === "CLOSED"
+      ? "Fermé"
+      : position !== null
+        ? `${position}%`
+        : "—";
+
+  return (
+    <span className="text-[11px] font-medium px-2 py-0.5 rounded-full bg-border-light text-text-secondary tabular-nums flex-shrink-0">
+      {label}
+    </span>
   );
 }
 

--- a/ui/src/components/home/ZoneEquipmentsView.tsx
+++ b/ui/src/components/home/ZoneEquipmentsView.tsx
@@ -8,6 +8,7 @@ import {
   Zap,
   Tv,
   WashingMachine,
+  Waves,
 } from "lucide-react";
 import { ShutterClosedIcon } from "../icons/ShutterIcons";
 import { WaterValveIcon } from "../icons/WaterValveIcon";
@@ -33,6 +34,7 @@ const EQUIPMENT_GROUPS: EquipmentGroup[] = [
   { labelKey: "equipments.group.media", types: ["media_player"], icon: <Tv size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
   { labelKey: "equipments.group.appliances", types: ["appliance"], icon: <WashingMachine size={14} strokeWidth={1.5} />, headerBg: "bg-text-tertiary/6", iconColor: "text-text-secondary" },
   { labelKey: "equipments.group.water", types: ["water_valve"], icon: <WaterValveIcon size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
+  { labelKey: "equipments.group.pool", types: ["pool_pump", "pool_cover"], icon: <Waves size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
   { labelKey: "equipments.group.other", types: ["switch", "button", "gate"], icon: <ToggleRight size={14} strokeWidth={1.5} />, headerBg: "bg-text-tertiary/6", iconColor: "text-text-secondary" },
 ];
 

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -202,6 +202,8 @@
   "equipments.type.media_player": "Media Player",
   "equipments.type.appliance": "Appliance",
   "equipments.type.water_valve": "Water valve",
+  "equipments.type.pool_pump": "Pool pump",
+  "equipments.type.pool_cover": "Pool cover",
 
   "water.open": "Open",
   "water.closed": "Closed",

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -228,6 +228,7 @@
   "equipments.group.media": "Media",
   "equipments.group.appliances": "Appliances",
   "equipments.group.water": "Water",
+  "equipments.group.pool": "Pool",
   "equipments.group.other": "Other",
 
   "equipments.noEquipments": "No equipments",

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -413,6 +413,7 @@
   "home.zoneDeleted": "This zone may have been deleted.",
   "home.backToHome": "Back to Home",
 
+  "deviceSelector.pickChannel": "Pick the channel to bind",
   "deviceSelector.loading": "Loading devices...",
   "deviceSelector.noDevices": "No devices found. Connect devices via MQTT first.",
   "deviceSelector.noCompatible": "No compatible devices found for this equipment type.",

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -894,6 +894,8 @@
 
   "plugins.title": "Plugins",
   "plugins.subtitle": "Install and manage extensions for Sowel.",
+  "plugins.refreshRegistry": "Refresh",
+  "plugins.refreshRegistryTitle": "Force-reload the plugin registry (bypasses cache)",
   "plugins.installed": "Installed",
   "plugins.store": "Store",
   "plugins.noPlugins": "No plugins installed",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -413,6 +413,7 @@
   "home.zoneDeleted": "Cette zone a peut-être été supprimée.",
   "home.backToHome": "Retour à l'accueil",
 
+  "deviceSelector.pickChannel": "Choisir le canal à lier",
   "deviceSelector.loading": "Chargement des appareils...",
   "deviceSelector.noDevices": "Aucun appareil trouvé. Connectez des appareils via MQTT d'abord.",
   "deviceSelector.noCompatible": "Aucun appareil compatible trouvé pour ce type d'équipement.",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -894,6 +894,8 @@
 
   "plugins.title": "Plugins",
   "plugins.subtitle": "Installez et gérez des extensions pour Sowel.",
+  "plugins.refreshRegistry": "Rafraîchir",
+  "plugins.refreshRegistryTitle": "Forcer le rechargement du registre des plugins (contourne le cache)",
   "plugins.installed": "Installés",
   "plugins.store": "Store",
   "plugins.noPlugins": "Aucun plugin installé",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -202,6 +202,8 @@
   "equipments.type.media_player": "Lecteur Multimédia",
   "equipments.type.appliance": "Électroménager",
   "equipments.type.water_valve": "Vanne d'arrosage",
+  "equipments.type.pool_pump": "Pompe de piscine",
+  "equipments.type.pool_cover": "Volet de piscine",
 
   "water.open": "Ouverte",
   "water.closed": "Fermée",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -228,6 +228,7 @@
   "equipments.group.media": "Multimédia",
   "equipments.group.appliances": "Électroménager",
   "equipments.group.water": "Eau",
+  "equipments.group.pool": "Piscine",
   "equipments.group.other": "Autres",
 
   "equipments.noEquipments": "Aucun équipement",

--- a/ui/src/lib/binding-candidates.ts
+++ b/ui/src/lib/binding-candidates.ts
@@ -23,7 +23,9 @@ const ONOFF_TOKENS = new Set(["ON", "OFF", "TOGGLE"]);
 function isOnOffEnum(order: DeviceOrder): boolean {
   if (order.type !== "enum") return false;
   if (!order.enumValues || order.enumValues.length === 0) return false;
-  return order.enumValues.every((v) => ONOFF_TOKENS.has(v.toUpperCase()));
+  return order.enumValues.every(
+    (v) => typeof v === "string" && ONOFF_TOKENS.has(v.toUpperCase()),
+  );
 }
 
 function extractShutterGroupKey(key: string): string | null {

--- a/ui/src/lib/binding-candidates.ts
+++ b/ui/src/lib/binding-candidates.ts
@@ -1,0 +1,94 @@
+/**
+ * Binding candidates (frontend mirror of src/equipments/binding-candidates.ts).
+ *
+ * A candidate is a logical group of device data/orders that together make up
+ * one equipment's worth of bindings. The UI uses this to:
+ *  - auto-bind when a device yields 1 candidate
+ *  - (future) show a picker when a device yields N candidates
+ *
+ * Keep in sync with the backend version — tests live there.
+ */
+
+import type { DeviceData, DeviceOrder, EquipmentType } from "../types";
+
+export interface BindingCandidate {
+  id: string;
+  label: string;
+  dataKeys: string[];
+  orderKeys: string[];
+}
+
+const ONOFF_TOKENS = new Set(["ON", "OFF", "TOGGLE"]);
+
+function isOnOffEnum(order: DeviceOrder): boolean {
+  if (order.type !== "enum") return false;
+  if (!order.enumValues || order.enumValues.length === 0) return false;
+  return order.enumValues.every((v) => ONOFF_TOKENS.has(v.toUpperCase()));
+}
+
+function extractShutterGroupKey(key: string): string | null {
+  const indexed = /^shutter(\d+)_(state|position|move)$/.exec(key);
+  if (indexed) return indexed[1];
+  const unindexed = /^shutter_(state|position|move)$/.exec(key);
+  if (unindexed) return "1";
+  return null;
+}
+
+export function computeBindingCandidates(
+  equipmentType: EquipmentType,
+  deviceData: readonly DeviceData[],
+  deviceOrders: readonly DeviceOrder[],
+): BindingCandidate[] {
+  switch (equipmentType) {
+    case "pool_pump":
+    case "switch":
+    case "light_onoff":
+    case "water_valve": {
+      const candidates: BindingCandidate[] = [];
+      for (const o of deviceOrders) {
+        if (!isOnOffEnum(o)) continue;
+        const matchingData = deviceData.find((d) => d.key === o.key);
+        candidates.push({
+          id: o.key,
+          label: o.key,
+          dataKeys: matchingData ? [matchingData.key] : [],
+          orderKeys: [o.key],
+        });
+      }
+      return candidates;
+    }
+
+    case "pool_cover":
+    case "shutter": {
+      const byGroup = new Map<string, { dataKeys: string[]; orderKeys: string[] }>();
+      for (const o of deviceOrders) {
+        const g = extractShutterGroupKey(o.key);
+        if (!g) continue;
+        const entry = byGroup.get(g) ?? { dataKeys: [], orderKeys: [] };
+        entry.orderKeys.push(o.key);
+        byGroup.set(g, entry);
+      }
+      for (const d of deviceData) {
+        const g = extractShutterGroupKey(d.key);
+        if (!g) continue;
+        const entry = byGroup.get(g) ?? { dataKeys: [], orderKeys: [] };
+        entry.dataKeys.push(d.key);
+        byGroup.set(g, entry);
+      }
+      const candidates: BindingCandidate[] = [];
+      for (const [g, entry] of byGroup) {
+        if (entry.orderKeys.length === 0) continue;
+        candidates.push({
+          id: `shutter${g}`,
+          label: g === "1" ? "Shutter" : `Shutter ${g}`,
+          dataKeys: entry.dataKeys,
+          orderKeys: entry.orderKeys,
+        });
+      }
+      return candidates;
+    }
+
+    default:
+      return [];
+  }
+}

--- a/ui/src/lib/binding-utils.ts
+++ b/ui/src/lib/binding-utils.ts
@@ -1,0 +1,17 @@
+import type { EquipmentWithDetails } from "../types";
+
+/** Build { deviceId → Set<device_order.key> } from all existing equipments.
+ * Used by DeviceSelector to hide candidates whose order keys are already
+ * consumed by another equipment. */
+export function buildBoundOrderKeysByDevice(
+  equipments: EquipmentWithDetails[],
+): Record<string, Set<string>> {
+  const map: Record<string, Set<string>> = {};
+  for (const eq of equipments) {
+    for (const ob of eq.orderBindings) {
+      const s = map[ob.deviceId] ?? (map[ob.deviceId] = new Set<string>());
+      s.add(ob.key);
+    }
+  }
+  return map;
+}

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -731,6 +731,7 @@ function ChangeDeviceModal({
 }) {
   const { t } = useTranslation();
   const [selectedDeviceIds, setSelectedDeviceIds] = useState<string[]>([]);
+  const [candidateByDevice, setCandidateByDevice] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -742,7 +743,7 @@ function ChangeDeviceModal({
       // Remove all existing bindings
       await removeAllBindings(equipment.id, equipment.dataBindings, equipment.orderBindings);
       // Create new bindings from selected devices
-      await autoCreateBindings(equipment.id, selectedDeviceIds, equipment.type);
+      await autoCreateBindings(equipment.id, selectedDeviceIds, equipment.type, candidateByDevice);
       onDone();
     } catch (err) {
       setError(err instanceof Error ? err.message : "An error occurred");
@@ -773,6 +774,7 @@ function ChangeDeviceModal({
             equipmentType={equipment.type}
             selectedDeviceIds={selectedDeviceIds}
             onSelectionChange={setSelectedDeviceIds}
+            onCandidateChange={setCandidateByDevice}
           />
           {error && <p className="text-[13px] text-error mt-3">{error}</p>}
         </div>

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -253,11 +253,22 @@ export function EquipmentDetailPage() {
         </div>
       )}
 
-      {/* Shutter controls */}
-      {isShutter && equipment.enabled && (
+      {/* Shutter controls (also used for pool_cover) */}
+      {(isShutter || equipment.type === "pool_cover") && equipment.enabled && (
         <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
           <h3 className="text-[14px] font-semibold text-text mb-3">{t("equipments.controls")}</h3>
           <ShutterControl
+            equipment={equipment}
+            onExecuteOrder={(alias, value) => executeOrder(equipment.id, alias, value)}
+          />
+        </div>
+      )}
+
+      {/* Pool pump controls — ON/OFF toggle via LightControl */}
+      {equipment.type === "pool_pump" && equipment.enabled && (
+        <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
+          <h3 className="text-[14px] font-semibold text-text mb-3">{t("equipments.controls")}</h3>
+          <LightControl
             equipment={equipment}
             onExecuteOrder={(alias, value) => executeOrder(equipment.id, alias, value)}
           />

--- a/ui/src/pages/EquipmentsPage.tsx
+++ b/ui/src/pages/EquipmentsPage.tsx
@@ -119,10 +119,6 @@ export function EquipmentsPage() {
           title={t("equipments.createEquipment")}
           zones={tree}
           excludeTypes={singletonExcludeTypes(equipments)}
-          boundDeviceIds={new Set(equipments.flatMap((e) => [
-            ...e.dataBindings.map((b) => b.deviceId),
-            ...e.orderBindings.map((b) => b.deviceId),
-          ]))}
           onSubmit={async (data) => {
             const equipment = await createEquipment({
               name: data.name,

--- a/ui/src/pages/EquipmentsPage.tsx
+++ b/ui/src/pages/EquipmentsPage.tsx
@@ -7,6 +7,7 @@ import { EquipmentForm } from "../components/equipments/EquipmentForm";
 import { Box, Loader2, Plus, Search, X } from "lucide-react";
 import type { EquipmentType, EquipmentWithDetails, ZoneWithChildren } from "../types";
 import { autoCreateBindings } from "../components/equipments/bindingUtils";
+import { buildBoundOrderKeysByDevice } from "../lib/binding-utils";
 import { useWsSubscription } from "../hooks/useWsSubscription";
 
 export function EquipmentsPage() {
@@ -119,6 +120,7 @@ export function EquipmentsPage() {
           title={t("equipments.createEquipment")}
           zones={tree}
           excludeTypes={singletonExcludeTypes(equipments)}
+          boundOrderKeysByDevice={buildBoundOrderKeysByDevice(equipments)}
           onSubmit={async (data) => {
             const equipment = await createEquipment({
               name: data.name,
@@ -154,6 +156,7 @@ function singletonExcludeTypes(equipments: EquipmentWithDetails[]): Set<Equipmen
   }
   return exclude;
 }
+
 
 function groupByZone(
   equipments: EquipmentWithDetails[],

--- a/ui/src/pages/EquipmentsPage.tsx
+++ b/ui/src/pages/EquipmentsPage.tsx
@@ -128,7 +128,12 @@ export function EquipmentsPage() {
 
             // Auto-create bindings for selected devices
             if (data.selectedDeviceIds.length > 0) {
-              await autoCreateBindings(equipment.id, data.selectedDeviceIds, data.type);
+              await autoCreateBindings(
+                equipment.id,
+                data.selectedDeviceIds,
+                data.type,
+                data.candidateByDevice,
+              );
               await fetchEquipments();
             }
           }}

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -268,10 +268,6 @@ export function HomePage() {
             if (equipments.some((eq) => eq.type === "energy_production_meter")) exclude.add("energy_production_meter");
             return exclude;
           })()}
-          boundDeviceIds={new Set(equipments.flatMap((e) => [
-            ...e.dataBindings.map((b) => b.deviceId),
-            ...e.orderBindings.map((b) => b.deviceId),
-          ]))}
           onSubmit={async (data) => {
             const equipment = await createEquipment({
               name: data.name,

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -27,6 +27,7 @@ import { ZoneRecipesSection } from "../components/recipes/ZoneRecipesSection";
 import { ZoneModesSection } from "../components/home/ZoneModesSection";
 import { EquipmentForm } from "../components/equipments/EquipmentForm";
 import { autoCreateBindings } from "../components/equipments/bindingUtils";
+import { buildBoundOrderKeysByDevice } from "../lib/binding-utils";
 import { useWsSubscription } from "../hooks/useWsSubscription";
 import type { EquipmentType, ZoneWithChildren } from "../types";
 
@@ -268,6 +269,7 @@ export function HomePage() {
             if (equipments.some((eq) => eq.type === "energy_production_meter")) exclude.add("energy_production_meter");
             return exclude;
           })()}
+          boundOrderKeysByDevice={buildBoundOrderKeysByDevice(equipments)}
           onSubmit={async (data) => {
             const equipment = await createEquipment({
               name: data.name,

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -275,7 +275,12 @@ export function HomePage() {
               zoneId: data.zoneId,
             });
             if (data.selectedDeviceIds.length > 0) {
-              await autoCreateBindings(equipment.id, data.selectedDeviceIds, data.type);
+              await autoCreateBindings(
+                equipment.id,
+                data.selectedDeviceIds,
+                data.type,
+                data.candidateByDevice,
+              );
               await fetchEquipments();
             }
           }}

--- a/ui/src/pages/PluginsPage.tsx
+++ b/ui/src/pages/PluginsPage.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Package, Loader2, Download, Trash2, Cpu, ArrowUpCircle } from "lucide-react";
+import { Package, Loader2, Download, Trash2, Cpu, ArrowUpCircle, RefreshCw } from "lucide-react";
 import { refreshPluginUpdateCount } from "../components/layout/usePluginUpdates";
 import * as LucideIcons from "lucide-react";
 import {
   getPlugins,
   getPluginStore,
+  refreshPluginStore,
   installPlugin,
   uninstallPlugin,
   enablePlugin,
@@ -37,6 +38,7 @@ export function PluginsPage() {
   const [plugins, setPlugins] = useState<PluginInfo[]>([]);
   const [store, setStore] = useState<PluginManifest[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [activeTab, setActiveTab] = useState<Tab>("installed");
   const [category, setCategory] = useState<CategoryFilter>("integration");
 
@@ -58,6 +60,18 @@ export function PluginsPage() {
 
   useEffect(() => {
     load();
+  }, [load]);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await refreshPluginStore();
+      await load();
+    } catch {
+      // ignore
+    } finally {
+      setRefreshing(false);
+    }
   }, [load]);
 
   if (loading) {
@@ -92,14 +106,30 @@ export function PluginsPage() {
   return (
     <div className="p-4 sm:p-6">
       {/* Header */}
-      <div className="mb-5">
-        <div className="flex items-center gap-2.5 mb-1">
-          <Package size={22} strokeWidth={1.5} className="text-text-secondary" />
-          <h1 className="text-[20px] sm:text-[24px] font-semibold text-text leading-[32px]">
-            {t("plugins.title")}
-          </h1>
+      <div className="mb-5 flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2.5 mb-1">
+            <Package size={22} strokeWidth={1.5} className="text-text-secondary" />
+            <h1 className="text-[20px] sm:text-[24px] font-semibold text-text leading-[32px]">
+              {t("plugins.title")}
+            </h1>
+          </div>
+          <p className="text-[13px] text-text-secondary mt-1">{t("plugins.subtitle")}</p>
         </div>
-        <p className="text-[13px] text-text-secondary mt-1">{t("plugins.subtitle")}</p>
+        <button
+          type="button"
+          onClick={handleRefresh}
+          disabled={refreshing}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-medium text-text-secondary border border-border rounded-[6px] hover:bg-border-light hover:text-text transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+          title={t("plugins.refreshRegistryTitle")}
+        >
+          {refreshing ? (
+            <Loader2 size={14} className="animate-spin" strokeWidth={1.5} />
+          ) : (
+            <RefreshCw size={14} strokeWidth={1.5} />
+          )}
+          {t("plugins.refreshRegistry")}
+        </button>
       </div>
 
       {/* Tabs: Installed / Store */}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -32,6 +32,8 @@ export type DataCategory =
   | "wind"
   | "action"
   | "gate_state"
+  | "cover_state"
+  | "runtime_daily"
   | "weather_condition"
   | "uv"
   | "solar_radiation"
@@ -56,7 +58,10 @@ export type OrderCategory =
   | "gate_trigger"
   | "valve_toggle"
   | "toggle_mute"
-  | "set_input";
+  | "set_input"
+  | "pool_pump_toggle"
+  | "pool_cover_move"
+  | "pool_cover_position";
 
 // ============================================================
 // Device
@@ -185,7 +190,9 @@ export type EquipmentType =
   | "energy_production_meter"
   | "media_player"
   | "appliance"
-  | "water_valve";
+  | "water_valve"
+  | "pool_pump"
+  | "pool_cover";
 
 export interface Equipment {
   id: string;
@@ -736,7 +743,7 @@ export interface IntegrationInfo {
 // Dashboard Widget
 // ============================================================
 
-export type WidgetFamily = "lights" | "shutters" | "heating" | "sensors" | "water";
+export type WidgetFamily = "lights" | "shutters" | "heating" | "sensors" | "water" | "pool";
 
 export interface WidgetConfig {
   /** Sensor widget: list of binding aliases to display (undefined = show all) */


### PR DESCRIPTION
## Summary

- Two new equipment types: **pool_pump** (filter pump with daily ON-time tracking) and **pool_cover** (motorized cover with derived OPEN / CLOSED / PARTIAL state).
- Custom widget icons (Designs F + G validated in earlier review session) and dedicated dashboard sub-widgets with toggle / open-stop-close buttons.
- Adds `category_override` on `order_bindings` so the same device order can be re-tagged depending on the equipment type using it (pool_pump_toggle, pool_cover_move, pool_cover_position).
- Adds `binding-candidates.ts` (groups a device's data/orders into discrete channels) — foundation for an upcoming \"1 device → N equipments\" UX.
- Side fix: water_valve dashboard widget now has the proper icon and an ON/OFF toggle.

## Changes

### Backend

- `migrations/006_pool_runtime_and_category_override.sql` — new `pool_runtime_state` table + `order_bindings.category_override` column.
- `src/shared/types.ts` / `src/shared/constants.ts` — new EquipmentType, WidgetFamily, OrderCategory, DataCategory values; pool family.
- `src/equipments/binding-candidates.ts` — `computeBindingCandidates`, `hasFreeCandidates`, `inferBindingCategory` helpers.
- `src/equipments/pool-runtime-tracker.ts` — daily ON-time tracker with persistence and local-midnight reset; surfaces `runtime_daily` as a `ComputedDataEntry`.
- `src/equipments/equipment-manager.ts` — `addOrderBinding` infers + persists override; type change retags all bindings; new `deriveCoverState` + virtual `cover_state` binding for pool_cover.
- `src/index.ts` — wires PoolRuntimeTracker into the engine.

### Frontend

- `WidgetIcons.tsx` — `PoolPumpIcon`, `PoolCoverIcon`, `WaterValveWidgetIcon`.
- `EquipmentWidget.tsx` — three new dashboard sub-widgets.
- Dropdowns / icon registry / family maps updated for the new types.
- i18n (FR/EN) labels added.

### Tests

27 new scenarios across 7 modules, all passing (365 / 365).

## Out of scope (follow-up)

- The full \"hide device with 0 free candidates\" + N-candidate picker UX in `DeviceSelector` / `EquipmentForm` / `AddBindingModal`. The backend helpers are in place and tested; the UI rewiring is a separate spec.

## Test plan

- [x] `npx tsc --noEmit` (backend) — zero errors
- [x] `cd ui && npx tsc -b --noEmit` (frontend) — zero errors
- [x] `npx vitest run` — 365 tests pass
- [x] `npx eslint src/ --ext .ts` — zero errors
- [ ] Manual: create POMPE / SPOT / VOLET from one Tasmota 4CH Pro (currently requires manual binding via AddBindingModal until follow-up picker lands)
- [ ] Manual: verify dashboard widgets render + toggle correctly (pool_pump, pool_cover, water_valve)
- [ ] Manual: verify runtime_daily accumulates across an ON/OFF cycle