### PR TITLE
fix(ui): render pool_heat_pump in mobile widget like a thermostat

### DIFF
--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -80,6 +80,7 @@ function useMobileState(
     isWaterValve,
     isPoolPump,
     isPoolCover,
+    isPoolHeatPump,
     isOn,
   } = useEquipmentState(equipment);
 
@@ -121,12 +122,20 @@ function useMobileState(
     };
   }
 
-  if (isThermostat) {
+  if (isThermostat || isPoolHeatPump) {
     const temp = equipment.dataBindings.find((b) => b.alias === "temperature");
+    const computedTemp = isPoolHeatPump
+      ? equipment.computedData?.find((c) => c.alias === "effective_water_temperature")
+      : null;
     const setpoint = equipment.dataBindings.find((b) => b.alias === "setpoint");
-    const tempVal = typeof temp?.value === "number" ? temp.value : null;
+    const tempVal = isPoolHeatPump && typeof computedTemp?.value === "number"
+      ? computedTemp.value
+      : typeof temp?.value === "number"
+        ? temp.value
+        : null;
     const spVal = typeof setpoint?.value === "number" ? setpoint.value : null;
-    const level = spVal !== null ? (spVal - 16) / (30 - 16) : undefined;
+    const minBound = isPoolHeatPump ? 10 : 16;
+    const level = spVal !== null ? (spVal - minBound) / (30 - minBound) : undefined;
     return {
       icon: customEntry
         ? createElement(customEntry.component, customEntry.previewProps)


### PR DESCRIPTION
Mobile dashboard didn't show the Thermometer icon or temperature line for PAC Piscine because MobileWidgetCard's isThermostat branch wasn't extended to pool_heat_pump. Falls back to effective_water_temperature when the computed alias is present.