### PR TITLE
fix(ui): equal-width columns for homogeneous recipe slot pairs

### DIFF
--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -1672,8 +1672,15 @@ function AddRecipeForm({
                           if (compactSlots.length === 0) return null;
                           const n = compactSlots.length;
                           const cols = n <= 3 ? n : n % 3 === 0 ? 3 : 2;
+                          // Use 1fr/auto only when a `number` slot wants a
+                          // narrow column (see per-slot w-[100px] below).
+                          // Otherwise give both columns equal width so two
+                          // time pickers (or any homogeneous pair) sit
+                          // side by side with the same size.
+                          const hasNarrowNumber = compactSlots.some((s) => s.type === "number");
+                          const twoColClass = hasNarrowNumber ? "grid-cols-[1fr_auto]" : "grid-cols-2";
                           return (
-                            <div className={`grid gap-1.5 ${cols === 1 ? "grid-cols-1" : cols === 2 ? "grid-cols-[1fr_auto]" : "grid-cols-3"}`}>
+                            <div className={`grid gap-1.5 ${cols === 1 ? "grid-cols-1" : cols === 2 ? twoColClass : "grid-cols-3"}`}>
                               {compactSlots.map((slot) => (
                                 <div key={slot.id} className={slot.type === "number" ? "w-[100px]" : ""}>
                                   <label className="block text-[10px] tracking-wider mb-0.5 text-text-tertiary">


### PR DESCRIPTION
## Summary

The create-recipe form rendered 2-slot groups with \`grid-cols-[1fr_auto]\`, designed for pairs like \`time + number\` (the \`number\` slot is forced to \`w-[100px]\`). When both slots are \`time\` — as in the new pool-pump-schedule recipe's start/end pair — the second column collapsed to the native picker's intrinsic width, leaving a wide Début field and a cramped Fin field.

## Changes

- \`ui/src/components/recipes/ZoneRecipesSection.tsx\`: 2-slot groups now pick their column layout based on whether a \`number\` slot is present.
  - Has a number slot → keeps \`grid-cols-[1fr_auto]\` (arrosage stays unchanged).
  - Otherwise → \`grid-cols-2\` (pool-pump start/end get equal width).

## Test plan

- [x] \`cd ui && npx tsc -b --noEmit\` — clean
- [ ] Manual: create Pool Pump Schedule recipe → "Créneau 1" shows Début and Fin with equal width
- [ ] Manual: create Arrosage Auto recipe → slot 1 time + duration unchanged