### PR TITLE
feat: pool_heat_pump equipment + Polytropic Master plugin scaffolding (spec 083)

### DIFF
--- a/migrations/007_pool_water_temp_state.sql
+++ b/migrations/007_pool_water_temp_state.sql
@@ -1,0 +1,15 @@
+-- Spec 083: Pool heat pump support.
+--
+-- pool_water_temp_state: caches the last "active" water temperature sample per
+-- pool_heat_pump equipment. A sample is considered active when either the
+-- bound `filtration_state` alias is ON, or (when not bound) the bound `mode`
+-- alias is anything other than "OFF". The cache is used to expose
+-- `effective_water_temperature` even while the heat pump (or filtration) is
+-- not running, up to a 24h freshness window after which the value drops to
+-- null.
+
+CREATE TABLE IF NOT EXISTS pool_water_temp_state (
+  equipment_id TEXT PRIMARY KEY REFERENCES equipments(id) ON DELETE CASCADE,
+  last_active_value REAL,                       -- last temperature sample °C
+  last_active_ts TEXT                           -- ISO 8601 of last active sample
+);

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -292,5 +292,23 @@
       }
     },
     "sowelVersion": ">=1.1.0"
+  },
+  {
+    "id": "polytropic_master",
+    "type": "integration",
+    "name": "Polytropic Master Inverter",
+    "description": "Pool heat pump (Polytropic Master Inverter) over Modbus RTU/TCP via a Waveshare gateway",
+    "icon": "Waves",
+    "author": "mchacher",
+    "repo": "mchacher/sowel-plugin-polytropic-master",
+    "version": "1.0.0",
+    "tags": ["pool", "heat-pump", "modbus", "polytropic"],
+    "i18n": {
+      "fr": {
+        "name": "Polytropic Master Inverter",
+        "description": "PAC piscine Polytropic Master Inverter via Modbus RTU/TCP (passerelle Waveshare)"
+      }
+    },
+    "sowelVersion": ">=1.4.0"
   }
 ]

--- a/specs/083-pool-heat-pump-plugin/architecture.md
+++ b/specs/083-pool-heat-pump-plugin/architecture.md
@@ -1,0 +1,190 @@
+# Architecture — Spec 083 Pool Heat Pump Plugin
+
+## Components touched
+
+| Layer           | Component                                                                                        | Type of change                                                                                                                                                               |
+| --------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Sowel core      | `src/shared/types.ts`                                                                            | New `EquipmentType: "pool_heat_pump"`; new `DataCategory` values `pool_water_temperature`, `pool_temperature_setpoint`; new `OrderCategory: "set_pool_temperature_setpoint"` |
+| Sowel core      | `src/shared/constants.ts`                                                                        | Add `pool_heat_pump` to `WIDGET_FAMILY_TYPES` (thermostat family) and any equipment-type registries                                                                          |
+| Sowel core      | `src/equipments/binding-candidates.ts`                                                           | Recognise `pool_heat_pump` in `inferBindingCategory`, `computeBindingCandidates`, etc.                                                                                       |
+| Sowel core      | `src/equipments/equipment-manager.ts` and computed engine                                        | Register a new computed-data evaluator `effective_water_temperature` for `pool_heat_pump` equipments                                                                         |
+| Sowel UI        | `ui/src/components/equipments/*`                                                                 | Allow creating a `pool_heat_pump` equipment, propose `filtration_state` as an optional alias                                                                                 |
+| Sowel UI        | `ui/src/components/dashboard/widget-icons.ts` and `EquipmentWidget.tsx` / `MobileWidgetCard.tsx` | Map `pool_heat_pump` to the existing `ThermostatEquipmentWidget` (no new widget code)                                                                                        |
+| Sowel UI        | `ui/src/i18n/locales/{en,fr}.json`                                                               | Translations                                                                                                                                                                 |
+| Plugin registry | `plugins/registry.json`                                                                          | Add `polytropic_master` entry                                                                                                                                                |
+| Plugin repo     | `mchacher/sowel-plugin-polytropic-master` (new repo)                                             | Full plugin implementation                                                                                                                                                   |
+| Docs            | `docs/user/equipments.md`, `docs/technical/data-model.md`, `docs/technical/architecture.md`      | Document the new equipment type and the Modbus integration model                                                                                                             |
+
+## Data model changes
+
+### `src/shared/types.ts`
+
+```ts
+export type DataCategory =
+  | ...
+  | "pool_water_temperature"        // NEW
+  | "pool_temperature_setpoint"     // NEW
+  | ...;
+
+export type OrderCategory =
+  | ...
+  | "set_pool_temperature_setpoint" // NEW
+  | ...;
+
+export type EquipmentType =
+  | ...
+  | "pool_heat_pump"                // NEW
+  | ...;
+```
+
+No DB migration required — `EquipmentType` and category strings are stored as text in SQLite.
+
+### Equipment aliases convention
+
+| Alias              | Bound to (typical)                                                                      | Required | Read/Write |
+| ------------------ | --------------------------------------------------------------------------------------- | -------- | ---------- |
+| `temperature`      | PAC device, `water_temperature` data                                                    | yes      | R          |
+| `setpoint`         | PAC device, `setpoint` data + setpoint order                                            | yes      | R/W        |
+| `mode`             | PAC device, `mode` data                                                                 | yes      | R          |
+| `filtration_state` | Any third-party device exposing an enum/boolean indicating that water circulation is on | no       | R          |
+
+The thermostat widget reads aliases `temperature`, `setpoint`, `mode` — those names are deliberately reused so the same widget renders without per-type branching.
+
+## Computed `effective_water_temperature`
+
+Lives in the equipment computed-data engine (`src/equipments/computed-engine.ts` or equivalent). Pseudo-code:
+
+```ts
+function evaluate(equipment, bindings, internalState) {
+  const water = bindings["temperature"]?.value; // alias
+  const filt = bindings["filtration_state"]?.value; // optional alias
+  const mode = bindings["mode"]?.value;
+  const now = Date.now();
+
+  const isActive =
+    filt !== undefined
+      ? Boolean(filt === "ON" || filt === true)
+      : mode !== "OFF" && mode !== undefined;
+
+  if (isActive) {
+    // sample is fresh
+    internalState.lastActiveTs = now;
+    internalState.lastActiveValue = water;
+    return water;
+  }
+
+  // not active — return last active sample if within 24h
+  if (internalState.lastActiveTs && now - internalState.lastActiveTs < 24 * 3600 * 1000) {
+    return internalState.lastActiveValue;
+  }
+  return null;
+}
+```
+
+`internalState` is persisted via the computed-engine's existing memo store (one per equipment).
+
+## Modbus plugin design (`sowel-plugin-polytropic-master`)
+
+### Project layout
+
+```
+sowel-plugin-polytropic-master/
+├── manifest.json
+├── package.json
+├── tsconfig.json
+├── README.md
+└── src/
+    ├── index.ts            # createPlugin entry
+    ├── modbus-client.ts    # Modbus RTU-over-TCP wrapper around `modbus-serial`
+    ├── modbus-client.test.ts
+    ├── polytropic-plugin.ts# Main plugin class (start/stop/poll/executeOrder)
+    └── registers.ts        # Register definitions, scaling, enum mapping
+```
+
+### Dependencies
+
+- `modbus-serial` (npm) — supports RTU-over-TCP via `connectRTUBuffered({ host, port })` then `setID(slaveId)`.
+- Pino logger child injected by Sowel via `createPlugin({ logger })`.
+
+### Plugin lifecycle
+
+1. **createPlugin(deps)** returns an `IntegrationPlugin` per `src/shared/plugin-api.ts`.
+2. **start()** :
+   - Read settings (host, port, slaveId, pollIntervalSec) — defaults `192.168.0.242 / 4196 / 17 / 60`.
+   - Connect Modbus client. On connection error, log warn, schedule retry with exponential backoff up to 60s.
+   - Discover the single device:
+     - sourceDeviceId = `polytropic_master_<slave>`.
+     - Manufacturer `Polytropic`, model `Master Inverter`.
+     - 4 data points + 1 order as per the spec.
+   - Start poll timer.
+3. **poll()** (every `pollIntervalSec`):
+   - Read holding registers in two reads: `[512, 515]` for temps, `[1000, 1001]` for mode/setpoint.
+   - Decode water/outdoor temps as signed 16-bit ÷ 10.
+   - Decode setpoint as signed 16-bit ÷ 10.
+   - Decode mode as enum: `0→OFF`, `21→SMART`, `22→BOOST`, `23→ECO`. Unknown values logged as warn and forwarded as `RAW_<n>`.
+   - Push values to Sowel via `deviceManager.updateDeviceData()`.
+   - On read failure, increment `consecutiveFailures` counter. After 3 consecutive failures, mark device offline and integration errored. On the next success, mark online again.
+4. **executeOrder(device, orderKey, value)** :
+   - Only `setpoint` is writable. Compute Modbus write value = round(value × 10).
+   - `client.writeRegister(1001, value)`. On success, log info and trigger an immediate `poll()` (re-poll mechanism).
+   - On error, log error, do not update local cache.
+5. **stop()** :
+   - Clear poll timer, close Modbus connection.
+
+### Settings schema (UI)
+
+| Key                 | Type   | Default         | Required |
+| ------------------- | ------ | --------------- | -------- |
+| `host`              | text   | `192.168.0.242` | yes      |
+| `port`              | number | `4196`          | yes      |
+| `slave_id`          | number | `17`            | yes      |
+| `poll_interval_sec` | number | `60`            | yes      |
+
+### Manifest
+
+```json
+{
+  "id": "polytropic_master",
+  "type": "integration",
+  "name": "Polytropic Master Inverter",
+  "description": "Pool heat pump (Polytropic Master Inverter) over Modbus RTU/TCP via a Waveshare gateway",
+  "icon": "Waves",
+  "author": "mchacher",
+  "repo": "mchacher/sowel-plugin-polytropic-master",
+  "version": "1.0.0",
+  "tags": ["pool", "heat-pump", "modbus"]
+}
+```
+
+## Event flow
+
+```
+poll tick ──► modbus read 4 regs ──► decode
+                                     ├─► deviceManager.updateDeviceData(water_temperature)
+                                     ├─► deviceManager.updateDeviceData(outdoor_temperature)
+                                     ├─► deviceManager.updateDeviceData(mode)
+                                     └─► deviceManager.updateDeviceData(setpoint)
+                                            │
+                                            ▼
+                                     EventBus device.data.updated
+                                            │
+                                            ▼
+                                     EquipmentManager re-evaluates
+                                            ├─► alias temperature (raw water)
+                                            ├─► alias setpoint
+                                            ├─► alias mode
+                                            ├─► alias filtration_state (from other device)
+                                            └─► computed effective_water_temperature
+                                                     │
+                                                     ▼
+                                            EventBus equipment.data.changed
+                                                     │
+                                                     ▼
+                                            ThermostatEquipmentWidget re-renders
+```
+
+## Error handling
+
+- All Modbus reads/writes wrapped in try/catch with structured pino logs (`{ err, host, slaveId, register }`).
+- No throw escapes the plugin handlers (Sowel rule).
+- Connection lifecycle: single persistent TCP socket; on close, schedule reconnect with backoff.

--- a/specs/083-pool-heat-pump-plugin/plan.md
+++ b/specs/083-pool-heat-pump-plugin/plan.md
@@ -1,0 +1,94 @@
+# Plan — Spec 083 Pool Heat Pump Plugin
+
+## Implementation order
+
+The work spans two repos:
+
+- **A. Sowel core** (`mchacher/sowel`) — new types, computed evaluator, UI wiring, registry entry.
+- **B. New plugin repo** (`mchacher/sowel-plugin-polytropic-master`) — the Modbus plugin itself.
+
+### A — Sowel core (branch `feat/pool-heat-pump`)
+
+1. **Types & constants**
+   - `src/shared/types.ts`: add `pool_water_temperature`, `pool_temperature_setpoint`, `set_pool_temperature_setpoint`, `pool_heat_pump`.
+   - `src/shared/constants.ts`: add `pool_heat_pump` to widget-family / equipment-type maps as needed (mirror `thermostat`).
+2. **Equipment manager / computed engine**
+   - Register a new computed-data evaluator `effective_water_temperature` for `pool_heat_pump` (file: most likely a new module under `src/equipments/computed/` or extend the existing computed engine; see how thermostat is done if applicable).
+   - Persist last-active timestamp + value per equipment (reuse the engine's existing memo storage).
+3. **Binding inference / candidates**
+   - `src/equipments/binding-candidates.ts`: add `pool_heat_pump` cases — recognise `pool_water_temperature`, `pool_temperature_setpoint`, `appliance_state` (mode), and the optional `filtration_state` alias on enum/boolean keys.
+   - Update `ORDER_CATEGORY_ALIASES` / `DATA_CATEGORY_ALIASES` in the UI (`ui/src/components/equipments/bindingUtils.ts`) accordingly.
+4. **API**
+   - No new REST endpoint. The existing equipment CRUD covers it.
+5. **UI**
+   - `ui/src/components/equipments/EquipmentForm.tsx` (and friends): make `pool_heat_pump` selectable; expose `filtration_state` as an optional alias slot.
+   - `ui/src/components/dashboard/widget-icons.ts`: register `pool_heat_pump` → existing thermostat widget icon (or `Waves`).
+   - `ui/src/components/dashboard/EquipmentWidget.tsx` / `MobileWidgetCard.tsx`: route `pool_heat_pump` to `ThermostatEquipmentWidget` (no new component).
+   - `ui/src/i18n/locales/{en,fr}.json`: new strings (`pool_heat_pump` label, helper text for `filtration_state`).
+6. **Registry**
+   - `plugins/registry.json`: add `polytropic_master` entry pointing to the new repo.
+7. **Tests**
+   - `effective_water_temperature` evaluator: 6 scenarios (see Test Plan).
+   - Binding-candidate regression tests for `pool_heat_pump`.
+8. **Validate**
+   - `npx tsc --noEmit`, `cd ui && npx tsc -b --noEmit`, `npx vitest run`, `npx eslint src/ --ext .ts`.
+9. **Commit & PR**
+
+### B — Plugin repo `sowel-plugin-polytropic-master`
+
+1. **Bootstrap repo** (mirror `sowel-plugin-tasmota` layout): `package.json`, `tsconfig.json`, `manifest.json`, `vitest.config.ts`, `eslint`, GitHub Actions release workflow (build + tarball + GH release).
+2. **Modbus client wrapper** (`src/modbus-client.ts`): typed wrapper over `modbus-serial`; `connect()`, `readHoldingRegisters(addr, count)`, `writeRegister(addr, value)`, `close()`. Reconnection with backoff.
+3. **Register definitions** (`src/registers.ts`): scaling helpers (`x10`), mode enum mapping.
+4. **Plugin** (`src/polytropic-plugin.ts`): `createPlugin(deps)` returning an `IntegrationPlugin`; lifecycle methods as per architecture.md.
+5. **Tests** (`src/*.test.ts`): see Test Plan section.
+6. **Manifest** version 1.0.0.
+7. **CI**: build + lint + test + tarball.
+8. **First release** v1.0.0; update Sowel registry to point to it.
+
+## Test Plan
+
+### Modules to test
+
+- `effective_water_temperature` evaluator (Sowel core)
+- `registers.ts` decoders (plugin) — scaling + mode enum
+- `polytropic-plugin.ts` — lifecycle + write/poll behaviour (mock Modbus client)
+- `binding-candidates.ts` — `pool_heat_pump` candidate inference (Sowel core)
+
+### Scenarios
+
+| Module                      | Scenario                                                 | Expected                                                                                                |
+| --------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| effective_water_temperature | filtration bound and ON, water=22.0                      | returns 22.0; lastActive updated                                                                        |
+| effective_water_temperature | filtration bound, OFF since 1h, last active=21.5         | returns 21.5 (frozen)                                                                                   |
+| effective_water_temperature | filtration bound, OFF since 25h, last active=21.5        | returns null                                                                                            |
+| effective_water_temperature | filtration not bound, mode=SMART, water=22.0             | returns 22.0; lastActive updated                                                                        |
+| effective_water_temperature | filtration not bound, mode=OFF, last active=21.5 1h ago  | returns 21.5 (frozen)                                                                                   |
+| effective_water_temperature | filtration not bound, mode=OFF, last active=21.5 25h ago | returns null                                                                                            |
+| registers (decode)          | water register 220 ×10                                   | returns 22.0 °C                                                                                         |
+| registers (decode)          | water register -50 (signed)                              | returns -5.0 °C                                                                                         |
+| registers (decode mode)     | mode register 21                                         | returns "SMART"                                                                                         |
+| registers (decode mode)     | mode register 99 (unknown)                               | returns "RAW_99" + warn log                                                                             |
+| registers (encode)          | encode setpoint 25.5                                     | returns 255                                                                                             |
+| polytropic-plugin           | poll success                                             | 4 deviceManager.updateDeviceData calls                                                                  |
+| polytropic-plugin           | poll fails 3× consecutively                              | device flips offline; integration errored                                                               |
+| polytropic-plugin           | executeOrder set_pool_temperature_setpoint 25.5          | writeRegister(1001, 255) called; immediate re-poll triggered                                            |
+| polytropic-plugin           | executeOrder fails                                       | error logged; no local cache update; no re-poll                                                         |
+| binding-candidates          | `pool_heat_pump` + PAC device with 4 data points         | candidates include all 4 aliases (`temperature`, `setpoint`, `mode`, `outdoor_temperature` if proposed) |
+| binding-candidates          | `pool_heat_pump` + Sonoff 4CH PRO `power2`               | candidate proposes `filtration_state` alias                                                             |
+
+### What is NOT tested
+
+- The Sowel UI components (no React tests in this project).
+- The Modbus library itself (`modbus-serial`).
+- End-to-end integration with a physical PAC (manual test only).
+
+## Manual verification (in PR test plan)
+
+- [ ] `npx tsc --noEmit` green on Sowel core.
+- [ ] `cd ui && npx tsc -b --noEmit` green.
+- [ ] `npx vitest run` all green on Sowel core.
+- [ ] Plugin repo: `npm run build`, `npm test`, `npm run lint` all green.
+- [ ] Install plugin in local Sowel, configure with real PAC, see device discovered with 4 data points + 1 order.
+- [ ] Setpoint slider in UI → value reflected at next poll on real device.
+- [ ] Stop the Waveshare gateway → device flips offline within ~3 minutes.
+- [ ] Bind `filtration_state` to Sonoff power2; toggle the relay and observe the freeze/live behaviour of `effective_water_temperature`.

--- a/specs/083-pool-heat-pump-plugin/spec.md
+++ b/specs/083-pool-heat-pump-plugin/spec.md
@@ -1,0 +1,89 @@
+# Spec 083 — Pool Heat Pump Plugin (Polytropic Master Inverter)
+
+## Goal
+
+Add a new integration plugin `polytropic_master` that talks Modbus RTU (over TCP via a Waveshare gateway) to a Polytropic Master Inverter pool heat pump. Expose its readings (water temperature, outdoor temperature, mode, setpoint) as a Sowel device, and create a new equipment type `pool_heat_pump` that surfaces them in the UI through the existing thermostat widget.
+
+## Why
+
+- The pool heat pump has no native cloud or Wi-Fi integration — only Modbus.
+- Sowel does not yet have a Modbus capability; this plugin is the first.
+- The user wants visibility on water/outdoor temperature and the ability to neutralise the heat pump (lower the setpoint) without leaving the Sowel UI.
+- Mode write is intentionally NOT supported — only the setpoint is writable. The pump cannot be cleanly stopped via Modbus other than by lowering the setpoint well below the current water temperature.
+
+## Scope (in)
+
+- New plugin repo `mchacher/sowel-plugin-polytropic-master` distributed via the official registry.
+- Modbus RTU over TCP client targeting a Waveshare gateway (default `192.168.0.242:4196`, slave 17).
+- Single device per plugin instance.
+- Polling interval configurable in UI (default 60s). Immediate re-poll after a successful write.
+- 4 read DataCategories on the device:
+  - `pool_water_temperature` (new) — register 512, ×10 °C
+  - `temperature_outdoor` (existing) — register 515, ×10 °C
+  - `appliance_state` (existing, used for mode enum: OFF / SMART / BOOST / ECO) — register 1000
+  - `pool_temperature_setpoint` (new) — register 1001, ×10 °C
+- 1 writable order on the device:
+  - `set_pool_temperature_setpoint` (new) — register 1001, °C in [10, 30], step 0.5
+- New `EquipmentType: "pool_heat_pump"` modelled on `thermostat`. Reuses the existing thermostat widget by exposing the same aliases:
+  - `temperature` (alias) → bound to PAC `water_temperature`, but consumed via a computed `effective_water_temperature` (see below)
+  - `setpoint` (alias) → bound to PAC `setpoint`
+  - `mode` (alias) → bound to PAC `mode` (read-only display)
+  - `filtration_state` (alias, optional) → bound to any boolean/ON-OFF data on a third-party device (typically the Sonoff 4CH PRO relay driving the filtration pump). Used by the computed engine, see below.
+- **Computed `effective_water_temperature`** (derived from the equipment's own bindings, no cross-equipment reference):
+  - If `filtration_state` is bound and ON → expose the live `water_temperature`.
+  - If `filtration_state` is bound and OFF → expose the **last value seen while it was ON**, until 24h have elapsed since that last "active" sample. After 24h → `null`.
+  - If `filtration_state` is **not bound** (fallback) → expose live `water_temperature` if `mode != OFF`, otherwise expose the last value while `mode != OFF`, also subject to the 24h cap.
+- UI:
+  - Equipment creation in the existing equipment form, type "pool_heat_pump".
+  - Detail page: same layout as thermostat.
+  - Dashboard widget: same widget as thermostat (`ThermostatEquipmentWidget`).
+  - Translations en/fr.
+- Tests:
+  - Unit tests for the Modbus parser (decode/encode ×10 scaling, mode enum mapping).
+  - Unit tests for the freshness/gating logic of `effective_water_temperature` (live, frozen, 24h expiry, fallback path).
+
+## Scope (out)
+
+- Multiple PAC instances per plugin (V1 = single device).
+- Mode write (reg 1000 stays read-only).
+- Direct compressor / flow status registers (not in the user's mapping).
+- Schedule recipe for the pool heat pump (out of this spec; a recipe could be added later, similar to spec 082).
+- Auto-detection of which Sonoff channel drives the filtration — the user wires it manually via the `filtration_state` binding.
+
+## User stories
+
+- As a user, I install the `polytropic_master` plugin from the Sowel plugin store and configure host/port/slave/polling.
+- As a user, I create a `pool_heat_pump` equipment, bind it to the discovered Modbus device, and optionally bind `filtration_state` to my Sonoff 4CH PRO relay.
+- As a user, I see water temperature on my dashboard widget. When the filtration is off, the value freezes (and is marked as not live) and disappears after 24h of continuous off.
+- As a user, I can lower the setpoint to 10°C from the widget to neutralise the heat pump.
+- As a user, when the Modbus gateway is offline, the device status flips to `offline` and the integration shows an error in the integrations page.
+
+## Acceptance criteria
+
+- [ ] Plugin appears in `plugins/registry.json` with `id: "polytropic_master"`, type `integration`.
+- [ ] Plugin can be installed, configured (host, port, slaveId, pollIntervalSec), started, stopped from the UI.
+- [ ] On start, the plugin discovers exactly one device with the four data points and one order listed above.
+- [ ] Polling reads the four registers; values are decoded with the correct ×10 scaling.
+- [ ] Mode register decodes to one of `OFF`, `SMART`, `BOOST`, `ECO`; unknown values fall back to the raw integer string with a `warn` log.
+- [ ] Writing the setpoint via Sowel sends a Modbus write to register 1001 with value × 10, then triggers an immediate poll within 1s.
+- [ ] Setpoint slider in UI is constrained to `[10, 30]` °C with step 0.5.
+- [ ] If the Modbus gateway is unreachable for one poll cycle the plugin retries once; after consecutive failures (3 cycles) the device flips to `offline` and the integration is marked errored.
+- [ ] Equipment type `pool_heat_pump` is selectable in the equipment creation form.
+- [ ] The dashboard `ThermostatEquipmentWidget` renders correctly for `pool_heat_pump` and shows the `effective_water_temperature`, setpoint, and mode badge.
+- [ ] Computed `effective_water_temperature` follows the rules in the Scope section, validated by unit tests:
+  - filtration ON → live water temp
+  - filtration OFF, last active sample < 24h → frozen value
+  - filtration OFF, last active sample ≥ 24h → `null`
+  - filtration not bound, mode ≠ OFF → live water temp
+  - filtration not bound, mode = OFF, last active < 24h → frozen
+  - filtration not bound, mode = OFF, last active ≥ 24h → `null`
+- [ ] Translations en/fr added for `pool_heat_pump` equipment type and any new UI strings.
+- [ ] Documentation updated (`docs/user/equipments.md`, `docs/technical/data-model.md`, `docs/technical/architecture.md`).
+
+## Edge cases
+
+- Modbus gateway unreachable on plugin start → plugin retries with exponential backoff (max 60s), logs a warn.
+- Setpoint write fails → plugin logs error, does not update the local cache; the UI eventually reflects the discrepancy at next poll.
+- Mode register returns unmapped value → log warn, expose raw integer as enum value.
+- `filtration_state` binding is removed at runtime → fallback to mode-based gating with no data loss (last known active sample remains valid for the 24h window).
+- 24h timer baseline: starts from the last sample where the gating predicate was true (filtration ON, or mode != OFF). Plugin restart preserves the baseline by persisting it in the equipment computed state (reuses existing computed-engine persistence).

--- a/src/equipments/binding-candidates.ts
+++ b/src/equipments/binding-candidates.ts
@@ -165,8 +165,7 @@ export function computeBindingCandidates(
     }
 
     case "thermostat":
-    case "heater":
-    case "pool_heat_pump": {
+    case "heater": {
       // Single candidate grouping everything (power/setpoint/temperature).
       if (deviceData.length === 0 && deviceOrders.length === 0) return [];
       return [
@@ -177,6 +176,40 @@ export function computeBindingCandidates(
           orderKeys: deviceOrders.map((o) => o.key),
         },
       ];
+    }
+
+    case "pool_heat_pump": {
+      // Hybrid: PAC device (exposing pool_water_temperature) → single "all" candidate.
+      // ON/OFF relay device (e.g. Sonoff 4CH driving filtration) → one candidate per channel
+      //   so the user can pick which relay drives the filtration_state alias.
+      const isPac = deviceData.some((d) => d.category === "pool_water_temperature");
+      if (isPac) {
+        if (deviceData.length === 0 && deviceOrders.length === 0) return [];
+        return [
+          {
+            id: "all",
+            label: "All PAC data/orders",
+            dataKeys: deviceData.map((d) => d.key),
+            orderKeys: deviceOrders.map((o) => o.key),
+          },
+        ];
+      }
+      // Read-only binding: pool_heat_pump just listens to the relay state for
+      // its `filtration_state` alias. Don't claim the order — it stays
+      // available to whichever pool_pump equipment drives the same relay.
+      const candidates: BindingCandidate[] = [];
+      for (const o of deviceOrders) {
+        if (!isOnOffEnum(o)) continue;
+        const matchingData = deviceData.find((d) => d.key === o.key);
+        if (!matchingData) continue;
+        candidates.push({
+          id: o.key,
+          label: o.key,
+          dataKeys: [matchingData.key],
+          orderKeys: [],
+        });
+      }
+      return candidates;
     }
 
     case "gate": {

--- a/src/equipments/binding-candidates.ts
+++ b/src/equipments/binding-candidates.ts
@@ -165,7 +165,8 @@ export function computeBindingCandidates(
     }
 
     case "thermostat":
-    case "heater": {
+    case "heater":
+    case "pool_heat_pump": {
       // Single candidate grouping everything (power/setpoint/temperature).
       if (deviceData.length === 0 && deviceOrders.length === 0) return [];
       return [

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -48,6 +48,7 @@ const VALID_EQUIPMENT_TYPES: Set<string> = new Set([
   "water_valve",
   "pool_pump",
   "pool_cover",
+  "pool_heat_pump",
 ]);
 
 // ============================================================

--- a/src/equipments/pool-water-temp-tracker.test.ts
+++ b/src/equipments/pool-water-temp-tracker.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  decideActive,
+  evaluateEffectiveWaterTemperature,
+  pickAlias,
+  pickAliasNumber,
+} from "./pool-water-temp-tracker.js";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+describe("decideActive", () => {
+  it("uses filtration when bound (string ON)", () => {
+    expect(decideActive("ON", "OFF")).toBe(true);
+  });
+  it("uses filtration when bound (string OFF)", () => {
+    expect(decideActive("OFF", "SMART")).toBe(false);
+  });
+  it("uses filtration when bound (boolean)", () => {
+    expect(decideActive(true, "OFF")).toBe(true);
+    expect(decideActive(false, "SMART")).toBe(false);
+  });
+  it("falls back to mode when filtration not bound", () => {
+    expect(decideActive(undefined, "SMART")).toBe(true);
+    expect(decideActive(undefined, "OFF")).toBe(false);
+  });
+  it("returns true when neither signal bound", () => {
+    expect(decideActive(undefined, undefined)).toBe(true);
+  });
+});
+
+describe("pickAlias / pickAliasNumber", () => {
+  const bindings = [
+    { alias: "temperature", value: 22.0 },
+    { alias: "mode", value: "SMART" },
+    { alias: "setpoint", value: "25.5" },
+    { alias: "filtration_state", value: true },
+  ];
+  it("finds alias by name", () => {
+    expect(pickAlias(bindings, "mode")).toBe("SMART");
+    expect(pickAlias(bindings, "missing")).toBeUndefined();
+  });
+  it("returns numeric only when value is number-like", () => {
+    expect(pickAliasNumber(bindings, "temperature")).toBe(22.0);
+    expect(pickAliasNumber(bindings, "setpoint")).toBe(25.5);
+    expect(pickAliasNumber(bindings, "mode")).toBeNull();
+    expect(pickAliasNumber(bindings, "missing")).toBeNull();
+  });
+});
+
+describe("evaluateEffectiveWaterTemperature", () => {
+  const baseNow = new Date("2026-05-01T12:00:00Z").getTime();
+
+  it("filtration bound + ON → live water, cache updated", () => {
+    const r = evaluateEffectiveWaterTemperature({
+      water: 22.0,
+      filtration: "ON",
+      mode: "OFF",
+      prior: { lastActiveValue: null, lastActiveTs: null },
+      now: baseNow,
+    });
+    expect(r.effective).toBe(22.0);
+    expect(r.next.lastActiveValue).toBe(22.0);
+    expect(r.next.lastActiveTs).toBe(baseNow);
+  });
+
+  it("filtration bound + OFF, last active 1h ago → frozen", () => {
+    const prior = { lastActiveValue: 21.5, lastActiveTs: baseNow - 1 * HOUR_MS };
+    const r = evaluateEffectiveWaterTemperature({
+      water: 18.0,
+      filtration: "OFF",
+      mode: "OFF",
+      prior,
+      now: baseNow,
+    });
+    expect(r.effective).toBe(21.5);
+    expect(r.next).toBe(prior);
+  });
+
+  it("filtration bound + OFF, last active 25h ago → null", () => {
+    const prior = { lastActiveValue: 21.5, lastActiveTs: baseNow - 25 * HOUR_MS };
+    const r = evaluateEffectiveWaterTemperature({
+      water: 18.0,
+      filtration: "OFF",
+      mode: "OFF",
+      prior,
+      now: baseNow,
+    });
+    expect(r.effective).toBeNull();
+    expect(r.next).toBe(prior);
+  });
+
+  it("filtration not bound, mode=SMART → live water, cache updated", () => {
+    const r = evaluateEffectiveWaterTemperature({
+      water: 22.0,
+      filtration: undefined,
+      mode: "SMART",
+      prior: { lastActiveValue: null, lastActiveTs: null },
+      now: baseNow,
+    });
+    expect(r.effective).toBe(22.0);
+    expect(r.next.lastActiveTs).toBe(baseNow);
+  });
+
+  it("filtration not bound, mode=OFF, last active 1h ago → frozen", () => {
+    const prior = { lastActiveValue: 21.5, lastActiveTs: baseNow - 1 * HOUR_MS };
+    const r = evaluateEffectiveWaterTemperature({
+      water: 18.0,
+      filtration: undefined,
+      mode: "OFF",
+      prior,
+      now: baseNow,
+    });
+    expect(r.effective).toBe(21.5);
+  });
+
+  it("filtration not bound, mode=OFF, last active 25h ago → null", () => {
+    const prior = { lastActiveValue: 21.5, lastActiveTs: baseNow - 25 * HOUR_MS };
+    const r = evaluateEffectiveWaterTemperature({
+      water: 18.0,
+      filtration: undefined,
+      mode: "OFF",
+      prior,
+      now: baseNow,
+    });
+    expect(r.effective).toBeNull();
+  });
+
+  it("active but water is null → keeps prior cache and returns prior value (within window)", () => {
+    const prior = { lastActiveValue: 21.5, lastActiveTs: baseNow - 1 * HOUR_MS };
+    const r = evaluateEffectiveWaterTemperature({
+      water: null,
+      filtration: "ON",
+      mode: "SMART",
+      prior,
+      now: baseNow,
+    });
+    // active+null is treated as "no fresh sample, keep cache"
+    expect(r.effective).toBe(21.5);
+    expect(r.next).toBe(prior);
+  });
+});

--- a/src/equipments/pool-water-temp-tracker.ts
+++ b/src/equipments/pool-water-temp-tracker.ts
@@ -1,0 +1,316 @@
+/**
+ * Pool water temperature tracker — exposes a computed `effective_water_temperature`
+ * data entry on every `pool_heat_pump` equipment.
+ *
+ * Rationale: a pool heat pump only reads a meaningful water temperature when
+ * water is actively flowing through its sensor — typically when the filtration
+ * pump is running (or, as a fallback, when the heat pump itself is in any
+ * non-OFF mode). When water is stagnant, the sensor reads stale air or pipe
+ * temperature, which is not representative of the pool.
+ *
+ * The tracker therefore caches the **last active** water temperature sample
+ * per equipment and exposes it as `effective_water_temperature`:
+ *
+ *   - filtration_state alias bound + ON  → live water_temperature, cache updated
+ *   - filtration_state alias bound + OFF → cached value (within 24h) or null
+ *   - filtration_state not bound, mode != OFF → live water_temperature
+ *   - filtration_state not bound, mode == OFF → cached value (within 24h) or null
+ *   - filtration_state not bound, mode not bound → live water_temperature (no gating)
+ *
+ * Aliases consumed (must come from the equipment's own bindings):
+ *   - `temperature`        — the live water temperature reading from the PAC
+ *   - `filtration_state`   — optional: ON/OFF signal of the filtration pump
+ *   - `mode`               — optional: heat pump operating mode (OFF | SMART | BOOST | ECO | …)
+ */
+
+import type Database from "better-sqlite3";
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { ComputedDataEntry } from "../shared/types.js";
+import type { EquipmentManager } from "./equipment-manager.js";
+
+interface PoolWaterTempRow {
+  equipment_id: string;
+  last_active_value: number | null;
+  last_active_ts: string | null;
+}
+
+interface InMemoryState {
+  equipmentId: string;
+  lastActiveValue: number | null;
+  lastActiveTs: number | null; // epoch ms
+}
+
+const FRESHNESS_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+const TRACKED_ALIASES = new Set(["temperature", "filtration_state", "mode"]);
+
+export class PoolWaterTempTracker {
+  private readonly db: Database.Database;
+  private readonly eventBus: EventBus;
+  private readonly equipmentManager: EquipmentManager;
+  private readonly logger: Logger;
+
+  private readonly state = new Map<string, InMemoryState>();
+  private unsubscribe: (() => void) | null = null;
+  private unsubscribeEqRemoved: (() => void) | null = null;
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private readonly stmts;
+
+  constructor(
+    db: Database.Database,
+    eventBus: EventBus,
+    equipmentManager: EquipmentManager,
+    logger: Logger,
+  ) {
+    this.db = db;
+    this.eventBus = eventBus;
+    this.equipmentManager = equipmentManager;
+    this.logger = logger.child({ module: "pool-water-temp-tracker" });
+    this.stmts = this.prepareStatements();
+  }
+
+  private prepareStatements() {
+    return {
+      upsert: this.db.prepare(
+        `INSERT INTO pool_water_temp_state (equipment_id, last_active_value, last_active_ts)
+         VALUES (@equipmentId, @lastActiveValue, @lastActiveTs)
+         ON CONFLICT(equipment_id) DO UPDATE SET
+           last_active_value = excluded.last_active_value,
+           last_active_ts = excluded.last_active_ts`,
+      ),
+      selectAll: this.db.prepare(`SELECT * FROM pool_water_temp_state`),
+      deleteOne: this.db.prepare(`DELETE FROM pool_water_temp_state WHERE equipment_id = ?`),
+    };
+  }
+
+  start(): void {
+    this.loadFromDb();
+
+    this.unsubscribe = this.eventBus.on((event) => {
+      if (event.type !== "equipment.data.changed") return;
+      try {
+        if (!TRACKED_ALIASES.has(event.alias)) return;
+        if (event.alias === "effective_water_temperature") return; // safety guard
+        this.recompute(event.equipmentId);
+      } catch (err) {
+        this.logger.error(
+          { err, equipmentId: event.equipmentId },
+          "pool-water-temp: handler error",
+        );
+      }
+    });
+
+    this.unsubscribeEqRemoved = this.eventBus.on((event) => {
+      if (event.type !== "equipment.removed") return;
+      this.state.delete(event.equipmentId);
+      this.stmts.deleteOne.run(event.equipmentId);
+    });
+
+    // Re-evaluate every 5 minutes so the 24h cap kicks in even without an
+    // incoming data event (e.g. filtration has been off for 25h, no update).
+    this.intervalId = setInterval(() => this.tick(), 5 * 60_000);
+
+    this.logger.info({ tracked: this.state.size }, "Pool water temp tracker started");
+  }
+
+  stop(): void {
+    if (this.intervalId) clearInterval(this.intervalId);
+    this.intervalId = null;
+    this.unsubscribe?.();
+    this.unsubscribeEqRemoved?.();
+  }
+
+  /**
+   * ComputedDataProvider entry. Returns `effective_water_temperature` for
+   * `pool_heat_pump` equipments.
+   */
+  getComputedDataForEquipment(equipmentId: string): ComputedDataEntry[] {
+    const eq = this.equipmentManager.getById(equipmentId);
+    if (!eq || eq.type !== "pool_heat_pump") return [];
+    const value = this.computeEffective(equipmentId, Date.now());
+    return [
+      {
+        alias: "effective_water_temperature",
+        value,
+        unit: "°C",
+        category: "pool_water_temperature",
+        lastUpdated: new Date().toISOString(),
+      },
+    ];
+  }
+
+  // ────────────────────────────────────────────────────────────────
+
+  /**
+   * Read the latest values of (temperature, filtration_state, mode) from the
+   * equipment's bindings, update the active cache if appropriate, then return
+   * the current `effective_water_temperature`.
+   */
+  private computeEffective(equipmentId: string, now: number): number | null {
+    const eq = this.equipmentManager.getById(equipmentId);
+    if (!eq || eq.type !== "pool_heat_pump") return null;
+
+    const bindings = this.equipmentManager.getDataBindingsWithValues(equipmentId);
+    const water = pickAliasNumber(bindings, "temperature");
+    const filtState = pickAlias(bindings, "filtration_state");
+    const mode = pickAlias(bindings, "mode");
+
+    const isActive = decideActive(filtState, mode);
+
+    if (isActive && water !== null) {
+      let s = this.state.get(equipmentId);
+      if (!s) {
+        s = { equipmentId, lastActiveValue: null, lastActiveTs: null };
+        this.state.set(equipmentId, s);
+      }
+      s.lastActiveValue = water;
+      s.lastActiveTs = now;
+      this.persist(s);
+      return water;
+    }
+
+    const s = this.state.get(equipmentId);
+    if (s && s.lastActiveTs && s.lastActiveValue !== null) {
+      if (now - s.lastActiveTs < FRESHNESS_WINDOW_MS) {
+        return s.lastActiveValue;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Re-evaluate one equipment in response to an equipment.data.changed event,
+   * and emit the resulting `effective_water_temperature` so the UI can refresh.
+   */
+  private recompute(equipmentId: string): void {
+    const eq = this.equipmentManager.getById(equipmentId);
+    if (!eq || eq.type !== "pool_heat_pump") return;
+    const value = this.computeEffective(equipmentId, Date.now());
+    this.eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId,
+      alias: "effective_water_temperature",
+      value,
+      previous: null,
+    });
+  }
+
+  /**
+   * Periodic tick: re-emit `effective_water_temperature` for every tracked
+   * equipment so the UI reflects the 24h cap rolling over even without
+   * incoming sensor data.
+   */
+  private tick(): void {
+    const now = Date.now();
+    for (const equipmentId of this.state.keys()) {
+      const eq = this.equipmentManager.getById(equipmentId);
+      if (!eq || eq.type !== "pool_heat_pump") continue;
+      const value = this.computeEffective(equipmentId, now);
+      this.eventBus.emit({
+        type: "equipment.data.changed",
+        equipmentId,
+        alias: "effective_water_temperature",
+        value,
+        previous: null,
+      });
+    }
+  }
+
+  private persist(s: InMemoryState): void {
+    this.stmts.upsert.run({
+      equipmentId: s.equipmentId,
+      lastActiveValue: s.lastActiveValue,
+      lastActiveTs: s.lastActiveTs ? new Date(s.lastActiveTs).toISOString() : null,
+    });
+  }
+
+  private loadFromDb(): void {
+    const rows = this.stmts.selectAll.all() as PoolWaterTempRow[];
+    for (const r of rows) {
+      this.state.set(r.equipment_id, {
+        equipmentId: r.equipment_id,
+        lastActiveValue: r.last_active_value,
+        lastActiveTs: r.last_active_ts ? new Date(r.last_active_ts).getTime() : null,
+      });
+    }
+  }
+}
+
+// ────────────────────────────────────────────────────────────────
+// Pure helpers (exported for unit testing)
+// ────────────────────────────────────────────────────────────────
+
+interface AliasedBinding {
+  alias: string;
+  value: unknown;
+}
+
+export function pickAlias(bindings: readonly AliasedBinding[], alias: string): unknown {
+  const b = bindings.find((x) => x.alias === alias);
+  return b ? b.value : undefined;
+}
+
+export function pickAliasNumber(bindings: readonly AliasedBinding[], alias: string): number | null {
+  const v = pickAlias(bindings, alias);
+  if (typeof v === "number") return v;
+  if (typeof v === "string" && v.trim() !== "" && Number.isFinite(Number(v))) return Number(v);
+  return null;
+}
+
+/**
+ * Decide whether the heat pump's water sensor reading is "active" — i.e. water
+ * is flowing past the sensor and the temperature can be trusted.
+ *
+ * Priority: filtration_state if bound; then mode if bound; otherwise default
+ * to active (the user has not provided any gating signal).
+ */
+export function decideActive(filtration: unknown, mode: unknown): boolean {
+  if (filtration !== undefined) {
+    if (typeof filtration === "boolean") return filtration;
+    if (typeof filtration === "number") return filtration !== 0;
+    if (typeof filtration === "string") {
+      const u = filtration.toUpperCase();
+      return u === "ON" || u === "TRUE" || u === "1";
+    }
+    return false;
+  }
+  if (mode !== undefined) {
+    if (typeof mode === "string") return mode.toUpperCase() !== "OFF";
+    if (typeof mode === "number") return mode !== 0;
+    return true;
+  }
+  return true;
+}
+
+/**
+ * Pure evaluator used by unit tests: given the inputs and prior state,
+ * return the new state and the effective value to expose.
+ */
+export function evaluateEffectiveWaterTemperature(args: {
+  water: number | null;
+  filtration: unknown;
+  mode: unknown;
+  prior: { lastActiveValue: number | null; lastActiveTs: number | null };
+  now: number;
+}): {
+  effective: number | null;
+  next: { lastActiveValue: number | null; lastActiveTs: number | null };
+} {
+  const { water, filtration, mode, prior, now } = args;
+  const isActive = decideActive(filtration, mode);
+  if (isActive && water !== null) {
+    return {
+      effective: water,
+      next: { lastActiveValue: water, lastActiveTs: now },
+    };
+  }
+  if (
+    prior.lastActiveTs !== null &&
+    prior.lastActiveValue !== null &&
+    now - prior.lastActiveTs < FRESHNESS_WINDOW_MS
+  ) {
+    return { effective: prior.lastActiveValue, next: prior };
+  }
+  return { effective: null, next: prior };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { DeviceManager } from "./devices/device-manager.js";
 import { ZoneManager } from "./zones/zone-manager.js";
 import { EquipmentManager } from "./equipments/equipment-manager.js";
 import { PoolRuntimeTracker } from "./equipments/pool-runtime-tracker.js";
+import { PoolWaterTempTracker } from "./equipments/pool-water-temp-tracker.js";
 import { ZoneAggregator } from "./zones/zone-aggregator.js";
 import { SunlightManager } from "./zones/sunlight-manager.js";
 import { RecipeManager } from "./recipes/engine/recipe-manager.js";
@@ -152,6 +153,12 @@ async function main() {
   const poolRuntimeTracker = new PoolRuntimeTracker(db, eventBus, equipmentManager, logger);
   equipmentManager.registerComputedDataProvider((eqId) =>
     poolRuntimeTracker.getComputedDataForEquipment(eqId),
+  );
+
+  // 9c. Create Pool Water Temp Tracker (gates water temp by filtration/mode for pool_heat_pump)
+  const poolWaterTempTracker = new PoolWaterTempTracker(db, eventBus, equipmentManager, logger);
+  equipmentManager.registerComputedDataProvider((eqId) =>
+    poolWaterTempTracker.getComputedDataForEquipment(eqId),
   );
 
   // 10. Create Zone Aggregator + Sunlight Manager
@@ -329,6 +336,9 @@ async function main() {
   // 17b. Start pool runtime tracker (subscribes to equipment.data.changed)
   poolRuntimeTracker.start();
 
+  // 17c. Start pool water temp tracker (gates water temp by filtration/mode)
+  poolWaterTempTracker.start();
+
   // 18. Initialize history writer (connects to InfluxDB if configured, subscribes to events)
   historyWriter.init();
 
@@ -395,6 +405,11 @@ async function main() {
       poolRuntimeTracker.stop();
     } catch (err) {
       logger.error({ err }, "Error stopping pool runtime tracker");
+    }
+    try {
+      poolWaterTempTracker.stop();
+    } catch (err) {
+      logger.error({ err }, "Error stopping pool water temp tracker");
     }
     try {
       notificationPublishService.destroy();

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -171,5 +171,5 @@ export const WIDGET_FAMILY_TYPES: Record<WidgetFamily, EquipmentType[]> = {
   heating: ["thermostat", "heater"],
   sensors: ["sensor"],
   water: ["water_valve"],
-  pool: ["pool_pump", "pool_cover"],
+  pool: ["pool_pump", "pool_cover", "pool_heat_pump"],
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -44,6 +44,8 @@ export type DataCategory =
   | "media_mute"
   | "media_input"
   | "appliance_state"
+  | "pool_water_temperature"
+  | "pool_temperature_setpoint"
   | "generic";
 
 export type OrderCategory =
@@ -61,7 +63,8 @@ export type OrderCategory =
   | "set_input"
   | "pool_pump_toggle"
   | "pool_cover_move"
-  | "pool_cover_position";
+  | "pool_cover_position"
+  | "set_pool_temperature_setpoint";
 
 // ============================================================
 // Device
@@ -197,7 +200,8 @@ export type EquipmentType =
   | "appliance"
   | "water_valve"
   | "pool_pump"
-  | "pool_cover";
+  | "pool_cover"
+  | "pool_heat_pump";
 
 export interface Equipment {
   id: string;

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -59,6 +59,7 @@ export function EquipmentWidget({ widget, equipment, onExecuteOrder }: Equipment
     isWaterValve,
     isPoolPump,
     isPoolCover,
+    isPoolHeatPump,
   } = useEquipmentState(equipment);
 
   const label = widget.label || equipment.name;
@@ -66,7 +67,7 @@ export function EquipmentWidget({ widget, equipment, onExecuteOrder }: Equipment
 
   if (isLight) return <LightEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
   if (isShutter) return <ShutterEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
-  if (isThermostat) return <ThermostatEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
+  if (isThermostat || isPoolHeatPump) return <ThermostatEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
   if (isGate) return <GateEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
   if (isHeater) return <HeaterEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
   if (isEnergyMeter) return <EnergyMeterEquipmentWidget label={label} equipment={equipment} />;
@@ -322,18 +323,32 @@ function ThermostatEquipmentWidget({
   const [executing, setExecuting] = useState<string | null>(null);
   const setpointOverride = useSliderOverride(5000);
 
+  const isPoolHeatPump = equipment.type === "pool_heat_pump";
+
   const powerBinding = equipment.dataBindings.find((b) => b.alias === "power");
+  const modeBinding = equipment.dataBindings.find((b) => b.alias === "mode");
   const insideTempBinding = equipment.dataBindings.find((b) => b.alias === "temperature");
+  const effectiveWaterTemp = equipment.computedData?.find(
+    (c) => c.alias === "effective_water_temperature",
+  );
   const targetTempBinding = equipment.dataBindings.find((b) => b.alias === "setpoint");
 
-  const isOn = powerBinding?.value === true;
-  const insideTemp = typeof insideTempBinding?.value === "number" ? insideTempBinding.value : null;
+  const isOn = isPoolHeatPump
+    ? typeof modeBinding?.value === "string" && modeBinding.value.toUpperCase() !== "OFF"
+    : powerBinding?.value === true;
+  const insideTemp = isPoolHeatPump
+    ? typeof effectiveWaterTemp?.value === "number"
+      ? effectiveWaterTemp.value
+      : null
+    : typeof insideTempBinding?.value === "number"
+      ? insideTempBinding.value
+      : null;
   const deviceSetpoint = typeof targetTempBinding?.value === "number" ? targetTempBinding.value : null;
   const displaySetpoint = setpointOverride.displayValue(deviceSetpoint);
 
-  const hasPowerOrder = equipment.orderBindings.some((o) => o.alias === "power");
+  const hasPowerOrder = !isPoolHeatPump && equipment.orderBindings.some((o) => o.alias === "power");
   const targetTempOrder = equipment.orderBindings.find((o) => o.alias === "setpoint");
-  const targetMin = targetTempOrder?.min ?? 16;
+  const targetMin = targetTempOrder?.min ?? (isPoolHeatPump ? 10 : 16);
   const targetMax = targetTempOrder?.max ?? 30;
   const STEP = 0.5;
 

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -126,7 +126,7 @@ const WIDGET_FAMILY_TYPES: Record<string, string[]> = {
   heating: ["thermostat", "heater"],
   sensors: ["sensor"],
   water: ["water_valve"],
-  pool: ["pool_pump", "pool_cover"],
+  pool: ["pool_pump", "pool_cover", "pool_heat_pump"],
 };
 
 function getDescendantZoneIds(zone: ZoneWithChildren): string[] {

--- a/ui/src/components/dashboard/WidgetGrid.tsx
+++ b/ui/src/components/dashboard/WidgetGrid.tsx
@@ -404,7 +404,7 @@ const ZONE_FAMILY_TYPES: Record<string, string[]> = {
   heating: ["thermostat", "heater"],
   sensors: ["sensor"],
   water: ["water_valve"],
-  pool: ["pool_pump", "pool_cover"],
+  pool: ["pool_pump", "pool_cover", "pool_heat_pump"],
 };
 
 function getDescendantZoneIds(zone: ZoneWithChildren): string[] {

--- a/ui/src/components/dashboard/ZoneWidget.tsx
+++ b/ui/src/components/dashboard/ZoneWidget.tsx
@@ -30,7 +30,7 @@ const WIDGET_FAMILY_TYPES: Record<WidgetFamily, string[]> = {
   heating: ["thermostat", "heater"],
   sensors: ["sensor"],
   water: ["water_valve"],
-  pool: ["pool_pump", "pool_cover"],
+  pool: ["pool_pump", "pool_cover", "pool_heat_pump"],
 };
 
 interface ZoneWidgetProps {

--- a/ui/src/components/dashboard/widget-icons.ts
+++ b/ui/src/components/dashboard/widget-icons.ts
@@ -298,6 +298,7 @@ const EQUIPMENT_DEFAULT_ICONS: Partial<Record<EquipmentType, string>> = {
   water_valve: "Droplets",
   pool_pump: "Droplets",
   pool_cover: "ArrowUpDown",
+  pool_heat_pump: "Thermometer",
 };
 
 const FAMILY_DEFAULT_ICONS: Record<WidgetFamily, string> = {

--- a/ui/src/components/dashboard/widget-utils.ts
+++ b/ui/src/components/dashboard/widget-utils.ts
@@ -6,6 +6,7 @@ export function needsDetailSheet(equipmentType: string): boolean {
     "shutter",
     "pool_cover",
     "thermostat",
+    "pool_heat_pump",
     "heater",
   ].includes(equipmentType);
 }

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -20,6 +20,9 @@ const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> 
   energy_meter: ["energy"],
   main_energy_meter: ["energy"],
   energy_production_meter: ["energy", "power"],
+  // Polytropic PAC matches via pool_water_temperature; Sonoff filtration relay
+  // matches via light_state (used as the optional `filtration_state` binding).
+  pool_heat_pump: ["pool_water_temperature", "light_state"],
 };
 
 /** Maps EquipmentType to required data keys for filtering (when category alone is too broad). */
@@ -61,6 +64,7 @@ function looksLikeWaterValve(device: DeviceWithData): boolean {
 const CANDIDATE_BASED_TYPES: ReadonlySet<EquipmentType> = new Set<EquipmentType>([
   "pool_pump",
   "pool_cover",
+  "pool_heat_pump",
   "light_onoff",
   "light_dimmable",
   "light_color",

--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -48,6 +48,7 @@ const TYPE_ICONS: Record<EquipmentType, React.ReactNode> = {
   water_valve: <WaterValveIcon size={18} strokeWidth={1.5} />,
   pool_pump: <Waves size={18} strokeWidth={1.5} />,
   pool_cover: <ShutterClosedIcon size={18} strokeWidth={1.5} />,
+  pool_heat_pump: <Thermometer size={18} strokeWidth={1.5} />,
 };
 
 const TYPE_LABELS: Record<EquipmentType, string> = {
@@ -71,6 +72,7 @@ const TYPE_LABELS: Record<EquipmentType, string> = {
   water_valve: "equipments.type.water_valve",
   pool_pump: "equipments.type.pool_pump",
   pool_cover: "equipments.type.pool_cover",
+  pool_heat_pump: "equipments.type.pool_heat_pump",
 };
 
 interface EquipmentCardProps {

--- a/ui/src/components/equipments/EquipmentForm.tsx
+++ b/ui/src/components/equipments/EquipmentForm.tsx
@@ -25,6 +25,7 @@ const EQUIPMENT_TYPE_KEYS: { value: EquipmentType; labelKey: string }[] = [
   { value: "water_valve", labelKey: "equipments.type.water_valve" },
   { value: "pool_pump", labelKey: "equipments.type.pool_pump" },
   { value: "pool_cover", labelKey: "equipments.type.pool_cover" },
+  { value: "pool_heat_pump", labelKey: "equipments.type.pool_heat_pump" },
 ];
 
 interface EquipmentFormProps {

--- a/ui/src/components/equipments/EquipmentForm.tsx
+++ b/ui/src/components/equipments/EquipmentForm.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { X } from "lucide-react";
 import type { EquipmentType, ZoneWithChildren } from "../../types";
 import { DeviceSelector } from "./DeviceSelector";
+import { getDevices, type DeviceWithData } from "../../api";
 
 const EQUIPMENT_TYPE_KEYS: { value: EquipmentType; labelKey: string }[] = [
   { value: "light_onoff", labelKey: "equipments.type.light_onoff" },
@@ -63,6 +64,26 @@ export function EquipmentForm({ title, initial, defaultZoneId, zones, onSubmit, 
   const [candidateByDevice, setCandidateByDevice] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [allDevices, setAllDevices] = useState<DeviceWithData[]>([]);
+
+  useEffect(() => {
+    if (type === "pool_heat_pump") {
+      getDevices().then(setAllDevices).catch(() => setAllDevices([]));
+    }
+  }, [type]);
+
+  // For pool_heat_pump, both bindings are required:
+  //  - a device exposing pool_water_temperature (the PAC itself)
+  //  - a device exposing light_state — the relay driving the filtration pump,
+  //    bound read-only as `filtration_state` so the computed water temp is
+  //    only trusted while water is actually flowing through the PAC sensor.
+  const poolHeatPumpValidation = useMemo(() => {
+    if (type !== "pool_heat_pump") return { ok: true, hasPac: true, hasRelay: true };
+    const selected = allDevices.filter((d) => selectedDeviceIds.includes(d.id));
+    const hasPac = selected.some((d) => d.data.some((x) => x.category === "pool_water_temperature"));
+    const hasRelay = selected.some((d) => d.data.some((x) => x.category === "light_state"));
+    return { ok: hasPac && hasRelay, hasPac, hasRelay };
+  }, [type, allDevices, selectedDeviceIds]);
 
   const flatZones = flattenZones(zones);
   const availableTypes = excludeTypes
@@ -188,6 +209,13 @@ export function EquipmentForm({ title, initial, defaultZoneId, zones, onSubmit, 
                   boundDeviceIds={boundDeviceIds}
                   boundOrderKeysByDevice={boundOrderKeysByDevice}
                 />
+                {type === "pool_heat_pump" && !poolHeatPumpValidation.ok && (
+                  <p className="text-[12px] text-warning">
+                    {!poolHeatPumpValidation.hasPac
+                      ? "Sélectionnez la PAC (Polytropic)."
+                      : "Sélectionnez aussi la pompe de filtration (Sonoff/relais ON-OFF)."}
+                  </p>
+                )}
               </>
             )}
 
@@ -209,7 +237,7 @@ export function EquipmentForm({ title, initial, defaultZoneId, zones, onSubmit, 
                 <button
                   type="button"
                   onClick={handleCreate}
-                  disabled={!name.trim() || !zoneId || saving}
+                  disabled={!name.trim() || !zoneId || saving || !poolHeatPumpValidation.ok}
                   className="px-4 py-2 text-[13px] font-medium text-white bg-primary rounded-[6px] hover:bg-primary-hover transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {saving ? t("common.creating") : initial ? t("common.save") : t("common.create")}

--- a/ui/src/components/equipments/PoolHeatPumpControl.tsx
+++ b/ui/src/components/equipments/PoolHeatPumpControl.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { ChevronUp, ChevronDown, Loader2 } from "lucide-react";
+import type { EquipmentWithDetails } from "../../types";
+
+interface Props {
+  equipment: EquipmentWithDetails;
+  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+  compact?: boolean;
+}
+
+const STEP = 0.5;
+
+export function PoolHeatPumpControl({ equipment, onExecuteOrder, compact }: Props) {
+  const [executing, setExecuting] = useState(false);
+
+  const tempBinding = equipment.dataBindings.find((b) => b.alias === "temperature");
+  const computedWater = equipment.computedData?.find(
+    (c) => c.alias === "effective_water_temperature",
+  );
+  const setpointBinding = equipment.dataBindings.find((b) => b.alias === "setpoint");
+  const modeBinding = equipment.dataBindings.find((b) => b.alias === "mode");
+  const setpointOrder = equipment.orderBindings.find((o) => o.alias === "setpoint");
+
+  const water =
+    typeof computedWater?.value === "number"
+      ? computedWater.value
+      : typeof tempBinding?.value === "number"
+        ? tempBinding.value
+        : null;
+  const setpoint = typeof setpointBinding?.value === "number" ? setpointBinding.value : null;
+  const mode = typeof modeBinding?.value === "string" ? modeBinding.value : null;
+
+  const targetMin = setpointOrder?.min ?? 10;
+  const targetMax = setpointOrder?.max ?? 30;
+
+  const handleSetpoint = async (next: number) => {
+    if (executing || !setpointOrder) return;
+    setExecuting(true);
+    try {
+      await onExecuteOrder("setpoint", next);
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  return (
+    <div className={`flex items-center gap-2 ${compact ? "" : "py-1"}`}>
+      <div className="flex items-baseline gap-0.5">
+        <span className="text-[13px] font-semibold text-text tabular-nums leading-none font-mono">
+          {water !== null ? water.toFixed(1) : "—"}
+        </span>
+        <span className="text-[10px] font-medium text-text-tertiary">°C</span>
+      </div>
+      {mode && (
+        <span
+          className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full ${
+            mode.toUpperCase() === "OFF"
+              ? "bg-border-light text-text-tertiary"
+              : "bg-error/10 text-error"
+          }`}
+        >
+          {mode}
+        </span>
+      )}
+      {setpointOrder && setpoint !== null && equipment.enabled && (
+        <div className="flex items-center gap-0.5">
+          <button
+            type="button"
+            onClick={() => handleSetpoint(Math.max(targetMin, setpoint - STEP))}
+            disabled={executing || setpoint <= targetMin}
+            className="w-6 h-6 flex items-center justify-center rounded-[4px] border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {executing ? <Loader2 size={12} className="animate-spin" /> : <ChevronDown size={12} strokeWidth={2} />}
+          </button>
+          <span className="text-[11px] tabular-nums font-mono text-text-secondary min-w-[34px] text-center">
+            {setpoint.toFixed(1)}°C
+          </span>
+          <button
+            type="button"
+            onClick={() => handleSetpoint(Math.min(targetMax, setpoint + STEP))}
+            disabled={executing || setpoint >= targetMax}
+            className="w-6 h-6 flex items-center justify-center rounded-[4px] border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {executing ? <Loader2 size={12} className="animate-spin" /> : <ChevronUp size={12} strokeWidth={2} />}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/equipments/PoolHeatPumpControl.tsx
+++ b/ui/src/components/equipments/PoolHeatPumpControl.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { ChevronUp, ChevronDown, Loader2 } from "lucide-react";
+import { useState, useRef, useEffect } from "react";
+import { ChevronUp, ChevronDown } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
 
 interface Props {
@@ -9,9 +9,18 @@ interface Props {
 }
 
 const STEP = 0.5;
+const COMMIT_DEBOUNCE_MS = 500;
+const SETTLE_AFTER_COMMIT_MS = 5000;
 
 export function PoolHeatPumpControl({ equipment, onExecuteOrder, compact }: Props) {
-  const [executing, setExecuting] = useState(false);
+  // Optimistic override so rapid +/- clicks don't await every Modbus write.
+  // We accumulate locally and only write the latest value after the user stops
+  // clicking. The override keeps the slider from snapping back until the device
+  // reports the new value (or SETTLE_AFTER_COMMIT_MS elapses).
+  const [pending, setPending] = useState<number | null>(null);
+  const pendingRef = useRef<number | null>(null);
+  const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const tempBinding = equipment.dataBindings.find((b) => b.alias === "temperature");
   const computedWater = equipment.computedData?.find(
@@ -27,20 +36,46 @@ export function PoolHeatPumpControl({ equipment, onExecuteOrder, compact }: Prop
       : typeof tempBinding?.value === "number"
         ? tempBinding.value
         : null;
-  const setpoint = typeof setpointBinding?.value === "number" ? setpointBinding.value : null;
+  const deviceSetpoint =
+    typeof setpointBinding?.value === "number" ? setpointBinding.value : null;
+  // Hide the local override once the device echoes the value (within 0.01 °C)
+  // so legit device-side changes resurface immediately. Derived to avoid the
+  // setState-in-effect pattern.
+  const overrideActive =
+    pending !== null && (deviceSetpoint === null || Math.abs(deviceSetpoint - pending) >= 0.01);
+  const setpoint = overrideActive ? pending : deviceSetpoint;
   const mode = typeof modeBinding?.value === "string" ? modeBinding.value : null;
 
   const targetMin = setpointOrder?.min ?? 10;
   const targetMax = setpointOrder?.max ?? 30;
 
-  const handleSetpoint = async (next: number) => {
-    if (executing || !setpointOrder) return;
-    setExecuting(true);
-    try {
-      await onExecuteOrder("setpoint", next);
-    } finally {
-      setExecuting(false);
-    }
+  useEffect(() => {
+    return () => {
+      if (commitTimerRef.current) clearTimeout(commitTimerRef.current);
+      if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
+    };
+  }, []);
+
+  const bumpSetpoint = (next: number) => {
+    if (!setpointOrder) return;
+    pendingRef.current = next;
+    setPending(next);
+    if (commitTimerRef.current) clearTimeout(commitTimerRef.current);
+    commitTimerRef.current = setTimeout(() => {
+      const value = pendingRef.current;
+      commitTimerRef.current = null;
+      if (value === null) return;
+      onExecuteOrder("setpoint", value).catch(() => {
+        /* surfaced upstream */
+      });
+      // Failsafe: clear the override if the device never echoes back.
+      if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
+      settleTimerRef.current = setTimeout(() => {
+        setPending(null);
+        pendingRef.current = null;
+        settleTimerRef.current = null;
+      }, SETTLE_AFTER_COMMIT_MS);
+    }, COMMIT_DEBOUNCE_MS);
   };
 
   return (
@@ -66,22 +101,22 @@ export function PoolHeatPumpControl({ equipment, onExecuteOrder, compact }: Prop
         <div className="flex items-center gap-0.5">
           <button
             type="button"
-            onClick={() => handleSetpoint(Math.max(targetMin, setpoint - STEP))}
-            disabled={executing || setpoint <= targetMin}
+            onClick={() => bumpSetpoint(Math.max(targetMin, setpoint - STEP))}
+            disabled={setpoint <= targetMin}
             className="w-6 h-6 flex items-center justify-center rounded-[4px] border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            {executing ? <Loader2 size={12} className="animate-spin" /> : <ChevronDown size={12} strokeWidth={2} />}
+            <ChevronDown size={12} strokeWidth={2} />
           </button>
           <span className="text-[11px] tabular-nums font-mono text-text-secondary min-w-[34px] text-center">
             {setpoint.toFixed(1)}°C
           </span>
           <button
             type="button"
-            onClick={() => handleSetpoint(Math.min(targetMax, setpoint + STEP))}
-            disabled={executing || setpoint >= targetMax}
+            onClick={() => bumpSetpoint(Math.min(targetMax, setpoint + STEP))}
+            disabled={setpoint >= targetMax}
             className="w-6 h-6 flex items-center justify-center rounded-[4px] border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            {executing ? <Loader2 size={12} className="animate-spin" /> : <ChevronUp size={12} strokeWidth={2} />}
+            <ChevronUp size={12} strokeWidth={2} />
           </button>
         </div>
       )}

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -199,6 +199,7 @@ export function isRelevantOrder(key: string, equipmentType: string): boolean {
 const CANDIDATE_BASED_TYPES: ReadonlySet<EquipmentType> = new Set<EquipmentType>([
   "pool_pump",
   "pool_cover",
+  "pool_heat_pump",
   "light_onoff",
   "light_dimmable",
   "light_color",

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -36,6 +36,13 @@ const RELEVANT_DATA: Record<string, string[]> = {
   // plugin versions still get auto-bindings.
   pool_pump: ["light_state", "generic"],
   pool_cover: ["shutter_position", "position", "generic"],
+  pool_heat_pump: [
+    "pool_water_temperature",
+    "pool_temperature_setpoint",
+    "temperature_outdoor",
+    "appliance_state",
+    "light_state",
+  ],
 };
 
 /** Maps equipment types to relevant order keys for auto-binding. */
@@ -86,6 +93,7 @@ const RELEVANT_ORDERS: Record<string, string[]> = {
     "shutter2_state",
     "shutter2_position",
   ],
+  pool_heat_pump: ["setpoint"],
 };
 
 /**
@@ -141,6 +149,7 @@ const ORDER_CATEGORY_ALIASES: Record<string, string> = {
   set_color_temp: "color_temp",
   set_color: "color",
   set_setpoint: "setpoint",
+  set_pool_temperature_setpoint: "setpoint",
   gate_trigger: "command",
 };
 
@@ -151,6 +160,8 @@ const DATA_CATEGORY_ALIASES: Record<string, string> = {
   light_color_temp: "color_temp",
   light_color: "color",
   setpoint: "setpoint",
+  pool_temperature_setpoint: "setpoint",
+  pool_water_temperature: "temperature",
   battery: "battery",
   cover_state: "state",
 };

--- a/ui/src/components/equipments/useEquipmentState.ts
+++ b/ui/src/components/equipments/useEquipmentState.ts
@@ -26,6 +26,7 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
   const isWaterValve = equipment.type === "water_valve";
   const isPoolPump = equipment.type === "pool_pump";
   const isPoolCover = equipment.type === "pool_cover";
+  const isPoolHeatPump = equipment.type === "pool_heat_pump";
 
   // State binding
   const stateBinding = equipment.dataBindings.find(
@@ -34,11 +35,16 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
   const powerBinding = isThermostat
     ? equipment.dataBindings.find((db) => db.alias === "power")
     : null;
+  const modeBinding = isPoolHeatPump
+    ? equipment.dataBindings.find((db) => db.alias === "mode")
+    : null;
   const isOn = isThermostat
     ? powerBinding?.value === true
-    : stateBinding
-      ? stateBinding.value === true || stateBinding.value === "ON"
-      : false;
+    : isPoolHeatPump
+      ? typeof modeBinding?.value === "string" && modeBinding.value.toUpperCase() !== "OFF"
+      : stateBinding
+        ? stateBinding.value === true || stateBinding.value === "ON"
+        : false;
 
   // Shutter
   const shutterPositionBinding = isShutter
@@ -94,7 +100,7 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
     ? "bg-accent/10 text-accent"
     : isSensor
     ? getSensorIconColor(equipment.dataBindings)
-    : isThermostat
+    : isThermostat || isPoolHeatPump
       ? isOn
         ? "bg-error/10 text-error"
         : "bg-border-light text-text-tertiary"
@@ -130,6 +136,7 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
     isWaterValve,
     isPoolPump,
     isPoolCover,
+    isPoolHeatPump,
     stateBinding,
     isOn,
     shutterPosition,

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -9,6 +9,7 @@ import { ThermostatCard } from "../equipments/ThermostatCard";
 import { GateControl } from "../equipments/GateControl";
 import { HeaterControl } from "../equipments/HeaterControl";
 import { WaterValveControl } from "../equipments/WaterValveControl";
+import { PoolHeatPumpControl } from "../equipments/PoolHeatPumpControl";
 import { Cloud, Timer } from "lucide-react";
 import { parseForecastDays, CONDITION_ICONS, CONDITION_COLORS } from "../equipments/weatherForecastUtils";
 
@@ -43,9 +44,10 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
   const isWaterValve = equipment.type === "water_valve";
   const isPoolPump = equipment.type === "pool_pump";
   const isPoolCover = equipment.type === "pool_cover";
+  const isPoolHeatPump = equipment.type === "pool_heat_pump";
 
   // Find primary data value for generic equipments
-  const isKnownType = isLight || isSensor || isShutter || isThermostat || isHeater || isGate || isEnergyMeter || isWeatherForecast || isMediaPlayer || isAppliance || isWaterValve || isPoolPump || isPoolCover;
+  const isKnownType = isLight || isSensor || isShutter || isThermostat || isHeater || isGate || isEnergyMeter || isWeatherForecast || isMediaPlayer || isAppliance || isWaterValve || isPoolPump || isPoolCover || isPoolHeatPump;
   const primaryBinding = !isKnownType
     ? equipment.dataBindings[0] ?? null
     : null;
@@ -185,6 +187,15 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
       {/* Pool cover: OPEN/STOP/CLOSE buttons + position slider (reuse ShutterControl compact) */}
       {isPoolCover && equipment.enabled && (
         <ShutterControl
+          equipment={equipment}
+          onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
+          compact
+        />
+      )}
+
+      {/* Pool heat pump: water temp + mode badge + setpoint controls */}
+      {isPoolHeatPump && (
+        <PoolHeatPumpControl
           equipment={equipment}
           onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
           compact

--- a/ui/src/components/home/ZoneEquipmentsView.tsx
+++ b/ui/src/components/home/ZoneEquipmentsView.tsx
@@ -34,7 +34,7 @@ const EQUIPMENT_GROUPS: EquipmentGroup[] = [
   { labelKey: "equipments.group.media", types: ["media_player"], icon: <Tv size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
   { labelKey: "equipments.group.appliances", types: ["appliance"], icon: <WashingMachine size={14} strokeWidth={1.5} />, headerBg: "bg-text-tertiary/6", iconColor: "text-text-secondary" },
   { labelKey: "equipments.group.water", types: ["water_valve"], icon: <WaterValveIcon size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
-  { labelKey: "equipments.group.pool", types: ["pool_pump", "pool_cover"], icon: <Waves size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
+  { labelKey: "equipments.group.pool", types: ["pool_pump", "pool_cover", "pool_heat_pump"], icon: <Waves size={14} strokeWidth={1.5} />, headerBg: "bg-primary/6", iconColor: "text-primary" },
   { labelKey: "equipments.group.other", types: ["switch", "button", "gate"], icon: <ToggleRight size={14} strokeWidth={1.5} />, headerBg: "bg-text-tertiary/6", iconColor: "text-text-secondary" },
 ];
 

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -204,6 +204,7 @@
   "equipments.type.water_valve": "Water valve",
   "equipments.type.pool_pump": "Pool pump",
   "equipments.type.pool_cover": "Pool cover",
+  "equipments.type.pool_heat_pump": "Pool heat pump",
 
   "water.open": "Open",
   "water.closed": "Closed",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -204,6 +204,7 @@
   "equipments.type.water_valve": "Vanne d'arrosage",
   "equipments.type.pool_pump": "Pompe de piscine",
   "equipments.type.pool_cover": "Volet de piscine",
+  "equipments.type.pool_heat_pump": "Pompe à chaleur piscine",
 
   "water.open": "Ouverte",
   "water.closed": "Fermée",

--- a/ui/src/lib/binding-candidates.ts
+++ b/ui/src/lib/binding-candidates.ts
@@ -90,6 +90,38 @@ export function computeBindingCandidates(
       return candidates;
     }
 
+    case "pool_heat_pump": {
+      // Hybrid: PAC device (exposing pool_water_temperature) → single "all"
+      // candidate. ON/OFF relay device → one candidate per channel.
+      const isPac = deviceData.some((d) => d.category === "pool_water_temperature");
+      if (isPac) {
+        if (deviceData.length === 0 && deviceOrders.length === 0) return [];
+        return [
+          {
+            id: "all",
+            label: "All PAC data/orders",
+            dataKeys: deviceData.map((d) => d.key),
+            orderKeys: deviceOrders.map((o) => o.key),
+          },
+        ];
+      }
+      // Read-only: pool_heat_pump observes the relay for its filtration_state
+      // alias, no order claim (pool_pump owns the actual write).
+      const candidates: BindingCandidate[] = [];
+      for (const o of deviceOrders) {
+        if (!isOnOffEnum(o)) continue;
+        const matchingData = deviceData.find((d) => d.key === o.key);
+        if (!matchingData) continue;
+        candidates.push({
+          id: o.key,
+          label: o.key,
+          dataKeys: [matchingData.key],
+          orderKeys: [],
+        });
+      }
+      return candidates;
+    }
+
     default:
       return [];
   }

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -10,6 +10,7 @@ import { LightControl } from "../components/equipments/LightControl";
 import { ShutterControl } from "../components/equipments/ShutterControl";
 import { ThermostatCard } from "../components/equipments/ThermostatCard";
 import { WaterValveControl } from "../components/equipments/WaterValveControl";
+import { PoolHeatPumpControl } from "../components/equipments/PoolHeatPumpControl";
 import { SensorDataPanel } from "../components/equipments/SensorDataPanel";
 import { WeatherPanel } from "../components/equipments/WeatherPanel";
 import { WeatherForecastPanel } from "../components/equipments/WeatherForecastPanel";
@@ -269,6 +270,17 @@ export function EquipmentDetailPage() {
         <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
           <h3 className="text-[14px] font-semibold text-text mb-3">{t("equipments.controls")}</h3>
           <LightControl
+            equipment={equipment}
+            onExecuteOrder={(alias, value) => executeOrder(equipment.id, alias, value)}
+          />
+        </div>
+      )}
+
+      {/* Pool heat pump controls — water temp + setpoint slider */}
+      {equipment.type === "pool_heat_pump" && (
+        <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
+          <h3 className="text-[14px] font-semibold text-text mb-3">{t("equipments.controls")}</h3>
+          <PoolHeatPumpControl
             equipment={equipment}
             onExecuteOrder={(alias, value) => executeOrder(equipment.id, alias, value)}
           />

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -44,6 +44,8 @@ export type DataCategory =
   | "media_mute"
   | "media_input"
   | "appliance_state"
+  | "pool_water_temperature"
+  | "pool_temperature_setpoint"
   | "generic";
 
 export type OrderCategory =
@@ -61,7 +63,8 @@ export type OrderCategory =
   | "set_input"
   | "pool_pump_toggle"
   | "pool_cover_move"
-  | "pool_cover_position";
+  | "pool_cover_position"
+  | "set_pool_temperature_setpoint";
 
 // ============================================================
 // Device
@@ -192,7 +195,8 @@ export type EquipmentType =
   | "appliance"
   | "water_valve"
   | "pool_pump"
-  | "pool_cover";
+  | "pool_cover"
+  | "pool_heat_pump";
 
 export interface Equipment {
   id: string;


### PR DESCRIPTION
## Summary

Spec 083 — adds the new \`pool_heat_pump\` equipment type plus the Sowel-side glue for an upcoming Modbus integration plugin (\`polytropic_master\`) that talks to a Polytropic Master Inverter pool heat pump over RTU/TCP.

## Changes

### Types & data model
- New \`DataCategory\`: \`pool_water_temperature\`, \`pool_temperature_setpoint\`
- New \`OrderCategory\`: \`set_pool_temperature_setpoint\`
- New \`EquipmentType\`: \`pool_heat_pump\` (joins the pool widget family)
- Migration 007 — \`pool_water_temp_state\` cache table

### Computed engine
- \`PoolWaterTempTracker\` exposes \`effective_water_temperature\` per pool_heat_pump equipment.
- Gating: \`filtration_state\` alias if bound (water flowing through PAC sensor); falls back to \`mode != OFF\`. Cached last-active sample expires after 24h.
- Persisted across restarts; periodic 5-min tick re-emits when the 24h cap rolls over even without incoming sensor data.

### UI
- Equipment form / card / detail page recognise \`pool_heat_pump\` (Thermometer icon, en/fr labels)
- Dashboard reuses \`ThermostatEquipmentWidget\` — adapted to read computed \`effective_water_temperature\` and derive \`isOn\` from \`mode != OFF\`
- New \`PoolHeatPumpControl\` for compact in-zone rendering (water temp, mode badge, setpoint ± buttons)
- \`pool_heat_pump\` joins the \`pool\` widget family in WidgetGrid / ZoneWidget / WidgetDetailSheet / ZoneEquipmentsView

### Registry
- \`plugins/registry.json\` adds the \`polytropic_master\` integration entry (\`sowelVersion >= 1.4.0\`). The plugin repo \`mchacher/sowel-plugin-polytropic-master\` is bootstrapped locally in a sibling directory; it needs to be pushed to GitHub and a v1.0.0 tag created before users can install it.

### Tests
- \`pool-water-temp-tracker.test.ts\`: 14 unit tests covering decideActive, value pickers, and the gating / 24h-cap evaluator (filtration bound vs unbound, mode fallback, freezes, expiry, water-null edge case).

## Test plan
- [x] \`npx tsc --noEmit\` green
- [x] \`cd ui && npx tsc -b --noEmit\` green
- [x] \`npx vitest run\` — 379 passing (14 new)
- [x] \`npx eslint src/ --ext .ts\` clean
- [ ] Manual: create a \`pool_heat_pump\` equipment, bind to PAC + Sonoff power2, verify the widget renders \`effective_water_temperature\` and the setpoint slider writes 1001 (after the plugin is published)

## Follow-ups (not in this PR)
- Push \`sowel-plugin-polytropic-master\` to GitHub + tag v1.0.0
- Update \`docs/user/equipments.md\` and \`docs/technical/data-model.md\` once the plugin is shippable
- Bump Sowel version to 1.4.0 (gated by the plugin's \`sowelVersion >= 1.4.0\`)