### PR TITLE
feat(mqtt): per-mapping enable/disable toggle

### DIFF
--- a/migrations/008_mqtt_publisher_mapping_enabled.sql
+++ b/migrations/008_mqtt_publisher_mapping_enabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mqtt_publisher_mappings ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1;

--- a/specs/090-mqtt-mapping-enable/architecture.md
+++ b/specs/090-mqtt-mapping-enable/architecture.md
@@ -1,0 +1,91 @@
+# Architecture — Spec 090
+
+## Data model
+
+### Migration `008_mqtt_publisher_mapping_enabled.sql`
+
+```sql
+ALTER TABLE mqtt_publisher_mappings ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1;
+```
+
+Existing rows get `enabled = 1` automatically (default applies on `ALTER TABLE`).
+
+### Types — `src/shared/types.ts`
+
+```ts
+export interface MqttPublisherMapping {
+  id: string;
+  publisherId: string;
+  publishKey: string;
+  sourceType: "equipment" | "zone" | "recipe";
+  sourceId: string;
+  sourceKey: string;
+  enabled: boolean; // NEW
+  createdAt: string;
+}
+```
+
+UI mirror in `ui/src/types.ts` — same field added.
+
+## Backend changes
+
+### `src/mqtt-publishers/mqtt-publisher-manager.ts`
+
+- `MappingRow` gets `enabled: number`.
+- `rowToMapping` reads `row.enabled === 1`.
+- `prepareStatements`:
+  - `insertMapping` adds `enabled` column.
+  - `updateMapping` SQL adds `enabled = ?`.
+- `addMapping(input)` accepts optional `enabled?: boolean` (default `true`).
+- `updateMapping(input)` accepts optional `enabled?: boolean`.
+- Both paths emit `mqtt-publisher.mapping.created` / `.updated` so the publish
+  service rebuilds its index. (Today only `created` exists for updates — keep that
+  same event so the service refreshes; no new event type needed.)
+
+### `src/mqtt-publishers/mqtt-publish-service.ts`
+
+`MappingRef` gets `mappingEnabled: boolean`. The skip condition becomes:
+
+```ts
+if (!ref.enabled || !ref.mappingEnabled || !ref.brokerId) continue;
+```
+
+`publishInitialSnapshot`, `publishInitialSnapshotForBroker`, and
+`publishSnapshotForPublisher` skip mappings where `mapping.enabled === false`.
+
+### API — `src/api/routes/mqtt-publishers.ts`
+
+- `POST /mqtt-publishers/:id/mappings` body adds `enabled?: boolean`.
+- `PUT /mqtt-publishers/:id/mappings/:mappingId` body adds `enabled?: boolean`.
+
+No new endpoint — the existing PUT is already used by the UI to change publish_key,
+sourceType, sourceId, sourceKey.
+
+## Frontend changes
+
+### `ui/src/api.ts`
+
+`addMqttPublisherMapping` and `updateMqttPublisherMapping` payloads accept `enabled?: boolean`.
+
+### `ui/src/pages/MqttPublishersPage.tsx`
+
+`MappingRow` (display mode):
+
+- Wrap row in `opacity-50` when `!mapping.enabled`.
+- Add a power-off / power-on icon button between the pencil and the trash:
+  - When `mapping.enabled`: `<Power />` icon, hover green / orange (use Lucide
+    `Power` stroke 1.5px).
+  - When not: muted state.
+- On click, `updateMqttPublisherMapping(publisherId, mapping.id, { enabled: !mapping.enabled })`
+  then `onRefresh()`.
+
+i18n keys (FR + EN): `mqttPublishers.mappingEnable`, `mqttPublishers.mappingDisable` for the
+icon `aria-label` / `title`.
+
+## Event flow
+
+Unchanged — toggling `enabled` triggers the existing
+`mqtt-publisher.mapping.created` event (emitted by `updateMapping`), which causes
+`MqttPublishService.rebuildIndex()` and `publishInitialSnapshot()`. The new index
+respects the per-mapping flag so a freshly disabled mapping is no longer in the live
+fan-out.

--- a/specs/090-mqtt-mapping-enable/plan.md
+++ b/specs/090-mqtt-mapping-enable/plan.md
@@ -1,0 +1,45 @@
+# Plan — Spec 090
+
+## Implementation steps
+
+1. Migration `migrations/008_mqtt_publisher_mapping_enabled.sql`.
+2. Types — backend `src/shared/types.ts` + UI `ui/src/types.ts`.
+3. Manager — `src/mqtt-publishers/mqtt-publisher-manager.ts`:
+   - extend `MappingRow`, `rowToMapping`, prepared statements
+   - extend `addMapping` / `updateMapping` signatures + bodies
+4. Publish service — `src/mqtt-publishers/mqtt-publish-service.ts`:
+   - extend `MappingRef`
+   - skip disabled mappings in live + snapshot + test paths
+5. API routes — `src/api/routes/mqtt-publishers.ts`: accept `enabled?` on POST + PUT.
+6. UI — `ui/src/api.ts` + `ui/src/pages/MqttPublishersPage.tsx`:
+   - new toggle button, opacity styling, i18n keys (`fr.json`, `en.json`)
+7. Tests (see below).
+8. Typecheck (backend + UI), lint, vitest.
+
+## Test Plan
+
+### Modules to test
+
+- `mqtt-publisher-manager` — CRUD with `enabled` field
+- `mqtt-publish-service` — disabled mappings are skipped in live + snapshot paths
+
+### Scenarios
+
+| Module                 | Scenario                                                     | Expected                                                 |
+| ---------------------- | ------------------------------------------------------------ | -------------------------------------------------------- |
+| mqtt-publisher-manager | `addMapping` without `enabled`                               | Stored with `enabled = true`                             |
+| mqtt-publisher-manager | `addMapping` with `enabled: false`                           | Stored with `enabled = false`                            |
+| mqtt-publisher-manager | `updateMapping` with `enabled: false`                        | Returned mapping has `enabled = false`, persisted        |
+| mqtt-publisher-manager | `updateMapping` without `enabled`                            | Existing `enabled` value preserved                       |
+| mqtt-publish-service   | live equipment data → enabled mapping                        | `client.publish` called once with right topic/payload    |
+| mqtt-publish-service   | live equipment data → disabled mapping                       | `client.publish` NOT called                              |
+| mqtt-publish-service   | initial snapshot skips disabled mappings                     | `publishInitialSnapshot` only emits for enabled mappings |
+| mqtt-publish-service   | manual `publishSnapshotForPublisher` skips disabled mappings | Returned count + publishes only cover enabled mappings   |
+
+### Existing test files
+
+- `src/mqtt-publishers/mqtt-publisher-manager.test.ts` (if present — extend it)
+- `src/mqtt-publishers/mqtt-publish-service.test.ts` (if present — extend it)
+
+If they don't exist, create them following the patterns of other manager/service tests
+(`equipment-manager.test.ts`, etc.) using a real in-memory SQLite via `better-sqlite3`.

--- a/specs/090-mqtt-mapping-enable/spec.md
+++ b/specs/090-mqtt-mapping-enable/spec.md
@@ -1,0 +1,53 @@
+# Spec 090 — MQTT mapping enable/disable
+
+## Summary
+
+Allow each MQTT publisher mapping to be individually enabled or disabled, in addition to
+the existing publisher-level toggle. A disabled mapping stops publishing (live + initial
+snapshot + manual test) but stays in the configuration so the user can re-enable it
+without losing the source/key wiring.
+
+## Why
+
+Today the only way to silence a single mapping is to delete it. When a source is
+temporarily inactive (e.g. seasonal equipment such as a stove in summer), users want to
+keep the mapping configured but stop pushing values to the broker.
+
+## Scope
+
+In:
+
+- New per-mapping `enabled` flag, default `true` for new and existing mappings.
+- UI toggle (power-off icon next to the pencil) that flips the flag.
+- Visual: disabled rows shown with reduced opacity.
+- Runtime: disabled mappings are skipped in live publishing, initial snapshot, and the
+  manual "Test" button.
+- API: `enabled` accepted on POST and PUT mapping endpoints.
+
+Out:
+
+- No retain-clearing message is sent when a mapping is disabled. Whatever was last
+  retained on the broker stays until the user clears it elsewhere.
+- No bulk enable/disable across mappings.
+
+## Acceptance criteria
+
+- [x] New `enabled` column on `mqtt_publisher_mappings`, default 1, applied to existing rows.
+- [x] `MqttPublisherMapping` type carries `enabled: boolean`.
+- [x] `addMapping` defaults `enabled` to `true` when omitted.
+- [x] `updateMapping` accepts `enabled?: boolean`.
+- [x] `MqttPublishService` skips disabled mappings in:
+  - live event handling (equipment / zone / recipe data changes),
+  - `publishInitialSnapshot` and `publishInitialSnapshotForBroker`,
+  - `publishSnapshotForPublisher` (Test button).
+- [x] UI: each mapping row has a power-off / power-on icon button between pencil and trash.
+- [x] UI: disabled rows render with reduced opacity (~ `opacity-50`).
+- [x] Toggling sends `PUT /mqtt-publishers/:id/mappings/:mappingId { enabled }` and refreshes.
+
+## Edge cases
+
+- Disabling a mapping does **not** publish a tombstone / empty payload. Retained values
+  on the broker remain until the user clears them out-of-band.
+- The publisher-level `enabled` flag still wins: if the publisher is off, all its
+  mappings are off regardless of their per-mapping flag.
+- Migrating an existing DB sets every existing mapping to `enabled = 1`.

--- a/src/api/routes/mqtt-publishers.ts
+++ b/src/api/routes/mqtt-publishers.ts
@@ -107,9 +107,10 @@ export function registerMqttPublisherRoutes(app: FastifyInstance, deps: MqttPubl
       sourceType: "equipment" | "zone" | "recipe";
       sourceId: string;
       sourceKey: string;
+      enabled?: boolean;
     };
   }>("/api/v1/mqtt-publishers/:id/mappings", async (request, reply) => {
-    const { publishKey, sourceType, sourceId, sourceKey } = request.body ?? {};
+    const { publishKey, sourceType, sourceId, sourceKey, enabled } = request.body ?? {};
     if (!publishKey) return reply.code(400).send({ error: "publishKey is required" });
     if (!sourceType) return reply.code(400).send({ error: "sourceType is required" });
     if (!sourceId) return reply.code(400).send({ error: "sourceId is required" });
@@ -121,6 +122,7 @@ export function registerMqttPublisherRoutes(app: FastifyInstance, deps: MqttPubl
         sourceType,
         sourceId,
         sourceKey,
+        enabled,
       });
       return reply.code(201).send(mapping);
     } catch (err) {
@@ -138,6 +140,7 @@ export function registerMqttPublisherRoutes(app: FastifyInstance, deps: MqttPubl
       sourceType?: "equipment" | "zone" | "recipe";
       sourceId?: string;
       sourceKey?: string;
+      enabled?: boolean;
     };
   }>("/api/v1/mqtt-publishers/:id/mappings/:mappingId", async (request, reply) => {
     try {

--- a/src/mqtt-publishers/mqtt-publish-service.test.ts
+++ b/src/mqtt-publishers/mqtt-publish-service.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+import { MqttBrokerManager } from "./mqtt-broker-manager.js";
+import { MqttPublisherManager } from "./mqtt-publisher-manager.js";
+
+// Fake MQTT client with a connect-then-publish surface.
+const fakeClient = {
+  connected: true,
+  on: vi.fn(),
+  publish: vi.fn(
+    (_topic: string, _payload: string, _opts: unknown, cb?: (err: Error | null) => void) => {
+      cb?.(null);
+    },
+  ),
+  endAsync: vi.fn().mockResolvedValue(undefined),
+  end: vi.fn(),
+};
+
+vi.mock("mqtt", () => ({
+  default: {
+    connect: () => {
+      // Reset publish mock between tests by binding to the same fakeClient across the suite.
+      return fakeClient;
+    },
+  },
+}));
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  const migrations = [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+    "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
+    "007_pool_water_temp_state.sql",
+    "008_mqtt_publisher_mapping_enabled.sql",
+  ];
+  for (const file of migrations) {
+    const sql = readFileSync(
+      resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),
+      "utf-8",
+    );
+    db.exec(sql);
+  }
+  return db;
+}
+
+const logger = createLogger("silent").logger;
+
+describe("MqttPublishService — disabled mappings are skipped", () => {
+  let db: Database.Database;
+  let eventBus: EventBus;
+  let brokerManager: MqttBrokerManager;
+  let publisherManager: MqttPublisherManager;
+  let publisherId: string;
+  let brokerId: string;
+
+  // Stub managers — mqtt-publish-service consumes only a small surface
+  const equipmentManager = {
+    getDataBindingsWithValues: vi.fn(() => [{ alias: "temperature", value: 21 }]),
+  } as unknown as import("../equipments/equipment-manager.js").EquipmentManager;
+
+  const zoneAggregator = {
+    getAll: vi.fn(() => ({})),
+  } as unknown as import("../zones/zone-aggregator.js").ZoneAggregator;
+
+  const recipeManager = {
+    getInstanceState: vi.fn(() => ({})),
+  } as unknown as import("../recipes/engine/recipe-manager.js").RecipeManager;
+
+  beforeEach(async () => {
+    fakeClient.publish.mockClear();
+    db = createTestDb();
+    eventBus = new EventBus(logger);
+    brokerManager = new MqttBrokerManager(db, eventBus, logger);
+    publisherManager = new MqttPublisherManager(db, eventBus, logger);
+
+    const broker = brokerManager.create({
+      name: "B",
+      url: "mqtt://x",
+      username: null,
+      password: null,
+    });
+    brokerId = broker.id;
+    const pub = publisherManager.create({
+      name: "P",
+      brokerId,
+      topic: "sowel/test",
+    });
+    publisherId = pub.id;
+  });
+
+  async function buildService() {
+    const { MqttPublishService } = await import("./mqtt-publish-service.js");
+    const service = new MqttPublishService(
+      eventBus,
+      brokerManager,
+      publisherManager,
+      equipmentManager,
+      zoneAggregator,
+      recipeManager,
+      logger,
+    );
+    service.init();
+    return service;
+  }
+
+  it("live equipment data: enabled mapping → publish; disabled mapping → no publish", async () => {
+    publisherManager.addMapping(publisherId, {
+      publishKey: "Tlive",
+      sourceType: "equipment",
+      sourceId: "eq-A",
+      sourceKey: "temperature",
+    });
+    publisherManager.addMapping(publisherId, {
+      publishKey: "Toff",
+      sourceType: "equipment",
+      sourceId: "eq-B",
+      sourceKey: "temperature",
+      enabled: false,
+    });
+    const service = await buildService();
+    fakeClient.publish.mockClear();
+
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: "eq-A",
+      alias: "temperature",
+      value: 22,
+    });
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: "eq-B",
+      alias: "temperature",
+      value: 99,
+    });
+
+    const calls = fakeClient.publish.mock.calls;
+    expect(calls.length).toBe(1);
+    expect(calls[0][1]).toBe(JSON.stringify({ Tlive: 22 }));
+
+    await service.destroy();
+  });
+
+  it("publishSnapshotForPublisher skips disabled mappings", async () => {
+    publisherManager.addMapping(publisherId, {
+      publishKey: "Tlive",
+      sourceType: "equipment",
+      sourceId: "eq-A",
+      sourceKey: "temperature",
+    });
+    publisherManager.addMapping(publisherId, {
+      publishKey: "Toff",
+      sourceType: "equipment",
+      sourceId: "eq-A",
+      sourceKey: "temperature",
+      enabled: false,
+    });
+    const service = await buildService();
+    fakeClient.publish.mockClear();
+
+    const count = service.publishSnapshotForPublisher(publisherId);
+
+    expect(count).toBe(1);
+    expect(fakeClient.publish.mock.calls.length).toBe(1);
+    expect(fakeClient.publish.mock.calls[0][1]).toBe(JSON.stringify({ Tlive: 21 }));
+
+    await service.destroy();
+  });
+
+  it("initial snapshot only fires for enabled mappings", async () => {
+    publisherManager.addMapping(publisherId, {
+      publishKey: "Tlive",
+      sourceType: "equipment",
+      sourceId: "eq-A",
+      sourceKey: "temperature",
+    });
+    publisherManager.addMapping(publisherId, {
+      publishKey: "Toff",
+      sourceType: "equipment",
+      sourceId: "eq-A",
+      sourceKey: "temperature",
+      enabled: false,
+    });
+    const service = await buildService();
+    // init() ran the initial snapshot once already; just inspect the result.
+    const tliveCalls = fakeClient.publish.mock.calls.filter(
+      (c) => typeof c[1] === "string" && (c[1] as string).includes("Tlive"),
+    );
+    const toffCalls = fakeClient.publish.mock.calls.filter(
+      (c) => typeof c[1] === "string" && (c[1] as string).includes("Toff"),
+    );
+    expect(tliveCalls.length).toBeGreaterThan(0);
+    expect(toffCalls.length).toBe(0);
+
+    await service.destroy();
+  });
+});

--- a/src/mqtt-publishers/mqtt-publish-service.ts
+++ b/src/mqtt-publishers/mqtt-publish-service.ts
@@ -16,6 +16,7 @@ interface MappingRef {
   publisherTopic: string;
   publishKey: string;
   enabled: boolean;
+  mappingEnabled: boolean;
   brokerId: string | null;
   onChangeOnly: boolean;
 }
@@ -155,6 +156,7 @@ export class MqttPublishService {
           publisherTopic: pub.topic,
           publishKey: mapping.publishKey,
           enabled: pub.enabled,
+          mappingEnabled: mapping.enabled,
           brokerId: pub.brokerId,
           onChangeOnly: pub.onChangeOnly,
         });
@@ -218,7 +220,7 @@ export class MqttPublishService {
 
     let published = 0;
     for (const ref of refs) {
-      if (!ref.enabled || !ref.brokerId) continue;
+      if (!ref.enabled || !ref.mappingEnabled || !ref.brokerId) continue;
       if (this.shouldSkip(ref, value)) continue;
       this.publish(ref.brokerId, ref.publisherTopic, ref.publishKey, value);
       published++;
@@ -237,7 +239,7 @@ export class MqttPublishService {
       if (!refs) continue;
 
       for (const ref of refs) {
-        if (!ref.enabled || !ref.brokerId) continue;
+        if (!ref.enabled || !ref.mappingEnabled || !ref.brokerId) continue;
         if (this.shouldSkip(ref, value)) continue;
         this.publish(ref.brokerId, ref.publisherTopic, ref.publishKey, value);
         published++;
@@ -257,7 +259,7 @@ export class MqttPublishService {
       if (!refs) continue;
 
       for (const ref of refs) {
-        if (!ref.enabled || !ref.brokerId) continue;
+        if (!ref.enabled || !ref.mappingEnabled || !ref.brokerId) continue;
         if (this.shouldSkip(ref, value)) continue;
         this.publish(ref.brokerId, ref.publisherTopic, ref.publishKey, value);
         published++;
@@ -313,6 +315,7 @@ export class MqttPublishService {
       if (!client?.connected) continue;
 
       for (const mapping of pub.mappings) {
+        if (!mapping.enabled) continue;
         const value = this.resolveCurrentValue(
           mapping.sourceType,
           mapping.sourceId,
@@ -338,6 +341,7 @@ export class MqttPublishService {
       if (!pub.enabled || pub.brokerId !== brokerId) continue;
 
       for (const mapping of pub.mappings) {
+        if (!mapping.enabled) continue;
         const value = this.resolveCurrentValue(
           mapping.sourceType,
           mapping.sourceId,
@@ -366,6 +370,7 @@ export class MqttPublishService {
 
     let published = 0;
     for (const mapping of publisher.mappings) {
+      if (!mapping.enabled) continue;
       const value = this.resolveCurrentValue(
         mapping.sourceType,
         mapping.sourceId,

--- a/src/mqtt-publishers/mqtt-publisher-manager.test.ts
+++ b/src/mqtt-publishers/mqtt-publisher-manager.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { MqttPublisherManager } from "./mqtt-publisher-manager.js";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  const migrations = [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+    "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
+    "007_pool_water_temp_state.sql",
+    "008_mqtt_publisher_mapping_enabled.sql",
+  ];
+  for (const file of migrations) {
+    const sql = readFileSync(
+      resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),
+      "utf-8",
+    );
+    db.exec(sql);
+  }
+  return db;
+}
+
+const logger = createLogger("silent").logger;
+
+describe("MqttPublisherManager — mapping enabled flag", () => {
+  let db: Database.Database;
+  let manager: MqttPublisherManager;
+  let publisherId: string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const eventBus = new EventBus(logger);
+    manager = new MqttPublisherManager(db, eventBus, logger);
+    const pub = manager.create({ name: "Test", brokerId: null, topic: "test/topic" });
+    publisherId = pub.id;
+  });
+
+  it("addMapping without enabled defaults to enabled=true", () => {
+    const m = manager.addMapping(publisherId, {
+      publishKey: "k",
+      sourceType: "equipment",
+      sourceId: "eq-1",
+      sourceKey: "alias",
+    });
+    expect(m.enabled).toBe(true);
+  });
+
+  it("addMapping with enabled=false stores enabled=false", () => {
+    const m = manager.addMapping(publisherId, {
+      publishKey: "k",
+      sourceType: "equipment",
+      sourceId: "eq-1",
+      sourceKey: "alias",
+      enabled: false,
+    });
+    expect(m.enabled).toBe(false);
+  });
+
+  it("updateMapping with enabled=false flips the flag and persists it", () => {
+    const m = manager.addMapping(publisherId, {
+      publishKey: "k",
+      sourceType: "zone",
+      sourceId: "z-1",
+      sourceKey: "temperature",
+    });
+    const updated = manager.updateMapping(publisherId, m.id, { enabled: false });
+    expect(updated.enabled).toBe(false);
+
+    const reloaded = manager.getMappings(publisherId).find((x) => x.id === m.id);
+    expect(reloaded?.enabled).toBe(false);
+  });
+
+  it("updateMapping without enabled preserves the existing value", () => {
+    const m = manager.addMapping(publisherId, {
+      publishKey: "k",
+      sourceType: "equipment",
+      sourceId: "eq-1",
+      sourceKey: "alias",
+      enabled: false,
+    });
+    const updated = manager.updateMapping(publisherId, m.id, { publishKey: "k2" });
+    expect(updated.enabled).toBe(false);
+    expect(updated.publishKey).toBe("k2");
+  });
+});

--- a/src/mqtt-publishers/mqtt-publisher-manager.ts
+++ b/src/mqtt-publishers/mqtt-publisher-manager.ts
@@ -29,6 +29,7 @@ interface MappingRow {
   source_type: string;
   source_id: string;
   source_key: string;
+  enabled: number;
   created_at: string;
 }
 
@@ -55,6 +56,7 @@ function rowToMapping(row: MappingRow): MqttPublisherMapping {
     sourceType: row.source_type as "equipment" | "zone" | "recipe",
     sourceId: row.source_id,
     sourceKey: row.source_key,
+    enabled: row.enabled === 1,
     createdAt: toISOUtc(row.created_at),
   };
 }
@@ -91,12 +93,12 @@ export class MqttPublisherManager {
         `SELECT * FROM mqtt_publisher_mappings WHERE publisher_id = ? ORDER BY publish_key`,
       ),
       insertMapping: this.db.prepare(
-        `INSERT INTO mqtt_publisher_mappings (id, publisher_id, publish_key, source_type, source_id, source_key, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
+        `INSERT INTO mqtt_publisher_mappings (id, publisher_id, publish_key, source_type, source_id, source_key, enabled, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
       ),
       getMapping: this.db.prepare(`SELECT * FROM mqtt_publisher_mappings WHERE id = ?`),
       updateMapping: this.db.prepare(
-        `UPDATE mqtt_publisher_mappings SET publish_key = ?, source_type = ?, source_id = ?, source_key = ?
+        `UPDATE mqtt_publisher_mappings SET publish_key = ?, source_type = ?, source_id = ?, source_key = ?, enabled = ?
          WHERE id = ? AND publisher_id = ?`,
       ),
       deleteMapping: this.db.prepare(
@@ -223,6 +225,7 @@ export class MqttPublisherManager {
       sourceType: "equipment" | "zone" | "recipe";
       sourceId: string;
       sourceKey: string;
+      enabled?: boolean;
     },
   ): MqttPublisherMapping {
     const publisher = this.getById(publisherId);
@@ -239,6 +242,7 @@ export class MqttPublisherManager {
     }
 
     const id = randomUUID();
+    const enabled = input.enabled === false ? 0 : 1;
     try {
       this.stmts.insertMapping.run(
         id,
@@ -247,6 +251,7 @@ export class MqttPublisherManager {
         input.sourceType,
         input.sourceId.trim(),
         input.sourceKey.trim(),
+        enabled,
       );
     } catch (err: unknown) {
       if (err instanceof Error && err.message.includes("UNIQUE constraint")) {
@@ -280,6 +285,7 @@ export class MqttPublisherManager {
       sourceType?: "equipment" | "zone" | "recipe";
       sourceId?: string;
       sourceKey?: string;
+      enabled?: boolean;
     },
   ): MqttPublisherMapping {
     const publisher = this.getById(publisherId);
@@ -295,6 +301,7 @@ export class MqttPublisherManager {
       input.sourceType ?? (existingRow.source_type as "equipment" | "zone" | "recipe");
     const sourceId = input.sourceId?.trim() ?? existingRow.source_id;
     const sourceKey = input.sourceKey?.trim() ?? existingRow.source_key;
+    const enabled = input.enabled !== undefined ? (input.enabled ? 1 : 0) : existingRow.enabled;
 
     try {
       this.stmts.updateMapping.run(
@@ -302,6 +309,7 @@ export class MqttPublisherManager {
         sourceType,
         sourceId,
         sourceKey,
+        enabled,
         mappingId,
         publisherId,
       );

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -835,6 +835,7 @@ export interface MqttPublisherMapping {
   sourceType: "equipment" | "zone" | "recipe";
   sourceId: string;
   sourceKey: string;
+  enabled: boolean;
   createdAt: string;
 }
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1026,6 +1026,7 @@ export async function addMqttPublisherMapping(
     sourceType: "equipment" | "zone" | "recipe";
     sourceId: string;
     sourceKey: string;
+    enabled?: boolean;
   },
 ): Promise<MqttPublisherMapping> {
   return fetchJSON<MqttPublisherMapping>(`${API_BASE}/mqtt-publishers/${publisherId}/mappings`, {
@@ -1042,6 +1043,7 @@ export async function updateMqttPublisherMapping(
     sourceType?: "equipment" | "zone" | "recipe";
     sourceId?: string;
     sourceKey?: string;
+    enabled?: boolean;
   },
 ): Promise<MqttPublisherMapping> {
   return fetchJSON<MqttPublisherMapping>(

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -763,6 +763,8 @@
   "mqttPublishers.mappings": "Mappings",
   "mqttPublishers.noMappings": "No mappings configured",
   "mqttPublishers.addMapping": "Add mapping",
+  "mqttPublishers.mappingEnable": "Enable this mapping",
+  "mqttPublishers.mappingDisable": "Disable this mapping",
   "mqttPublishers.publishKey": "Publish Key",
   "mqttPublishers.sourceType": "Source Type",
   "mqttPublishers.source": "Source",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -763,6 +763,8 @@
   "mqttPublishers.mappings": "Mappings",
   "mqttPublishers.noMappings": "Aucun mapping configuré",
   "mqttPublishers.addMapping": "Ajouter un mapping",
+  "mqttPublishers.mappingEnable": "Activer ce mapping",
+  "mqttPublishers.mappingDisable": "Désactiver ce mapping",
   "mqttPublishers.publishKey": "Clé de publication",
   "mqttPublishers.sourceType": "Type de source",
   "mqttPublishers.source": "Source",

--- a/ui/src/pages/MqttPublishersPage.tsx
+++ b/ui/src/pages/MqttPublishersPage.tsx
@@ -830,6 +830,15 @@ function MappingRow({
     }
   };
 
+  const handleToggleEnabled = async () => {
+    try {
+      await updateMqttPublisherMapping(publisherId, mapping.id, { enabled: !mapping.enabled });
+      onRefresh();
+    } catch {
+      // ignore
+    }
+  };
+
   const handleCancel = () => {
     setEditing(false);
     setPublishKey(mapping.publishKey);
@@ -994,7 +1003,11 @@ function MappingRow({
   }
 
   return (
-    <div className="flex items-center justify-between px-3 py-1.5 bg-bg rounded-[4px]">
+    <div
+      className={`flex items-center justify-between px-3 py-1.5 bg-bg rounded-[4px] ${
+        mapping.enabled ? "" : "opacity-50"
+      }`}
+    >
       <div className="flex items-center gap-3 min-w-0">
         <span className="text-[12px] font-mono text-text font-medium shrink-0">
           {mapping.publishKey}
@@ -1008,12 +1021,25 @@ function MappingRow({
         <button
           onClick={() => setEditing(true)}
           className="p-1 rounded hover:bg-surface transition-colors text-text-tertiary hover:text-text"
+          title={t("common.edit")}
         >
           <Pencil size={12} />
         </button>
         <button
+          onClick={handleToggleEnabled}
+          className="p-1 rounded hover:bg-surface transition-colors text-text-tertiary hover:text-text"
+          title={
+            mapping.enabled
+              ? t("mqttPublishers.mappingDisable")
+              : t("mqttPublishers.mappingEnable")
+          }
+        >
+          {mapping.enabled ? <Power size={12} /> : <PowerOff size={12} />}
+        </button>
+        <button
           onClick={handleDelete}
           className="p-1 rounded hover:bg-surface transition-colors text-text-tertiary hover:text-red-500"
+          title={t("common.delete")}
         >
           <Trash2 size={12} />
         </button>

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -641,6 +641,7 @@ export interface MqttPublisherMapping {
   sourceType: "equipment" | "zone" | "recipe";
   sourceId: string;
   sourceKey: string;
+  enabled: boolean;
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary

- Adds a per-mapping `enabled` flag on MQTT publisher mappings (default true).
- Toggle is exposed in the UI as a power-off icon between the pencil and trash; disabled rows render at 50% opacity.
- Disabled mappings are skipped in live publishing, the initial broker snapshot, and the manual Test button.

Spec: [specs/090-mqtt-mapping-enable](specs/090-mqtt-mapping-enable/spec.md).

## Changes

- Migration `008_mqtt_publisher_mapping_enabled.sql` — `ALTER TABLE … ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1`.
- `MqttPublisherMapping` carries `enabled: boolean` (backend + UI types).
- `MqttPublisherManager.addMapping` / `updateMapping` accept optional `enabled`.
- `MqttPublishService` filters disabled mappings in live + snapshot + test paths.
- API: `enabled?: boolean` accepted on POST and PUT mapping endpoints.
- UI: `Power` / `PowerOff` toggle button in `MappingRow`, opacity-50 on disabled rows, FR/EN i18n keys.
- Tests: 4 manager scenarios + 3 publish-service scenarios (vi.mock("mqtt") + in-memory SQLite).

## Test plan

- [x] `npx tsc --noEmit` (backend) — clean
- [x] `cd ui && npx tsc -b --noEmit` — clean
- [x] `npx vitest run` — 419 passed
- [x] `npx eslint src/ --ext .ts` — clean
- [ ] Manual: toggle a mapping in UI, confirm broker stops/resumes receiving the key on the next data change