### PR TITLE
style(ui): show Ouvert/Fermé pill in compact shutter cards

### DIFF
--- a/ui/src/components/equipments/ShutterControl.tsx
+++ b/ui/src/components/equipments/ShutterControl.tsx
@@ -67,9 +67,19 @@ export function ShutterControl({ equipment, onExecuteOrder, compact }: ShutterCo
               onClick={(e) => e.stopPropagation()}
               className="w-[60px]"
             />
-            <span className="text-[11px] text-text-tertiary w-8 text-right tabular-nums">
-              {position}%
-            </span>
+            {position === 100 ? (
+              <span className="text-[11px] font-medium text-success px-1.5 py-0.5 rounded bg-success/10">
+                {t("controls.opened")}
+              </span>
+            ) : position === 0 ? (
+              <span className="text-[11px] font-medium text-text-secondary px-1.5 py-0.5 rounded bg-border-light">
+                {t("controls.closed")}
+              </span>
+            ) : (
+              <span className="text-[11px] text-text-tertiary w-8 text-right tabular-nums">
+                {position}%
+              </span>
+            )}
           </div>
         )}
         {!hasPositionOrder && position !== null && (


### PR DESCRIPTION
Zone-view mini card for a shutter / pool_cover with a position order bound showed only `100%` — visually identical to any mid-travel value. Now shows an "Ouvert" pill at 100%, "Fermé" at 0%, and the `%` elsewhere. Same pattern as the full ShutterEquipmentWidget.

## Test plan
- [x] tsc clean
- [ ] Manual: volet à 100% → pill verte "Ouvert"
- [ ] Manual: volet à 0% → pill grise "Fermé"
- [ ] Manual: volet à 50% → affiche "50%"