### PR TITLE
feat(energy): spec 086 — Shelly drives energy roles + self-consumption + aggregator fixes

### DIFF
--- a/scripts/energy/migrate-orphan-equipments.ts
+++ b/scripts/energy/migrate-orphan-equipments.ts
@@ -42,7 +42,10 @@ interface Migration {
  */
 const DEFAULT_MIGRATIONS: Migration[] = [];
 
-const BUCKETS = ["sowel-energy-hourly", "sowel-energy-daily"];
+// All buckets that store equipment data tagged with equipmentId.
+// `sowel` is the raw bucket (7-day retention) — needed for "day" view of
+// recent dates, which queries raw before falling back to -energy-hourly.
+const BUCKETS = ["sowel", "sowel-energy-hourly", "sowel-energy-daily"];
 const APPLY = process.argv.includes("--apply");
 
 function parseCliPairs(): Migration[] {
@@ -65,18 +68,33 @@ if (MIGRATIONS.length === 0) {
   process.exit(1);
 }
 
-// ── Load Influx config from local Sowel SQLite settings ────────────────
+// ── Load Influx config — env vars first (production), SQLite fallback ──
 
-const db = new Database("data/sowel.db", { readonly: true });
-function getSetting(key: string): string {
-  const row = db.prepare("SELECT value FROM settings WHERE key=?").get(key) as { value: string } | undefined;
-  if (!row) throw new Error(`Setting not found: ${key}`);
-  return row.value;
+function getInfluxConfig(): { url: string; token: string; org: string } {
+  const fromEnv = {
+    url: process.env["INFLUX_URL"],
+    token: process.env["INFLUX_TOKEN"],
+    org: process.env["INFLUX_ORG"],
+  };
+  if (fromEnv.url && fromEnv.token && fromEnv.org) {
+    return { url: fromEnv.url, token: fromEnv.token, org: fromEnv.org };
+  }
+  const db = new Database("data/sowel.db", { readonly: true });
+  const get = (key: string) => {
+    const row = db.prepare("SELECT value FROM settings WHERE key=?").get(key) as { value: string } | undefined;
+    if (!row) throw new Error(`Setting not found: ${key} (and env var not set)`);
+    return row.value;
+  };
+  const cfg = {
+    url: fromEnv.url ?? get("history.influx.url"),
+    token: fromEnv.token ?? get("history.influx.token"),
+    org: fromEnv.org ?? get("history.influx.org"),
+  };
+  db.close();
+  return cfg;
 }
-const INFLUX_URL = getSetting("history.influx.url");
-const INFLUX_TOKEN = getSetting("history.influx.token");
-const INFLUX_ORG = getSetting("history.influx.org");
-db.close();
+
+const { url: INFLUX_URL, token: INFLUX_TOKEN, org: INFLUX_ORG } = getInfluxConfig();
 
 const influx = new InfluxDB({ url: INFLUX_URL, token: INFLUX_TOKEN });
 

--- a/specs/086-shelly-em-energy-roles/architecture.md
+++ b/specs/086-shelly-em-energy-roles/architecture.md
@@ -1,0 +1,189 @@
+# Spec 086 — Architecture
+
+## Data flow
+
+```
+Shelly Pro 3EM
+  └── MQTT topic shelly/<id>/status/em1data:N      (cumulative, ~1/min)
+       │  total_act_energy        (Wh forward, monotonic)
+       │  total_act_ret_energy    (Wh reverse, monotonic)
+       │
+       ▼
+sowel-plugin-shelly-mqtt v1.1.0
+  ├── parseEm1DataStatus → { energy_forward, energy_reverse }
+  ├── ENERGY-DELTA SYNTHESISER  (NEW)
+  │     last_fwd, last_rev   (loaded from device_data SQLite at start)
+  │     delta_fwd = current_fwd − last_fwd     (or 0 if < 0)
+  │     delta_rev = current_rev − last_rev     (or 0 if < 0)
+  │     energy   = delta_fwd − delta_rev       (signed, Wh)
+  │     persist current_fwd / current_rev as new baseline
+  └── deviceManager.updateDeviceData(integrationId, sourceDeviceId, {
+        energy_forward, energy_reverse, energy
+      })
+       │
+       ▼
+DeviceManager (unchanged)
+  └── persists key/value to SQLite device_data table
+       │
+       ▼
+EquipmentManager (unchanged)
+  └── propagates value through bindings
+       │
+       ▼
+Event Bus: equipment.data.changed { alias: "energy", category: "energy", value: Δ }
+       │   ┌──────────────┬──────────────────────────────┐
+       │   ▼              ▼                              ▼
+       │  HistoryWriter   EnergyAggregator              WebSocket → UI
+       │  └─ writes raw   └─ debounced refresh
+       │     point +         from InfluxDB:
+       │     HP/HC split     hour / day / month / year
+       │
+       ▼
+InfluxDB sowel + sowel-energy-hourly + sowel-energy-daily
+```
+
+## Key design decisions
+
+### Plugin synthesises `energy` (not the aggregator)
+
+The aggregator is generic and currently triggers on `alias === "energy"`
+([energy-aggregator.ts:77](src/energy/energy-aggregator.ts#L77)). Keeping
+this trigger means **zero changes to the aggregator** — the smallest
+surface area for a behaviour-preserving change.
+
+The plugin is the right place to synthesise `energy` because it is the
+only component that knows the cadence at which forward/reverse counters
+arrive (1/min via `em1data:N` notifications). It can compute deltas
+between two consecutive readings of the same channel deterministically.
+
+### Baseline persistence via existing `device_data` table
+
+Sowel already persists the latest known value for every device data key
+into SQLite. The plugin re-uses this on start:
+
+```ts
+const lastFwd = deviceManager.getDeviceDataValue(integrationId, sourceDeviceId, "energy_forward");
+const lastRev = deviceManager.getDeviceDataValue(integrationId, sourceDeviceId, "energy_reverse");
+```
+
+No new file, no new schema, no new migration.
+
+### Reset detection
+
+A monotonic counter that goes backwards means one of:
+
+- Shelly factory reset (rare, manual user action)
+- Out-of-order MQTT delivery within QoS 0 (rare, single VM)
+- Counter rollover (extremely rare, takes years at Wh granularity)
+
+In all three cases, emitting a negative delta would corrupt every
+downstream cumul. The plugin treats `current < last` as
+`delta = 0` and refreshes the baseline to `current`. The lost interval
+between `last` and the rollover is accepted — the alternative would
+introduce false-positive rollback paths.
+
+### `energy_forward` and `energy_reverse` stay raw cumulative
+
+These two aliases continue to carry the **cumulative** Shelly counters
+(monotonic), as today. They remain useful for:
+
+- The Live page (no consumption — Live uses `power`).
+- Future scenarios that need to know absolute milestones (e.g., "alert
+  when monthly imports cross 200 kWh").
+- The forthcoming `energydata-stack` (spec 087) — Telegraf will read the
+  same MQTT topics and store the same raw counters in its own Influx,
+  independently.
+
+## File changes
+
+### Sowel core — small public API addition
+
+The plugin needs to read the last persisted value of a device data key
+to hydrate its baseline at start. The existing `DeviceManager` only
+exposes setters to plugins; a small public getter is added.
+
+| File                                 | Change                                                                                                                                                                                          |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/devices/device-manager.ts`      | Expose a public method `getDeviceDataValue(integrationId, sourceDeviceId, key): string \| number \| boolean \| null`. Internally re-uses the existing `findDeviceDataByDeviceAndKey` statement. |
+| `src/devices/device-manager.test.ts` | Add coverage for the getter (returns `null` for unknown device or unknown key, returns the typed value otherwise).                                                                              |
+| `plugins/registry.json`              | Bump `shelly_mqtt` entry to 1.1.0.                                                                                                                                                              |
+| `specs/086-…/spec.md`, `plan.md`     | Mark acceptance criteria + tasks as done at the end.                                                                                                                                            |
+
+The change is purely additive (no signature change to existing methods),
+so existing plugins keep compiling. A Sowel patch release is needed
+nonetheless because the plugin's TS will reference the new symbol.
+
+### `sowel-plugin-shelly-mqtt` (separate repo)
+
+| File                            | Change                                                                                                              |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `src/shelly-plugin.ts`          | Extend the local `DeviceManager` interface to include the new `getDeviceDataValue` method.                          |
+| `src/shelly-plugin.ts`          | Add private map `lastCumul: Map<sid, { fwd?: number; rev?: number }>`.                                              |
+| `src/shelly-plugin.ts`          | On `start()`, hydrate `lastCumul` from `device_data` for each known channel via `getDeviceDataValue`.               |
+| `src/shelly-plugin.ts`          | Update `handleEm1DataStatus`: compute deltas, synthesise `energy`, refresh baseline.                                |
+| `src/shelly-parser.test.ts`     | Already covers `parseEm1DataStatus`; add new tests for the synthesiser logic.                                       |
+| `src/shelly-plugin.test.ts`     | New file: ESM mock of DeviceManager, exercise restart / reset / first-event flows.                                  |
+| `manifest.json`, `package.json` | Bump version 1.0.0 → 1.1.0; bump `manifest.json` `sowelVersion` to `>=1.5.1` (the version that exposes the getter). |
+
+### Equipment bindings (operational, not code)
+
+After the plugin is updated, the user adds `energy_forward`,
+`energy_reverse`, `energy` aliases to `Shelly Grid` and `Shelly Solar`
+via the Sowel UI (Equipment edit). No DB migration: bindings are stored
+per-equipment in SQLite already.
+
+## Event flow (concrete example)
+
+Time `t` (em1data:0 received from Shelly):
+
+```
+total_act_energy      = 6105.7 Wh
+total_act_ret_energy  = 4690.3 Wh
+```
+
+State before:
+
+```
+last_fwd = 6100.2
+last_rev = 4685.4
+```
+
+Plugin computes:
+
+```
+delta_fwd = 5.5
+delta_rev = 4.9
+energy    = 0.6 (signed Wh, 0.6 Wh net imported in the last minute)
+```
+
+Plugin emits:
+
+```
+deviceManager.updateDeviceData(integrationId, "shelly-pro3em_00-em0", {
+  energy_forward: 6105.7,
+  energy_reverse: 4690.3,
+  energy:         0.6,
+});
+```
+
+State after (persisted via DeviceManager → SQLite):
+
+```
+last_fwd = 6105.7
+last_rev = 4690.3
+```
+
+Equipment Manager fires `equipment.data.changed` for the `energy`
+binding on Shelly Grid → HistoryWriter writes the 0.6 Wh delta to Influx
+
+- HP/HC classification → EnergyAggregator schedules a debounced refresh
+  → Consumption page sees the new hour / day total via WebSocket.
+
+## What does NOT change
+
+- `EnergyAggregator` code: untouched.
+- `HistoryWriter` code: untouched.
+- `TariffClassifier`: untouched.
+- Influx schema (measurements, tags, fields): untouched.
+- Energy REST API + WebSocket payloads: untouched.
+- Energy UI pages: untouched.

--- a/specs/086-shelly-em-energy-roles/plan.md
+++ b/specs/086-shelly-em-energy-roles/plan.md
@@ -6,14 +6,14 @@
 
 1. [ ] In `src/devices/device-manager.ts`, add a public method
        `getDeviceDataValue(integrationId: string, sourceDeviceId: string,
-   key: string): string | number | boolean | null` that re-uses
+key: string): string | number | boolean | null` that re-uses
        `findDeviceDataByDeviceAndKey` and decodes the stored value
        according to the `type` column.
 2. [ ] Add unit tests in `src/devices/device-manager.test.ts`: returns
        `null` for unknown device, unknown key, or null-valued key;
        returns the typed value when present.
 3. [ ] Run `npx tsc --noEmit`, `npx vitest run`, `npx eslint src/ --ext
-   .ts` — all green.
+.ts` — all green.
 4. [ ] Commit on branch `feat/086-energy-roles`, open a PR, wait for
        CI, merge after explicit user approval.
 5. [ ] Release Sowel v1.5.1 via `scripts/release.sh 1.5.1` so the
@@ -24,7 +24,7 @@
 6. [ ] Extend the local `DeviceManager` interface in
        `src/shelly-plugin.ts` to include `getDeviceDataValue`.
 7. [ ] Add `private lastCumul = new Map<string, { fwd?: number; rev?:
-   number }>()` to `ShellyEngine`.
+number }>()` to `ShellyEngine`.
 8. [ ] On `start()`, after subscribing, hydrate `lastCumul` for every
        already-known channel (`this.known`) by reading
        `energy_forward` / `energy_reverse` from `device_data`. New
@@ -51,6 +51,53 @@
 15. [ ] Manual UI step (operational, not code): - Edit equipment `Shelly Grid` → add bindings for
         `energy_forward`, `energy_reverse`, `energy`. - Same for `Shelly Solar`. - Save → equipments emit `equipment.data.changed` for `energy`,
         the aggregator picks them up.
+
+### Step E — Sowel core fixes uncovered by IT 086
+
+Iteration 086 surfaces several latent bugs in the energy pipeline that
+only become visible once the Shelly plugin starts emitting multiple
+energy-category aliases on the same equipment. Bundled in the same PR.
+
+19. [x] `EquipmentManager.addDataBinding` / `removeDataBinding` /
+        `setHistorize` / `addOrderBinding` / `removeOrderBinding` —
+        emit `equipment.updated` so the `HistoryWriter` cache (and
+        every other listener with a similar binding-keyed cache)
+        refreshes. Without this, freshly-added bindings are invisible
+        to the writer until the equipment is otherwise modified — and
+        the new `energy` binding on `Shelly Grid` / `Shelly Solar`
+        would not be historized after the user saves it in the UI.
+20. [x] `EnergyAggregator` Flux queries — add `r.alias == "energy"`
+        to the filters. Without this, the cumul query iterates one
+        result row per (alias, equipment) and overwrites
+        `energyDayWh` / etc. with the _last_ alias seen — typically
+        `energy_reverse` (cumulative counter), corrupting every cumul
+        downstream. Also include the current hour from the raw bucket
+        in the day cumul; the previous code only summed the hourly
+        bucket, missing the in-flight hour.
+21. [x] `HistoryWriter.ALIAS_DEFAULTS_OFF` — add `energy_forward` and
+        `energy_reverse`. These are monotonic Shelly cumuls (hundreds
+        of kWh) that pollute every category=energy aggregation. The
+        plugin still emits them as latest values for the Live page;
+        the historize default just stops them from being written as
+        time-series points.
+
+### Step F — Self-consumption writer (replaces Netatmo poller)
+
+The previous Netatmo HC poller (decommissioned with IT 085) wrote
+`autoconso` and `injection` aliases to the production equipment's
+Influx tag. With Shelly providing only the raw counters, this split
+needs to be derived in Sowel.
+
+22. [x] New `src/energy/self-consumption-writer.ts` listens to
+        `equipment.data.changed` events with `alias == "energy"`,
+        keeps the latest signed delta for the Grid + Solar equipments,
+        and on each new tick computes: - `injection = max(0, -gridΔ)` - `autoconso = max(0, solarΔ - injection)`
+        and writes 2 points to InfluxDB (`autoconso` + `injection`)
+        tagged with the production equipment's id, mirroring how
+        `writeEnergyHpHc` handles the HP/HC split.
+23. [x] Wire it into `src/index.ts` next to `historyWriter.init()`.
+24. [x] 11 unit tests covering grid-importing / grid-exporting / no
+        flow / restart / out-of-window / disabled Influx / no-solar.
 
 ### Step D — Validation
 

--- a/specs/086-shelly-em-energy-roles/plan.md
+++ b/specs/086-shelly-em-energy-roles/plan.md
@@ -1,0 +1,103 @@
+# Spec 086 — Implementation plan
+
+## Tasks
+
+### Step A — Sowel core (must ship first)
+
+1. [ ] In `src/devices/device-manager.ts`, add a public method
+       `getDeviceDataValue(integrationId: string, sourceDeviceId: string,
+   key: string): string | number | boolean | null` that re-uses
+       `findDeviceDataByDeviceAndKey` and decodes the stored value
+       according to the `type` column.
+2. [ ] Add unit tests in `src/devices/device-manager.test.ts`: returns
+       `null` for unknown device, unknown key, or null-valued key;
+       returns the typed value when present.
+3. [ ] Run `npx tsc --noEmit`, `npx vitest run`, `npx eslint src/ --ext
+   .ts` — all green.
+4. [ ] Commit on branch `feat/086-energy-roles`, open a PR, wait for
+       CI, merge after explicit user approval.
+5. [ ] Release Sowel v1.5.1 via `scripts/release.sh 1.5.1` so the
+       plugin can target it.
+
+### Step B — Plugin `sowel-plugin-shelly-mqtt` v1.1.0
+
+6. [ ] Extend the local `DeviceManager` interface in
+       `src/shelly-plugin.ts` to include `getDeviceDataValue`.
+7. [ ] Add `private lastCumul = new Map<string, { fwd?: number; rev?:
+   number }>()` to `ShellyEngine`.
+8. [ ] On `start()`, after subscribing, hydrate `lastCumul` for every
+       already-known channel (`this.known`) by reading
+       `energy_forward` / `energy_reverse` from `device_data`. New
+       channels discovered later populate `lastCumul` lazily inside
+       `handleEm1DataStatus`.
+9. [ ] Refactor `handleEm1DataStatus` to:
+   1. Parse `parseEm1DataStatus` as today.
+   2. Compute `deltaFwd = max(0, currentFwd − lastFwd)` and
+      `deltaRev = max(0, currentRev − lastRev)`.
+   3. `energy = deltaFwd − deltaRev` (signed Wh).
+   4. Update `lastCumul.set(sid, { fwd: currentFwd, rev: currentRev })`.
+   5. Build `data = { energy_forward, energy_reverse, energy }` and
+      forward to `deviceManager.updateDeviceData(...)`.
+10. [ ] Bump `manifest.json` (`version` to `1.1.0`, `sowelVersion` to
+        `>=1.5.1`) and `package.json` (`version` to `1.1.0`).
+11. [ ] Tests (see plan below).
+12. [ ] Build, commit, tag `v1.1.0`, push.
+
+### Step C — Sowel registry + operational
+
+13. [ ] Update `plugins/registry.json` — `shelly_mqtt` version → `1.1.0`,
+        `sowelVersion` → `>=1.5.1`. Commit on `main`. No Sowel release.
+14. [ ] In production, update the plugin via UI Integrations.
+15. [ ] Manual UI step (operational, not code): - Edit equipment `Shelly Grid` → add bindings for
+        `energy_forward`, `energy_reverse`, `energy`. - Same for `Shelly Solar`. - Save → equipments emit `equipment.data.changed` for `energy`,
+        the aggregator picks them up.
+
+### Step D — Validation
+
+16. [ ] After 24 h of running, query the Sowel Consumption page and
+        compare daily total to: - Legrand / Netatmo dashboard (`home.netatmo.com/control/dashboard`). - Shelly's own `total_act_energy` end-of-day minus start-of-day
+        (visible in DeviceData via API).
+17. [ ] Spot-check HP/HC totals against the configured tariff schedule.
+18. [ ] Verify reset behaviour by restarting the Sowel container and
+        confirming the next plugin event produces no spurious daily
+        spike.
+
+## Test plan
+
+### Modules to test
+
+- `src/devices/device-manager.ts` — new public getter
+  `getDeviceDataValue`.
+- `sowel-plugin-shelly-mqtt/src/shelly-plugin.ts` — energy delta
+  synthesiser, restart hydration, reset detection.
+
+### Scenarios
+
+| Module        | Scenario                                                                | Expected                                                        |
+| ------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------- |
+| DeviceManager | `getDeviceDataValue` for an unknown device                              | returns `null`                                                  |
+| DeviceManager | `getDeviceDataValue` for an unknown key on an existing device           | returns `null`                                                  |
+| DeviceManager | `getDeviceDataValue` for a `number`-typed key                           | returns the numeric value                                       |
+| DeviceManager | `getDeviceDataValue` for a `boolean`-typed key                          | returns the boolean value                                       |
+| DeviceManager | `getDeviceDataValue` for a key whose value is null                      | returns `null`                                                  |
+| ShellyEngine  | First em1data event for a new channel                                   | `energy = 0`, `lastCumul[sid]` populated with the current cumul |
+| ShellyEngine  | Steady-state — fwd grows, rev unchanged                                 | `energy = +deltaFwd`                                            |
+| ShellyEngine  | Steady-state — rev grows, fwd unchanged                                 | `energy = −deltaRev`                                            |
+| ShellyEngine  | Both fwd and rev grow within the same window                            | `energy = deltaFwd − deltaRev`                                  |
+| ShellyEngine  | Counter reset — current fwd < last fwd                                  | `energy = 0`, baseline updated to current                       |
+| ShellyEngine  | Out-of-order — old `em1data` arrives after a newer one (current < last) | `energy = 0`, no negative emission                              |
+| ShellyEngine  | Plugin restart — DeviceManager has previously persisted fwd/rev         | `lastCumul` hydrated; first delta uses persisted baseline       |
+| ShellyEngine  | Plugin restart — DeviceManager has no prior data                        | First event treats current as baseline, `energy = 0`            |
+| ShellyEngine  | em1data with only one of fwd/rev present (partial payload)              | Compute delta on the field that arrived; the other is unchanged |
+
+### Notes
+
+- Re-use the existing test scaffolding in
+  `sowel-plugin-shelly-mqtt/src/shelly-parser.test.ts` (Vitest).
+- For the engine tests, mock `DeviceManager` with a small in-memory
+  Map<sid → key → value> and a stub `updateDeviceData` that captures
+  arguments.
+- No InfluxDB / Sowel core in the test loop — the plugin tests run in
+  isolation against the pure functions and the engine.
+- Sowel core has zero behaviour change in this iteration → no new tests
+  on Sowel side.

--- a/specs/086-shelly-em-energy-roles/spec.md
+++ b/specs/086-shelly-em-energy-roles/spec.md
@@ -5,37 +5,101 @@
 
 ## Goal
 
-Now that the live power view from iteration 1 has been validated against
-Legrand, promote two of the Shelly channels to fill the
-`main_energy_meter` and `energy_production_meter` roles, and disable the
-Legrand integration. Sowel's existing `EnergyAggregator` keeps doing
-HP/HC classification and cumulative aggregation, but reads from Shelly
-forward/reverse counters instead of Legrand cumulative readings. The
-energy page in Sowel's UI continues to look the same — only the source
-changed.
+Plug the Shelly Pro 3EM channels into Sowel's existing `EnergyAggregator`
+so the **Consumption / Production** pages show kWh figures derived from
+Shelly's per-channel forward/reverse counters, with the same HP/HC tariff
+classification as before. The Live page (iteration 1) keeps working
+unchanged.
 
-## Key design decisions
+After this iteration, Legrand is fully retired (already done in IT 085
+during the migration session) and the Sowel-internal Influx contains a
+continuous energy history fed entirely by Shelly.
 
-- Each `main_energy_meter` / `energy_production_meter` equipment exposes
-  two cumulative aliases: `energy_forward` (= imports / production) and
-  `energy_reverse` (= exports). The `EnergyAggregator` treats them
-  separately for accurate billing.
-- Sub-load CT (3rd channel, optional) stays as `energy_meter` —
-  informational only, **not summed into the household balance**.
-- HP/HC tariff classification remains Sowel-side (timestamp-based) — same
-  code as today.
+## In scope
 
-## Out of scope of this iteration
+- Shelly plugin (`sowel-plugin-shelly-mqtt`) v1.1.0:
+  - Synthesise a signed `energy` delta alias on each `em1data:N` update,
+    computed as `(forward_t − forward_{t-1}) − (reverse_t − reverse_{t-1})`.
+  - Track the last cumulative `total_act_energy` /
+    `total_act_ret_energy` per channel using the existing `device_data`
+    SQLite as the persistent baseline (no new on-disk state file).
+  - Reset detection: when the current cumulative reading is lower than
+    the persisted baseline (Shelly factory reset, firmware reset, or
+    out-of-order delivery), emit `energy = 0` and refresh the baseline
+    to the current value.
+  - Keep emitting `power`, `energy_forward`, `energy_reverse` as today
+    — they remain useful for the Live page and future scenarios.
+- Equipment bindings on `Shelly Grid` (main_energy_meter) and
+  `Shelly Solar` (energy_production_meter):
+  - `power` (already there)
+  - `energy_forward`
+  - `energy_reverse`
+  - `energy` — required for the aggregator trigger
+- Plugin registry update (`plugins/registry.json`) bumping
+  `shelly_mqtt` to 1.1.0.
 
-- Independent Influx archive (iteration 3).
-- Backfill (iteration 4).
-- Per-load self-consumption split.
+## Out of scope
 
-## To detail later
+- Computed/derived metrics for scenarios (rolling averages, "solar
+  excess available", etc.). Tracked separately, future spec.
+- Backfill of Sowel-internal Influx with historical Shelly data
+  (n/a — IT 085 already migrated Legrand history to the new equipment
+  ids).
+- The independent `energydata-stack` (Telegraf / dedicated Influx /
+  Grafana) — that is iteration 087.
+- Changes to `EnergyAggregator` itself. The current trigger
+  (`alias === "energy"`) is preserved; only the source changes.
+- Per-load self-consumption split. The 3rd CT (em2) stays as a
+  discovered device with no equipment until the user clamps a sub-load.
 
-- Migration path: equipment type change vs. new equipments + retire old?
-- How the EnergyAggregator should consume two separate counters
-  (forward + reverse) to derive imports, exports, self-consumption, total.
-- Validation criteria: 1 month overlap, daily kWh diff < 3%.
-- Rollback: re-enable Legrand and demote Shelly to generic if validation
-  fails.
+## Acceptance criteria
+
+- [ ] Plugin v1.1.0 emits an `energy` value (signed Wh delta) alongside
+      `power`, `energy_forward`, `energy_reverse` on each em1:N device.
+- [ ] Plugin restart leaves no spurious delta: first event after
+      restart uses the persisted cumul as baseline (or emits 0 if cumul
+      was lower).
+- [ ] `Shelly Grid` and `Shelly Solar` equipments are bound to the new
+      `energy` alias and start producing `equipment.data.changed`
+      events with `alias === "energy"`.
+- [ ] `EnergyAggregator` picks up the new equipments, refreshes from
+      InfluxDB, and exposes `energy_hour` / `energy_day` /
+      `energy_month` / `energy_year` values via REST + WebSocket.
+- [ ] HP/HC classification continues to work — Consumption page shows
+      `energy_hp` / `energy_hc` daily totals.
+- [ ] All existing energy pages render with no code change.
+
+## Validation
+
+Manual sanity check, no automated test against external data:
+
+1. Compare Sowel's daily kWh (Consumption + Production pages) with
+   the Legrand mobile app and the Netatmo dashboard
+   (`home.netatmo.com/control/dashboard`) — both still display the
+   historical Shelly data because IT 085 migrated the equipment ids.
+2. Cross-check Sowel's daily figures against Shelly's own
+   `total_act_energy` deltas exposed in the device data table:
+   `daily kWh ≈ counter[end_of_day] − counter[start_of_day]` per
+   channel.
+3. Spot-check HP / HC totals against the configured tariff schedule.
+
+A daily diff < 3 % between Sowel and Shelly's own counters is the bar.
+Larger drift means the synthesis or the reset detection is broken.
+
+## Edge cases
+
+- **First-ever em1data event for a new install** : no baseline → emit
+  0 and store the current cumul as baseline.
+- **Plugin restart** : load last forward/reverse from `device_data`
+  via DeviceManager → first delta after restart is the "missed window"
+  during downtime (small).
+- **Counter reset** (current < last) → emit 0, refresh baseline.
+- **Out-of-order MQTT messages** : same handling as reset (delta < 0
+  → emit 0). MQTT QoS 0 within a single broker on the same VM makes
+  this rare in practice.
+- **Shelly offline** : no events; existing `online` LWT handling
+  already flips device status. When it comes back, first `em1data`
+  produces a large delta that represents the missed window — accepted
+  (better than losing it).
+- **3rd CT (em2)** : still discovered as a device but no equipment
+  binding, so no aggregator side effect.

--- a/specs/088-energy-backfill-plugin/spec.md
+++ b/specs/088-energy-backfill-plugin/spec.md
@@ -15,6 +15,31 @@ backfilled from the always-on archive.
 This plugin is opt-in. It requires `energydata-stack` to be deployed and
 reachable.
 
+## Why this iteration matters (carry-over from IT 086)
+
+Iteration 086 made the Shelly plugin synthesise an `energy` delta on
+each `em1data:N` update. When Sowel is down for several hours, the
+Shelly counters keep advancing inside the device, but the plugin can
+only observe the gap at the next event after restart. The current
+behaviour is to emit the full delta as a single point at the restart
+timestamp:
+
+- Daily kWh totals stay correct.
+- The hourly granularity collapses (a spike at restart, flat zeros
+  during the downtime).
+- HP/HC tariff classification is wrong if the downtime crosses an
+  HP↔HC boundary (the whole delta inherits the tariff at restart).
+
+This iteration's backfill plugin is the proper fix. It pulls the
+missing window from `energydata-stack`'s always-on Influx (which kept
+recording during the Sowel downtime) and reconstructs Sowel's internal
+hourly + daily buckets with the correct timestamps and tariff splits.
+
+Until this iteration ships, the IT 086 behaviour is accepted as-is —
+brief restarts (≤ a few minutes) are barely visible, and longer
+downtimes produce a flagged spike that is easy to spot on the energy
+page.
+
 ## Key design decisions
 
 - The plugin does not write to InfluxDB directly via `HistoryWriter`. It

--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -454,4 +454,65 @@ describe("DeviceManager", () => {
       expect(JSON.parse(row.enum_values!)).toEqual(["1_single", "1_double"]);
     });
   });
+
+  describe("getDeviceDataValue", () => {
+    const sampleEm = {
+      ieeeAddress: "0xshelly00",
+      friendlyName: "shelly-pro3em_00-em0",
+      manufacturer: "Shelly",
+      model: "Pro3EM",
+      data: [
+        { key: "energy_forward", type: "number" as const, category: "energy" as const, unit: "Wh" },
+        { key: "energy_reverse", type: "number" as const, category: "energy" as const, unit: "Wh" },
+        { key: "online", type: "boolean" as const, category: "generic" as const },
+        { key: "label", type: "text" as const, category: "generic" as const },
+      ],
+      orders: [],
+      rawExpose: [],
+    };
+
+    it("returns null for an unknown device", () => {
+      expect(manager.getDeviceDataValue("shelly_mqtt", "ghost", "energy_forward")).toBeNull();
+    });
+
+    it("returns null for an unknown key on an existing device", () => {
+      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
+      expect(
+        manager.getDeviceDataValue("shelly_mqtt", "shelly-pro3em_00-em0", "missing_key"),
+      ).toBeNull();
+    });
+
+    it("returns null when the key value has never been written", () => {
+      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
+      expect(
+        manager.getDeviceDataValue("shelly_mqtt", "shelly-pro3em_00-em0", "energy_forward"),
+      ).toBeNull();
+    });
+
+    it("returns the numeric value for a number-typed key", () => {
+      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
+      manager.updateDeviceData("shelly_mqtt", "shelly-pro3em_00-em0", {
+        energy_forward: 6105.7,
+      });
+      expect(
+        manager.getDeviceDataValue("shelly_mqtt", "shelly-pro3em_00-em0", "energy_forward"),
+      ).toBe(6105.7);
+    });
+
+    it("returns the boolean value for a boolean-typed key", () => {
+      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
+      manager.updateDeviceData("shelly_mqtt", "shelly-pro3em_00-em0", { online: true });
+      expect(manager.getDeviceDataValue("shelly_mqtt", "shelly-pro3em_00-em0", "online")).toBe(
+        true,
+      );
+    });
+
+    it("returns the string value for a text-typed key", () => {
+      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
+      manager.updateDeviceData("shelly_mqtt", "shelly-pro3em_00-em0", { label: "main" });
+      expect(manager.getDeviceDataValue("shelly_mqtt", "shelly-pro3em_00-em0", "label")).toBe(
+        "main",
+      );
+    });
+  });
 });

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -492,6 +492,45 @@ export class DeviceManager {
     return rows.map(rowToDeviceData);
   }
 
+  /**
+   * Read the last persisted value of a device data key, decoded according
+   * to its declared `type`. Used by plugins that need to hydrate state at
+   * start (e.g. the Shelly plugin loading the last cumulative counter to
+   * compute the next delta).
+   *
+   * Returns `null` for unknown device, unknown key, null-valued key, or
+   * any deserialization mismatch with the declared type.
+   */
+  getDeviceDataValue(
+    integrationId: string,
+    sourceDeviceId: string,
+    key: string,
+  ): string | number | boolean | null {
+    const device = this.stmts.findDeviceBySource.get(integrationId, sourceDeviceId) as
+      | DeviceRow
+      | undefined;
+    if (!device) return null;
+    const row = this.stmts.findDeviceDataByDeviceAndKey.get(device.id, key) as
+      | DeviceDataRow
+      | undefined;
+    if (!row || row.value === null) return null;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(row.value);
+    } catch {
+      return null;
+    }
+    if (parsed === null) return null;
+    switch (row.type as DataType) {
+      case "number":
+        return typeof parsed === "number" ? parsed : null;
+      case "boolean":
+        return typeof parsed === "boolean" ? parsed : null;
+      default:
+        return typeof parsed === "string" ? parsed : null;
+    }
+  }
+
   getDeviceOrders(deviceId: string): DeviceOrder[] {
     const rows = this.stmts.getDeviceOrders.all(deviceId) as DeviceOrderRow[];
     return rows.map(rowToDeviceOrder);

--- a/src/energy/energy-aggregator.ts
+++ b/src/energy/energy-aggregator.ts
@@ -143,6 +143,7 @@ export class EnergyAggregator {
   |> filter(fn: (r) => r._measurement == "equipment_data")
   |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
   |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r.alias == "energy")
   |> filter(fn: (r) => r._field == "value_number")
   |> sum()`;
 
@@ -151,20 +152,25 @@ export class EnergyAggregator {
       if (row._value > 0) energyHourWh = row._value;
     }
 
-    // Day cumul: sum hourly points today + raw points in current hour (hourly task may not have run yet)
-    let energyDayWh = 0;
+    // Day cumul: previous hours of today come from the hourly bucket
+    // (downsampled at the end of each hour), the current hour is still in
+    // the raw bucket. Sum both — they don't overlap because the hourly
+    // task only writes completed hours.
+    let energyDayPrevHoursWh = 0;
     const dayFlux = `from(bucket: "${hourlyBucket}")
-  |> range(start: ${todayMidnight.toISOString()}, stop: ${tomorrowMidnight.toISOString()})
+  |> range(start: ${todayMidnight.toISOString()}, stop: ${currentHourStart.toISOString()})
   |> filter(fn: (r) => r._measurement == "equipment_data")
   |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
   |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r.alias == "energy")
   |> filter(fn: (r) => r._field == "value_number")
   |> sum()`;
 
     for await (const { values, tableMeta } of queryApi.iterateRows(dayFlux)) {
       const row = tableMeta.toObject(values) as { _value: number };
-      if (row._value > 0) energyDayWh = row._value;
+      if (row._value > 0) energyDayPrevHoursWh = row._value;
     }
+    const energyDayWh = energyDayPrevHoursWh + energyHourWh;
 
     // Month cumul: daily points this month (excluding today) + today's day total
     const monthFirst = new Date(now.getFullYear(), now.getMonth(), 1);
@@ -174,6 +180,7 @@ export class EnergyAggregator {
   |> filter(fn: (r) => r._measurement == "equipment_data")
   |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
   |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r.alias == "energy")
   |> filter(fn: (r) => r._field == "value_number")
   |> sum()`;
 
@@ -190,6 +197,7 @@ export class EnergyAggregator {
   |> filter(fn: (r) => r._measurement == "equipment_data")
   |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
   |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r.alias == "energy")
   |> filter(fn: (r) => r._field == "value_number")
   |> sum()`;
 

--- a/src/energy/self-consumption-writer.test.ts
+++ b/src/energy/self-consumption-writer.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+import { SelfConsumptionWriter } from "./self-consumption-writer.js";
+import { Point } from "../core/influx-client.js";
+import type { InfluxClient } from "../core/influx-client.js";
+import type { EquipmentManager } from "../equipments/equipment-manager.js";
+
+const logger = createLogger("silent").logger;
+
+const GRID_ID = "grid-uuid";
+const SOLAR_ID = "solar-uuid";
+const ZONE_ID = "zone-uuid";
+
+interface CapturedPoint {
+  alias: string;
+  value: number;
+  timestamp: number | undefined;
+  equipmentId: string;
+}
+
+class StubInfluxClient {
+  connected = true;
+  written: CapturedPoint[] = [];
+  isConnected(): boolean {
+    return this.connected;
+  }
+  writePoint(point: Point): void {
+    const tags = (point as unknown as { tags: Record<string, string> }).tags ?? {};
+    const fields = (point as unknown as { fields: Record<string, string> }).fields ?? {};
+    const tsNs = (point as unknown as { time?: string }).time;
+    this.written.push({
+      alias: tags.alias,
+      equipmentId: tags.equipmentId,
+      value: parseFloat(fields.value_number ?? "0"),
+      timestamp: tsNs ? Math.floor(parseInt(tsNs, 10) / 1e9) : undefined,
+    });
+  }
+}
+
+function makeStubEquipmentManager(opts: {
+  gridEnabled?: boolean;
+  solarEnabled?: boolean;
+  hasGrid?: boolean;
+  hasSolar?: boolean;
+}): EquipmentManager {
+  const eqs: Array<{ id: string; type: string; enabled: boolean; zoneId: string }> = [];
+  if (opts.hasGrid !== false) {
+    eqs.push({
+      id: GRID_ID,
+      type: "main_energy_meter",
+      enabled: opts.gridEnabled ?? true,
+      zoneId: ZONE_ID,
+    });
+  }
+  if (opts.hasSolar !== false) {
+    eqs.push({
+      id: SOLAR_ID,
+      type: "energy_production_meter",
+      enabled: opts.solarEnabled ?? true,
+      zoneId: ZONE_ID,
+    });
+  }
+  return {
+    getById: (id: string) => eqs.find((e) => e.id === id) ?? null,
+    getAll: () => eqs,
+  } as unknown as EquipmentManager;
+}
+
+function emitEnergyChange(
+  bus: EventBus,
+  equipmentId: string,
+  value: number,
+  sourceTimestamp?: number,
+): void {
+  bus.emit({
+    type: "equipment.data.changed",
+    equipmentId,
+    alias: "energy",
+    value,
+    previous: null,
+    ...(sourceTimestamp !== undefined ? { sourceTimestamp } : {}),
+  } as never);
+}
+
+describe("SelfConsumptionWriter", () => {
+  let bus: EventBus;
+  let influx: StubInfluxClient;
+  let writer: SelfConsumptionWriter;
+
+  beforeEach(() => {
+    bus = new EventBus(logger);
+    influx = new StubInfluxClient();
+  });
+
+  it("writes autoconso=solar and injection=0 when grid is importing (grid > 0)", () => {
+    writer = new SelfConsumptionWriter(
+      bus,
+      makeStubEquipmentManager({}),
+      influx as unknown as InfluxClient,
+      logger,
+    );
+    writer.init();
+
+    const t = 1714723200; // arbitrary epoch s
+    emitEnergyChange(bus, GRID_ID, 5, t);
+    emitEnergyChange(bus, SOLAR_ID, 3, t);
+
+    const auto = influx.written.find((p) => p.alias === "autoconso");
+    const inj = influx.written.find((p) => p.alias === "injection");
+    expect(auto?.value).toBe(3);
+    expect(auto?.equipmentId).toBe(SOLAR_ID);
+    expect(inj?.value).toBe(0);
+  });
+
+  it("writes injection=|grid| and autoconso=solar-injection when exporting (grid < 0)", () => {
+    writer = new SelfConsumptionWriter(
+      bus,
+      makeStubEquipmentManager({}),
+      influx as unknown as InfluxClient,
+      logger,
+    );
+    writer.init();
+
+    const t = 1714723200;
+    // Solar produces 8, house uses 3 → grid exports 5 (gridΔ = -5)
+    emitEnergyChange(bus, GRID_ID, -5, t);
+    emitEnergyChange(bus, SOLAR_ID, 8, t);
+
+    const auto = influx.written.find((p) => p.alias === "autoconso");
+    const inj = influx.written.find((p) => p.alias === "injection");
+    expect(inj?.value).toBe(5);
+    expect(auto?.value).toBe(3); // 8 - 5
+  });
+
+  it("writes 0/0 when neither side is producing/consuming", () => {
+    writer = new SelfConsumptionWriter(
+      bus,
+      makeStubEquipmentManager({}),
+      influx as unknown as InfluxClient,
+      logger,
+    );
+    writer.init();
+
+    const t = 1714723200;
+    emitEnergyChange(bus, GRID_ID, 0, t);
+    emitEnergyChange(bus, SOLAR_ID, 0, t);
+
+    const auto = influx.written.find((p) => p.alias === "autoconso");
+    const inj = influx.written.find((p) => p.alias === "injection");
+    expect(auto?.value).toBe(0);
+    expect(inj?.value).toBe(0);
+  });
+
+  it("does not write if only Grid arrived (no Solar tick yet)", () => {
+    writer = new SelfConsumptionWriter(
+      bus,
+      makeStubEquipmentManager({}),
+      influx as unknown as InfluxClient,
+      logger,
+    );
+    writer.init();
+
+    emitEnergyChange(bus, GRID_ID, 5, 1714723200);
+
+    expect(influx.written).toHaveLength(0);
+  });
+
+  it("does not write twice for the same minute", () => {
+    writer = new SelfConsumptionWriter(
+      bus,
+      makeStubEquipmentManager({}),
+      influx as unknown as InfluxClient,
+      logger,
+    );
+    writer.init();
+
+    const t = 1714723200; // minute boundary
+    emitEnergyChange(bus, GRID_ID, 5, t);
+    emitEnergyChange(bus, SOLAR_ID, 3, t);
+    // Second pair within the same minute (e.g. retry / duplicate)
+    emitEnergyChange(bus, GRID_ID, 6, t + 10);
+    emitEnergyChange(bus, SOLAR_ID, 4, t + 10);
+
+    const autos = influx.written.filter((p) => p.alias === "autoconso");
+    expect(autos).toHaveLength(1);
+  });
+
+  it("writes again on the next minute", () => {
+    writer = new SelfConsumptionWriter(
+      bus,
+      makeStubEquipmentManager({}),
+      influx as unknown as InfluxClient,
+      logger,
+    );
+    writer.init();
+
+    const t1 = 1714723200;
+    const t2 = t1 + 60;
+    emitEnergyChange(bus, GRID_ID, 5, t1);
+    emitEnergyChange(bus, SOLAR_ID, 3, t1);
+    emitEnergyChange(bus, GRID_ID, 6, t2);
+    emitEnergyChange(bus, SOLAR_ID, 4, t2);
+
+    const autos = influx.written.filter((p) => p.alias === "autoconso");
+    expect(autos).toHaveLength(2);
+    expect(autos[0].value).toBe(3);
+    expect(autos[1].value).toBe(4);
+  });
+
+  it("ignores ticks when skew between Grid and Solar exceeds the match window (90s)", () => {
+    writer = new SelfConsumptionWriter(
+      bus,
+      makeStubEquipmentManager({}),
+      influx as unknown as InfluxClient,
+      logger,
+    );
+    writer.init();
+
+    emitEnergyChange(bus, GRID_ID, 5, 1714723200);
+    // Solar event 2 minutes later — skew > 90s
+    emitEnergyChange(bus, SOLAR_ID, 3, 1714723200 + 120);
+
+    expect(influx.written).toHaveLength(0);
+  });
+
+  it("ignores other aliases (e.g. energy_hp, energy_forward) — only `energy` triggers", () => {
+    writer = new SelfConsumptionWriter(
+      bus,
+      makeStubEquipmentManager({}),
+      influx as unknown as InfluxClient,
+      logger,
+    );
+    writer.init();
+
+    bus.emit({
+      type: "equipment.data.changed",
+      equipmentId: GRID_ID,
+      alias: "energy_forward",
+      value: 19000,
+      previous: null,
+    } as never);
+    bus.emit({
+      type: "equipment.data.changed",
+      equipmentId: SOLAR_ID,
+      alias: "energy_hp",
+      value: 5,
+      previous: null,
+    } as never);
+
+    expect(influx.written).toHaveLength(0);
+  });
+
+  it("does not write if Solar production_meter is missing", () => {
+    writer = new SelfConsumptionWriter(
+      bus,
+      makeStubEquipmentManager({ hasSolar: false }),
+      influx as unknown as InfluxClient,
+      logger,
+    );
+    writer.init();
+
+    emitEnergyChange(bus, GRID_ID, 5, 1714723200);
+    expect(influx.written).toHaveLength(0);
+  });
+
+  it("does not write if Influx is disconnected", () => {
+    influx.connected = false;
+    writer = new SelfConsumptionWriter(
+      bus,
+      makeStubEquipmentManager({}),
+      influx as unknown as InfluxClient,
+      logger,
+    );
+    writer.init();
+
+    emitEnergyChange(bus, GRID_ID, 5, 1714723200);
+    emitEnergyChange(bus, SOLAR_ID, 3, 1714723200);
+    expect(influx.written).toHaveLength(0);
+  });
+
+  it("destroy() unsubscribes — no further writes after destroy", () => {
+    writer = new SelfConsumptionWriter(
+      bus,
+      makeStubEquipmentManager({}),
+      influx as unknown as InfluxClient,
+      logger,
+    );
+    writer.init();
+    writer.destroy();
+
+    emitEnergyChange(bus, GRID_ID, 5, 1714723200);
+    emitEnergyChange(bus, SOLAR_ID, 3, 1714723200);
+    expect(influx.written).toHaveLength(0);
+  });
+});

--- a/src/energy/self-consumption-writer.ts
+++ b/src/energy/self-consumption-writer.ts
@@ -1,0 +1,167 @@
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import type { InfluxClient } from "../core/influx-client.js";
+import { Point } from "../core/influx-client.js";
+
+/**
+ * Maximum time skew (seconds) between the latest Grid energy tick and
+ * the latest Solar energy tick we accept as "same window". Shelly
+ * publishes em1data:0 and em1data:1 in immediate succession (a few ms
+ * apart), so 30s is generous. A wider window risks pairing a stale tick
+ * from one channel with a fresh one from the other when one channel
+ * temporarily drops a minute (e.g. brief MQTT hiccup).
+ */
+const MATCH_WINDOW_S = 30;
+
+interface LatestTick {
+  /** Signed energy delta (Wh) over the last sampling window. */
+  value: number;
+  /** Epoch seconds. Source timestamp when present, else Date.now()/1000. */
+  t: number;
+}
+
+/**
+ * Computes household-level self-consumption split from Shelly Pro 3EM
+ * and writes `autoconso` / `injection` aliases on the production
+ * equipment so the existing energy API + UI display them as before.
+ *
+ * Inputs (signed energy deltas, Wh, per minute):
+ *   gridΔ  = main_energy_meter `energy`     (positive = imported, negative = exported)
+ *   solarΔ = energy_production_meter `energy` (≥ 0 in normal operation)
+ *
+ * Output (per minute, written to InfluxDB on the production equipmentId):
+ *   injection = max(0, -gridΔ)              (excess solar pushed to the grid)
+ *   autoconso = max(0, solarΔ - injection)  (solar consumed in-house)
+ *
+ * Properties:
+ *   - autoconso + injection ≤ solarΔ      (split conserves total production)
+ *   - house_total_consumption ≈ max(0, gridΔ) + autoconso (for charts that
+ *     overlay autoconso on top of the grid HP/HC bars).
+ *
+ * Why this lives outside HistoryWriter: keeps each writer single-purpose
+ * (the same precedent as TariffClassifier — the HP/HC writer is also
+ * called out from HistoryWriter, but it's a self-contained helper).
+ *
+ * Discovery: equipment ids are resolved by `type` on every relevant event,
+ * so users can add/remove the meters at runtime without restarting Sowel.
+ */
+export class SelfConsumptionWriter {
+  private readonly logger: Logger;
+  private readonly eventBus: EventBus;
+  private readonly equipmentManager: EquipmentManager;
+  private readonly influxClient: InfluxClient;
+
+  private latestGrid: LatestTick | null = null;
+  private latestSolar: LatestTick | null = null;
+  /** Epoch-minute of the last write — prevents double-writes when both
+   *  events fire close in time and re-trigger compute. */
+  private lastWrittenMinute = 0;
+
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(
+    eventBus: EventBus,
+    equipmentManager: EquipmentManager,
+    influxClient: InfluxClient,
+    logger: Logger,
+  ) {
+    this.eventBus = eventBus;
+    this.equipmentManager = equipmentManager;
+    this.influxClient = influxClient;
+    this.logger = logger.child({ module: "self-consumption-writer" });
+  }
+
+  init(): void {
+    this.unsubscribe = this.eventBus.on((event) => {
+      try {
+        if (event.type !== "equipment.data.changed") return;
+        if (event.alias !== "energy") return;
+        if (typeof event.value !== "number") return;
+
+        const role = this.resolveEquipmentRole(event.equipmentId);
+        if (!role) return;
+
+        const tick: LatestTick = {
+          value: event.value,
+          t: event.sourceTimestamp ?? Math.floor(Date.now() / 1000),
+        };
+        if (role === "grid") this.latestGrid = tick;
+        else this.latestSolar = tick;
+
+        this.tryCompute();
+      } catch (err) {
+        this.logger.error({ err }, "Error in self-consumption writer event handler");
+      }
+    });
+    this.logger.info({}, "Self-consumption writer initialized");
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+  }
+
+  /**
+   * Resolve the role of an equipmentId by querying the EquipmentManager
+   * fresh each time. Cheaper than maintaining a cache that has to track
+   * `equipment.created/updated/removed` and the type-change edge case.
+   */
+  private resolveEquipmentRole(equipmentId: string): "grid" | "solar" | null {
+    const eq = this.equipmentManager.getById(equipmentId);
+    if (!eq?.enabled) return null;
+    if (eq.type === "main_energy_meter") return "grid";
+    if (eq.type === "energy_production_meter") return "solar";
+    return null;
+  }
+
+  private tryCompute(): void {
+    if (!this.latestGrid || !this.latestSolar) return;
+    if (Math.abs(this.latestGrid.t - this.latestSolar.t) > MATCH_WINDOW_S) return;
+
+    const ts = Math.max(this.latestGrid.t, this.latestSolar.t);
+    const minuteBucket = Math.floor(ts / 60);
+    if (minuteBucket === this.lastWrittenMinute) return;
+    this.lastWrittenMinute = minuteBucket;
+
+    const grid = this.latestGrid.value;
+    const solar = this.latestSolar.value;
+    const injection = Math.max(0, -grid);
+    const autoconso = Math.max(0, solar - injection);
+
+    this.writePoints(autoconso, injection, ts);
+  }
+
+  private writePoints(autoconso: number, injection: number, sourceTimestamp: number): void {
+    if (!this.influxClient.isConnected()) return;
+
+    const prodEquipment = this.findProductionEquipment();
+    if (!prodEquipment) return;
+
+    for (const [alias, value] of [
+      ["autoconso", autoconso],
+      ["injection", injection],
+    ] as const) {
+      const point = new Point("equipment_data")
+        .tag("equipmentId", prodEquipment.id)
+        .tag("alias", alias)
+        .tag("category", "energy")
+        .tag("zoneId", prodEquipment.zoneId)
+        .tag("type", "number")
+        .floatField("value_number", value)
+        .timestamp(sourceTimestamp);
+
+      this.influxClient.writePoint(point);
+    }
+
+    this.logger.trace({ autoconso, injection, sourceTimestamp }, "Self-consumption points written");
+  }
+
+  private findProductionEquipment(): { id: string; zoneId: string } | null {
+    const eq = this.equipmentManager
+      .getAll()
+      .find((e) => e.type === "energy_production_meter" && e.enabled);
+    if (!eq) return null;
+    return { id: eq.id, zoneId: eq.zoneId };
+  }
+}

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -383,6 +383,87 @@ describe("EquipmentManager", () => {
     });
   });
 
+  describe("binding mutations emit equipment.updated", () => {
+    // Downstream caches (HistoryWriter, EnergyAggregator) refresh on
+    // equipment.updated — without this event, freshly added bindings would
+    // be invisible until the equipment itself is otherwise modified.
+    it("addDataBinding emits equipment.updated", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Spots", type: "light_dimmable", zoneId: zone.id });
+      const { dataIds } = seedDevice(db, {
+        dataKeys: [{ key: "state", category: "light_state" }],
+      });
+      events.length = 0;
+
+      manager.addDataBinding(eq.id, dataIds[0], "state");
+
+      const updated = events.filter((e) => e.type === "equipment.updated");
+      expect(updated).toHaveLength(1);
+      if (updated[0].type === "equipment.updated") {
+        expect(updated[0].equipment.id).toBe(eq.id);
+      }
+    });
+
+    it("removeDataBinding emits equipment.updated", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Spots", type: "light_dimmable", zoneId: zone.id });
+      const { dataIds } = seedDevice(db, {
+        dataKeys: [{ key: "state", category: "light_state" }],
+      });
+      const binding = manager.addDataBinding(eq.id, dataIds[0], "state");
+      events.length = 0;
+
+      manager.removeDataBinding(eq.id, binding.id);
+
+      const updated = events.filter((e) => e.type === "equipment.updated");
+      expect(updated).toHaveLength(1);
+    });
+
+    it("setHistorize emits equipment.updated", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Spots", type: "light_dimmable", zoneId: zone.id });
+      const { dataIds } = seedDevice(db, {
+        dataKeys: [{ key: "state", category: "light_state" }],
+      });
+      const binding = manager.addDataBinding(eq.id, dataIds[0], "state");
+      events.length = 0;
+
+      manager.setHistorize(binding.id, 1);
+
+      const updated = events.filter((e) => e.type === "equipment.updated");
+      expect(updated).toHaveLength(1);
+    });
+
+    it("addOrderBinding emits equipment.updated", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Spots", type: "light_dimmable", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        orderKeys: [{ key: "state", category: "light_toggle" }],
+      });
+      events.length = 0;
+
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      const updated = events.filter((e) => e.type === "equipment.updated");
+      expect(updated).toHaveLength(1);
+    });
+
+    it("removeOrderBinding emits equipment.updated", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Spots", type: "light_dimmable", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        orderKeys: [{ key: "state", category: "light_toggle" }],
+      });
+      const binding = manager.addOrderBinding(eq.id, orderIds[0], "state");
+      events.length = 0;
+
+      manager.removeOrderBinding(eq.id, binding.id);
+
+      const updated = events.filter((e) => e.type === "equipment.updated");
+      expect(updated).toHaveLength(1);
+    });
+  });
+
   describe("getDataBindingsWithValues", () => {
     it("returns bindings with resolved device data values", () => {
       const zone = zoneManager.create({ name: "Salon" });

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -463,6 +463,18 @@ export class EquipmentManager {
     return row.count;
   }
 
+  /**
+   * Emit `equipment.updated` after a binding mutation (data or order).
+   * Downstream caches (HistoryWriter.historizedBindings, etc.) listen on
+   * this event to refresh — without it, freshly added bindings would not
+   * be picked up until the equipment itself is otherwise modified.
+   */
+  private emitEquipmentUpdated(equipmentId: string): void {
+    const equipment = this.getById(equipmentId);
+    if (!equipment) return;
+    this.eventBus.emit({ type: "equipment.updated", equipment });
+  }
+
   // ============================================================
   // DataBinding management
   // ============================================================
@@ -486,6 +498,7 @@ export class EquipmentManager {
     }
 
     this.logger.info({ equipmentId, alias, deviceDataId }, "DataBinding added");
+    this.emitEquipmentUpdated(equipmentId);
     return { id, equipmentId, deviceDataId, alias };
   }
 
@@ -497,6 +510,7 @@ export class EquipmentManager {
 
     this.stmts.deleteDataBinding.run(bindingId);
     this.logger.info({ equipmentId, bindingId }, "DataBinding removed");
+    this.emitEquipmentUpdated(equipmentId);
   }
 
   getDataBindingsWithValues(equipmentId: string): DataBindingWithValue[] {
@@ -522,8 +536,10 @@ export class EquipmentManager {
 
   /** Set the historize flag on a data binding. NULL = category default, 1 = force ON, 0 = force OFF. */
   setHistorize(bindingId: string, historize: number | null): void {
+    const binding = this.stmts.getDataBindingById.get(bindingId) as DataBindingRow | undefined;
     this.stmts.setHistorize.run(historize, bindingId);
     this.logger.info({ bindingId, historize }, "DataBinding historize flag updated");
+    if (binding) this.emitEquipmentUpdated(binding.equipment_id);
   }
 
   // ============================================================
@@ -572,6 +588,7 @@ export class EquipmentManager {
     }
 
     this.logger.info({ equipmentId, alias, deviceOrderId, categoryOverride }, "OrderBinding added");
+    this.emitEquipmentUpdated(equipmentId);
     return { id, equipmentId, deviceOrderId, alias };
   }
 
@@ -583,6 +600,7 @@ export class EquipmentManager {
 
     this.stmts.deleteOrderBinding.run(bindingId);
     this.logger.info({ equipmentId, bindingId }, "OrderBinding removed");
+    this.emitEquipmentUpdated(equipmentId);
   }
 
   getOrderBindingsWithDetails(equipmentId: string): OrderBindingWithDetails[] {

--- a/src/history/history-writer.ts
+++ b/src/history/history-writer.ts
@@ -34,8 +34,18 @@ const CATEGORY_DEFAULTS_ON: ReadonlySet<string> = new Set([
 /** Aliases historized ON regardless of category (handles generic bindings). */
 const ALIAS_DEFAULTS_ON: ReadonlySet<string> = new Set(["setpoint", "power"]);
 
-/** Aliases forced OFF — live-only values, not useful as time series. */
-const ALIAS_DEFAULTS_OFF: ReadonlySet<string> = new Set(["demand_30min"]);
+/** Aliases forced OFF — live-only values, not useful as time series.
+ * `energy_forward` / `energy_reverse` are the raw cumulative Shelly
+ * counters: monotonically growing, several hundred kWh in absolute
+ * terms. They are needed as latest values (Live page) but writing them
+ * as time-series points would pollute every category=energy aggregation
+ * with the cumul (sum-of-cumuls), since the EnergyAggregator and the
+ * downsampling tasks group on category, not alias. */
+const ALIAS_DEFAULTS_OFF: ReadonlySet<string> = new Set([
+  "demand_30min",
+  "energy_forward",
+  "energy_reverse",
+]);
 
 /** Deadband thresholds by category — skip writes if delta is below this. */
 const DEADBAND: Record<string, number> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { CalendarManager } from "./modes/calendar-manager.js";
 import { ButtonActionManager } from "./buttons/button-action-manager.js";
 import { IntegrationRegistry } from "./integrations/integration-registry.js";
 import { EnergyAggregator } from "./energy/energy-aggregator.js";
+import { SelfConsumptionWriter } from "./energy/self-consumption-writer.js";
 import { HistoryWriter } from "./history/history-writer.js";
 import { InfluxClient } from "./core/influx-client.js";
 import { ChartManager } from "./charts/chart-manager.js";
@@ -342,6 +343,16 @@ async function main() {
   // 18. Initialize history writer (connects to InfluxDB if configured, subscribes to events)
   historyWriter.init();
 
+  // 18-bis. Self-consumption writer: derives autoconso/injection from
+  // Grid + Solar energy ticks (spec 086 step E).
+  const selfConsumptionWriter = new SelfConsumptionWriter(
+    eventBus,
+    equipmentManager,
+    influxClient,
+    logger,
+  );
+  selfConsumptionWriter.init();
+
   // 18a. Start Energy Aggregator
   const energyAggregator = new EnergyAggregator(equipmentManager, influxClient, eventBus, logger);
   await energyAggregator
@@ -425,6 +436,11 @@ async function main() {
       historyWriter.destroy();
     } catch (err) {
       logger.error({ err }, "Error stopping history writer");
+    }
+    try {
+      selfConsumptionWriter.destroy();
+    } catch (err) {
+      logger.error({ err }, "Error stopping self-consumption writer");
     }
     try {
       await influxClient.disconnect();


### PR DESCRIPTION
Implements [spec 086](specs/086-shelly-em-energy-roles/spec.md) end-to-end on the Sowel side.

## Summary

The Shelly Pro 3EM plugin (v1.1.0, separate repo) starts emitting a synthesised `energy` delta alongside its raw cumulative counters. To make this work cleanly across the whole pipeline, this PR ships:

- **Step A — `getDeviceDataValue`** on `DeviceManager` so the plugin can hydrate its baseline at start.
- **Step E — Three latent bugs fixed** that only became visible once Shelly emits multiple energy-category aliases on the same equipment.
- **Step F — `SelfConsumptionWriter`** to recompute the household-level autoconso/injection split (previously written by the now-decommissioned Netatmo HC poller).

## Changes

### Sowel core API (Step A)
- `src/devices/device-manager.ts` — new `getDeviceDataValue(integrationId, sourceDeviceId, key) → string | number | boolean | null`. Re-uses `findDeviceDataByDeviceAndKey` and decodes the value according to the declared `type`.
- `src/devices/device-manager.test.ts` — 6 new scenarios.

### Bug fixes (Step E)
- `src/equipments/equipment-manager.ts` — `addDataBinding` / `removeDataBinding` / `setHistorize` / `addOrderBinding` / `removeOrderBinding` now emit `equipment.updated`. Without this, freshly added bindings were invisible to the `HistoryWriter` cache until the equipment was otherwise modified.
- `src/energy/energy-aggregator.ts` — every Flux query (hour, day, month, year) filters `r.alias == "energy"` instead of grouping by all category=energy aliases (which led to `energyDayWh` being set to whatever alias came last — typically `energy_reverse`, a multi-hundred-kWh cumul). The day cumul also adds the in-flight current hour from the raw bucket on top of the past hours from the hourly bucket — the previous code missed whatever had not been downsampled yet.
- `src/history/history-writer.ts` — `ALIAS_DEFAULTS_OFF` now contains `energy_forward` / `energy_reverse`. These monotonic Shelly cumuls (hundreds of kWh) used to pollute every category=energy aggregation; they remain available as `device_data` latest values for the Live page.
- 5 new `EquipmentManager` tests cover the new event emissions.

### Self-consumption writer (Step F)
- `src/energy/self-consumption-writer.ts` — listens to `equipment.data.changed` (alias = energy), keeps the latest signed delta for the Grid + Solar equipments, and on each new tick computes `injection = max(0, -gridΔ)` and `autoconso = max(0, solarΔ - injection)`. Writes 2 InfluxDB points per minute tagged with the production equipment id, mirroring `writeEnergyHpHc`.
- Wired in `src/index.ts` next to `historyWriter.init()`.
- 11 unit tests.

### Misc (drive-by)
- `scripts/energy/migrate-orphan-equipments.ts` — env-var-aware Influx config + raw bucket support (used hier in prod for the Legrand→Shelly history migration).

## Test plan

- [x] `npx tsc --noEmit` — green
- [x] `cd ui && npx tsc -b --noEmit` — green
- [x] `npx vitest run` — 401 passed, 2 skipped (16 new tests vs main)
- [x] `npx eslint src/ --ext .ts` — green
- [x] **End-to-end harness** (`/tmp/it086-test/harness.mjs` from session) — real DeviceManager + plugin v1.1.0 + mosquitto, all 7 scenarios pass (delta synthesis, reset, restart hydration, partial payload).
- [x] **Local UI validation** (Playwright) — Live + Consumption + Production pages render correct values; equipment + graph cumuls coherent at the API level.
- [ ] **Production validation (Step D)** — after merge + release v1.5.1 + plugin tag v1.1.0 + registry bump, deploy on sowelox, add `energy` binding on Shelly Grid / Solar, soak 24h and compare with Legrand mobile app + home.netatmo.com dashboard.

## Out of scope

- **Production graph auto-refresh** — `/energy/production` and `/energy/consumption` only fetch on mount, no WebSocket subscription. Causes a visible stale value when comparing with the live equipment cumul. Tracked separately.
- **Tooltip mis-alignment on production chart** — hovering at the visible bar position shows a different hour bucket label. Pre-existing, tracked separately.