### PR TITLE
feat(energy): power-only submeters + by-usage chart

### DIFF
--- a/migrations/009_submeter_integrator_state.sql
+++ b/migrations/009_submeter_integrator_state.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS submeter_integrator_state (
+  equipment_id    TEXT PRIMARY KEY REFERENCES equipments(id) ON DELETE CASCADE,
+  pending_wh      REAL NOT NULL DEFAULT 0,
+  last_sample_at  TEXT,
+  last_sample_w   REAL,
+  last_write_at   TEXT,
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/migrations/009_submeter_integrator_state.sql
+++ b/migrations/009_submeter_integrator_state.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS submeter_integrator_state (
   equipment_id    TEXT PRIMARY KEY REFERENCES equipments(id) ON DELETE CASCADE,
   pending_wh      REAL NOT NULL DEFAULT 0,
+  cumulative_wh   REAL NOT NULL DEFAULT 0,
   last_sample_at  TEXT,
   last_sample_w   REAL,
   last_write_at   TEXT,

--- a/specs/091-energy-submeters-by-usage/architecture.md
+++ b/specs/091-energy-submeters-by-usage/architecture.md
@@ -1,0 +1,214 @@
+# Architecture — Spec 091
+
+## Data model
+
+### DeviceSelector eligibility — UI only
+
+`ui/src/components/equipments/DeviceSelector.tsx`:
+
+```ts
+const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> = {
+  // ...
+  energy_meter: ["energy", "power"], // was ["energy"]
+  // main_energy_meter unchanged — power-only main meter is out of scope.
+};
+```
+
+This is purely a filter to surface the device in the picker. The
+`bindingUtils` mapping for `energy_meter`'s expected aliases also gets
+`power` added so the alias picker shows it.
+
+### New SQLite table — `submeter_integrator_state`
+
+```sql
+CREATE TABLE IF NOT EXISTS submeter_integrator_state (
+  equipment_id    TEXT PRIMARY KEY REFERENCES equipments(id) ON DELETE CASCADE,
+  pending_wh      REAL NOT NULL DEFAULT 0,    -- Wh accumulated since the last write
+  last_sample_at  TEXT,                       -- ISO 8601 of the last power sample
+  last_sample_w   REAL,                       -- last power value (signed)
+  last_write_at   TEXT,                       -- ISO 8601 of the last InfluxDB write
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+Submeter writes are **per-minute deltas** (Wh consumed in that minute), aligning with how the main meter writes. The energy downsampling tasks
+(`sowel-energy-sum-hourly` / `sowel-energy-sum-daily`) sum across category=energy points — submeters must therefore emit deltas, not cumulatives.
+
+Migration `009_submeter_integrator_state.sql`. Per-submeter rather than
+per-binding to keep the equipment as the unit of truth — multiple
+power-bindings on one submeter equipment (rare) sum into one stream.
+
+### New module — `src/energy/power-submeter-integrator.ts`
+
+```
+SubmeterIntegrator
+  on equipment.data.changed (alias = "power", equipment.type = "energy_meter")
+    if device-level binding category was "power" (i.e. device has no
+    real "energy"):
+      now = event.timestamp
+      prev = state.last_sample_at, prevW = state.last_sample_w
+      if prev exists and (now - prev) <= STALE_THRESHOLD_S (600s):
+        ΔWh = trapezoidal((prevW + currentW) / 2) * (now - prev) / 3600
+        if ΔWh < 0: ΔWh = 0    (clamped + logged once)
+        state.cumulative_wh += ΔWh
+      state.last_sample_at = now
+      state.last_sample_w = currentW
+      persist(state)
+
+  every minute (writer ticker):
+    for each submeter with last_write_value_wh != cumulative_wh:
+      historyWriter.writeAligned(
+        equipmentId, alias="energy", value=cumulative_wh,
+        category="energy", timestamp=floor-to-minute(now),
+      )
+      state.last_write_at = now
+      state.last_write_value_wh = cumulative_wh
+      persist(state)
+```
+
+Why two phases (integrate on event, write on tick): we want sample-accurate
+integration (using the actual report timestamps) but a steady, bounded
+write rate to InfluxDB. The minute ticker also acts as a heartbeat — if no
+power events arrive (device dropped), we simply re-write the same value
+(or skip — see dedup).
+
+Stale handling: if the gap since the last sample exceeds
+`STALE_THRESHOLD_S = 600s`, the integrator does **not** extrapolate — it
+just refreshes `last_sample_at/last_sample_w` to the new sample but does
+not increment `cumulative_wh`. This avoids runaway numbers during device
+offline windows.
+
+### History attribution
+
+Submeter integrator calls `HistoryWriter` directly with explicit
+metadata so the point lands in the energy buckets like a main meter
+write:
+
+```ts
+historyWriter.writeAligned({
+  equipmentId,
+  alias: "energy",
+  value: cumulativeWh,
+  category: "energy",
+  timestamp: minuteAlignedEpochMs,
+});
+```
+
+`HistoryWriter` already knows that `category=energy` routes through the
+energy buckets and runs the HP/HC split for `alias=energy`. We deliberately
+**skip** the HP/HC split for submeters: we add a check in `HistoryWriter`
+that suppresses the HP/HC sub-write when the equipment type is
+`energy_meter`. (Submeters report consumption only, not tariff-bucketed.)
+
+### Boot path
+
+On engine boot, `SubmeterIntegrator` loads its state from SQLite and
+re-arms the minute ticker. Cumulative values resume from the persisted
+value — no backfill of the off-period.
+
+If a submeter's `equipmentId` no longer exists (deleted), the row is
+dropped via the FK cascade.
+
+## API
+
+New endpoint:
+
+```
+GET /api/v1/energy/by-usage?period=day|week|month|year&date=YYYY-MM-DD
+
+Response:
+{
+  "period": "day",
+  "from": "...",
+  "to": "...",
+  "resolution": "1h",
+  "submeters": [
+    { "id": "<equipmentId>", "name": "PAC",      "color": "#…", "points": [{ "time":"…", "wh": 1234 }, …] },
+    { "id": "<equipmentId>", "name": "Piscine",  "color": "#…", "points": [...] },
+  ],
+  "other": { "points": [{ "time": "...", "wh": 567 }, ...] },
+  "totals": {
+    "byEquipment": { "<id>": 12345, "<id>": 6789 },
+    "other": 4500,
+    "total": 23634
+  }
+}
+```
+
+Implementation reuses the existing `computeRange()` and the same
+Flux query template as `queryEnergyPoints`, repeated per submeter:
+
+```flux
+from(bucket: "${bucket}")
+  |> range(start: ${from}, stop: ${to})
+  |> filter(fn: (r) => r._measurement == "device_data")
+  |> filter(fn: (r) => r.equipmentId == "${submeterId}")
+  |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r._field == "energy")
+  |> aggregateWindow(every: ${resolution}, fn: sum, timeSrc: "_start")
+```
+
+`other.points[i].wh = max(0, total.points[i].wh - Σ submeters[i].wh)`.
+
+Color per submeter: deterministic palette indexed by submeter id (sorted),
+using the same accent palette as the rest of the design system.
+
+## UI
+
+`ui/src/components/energy/EnergyPage.tsx`:
+
+- New piece of state `viewMode: "total" | "by-usage"`.
+- Toggle button group above the chart, hidden when no submeter exists.
+- When `by-usage`:
+  - Fetch `/energy/by-usage` (in addition to or in place of `/energy/history`
+    — TBD by impl: simplest is to fetch both, the totals widgets keep
+    using `/energy/history`).
+  - Render `EnergyBarChart` with one `dataKey` per submeter +
+    `dataKey="other"`. Reuse the existing stacked bar shape; just change
+    the keys/colors.
+
+`ui/src/components/energy/EnergyBarChart.tsx`:
+
+- Accept a `series: { id, name, color, points }[]` prop alternative to
+  the current hp/hc/prod/autoconso/injection layout. Tooltip shows
+  per-equipment Wh and the "Other" residual.
+
+i18n keys (FR + EN):
+
+- `energy.viewMode.total` → "Total" / "Total"
+- `energy.viewMode.byUsage` → "Par usage" / "By usage"
+- `energy.byUsage.other` → "Autre" / "Other"
+
+## Event flow
+
+```
+zigbee2mqtt plugin → DeviceManager.updateDeviceData(power=W)
+  → equipment.data.changed event (alias="power")
+    → SubmeterIntegrator.handlePowerEvent
+      (updates cumulative_wh in memory + SQLite)
+
+minute ticker
+  → SubmeterIntegrator.flushAll
+    → HistoryWriter.writeAligned(category="energy", value=cumulative_wh)
+      → InfluxDB sowel bucket
+        → existing downsampling tasks → sowel-energy-hourly + daily
+```
+
+## Files
+
+| Action | File                                                                                   |
+| ------ | -------------------------------------------------------------------------------------- |
+| add    | `migrations/009_submeter_integrator_state.sql`                                         |
+| add    | `src/energy/power-submeter-integrator.ts`                                              |
+| add    | `src/energy/power-submeter-integrator.test.ts`                                         |
+| edit   | `src/index.ts` — wire up SubmeterIntegrator at boot                                    |
+| edit   | `src/history/history-writer.ts` — skip HP/HC split for `energy_meter` type             |
+| edit   | `src/api/routes/energy.ts` — add `/energy/by-usage` endpoint                           |
+| add    | `src/api/routes/energy-by-usage.test.ts`                                               |
+| edit   | `ui/src/components/equipments/DeviceSelector.tsx` — `power` allowed for `energy_meter` |
+| edit   | `ui/src/components/equipments/bindingUtils.ts` — alias mapping                         |
+| edit   | `ui/src/components/energy/EnergyPage.tsx` — toggle + by-usage data fetch               |
+| edit   | `ui/src/components/energy/EnergyBarChart.tsx` — multi-series mode                      |
+| edit   | `ui/src/api.ts` — `getEnergyByUsage()` client                                          |
+| edit   | `ui/src/types.ts` — response types                                                     |
+| edit   | `ui/src/i18n/locales/{fr,en}.json` — labels                                            |

--- a/specs/091-energy-submeters-by-usage/plan.md
+++ b/specs/091-energy-submeters-by-usage/plan.md
@@ -1,0 +1,76 @@
+# Plan — Spec 091
+
+## Implementation steps (in order)
+
+1. **Migration `009_submeter_integrator_state.sql`** — new SQLite table.
+
+2. **Types** — `src/shared/types.ts`:
+   - `EnergyByUsageResponse`, `EnergyByUsagePoint`, `SubmeterSeries`.
+   - Mirror in `ui/src/types.ts`.
+
+3. **`SubmeterIntegrator`** — `src/energy/power-submeter-integrator.ts`:
+   - Class with `init()` (load state from SQLite), `start()` (subscribe to event bus + start minute ticker), `stop()`.
+   - Subscribes to `equipment.data.changed` filtered on alias=`power` and equipment.type=`energy_meter` whose backing device data has category `power` (i.e. no real `energy`).
+   - Trapezoidal integration on event, persistence to SQLite per update.
+   - Minute ticker: writes via `HistoryWriter.writeAligned`.
+   - Unit-testable: inject clock + event bus + db + history-writer mock.
+
+4. **`HistoryWriter`** — skip HP/HC sub-write when equipment is of type `energy_meter`.
+   - Add `equipmentType?: EquipmentType` to the metadata cache (already populated when loading bindings).
+   - In `recordEnergyHpHcSplit`, return early if `meta.equipmentType === "energy_meter"`.
+
+5. **Wiring at boot** — `src/index.ts`: instantiate `SubmeterIntegrator` after `HistoryWriter` and `EquipmentManager`, call `.init().start()`.
+
+6. **API** — `src/api/routes/energy.ts`:
+   - Add `GET /api/v1/energy/by-usage` route.
+   - Reuse `computeRange()`, `findEnergyEquipmentId()`.
+   - Per submeter (filter `getAll().filter(eq => eq.type === "energy_meter")`), run a Flux query identical in shape to `queryEnergyPoints` but parameterized by submeter equipmentId.
+   - Compute `other` series.
+   - Color picker: deterministic palette function shared with UI (or just emitted in response).
+
+7. **UI** — additive:
+   - `ui/src/components/equipments/DeviceSelector.tsx`: extend `EQUIPMENT_TYPE_CATEGORIES.energy_meter` to `["energy", "power"]`.
+   - `ui/src/components/equipments/bindingUtils.ts`: ensure `power` alias accepted for `energy_meter` (already).
+   - `ui/src/api.ts`: `getEnergyByUsage(period, date)`.
+   - `ui/src/components/energy/EnergyPage.tsx`: `viewMode` state, toggle, conditional data fetch & render.
+   - `ui/src/components/energy/EnergyBarChart.tsx`: support an alternative `series[]` mode in addition to the existing fixed-key mode.
+   - i18n strings.
+
+8. **Tests** (see Test Plan).
+
+9. **Validate**: backend `tsc --noEmit`, UI `tsc -b --noEmit`, `vitest run`, `eslint`.
+
+10. **Commit, push, PR.**
+
+## Test Plan
+
+### Modules to test
+
+- `power-submeter-integrator` — integration math + persistence + stale handling.
+- `history-writer` — submeter writes do **not** generate HP/HC sub-points.
+- `energy-by-usage` API route — query shape, "other" residual computation.
+
+### Scenarios
+
+| Module                    | Scenario                                                                      | Expected                                                              |
+| ------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| power-submeter-integrator | First sample after boot                                                       | Sets `last_sample_*` only, cumulative stays 0                         |
+| power-submeter-integrator | Second sample 60 s later, both at 1000 W                                      | cumulative_wh += 1000 \* 60 / 3600 ≈ 16.67                            |
+| power-submeter-integrator | Trapezoid: prev=500 W, current=1500 W, Δt=60 s                                | cumulative_wh += (500+1500)/2 \* 60 / 3600 ≈ 16.67                    |
+| power-submeter-integrator | Negative power (clamp wired backwards) → integrate abs                        | Cumulative goes up, not down. WARN logged once.                       |
+| power-submeter-integrator | Stale sample (Δt > 600 s)                                                     | No integration; just refreshes `last_sample_*`.                       |
+| power-submeter-integrator | Restart with persisted state                                                  | After init, `cumulative_wh` matches the SQLite row.                   |
+| power-submeter-integrator | Minute ticker after no change                                                 | No write (dedup via `last_write_value_wh`).                           |
+| power-submeter-integrator | Minute ticker after a change                                                  | `historyWriter.writeAligned` called once with the new cumulative.     |
+| history-writer            | `category=energy, alias=energy, equipmentType=energy_meter`                   | No HP/HC sub-points written (only the main energy point).             |
+| history-writer            | `category=energy, alias=energy, equipmentType=main_energy_meter` (regression) | HP/HC sub-points still written as before.                             |
+| api energy-by-usage       | No submeter configured                                                        | `submeters` empty, `other` empty, totals zero.                        |
+| api energy-by-usage       | Two submeters with data, total > sum                                          | `other.points[i].wh = total - Σ submeters` per timestamp; clamp at 0. |
+| api energy-by-usage       | Submeter exists but no data in window                                         | Submeter present in response with empty points array.                 |
+
+## Out of scope (explicit)
+
+- No backfill of historical data prior to v1.5.7.
+- No live (real-time) view extension.
+- No stats or daily summaries per submeter beyond what the chart shows.
+- No HP/HC tariff for submeters.

--- a/specs/091-energy-submeters-by-usage/spec.md
+++ b/specs/091-energy-submeters-by-usage/spec.md
@@ -1,0 +1,107 @@
+# Spec 091 — Power-only submeters & by-usage consumption chart
+
+## Summary
+
+Allow `energy_meter` (sub-meter) equipments to be backed by devices that
+expose only instantaneous **power** (W) and not cumulative energy (Wh) —
+typical of cheap zigbee meters like the Legrand GEM. Sowel integrates the
+power signal locally into a Wh stream and writes it to InfluxDB on the
+same per-minute cadence as the main meter, attributed to that submeter
+equipment. A new toggle on the Energy page replaces the existing chart
+with a "consumption by usage" stacked breakdown: one bar per submeter
+plus an "Other" bar for the residual not captured by any submeter.
+
+## Why
+
+The user added zigbee Legrand GEM clamps on dedicated circuits (PAC, pool)
+to break down the home's consumption. The clamps report only `power` (W),
+which today's `energy_meter` device picker rejects (it requires the
+`energy` data category). Even if bound, no by-usage chart exists: the
+existing chart only shows total HP/HC/prod/autoconso/injection.
+
+## Scope
+
+In:
+
+- DeviceSelector accepts `power` as an alternative to `energy` for type
+  `energy_meter`.
+- Sowel computes `energy` (Wh, monotonic cumulative) from `power` (W) by
+  trapezoidal integration over the time deltas between samples, per
+  submeter. The integrated value is written to InfluxDB every minute,
+  same cadence as the main meter, on the submeter's `equipmentId`.
+- Power-integrated submeters write only `category=energy`, not the raw
+  `power` (which is already historized by `HistoryWriter` from the
+  device-level binding).
+- The integration state (running cumulative + last sample timestamp +
+  last sample value) survives restart by being persisted to SQLite per
+  submeter.
+- Energy API exposes a new endpoint that returns per-submeter
+  consumption time series for a given period, aligned to the same
+  buckets as `/energy/history`.
+- New UI mode on the Energy page: a toggle replaces the existing stacked
+  bar chart with a "by usage" stacked bar chart — one stack per
+  submeter, plus an "Other" stack for `total_consumption - Σ submeters`
+  (clamped to ≥ 0 for safety, even though the user expects this never
+  to underflow).
+- Submeters use the same retention stack as the main meter:
+  raw bucket → `sowel-energy-hourly` → `sowel-energy-daily` via the
+  existing downsampling tasks. No new buckets, no new downsampling tasks.
+
+Out:
+
+- No HP/HC tariff classification on submeters. Only `total_consumption`
+  per submeter is exposed in the by-usage view.
+- No backfill of historical submeter values from before this feature
+  ships. Series start at activation time.
+- No retroactive deletion: a deleted submeter keeps its history in
+  InfluxDB and continues appearing in the past view of the chart (the
+  same way the main meter does today).
+- No support for submeters with cumulative `energy` (Wh) in this spec —
+  the integration path is power-only. Existing submeters already
+  bound on a real `energy` device keep working unchanged via
+  `HistoryWriter` (no integration applied to them).
+- No live (real-time) breakdown view. The existing "Live" page is
+  untouched.
+- Support is for V2 plugins only — power-only submeters require the
+  device's `power` data category to be reported reliably with sample
+  cadence ≥ 1 every few minutes. We do not introduce a polling
+  fallback.
+
+## Acceptance criteria
+
+- [x] DeviceSelector lists devices that expose `power` (W) as eligible
+      for `energy_meter` even without an `energy` data point.
+- [x] When the user binds a power-only device to an `energy_meter`,
+      Sowel starts integrating its `power` into a cumulative Wh stream
+      attributed to that submeter equipment.
+- [x] Cumulative submeter energy is written to InfluxDB every minute,
+      `category=energy`, `alias=energy`, with the submeter's
+      `equipmentId` as tag — visible in the existing energy buckets and
+      downsampled normally.
+- [x] Integration state is persisted across restart: after a Sowel
+      restart, the previous cumulative value resumes (no rollover, no
+      backfill of the off-period).
+- [x] New endpoint `GET /api/v1/energy/by-usage?period=<>&date=<>` returns
+      per-equipment consumption series aligned to the same time buckets
+      as `/api/v1/energy/history`.
+- [x] Energy page exposes a toggle "Total / By usage". When "By usage"
+      is selected, the chart renders stacked bars per submeter +
+      "Other"; totals/HP/HC/prod widgets stay unchanged.
+- [x] When no submeter is configured, the toggle is hidden.
+- [x] Existing main-meter and production-meter behavior is unchanged.
+      Self-consumption writer and current `/energy/history` endpoint
+      are untouched.
+
+## Edge cases
+
+- A submeter with `power < 0` (clamp wired backwards): we integrate
+  the absolute value to avoid Wh going negative. Logged once at WARN.
+- A submeter with stale `power` (no update for > 10 minutes): we
+  freeze its cumulative value (don't extrapolate) until next update,
+  to avoid runaway integrations during device offline windows.
+- A submeter recreated with the same name: gets a new `equipmentId`
+  and starts a fresh cumulative — old history stays under the old id
+  in Influx but is not stitched.
+- "By usage" toggle with submeters but no main meter: chart still
+  renders with submeter stacks; the "Other" bar is hidden because we
+  don't know the total. (Pure breakdown of what we measure.)

--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -10,6 +10,9 @@ import type {
   EnergyHistoryResponse,
   EnergyStatus,
   TariffConfig,
+  EnergyByUsageResponse,
+  SubmeterSeries,
+  EnergyByUsagePoint,
 } from "../../shared/types.js";
 
 interface EnergyDeps {
@@ -187,6 +190,114 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
     } catch (err) {
       logger.error({ err, period, dateStr }, "Energy history query failed");
       return reply.status(500).send({ error: "Failed to query energy data" });
+    }
+  });
+
+  // ============================================================
+  // GET /api/v1/energy/by-usage
+  // ============================================================
+  app.get<{
+    Querystring: { period?: string; date?: string };
+  }>("/api/v1/energy/by-usage", async (request, reply) => {
+    const period = request.query.period ?? "day";
+    const dateStr = request.query.date ?? new Date().toISOString().slice(0, 10);
+
+    if (!["day", "week", "month", "year"].includes(period)) {
+      return reply.status(400).send({ error: "Invalid period. Use: day, week, month, year" });
+    }
+
+    const config = influxClient.getConfig();
+    const client = influxClient.getClient();
+    if (!config || !client) {
+      return reply.status(503).send({ error: "InfluxDB not configured" });
+    }
+
+    const submeterEquipments = equipmentManager.getAll().filter((eq) => eq.type === "energy_meter");
+    const mainEquipmentId = findEnergyEquipmentId(equipmentManager);
+
+    const { from, to, resolution, bucket } = computeRange(period, dateStr, config.bucket);
+
+    try {
+      const buckets = [bucket];
+      if (period === "day" && !bucket.includes("-energy-")) {
+        buckets.push(`${config.bucket}-energy-hourly`);
+      }
+
+      // Per-submeter series
+      const submeters: SubmeterSeries[] = [];
+      const totalsByEquipment: Record<string, number> = {};
+      const sumPerTime = new Map<string, number>();
+
+      const sortedSubmeters = [...submeterEquipments].sort((a, b) => a.id.localeCompare(b.id));
+      for (let i = 0; i < sortedSubmeters.length; i++) {
+        const eq = sortedSubmeters[i];
+        let points: EnergyByUsagePoint[] = [];
+        for (const b of buckets) {
+          points = await querySubmeterPoints(client, config.org, b, eq.id, from, to, resolution);
+          if (points.length > 0) break;
+        }
+        const total = points.reduce((acc, p) => acc + p.wh, 0);
+        totalsByEquipment[eq.id] = total;
+        for (const p of points) {
+          sumPerTime.set(p.time, (sumPerTime.get(p.time) ?? 0) + p.wh);
+        }
+        submeters.push({
+          id: eq.id,
+          name: eq.name,
+          color: pickPaletteColor(i),
+          points,
+        });
+      }
+
+      // "Other" residual = main meter consumption per time - Σ submeters per time, clamped ≥ 0
+      const otherPoints: EnergyByUsagePoint[] = [];
+      let otherTotal = 0;
+      let mainTotal = 0;
+
+      if (mainEquipmentId) {
+        let mainPoints: EnergyByUsagePoint[] = [];
+        for (const b of buckets) {
+          mainPoints = await queryMainConsumptionPoints(
+            client,
+            config.org,
+            b,
+            mainEquipmentId,
+            from,
+            to,
+            resolution,
+          );
+          if (mainPoints.length > 0) break;
+        }
+        for (const p of mainPoints) {
+          mainTotal += p.wh;
+          const subs = sumPerTime.get(p.time) ?? 0;
+          const other = Math.max(0, p.wh - subs);
+          if (other > 0) otherPoints.push({ time: p.time, wh: other });
+          otherTotal += other;
+        }
+      }
+
+      const totalSubmeters = Object.values(totalsByEquipment).reduce((a, b) => a + b, 0);
+      const total = mainEquipmentId ? mainTotal : totalSubmeters;
+
+      const response: EnergyByUsageResponse = {
+        period,
+        from: from.toISOString(),
+        to: to.toISOString(),
+        resolution,
+        submeters,
+        other: { points: otherPoints },
+        totals: {
+          byEquipment: totalsByEquipment,
+          other: otherTotal,
+          total,
+        },
+      };
+
+      return response;
+    } catch (err) {
+      logger.error({ err, period, dateStr }, "Energy by-usage query failed");
+      return reply.status(500).send({ error: "Failed to query energy by-usage data" });
     }
   });
 
@@ -485,6 +596,132 @@ async function queryProductionPoints(
 
   points.sort((a, b) => a.time.localeCompare(b.time));
   return points;
+}
+
+/**
+ * Submeter points: alias=energy attached to an `energy_meter` equipment.
+ * Same shape as the main meter's legacy energy series.
+ */
+async function querySubmeterPoints(
+  client: import("@influxdata/influxdb-client").InfluxDB,
+  org: string,
+  bucket: string,
+  equipmentId: string,
+  from: Date,
+  to: Date,
+  resolution: "5min" | "1h" | "1d",
+): Promise<EnergyByUsagePoint[]> {
+  const queryApi = client.getQueryApi(org);
+  const needsAggregation = resolution === "1h" && !bucket.includes("-energy-");
+
+  const flux = needsAggregation
+    ? `from(bucket: "${bucket}")
+  |> range(start: ${from.toISOString()}, stop: ${to.toISOString()})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => r.alias == "energy")
+  |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> aggregateWindow(every: 1h, fn: sum, createEmpty: false, timeSrc: "_start")
+  |> sort(columns: ["_time"])`
+    : `from(bucket: "${bucket}")
+  |> range(start: ${from.toISOString()}, stop: ${to.toISOString()})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => r.alias == "energy")
+  |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> sort(columns: ["_time"])`;
+
+  const sums = new Map<string, number>();
+  const rows = queryApi.iterateRows(flux);
+  for await (const { values, tableMeta } of rows) {
+    const row = tableMeta.toObject(values) as { _time: string; _value: number };
+    if (row._value == null) continue;
+    sums.set(row._time, (sums.get(row._time) ?? 0) + row._value);
+  }
+  return [...sums.entries()]
+    .filter(([, wh]) => wh > 0)
+    .map(([time, wh]) => ({ time, wh }))
+    .sort((a, b) => a.time.localeCompare(b.time));
+}
+
+/**
+ * Main-meter consumption per time bucket, summed across HP/HC + legacy
+ * energy alias. Used as the "total" baseline from which submeters are
+ * subtracted to compute the "Other" residual.
+ */
+async function queryMainConsumptionPoints(
+  client: import("@influxdata/influxdb-client").InfluxDB,
+  org: string,
+  bucket: string,
+  equipmentId: string,
+  from: Date,
+  to: Date,
+  resolution: "5min" | "1h" | "1d",
+): Promise<EnergyByUsagePoint[]> {
+  const queryApi = client.getQueryApi(org);
+  const needsAggregation = resolution === "1h" && !bucket.includes("-energy-");
+  const aliasFilter = `r.alias == "energy_hp" or r.alias == "energy_hc" or r.alias == "energy"`;
+
+  const flux = needsAggregation
+    ? `from(bucket: "${bucket}")
+  |> range(start: ${from.toISOString()}, stop: ${to.toISOString()})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => ${aliasFilter})
+  |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> aggregateWindow(every: 1h, fn: sum, createEmpty: false, timeSrc: "_start")
+  |> sort(columns: ["_time"])`
+    : `from(bucket: "${bucket}")
+  |> range(start: ${from.toISOString()}, stop: ${to.toISOString()})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => ${aliasFilter})
+  |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> sort(columns: ["_time"])`;
+
+  // Sum HP+HC at each timestamp (legacy "energy" rows are already the total).
+  // De-dupe: if both HP/HC and legacy exist for the same time, prefer HP+HC.
+  const hpHcByTime = new Map<string, number>();
+  const legacyByTime = new Map<string, number>();
+  const rows = queryApi.iterateRows(flux);
+  for await (const { values, tableMeta } of rows) {
+    const row = tableMeta.toObject(values) as { _time: string; _value: number; alias: string };
+    if (row._value == null) continue;
+    if (row.alias === "energy_hp" || row.alias === "energy_hc") {
+      hpHcByTime.set(row._time, (hpHcByTime.get(row._time) ?? 0) + row._value);
+    } else if (row.alias === "energy") {
+      legacyByTime.set(row._time, (legacyByTime.get(row._time) ?? 0) + row._value);
+    }
+  }
+
+  const allTimes = new Set([...hpHcByTime.keys(), ...legacyByTime.keys()]);
+  const points: EnergyByUsagePoint[] = [];
+  for (const time of allTimes) {
+    const wh = hpHcByTime.get(time) ?? legacyByTime.get(time) ?? 0;
+    if (wh > 0) points.push({ time, wh });
+  }
+  points.sort((a, b) => a.time.localeCompare(b.time));
+  return points;
+}
+
+/** Deterministic palette for submeter colors (Tailwind-friendly). */
+const SUBMETER_PALETTE = [
+  "#1A4F6E", // primary
+  "#D4963F", // accent
+  "#7DB46C", // sage
+  "#B05B7B", // wine
+  "#5A8FB8", // pale blue
+  "#C97D4A", // terracotta
+  "#6E5BA6", // violet
+  "#3F8D87", // teal
+];
+
+function pickPaletteColor(index: number): string {
+  return SUBMETER_PALETTE[index % SUBMETER_PALETTE.length];
 }
 
 function computeTotals(points: EnergyPoint[]): EnergyTotals {

--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -708,16 +708,19 @@ async function queryMainConsumptionPoints(
   return points;
 }
 
-/** Deterministic palette for submeter colors (Tailwind-friendly). */
+/** Deterministic vivid palette for submeter colors. Aligned with the
+ *  Sowel design system (primary, accent, active) plus the in-chart
+ *  conventions already used by the consumption chart (HP/HC blues,
+ *  autoconso green). Picked for distinct, lively bars. */
 const SUBMETER_PALETTE = [
-  "#1A4F6E", // primary
-  "#D4963F", // accent
-  "#7DB46C", // sage
-  "#B05B7B", // wine
-  "#5A8FB8", // pale blue
-  "#C97D4A", // terracotta
-  "#6E5BA6", // violet
-  "#3F8D87", // teal
+  "#4F7BE8", // vivid blue (matches HP_COLOR in EnergyBarChart)
+  "#D4963F", // amber — design system accent
+  "#6BCB77", // green (matches AUTOCONSO_COLOR)
+  "#E15A5A", // coral
+  "#9C7DD9", // violet
+  "#4FBDD0", // bright teal
+  "#E89A4F", // orange
+  "#FACC15", // yellow — design system active
 ];
 
 function pickPaletteColor(index: number): string {

--- a/src/energy/power-submeter-integrator.test.ts
+++ b/src/energy/power-submeter-integrator.test.ts
@@ -221,6 +221,28 @@ describe("PowerSubmeterIntegrator", () => {
     integ2.stop();
   });
 
+  it("getComputedDataForEquipment exposes cumulative_wh as a computed energy entry", () => {
+    const { equipmentManager, influxClient } = makeStubs();
+    let now = 1_700_000_000_000;
+    const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {
+      now: () => now,
+      flushIntervalMs: 60_000,
+    });
+    integ.init();
+    integ.start();
+
+    emitPower(bus, "eq-pac", 1000);
+    now += 60_000;
+    emitPower(bus, "eq-pac", 1000);
+
+    const computed = integ.getComputedDataForEquipment("eq-pac");
+    expect(computed).toHaveLength(1);
+    expect(computed[0].alias).toBe("energy");
+    expect(computed[0].category).toBe("energy");
+    expect(computed[0].value).toBeCloseTo((1000 * 60) / 3600, 2);
+    integ.stop();
+  });
+
   it("flush with zero pending_wh writes nothing", () => {
     const { equipmentManager, influxClient, writePoint } = makeStubs();
     const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {

--- a/src/energy/power-submeter-integrator.test.ts
+++ b/src/energy/power-submeter-integrator.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { PowerSubmeterIntegrator } from "./power-submeter-integrator.js";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import type { InfluxClient } from "../core/influx-client.js";
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  const migrations = [
+    "001_initial.sql",
+    "002_mqtt_publisher_on_change_only.sql",
+    "003_device_order_category.sql",
+    "004_drop_dispatch_config.sql",
+    "005_device_data_enum_values.sql",
+    "006_pool_runtime_and_category_override.sql",
+    "007_pool_water_temp_state.sql",
+    "008_mqtt_publisher_mapping_enabled.sql",
+    "009_submeter_integrator_state.sql",
+  ];
+  for (const file of migrations) {
+    const sql = readFileSync(
+      resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),
+      "utf-8",
+    );
+    db.exec(sql);
+  }
+  // Insert minimum zone + equipment rows to satisfy FK on submeter state inserts.
+  db.prepare(`INSERT INTO zones (id, name) VALUES (?, ?)`).run("zone-1", "Test");
+  db.prepare(
+    `INSERT INTO equipments (id, name, zone_id, type, enabled) VALUES (?, ?, ?, ?, 1)`,
+  ).run("eq-pac", "PAC", "zone-1", "energy_meter");
+  return db;
+}
+
+const logger = createLogger("silent").logger;
+
+function makeStubs(
+  opts: { isPowerOnly: boolean; influxConnected?: boolean } = { isPowerOnly: true },
+) {
+  const equipmentManager = {
+    getById: vi.fn((id: string) =>
+      id === "eq-pac"
+        ? { id, name: "PAC", zoneId: "zone-1", type: "energy_meter", enabled: true }
+        : null,
+    ),
+    getDataBindingsWithValues: vi.fn(() =>
+      opts.isPowerOnly
+        ? [{ alias: "power", category: "power", value: 1000 }]
+        : [{ alias: "energy", category: "energy", value: 0 }],
+    ),
+  } as unknown as EquipmentManager;
+
+  const writePoint = vi.fn();
+  const influxClient = {
+    isConnected: vi.fn(() => opts.influxConnected ?? true),
+    writePoint,
+  } as unknown as InfluxClient;
+
+  return { equipmentManager, influxClient, writePoint };
+}
+
+function emitPower(bus: EventBus, equipmentId: string, value: number) {
+  bus.emit({
+    type: "equipment.data.changed",
+    equipmentId,
+    alias: "power",
+    value,
+    previous: null,
+  });
+}
+
+describe("PowerSubmeterIntegrator", () => {
+  let db: Database.Database;
+  let bus: EventBus;
+
+  beforeEach(() => {
+    db = createTestDb();
+    bus = new EventBus(logger);
+  });
+
+  it("first sample sets last_sample_* but does not credit any Wh", () => {
+    const { equipmentManager, influxClient, writePoint } = makeStubs();
+    const t0 = 1_700_000_000_000;
+    const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {
+      now: () => t0,
+      flushIntervalMs: 60_000,
+    });
+    integ.init();
+    integ.start();
+
+    emitPower(bus, "eq-pac", 1000);
+    integ.flushAll();
+
+    expect(writePoint).not.toHaveBeenCalled();
+    integ.stop();
+  });
+
+  it("integrates two samples with constant power", () => {
+    const { equipmentManager, influxClient, writePoint } = makeStubs();
+    let now = 1_700_000_000_000;
+    const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {
+      now: () => now,
+      flushIntervalMs: 60_000,
+    });
+    integ.init();
+    integ.start();
+
+    emitPower(bus, "eq-pac", 1000);
+    now += 60_000;
+    emitPower(bus, "eq-pac", 1000);
+    integ.flushAll();
+
+    expect(writePoint).toHaveBeenCalledOnce();
+    integ.stop();
+  });
+
+  it("trapezoidal integration with rising power: prev=500, curr=1500, dt=60s → ~16.67 Wh", () => {
+    const { equipmentManager, influxClient, writePoint } = makeStubs();
+    let now = 1_700_000_000_000;
+    const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {
+      now: () => now,
+      flushIntervalMs: 60_000,
+    });
+    integ.init();
+    integ.start();
+
+    emitPower(bus, "eq-pac", 500);
+    now += 60_000;
+    emitPower(bus, "eq-pac", 1500);
+    integ.flushAll();
+
+    expect(writePoint).toHaveBeenCalledOnce();
+    // 500 + 1500 = 2000 / 2 = 1000 W mean × 60s / 3600 = 16.666... Wh
+    const row = db
+      .prepare(`SELECT pending_wh FROM submeter_integrator_state WHERE equipment_id = 'eq-pac'`)
+      .get() as { pending_wh: number };
+    expect(row.pending_wh).toBeCloseTo(0, 5); // flushed already
+    integ.stop();
+  });
+
+  it("negative power → integrate absolute value, warn once", () => {
+    const { equipmentManager, influxClient } = makeStubs();
+    let now = 1_700_000_000_000;
+    const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {
+      now: () => now,
+      flushIntervalMs: 60_000,
+    });
+    integ.init();
+    integ.start();
+
+    emitPower(bus, "eq-pac", -1000);
+    now += 60_000;
+    emitPower(bus, "eq-pac", -1000);
+    // Read pending_wh BEFORE flush to inspect raw integration
+    const row = db
+      .prepare(`SELECT pending_wh FROM submeter_integrator_state WHERE equipment_id = 'eq-pac'`)
+      .get() as { pending_wh: number };
+    expect(row.pending_wh).toBeCloseTo((1000 * 60) / 3600, 5);
+    integ.stop();
+  });
+
+  it("stale sample (Δt > 600s) → no integration, just refresh baseline", () => {
+    const { equipmentManager, influxClient, writePoint } = makeStubs();
+    let now = 1_700_000_000_000;
+    const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {
+      now: () => now,
+      flushIntervalMs: 60_000,
+    });
+    integ.init();
+    integ.start();
+
+    emitPower(bus, "eq-pac", 1000);
+    now += 700 * 1000; // 11.66 min
+    emitPower(bus, "eq-pac", 1000);
+    integ.flushAll();
+
+    expect(writePoint).not.toHaveBeenCalled();
+    integ.stop();
+  });
+
+  it("state survives restart — pending_wh persisted, restored on init", () => {
+    const stubs = makeStubs();
+    let now = 1_700_000_000_000;
+    {
+      const integ = new PowerSubmeterIntegrator(
+        db,
+        bus,
+        stubs.equipmentManager,
+        stubs.influxClient,
+        logger,
+        { now: () => now, flushIntervalMs: 60_000 },
+      );
+      integ.init();
+      integ.start();
+      emitPower(bus, "eq-pac", 1000);
+      now += 60_000;
+      emitPower(bus, "eq-pac", 1000);
+      integ.stop();
+    }
+
+    // New integrator on the same DB
+    const stubs2 = makeStubs();
+    const integ2 = new PowerSubmeterIntegrator(
+      db,
+      new EventBus(logger),
+      stubs2.equipmentManager,
+      stubs2.influxClient,
+      logger,
+      { now: () => now, flushIntervalMs: 60_000 },
+    );
+    integ2.init();
+    integ2.start();
+    integ2.flushAll();
+
+    expect(stubs2.writePoint).toHaveBeenCalledOnce();
+    integ2.stop();
+  });
+
+  it("flush with zero pending_wh writes nothing", () => {
+    const { equipmentManager, influxClient, writePoint } = makeStubs();
+    const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {
+      now: () => 1_700_000_000_000,
+      flushIntervalMs: 60_000,
+    });
+    integ.init();
+    integ.start();
+    integ.flushAll();
+    expect(writePoint).not.toHaveBeenCalled();
+    integ.stop();
+  });
+
+  it("ignores equipment that has cumulative energy (not a power-only submeter)", () => {
+    const { equipmentManager, influxClient, writePoint } = makeStubs({
+      isPowerOnly: false,
+    });
+    let now = 1_700_000_000_000;
+    const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {
+      now: () => now,
+      flushIntervalMs: 60_000,
+    });
+    integ.init();
+    integ.start();
+
+    emitPower(bus, "eq-pac", 1000);
+    now += 60_000;
+    emitPower(bus, "eq-pac", 1000);
+    integ.flushAll();
+
+    expect(writePoint).not.toHaveBeenCalled();
+    integ.stop();
+  });
+});

--- a/src/energy/power-submeter-integrator.test.ts
+++ b/src/energy/power-submeter-integrator.test.ts
@@ -48,6 +48,9 @@ function makeStubs(
         ? { id, name: "PAC", zoneId: "zone-1", type: "energy_meter", enabled: true }
         : null,
     ),
+    getAll: vi.fn(() => [
+      { id: "eq-pac", name: "PAC", zoneId: "zone-1", type: "energy_meter", enabled: true },
+    ]),
     getDataBindingsWithValues: vi.fn(() =>
       opts.isPowerOnly
         ? [{ alias: "power", category: "power", value: 1000 }]
@@ -219,6 +222,25 @@ describe("PowerSubmeterIntegrator", () => {
 
     expect(stubs2.writePoint).toHaveBeenCalledOnce();
     integ2.stop();
+  });
+
+  it("catchUpFromBindings: integrates from current binding value when no events arrive (steady-state device)", () => {
+    const { equipmentManager, influxClient, writePoint } = makeStubs();
+    let now = 1_700_000_000_000;
+    const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {
+      now: () => now,
+      flushIntervalMs: 60_000,
+    });
+    integ.init();
+    integ.start();
+
+    // No event emitted, but binding has a value (steady 1000 W).
+    integ.flushAll(); // 1st: sets baseline only
+    now += 60_000;
+    integ.flushAll(); // 2nd: should integrate 1000W * 60s = 16.67 Wh
+
+    expect(writePoint).toHaveBeenCalledOnce();
+    integ.stop();
   });
 
   it("getComputedDataForEquipment exposes cumulative_wh as a computed energy entry", () => {

--- a/src/energy/power-submeter-integrator.ts
+++ b/src/energy/power-submeter-integrator.ts
@@ -34,6 +34,9 @@ const MIN_WRITE_WH = 0.001; // skip writing absurdly small deltas
 
 interface IntegratorState {
   pendingWh: number;
+  /** Lifetime Wh integrated by Sowel for this submeter. Surfaced as
+   *  computed data on the equipment so the user sees something growing. */
+  cumulativeWh: number;
   lastSampleAt: number | null; // epoch seconds
   lastSampleW: number | null;
   lastWriteAt: string | null;
@@ -43,6 +46,7 @@ interface IntegratorState {
 interface StateRow {
   equipment_id: string;
   pending_wh: number;
+  cumulative_wh: number;
   last_sample_at: string | null;
   last_sample_w: number | null;
   last_write_at: string | null;
@@ -130,10 +134,11 @@ export class PowerSubmeterIntegrator {
     return {
       selectAll: this.db.prepare(`SELECT * FROM submeter_integrator_state`),
       upsert: this.db.prepare(
-        `INSERT INTO submeter_integrator_state (equipment_id, pending_wh, last_sample_at, last_sample_w, last_write_at, updated_at)
-         VALUES (@equipmentId, @pendingWh, @lastSampleAt, @lastSampleW, @lastWriteAt, datetime('now'))
+        `INSERT INTO submeter_integrator_state (equipment_id, pending_wh, cumulative_wh, last_sample_at, last_sample_w, last_write_at, updated_at)
+         VALUES (@equipmentId, @pendingWh, @cumulativeWh, @lastSampleAt, @lastSampleW, @lastWriteAt, datetime('now'))
          ON CONFLICT(equipment_id) DO UPDATE SET
            pending_wh = excluded.pending_wh,
+           cumulative_wh = excluded.cumulative_wh,
            last_sample_at = excluded.last_sample_at,
            last_sample_w = excluded.last_sample_w,
            last_write_at = excluded.last_write_at,
@@ -147,6 +152,7 @@ export class PowerSubmeterIntegrator {
     for (const row of rows) {
       this.states.set(row.equipment_id, {
         pendingWh: row.pending_wh,
+        cumulativeWh: row.cumulative_wh,
         lastSampleAt: row.last_sample_at ? Math.floor(Date.parse(row.last_sample_at) / 1000) : null,
         lastSampleW: row.last_sample_w,
         lastWriteAt: row.last_write_at,
@@ -177,6 +183,7 @@ export class PowerSubmeterIntegrator {
     const nowS = Math.floor(this.now() / 1000);
     const state = this.states.get(equipmentId) ?? {
       pendingWh: 0,
+      cumulativeWh: 0,
       lastSampleAt: null,
       lastSampleW: null,
       lastWriteAt: null,
@@ -203,6 +210,7 @@ export class PowerSubmeterIntegrator {
         const meanW = (prevAbsW + absW) / 2;
         const deltaWh = (meanW * dtS) / 3600;
         state.pendingWh += deltaWh;
+        state.cumulativeWh += deltaWh;
       } else if (dtS > STALE_THRESHOLD_S) {
         this.logger.debug({ equipmentId, dtS }, "Stale sample, skipping integration window");
       }
@@ -251,9 +259,34 @@ export class PowerSubmeterIntegrator {
     this.stmts.upsert.run({
       equipmentId,
       pendingWh: state.pendingWh,
+      cumulativeWh: state.cumulativeWh,
       lastSampleAt: lastSampleAtIso,
       lastSampleW: state.lastSampleW,
       lastWriteAt: state.lastWriteAt,
     });
+  }
+
+  /**
+   * ComputedDataProvider: surface a live `energy` cumulative on the submeter
+   * equipment so the user sees a growing Wh value alongside the raw `power`
+   * binding. Called by EquipmentManager when serializing the equipment.
+   */
+  getComputedDataForEquipment(
+    equipmentId: string,
+  ): import("../shared/types.js").ComputedDataEntry[] {
+    const state = this.states.get(equipmentId);
+    if (!state) return [];
+    if (!this.isPowerOnlySubmeter(equipmentId)) return [];
+    const lastUpdated =
+      state.lastSampleAt !== null ? new Date(state.lastSampleAt * 1000).toISOString() : null;
+    return [
+      {
+        alias: "energy",
+        value: Math.round(state.cumulativeWh * 100) / 100,
+        unit: "Wh",
+        category: "energy",
+        lastUpdated,
+      },
+    ];
   }
 }

--- a/src/energy/power-submeter-integrator.ts
+++ b/src/energy/power-submeter-integrator.ts
@@ -248,6 +248,18 @@ export class PowerSubmeterIntegrator {
       "Submeter delta written",
     );
 
+    // Emit equipment.data.changed for alias=energy so EnergyAggregator
+    // picks up this submeter and computes hour/day/month/year cumuls from
+    // InfluxDB, like it does for main_energy_meter. HistoryWriter ignores
+    // this event because no binding for `energy` exists on the equipment.
+    this.eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId,
+      alias: "energy",
+      value: state.pendingWh,
+      previous: null,
+    });
+
     state.pendingWh = 0;
     state.lastWriteAt = new Date(minuteEpochMs).toISOString();
     this.persist(equipmentId, state);

--- a/src/energy/power-submeter-integrator.ts
+++ b/src/energy/power-submeter-integrator.ts
@@ -1,0 +1,259 @@
+import type Database from "better-sqlite3";
+import { Point } from "@influxdata/influxdb-client";
+import type { EventBus } from "../core/event-bus.js";
+import type { Logger } from "../core/logger.js";
+import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import type { InfluxClient } from "../core/influx-client.js";
+
+/**
+ * Power-only submeter integration.
+ *
+ * Devices like the Legrand GEM zigbee clamps report only instantaneous
+ * power (W). To historize their consumption alongside the main meter we
+ * trapezoidal-integrate W between samples and write the result, in 1-minute
+ * delta Wh chunks, to InfluxDB on the submeter's `equipmentId`.
+ *
+ * Why deltas, not cumulatives: the existing energy downsampling tasks
+ * (`sowel-energy-sum-hourly`, `sowel-energy-sum-daily`) sum on
+ * `category=energy`. Cumulative writes would multiply absurdly. Deltas
+ * line up with how the main meter writes today.
+ *
+ * Stale guard: a sample older than STALE_THRESHOLD_S compared to the new
+ * one means the device was offline. We do not extrapolate over that gap —
+ * the new sample resets the integration baseline without crediting any
+ * pending Wh.
+ *
+ * Negative power: zigbee clamps sometimes report a negative reading when
+ * wired backwards. Per spec 091 we integrate the absolute value, log
+ * once, and continue. We never emit negative Wh deltas.
+ */
+
+const STALE_THRESHOLD_S = 600; // 10 minutes
+const FLUSH_INTERVAL_MS = 60_000; // 1 minute
+const MIN_WRITE_WH = 0.001; // skip writing absurdly small deltas
+
+interface IntegratorState {
+  pendingWh: number;
+  lastSampleAt: number | null; // epoch seconds
+  lastSampleW: number | null;
+  lastWriteAt: string | null;
+  warnedNegative: boolean;
+}
+
+interface StateRow {
+  equipment_id: string;
+  pending_wh: number;
+  last_sample_at: string | null;
+  last_sample_w: number | null;
+  last_write_at: string | null;
+}
+
+export class PowerSubmeterIntegrator {
+  private readonly logger: Logger;
+  private readonly states: Map<string, IntegratorState> = new Map();
+  private unsubscribe: (() => void) | null = null;
+  private flushTimer: ReturnType<typeof setInterval> | null = null;
+  private stmts!: ReturnType<typeof this.prepareStatements>;
+  private now: () => number;
+  private flushIntervalMs: number;
+
+  constructor(
+    private readonly db: Database.Database,
+    private readonly eventBus: EventBus,
+    private readonly equipmentManager: EquipmentManager,
+    private readonly influxClient: InfluxClient,
+    logger: Logger,
+    options: { now?: () => number; flushIntervalMs?: number } = {},
+  ) {
+    this.logger = logger.child({ module: "power-submeter-integrator" });
+    this.now = options.now ?? (() => Date.now());
+    this.flushIntervalMs = options.flushIntervalMs ?? FLUSH_INTERVAL_MS;
+  }
+
+  init(): void {
+    this.stmts = this.prepareStatements();
+    this.loadStateFromDb();
+  }
+
+  start(): void {
+    this.unsubscribe = this.eventBus.on((event) => {
+      try {
+        if (event.type === "equipment.data.changed") {
+          this.handleEvent(event.equipmentId, event.alias, event.value);
+        } else if (
+          event.type === "equipment.created" ||
+          event.type === "equipment.updated" ||
+          event.type === "equipment.removed"
+        ) {
+          // Equipment list may have changed — re-evaluate which equipments
+          // qualify as power-only submeters on the next sample.
+        }
+      } catch (err) {
+        this.logger.error({ err }, "Error in submeter integrator event handler");
+      }
+    });
+
+    this.flushTimer = setInterval(() => {
+      try {
+        this.flushAll();
+      } catch (err) {
+        this.logger.error({ err }, "Error flushing submeter integrators");
+      }
+    }, this.flushIntervalMs);
+
+    this.logger.info({ submeters: this.states.size }, "Power submeter integrator started");
+  }
+
+  stop(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+  }
+
+  /**
+   * Test / shutdown helper: flush pending Wh deltas to InfluxDB now.
+   */
+  flushAll(): void {
+    for (const [equipmentId, state] of this.states) {
+      this.flushOne(equipmentId, state);
+    }
+  }
+
+  // ============================================================
+  // Internal
+  // ============================================================
+
+  private prepareStatements() {
+    return {
+      selectAll: this.db.prepare(`SELECT * FROM submeter_integrator_state`),
+      upsert: this.db.prepare(
+        `INSERT INTO submeter_integrator_state (equipment_id, pending_wh, last_sample_at, last_sample_w, last_write_at, updated_at)
+         VALUES (@equipmentId, @pendingWh, @lastSampleAt, @lastSampleW, @lastWriteAt, datetime('now'))
+         ON CONFLICT(equipment_id) DO UPDATE SET
+           pending_wh = excluded.pending_wh,
+           last_sample_at = excluded.last_sample_at,
+           last_sample_w = excluded.last_sample_w,
+           last_write_at = excluded.last_write_at,
+           updated_at = datetime('now')`,
+      ),
+    };
+  }
+
+  private loadStateFromDb(): void {
+    const rows = this.stmts.selectAll.all() as StateRow[];
+    for (const row of rows) {
+      this.states.set(row.equipment_id, {
+        pendingWh: row.pending_wh,
+        lastSampleAt: row.last_sample_at ? Math.floor(Date.parse(row.last_sample_at) / 1000) : null,
+        lastSampleW: row.last_sample_w,
+        lastWriteAt: row.last_write_at,
+        warnedNegative: false,
+      });
+    }
+  }
+
+  /**
+   * Decide if an equipment is a power-only submeter (i.e. `energy_meter`
+   * with a `power` data binding and no `energy` binding). Computed each
+   * time because bindings are stable enough that recomputing is cheap.
+   */
+  private isPowerOnlySubmeter(equipmentId: string): boolean {
+    const eq = this.equipmentManager.getById(equipmentId);
+    if (!eq || eq.type !== "energy_meter" || !eq.enabled) return false;
+    const bindings = this.equipmentManager.getDataBindingsWithValues(equipmentId);
+    const hasPower = bindings.some((b) => b.alias === "power" || b.category === "power");
+    const hasEnergy = bindings.some((b) => b.alias === "energy" || b.category === "energy");
+    return hasPower && !hasEnergy;
+  }
+
+  private handleEvent(equipmentId: string, alias: string, value: unknown): void {
+    if (alias !== "power") return;
+    if (typeof value !== "number" || !Number.isFinite(value)) return;
+    if (!this.isPowerOnlySubmeter(equipmentId)) return;
+
+    const nowS = Math.floor(this.now() / 1000);
+    const state = this.states.get(equipmentId) ?? {
+      pendingWh: 0,
+      lastSampleAt: null,
+      lastSampleW: null,
+      lastWriteAt: null,
+      warnedNegative: false,
+    };
+
+    const currentW = value;
+    let absW = currentW;
+    if (currentW < 0) {
+      if (!state.warnedNegative) {
+        this.logger.warn(
+          { equipmentId, sampleW: currentW },
+          "Negative power on submeter — integrating absolute value (clamp likely wired backwards)",
+        );
+        state.warnedNegative = true;
+      }
+      absW = -currentW;
+    }
+
+    if (state.lastSampleAt !== null && state.lastSampleW !== null) {
+      const dtS = nowS - state.lastSampleAt;
+      if (dtS > 0 && dtS <= STALE_THRESHOLD_S) {
+        const prevAbsW = Math.abs(state.lastSampleW);
+        const meanW = (prevAbsW + absW) / 2;
+        const deltaWh = (meanW * dtS) / 3600;
+        state.pendingWh += deltaWh;
+      } else if (dtS > STALE_THRESHOLD_S) {
+        this.logger.debug({ equipmentId, dtS }, "Stale sample, skipping integration window");
+      }
+    }
+
+    state.lastSampleAt = nowS;
+    state.lastSampleW = currentW;
+    this.states.set(equipmentId, state);
+    this.persist(equipmentId, state);
+  }
+
+  private flushOne(equipmentId: string, state: IntegratorState): void {
+    if (state.pendingWh < MIN_WRITE_WH) return;
+    if (!this.influxClient.isConnected()) return;
+
+    const eq = this.equipmentManager.getById(equipmentId);
+    if (!eq) return;
+
+    // Align timestamp on minute boundary so points cleanly downsample.
+    const minuteEpochMs = Math.floor(this.now() / 60_000) * 60_000;
+
+    const point = new Point("equipment_data")
+      .tag("equipmentId", equipmentId)
+      .tag("alias", "energy")
+      .tag("category", "energy")
+      .tag("zoneId", eq.zoneId)
+      .tag("type", "number")
+      .floatField("value_number", state.pendingWh)
+      .timestamp(Math.floor(minuteEpochMs / 1000));
+
+    this.influxClient.writePoint(point);
+
+    this.logger.trace(
+      { equipmentId, deltaWh: state.pendingWh, time: new Date(minuteEpochMs).toISOString() },
+      "Submeter delta written",
+    );
+
+    state.pendingWh = 0;
+    state.lastWriteAt = new Date(minuteEpochMs).toISOString();
+    this.persist(equipmentId, state);
+  }
+
+  private persist(equipmentId: string, state: IntegratorState): void {
+    const lastSampleAtIso =
+      state.lastSampleAt !== null ? new Date(state.lastSampleAt * 1000).toISOString() : null;
+    this.stmts.upsert.run({
+      equipmentId,
+      pendingWh: state.pendingWh,
+      lastSampleAt: lastSampleAtIso,
+      lastSampleW: state.lastSampleW,
+      lastWriteAt: state.lastWriteAt,
+    });
+  }
+}

--- a/src/energy/power-submeter-integrator.ts
+++ b/src/energy/power-submeter-integrator.ts
@@ -119,10 +119,35 @@ export class PowerSubmeterIntegrator {
 
   /**
    * Test / shutdown helper: flush pending Wh deltas to InfluxDB now.
+   *
+   * Also catches up integration for any submeter equipment that hasn't
+   * received an event since the last flush — many zigbee meters only
+   * report on value change, so a steady load would otherwise integrate
+   * to 0. We synthesize a sample at "now" using the current binding value
+   * and the last known timestamp.
    */
   flushAll(): void {
+    this.catchUpFromBindings();
     for (const [equipmentId, state] of this.states) {
       this.flushOne(equipmentId, state);
+    }
+  }
+
+  /**
+   * For every power-only submeter, look at the equipment's current `power`
+   * binding value and integrate from the last sample to "now". This keeps
+   * the energy counter moving when the device only reports on change.
+   */
+  private catchUpFromBindings(): void {
+    const equipments = this.equipmentManager.getAll().filter((e) => e.type === "energy_meter");
+    for (const eq of equipments) {
+      if (!this.isPowerOnlySubmeter(eq.id)) continue;
+      const bindings = this.equipmentManager.getDataBindingsWithValues(eq.id);
+      const powerBinding = bindings.find((b) => b.alias === "power" || b.category === "power");
+      if (!powerBinding) continue;
+      const value = powerBinding.value;
+      if (typeof value !== "number" || !Number.isFinite(value)) continue;
+      this.handleEvent(eq.id, "power", value);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { IntegrationRegistry } from "./integrations/integration-registry.js";
 import { EnergyAggregator } from "./energy/energy-aggregator.js";
 import { SelfConsumptionWriter } from "./energy/self-consumption-writer.js";
 import { HistoryWriter } from "./history/history-writer.js";
+import { PowerSubmeterIntegrator } from "./energy/power-submeter-integrator.js";
 import { InfluxClient } from "./core/influx-client.js";
 import { ChartManager } from "./charts/chart-manager.js";
 import { MqttBrokerManager } from "./mqtt-publishers/mqtt-broker-manager.js";
@@ -362,6 +363,19 @@ async function main() {
     .start()
     .catch((err) => logger.warn({ err }, "Energy aggregator start failed"));
 
+  // 18b. Power-only submeter integrator (Legrand GEM-style clamps that
+  // expose `power` but not cumulative `energy`). Integrates W → Wh and
+  // writes per-minute deltas attributed to the submeter equipment.
+  const powerSubmeterIntegrator = new PowerSubmeterIntegrator(
+    db,
+    eventBus,
+    equipmentManager,
+    influxClient,
+    logger,
+  );
+  powerSubmeterIntegrator.init();
+  powerSubmeterIntegrator.start();
+
   // 18a-bis. Start Weather Aggregator (rain cumuls)
   const { WeatherAggregator } = await import("./weather/weather-aggregator.js");
   const weatherAggregator = new WeatherAggregator(equipmentManager, influxClient, eventBus, logger);
@@ -444,6 +458,12 @@ async function main() {
       selfConsumptionWriter.destroy();
     } catch (err) {
       logger.error({ err }, "Error stopping self-consumption writer");
+    }
+    try {
+      powerSubmeterIntegrator.flushAll();
+      powerSubmeterIntegrator.stop();
+    } catch (err) {
+      logger.error({ err }, "Error stopping power submeter integrator");
     }
     try {
       await influxClient.disconnect();

--- a/src/index.ts
+++ b/src/index.ts
@@ -375,6 +375,9 @@ async function main() {
   );
   powerSubmeterIntegrator.init();
   powerSubmeterIntegrator.start();
+  equipmentManager.registerComputedDataProvider((eqId) =>
+    powerSubmeterIntegrator.getComputedDataForEquipment(eqId),
+  );
 
   // 18a-bis. Start Weather Aggregator (rain cumuls)
   const { WeatherAggregator } = await import("./weather/weather-aggregator.js");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -971,6 +971,33 @@ export interface EnergyStatus {
   tariffConfigured: boolean;
 }
 
+export interface EnergyByUsagePoint {
+  time: string;
+  wh: number;
+}
+
+export interface SubmeterSeries {
+  id: string;
+  name: string;
+  color: string;
+  points: EnergyByUsagePoint[];
+}
+
+export interface EnergyByUsageResponse {
+  period: string;
+  from: string;
+  to: string;
+  resolution: "5min" | "1h" | "1d";
+  submeters: SubmeterSeries[];
+  /** Residual = main meter consumption minus sum of submeters (clamped ≥ 0). Empty if no main meter. */
+  other: { points: EnergyByUsagePoint[] };
+  totals: {
+    byEquipment: Record<string, number>;
+    other: number;
+    total: number;
+  };
+}
+
 // ============================================================
 // Tariff Configuration
 // ============================================================

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -17,7 +17,7 @@ import type {
   MqttBroker,
   MqttPublisher, MqttPublisherMapping, MqttPublisherWithMappings,
   DashboardWidget, WidgetConfig, WidgetFamily,
-  EnergyHistoryResponse, EnergyStatus, TariffConfig,
+  EnergyHistoryResponse, EnergyStatus, TariffConfig, EnergyByUsageResponse,
 } from "./types";
 
 const API_BASE = "/api/v1";
@@ -1225,6 +1225,15 @@ export async function getEnergyHistory(
 ): Promise<EnergyHistoryResponse> {
   return fetchJSON<EnergyHistoryResponse>(
     `${API_BASE}/energy/history?period=${period}&date=${date}`,
+  );
+}
+
+export async function getEnergyByUsage(
+  period: string,
+  date: string,
+): Promise<EnergyByUsageResponse> {
+  return fetchJSON<EnergyByUsageResponse>(
+    `${API_BASE}/energy/by-usage?period=${period}&date=${date}`,
   );
 }
 

--- a/ui/src/components/energy/EnergyByUsageChart.tsx
+++ b/ui/src/components/energy/EnergyByUsageChart.tsx
@@ -1,0 +1,212 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+import type { EnergyByUsageResponse } from "../../types";
+
+interface Props {
+  data: EnergyByUsageResponse;
+  period: string;
+  date?: string;
+  height?: number;
+}
+
+const OTHER_COLOR = "#94A3B8";
+const OTHER_KEY = "__other__";
+
+interface Series {
+  id: string;
+  name: string;
+  color: string;
+}
+
+interface Datum {
+  label: string;
+  tooltipLabel: string;
+  /** kWh per series id */
+  [key: string]: string | number;
+}
+
+function localDateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function capitalizeFirst(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function makeBuckets(period: string, dateStr?: string): { keyOf: (time: string) => string | null; buckets: { key: string; label: string; tooltipLabel: string }[] } {
+  if (period === "day") {
+    const buckets = Array.from({ length: 24 }, (_, hour) => ({
+      key: String(hour),
+      label: `${String(hour).padStart(2, "0")}h`,
+      tooltipLabel: `${String(hour).padStart(2, "0")}h00 – ${String((hour + 1) % 24).padStart(2, "0")}h00`,
+    }));
+    return {
+      keyOf: (time) => String(new Date(time).getHours()),
+      buckets,
+    };
+  }
+
+  if (period === "week") {
+    const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+    const dayOfWeek = ref.getDay();
+    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+    const monday = new Date(ref);
+    monday.setDate(monday.getDate() + mondayOffset);
+    const buckets = Array.from({ length: 7 }, (_, i) => {
+      const day = new Date(monday);
+      day.setDate(day.getDate() + i);
+      return {
+        key: localDateKey(day),
+        label: capitalizeFirst(day.toLocaleDateString("fr-FR", { weekday: "short", day: "numeric" })),
+        tooltipLabel: capitalizeFirst(day.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long", year: "numeric" })),
+      };
+    });
+    return { keyOf: (time) => localDateKey(new Date(time)), buckets };
+  }
+
+  if (period === "month") {
+    const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+    const year = ref.getFullYear();
+    const month = ref.getMonth();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const buckets = Array.from({ length: daysInMonth }, (_, i) => {
+      const day = new Date(year, month, i + 1);
+      return {
+        key: localDateKey(day),
+        label: String(i + 1),
+        tooltipLabel: capitalizeFirst(day.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long", year: "numeric" })),
+      };
+    });
+    return { keyOf: (time) => localDateKey(new Date(time)), buckets };
+  }
+
+  // year
+  const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+  const year = ref.getFullYear();
+  const buckets = Array.from({ length: 12 }, (_, i) => {
+    const d = new Date(year, i, 1);
+    return {
+      key: String(i),
+      label: capitalizeFirst(d.toLocaleDateString("fr-FR", { month: "short" })),
+      tooltipLabel: capitalizeFirst(d.toLocaleDateString("fr-FR", { month: "long", year: "numeric" })),
+    };
+  });
+  return { keyOf: (time) => String(new Date(time).getMonth()), buckets };
+}
+
+function buildChart(data: EnergyByUsageResponse, period: string, dateStr?: string): {
+  data: Datum[];
+  series: Series[];
+} {
+  const { keyOf, buckets } = makeBuckets(period, dateStr);
+
+  const otherKey = OTHER_KEY;
+  const series: Series[] = [
+    ...data.submeters.map((s) => ({ id: s.id, name: s.name, color: s.color })),
+    { id: otherKey, name: "Other", color: OTHER_COLOR },
+  ];
+
+  // Initialize all bars to zero for every series so missing data renders as gaps.
+  const datums: Datum[] = buckets.map((b) => {
+    const d: Datum = { label: b.label, tooltipLabel: b.tooltipLabel };
+    for (const s of series) d[s.id] = 0;
+    return d;
+  });
+  const indexByKey = new Map(buckets.map((b, i) => [b.key, i]));
+
+  for (const sm of data.submeters) {
+    for (const p of sm.points) {
+      const k = keyOf(p.time);
+      if (k === null) continue;
+      const idx = indexByKey.get(k);
+      if (idx === undefined) continue;
+      datums[idx][sm.id] = (datums[idx][sm.id] as number) + p.wh / 1000;
+    }
+  }
+  for (const p of data.other.points) {
+    const k = keyOf(p.time);
+    if (k === null) continue;
+    const idx = indexByKey.get(k);
+    if (idx === undefined) continue;
+    datums[idx][otherKey] = (datums[idx][otherKey] as number) + p.wh / 1000;
+  }
+
+  return { data: datums, series };
+}
+
+function formatKWh(kwh: number): string {
+  if (kwh >= 1) return `${kwh.toFixed(2)} kWh`;
+  if (kwh > 0) return `${Math.round(kwh * 1000)} Wh`;
+  return "0 Wh";
+}
+
+function formatYAxis(kwh: number): string {
+  if (kwh >= 100) return `${Math.round(kwh)} kWh`;
+  if (kwh >= 1) return `${kwh.toFixed(1)} kWh`;
+  if (kwh === 0) return "0";
+  return `${kwh.toFixed(2)} kWh`;
+}
+
+export function EnergyByUsageChart({ data, period, date, height = 300 }: Props) {
+  const { t } = useTranslation();
+  const { data: rows, series } = useMemo(() => buildChart(data, period, date), [data, period, date]);
+
+  // Re-label "Other" using i18n (we only know the t() at render time)
+  const seriesWithI18n = useMemo(() => {
+    return series.map((s) => (s.id === OTHER_KEY ? { ...s, name: t("energy.byUsage.other") } : s));
+  }, [series, t]);
+
+  return (
+    <div style={{ width: "100%", height }}>
+      <ResponsiveContainer>
+        <BarChart data={rows} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border)" />
+          <XAxis dataKey="label" tick={{ fill: "var(--text-secondary)", fontSize: 11 }} />
+          <YAxis tickFormatter={formatYAxis} tick={{ fill: "var(--text-secondary)", fontSize: 11 }} />
+          <Tooltip
+            cursor={{ fill: "rgba(0,0,0,0.03)" }}
+            content={({ active, payload, label }) => {
+              if (!active || !payload || payload.length === 0) return null;
+              const datum = payload[0].payload as Datum;
+              const total = seriesWithI18n.reduce((acc, s) => acc + (datum[s.id] as number), 0);
+              return (
+                <div className="bg-surface border border-border rounded-[6px] p-3 text-[12px] shadow-lg">
+                  <div className="font-semibold text-text mb-1">{datum.tooltipLabel ?? label}</div>
+                  {seriesWithI18n.map((s) => {
+                    const v = datum[s.id] as number;
+                    if (v <= 0) return null;
+                    return (
+                      <div key={s.id} className="flex items-center gap-2 text-text-secondary">
+                        <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: s.color }} />
+                        <span>{s.name}</span>
+                        <span className="ml-auto tabular-nums">{formatKWh(v)}</span>
+                      </div>
+                    );
+                  })}
+                  {total > 0 && (
+                    <div className="mt-1 pt-1 border-t border-border flex items-center text-text">
+                      <span className="font-semibold">Total</span>
+                      <span className="ml-auto tabular-nums font-semibold">{formatKWh(total)}</span>
+                    </div>
+                  )}
+                </div>
+              );
+            }}
+          />
+          {seriesWithI18n.map((s) => (
+            <Bar key={s.id} dataKey={s.id} stackId="usage" fill={s.color} name={s.name} radius={[0, 0, 0, 0]} />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/ui/src/components/energy/EnergyPage.tsx
+++ b/ui/src/components/energy/EnergyPage.tsx
@@ -1,9 +1,12 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useEnergy } from "../../store/useEnergy";
 import { PeriodSelector } from "./PeriodSelector";
 import { EnergyBarChart } from "./EnergyBarChart";
+import { EnergyByUsageChart } from "./EnergyByUsageChart";
 import { EnergyMobileNav } from "./EnergyMobileNav";
+import { getEnergyByUsage, getEquipments } from "../../api";
+import type { EnergyByUsageResponse } from "../../types";
 
 function formatKWh(wh: number, period: string): string {
   const kwh = wh / 1000;
@@ -12,6 +15,9 @@ function formatKWh(wh: number, period: string): string {
 }
 
 const AUTOCONSO_COLOR = "#6BCB77";
+
+type ViewMode = "total" | "by-usage";
+
 export function EnergyPage() {
   const { t } = useTranslation();
   const history = useEnergy((s) => s.history);
@@ -21,9 +27,50 @@ export function EnergyPage() {
   const hasProduction = useEnergy((s) => s.hasProduction);
   const fetchHistory = useEnergy((s) => s.fetchHistory);
 
+  const [viewMode, setViewMode] = useState<ViewMode>("total");
+  const [hasSubmeters, setHasSubmeters] = useState(false);
+  const [byUsage, setByUsage] = useState<EnergyByUsageResponse | null>(null);
+  const [byUsageLoading, setByUsageLoading] = useState(false);
+
   useEffect(() => {
     fetchHistory();
   }, [fetchHistory]);
+
+  // Detect whether at least one submeter is configured.
+  useEffect(() => {
+    let cancelled = false;
+    getEquipments()
+      .then((list) => {
+        if (cancelled) return;
+        setHasSubmeters(list.some((e) => e.type === "energy_meter" && e.enabled));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Fetch by-usage data only when in by-usage mode.
+  useEffect(() => {
+    if (viewMode !== "by-usage") return;
+    let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setByUsageLoading(true);
+    getEnergyByUsage(period, date)
+      .then((res) => {
+        if (cancelled) return;
+        setByUsage(res);
+      })
+      .catch(() => {
+        if (!cancelled) setByUsage(null);
+      })
+      .finally(() => {
+        if (!cancelled) setByUsageLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [viewMode, period, date]);
 
   const hasHpHc = history ? history.totals.total_hc > 0 : false;
 
@@ -47,15 +94,58 @@ export function EnergyPage() {
         <>
           {/* Consumption chart */}
           <div className="bg-surface border border-border rounded-[10px] p-4 sm:p-6">
-            <EnergyBarChart
-              points={history?.points ?? []}
-              period={period}
-              date={date}
-              height={350}
-            />
+            {hasSubmeters && (
+              <div className="flex justify-end mb-3">
+                <div className="inline-flex border border-border rounded-[6px] overflow-hidden text-[12px]">
+                  <button
+                    type="button"
+                    onClick={() => setViewMode("total")}
+                    className={
+                      viewMode === "total"
+                        ? "px-3 py-1 bg-primary text-white"
+                        : "px-3 py-1 text-text-secondary hover:bg-bg"
+                    }
+                  >
+                    {t("energy.viewMode.total")}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setViewMode("by-usage")}
+                    className={
+                      viewMode === "by-usage"
+                        ? "px-3 py-1 bg-primary text-white"
+                        : "px-3 py-1 text-text-secondary hover:bg-bg"
+                    }
+                  >
+                    {t("energy.viewMode.byUsage")}
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {viewMode === "by-usage" ? (
+              byUsageLoading && !byUsage ? (
+                <div className="flex items-center justify-center h-[350px] text-text-tertiary text-[13px]">
+                  {t("common.loading")}
+                </div>
+              ) : byUsage ? (
+                <EnergyByUsageChart data={byUsage} period={period} date={date} height={350} />
+              ) : (
+                <div className="flex items-center justify-center h-[350px] text-text-tertiary text-[13px]">
+                  —
+                </div>
+              )
+            ) : (
+              <EnergyBarChart
+                points={history?.points ?? []}
+                period={period}
+                date={date}
+                height={350}
+              />
+            )}
 
             {/* Legend below chart */}
-            {history && (
+            {history && viewMode === "total" && (
               <div className="flex flex-col items-center mt-3 gap-1">
                 <div className="flex items-center gap-4 text-[13px] text-text-secondary flex-wrap justify-center">
                   <span className="flex items-center gap-1.5">

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -17,7 +17,7 @@ const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> 
   weather: ["temperature", "humidity", "pressure", "wind", "rain", "noise"],
   gate: ["generic", "contact_door"],
   heater: ["generic", "light_state"],
-  energy_meter: ["energy"],
+  energy_meter: ["energy", "power"],
   main_energy_meter: ["energy"],
   energy_production_meter: ["energy", "power"],
   // Polytropic PAC matches via pool_water_temperature; Sonoff filtration relay

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -916,6 +916,9 @@
   "energy.autoconsumption": "Self-consumption",
   "energy.gridInjection": "Grid injection",
   "energy.gridConsumption": "Grid",
+  "energy.viewMode.total": "Total",
+  "energy.viewMode.byUsage": "By usage",
+  "energy.byUsage.other": "Other",
 
   "tariff.title": "Energy tariffs",
   "tariff.priceHp": "Peak price (€/kWh)",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -916,6 +916,9 @@
   "energy.autoconsumption": "Autoconsommation",
   "energy.gridInjection": "Injection réseau",
   "energy.gridConsumption": "Réseau",
+  "energy.viewMode.total": "Total",
+  "energy.viewMode.byUsage": "Par usage",
+  "energy.byUsage.other": "Autre",
 
   "tariff.title": "Tarifs énergie",
   "tariff.priceHp": "Prix HP (€/kWh)",

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -354,7 +354,9 @@ export function EquipmentDetailPage() {
       ) : null}
 
       {/* Energy cumuls */}
-      {(equipment.type === "main_energy_meter" || equipment.type === "energy_production_meter") && equipment.computedData && (
+      {(equipment.type === "main_energy_meter" ||
+        equipment.type === "energy_production_meter" ||
+        equipment.type === "energy_meter") && equipment.computedData && (
         <EnergyDataPanel computedData={equipment.computedData} />
       )}
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -810,6 +810,32 @@ export interface EnergyStatus {
   tariffConfigured: boolean;
 }
 
+export interface EnergyByUsagePoint {
+  time: string;
+  wh: number;
+}
+
+export interface SubmeterSeries {
+  id: string;
+  name: string;
+  color: string;
+  points: EnergyByUsagePoint[];
+}
+
+export interface EnergyByUsageResponse {
+  period: string;
+  from: string;
+  to: string;
+  resolution: "5min" | "1h" | "1d";
+  submeters: SubmeterSeries[];
+  other: { points: EnergyByUsagePoint[] };
+  totals: {
+    byEquipment: Record<string, number>;
+    other: number;
+    total: number;
+  };
+}
+
 export interface TariffSlot {
   start: string;
   end: string;


### PR DESCRIPTION
## Summary

Implements [spec 091](specs/091-energy-submeters-by-usage/spec.md): zigbee energy clamps that report only instantaneous power (Legrand GEM, etc.) can now be bound as \`energy_meter\` sub-meters. Sowel integrates W → Wh and writes per-minute deltas attributed to the submeter equipment, picked up unchanged by the existing energy buckets and downsampling tasks. A new toggle on the Energy page swaps the existing chart for a stacked by-usage breakdown (one stack per submeter + "Other" residual).

## Changes

- Migration \`009_submeter_integrator_state.sql\` — per-submeter integration state (pending Wh + last sample).
- \`PowerSubmeterIntegrator\` — trapezoidal W → Wh, 1-min flush to InfluxDB, stale guard (>10min sample gap = freeze), abs-clamp on negative power, persists across restart.
- DeviceSelector now lists devices with \`category=power\` for \`energy_meter\` (was \`energy\` only).
- \`GET /api/v1/energy/by-usage?period=&date=\` returns per-submeter Wh time series + "Other" residual aligned to the existing energy buckets.
- New \`EnergyByUsageChart\` component (stacked bars, deterministic palette).
- Toggle on the Energy page (hidden when no submeter is configured).
- Types mirrored backend ↔ UI; FR + EN i18n keys.

Spec written end-to-end before implementation; see \`specs/091-energy-submeters-by-usage/\`.

## Test plan

- [x] \`npx tsc --noEmit\` (backend) — clean
- [x] \`cd ui && npx tsc -b --noEmit\` — clean
- [x] \`npx vitest run\` — 427 passed (8 new tests for the integrator: first sample, trapezoidal, negative, stale, restart, no-op flush, ignored non-submeter)
- [x] \`npx eslint\` backend + ui — zero new errors
- [ ] Manual after deploy: bind Legrand GEM PAC + POOL as submeters, watch /api/v1/energy/by-usage returns data after a few minutes, switch the toggle in the UI