### PR TITLE
fix(plugins): always stop() in unloadPlugin to avoid double-instance race

### DIFF
--- a/src/plugins/plugin-loader.test.ts
+++ b/src/plugins/plugin-loader.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { PluginLoader } from "./plugin-loader.js";
+import { createLogger } from "../core/logger.js";
+import type {
+  IntegrationPlugin,
+  IntegrationRegistry,
+} from "../integrations/integration-registry.js";
+import type { PackageManager } from "../packages/package-manager.js";
+import type { PluginDeps } from "../shared/plugin-api.js";
+
+const logger = createLogger("silent").logger;
+
+/**
+ * Minimal stub plugin whose status mimics a slow-starting MQTT plugin —
+ * `status` stays "disconnected" until something flips it. The real bug
+ * race only became visible when the loader called `unloadPlugin()` on a
+ * plugin still inside an in-flight `start()` (so its status was "disconnected"
+ * not "connected"), and we want to ensure stop() is called regardless.
+ */
+function makeStubPlugin(
+  opts: {
+    id?: string;
+    status?: "connected" | "disconnected" | "error" | "not_configured";
+  } = {},
+): IntegrationPlugin & { stopCalls: number } {
+  let stopCalls = 0;
+  const plugin = {
+    id: opts.id ?? "stub_plugin",
+    name: "Stub",
+    description: "Stub plugin for unit tests",
+    icon: "Zap",
+    apiVersion: 2 as const,
+    getStatus: () => opts.status ?? "disconnected",
+    isConfigured: () => true,
+    getSettingsSchema: () => [],
+    start: async () => {},
+    stop: async () => {
+      stopCalls++;
+    },
+    executeOrder: async () => {},
+    get stopCalls() {
+      return stopCalls;
+    },
+  };
+  return plugin as unknown as IntegrationPlugin & { stopCalls: number };
+}
+
+function makePackageManager(): PackageManager {
+  return {
+    ensureDir: vi.fn(),
+    getInstalledByType: vi.fn(() => []),
+    getLatestVersions: vi.fn(() => ({})),
+    setEnabled: vi.fn(),
+    getById: vi.fn(),
+  } as unknown as PackageManager;
+}
+
+function makeIntegrationRegistry(): IntegrationRegistry & { unregisterCalls: string[] } {
+  const calls: string[] = [];
+  const reg = {
+    register: vi.fn(),
+    unregister: (id: string) => {
+      calls.push(id);
+    },
+    getById: vi.fn(),
+    unregisterCalls: calls,
+  };
+  return reg as unknown as IntegrationRegistry & { unregisterCalls: string[] };
+}
+
+function makeCoreDeps(): Omit<PluginDeps, "pluginDir"> {
+  return {
+    logger,
+    eventBus: { on: () => () => {}, emit: () => {} } as unknown as PluginDeps["eventBus"],
+    settingsManager: {
+      get: () => undefined,
+      set: () => {},
+    } as unknown as PluginDeps["settingsManager"],
+    deviceManager: { getAll: () => [] } as unknown as PluginDeps["deviceManager"],
+  };
+}
+
+describe("PluginLoader.unloadPlugin", () => {
+  let loader: PluginLoader;
+  let packageManager: PackageManager;
+  let registry: IntegrationRegistry & { unregisterCalls: string[] };
+
+  beforeEach(() => {
+    packageManager = makePackageManager();
+    registry = makeIntegrationRegistry();
+    loader = new PluginLoader(packageManager, registry, makeCoreDeps(), logger);
+  });
+
+  /**
+   * Drop a fake plugin into the loader's private map so we can exercise
+   * unload paths without going through dynamic-import / packageManager.
+   */
+  function inject(plugin: IntegrationPlugin): void {
+    (loader as unknown as { loadedPlugins: Map<string, IntegrationPlugin> }).loadedPlugins.set(
+      plugin.id,
+      plugin,
+    );
+  }
+
+  async function unload(pluginId: string): Promise<void> {
+    await (loader as unknown as { unloadPlugin: (id: string) => Promise<void> }).unloadPlugin(
+      pluginId,
+    );
+  }
+
+  it("calls stop() on a plugin in 'connected' status", async () => {
+    const p = makeStubPlugin({ status: "connected" });
+    inject(p);
+    await unload(p.id);
+    expect(p.stopCalls).toBe(1);
+  });
+
+  it("calls stop() on a plugin in 'error' status", async () => {
+    const p = makeStubPlugin({ status: "error" });
+    inject(p);
+    await unload(p.id);
+    expect(p.stopCalls).toBe(1);
+  });
+
+  it("calls stop() on a plugin in 'disconnected' status (regression for prod race)", async () => {
+    // Reproduces the prod race: when the user clicks "Update plugin" while
+    // the plugin's start() is still inside `await mqtt.connect()`, status
+    // is still "disconnected" — the previous guard skipped stop() here and
+    // left the plugin's MQTT subscription / engine running in parallel
+    // with the freshly-loaded new plugin instance.
+    const p = makeStubPlugin({ status: "disconnected" });
+    inject(p);
+    await unload(p.id);
+    expect(p.stopCalls).toBe(1);
+  });
+
+  it("calls stop() on a plugin in 'not_configured' status", async () => {
+    const p = makeStubPlugin({ status: "not_configured" });
+    inject(p);
+    await unload(p.id);
+    expect(p.stopCalls).toBe(1);
+  });
+
+  it("removes the plugin from the registry even if stop() throws", async () => {
+    const p = makeStubPlugin({ status: "connected" });
+    p.stop = async () => {
+      throw new Error("boom");
+    };
+    inject(p);
+
+    await unload(p.id); // does not throw
+
+    expect(registry.unregisterCalls).toContain(p.id);
+    const loaded = (loader as unknown as { loadedPlugins: Map<string, IntegrationPlugin> })
+      .loadedPlugins;
+    expect(loaded.has(p.id)).toBe(false);
+  });
+
+  it("is a no-op for an unknown pluginId", async () => {
+    await unload("does-not-exist"); // does not throw
+    expect(registry.unregisterCalls).toContain("does-not-exist");
+  });
+});

--- a/src/plugins/plugin-loader.ts
+++ b/src/plugins/plugin-loader.ts
@@ -290,11 +290,13 @@ export class PluginLoader {
   private async unloadPlugin(pluginId: string): Promise<void> {
     const plugin = this.loadedPlugins.get(pluginId);
     if (plugin) {
+      // Always call stop() — plugin.stop() must be idempotent. The previous
+      // implementation skipped stop() when status was "disconnected", which
+      // missed plugins still inside an in-flight start() (status not yet
+      // flipped to "connected"). When that races with `update()`, the old
+      // plugin keeps its MQTT/poller running in parallel with the new one.
       try {
-        const status = plugin.getStatus();
-        if (status === "connected" || status === "error") {
-          await plugin.stop();
-        }
+        await plugin.stop();
       } catch (err) {
         this.logger.error({ err, pluginId }, "Error stopping plugin");
       }


### PR DESCRIPTION
## Summary

Fixes a race in `PluginLoader.unloadPlugin` where the previous status guard left an orphan plugin instance running. Most importantly: when the user clicks **Update plugin** in the UI while the plugin's `start()` is still inside `await mqtt.connect()` (status still "disconnected"), the old plugin is **not** stopped, and ends up running in parallel with the freshly-loaded new plugin.

This was observed in production today during the IT 086 deployment: two `ShellyEngine` instances ran in parallel, each calling `upsertFromDiscovery` on every `em1data` tick. Because v1.0.0's `CHANNEL_DATA_DEF` didn't include the new `energy` key, the "remove stale data entries" loop in `DeviceManager` deleted the `energy` row right after v1.1.0 inserted it — `energy` never showed up in `device_data`, blocking the new equipment binding from working.

A clean Sowel container restart resolved it (single fresh load), but that's a workaround.

## Repro race (prod logs from today)

```
07:24:08 [info] Subscribed topicFilter=shelly/#       ← plugin v1.0.0 finally connects
07:24:09 [info] Subscribed topicFilter=shelly/#       ← plugin v1.1.0 connects right after
07:24:17 [info] Channel discovered ...em0  (twice)
07:24:17 [info] Channel discovered ...em1  (twice)
07:24:17 [info] Channel discovered ...em2  (twice)
```

Sequence:
1. boot → `loadAll()` loads plugin v1.0.0 (booted=false, no auto-start).
2. `booted=true`, `integrationRegistry.startAll()` runs in background.
3. `startAll` calls `await shellyPlugin.start({})`. Inside, `await mqtt.connect()` takes a few seconds. Until it resolves, `this.status` is still "disconnected" (the line `this.status = "connected"` only runs after the await).
4. user clicks **Update plugin** in the UI → `pluginLoader.update()`:
   - `unloadPlugin` → `getStatus() === "disconnected"` → **`stop()` SKIPPED**.
   - `updateFiles` → new tarball extracted.
   - `loadPlugin` → new plugin instance, awaits its own `mqtt.connect()`.
5. Eventually both old AND new `start()` resolve, both subscribe to MQTT, both engines process every `em1data` tick.

## Fix

Always call `plugin.stop()` regardless of status. Plugin implementations are expected to make `stop()` idempotent — the Shelly plugin's already is (`if (this.mqtt) await mqtt.disconnect()` no-ops when not started).

## Tests

6 unit tests added in `src/plugins/plugin-loader.test.ts`:
- stop() called on `connected` / `error` / **`disconnected`** (regression) / `not_configured`
- registry cleanup happens even when stop() throws
- no-op for unknown pluginId

The "disconnected" test fails on the previous guard — direct regression proof.

## Test plan

- [x] `npx tsc --noEmit` — green
- [x] `npx vitest run` — 407 / 409 (6 new)
- [x] `npx eslint src/ --ext .ts` — green
- [x] Manual repro check: revert the fix → 2 tests fail (`disconnected`, `not_configured`); reapply → all green.