### PR TITLE
chore(registry): bump shelly_mqtt to v1.2.1 with relaxed sowelVersion

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -301,7 +301,7 @@
     "icon": "Zap",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-shelly-mqtt",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "tags": ["shelly", "mqtt", "energy", "em", "solar", "grid"],
     "i18n": {
       "fr": {
@@ -309,7 +309,7 @@
         "description": "Appareils Shelly Pro / Plus via MQTT — puissance live + énergies cumulées par canal (Pro 3EM en V1)"
       }
     },
-    "sowelVersion": ">=1.5.4"
+    "sowelVersion": ">=1.5.1"
   },
   {
     "id": "polytropic_master",


### PR DESCRIPTION
v1.2.0 had a broken manifest (still said 1.1.0 inside) → infinite update loop. v1.2.1 re-tagged with fixed manifest + lowered sowelVersion to >=1.5.1 (backfill is gated behind a runtime typeof check, no crash on older hosts).