### PR TITLE
feat(plugins): add state-trigger-light recipe (spec 092)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -222,6 +222,24 @@
     "sowelVersion": ">=0.10.0"
   },
   {
+    "id": "state-trigger-light",
+    "type": "recipe",
+    "name": "State-Triggered Light",
+    "description": "Turn lights on for a fixed duration when an equipment's state changes to a target value (e.g. gate → open at night)",
+    "icon": "Bell",
+    "author": "mchacher",
+    "repo": "mchacher/sowel-recipe-state-trigger-light",
+    "version": "0.1.0",
+    "tags": ["automation", "state", "trigger", "light"],
+    "i18n": {
+      "fr": {
+        "name": "Lumière sur changement d'état",
+        "description": "Allume des lumières pour une durée fixe quand l'état d'un équipement passe à une valeur cible (ex: portail ouvert la nuit)."
+      }
+    },
+    "sowelVersion": ">=1.5.7"
+  },
+  {
     "id": "motion-light-dimmable",
     "type": "recipe",
     "name": "Motion Light (Dimmable)",

--- a/specs/092-state-trigger-light-recipe/architecture.md
+++ b/specs/092-state-trigger-light-recipe/architecture.md
@@ -1,0 +1,160 @@
+# Architecture — Spec 092
+
+## Plugin shape
+
+External recipe plugin packaged as `sowel-recipe-state-trigger-light`.
+Mirrors the layout of `sowel-recipe-motion-light` (same RecipeContext
+shape, same TS-only single-file plugin, same GitHub Actions release).
+
+```
+sowel-recipe-state-trigger-light/
+├── src/index.ts            # plugin code (single file)
+├── package.json
+├── manifest.json
+├── tsconfig.json
+├── .gitignore
+└── .github/workflows/release.yml
+```
+
+## Manifest
+
+```json
+{
+  "id": "state-trigger-light",
+  "type": "recipe",
+  "name": "State-Triggered Light",
+  "description": "Turn lights on for a fixed duration when a watched equipment's state changes to a configured value (e.g. gate → open at night).",
+  "icon": "Bell",
+  "repo": "mchacher/sowel-recipe-state-trigger-light",
+  "author": "mchacher",
+  "sowelVersion": ">=1.5.7"
+}
+```
+
+`sowelVersion` is `>=1.5.7` because we rely on
+`zoneAggregator.getByZoneId(rootZoneId).isDaylight` and on the existing
+RecipeContext interface (no new APIs needed).
+
+## Slot definitions
+
+```ts
+[
+  { id: "zone", name: "Zone", type: "zone", required: true },
+  {
+    id: "trigger",
+    name: "Trigger equipment",
+    description: "Equipment whose state alias is watched",
+    type: "equipment",
+    required: true,
+    // The DeviceSelector / equipment picker doesn't natively filter by
+    // alias presence; the recipe form allows any equipment and we
+    // validate at instance-create time that the equipment exposes a
+    // `state` data binding. The picker UI may show a banner if not.
+  },
+  {
+    id: "stateValue",
+    name: "Target state value",
+    description:
+      "Recipe fires when the equipment's state changes to this value (e.g. 'open', 'ON', 'true')",
+    type: "text",
+    required: true,
+  },
+  {
+    id: "lights",
+    name: "Lights",
+    type: "equipment",
+    required: true,
+    list: true,
+    constraints: { equipmentType: "light_onoff" },
+  },
+  {
+    id: "duration",
+    name: "Duration",
+    description: "How long the lights stay on after a trigger",
+    type: "duration",
+    required: true,
+    defaultValue: "5m",
+  },
+  {
+    id: "nightOnly",
+    name: "Night only",
+    description: "Only fire when it's dark outside (uses sunrise/sunset)",
+    type: "boolean",
+    required: false,
+    defaultValue: true,
+  },
+];
+```
+
+## Event flow
+
+```
+equipment.data.changed (alias=state, equipmentId=trigger)
+  → if value === stateValue && previous !== value:
+      → if nightOnly && root.isDaylight === true: skip
+      → if any light already ON: skip (manual override)
+      → turnOnLights(lights)
+      → schedule offTimer = duration ms
+        → ctx.state.set("expiresAt", iso)
+
+equipment.data.changed (alias=state on a light, value=OFF, while timer running)
+  → external/manual off — cancelOffTimer + clear state
+
+offTimer fires
+  → turnOffLights(lights)
+  → ctx.state.delete("expiresAt")
+```
+
+## State persistence
+
+A single state key on the recipe instance: `expiresAt` (ISO 8601). On
+`createInstance`:
+
+1. Read `ctx.state.get("expiresAt")`.
+2. If present and in the future: arm `offTimer` for the remaining
+   duration. If lights are off (e.g. user turned them off while Sowel
+   was down), don't re-light them — just clear state.
+3. If present and in the past: fire the off action once
+   (`turnOffLights`), clear state.
+
+## Validate
+
+- `zone` exists.
+- `trigger` exists and exposes a `state` data binding (alias === "state").
+- `stateValue` is non-empty trimmed string.
+- `lights` is non-empty, all ids exist with type `light_onoff`.
+- `trigger` ∉ `lights` (no self-watching).
+- `duration` parses, is > 0.
+
+## i18n
+
+```ts
+i18n: {
+  fr: {
+    name: "Lumière sur changement d'état",
+    description: "Allume des lumières pour une durée fixe quand l'état d'un équipement change vers une valeur cible (ex: portail ouvert la nuit).",
+    slots: {
+      zone:        { name: "Zone", description: "Zone des lumières" },
+      trigger:     { name: "Équipement déclencheur", description: "Équipement dont l'état est surveillé (alias 'state')" },
+      stateValue:  { name: "Valeur cible", description: "La recette se déclenche quand l'état devient cette valeur (ex: 'open', 'ON')" },
+      lights:      { name: "Lumières", description: "Lumières à allumer" },
+      duration:    { name: "Durée", description: "Durée d'allumage après le déclenchement" },
+      nightOnly:   { name: "Seulement la nuit", description: "Ne se déclenche que si le soleil est couché" },
+    },
+  },
+}
+```
+
+## Files
+
+| Action | File                                                             |
+| ------ | ---------------------------------------------------------------- |
+| add    | `sowel-recipe-state-trigger-light/src/index.ts`                  |
+| add    | `sowel-recipe-state-trigger-light/package.json`                  |
+| add    | `sowel-recipe-state-trigger-light/manifest.json`                 |
+| add    | `sowel-recipe-state-trigger-light/tsconfig.json`                 |
+| add    | `sowel-recipe-state-trigger-light/.gitignore`                    |
+| add    | `sowel-recipe-state-trigger-light/.github/workflows/release.yml` |
+| edit   | `Sowel/plugins/registry.json` — add the plugin entry             |
+
+No changes to Sowel core.

--- a/specs/092-state-trigger-light-recipe/plan.md
+++ b/specs/092-state-trigger-light-recipe/plan.md
@@ -1,0 +1,65 @@
+# Plan — Spec 092
+
+## Implementation steps
+
+1. **Bootstrap repo**: copy structure from `sowel-recipe-motion-light` (package.json, tsconfig.json, .github/workflows/release.yml, .gitignore). Replace ids/names with `state-trigger-light`.
+
+2. **Manifest** (`manifest.json`).
+
+3. **Plugin code** (`src/index.ts`):
+   - Type imports for RecipeContext / RecipeDefinition (copied from existing plugins).
+   - `createRecipe()` that returns the slot definitions, i18n, validate, createInstance.
+   - `validate(params, ctx)`: see Architecture.
+   - `createInstance(params, ctx)`:
+     - Resolve params (zone, trigger, stateValue, lightIds, durationMs, nightOnly).
+     - Restore `expiresAt` from ctx.state if present.
+     - Subscribe to `equipment.data.changed` for the trigger equipment, alias=state.
+     - Subscribe to `equipment.data.changed` for each light (alias=state) to detect manual off.
+     - Implement turn-on / turn-off / arm-timer / cancel-timer / restore-from-state.
+     - Return `{ stop }`.
+
+4. **Tests** (vitest) — see Test Plan below.
+
+5. **Build** locally (`npm run build`) — check dist/ matches expected.
+
+6. **Initial release**:
+   - Create empty GitHub repo `mchacher/sowel-recipe-state-trigger-light`.
+   - Push `main`, tag `v0.1.0` — GitHub Actions builds tarball and creates release.
+
+7. **Add to registry**: bump `Sowel/plugins/registry.json` with the plugin entry.
+
+8. **Validate**: install via UI in dev → bind a gate or contact equipment → check trigger fires.
+
+## Test Plan
+
+### Modules to test
+
+- `state-trigger-light` plugin's `createInstance` behavior — tested at the recipe-instance level using the same Vitest harness as `sowel-recipe-motion-light` (mock RecipeContext: eventBus, equipmentManager, zoneAggregator, helpers, state).
+
+### Scenarios
+
+| Scenario                                                                                  | Expected                                           |
+| ----------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Trigger event with value=stateValue, previous=other, lights off, night                    | Lights ON, offTimer armed, ctx.state.expiresAt set |
+| Trigger event with value=stateValue, previous=stateValue (no change)                      | Nothing happens (filtered by `previous !== value`) |
+| Trigger event with value!=stateValue                                                      | Nothing happens                                    |
+| Trigger event, nightOnly=true, root.isDaylight=true                                       | Skipped                                            |
+| Trigger event, nightOnly=true, root.isDaylight=null                                       | Treated as night → fires                           |
+| Trigger event, nightOnly=false, daylight=true                                             | Fires                                              |
+| Trigger event while at least one light already ON                                         | Skipped (no timer armed)                           |
+| offTimer fires                                                                            | turnOffLights called, ctx.state.expiresAt cleared  |
+| Manual light off during timer (light goes from ON to OFF, not via the recipe's own order) | offTimer cancelled, ctx.state.expiresAt cleared    |
+| Restart with persisted expiresAt in the future                                            | offTimer armed for remainder                       |
+| Restart with persisted expiresAt in the past                                              | turnOffLights fired once, state cleared            |
+| Re-trigger during running timer                                                           | No-op (lights already on, timer untouched)         |
+| Validate: trigger ∈ lights                                                                | Throws                                             |
+| Validate: trigger has no `state` binding                                                  | Throws                                             |
+| Validate: stateValue empty                                                                | Throws                                             |
+| Validate: lights empty                                                                    | Throws                                             |
+
+## Out of scope
+
+- Brightness control (covered by future `state-trigger-light-dimmable`).
+- "From → to" transitions.
+- Daytime-only mode.
+- Multiple state aliases (only `state`).

--- a/specs/092-state-trigger-light-recipe/spec.md
+++ b/specs/092-state-trigger-light-recipe/spec.md
@@ -1,0 +1,106 @@
+# Spec 092 — State-triggered light recipe
+
+## Summary
+
+A new external recipe plugin `state-trigger-light` that turns lights on
+for a fixed duration when a watched equipment's `state` alias changes
+to a configured target value. Typical use cases: "turn on the driveway
+lights for 5 minutes when the gate opens at night", "turn on the
+hallway light when the garage door opens after sunset". Optionally
+restricted to nighttime only.
+
+## Why
+
+Today motion-based automation requires a PIR sensor. Many practical
+triggers in the home are not motion but **state transitions** of
+existing equipments — a gate opening, a garage door opening, a contact
+sensor closing. Sowel already aggregates day/night via the sunlight
+manager, and the gate/appliance/contact equipments expose `state`. A
+small recipe ties the two together without needing extra hardware.
+
+## Scope
+
+In:
+
+- New external plugin repo `sowel-recipe-state-trigger-light` distributed
+  via GitHub releases, registered in `plugins/registry.json`.
+- Recipe definition with the slots described below.
+- Subscribes to `equipment.data.changed` for the watched equipment.
+- Fires when `alias === "state"` AND `value === stateValue` AND
+  `previous !== value` (i.e. it's a transition into the target value,
+  not a stable repeat).
+- If `nightOnly` is on, checks `zone.aggregatedData.isDaylight` for the
+  root zone — skips when daytime.
+- If lights are already ON at the moment the trigger fires, the recipe
+  does **nothing** (manual override is respected).
+- Otherwise turns lights ON and arms a fixed timer; on timer expiry
+  turns them OFF.
+
+Out:
+
+- No "from → to" transitions — only the target value matters.
+  Entering the target value from any previous value triggers.
+- No timer extension on re-trigger. If the watched state re-enters the
+  target value while the timer is running, nothing happens (lights are
+  already on, timer keeps its original deadline).
+- No brightness control. State `ON` only — for dimmable use cases the
+  user can wire in `motion-light-dimmable` or wait for a future
+  `state-trigger-light-dimmable` variant.
+- No tariff/HP-HC awareness — irrelevant here.
+- No daytime-only or "any time" mode in v1 — just the nightOnly toggle.
+- No support for state aliases that are not `state` (e.g. firing on
+  `temperature` crossing a threshold). That's a separate "rule" feature.
+
+## Slots
+
+| id         | type        | required | default | constraint / notes                                                      |
+| ---------- | ----------- | -------- | ------- | ----------------------------------------------------------------------- |
+| zone       | zone        | yes      | —       | Where the lights live; the watched equipment can be in another zone     |
+| trigger    | equipment   | yes      | —       | Equipment whose `state` alias is watched. Filtered to those exposing it |
+| stateValue | text        | yes      | —       | Exact target value (e.g. `open`, `ON`, `true`, `closed`)                |
+| lights     | equipment[] | yes      | —       | Lights to turn on. Constraint: equipmentType `light_onoff`              |
+| duration   | duration    | yes      | "5m"    | How long the lights stay on after a trigger                             |
+| nightOnly  | boolean     | no       | true    | When true, only fire when daylight=false at the root zone               |
+
+## Acceptance criteria
+
+- [x] New repo `mchacher/sowel-recipe-state-trigger-light` with the same
+      build / release pattern as the other recipe plugins (tsc to dist,
+      GitHub Actions tarball, manifest.json, package.json).
+- [x] Plugin id `state-trigger-light`, type `recipe`.
+- [x] Equipment selector for `trigger` filtered to equipments exposing a
+      `state` data binding.
+- [x] On state-change event matching `stateValue`, light turns ON for
+      `duration`, then OFF.
+- [x] When `nightOnly` is on and daylight is true, the trigger event is
+      ignored.
+- [x] When the lights are already ON at trigger time, recipe leaves them
+      alone (no timer armed, no off later).
+- [x] When the lights are turned off externally during the timer, the
+      recipe cancels its pending off.
+- [x] State persisted across Sowel restart: a timer in flight at restart
+      resumes with its remaining duration if `expiresAt` is still in the
+      future, or fires immediately if past.
+- [x] Added to `plugins/registry.json`.
+- [x] Tests cover: trigger fires on transition, ignored when same value
+      repeats, ignored in daytime when nightOnly, ignored when lights
+      already on, timer fires off, restart resumes timer, manual off
+      cancels.
+
+## Edge cases
+
+- The watched equipment is offline: events stop arriving, the recipe
+  simply waits. If the timer is running, it continues normally.
+- The target stateValue does not match any value the equipment ever
+  reports (typo): the recipe never fires; logged at debug for dev
+  troubleshooting but no user-facing alarm.
+- The `trigger` equipment is the same as one of the `lights` (silly
+  config but possible): the recipe can't both watch and drive — we add
+  a validate() check that rejects this.
+- The lights array contains a non-existent equipment id: skipped at run
+  time, logged at warn.
+- Multiple state changes in rapid succession (e.g. gate flapping):
+  first change arms the timer, subsequent changes within the timer
+  window are no-ops.
+- Sunlight not configured (root zone has `isDaylight === null`): treat
+  as nighttime so the recipe still fires (better safe than silent).


### PR DESCRIPTION
## Summary

New external recipe plugin **state-trigger-light** ([repo](https://github.com/mchacher/sowel-recipe-state-trigger-light)) that turns lights on for a fixed duration when a watched equipment's state alias changes to a configured target value. Typical use: gate → open at night → driveway lights for 5 min.

Spec: [specs/092-state-trigger-light-recipe](specs/092-state-trigger-light-recipe/spec.md).

## Changes (this repo)

- Add the plugin to \`plugins/registry.json\` at v0.1.0, \`sowelVersion >= 1.5.7\`.
- No core code changes.

## Plugin (separate repo, already published)

- \`mchacher/sowel-recipe-state-trigger-light\` v0.1.0 tagged and released via GitHub Actions.
- Single-file TS recipe (\`src/index.ts\`), no Sowel API additions needed.
- 17 vitest tests covering trigger transitions, nightOnly, override (lights already on), manual-off detection, restart resume (future and past expiresAt), validate errors.

## Test plan

- [x] Plugin tests pass (17/17 in the plugin repo)
- [ ] Manual: install via UI → bind on a gate equipment with state value \`open\` and a light → open the gate at night → light turns on for 5 min, then off