### PR TITLE
chore(plugins): bump motion-light to 1.0.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -211,7 +211,7 @@
     "icon": "Lightbulb",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-motion-light",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "tags": ["automation", "motion", "light"],
     "i18n": {
       "fr": {


### PR DESCRIPTION
Fixes the failsafe-echo race that left lights on indefinitely when a PIR was stuck on motion=true. Plugin PR: https://github.com/mchacher/sowel-recipe-motion-light/pull/1