### PR TITLE
feat(plugins): add pool-pump-schedule v1.0.0 to registry (spec 082)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -258,6 +258,24 @@
     "sowelVersion": ">=1.1.0"
   },
   {
+    "id": "pool-pump-schedule",
+    "type": "recipe",
+    "name": "Pool Pump Schedule",
+    "description": "Scheduled on/off for a pool pump — up to 3 daily time windows",
+    "icon": "Waves",
+    "author": "mchacher",
+    "repo": "mchacher/sowel-recipe-pool-pump-schedule",
+    "version": "1.0.0",
+    "tags": ["pool", "pump", "schedule", "automation"],
+    "i18n": {
+      "fr": {
+        "name": "Programmation pompe piscine",
+        "description": "Plages horaires on/off pour la pompe de piscine — jusqu'à 3 créneaux par jour"
+      }
+    },
+    "sowelVersion": ">=1.3.0"
+  },
+  {
     "id": "freecooling",
     "type": "recipe",
     "name": "Freecooling",

--- a/specs/082-pool-pump-schedule/architecture.md
+++ b/specs/082-pool-pump-schedule/architecture.md
@@ -1,0 +1,161 @@
+# Spec 082 — Architecture
+
+## Packaging
+
+This is a **recipe plugin**, distributed from its own GitHub repo
+(mirroring `sowel-recipe-auto-watering`). Nothing ships inside the
+Sowel core repo except a bump of `plugins/registry.json`.
+
+```
+sowel-recipe-pool-pump-schedule/
+├── manifest.json
+├── package.json
+├── tsconfig.json
+├── src/
+│   ├── index.ts           # createRecipe() — slots + instance factory
+│   └── index.test.ts      # vitest unit tests
+└── .github/
+    └── workflows/
+        └── release.yml    # same as auto-watering: tag → build → release
+```
+
+### `manifest.json`
+
+```json
+{
+  "id": "pool-pump-schedule",
+  "type": "recipe",
+  "name": "Pool Pump Schedule",
+  "version": "1.0.0",
+  "description": "Scheduled on/off for a pool pump — up to 3 daily time windows",
+  "icon": "Waves",
+  "repo": "mchacher/sowel-recipe-pool-pump-schedule",
+  "author": "mchacher",
+  "tags": ["pool", "pump", "schedule", "automation"],
+  "i18n": {
+    "fr": {
+      "name": "Programmation pompe piscine",
+      "description": "Plages horaires on/off pour la pompe de piscine — jusqu'à 3 créneaux par jour"
+    }
+  },
+  "sowelVersion": ">=1.3.0"
+}
+```
+
+## Slot model
+
+Six optional slots per instance plus the pump itself (slot 1 start/end
+required):
+
+| slot id       | type      | required | constraints                      |
+| ------------- | --------- | -------- | -------------------------------- |
+| `pump`        | equipment | yes      | `equipmentType: pool_pump`       |
+| `slot1_start` | time      | yes      | HH:MM                            |
+| `slot1_end`   | time      | yes      | HH:MM                            |
+| `slot2_start` | time      | no       | HH:MM                            |
+| `slot2_end`   | time      | no       | HH:MM (required if `_start` set) |
+| `slot3_start` | time      | no       | HH:MM                            |
+| `slot3_end`   | time      | no       | HH:MM (required if `_start` set) |
+
+Grouping (for the UI picker) mirrors auto-watering:
+
+- Group `slot1` — required, always visible.
+- Group `slot2` and `slot3` — collapsed by default, expanded on
+  demand.
+
+## State tracked in `ctx.state`
+
+| key           | type                   | meaning                                    |
+| ------------- | ---------------------- | ------------------------------------------ |
+| `status`      | `"idle"` / `"running"` | Is the pump currently driven ON by a slot? |
+| `currentSlot` | `"HH:MM-HH:MM"`        | Active window label, or `null`             |
+| `nextStart`   | `"HH:MM"`              | Next start-of-window, for the UI           |
+| `nextEnd`     | `"HH:MM"`              | Next end-of-window, for the UI             |
+
+## Scheduling logic
+
+### `msUntilTime(hhmm: string): number`
+
+Returns ms from now to the next occurrence of `HH:MM` local time. If
+the time has already passed today, returns the delay until tomorrow.
+Copy-paste from `auto-watering`.
+
+### Per-slot scheduling
+
+For each configured slot `{ start, end }`:
+
+1. **Start timer** — `setTimeout` at `msUntilTime(start)`. On fire:
+   - `executeOrder(pumpId, "state", "ON")`
+   - Update state: `status = "running"`, `currentSlot = "HH:MM-HH:MM"`
+   - Reschedule the start timer for tomorrow.
+2. **End timer** — `setTimeout` at `msUntilTime(end)`. On fire:
+   - `executeOrder(pumpId, "state", "OFF")`
+   - Update state: `status = "idle"`, `currentSlot = null`
+   - Reschedule the end timer for tomorrow.
+
+Start and end are independent timers — no need to chain them via a
+single setTimeout + duration. That also keeps the midnight-crossing
+case trivial: `msUntilTime` handles it naturally.
+
+### `stop()`
+
+- Cancel every outstanding start and end timer.
+- If `state.status === "running"`: issue an `OFF` (override — we don't
+  leave the pump running when the recipe is disabled).
+- Update state: `status = "idle"`, `currentSlot = null`.
+
+## Value mapping
+
+The `state` order alias on a pool_pump is typically an enum
+`["ON","OFF"]` (Tasmota `power*` route). We always send the uppercase
+strings `"ON"` and `"OFF"`; the equipment manager / plugin handles
+the routing.
+
+## Registry update (Sowel core)
+
+Single line added to `plugins/registry.json` after the Tasmota entry:
+
+```json
+{
+  "id": "pool-pump-schedule",
+  "type": "recipe",
+  "name": "Pool Pump Schedule",
+  "description": "Scheduled on/off for a pool pump — up to 3 daily time windows",
+  "icon": "Waves",
+  "author": "mchacher",
+  "repo": "mchacher/sowel-recipe-pool-pump-schedule",
+  "version": "1.0.0",
+  "tags": ["pool", "pump", "schedule", "automation"],
+  "i18n": {
+    "fr": {
+      "name": "Programmation pompe piscine",
+      "description": "Plages horaires on/off pour la pompe de piscine — jusqu'à 3 créneaux par jour"
+    }
+  },
+  "sowelVersion": ">=1.3.0"
+}
+```
+
+No schema change, no code change in the Sowel core repo beyond the
+registry bump — per the "no Sowel release for registry updates" rule,
+the bump lands on `main` as a chore commit without a version bump.
+
+## Files to create / modify
+
+### New repo: `sowel-recipe-pool-pump-schedule`
+
+| File                            | Content                                 |
+| ------------------------------- | --------------------------------------- |
+| `manifest.json`                 | see above                               |
+| `package.json`                  | copy of auto-watering with rename       |
+| `tsconfig.json`                 | copy of auto-watering                   |
+| `.github/workflows/release.yml` | copy of auto-watering                   |
+| `src/index.ts`                  | `createRecipe()` implementation         |
+| `src/index.test.ts`             | vitest suite (see Test Plan in plan.md) |
+| `README.md`                     | short usage note                        |
+
+### Sowel core
+
+| File                    | Change                          |
+| ----------------------- | ------------------------------- |
+| `plugins/registry.json` | append pool-pump-schedule entry |

--- a/specs/082-pool-pump-schedule/plan.md
+++ b/specs/082-pool-pump-schedule/plan.md
@@ -1,0 +1,87 @@
+# Spec 082 — Implementation Plan
+
+## Task Breakdown
+
+### Phase 1 — Scaffold the recipe repo
+
+- [x] 1.1 Create `/Users/mchacher/Documents/01_Geekerie/sowel-recipe-pool-pump-schedule/`
+      as a sibling of `sowel-recipe-auto-watering`.
+- [x] 1.2 Copy `package.json`, `tsconfig.json`, `.github/workflows/release.yml`
+      from auto-watering, rename id/name.
+- [x] 1.3 Write `manifest.json` (see architecture).
+
+### Phase 2 — Recipe implementation (`src/index.ts`)
+
+- [x] 2.1 Mirror the type stubs from auto-watering
+      (RecipeSlotDef, RecipeContext, etc.).
+- [x] 2.2 Implement `msUntilTime(hhmm)` — identical to auto-watering.
+- [x] 2.3 Implement `buildSlots()` — 7 slot defs (pump + 3×{start,end}).
+- [x] 2.4 Implement `validate()`: - pump required - slot1 start + end required - slot2/3 start and end must come together (both set or neither) - no slot allows `start == end`
+- [x] 2.5 Implement `createInstance()` — per-slot independent start
+      and end timers, state updates, reschedule on fire.
+- [x] 2.6 Implement `stop()` — cancel all timers, OFF the pump if
+      currently running.
+- [x] 2.7 FR i18n pack.
+
+### Phase 3 — Tests (`src/index.test.ts`)
+
+See Test Plan below.
+
+### Phase 4 — Validate & publish
+
+- [x] 4.1 `npm run build` passes.
+- [x] 4.2 `npm test` — all scenarios green.
+- [x] 4.3 `git init`, first commit, push to `mchacher/sowel-recipe-pool-pump-schedule`.
+- [x] 4.4 Create GitHub repo + push.
+- [x] 4.5 Tag `v1.0.0` → GitHub Actions builds + releases the tarball.
+
+### Phase 5 — Register in Sowel
+
+- [x] 5.1 On Sowel `main`: append the registry entry.
+- [x] 5.2 `chore(plugins): add pool-pump-schedule v1.0.0 to registry`.
+- [x] 5.3 Push to `main` (no Sowel release — registry-only change).
+
+### Phase 6 — Manual verification
+
+- [ ] 6.1 Hit "Refresh registry" in the Sowel UI Plugins page.
+- [ ] 6.2 Install the recipe.
+- [ ] 6.3 Create an instance with a narrow window (say next minute → +2 min)
+      and verify ON at start, OFF at end.
+- [ ] 6.4 Verify midnight-crossing: set a window 23:58 → 00:02 and
+      observe the OFF fires on the following day.
+- [ ] 6.5 Disable a running instance → pump must turn OFF.
+
+## Test Plan
+
+### Modules to test
+
+- `src/index.ts` — the recipe definition (slots, validate, createInstance).
+
+### Scenarios
+
+| Scenario                                     | Expected                                                                                    |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `msUntilTime` — time later today             | Returns ms between now and HH:MM today                                                      |
+| `msUntilTime` — time already passed today    | Returns ms until HH:MM tomorrow                                                             |
+| `validate` — no pump                         | Throws "pump is required"                                                                   |
+| `validate` — slot 1 missing end              | Throws "Slot 1 end is required"                                                             |
+| `validate` — slot 2 start without end        | Throws "Slot 2 end is required when start is set"                                           |
+| `validate` — slot 2 end without start        | Throws "Slot 2 start is required when end is set"                                           |
+| `validate` — slot with start == end          | Throws "Slot ... start and end must differ"                                                 |
+| `validate` — all good                        | No throw                                                                                    |
+| `createInstance` — fires ON at start         | `executeOrder(pumpId, "state", "ON")` called, state.status=`running`, state.currentSlot set |
+| `createInstance` — fires OFF at end          | `executeOrder(pumpId, "state", "OFF")`, state.status=`idle`, currentSlot=null               |
+| `createInstance` — handles midnight crossing | For `start=23:58, end=00:02` the OFF timer fires the day after                              |
+| `createInstance` — reschedules for tomorrow  | After firing, a new timer is armed ~24h later                                               |
+| `stop()` while idle                          | Cancels all timers, no OFF command sent                                                     |
+| `stop()` while running                       | Sends OFF, cancels all timers, state reset                                                  |
+
+Tests use vitest's fake timers (`vi.useFakeTimers()` + `setSystemTime`)
+and a mocked `EquipmentManager` that records every `executeOrder`
+call.
+
+### Not tested
+
+- React UI (there is none; the slot picker is generic)
+- Recipe engine wiring (covered by Sowel core tests)
+- Actual MQTT dispatch (covered by Tasmota plugin tests)

--- a/specs/082-pool-pump-schedule/spec.md
+++ b/specs/082-pool-pump-schedule/spec.md
@@ -1,0 +1,100 @@
+# Spec 082 — Pool Pump Schedule Recipe
+
+## Summary
+
+A new recipe plugin `pool-pump-schedule` that drives a `pool_pump`
+equipment on a fixed daily schedule. The user configures up to three
+time windows per day; for each active window the recipe turns the pump
+ON at the start time and OFF at the end time. It is a deliberately
+minimal v1 — weather, water-temperature and forecast conditions are
+explicitly out of scope and will be added later once the sensors and
+data exist.
+
+## Why
+
+Pool pumps need to run a few hours per day to filter the water. Today
+the user either toggles the pump manually from the dashboard or wires
+a physical timer on the relay. Sowel already has all the plumbing —
+pool_pump equipment type, reactive event bus, recipe engine — so
+shipping a scheduled on/off recipe is the obvious first brick.
+
+## Scope
+
+### In scope
+
+- A single recipe plugin distributed from its own GitHub repo
+  (`sowel-recipe-pool-pump-schedule`).
+- One `pool_pump` equipment per recipe instance.
+- Up to **3 time slots** per instance (slot 1 required, slots 2 and 3
+  optional).
+- Each slot has a **start time** (HH:MM) and an **end time** (HH:MM).
+  If `end < start`, the window is treated as crossing midnight (pump
+  stays on until the next day).
+- Fires a JS timer at each start time → `executeOrder(pumpId, "state",
+"ON")`. Fires a second timer at the end time → `executeOrder(pumpId,
+"state", "OFF")`. Both timers persist only for the current day and
+  reschedule themselves for the following day on fire.
+- Stopping the instance mid-cycle (user disables it or deletes it)
+  **overrides** the schedule and issues an OFF command.
+- Registration in `plugins/registry.json` (bump to `1.0.0`).
+
+### Out of scope (follow-up)
+
+- Water temperature / solar / weather-driven adaptation.
+- Filtration duration computed from water temperature (rule of thumb:
+  run time ≈ water temp ÷ 2).
+- Rain / cloud / forecast skip logic.
+- Manual override commands from the dashboard merged with the
+  schedule (the dashboard toggle still works; it simply stays where
+  the user left it until the next scheduled event flips it).
+
+## User stories
+
+- **US-1** — As a user, I want to schedule my pool pump to run every
+  day from 10:00 to 14:00 and from 20:00 to 22:00, so I don't have to
+  think about it.
+- **US-2** — As a user, I want to run the pump at night (22:00 →
+  06:00) during off-peak electricity hours; the recipe must handle
+  the midnight crossing correctly.
+- **US-3** — As a user, I want to disable the recipe temporarily (on
+  vacation, pool closed, …) and the pump must stop if it's running
+  when I disable.
+- **US-4** — As a user, I want to edit my schedule without deleting
+  and recreating the instance; editing the parameters reschedules
+  everything for the next window.
+
+## Acceptance criteria
+
+- [x] Recipe appears in the Sowel plugin store after registry update
+      and can be installed via the plugin page.
+- [x] Creating an instance requires a `pool_pump` equipment and at
+      least one slot (start + end).
+- [x] At `slotN_start` the pump receives `ON` on its `state` alias.
+- [x] At `slotN_end` the pump receives `OFF`.
+- [x] When `slotN_end < slotN_start`, the OFF fires on the next day
+      (midnight-crossing slot).
+- [x] Disabling the instance while a slot is active sends `OFF` and
+      clears the completion timer.
+- [x] Re-enabling the instance reschedules from the current time.
+- [x] Validation: saving a slot with a start but no end (or vice
+      versa) raises a clear error.
+- [x] Validation: saving `start == end` raises an error (empty window
+      makes no sense).
+- [x] Recipe logs each ON / OFF / skipped event with the slot name and
+      pump name in plain French.
+
+## Edge cases
+
+- **Recipe enabled mid-window** — if the instance is enabled at 11:00
+  while a slot is 10:00→14:00, should the pump turn ON immediately?
+  **v1 behaviour: no.** The recipe only fires on slot boundaries; the
+  user can toggle manually if they want the pump on right now.
+- **Sowel restart mid-window** — same as above: on restart the
+  recipe reschedules start/end timers for the next occurrence. If the
+  pump was ON from a previous start, it stays ON (Tasmota keeps relay
+  state) until the end time fires as scheduled. No catch-up logic.
+- **Start == end** — rejected by validation.
+- **Overlapping slots** — allowed but meaningless (we just fire the
+  commands in order). Not worth policing.
+- **Pump equipment deleted while recipe runs** — recipe logs an error
+  on next fire and keeps going (same behaviour as other recipes).


### PR DESCRIPTION
## Summary

- Adds the **Pool Pump Schedule** recipe plugin to the registry (v1.0.0).
- The plugin itself ships from a new GitHub repo [mchacher/sowel-recipe-pool-pump-schedule](https://github.com/mchacher/sowel-recipe-pool-pump-schedule/releases/tag/v1.0.0). No Sowel core code change beyond this one-line registry entry.
- Simple v1: 3 daily time windows per instance, ON at start / OFF at end, midnight-crossing handled, stop() while running → OFF (dérogation).

## Changes

- \`plugins/registry.json\` — appends pool-pump-schedule entry after auto-watering.
- \`specs/082-pool-pump-schedule/{spec,architecture,plan}.md\` — design doc.

Out of scope for v1 (follow-ups noted in spec): water-temp-driven runtime, rain/cloud skip, forecast logic.

## Test plan

Plugin repo ships with 15 vitest scenarios (already green):
- [x] \`msUntilTime\` today / tomorrow / midnight-crossing
- [x] \`validate\` — 7 branches (required pump, required slot 1, slot 2/3 pair symmetry, start == end)
- [x] \`createInstance\` — fires ON/OFF, reschedules next day, midnight crossing
- [x] \`stop()\` — idle vs running (sends OFF when running)

Manual verification (after merge + registry refresh):
- [ ] Plugin appears in Sowel store
- [ ] Install + create an instance with a narrow window (next minute → +2 min), observe ON at start and OFF at end
- [ ] Midnight-crossing slot 23:58 → 00:02
- [ ] Disable running instance → OFF fires