### PR TITLE
fix(plugins): cache-bust transitive imports during hot-load

### DIFF
--- a/src/plugins/plugin-loader.ts
+++ b/src/plugins/plugin-loader.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { existsSync, readFileSync } from "node:fs";
+import { cpSync, existsSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import type { Logger } from "../core/logger.js";
 import type {
   IntegrationRegistry,
@@ -248,14 +248,36 @@ export class PluginLoader {
       pluginDir: pkgDir,
     };
 
-    // Dynamic import of the plugin entry point
-    const entryPath = resolve(pkgDir, "dist/index.js");
+    // Dynamic import of the plugin entry point.
+    //
+    // Node ESM caches modules by canonical URL forever — once a plugin's
+    // dist/some-file.js is imported, a later hot-reload of the same path
+    // returns the same cached module, even if the file on disk has
+    // changed. The query-string trick (`?t=...`) only cache-busts the
+    // entry point we explicitly call `import()` on; relative imports
+    // inside that entry (e.g. `import "./backfill-manager.js"`) inherit
+    // the canonical URL of the resolved file and are NOT cache-busted.
+    //
+    // Workaround: at every load, copy `dist/` to a fresh subdirectory
+    // `.hot/<timestamp>/` and import from there. Each load gets a brand
+    // new URL space, so all transitive imports are resolved fresh.
+    // Older `.hot/*` directories are pruned (last 2 kept for safety
+    // against in-flight code holding old references).
+    const distDir = resolve(pkgDir, "dist");
+    if (!existsSync(distDir)) {
+      throw new Error(`Plugin dist directory not found: ${distDir}`);
+    }
+    const hotRoot = resolve(pkgDir, ".hot");
+    const hotDir = resolve(hotRoot, String(Date.now()));
+    cpSync(distDir, hotDir, { recursive: true });
+    pruneOldHotDirs(hotRoot, 2, this.logger);
+
+    const entryPath = resolve(hotDir, "index.js");
     if (!existsSync(entryPath)) {
-      throw new Error(`Plugin entry point not found: ${entryPath}`);
+      throw new Error(`Plugin entry point not found after copy: ${entryPath}`);
     }
 
-    // Cache-bust: append timestamp to force fresh import after reinstall
-    const mod = (await import(`${pathToFileURL(entryPath).href}?t=${Date.now()}`)) as {
+    const mod = (await import(pathToFileURL(entryPath).href)) as {
       createPlugin?: PluginFactory;
       default?: { createPlugin?: PluginFactory };
     };
@@ -304,5 +326,29 @@ export class PluginLoader {
     }
 
     this.integrationRegistry.unregister(pluginId);
+  }
+}
+
+/**
+ * Keep at most `keep` newest entries in the plugin's `.hot/` directory.
+ * Older entries are removed best-effort — a failure here is non-fatal
+ * (the plugin keeps working, the disk just keeps a few extra dirs).
+ */
+function pruneOldHotDirs(hotRoot: string, keep: number, logger: Logger): void {
+  if (!existsSync(hotRoot)) return;
+  try {
+    const entries = readdirSync(hotRoot)
+      .filter((n) => /^\d+$/.test(n))
+      .map((n) => ({ name: n, ts: Number(n) }))
+      .sort((a, b) => b.ts - a.ts);
+    for (const e of entries.slice(keep)) {
+      try {
+        rmSync(resolve(hotRoot, e.name), { recursive: true, force: true });
+      } catch (err) {
+        logger.debug({ err, hotDir: e.name }, "Failed to prune hot dir (non-fatal)");
+      }
+    }
+  } catch (err) {
+    logger.debug({ err, hotRoot }, "Failed to list hot dir (non-fatal)");
   }
 }


### PR DESCRIPTION
## Bug

Node ESM caches modules by canonical URL forever. The hot-load adds \`?t=<ts>\` to the entry import only — relative imports inside the entry (e.g. \`import \"./backfill-manager.js\"\`) are resolved against the entry's canonical URL **without** the query string, so they're returned from cache on every reload after the first.

Surfaced by the spec 088 backfill plugin: after hot-updating from 1.2.1 → 1.2.2, the new \`backfill-manager.js\` on disk was correct but the loaded module kept running the 1.2.1 code because the canonical URL was already cached. A container restart cleared it; this patch makes restarts unnecessary.

## Fix

At every load, copy \`plugins/<id>/dist/\` to a fresh \`plugins/<id>/.hot/<timestamp>/\` and import from there. Each load gets a brand-new URL space so all transitive imports resolve fresh. Last 2 hot dirs are kept (older ones pruned) in case in-flight code still references the old paths.

Cost: one synchronous directory copy per load. Plugin dist trees are tiny (<1 MB typically) — negligible.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — 412 tests pass (incl. 6 plugin-loader tests)
- [x] \`npx eslint src/plugins/ --ext .ts\` — zero warnings
- [ ] Manual prod validation post-deploy: update an in-place plugin, verify the new code runs without container restart