### PR TITLE
fix(api): production query falls back to -energy-hourly bucket on day period

### DIFF
--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -129,20 +129,27 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
       }
       consumptionPoints.sort((a, b) => a.time.localeCompare(b.time));
 
-      // Query production data if production Equipment exists
+      // Query production data if production Equipment exists.
+      // Same bucket-fallback logic as the consumption side: when period=day
+      // the primary bucket is raw (7d retention), but a backfill — or simply
+      // the live downsample — may have written the data only to
+      // `-energy-hourly`. Fall back to it when the primary bucket is empty.
       const prodMap = new Map<string, { prod: number; autoconso: number; injection: number }>();
       if (productionEquipmentId) {
-        const prodPoints = await queryProductionPoints(
-          client,
-          config.org,
-          bucket,
-          productionEquipmentId,
-          from,
-          to,
-          resolution,
-        );
-        for (const p of prodPoints) {
-          prodMap.set(p.time, p);
+        for (const b of buckets) {
+          const prodPoints = await queryProductionPoints(
+            client,
+            config.org,
+            b,
+            productionEquipmentId,
+            from,
+            to,
+            resolution,
+          );
+          for (const p of prodPoints) {
+            prodMap.set(p.time, p);
+          }
+          if (prodMap.size > 0) break;
         }
       }
 


### PR DESCRIPTION
## Summary

The day-period energy API queries the raw bucket (7-day retention) for recent days. Consumption already falls back to \`-energy-hourly\` when raw is empty (lines 80-83). Production didn't — single bucket, no fallback.

## Why this surfaces now

The Legrand backfill script (\`scripts/energy/backfill-from-legrand.ts\`) writes to hourly + daily buckets only (raw has 7d retention so historical writes aren't possible there). For a day where the raw bucket has no production data — typical for a Sowel downtime or for yesterday after a fresh Shelly switch-over — the chart shows the consumption fine but production silently 0.

Reproducible on prod with 2026-05-02:
- raw bucket: no production data (Netatmo cloud was down all day, Shelly switch was today)
- \`-energy-hourly\` bucket: 24 hourly entries from the backfill
- API \`/api/v1/energy/history?period=day&date=2026-05-02\` returned \`total_production: 0\` despite the data being there

## Fix

Iterate \`buckets\` for the production query, same as consumption. Break on first non-empty.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — 409 tests pass
- [x] \`npx eslint src/ --ext .ts\` — zero warnings
- [ ] Manual: \`/energy/consumption\` 2026-05-02 view should show production bar matching the backfilled value (~5.6 kWh for a day with autoconso + injection)