### PR TITLE
fix(ui): consumption tooltip — HP/HC grid-only so total math is consistent

### DIFF
--- a/ui/src/components/energy/EnergyBarChart.tsx
+++ b/ui/src/components/energy/EnergyBarChart.tsx
@@ -267,7 +267,19 @@ export function EnergyBarChart({ points, period, date, height = 300 }: EnergyBar
             if (!active || !payload?.length) return null;
             const datum = payload[0]?.payload as ChartDatum | undefined;
             if (!datum) return null;
-            const total = datum.hp + datum.hc;
+            // Per-slot hp/hc from Influx already include autoconso (= household).
+            // Match the API totals semantic (energy.ts/computeTotals): show
+            // grid-only HP and HC by subtracting autoconso pro rata, so that
+            // HP + HC + autoconso = household = bar height.
+            const consoTotal = datum.hp + datum.hc;
+            const hpGrid =
+              consoTotal > 0
+                ? Math.max(0, datum.hp - datum.autoconso * (datum.hp / consoTotal))
+                : datum.hp;
+            const hcGrid =
+              consoTotal > 0
+                ? Math.max(0, datum.hc - datum.autoconso * (datum.hc / consoTotal))
+                : datum.hc;
             return (
               <div
                 style={{
@@ -279,9 +291,9 @@ export function EnergyBarChart({ points, period, date, height = 300 }: EnergyBar
                 }}
               >
                 <div style={{ fontWeight: 600, marginBottom: 4 }}>{datum.tooltipLabel}</div>
-                <div style={{ fontWeight: 600, marginBottom: 4 }}>{t("energy.consumption")} : {formatKWh(total)}</div>
-                <div style={{ color: HP_COLOR }}>{t("energy.peakHours")} : {formatKWh(datum.hp)}</div>
-                <div style={{ color: HC_COLOR }}>{t("energy.offPeakHours")} : {formatKWh(datum.hc)}</div>
+                <div style={{ fontWeight: 600, marginBottom: 4 }}>{t("energy.consumption")} : {formatKWh(consoTotal)}</div>
+                <div style={{ color: HP_COLOR }}>{t("energy.peakHours")} : {formatKWh(hpGrid)}</div>
+                <div style={{ color: HC_COLOR }}>{t("energy.offPeakHours")} : {formatKWh(hcGrid)}</div>
                 {datum.autoconso > 0 && (
                   <div style={{ color: AUTOCONSO_COLOR }}>
                     {t("energy.autoconsumption")} : {formatKWh(datum.autoconso)}


### PR DESCRIPTION
## Summary

The consumption chart tooltip showed contradictory numbers when autoconso > 0: it computed \`Consommation = HP + HC\`, then displayed \`Autoconso\` as a separate line, with no way for the user to reconcile the math.

Root cause: per-slot \`energy_hp\` / \`energy_hc\` written by SelfConsumptionWriter are classified on household (= grid_import + autoconso), so per-slot HP+HC already equals household. The tooltip displayed those values as the HP/HC breakdown, but the API-side totals (\`computeTotals\` in \`src/api/routes/energy.ts\`) prorate autoconso out of HP/HC to expose grid-only values.

## Fix

Apply the same proration in the tooltip:

\`\`\`ts
const consoTotal = datum.hp + datum.hc;  // = household
const hpGrid = consoTotal > 0 ? Math.max(0, datum.hp - datum.autoconso * (datum.hp / consoTotal)) : datum.hp;
const hcGrid = consoTotal > 0 ? Math.max(0, datum.hc - datum.autoconso * (datum.hc / consoTotal)) : datum.hc;
\`\`\`

Now \`HP + HC + autoconso = consommation = bar height\`. Chart visuals unchanged.

## Test plan

- [x] \`cd ui && npx tsc -b --noEmit\` — clean
- [x] \`cd ui && npm run build\` — succeeds
- [ ] Manual: hover a slot with autoconso > 0 on \`/energy/consumption\` → confirm HP + HC + autoconso = displayed total
- [ ] Manual: hover a night slot (autoconso = 0) → confirm same as before (no regression)