### PR TITLE
chore(plugins): bump panasonic_cc to 2.3.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -43,7 +43,7 @@
     "icon": "AirVent",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-panasonic-cc",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "tags": ["panasonic", "ac", "heating", "cooling", "comfort-cloud"],
     "sowelVersion": ">=1.2.12"
   },


### PR DESCRIPTION
Fixes the dict.get eager-default bug that broke all enum order params (mode/fan/swings/eco/nanoe) on Panasonic ACs. Plugin PR: https://github.com/mchacher/sowel-plugin-panasonic-cc/pull/1