### PR TITLE
chore(energy): finalise spec 088 + ship backfill scripts

### DIFF
--- a/scripts/energy/backfill-from-legrand.ts
+++ b/scripts/energy/backfill-from-legrand.ts
@@ -1,0 +1,470 @@
+#!/usr/bin/env npx tsx
+/**
+ * Backfill missing days from the Legrand-Energy / Netatmo cloud API.
+ *
+ * Pulls 30-min `getmeasure` data for each requested day, aggregates by
+ * hour, applies the same household-semantic mapping that
+ * SelfConsumptionWriter writes for live data, and upserts hourly + daily
+ * points in InfluxDB.
+ *
+ * Schema written (per requested day, on the Sowel equipments inherited
+ * by the Shelly grid + solar after the orphan-migration):
+ *
+ *   on main_energy_meter (grid):
+ *     energy     = household = HP_grid + HC_grid + autoconso
+ *     energy_hp  = TariffClassifier(household, ts).hp
+ *     energy_hc  = TariffClassifier(household, ts).hc
+ *
+ *   on energy_production_meter (solar):
+ *     energy     = production = autoconso + injection
+ *     autoconso  = autoconso (Netatmo `sum_energy_self_consumption`)
+ *     injection  = injection (Netatmo `sum_energy_resell_to_grid`)
+ *
+ * Default mode: dry-run (per-day totals printed). Pass --apply to write.
+ *
+ * Usage (run inside the Sowel container so it shares Influx + SQLite):
+ *   docker exec -w /app sowel npx -y tsx scripts/energy/backfill-from-legrand.ts \
+ *     --days 2025-04-10,2025-04-12,2025-04-16 \
+ *     [--apply]
+ *
+ *   # or --range
+ *   docker exec -w /app sowel npx -y tsx scripts/energy/backfill-from-legrand.ts \
+ *     --range 2025-04-18,2025-04-22 [--apply]
+ *
+ * SAFETY:
+ * - Idempotent: deletes existing hourly+daily for the requested day on
+ *   the matching equipmentId/alias set before writing.
+ * - Skips days where Netatmo returns no data.
+ * - Token refresh is automatic; new tokens are persisted to
+ *   data/legrand-energy-tokens.json (same path the live plugin uses).
+ */
+import Database from "better-sqlite3";
+import { readFileSync, writeFileSync } from "node:fs";
+import { InfluxDB, Point } from "@influxdata/influxdb-client";
+
+// ── CLI ───────────────────────────────────────────────────────────────
+
+const APPLY = process.argv.includes("--apply");
+
+function getArg(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  if (i === -1) return undefined;
+  return process.argv[i + 1];
+}
+
+function parseDayList(): string[] {
+  const days = getArg("--days");
+  if (days) return days.split(",").map((s) => s.trim()).filter(Boolean);
+  const range = getArg("--range");
+  if (range) {
+    const [from, to] = range.split(",").map((s) => s.trim());
+    if (!from || !to) throw new Error("--range expects YYYY-MM-DD,YYYY-MM-DD");
+    const out: string[] = [];
+    const d = new Date(from + "T12:00:00Z");
+    const end = new Date(to + "T12:00:00Z");
+    while (d <= end) {
+      out.push(d.toISOString().slice(0, 10));
+      d.setUTCDate(d.getUTCDate() + 1);
+    }
+    return out;
+  }
+  console.error("Pass --days YYYY-MM-DD[,YYYY-MM-DD,...] or --range YYYY-MM-DD,YYYY-MM-DD");
+  process.exit(1);
+}
+
+const DAYS = parseDayList();
+
+// ── SQLite settings + equipments ──────────────────────────────────────
+
+const DB_PATH = "./data/sowel.db";
+const TOKEN_PATH = "./data/legrand-energy-tokens.json";
+
+const db = new Database(DB_PATH, { readonly: true });
+const get = (key: string): string | undefined =>
+  (db.prepare("SELECT value FROM settings WHERE key = ?").get(key) as { value: string } | undefined)
+    ?.value;
+
+// Env vars take precedence (matches the docker container layout where
+// settings hold "localhost" but the actual hostname is the docker alias).
+const INFLUX_URL = process.env["INFLUX_URL"] ?? get("history.influx.url")!;
+const INFLUX_TOKEN = process.env["INFLUX_TOKEN"] ?? get("history.influx.token")!;
+const INFLUX_ORG = process.env["INFLUX_ORG"] ?? get("history.influx.org")!;
+const RAW_BUCKET = process.env["INFLUX_BUCKET"] ?? get("history.influx.bucket")!;
+const HOURLY_BUCKET = `${RAW_BUCKET}-energy-hourly`;
+const DAILY_BUCKET = `${RAW_BUCKET}-energy-daily`;
+const CLIENT_ID = get("integration.legrand_energy.client_id")!;
+const CLIENT_SECRET = get("integration.legrand_energy.client_secret")!;
+
+interface EqRow { id: string; zone_id: string; }
+const grid = db
+  .prepare("SELECT id, zone_id FROM equipments WHERE type='main_energy_meter' AND enabled=1 LIMIT 1")
+  .get() as EqRow | undefined;
+const prod = db
+  .prepare("SELECT id, zone_id FROM equipments WHERE type='energy_production_meter' AND enabled=1 LIMIT 1")
+  .get() as EqRow | undefined;
+if (!grid || !prod) {
+  console.error(`Missing equipment(s): grid=${!!grid} prod=${!!prod}`);
+  process.exit(1);
+}
+
+const tariffRaw = get("energy.tariff");
+db.close();
+
+// ── Tariff classifier (inlined) ───────────────────────────────────────
+
+interface TariffSlot { start: string; end: string; tariff: "hp" | "hc"; }
+interface DaySchedule { days: number[]; slots: TariffSlot[]; }
+interface TariffConfig { schedules: DaySchedule[]; prices: { hp: number; hc: number }; }
+const tariff: TariffConfig | null = tariffRaw ? JSON.parse(tariffRaw) : null;
+if (!tariff) console.warn("No tariff schedule — hp will = household, hc = 0.");
+
+const parseMin = (t: string): number => {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+};
+
+/**
+ * 60-min window classifier (we aggregate by hour, not 30 min). Linear
+ * prorata across slot transitions.
+ */
+function classifyHpHc(totalWh: number, epochS: number): { hp: number; hc: number } {
+  if (!tariff) return { hp: totalWh, hc: 0 };
+  const d = new Date(epochS * 1000);
+  const sched = tariff.schedules.find((s) => s.days.includes(d.getDay()));
+  if (!sched || sched.slots.length === 0) return { hp: totalWh, hc: 0 };
+  const start = d.getHours() * 60 + d.getMinutes();
+  const end = start + 60; // hourly window
+  let hp = 0;
+  let hc = 0;
+  for (const slot of sched.slots) {
+    const ss = parseMin(slot.start);
+    let se = parseMin(slot.end);
+    if (se === 0) se = 1440;
+    const ranges: Array<[number, number]> = se <= ss ? [[ss, 1440], [0, se]] : [[ss, se]];
+    for (const [rs, re] of ranges) {
+      const overlap = Math.max(0, Math.min(end, re) - Math.max(start, rs));
+      if (overlap > 0) {
+        if (slot.tariff === "hp") hp += overlap;
+        else hc += overlap;
+      }
+    }
+  }
+  const total = hp + hc;
+  if (total === 0) return { hp: totalWh, hc: 0 };
+  return {
+    hp: Math.round((totalWh * hp) / total),
+    hc: Math.round((totalWh * hc) / total),
+  };
+}
+
+// ── Netatmo auth ──────────────────────────────────────────────────────
+
+interface Tokens { accessToken: string; refreshToken: string; expiresAt: number; }
+let tokens: Tokens = JSON.parse(readFileSync(TOKEN_PATH, "utf-8"));
+
+async function refresh(): Promise<string> {
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: tokens.refreshToken,
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+  });
+  const r = await fetch("https://api.netatmo.com/oauth2/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!r.ok) throw new Error(`Token refresh failed: ${await r.text()}`);
+  const d = (await r.json()) as { access_token: string; refresh_token: string; expires_in: number };
+  tokens = {
+    accessToken: d.access_token,
+    refreshToken: d.refresh_token,
+    expiresAt: Date.now() + d.expires_in * 1000,
+  };
+  writeFileSync(TOKEN_PATH, JSON.stringify(tokens, null, 2));
+  return tokens.accessToken;
+}
+
+async function token(): Promise<string> {
+  if (tokens.accessToken && tokens.expiresAt > Date.now() + 60_000) return tokens.accessToken;
+  return refresh();
+}
+
+// ── Netatmo getmeasure ────────────────────────────────────────────────
+
+let bridgeIdCache: string | null = null;
+async function bridgeId(): Promise<string> {
+  if (bridgeIdCache) return bridgeIdCache;
+  const t = await token();
+  const r = await fetch("https://api.netatmo.com/api/homesdata", {
+    headers: { Authorization: `Bearer ${t}` },
+  });
+  if (!r.ok) throw new Error(`homesdata failed: ${await r.text()}`);
+  const data = (await r.json()) as {
+    body: { homes: Array<{ modules: Array<{ type: string; bridge?: string }> }> };
+  };
+  for (const h of data.body.homes) {
+    for (const m of h.modules) {
+      if (m.type === "NLPC" && m.bridge) {
+        bridgeIdCache = m.bridge;
+        return m.bridge;
+      }
+    }
+  }
+  throw new Error("No NLPC bridge found in homesdata.");
+}
+
+const ENERGY_TYPES =
+  "sum_energy_buy_from_grid$1,sum_energy_buy_from_grid$2,sum_energy_self_consumption,sum_energy_resell_to_grid";
+
+interface DaySlot {
+  ts: number;
+  hp_grid: number;
+  hc_grid: number;
+  autoconso: number;
+  injection: number;
+}
+
+async function fetchDay(date: string): Promise<DaySlot[]> {
+  // Use LOCAL midnight (no Z) so the day boundary matches what the
+  // existing Sowel data uses. Container TZ=Europe/Paris.
+  const dayStart = Math.floor(new Date(date + "T00:00:00").getTime() / 1000);
+  const dayEnd = dayStart + 86400;
+  const t = await token();
+  const bid = await bridgeId();
+  const params = new URLSearchParams({
+    device_id: bid,
+    module_id: bid,
+    type: ENERGY_TYPES,
+    scale: "30min",
+    optimize: "false",
+    date_begin: String(dayStart),
+    date_end: String(dayEnd),
+  });
+  const r = await fetch(`https://api.netatmo.com/api/getmeasure?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${t}` },
+  });
+  if (!r.ok) throw new Error(`getmeasure ${date} failed: ${r.status} ${await r.text()}`);
+  const data = (await r.json()) as { body: Record<string, (number | null)[]> };
+  const out: DaySlot[] = [];
+  for (const [tsStr, values] of Object.entries(data.body)) {
+    const ts = parseInt(tsStr, 10);
+    if (ts >= dayEnd) continue;
+    const slot: DaySlot = {
+      ts: Math.floor(ts / 1800) * 1800, // align to 30-min boundary
+      hp_grid: values[0] ?? 0,
+      hc_grid: values[1] ?? 0,
+      autoconso: values[2] ?? 0,
+      injection: values[3] ?? 0,
+    };
+    if (slot.hp_grid + slot.hc_grid + slot.autoconso + slot.injection > 0) out.push(slot);
+  }
+  out.sort((a, b) => a.ts - b.ts);
+  return out;
+}
+
+// ── Influx I/O ────────────────────────────────────────────────────────
+
+const influx = new InfluxDB({ url: INFLUX_URL, token: INFLUX_TOKEN });
+
+function buildPoint(args: {
+  bucket: string;
+  equipmentId: string;
+  zoneId: string;
+  alias: string;
+  value: number;
+  epochS: number;
+}): Point {
+  return new Point("equipment_data")
+    .tag("equipmentId", args.equipmentId)
+    .tag("alias", args.alias)
+    .tag("category", "energy")
+    .tag("zoneId", args.zoneId)
+    .tag("type", "number")
+    .floatField("value_number", args.value)
+    .timestamp(args.epochS);
+}
+
+async function deleteDay(bucket: string, equipmentId: string, aliases: string[], dayStart: Date, dayEnd: Date): Promise<void> {
+  // InfluxDB delete API is INCLUSIVE on both bounds. Subtract 1 second
+  // from stop so we don't sweep the next day's local-midnight entry.
+  const stopEpochS = Math.floor(dayEnd.getTime() / 1000) - 1;
+  const stopIso = new Date(stopEpochS * 1000).toISOString();
+  for (const alias of aliases) {
+    const r = await fetch(
+      `${INFLUX_URL}/api/v2/delete?org=${encodeURIComponent(INFLUX_ORG)}&bucket=${encodeURIComponent(bucket)}`,
+      {
+        method: "POST",
+        headers: { Authorization: `Token ${INFLUX_TOKEN}`, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          start: dayStart.toISOString(),
+          stop: stopIso,
+          predicate: `_measurement="equipment_data" AND equipmentId="${equipmentId}" AND alias="${alias}"`,
+        }),
+      },
+    );
+    if (!r.ok) throw new Error(`Delete failed (${bucket}/${alias}): ${r.status} ${await r.text()}`);
+  }
+}
+
+interface DayResult {
+  date: string;
+  slotsFetched: number;
+  household: number;
+  production: number;
+  autoconso: number;
+  injection: number;
+  hp: number;
+  hc: number;
+}
+
+async function processDay(date: string): Promise<DayResult | null> {
+  const slots = await fetchDay(date);
+  if (slots.length === 0) return null;
+
+  // Aggregate by hour
+  const byHour = new Map<number, { household: number; production: number; autoconso: number; injection: number }>();
+  for (const s of slots) {
+    const hour = Math.floor(s.ts / 3600) * 3600;
+    const acc = byHour.get(hour) ?? { household: 0, production: 0, autoconso: 0, injection: 0 };
+    acc.household += s.hp_grid + s.hc_grid + s.autoconso;
+    acc.production += s.autoconso + s.injection;
+    acc.autoconso += s.autoconso;
+    acc.injection += s.injection;
+    byHour.set(hour, acc);
+  }
+
+  // Daily aggregates — use LOCAL midnight (matches existing data convention).
+  let dHousehold = 0, dProd = 0, dAuto = 0, dInj = 0, dHp = 0, dHc = 0;
+  const dayStart = new Date(date + "T00:00:00");
+  const dayEnd = new Date(dayStart);
+  dayEnd.setDate(dayEnd.getDate() + 1);
+  const dayStartTs = Math.floor(dayStart.getTime() / 1000);
+
+  // Build per-hour points + classify
+  const hourlyPoints: Point[] = [];
+  for (const [hour, acc] of byHour.entries()) {
+    const split = classifyHpHc(acc.household, hour);
+    dHousehold += acc.household;
+    dProd += acc.production;
+    dAuto += acc.autoconso;
+    dInj += acc.injection;
+    dHp += split.hp;
+    dHc += split.hc;
+    hourlyPoints.push(
+      buildPoint({ bucket: HOURLY_BUCKET, equipmentId: grid!.id, zoneId: grid!.zone_id, alias: "energy", value: acc.household, epochS: hour }),
+      buildPoint({ bucket: HOURLY_BUCKET, equipmentId: grid!.id, zoneId: grid!.zone_id, alias: "energy_hp", value: split.hp, epochS: hour }),
+      buildPoint({ bucket: HOURLY_BUCKET, equipmentId: grid!.id, zoneId: grid!.zone_id, alias: "energy_hc", value: split.hc, epochS: hour }),
+      buildPoint({ bucket: HOURLY_BUCKET, equipmentId: prod!.id, zoneId: prod!.zone_id, alias: "energy", value: acc.production, epochS: hour }),
+      buildPoint({ bucket: HOURLY_BUCKET, equipmentId: prod!.id, zoneId: prod!.zone_id, alias: "autoconso", value: acc.autoconso, epochS: hour }),
+      buildPoint({ bucket: HOURLY_BUCKET, equipmentId: prod!.id, zoneId: prod!.zone_id, alias: "injection", value: acc.injection, epochS: hour }),
+    );
+  }
+
+  // Daily points
+  const dailyPoints: Point[] = [
+    buildPoint({ bucket: DAILY_BUCKET, equipmentId: grid!.id, zoneId: grid!.zone_id, alias: "energy", value: dHousehold, epochS: dayStartTs }),
+    buildPoint({ bucket: DAILY_BUCKET, equipmentId: grid!.id, zoneId: grid!.zone_id, alias: "energy_hp", value: dHp, epochS: dayStartTs }),
+    buildPoint({ bucket: DAILY_BUCKET, equipmentId: grid!.id, zoneId: grid!.zone_id, alias: "energy_hc", value: dHc, epochS: dayStartTs }),
+    buildPoint({ bucket: DAILY_BUCKET, equipmentId: prod!.id, zoneId: prod!.zone_id, alias: "energy", value: dProd, epochS: dayStartTs }),
+    buildPoint({ bucket: DAILY_BUCKET, equipmentId: prod!.id, zoneId: prod!.zone_id, alias: "autoconso", value: dAuto, epochS: dayStartTs }),
+    buildPoint({ bucket: DAILY_BUCKET, equipmentId: prod!.id, zoneId: prod!.zone_id, alias: "injection", value: dInj, epochS: dayStartTs }),
+  ];
+
+  if (APPLY) {
+    // Idempotent: delete first
+    const aliasGrid = ["energy", "energy_hp", "energy_hc"];
+    const aliasProd = ["energy", "autoconso", "injection"];
+    await deleteDay(HOURLY_BUCKET, grid!.id, aliasGrid, dayStart, dayEnd);
+    await deleteDay(HOURLY_BUCKET, prod!.id, aliasProd, dayStart, dayEnd);
+    await deleteDay(DAILY_BUCKET, grid!.id, aliasGrid, dayStart, dayEnd);
+    await deleteDay(DAILY_BUCKET, prod!.id, aliasProd, dayStart, dayEnd);
+
+    const wh = influx.getWriteApi(INFLUX_ORG, HOURLY_BUCKET, "s", { batchSize: 200, flushInterval: 5000, maxRetries: 3 });
+    for (const p of hourlyPoints) wh.writePoint(p);
+    await wh.close();
+
+    const wd = influx.getWriteApi(INFLUX_ORG, DAILY_BUCKET, "s", { batchSize: 50, flushInterval: 5000, maxRetries: 3 });
+    for (const p of dailyPoints) wd.writePoint(p);
+    await wd.close();
+  }
+
+  return {
+    date,
+    slotsFetched: slots.length,
+    household: dHousehold,
+    production: dProd,
+    autoconso: dAuto,
+    injection: dInj,
+    hp: dHp,
+    hc: dHc,
+  };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+(async () => {
+  console.log("=== Backfill from Legrand-Energy / Netatmo ===");
+  console.log(`Mode      : ${APPLY ? "APPLY" : "DRY-RUN"}`);
+  console.log(`Days      : ${DAYS.length} (${DAYS[0]}${DAYS.length > 1 ? `, ..., ${DAYS[DAYS.length - 1]}` : ""})`);
+  console.log(`Influx    : ${INFLUX_URL} org=${INFLUX_ORG}`);
+  console.log(`Grid eq   : ${grid!.id}`);
+  console.log(`Prod eq   : ${prod!.id}`);
+  console.log(`Tariff    : ${tariff ? "loaded" : "not configured"}\n`);
+
+  const fmt = (wh: number) => `${(wh / 1000).toFixed(2)} kWh`;
+  const results: DayResult[] = [];
+  let skipped = 0;
+
+  for (let i = 0; i < DAYS.length; i++) {
+    const day = DAYS[i];
+    try {
+      const r = await processDay(day);
+      if (!r) {
+        console.log(`  ${day}  —  no data`);
+        skipped++;
+      } else {
+        console.log(
+          `  ${day}  ✓  ${r.slotsFetched} slots, hh=${fmt(r.household).padStart(8)}  prod=${fmt(r.production).padStart(7)}  ac=${fmt(r.autoconso).padStart(7)}  inj=${fmt(r.injection).padStart(7)}  hp=${fmt(r.hp).padStart(7)}  hc=${fmt(r.hc).padStart(7)}`,
+        );
+        results.push(r);
+      }
+    } catch (err) {
+      const cause = err instanceof Error && "cause" in err ? (err as { cause: unknown }).cause : null;
+      const causeMsg = cause instanceof Error ? cause.message : cause ? String(cause) : "";
+      console.error(
+        `  ${day}  ✗  ${err instanceof Error ? err.message : String(err)}${causeMsg ? ` (cause: ${causeMsg})` : ""}`,
+      );
+      if (err instanceof Error && err.stack) {
+        console.error(err.stack.split("\n").slice(0, 4).join("\n"));
+      }
+    }
+    if ((i + 1) % 10 === 0) {
+      console.log("    (rate-limit pause 3s)");
+      await new Promise((r) => setTimeout(r, 3000));
+    }
+  }
+
+  console.log();
+  console.log(
+    `Summary: ${results.length} day(s) processed, ${skipped} skipped, ${DAYS.length - results.length - skipped} error(s)`,
+  );
+  if (results.length > 0) {
+    const t = results.reduce(
+      (a, r) => ({
+        h: a.h + r.household, p: a.p + r.production, ac: a.ac + r.autoconso,
+        inj: a.inj + r.injection, hp: a.hp + r.hp, hc: a.hc + r.hc,
+      }),
+      { h: 0, p: 0, ac: 0, inj: 0, hp: 0, hc: 0 },
+    );
+    console.log(
+      `Totals : household=${fmt(t.h)}  prod=${fmt(t.p)}  ac=${fmt(t.ac)}  inj=${fmt(t.inj)}  hp=${fmt(t.hp)}  hc=${fmt(t.hc)}`,
+    );
+  }
+  if (!APPLY && results.length > 0) {
+    console.log("\nDry-run only. Re-run with --apply to write.");
+  }
+})().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/energy/backfill-shelly-archive.ts
+++ b/scripts/energy/backfill-shelly-archive.ts
@@ -1,0 +1,530 @@
+#!/usr/bin/env npx tsx
+/**
+ * One-off backfill of the Sowel raw bucket from the Shelly Pro 3EM's own
+ * minute-resolution archive (`EM1Data.GetData` RPC).
+ *
+ * Use case: Sowel was offline / not yet running for some hours of the day,
+ * but the Shelly was already measuring. The device stores ~60 days of
+ * minute-resolution data in flash and exposes it via HTTP RPC.
+ *
+ * The script:
+ *   1. Reads tariff config + main_energy_meter / energy_production_meter
+ *      equipment IDs from SQLite.
+ *   2. Queries Shelly RPC for channels 0 (grid) and 1 (solar) over the
+ *      requested window, paginated.
+ *   3. Pairs grid + solar per minute, computes household-semantic values
+ *      (energy = household, energy_hp/hc, autoconso, injection).
+ *   4. Upserts into the raw Influx bucket on (equipmentId, alias, ts).
+ *   5. Clears the affected hours in <bucket>-energy-hourly so the
+ *      downsample task regenerates them.
+ *
+ * Default mode: dry-run. Pass --apply to execute.
+ *
+ * Usage (run inside the Sowel container so it shares Influx + SQLite):
+ *   docker exec -w /app sowel npx -y tsx scripts/energy/backfill-shelly-archive.ts \
+ *     --shelly-host 192.168.0.69 \
+ *     [--since 2026-05-03T00:00:00Z] \
+ *     [--until 2026-05-03T07:00:00Z] \
+ *     [--apply]
+ *
+ * SAFETY:
+ * - This is essentially the same pattern as
+ *   `recompute-household-energy.ts` but reading from the Shelly RPC.
+ * - Take an InfluxDB backup before --apply on a non-trivial window.
+ * - The script will NOT touch hours the device's archive doesn't hold
+ *   (gaps in `data_blocks` are skipped with a warn).
+ */
+import Database from "better-sqlite3";
+import { InfluxDB, Point } from "@influxdata/influxdb-client";
+
+// ── CLI ───────────────────────────────────────────────────────────────
+
+function getArg(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  if (i === -1) return undefined;
+  const v = process.argv[i + 1];
+  if (!v) throw new Error(`${name} requires a value`);
+  return v;
+}
+
+const APPLY = process.argv.includes("--apply");
+const SHELLY_HOST = getArg("--shelly-host") ?? "192.168.0.69";
+
+function defaultSince(): string {
+  // Local midnight, expressed in UTC. With TZ=Europe/Paris in CEST that's
+  // yesterday 22:00Z; in CET, yesterday 23:00Z.
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString();
+}
+const SINCE_ISO = getArg("--since") ?? defaultSince();
+const UNTIL_ARG = getArg("--until");
+const SINCE_S = Math.floor(new Date(SINCE_ISO).getTime() / 1000);
+
+// Pair grid/solar within this many seconds (records share the same minute boundary).
+const MATCH_WINDOW_S = 30;
+
+// ── SQLite settings + equipments ──────────────────────────────────────
+
+const DB_PATH = "./data/sowel.db";
+const db = new Database(DB_PATH, { readonly: true });
+
+function getSetting(key: string): string | undefined {
+  const row = db.prepare("SELECT value FROM settings WHERE key = ?").get(key) as
+    | { value: string }
+    | undefined;
+  return row?.value;
+}
+
+function getInfluxConfig(): {
+  url: string;
+  token: string;
+  org: string;
+  bucket: string;
+} {
+  const fromEnv = {
+    url: process.env["INFLUX_URL"],
+    token: process.env["INFLUX_TOKEN"],
+    org: process.env["INFLUX_ORG"],
+    bucket: process.env["INFLUX_BUCKET"],
+  };
+  return {
+    url: fromEnv.url ?? getSetting("history.influx.url") ?? "",
+    token: fromEnv.token ?? getSetting("history.influx.token") ?? "",
+    org: fromEnv.org ?? getSetting("history.influx.org") ?? "",
+    bucket: fromEnv.bucket ?? getSetting("history.influx.bucket") ?? "",
+  };
+}
+
+const { url: INFLUX_URL, token: INFLUX_TOKEN, org: INFLUX_ORG, bucket: RAW_BUCKET } =
+  getInfluxConfig();
+if (!INFLUX_URL || !INFLUX_TOKEN || !INFLUX_ORG || !RAW_BUCKET) {
+  console.error("InfluxDB not configured (set env vars or settings).");
+  process.exit(1);
+}
+const HOURLY_BUCKET = `${RAW_BUCKET}-energy-hourly`;
+
+interface EqRow {
+  id: string;
+  zone_id: string;
+}
+
+function findEquipment(type: string): EqRow | null {
+  const row = db
+    .prepare(
+      "SELECT id, zone_id FROM equipments WHERE type = ? AND enabled = 1 LIMIT 1",
+    )
+    .get(type) as EqRow | undefined;
+  return row ?? null;
+}
+
+const grid = findEquipment("main_energy_meter");
+const prod = findEquipment("energy_production_meter");
+if (!grid || !prod) {
+  console.error(
+    `Missing required equipment(s): grid=${!!grid} prod=${!!prod}.`,
+  );
+  process.exit(1);
+}
+
+// ── Tariff classifier (inlined — mirrors src/energy/tariff-classifier.ts) ──
+
+interface TariffSlot {
+  start: string;
+  end: string;
+  tariff: "hp" | "hc";
+}
+interface DaySchedule {
+  days: number[];
+  slots: TariffSlot[];
+}
+interface TariffConfig {
+  schedules: DaySchedule[];
+  prices: { hp: number; hc: number };
+}
+
+const tariffRaw = getSetting("energy.tariff");
+const tariff: TariffConfig | null = tariffRaw ? JSON.parse(tariffRaw) : null;
+if (!tariff) {
+  console.warn(
+    "No tariff schedule configured — hp/hc will both be 0 except hp=household.",
+  );
+}
+
+function parseTimeMinutes(t: string): number {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function classifyHpHc(totalWh: number, epochS: number): { hp: number; hc: number } {
+  if (!tariff) return { hp: totalWh, hc: 0 };
+  const d = new Date(epochS * 1000);
+  const day = d.getDay();
+  const sched = tariff.schedules.find((s) => s.days.includes(day));
+  if (!sched || sched.slots.length === 0) return { hp: totalWh, hc: 0 };
+
+  const startMin = d.getHours() * 60 + d.getMinutes();
+  const endMin = startMin + 30;
+  let hp = 0;
+  let hc = 0;
+  for (const slot of sched.slots) {
+    const ss = parseTimeMinutes(slot.start);
+    let se = parseTimeMinutes(slot.end);
+    if (se === 0) se = 1440;
+    const ranges: Array<[number, number]> =
+      se <= ss ? [[ss, 1440], [0, se]] : [[ss, se]];
+    for (const [rs, re] of ranges) {
+      const overlap = Math.max(0, Math.min(endMin, re) - Math.max(startMin, rs));
+      if (overlap > 0) {
+        if (slot.tariff === "hp") hp += overlap;
+        else hc += overlap;
+      }
+    }
+  }
+  const total = hp + hc;
+  if (total === 0) return { hp: totalWh, hc: 0 };
+  return {
+    hp: Math.round((totalWh * hp) / total),
+    hc: Math.round((totalWh * hc) / total),
+  };
+}
+
+db.close();
+
+// ── Shelly RPC client ─────────────────────────────────────────────────
+
+interface MinuteRecord {
+  ts: number;
+  totalActEnergy: number;
+  totalActRetEnergy: number;
+}
+
+interface DataBlock {
+  ts: number;
+  period: number;
+  records: number;
+}
+
+async function getRecords(channelId: number): Promise<DataBlock[]> {
+  const url = `http://${SHELLY_HOST}/rpc/EM1Data.GetRecords?id=${channelId}`;
+  const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  if (!res.ok) throw new Error(`GetRecords failed (${res.status})`);
+  const json = (await res.json()) as { data_blocks: DataBlock[] };
+  return json.data_blocks ?? [];
+}
+
+async function getDataPaginated(
+  channelId: number,
+  startTs: number,
+  endTs: number,
+): Promise<MinuteRecord[]> {
+  const out: MinuteRecord[] = [];
+  let cursor = startTs;
+  while (cursor < endTs) {
+    const url = `http://${SHELLY_HOST}/rpc/EM1Data.GetData?id=${channelId}&ts=${cursor}&end_ts=${endTs}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+    if (!res.ok) throw new Error(`GetData failed (${res.status})`);
+    const json = (await res.json()) as {
+      keys: string[];
+      data: Array<{ ts: number; period: number; values: number[][] }>;
+      next_record_ts?: number;
+    };
+    if (!json.data || json.data.length === 0) break;
+    const fwdIdx = json.keys.indexOf("total_act_energy");
+    const revIdx = json.keys.indexOf("total_act_ret_energy");
+    for (const block of json.data) {
+      const baseTs = block.ts;
+      block.values.forEach((row, i) => {
+        out.push({
+          ts: baseTs + i * block.period,
+          totalActEnergy: row[fwdIdx],
+          totalActRetEnergy: row[revIdx],
+        });
+      });
+    }
+    if (!json.next_record_ts || json.next_record_ts <= cursor) break;
+    cursor = json.next_record_ts;
+  }
+  return out;
+}
+
+// ── Pairing + computation ─────────────────────────────────────────────
+
+interface PairedTick {
+  epochS: number;
+  signedGrid: number;
+  solar: number;
+  household: number;
+  autoconso: number;
+  injection: number;
+  hp: number;
+  hc: number;
+}
+
+function pairAndCompute(
+  gridRecs: MinuteRecord[],
+  solarRecs: MinuteRecord[],
+): PairedTick[] {
+  const solarByMinute = new Map<number, MinuteRecord>();
+  for (const r of solarRecs) solarByMinute.set(Math.floor(r.ts / 60), r);
+
+  const out: PairedTick[] = [];
+  for (const g of gridRecs) {
+    const minute = Math.floor(g.ts / 60);
+    const candidate =
+      solarByMinute.get(minute) ??
+      solarByMinute.get(minute - 1) ??
+      solarByMinute.get(minute + 1);
+    if (!candidate) continue;
+    if (Math.abs(candidate.ts - g.ts) > MATCH_WINDOW_S) continue;
+
+    const signedGrid = g.totalActEnergy - g.totalActRetEnergy;
+    // Solar: signed delta to match what the live plugin emits as `energy` on
+    // the production equipment. Reverse on a production CT is the inverter's
+    // standby draw and must be subtracted.
+    const solar = candidate.totalActEnergy - candidate.totalActRetEnergy;
+    const injection = Math.max(0, -signedGrid);
+    const autoconso = Math.max(0, solar - injection);
+    const household = Math.max(0, signedGrid) + autoconso;
+    const ts = Math.max(g.ts, candidate.ts);
+    const split = classifyHpHc(household, ts);
+    out.push({
+      epochS: ts,
+      signedGrid,
+      solar,
+      household,
+      autoconso,
+      injection,
+      hp: split.hp,
+      hc: split.hc,
+    });
+  }
+  return out;
+}
+
+// ── Influx I/O ────────────────────────────────────────────────────────
+
+const influx = new InfluxDB({ url: INFLUX_URL, token: INFLUX_TOKEN });
+
+function buildPoint(args: {
+  equipmentId: string;
+  zoneId: string;
+  alias: string;
+  value: number;
+  epochS: number;
+}): Point {
+  return new Point("equipment_data")
+    .tag("equipmentId", args.equipmentId)
+    .tag("alias", args.alias)
+    .tag("category", "energy")
+    .tag("zoneId", args.zoneId)
+    .tag("type", "number")
+    .floatField("value_number", args.value)
+    .timestamp(args.epochS);
+}
+
+async function writeBatch(points: Point[]): Promise<void> {
+  const writeApi = influx.getWriteApi(INFLUX_ORG, RAW_BUCKET, "s", {
+    batchSize: 500,
+    flushInterval: 10_000,
+    maxRetries: 3,
+  });
+  for (const p of points) writeApi.writePoint(p);
+  await writeApi.close();
+}
+
+async function clearHourly(startIso: string, stopIso: string): Promise<void> {
+  const aliases = ["energy", "energy_hp", "energy_hc", "autoconso", "injection"];
+  for (const alias of aliases) {
+    const res = await fetch(
+      `${INFLUX_URL}/api/v2/delete?org=${encodeURIComponent(INFLUX_ORG)}&bucket=${encodeURIComponent(HOURLY_BUCKET)}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Token ${INFLUX_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          start: startIso,
+          stop: stopIso,
+          predicate: `_measurement="equipment_data" AND alias="${alias}"`,
+        }),
+      },
+    );
+    if (!res.ok) {
+      throw new Error(
+        `Hourly delete (alias=${alias}) failed: ${res.status} ${await res.text()}`,
+      );
+    }
+    console.log(`  Hourly bucket: cleared alias=${alias} in [${startIso}, ${stopIso}]`);
+  }
+}
+
+// ── Auto-detect --until to avoid double-count with live points ────────
+
+async function detectUntil(): Promise<{ untilS: number; untilIso: string; reason: string }> {
+  if (UNTIL_ARG) {
+    const s = Math.floor(new Date(UNTIL_ARG).getTime() / 1000);
+    return { untilS: s, untilIso: UNTIL_ARG, reason: "explicit --until" };
+  }
+  // Query the earliest existing grid `energy` point in [since, now] in raw bucket.
+  const queryApi = influx.getQueryApi(INFLUX_ORG);
+  const flux = `from(bucket: "${RAW_BUCKET}")
+  |> range(start: ${SINCE_ISO}, stop: ${new Date().toISOString()})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> filter(fn: (r) => r.equipmentId == "${grid!.id}")
+  |> filter(fn: (r) => r.alias == "energy")
+  |> sort(columns: ["_time"])
+  |> limit(n: 1)`;
+  const firstTs = await new Promise<number | null>((resolve, reject) => {
+    let found: number | null = null;
+    queryApi.queryRows(flux, {
+      next(row, meta) {
+        const o = meta.toObject(row) as { _time?: string };
+        if (o._time && found === null) {
+          found = Math.floor(new Date(o._time).getTime() / 1000);
+        }
+      },
+      error: (err) => reject(err),
+      complete: () => resolve(found),
+    });
+  });
+  if (firstTs === null) {
+    const nowS = Math.floor(Date.now() / 1000);
+    return { untilS: nowS, untilIso: new Date(nowS * 1000).toISOString(), reason: "no existing live data → bound = now" };
+  }
+  return {
+    untilS: firstTs,
+    untilIso: new Date(firstTs * 1000).toISOString(),
+    reason: `auto: first existing grid energy point at ${new Date(firstTs * 1000).toISOString()} — backfill stops here to avoid overlap`,
+  };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+(async () => {
+  console.log("=== Backfill from Shelly archive ===");
+  console.log(`Mode      : ${APPLY ? "APPLY" : "DRY-RUN"}`);
+  console.log(`Shelly    : ${SHELLY_HOST}`);
+
+  const { untilS: UNTIL_S, untilIso: UNTIL_ISO, reason: untilReason } = await detectUntil();
+  if (SINCE_S >= UNTIL_S) {
+    console.error(`Invalid range: ${SINCE_ISO} → ${UNTIL_ISO} (${untilReason})`);
+    process.exit(1);
+  }
+  console.log(`Range     : ${SINCE_ISO}  →  ${UNTIL_ISO}    [${untilReason}]`);
+  console.log(`Influx    : ${INFLUX_URL} org=${INFLUX_ORG} bucket=${RAW_BUCKET}`);
+  console.log(`Grid      : ${grid.id}`);
+  console.log(`Prod      : ${prod.id}`);
+  console.log(`Tariff    : ${tariff ? "loaded" : "not configured (hp=household, hc=0)"}\n`);
+
+  console.log("Reading data_blocks from Shelly...");
+  const [gridBlocks, solarBlocks] = await Promise.all([getRecords(0), getRecords(1)]);
+  console.log(
+    `  channel 0 (grid):  ${gridBlocks.length} block(s), ${gridBlocks.reduce((a, b) => a + b.records, 0)} records total`,
+  );
+  console.log(
+    `  channel 1 (solar): ${solarBlocks.length} block(s), ${solarBlocks.reduce((a, b) => a + b.records, 0)} records total`,
+  );
+
+  // Window intersect each block with [since, until], fetch, paginate.
+  function intersectBlocks(blocks: DataBlock[]): Array<[number, number]> {
+    const out: Array<[number, number]> = [];
+    for (const b of blocks) {
+      const blockStart = b.ts;
+      const blockEnd = b.ts + b.period * b.records;
+      const start = Math.max(blockStart, SINCE_S);
+      const end = Math.min(blockEnd, UNTIL_S);
+      if (end > start) out.push([start, end]);
+    }
+    return out;
+  }
+  const gridRanges = intersectBlocks(gridBlocks);
+  const solarRanges = intersectBlocks(solarBlocks);
+
+  console.log(`\nFetching grid records...`);
+  const gridRecs: MinuteRecord[] = [];
+  for (const [s, e] of gridRanges) {
+    const recs = await getDataPaginated(0, s, e);
+    gridRecs.push(...recs);
+    console.log(`  [${new Date(s * 1000).toISOString()} → ${new Date(e * 1000).toISOString()}] ${recs.length} records`);
+  }
+
+  console.log(`Fetching solar records...`);
+  const solarRecs: MinuteRecord[] = [];
+  for (const [s, e] of solarRanges) {
+    const recs = await getDataPaginated(1, s, e);
+    solarRecs.push(...recs);
+    console.log(`  [${new Date(s * 1000).toISOString()} → ${new Date(e * 1000).toISOString()}] ${recs.length} records`);
+  }
+
+  const ticks = pairAndCompute(gridRecs, solarRecs);
+  console.log(`\nPaired ticks: ${ticks.length}\n`);
+
+  if (ticks.length === 0) {
+    console.log("Nothing to do — no paired records in the requested window.");
+    return;
+  }
+
+  const totals = ticks.reduce(
+    (acc, t) => ({
+      gridImport: acc.gridImport + Math.max(0, t.signedGrid),
+      gridExport: acc.gridExport + Math.max(0, -t.signedGrid),
+      solar: acc.solar + t.solar,
+      household: acc.household + t.household,
+      autoconso: acc.autoconso + t.autoconso,
+      injection: acc.injection + t.injection,
+      hp: acc.hp + t.hp,
+      hc: acc.hc + t.hc,
+    }),
+    { gridImport: 0, gridExport: 0, solar: 0, household: 0, autoconso: 0, injection: 0, hp: 0, hc: 0 },
+  );
+
+  const fmt = (wh: number) => `${(wh / 1000).toFixed(3)} kWh`;
+  console.log("Totals over range:");
+  console.log(`  grid import : ${fmt(totals.gridImport)}`);
+  console.log(`  grid export : ${fmt(totals.gridExport)}`);
+  console.log(`  solar       : ${fmt(totals.solar)}`);
+  console.log(`  household   : ${fmt(totals.household)}   (= grid_import + autoconso)`);
+  console.log(`  autoconso   : ${fmt(totals.autoconso)}`);
+  console.log(`  injection   : ${fmt(totals.injection)}`);
+  console.log(`  household HP/HC: hp=${fmt(totals.hp)}  hc=${fmt(totals.hc)}\n`);
+
+  console.log("Sample ticks (first 3, last 3):");
+  const sample = [...ticks.slice(0, 3), ...ticks.slice(-3)];
+  for (const t of sample) {
+    console.log(
+      `  ${new Date(t.epochS * 1000).toISOString()}  grid=${t.signedGrid.toFixed(0).padStart(6)}  solar=${t.solar.toFixed(0).padStart(6)}  → hh=${t.household.toFixed(0).padStart(5)}  ac=${t.autoconso.toFixed(0).padStart(4)}  inj=${t.injection.toFixed(0).padStart(4)}  hp=${t.hp.toFixed(0).padStart(5)}  hc=${t.hc.toFixed(0).padStart(4)}`,
+    );
+  }
+  console.log();
+
+  if (!APPLY) {
+    console.log("Dry-run complete. Re-run with --apply to write to Influx.");
+    return;
+  }
+
+  console.log(`Writing ${ticks.length * 6} points to ${RAW_BUCKET}...`);
+  const points: Point[] = [];
+  for (const t of ticks) {
+    points.push(buildPoint({ equipmentId: grid.id, zoneId: grid.zone_id, alias: "energy", value: t.household, epochS: t.epochS }));
+    points.push(buildPoint({ equipmentId: grid.id, zoneId: grid.zone_id, alias: "energy_hp", value: t.hp, epochS: t.epochS }));
+    points.push(buildPoint({ equipmentId: grid.id, zoneId: grid.zone_id, alias: "energy_hc", value: t.hc, epochS: t.epochS }));
+    points.push(buildPoint({ equipmentId: prod.id, zoneId: prod.zone_id, alias: "energy", value: t.solar, epochS: t.epochS }));
+    points.push(buildPoint({ equipmentId: prod.id, zoneId: prod.zone_id, alias: "autoconso", value: t.autoconso, epochS: t.epochS }));
+    points.push(buildPoint({ equipmentId: prod.id, zoneId: prod.zone_id, alias: "injection", value: t.injection, epochS: t.epochS }));
+  }
+  await writeBatch(points);
+  console.log("  Raw bucket points written.\n");
+
+  console.log(`Clearing affected aliases in ${HOURLY_BUCKET}...`);
+  await clearHourly(SINCE_ISO, UNTIL_ISO);
+  console.log();
+
+  console.log("=== Done ===");
+  console.log("Trigger the hourly downsample task manually to refresh charts immediately.");
+})().catch((err) => {
+  console.error("Backfill failed:", err);
+  process.exit(1);
+});

--- a/specs/088-energy-backfill-plugin/architecture.md
+++ b/specs/088-energy-backfill-plugin/architecture.md
@@ -1,0 +1,241 @@
+# Spec 088 — Architecture
+
+## Repository / version
+
+- Repository: `sowel-plugin-shelly-mqtt` (existing).
+- Version bump: `1.1.0` → `1.2.0`.
+- No change to Sowel core.
+
+## File layout (additions)
+
+```
+sowel-plugin-shelly-mqtt/
+├── src/
+│   ├── shelly-plugin.ts         (existing — wire backfill manager into start/stop)
+│   ├── shelly-rpc.ts            (NEW — typed HTTP client over EM1Data RPC + mDNS resolution)
+│   ├── shelly-rpc.test.ts       (NEW)
+│   ├── backfill-manager.ts      (NEW — orchestrates gap detection + replay)
+│   ├── backfill-manager.test.ts (NEW)
+│   └── index.ts                 (existing — extend settings schema)
+└── package.json                 (bump version, add no new runtime deps)
+```
+
+## Module responsibilities
+
+### `shelly-rpc.ts`
+
+Thin async client over the Shelly Pro 3EM `EM1Data.*` RPC subset. No
+state, no caching — caller decides.
+
+```ts
+export interface ShellyRpcClient {
+  getRecords(channelId: number): Promise<DataBlock[]>;
+  getData(channelId: number, ts: number, endTs: number): Promise<MinuteRecord[]>;
+}
+export interface DataBlock {
+  ts: number;
+  period: number;
+  records: number;
+}
+export interface MinuteRecord {
+  ts: number;
+  totalActEnergy: number; // Wh in that minute
+  totalActRetEnergy: number; // Wh in that minute (reverse)
+}
+
+export function createShellyRpcClient(opts: {
+  hostOverride?: string; // explicit IP / hostname
+  sourceDeviceId: string; // used to derive `<sid>.local` if no override
+  auth?: { user: string; password: string };
+  fetch?: typeof fetch; // injectable for tests
+  logger: Logger;
+}): ShellyRpcClient;
+```
+
+- Pagination: `getData` follows `next_record_ts` until `end_ts` is
+  reached or the response omits the field. Returns the flat list of
+  `MinuteRecord`s.
+- Timeouts: 10s per HTTP call.
+- Retries: up to 3 with exponential backoff (250ms / 750ms / 2000ms).
+  Beyond that, throw — the caller skips this run.
+- HTTP digest auth: only if `auth` is provided AND the first
+  unauthenticated call returns 401.
+
+### `backfill-manager.ts`
+
+Owns the lifecycle of the backfill loop. One instance per plugin start.
+
+```ts
+export class BackfillManager {
+  start(opts: BackfillOptions): void; // schedules boot run + hourly cron
+  stop(): void; // clears timers, stops in-flight runs
+  // internal:
+  private async runForDevice(device: ShellyChannelGroup): Promise<void>;
+}
+
+interface BackfillOptions {
+  enabled: boolean;
+  scanHours: number; // 1..168, validated at parse time
+  gapThresholdSec: number; // const = 5*60, not configurable
+  channels: ShellyChannelGroup[]; // discovered from `known` set
+  rpcFor(deviceId: string): ShellyRpcClient;
+  deviceManager: DeviceManager; // for getDeviceDataValue + lastUpdated
+  emit: (sid: string, data: Record<string, unknown>, sourceTimestamp: number) => void;
+  logger: Logger;
+}
+
+interface ShellyChannelGroup {
+  sourceDeviceId: string; // Shelly device id, e.g. "shelly-pro3em_00-em0"
+  shellyHostId: string; // base id for mDNS, e.g. "shellypro3em-2cbcbbb2cf48"
+  channelId: number; // 0, 1, 2 — derived from sourceDeviceId suffix
+}
+```
+
+Run loop per device (one Pro 3EM = up to 3 channels sharing a host):
+
+1. Read `device_data.lastUpdated` for `energy_forward` of each channel.
+   Take the **oldest** across the channels — that's our recovery
+   anchor. Rationale: if any channel is stale, we want to refresh all
+   of them on the same window (bookkeeping simpler, no skew).
+2. If `now - oldest < gapThreshold` → no-op, log debug.
+3. `windowStart = max(oldest, now - scanHours * 3600)`.
+4. Query `EM1Data.GetRecords` for channel 0; pick `data_blocks` that
+   intersect `[windowStart, now]`. Same query repeated per channel
+   (channel 0/1/2 may have different blocks, but on a Pro 3EM they
+   typically match — we still query each independently).
+5. For each intersecting block, fetch records via `EM1Data.GetData`,
+   per channel, with pagination.
+6. Merge per-channel results into a chronological stream of
+   `(channelId, MinuteRecord)` interleaved minute by minute:
+   `(0, T) → (1, T) → (2, T) → (0, T+1) → ...`.
+7. Update each channel's `lastCumul` baseline to the LAST record's
+   `total_act_energy` / `total_act_ret_energy` so the live MQTT loop
+   doesn't re-emit a duplicate delta on its next tick.
+8. For each `(channelId, record)` in order, call `emit(...)` with:
+   - `energy_forward = record.totalActEnergy + cumulativeBefore` — but
+     we don't actually have this. So we emit the _delta_ mode: the
+     plugin already converts cumul to delta in the live path. For
+     replay we already have minute deltas → we emit them DIRECTLY as
+     `energy = (fwd - rev)`, plus the absolute `energy_forward` /
+     `energy_reverse` reconstructed by walking forward from the last
+     known cumul before the window.
+9. Log one info per device with `{ channelId, recordsWritten,
+windowStart, windowEnd }`.
+
+#### Cumul reconstruction
+
+The Shelly archive returns _deltas per minute_, not cumuls. But the
+plugin's contract with Sowel is:
+
+- `energy` = signed minute delta (Wh)
+- `energy_forward` = monotonic cumulative Wh (forward)
+- `energy_reverse` = monotonic cumulative Wh (reverse)
+
+To stay consistent the backfill must reconstruct the cumuls. Algorithm
+per channel:
+
+1. Read `cumulFwdBefore = device_data["energy_forward"]` (last known
+   value before the window — what the plugin itself last persisted).
+2. Same for reverse.
+3. Sort backfill records ascending. For each minute:
+   - `cumulFwd_i = cumulFwdBefore + Σ totalActEnergy[0..i]`
+   - `cumulRev_i = cumulRevBefore + Σ totalActRetEnergy[0..i]`
+   - `energy_i  = totalActEnergy[i] - totalActRetEnergy[i]`
+   - emit `{ energy_forward: cumulFwd_i, energy_reverse: cumulRev_i, energy: energy_i }`
+     with `sourceTimestamp = ts_i`.
+4. After the last record, `lastCumul` is updated in-memory to the final
+   reconstructed cumul. The very next live MQTT tick will compute
+   `delta = currentDeviceCumul - lastCumul` — which equals exactly the
+   amount of energy consumed _between the last archive record and
+   live_, typically a few seconds.
+
+This keeps the cumul series monotonic and free of regressions, which
+the EnergyAggregator and downsample tasks all assume.
+
+### `index.ts` changes
+
+- Add to `getSettingsSchema()`:
+  - `{ key: "backfill_enabled", label: "Enable historical backfill", type: "boolean", required: false, defaultValue: "true" }`
+  - `{ key: "backfill_hours", label: "Backfill window (hours)", type: "number", required: false, defaultValue: "24", min: 1, max: 168 }`
+- In `start()` after `engine.start()`:
+  - Read `backfill_enabled` (default `true`).
+  - If enabled, instantiate `BackfillManager`, call `start()`.
+- In `stop()`: call `backfillManager.stop()` first, then existing
+  cleanup. Backfill must finish or abort cleanly before MQTT
+  disconnect.
+
+### `shelly-plugin.ts` changes
+
+Minimal:
+
+- Expose a `getKnownChannelGroups()` accessor so `BackfillManager` can
+  iterate the Shelly channels currently known.
+- Expose a `setLastCumul(sid, baseline)` so backfill can update the
+  in-memory baseline after a replay (avoids the next live tick double-
+  counting).
+- Widen the local `DeviceManager` interface to accept the optional 4th
+  `sourceTimestamp` parameter on `updateDeviceData` (Sowel core already
+  supports it since v1.5.1, just not declared in the plugin's mirror).
+
+## Event flow
+
+```
+Plugin start
+  ├─ engine.start(topicFilter)              [existing]
+  └─ backfillManager.start({...})
+       └─ runForDevice(channelGroup)         [for each known device]
+            ├─ read device_data.lastUpdated  [DeviceManager]
+            ├─ if gap > 5min:
+            │    ├─ rpc.getRecords(0,1,2)    [Shelly HTTP]
+            │    ├─ rpc.getData(0/1/2,...)   [Shelly HTTP, paginated]
+            │    ├─ for each interleaved minute:
+            │    │   deviceManager.updateDeviceData(
+            │    │     id, sid,
+            │    │     { energy_forward, energy_reverse, energy },
+            │    │     sourceTimestamp = ts )
+            │    │       ↓ (Sowel pipeline, unchanged)
+            │    │       device.data.updated → equipment.data.changed → HistoryWriter
+            │    │                                                   → TariffClassifier
+            │    │                                                   → SelfConsumptionWriter
+            │    │                                                   → InfluxDB raw bucket
+            │    └─ engine.setLastCumul(sid, finalBaseline)
+            └─ schedule next run in 1h
+```
+
+## Persistence / state
+
+- No new SQLite table, no new migration.
+- `lastCumul` stays in plugin memory (already the case).
+- `device_data` writes go through the existing `updateDeviceData` path
+  → SQLite + Influx via HistoryWriter.
+
+## Configuration discovery
+
+The plugin learns Shelly devices via MQTT announces. The
+`sourceDeviceId` for a Pro 3EM channel is `shelly-pro3em_00-em0`,
+`shelly-pro3em_00-em1`, `shelly-pro3em_00-em2`. The Shelly host id is
+the second token of the MQTT `src` field on `events/rpc` topics — e.g.
+`shellypro3em-2cbcbbb2cf48`. We extract it on first sight and remember
+it, mapped to the host (or override if set in settings).
+
+## Failure modes
+
+| Failure                      | Behaviour                                                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| mDNS resolution fails        | Log warn, skip this run, retry on next hourly tick.                                                                |
+| HTTP RPC times out / 5xx     | Retry 3 times with backoff. Beyond that: skip.                                                                     |
+| HTTP 401 (auth required)     | Read `shelly_auth_*`. If empty → log error and skip.                                                               |
+| Window is empty in archive   | Treat as real gap (Shelly was off too). Log warn, no write.                                                        |
+| Plugin stops mid-replay      | Abort the in-flight loop; partial state in Influx is OK because writes are idempotent on retry.                    |
+| `lastCumul` is null at start | Fallback: skip backfill on first ever run; let `ensureBaseline` initialise from device_data on the next live tick. |
+
+## What is NOT changed
+
+- Live MQTT path (`handleEm1Status`, `handleEm1DataStatus`,
+  `ensureBaseline`).
+- Sowel core: HistoryWriter, TariffClassifier, SelfConsumptionWriter,
+  EnergyAggregator. They all already accept `sourceTimestamp` and
+  upsert by tag-set+timestamp.
+- Plugin API contract — backfill consumes only what Sowel v1.5.1
+  already exposes (`updateDeviceData(... sourceTimestamp)` and
+  `getDeviceDataValue`).

--- a/specs/088-energy-backfill-plugin/plan.md
+++ b/specs/088-energy-backfill-plugin/plan.md
@@ -1,0 +1,113 @@
+# Spec 088 — Implementation Plan
+
+## Implementation order
+
+Strict order — each step must compile + tests pass before moving to the
+next:
+
+1. **`shelly-rpc.ts`** + tests — typed RPC client, pure I/O, easy to
+   mock.
+2. **Plugin types/interfaces** — widen the local `DeviceManager`
+   interface in `shelly-plugin.ts` to accept `sourceTimestamp` on
+   `updateDeviceData`. Add `getKnownChannelGroups()` and
+   `setLastCumul()` accessors on `ShellyEngine`. No behaviour change
+   yet, ensures green build before adding orchestration.
+3. **`backfill-manager.ts`** + tests — the orchestration logic; pure
+   in-memory, mocks the RPC client and DeviceManager.
+4. **Wire into `index.ts`** — settings schema additions, start/stop
+   lifecycle integration. Tested manually + integration test.
+5. **Bump `package.json`** to 1.2.0, README update.
+
+## Tasks
+
+- [ ] T1. Write `shelly-rpc.ts`:
+  - [ ] `createShellyRpcClient(opts)` returns `ShellyRpcClient`
+  - [ ] `getRecords(channelId)` → `DataBlock[]`
+  - [ ] `getData(channelId, ts, endTs)` → `MinuteRecord[]` with
+        pagination via `next_record_ts`
+  - [ ] Timeout (10s), retry x3 with exponential backoff
+  - [ ] Optional digest auth wrapper
+  - [ ] Injectable `fetch` for tests
+- [ ] T2. Write `shelly-rpc.test.ts` (use Vitest fetch mocks).
+- [ ] T3. Update `shelly-plugin.ts`:
+  - [ ] Widen `DeviceManager` local interface (4th param)
+  - [ ] Add `getKnownChannelGroups(): ShellyChannelGroup[]`
+  - [ ] Add `setLastCumul(sid, baseline)`
+  - [ ] Track `shellyHostId` in the `known` set when discovered (extend
+        the parser/dispatcher to capture the hostId from the `src`
+        field on `events/rpc` topics)
+- [ ] T4. Write `backfill-manager.ts`:
+  - [ ] Constructor + `start({...opts})` schedules boot run + setInterval
+  - [ ] `stop()` clears timers, awaits any in-flight run (best effort)
+  - [ ] `runForDevice(channelGroup)` implements the algorithm in
+        architecture.md
+  - [ ] Cumul reconstruction logic
+  - [ ] Channel-interleaved emission
+  - [ ] All structured logging via the injected logger
+- [ ] T5. Write `backfill-manager.test.ts`.
+- [ ] T6. Wire into `index.ts`:
+  - [ ] Add 2 new settings to schema (`backfill_enabled`,
+        `backfill_hours`)
+  - [ ] Optional setting `shelly_host_<sid>` documented but not
+        validated in schema (free-form key)
+  - [ ] Auth settings (`shelly_auth_user`, `shelly_auth_password`)
+  - [ ] In `start()`: instantiate + start BackfillManager when enabled
+  - [ ] In `stop()`: stop BackfillManager first
+- [ ] T7. Bump version 1.1.0 → 1.2.0.
+- [ ] T8. Update plugin README with the new settings + brief operation
+      description.
+- [ ] T9. Manual production validation:
+  - [ ] Stop Sowel for ≥ 10 min with the plugin running before stop
+  - [ ] Restart Sowel, watch logs for `backfill: gap detected (...) → fetched X records, wrote Y points`
+  - [ ] Check Influx raw bucket for points at the exact gap timestamps
+  - [ ] Trigger the hourly downsample task; verify charts fill in
+- [ ] T10. Update `specs-index.md` status to `Active`.
+
+## Test Plan
+
+### Modules to test
+
+- `shelly-rpc.ts` — RPC client with pagination, retries, timeouts.
+- `backfill-manager.ts` — gap detection, scheduling, channel
+  interleaving, cumul reconstruction.
+
+No tests on `index.ts` — that's wiring only and is exercised by the
+manual validation in T9.
+
+### Scenarios
+
+| Module             | Scenario                                                | Expected                                                                           |
+| ------------------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `shelly-rpc`       | `getRecords` happy path                                 | Returns `DataBlock[]` parsed from response                                         |
+| `shelly-rpc`       | `getData` single page (no `next_record_ts`)             | Returns single batch, decoded by index from `keys`                                 |
+| `shelly-rpc`       | `getData` paginated (3 pages)                           | Calls fetch 3 times, returns concatenated chronological list                       |
+| `shelly-rpc`       | HTTP 500 on first call, success on retry                | Retries with backoff, returns success                                              |
+| `shelly-rpc`       | HTTP 401 with auth provided                             | Re-issues with digest header                                                       |
+| `shelly-rpc`       | HTTP 401 with no auth set                               | Throws auth error, no further retries                                              |
+| `shelly-rpc`       | All 3 retries exhausted                                 | Throws after 3 attempts                                                            |
+| `shelly-rpc`       | Timeout exceeds 10s                                     | AbortController fires, retry path                                                  |
+| `backfill-manager` | No channels known yet                                   | `start()` is no-op, `stop()` is safe                                               |
+| `backfill-manager` | `lastUpdated` < 5 min ago                               | No backfill, debug log only, RPC client never called                               |
+| `backfill-manager` | `lastUpdated` 30 min ago, archive holds the full window | RPC `getRecords` + `getData` called, all 30 minutes emitted via `updateDeviceData` |
+| `backfill-manager` | Gap is 24h, scan window is 24h                          | Full 24h × 60 records replayed                                                     |
+| `backfill-manager` | Gap is 90d but `backfill_hours = 24` (default)          | Only the last 24h replayed (window clamped)                                        |
+| `backfill-manager` | `data_blocks` has a hole within the requested window    | Skips the missing block, logs warn, replays the available blocks                   |
+| `backfill-manager` | Channel-interleaved emission                            | Order is `(c0,T)→(c1,T)→(c2,T)→(c0,T+1)→…` not `(c0,T)→(c0,T+1)→…`                 |
+| `backfill-manager` | Cumul reconstruction starts from `device_data` baseline | Emitted `energy_forward[i]` = baselineFwd + Σ deltas[0..i]                         |
+| `backfill-manager` | After replay, `setLastCumul` is called with final cumul | The next live MQTT tick will not double-count                                      |
+| `backfill-manager` | RPC throws on first device, second device still runs    | Per-device isolation; one failure does not poison the loop                         |
+| `backfill-manager` | `stop()` mid-run                                        | Loop aborts at next iteration, does not crash                                      |
+| `backfill-manager` | Periodic cron tick when no gap exists                   | No-op, no RPC calls                                                                |
+| `backfill-manager` | `backfill_enabled` is false                             | `start()` does not schedule cron, no boot run                                      |
+
+### Coverage gates
+
+- All tests pass under `npx vitest run` in the plugin repo.
+- `shelly-rpc.test.ts` covers the 8 scenarios above.
+- `backfill-manager.test.ts` covers the 12 scenarios above.
+
+## Out of test scope
+
+- E2E test against a real Shelly: covered by T9 manual validation.
+- React UI tests: no UI changes.
+- Sowel core test changes: zero — Sowel doesn't know about backfill.

--- a/specs/088-energy-backfill-plugin/spec.md
+++ b/specs/088-energy-backfill-plugin/spec.md
@@ -91,24 +91,48 @@ live or historical. Backfilled minutes therefore land in the raw bucket
 with the correct `_time` and are classified HP/HC against their actual
 hour-of-day, not the time of replay.
 
+**Channel interleaving is required**: SelfConsumptionWriter pairs a Grid
+tick with a Solar tick within a 30-second window before computing
+`autoconso` / `injection`. Replaying all of channel 0 first then all of
+channel 1 would defeat that pairing — only the last 1-2 minutes would
+align. The plugin therefore **emits one minute at a time across all
+channels**, in chronological order: `(grid, T) → (solar, T) → (aux, T)
+→ (grid, T+1) → (solar, T+1) → ...`.
+
 The downsample task `sowel-energy-sum-hourly` then regenerates the
 hourly bucket on its next 1h tick. The same mechanism was validated end
 to end on 2026-05-03 by the `recompute-household-energy.ts` migration.
 
-### Gap detection
+### Gap detection — driven by `device_data.lastUpdated`, no Influx access
 
-A "gap" is an hour in the configured scan window during which:
+Plugins do not have direct InfluxDB access, and giving them a query
+contract would needlessly extend the plugin API for one consumer. The
+plugin already reads persisted `device_data` values (the same path
+`ensureBaseline` uses to hydrate baselines on cold start), and Sowel
+records `lastUpdated` on every write — so the live freshness of any
+channel is observable from the plugin without crossing into Sowel core.
 
-- the plugin's MQTT live stream wrote nothing to the raw bucket, **or**
-- the raw bucket has < N records for that hour where N is the expected
-  cadence (60 for 1-min ticks).
+Algorithm (per channel):
 
-The detection query is a single Flux: `count()` per hour over the scan
-window, filtered by the equipment IDs bound to Shelly channels. Any
-hour with `count < threshold` is a candidate.
+1. At plugin start (after the existing baseline hydration) and on every
+   hourly cron tick, read the `device_data.lastUpdated` for
+   `energy_forward` of channel `id=N`.
+2. Compute `gap = now - lastUpdated`.
+3. If `gap > GAP_THRESHOLD_S` (default 5 min), schedule a backfill for
+   the window `[max(lastUpdated, now - backfill_hours * 3600), now]`.
+4. Otherwise, no-op.
 
-Hours fully outside Shelly's own retention (> 60 days back) are skipped
-silently with a warn log — nothing can recover them.
+The 5-min threshold is conservative: a normal MQTT heartbeat is every
+~60s, so even with a noisy network we expect ticks within 2-3 min.
+Anything past 5 min is a real gap.
+
+Hours fully outside Shelly's own ~60-day retention are skipped silently
+with a warn log — nothing can recover them.
+
+To detect the recovery boundary the plugin calls
+`EM1Data.GetRecords?id=N` first; the response lists the available
+`data_blocks`. The actual fetch range is intersected with `[gap window]`
+to avoid asking for data the device does not hold.
 
 ### Run cadence
 
@@ -127,12 +151,13 @@ re-running on an already-correct hour is a no-op.
 
 Added to the plugin's existing settings schema:
 
-| Key                    | Type     | Default | Range    | Purpose                                                                              |
-| ---------------------- | -------- | ------- | -------- | ------------------------------------------------------------------------------------ |
-| `backfill_enabled`     | boolean  | `true`  | —        | Master toggle.                                                                       |
-| `backfill_hours`       | int      | `24`    | `1..168` | Scan window. 168h = 7d. Above that the use case is exotic and we don't encourage it. |
-| `shelly_auth_user`     | string   | `""`    | —        | Optional, only used if device requires auth.                                         |
-| `shelly_auth_password` | password | `""`    | —        | Same.                                                                                |
+| Key                    | Type     | Default | Range    | Purpose                                                                                                                  |
+| ---------------------- | -------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `backfill_enabled`     | boolean  | `true`  | —        | Master toggle.                                                                                                           |
+| `backfill_hours`       | int      | `24`    | `1..168` | Scan window. 168h = 7d. Above that the use case is exotic and we don't encourage it.                                     |
+| `shelly_host_<sid>`    | string   | `""`    | —        | Optional per-device override (IP or hostname). Empty → fall back to `<sid>.local` mDNS. Free-form key, validated lazily. |
+| `shelly_auth_user`     | string   | `""`    | —        | Optional, only used if device requires auth.                                                                             |
+| `shelly_auth_password` | password | `""`    | —        | Same.                                                                                                                    |
 
 Note: there is no setting for "backfill on boot" vs "periodic" — both
 are always on when the master toggle is on. They share the same logic.


### PR DESCRIPTION
## Summary

Wraps up the energy work from today's session before the v1.5.3 release.

## Changes

- **specs/088-energy-backfill-plugin/**: spec.md final (gap detection via \`device_data.lastUpdated\` instead of Flux query, channel-interleaved replay), architecture.md and plan.md added (test plan: 8 + 12 scenarios).
- **scripts/energy/backfill-shelly-archive.ts**: pulls from Shelly Pro 3EM internal flash archive via \`EM1Data.GetData\` RPC; idempotent dry-run / --apply.
- **scripts/energy/backfill-from-legrand.ts**: pulls from Legrand-Energy / Netatmo cloud \`getmeasure\` for older days; same household-semantic schema as SelfConsumptionWriter.

Both scripts were used today to backfill production: Shelly RPC for 2026-05-03 00:00 → 07:32 UTC, Netatmo for ~36 isolated outage days from 2025-04 to 2026-05.

## Test plan

- [x] No source code changes; specs + scripts only.
- [x] Both scripts validated in production via dry-run + apply.