### PR TITLE
feat(devices): expose getDeviceDataLastUpdated to plugins + bump shelly_mqtt to 1.2.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -301,7 +301,7 @@
     "icon": "Zap",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-shelly-mqtt",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "tags": ["shelly", "mqtt", "energy", "em", "solar", "grid"],
     "i18n": {
       "fr": {
@@ -309,7 +309,7 @@
         "description": "Appareils Shelly Pro / Plus via MQTT — puissance live + énergies cumulées par canal (Pro 3EM en V1)"
       }
     },
-    "sowelVersion": ">=1.5.1"
+    "sowelVersion": ">=1.5.4"
   },
   {
     "id": "polytropic_master",

--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -515,4 +515,47 @@ describe("DeviceManager", () => {
       );
     });
   });
+
+  describe("getDeviceDataLastUpdated", () => {
+    const sampleEm = {
+      ieeeAddress: "0xshelly00",
+      friendlyName: "shelly-pro3em_00-em0",
+      manufacturer: "Shelly",
+      model: "Pro3EM",
+      data: [
+        { key: "energy_forward", type: "number" as const, category: "energy" as const, unit: "Wh" },
+      ],
+      orders: [],
+      rawExpose: [],
+    };
+
+    it("returns null for an unknown device", () => {
+      expect(manager.getDeviceDataLastUpdated("shelly_mqtt", "ghost", "energy_forward")).toBeNull();
+    });
+
+    it("returns null when the key has never been written", () => {
+      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
+      expect(
+        manager.getDeviceDataLastUpdated("shelly_mqtt", "shelly-pro3em_00-em0", "energy_forward"),
+      ).toBeNull();
+    });
+
+    it("returns an ISO 8601 UTC timestamp after a write", () => {
+      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
+      manager.updateDeviceData("shelly_mqtt", "shelly-pro3em_00-em0", {
+        energy_forward: 6105.7,
+      });
+      const ts = manager.getDeviceDataLastUpdated(
+        "shelly_mqtt",
+        "shelly-pro3em_00-em0",
+        "energy_forward",
+      );
+      // SQLite returns "YYYY-MM-DD HH:MM:SS" with a space; toISOUtc appends Z.
+      expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?Z$/);
+      // Parsable into a recent timestamp (within last 10 min).
+      const ageMs = Date.now() - new Date(ts!).getTime();
+      expect(ageMs).toBeGreaterThanOrEqual(0);
+      expect(ageMs).toBeLessThan(10 * 60 * 1000);
+    });
+  });
 });

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -531,6 +531,29 @@ export class DeviceManager {
     }
   }
 
+  /**
+   * Last-updated timestamp of a device data key, as ISO 8601 UTC. Used by
+   * plugins to detect gaps in their own data flow without crossing into
+   * Sowel-internal Influx queries (e.g. spec 088 backfill manager).
+   *
+   * Returns `null` for unknown device, unknown key, or no recorded value.
+   */
+  getDeviceDataLastUpdated(
+    integrationId: string,
+    sourceDeviceId: string,
+    key: string,
+  ): string | null {
+    const device = this.stmts.findDeviceBySource.get(integrationId, sourceDeviceId) as
+      | DeviceRow
+      | undefined;
+    if (!device) return null;
+    const row = this.stmts.findDeviceDataByDeviceAndKey.get(device.id, key) as
+      | DeviceDataRow
+      | undefined;
+    if (!row?.last_updated) return null;
+    return toISOUtc(row.last_updated);
+  }
+
   getDeviceOrders(deviceId: string): DeviceOrder[] {
     const rows = this.stmts.getDeviceOrders.all(deviceId) as DeviceOrderRow[];
     return rows.map(rowToDeviceOrder);


### PR DESCRIPTION
## Summary

Adds \`DeviceManager.getDeviceDataLastUpdated(integrationId, sourceDeviceId, key)\`, returning the ISO 8601 timestamp of the last write to a device data key (or \`null\` when device/key is unknown / never written).

The \`DeviceManager\` instance is passed by reference to plugins via the existing \`PluginDeps\` plumbing, so the new method is automatically available — no \`plugin-api.ts\` interface change.

## Why

\`sowel-plugin-shelly-mqtt\` v1.2.0 (just shipped) needs this signal to detect gaps in its own MQTT stream without crossing into Sowel-internal Influx queries. With this exposed, the plugin's \`BackfillManager\` activates: at start (and every hour after), it checks each channel's \`energy_forward.lastUpdated\`; anything older than 5 minutes triggers a replay of the missing minutes from the Pro 3EM's flash archive. Until this PR ships, the plugin is loaded but the manager is a permanent no-op.

## Changes

- \`src/devices/device-manager.ts\` — new \`getDeviceDataLastUpdated\` method (~10 lines, mirrors \`getDeviceDataValue\`).
- \`src/devices/device-manager.test.ts\` — 3 new test cases (unknown device / never written / happy path).
- \`plugins/registry.json\` — \`shelly_mqtt\` bumped to v1.2.0 with \`sowelVersion\": \">=1.5.4\"\` so the package manager only offers the upgrade once this API is in place.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — **412 tests pass** (3 new in device-manager)
- [x] \`npx eslint src/ --ext .ts\` — zero warnings
- [ ] Post-deploy: tail prod logs after Sowel v1.5.4 + plugin v1.2.0 land; expect \`shelly-backfill: backfill manager started\` then either \`below gap threshold, skip\` (normal steady state) or \`backfill replayed\` after a Sowel restart.