### PR TITLE
chore(registry): bump shelly_mqtt 1.2.1 → 1.2.2

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -301,7 +301,7 @@
     "icon": "Zap",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-shelly-mqtt",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "tags": ["shelly", "mqtt", "energy", "em", "solar", "grid"],
     "i18n": {
       "fr": {


### PR DESCRIPTION
Picks up the BackfillManager boot race fix (poll for channels until discovered).