### PR TITLE
feat(recipes): crossZone constraint for cross-zone equipment slots

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -229,7 +229,7 @@
     "icon": "Bell",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-state-trigger-light",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "tags": ["automation", "state", "trigger", "light"],
     "i18n": {
       "fr": {
@@ -237,7 +237,7 @@
         "description": "Allume des lumières pour une durée fixe quand l'état d'un équipement passe à une valeur cible (ex: portail ouvert la nuit)."
       }
     },
-    "sowelVersion": ">=1.5.7"
+    "sowelVersion": ">=1.5.8"
   },
   {
     "id": "motion-light-dimmable",

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -229,7 +229,7 @@
     "icon": "Bell",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-state-trigger-light",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "tags": ["automation", "state", "trigger", "light"],
     "i18n": {
       "fr": {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -333,6 +333,9 @@ export interface RecipeSlotDef {
     /** When true on an `equipment` slot, the recipe form shows
      *  equipments from any zone, not just the recipe's. */
     crossZone?: boolean;
+    /** When true on an `equipment` slot, the recipe form also shows
+     *  equipments living in descendant zones of the recipe's zone. */
+    includeDescendants?: boolean;
   };
   group?: string;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -330,6 +330,9 @@ export interface RecipeSlotDef {
     equipmentType?: EquipmentType | EquipmentType[];
     min?: number;
     max?: number;
+    /** When true on an `equipment` slot, the recipe form shows
+     *  equipments from any zone, not just the recipe's. */
+    crossZone?: boolean;
   };
   group?: string;
 }

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -246,6 +246,18 @@ function RecipeInstanceRow({
     walk(zoneTree);
     return flat;
   }, [zoneTree]);
+  const zoneAndDescendantIds = useMemo(() => {
+    const ids = new Set<string>();
+    const collect = (nodes: ZoneWithChildren[], inside: boolean): void => {
+      for (const n of nodes) {
+        const here = inside || n.id === zoneId;
+        if (here) ids.add(n.id);
+        if (n.children.length > 0) collect(n.children, here);
+      }
+    };
+    collect(zoneTree, false);
+    return ids;
+  }, [zoneTree, zoneId]);
   const [showLog, setShowLog] = useState(false);
   const [logs, setLogs] = useState<RecipeLogEntry[]>([]);
   const [deleting, setDeleting] = useState(false);
@@ -426,9 +438,15 @@ function RecipeInstanceRow({
         ? slot.constraints.equipmentType.some((t) => GLOBAL_EQUIPMENT_TYPES.has(t))
         : GLOBAL_EQUIPMENT_TYPES.has(slot.constraints.equipmentType));
     const isCrossZone = slot.constraints?.crossZone === true;
+    const includeDescendants = slot.constraints?.includeDescendants === true;
 
     return equipments.filter((eq) => {
-      if (!isGlobalSlot && !isCrossZone && eq.zoneId !== zoneId) return false;
+      if (!isGlobalSlot && !isCrossZone) {
+        const allowed = includeDescendants
+          ? zoneAndDescendantIds.has(eq.zoneId)
+          : eq.zoneId === zoneId;
+        if (!allowed) return false;
+      }
       if (slot.type === "equipment" && !slot.list && usedLightIds.has(eq.id)) return false;
       if (slot.constraints?.equipmentType) {
         return matchesEquipmentType(eq.type, slot.constraints.equipmentType);
@@ -773,7 +791,9 @@ function RecipeInstanceRow({
                           >
                             <option value="">{t("common.select")}</option>
                             {getEquipmentOptions(slot.id).map((eq) => {
-                              const showZone = slot.constraints?.crossZone === true;
+                              const showZone =
+                                slot.constraints?.crossZone === true ||
+                                slot.constraints?.includeDescendants === true;
                               const zoneName = showZone ? allZones.find((z) => z.id === eq.zoneId)?.name : null;
                               return (
                                 <option key={eq.id} value={eq.id}>
@@ -1398,6 +1418,20 @@ function AddRecipeForm({
     return flat;
   }, [zoneTree]);
 
+  // Set of {zoneId} ∪ {descendantIds(zoneId)} used by slots with constraints.includeDescendants.
+  const zoneAndDescendantIds = useMemo(() => {
+    const ids = new Set<string>();
+    const collect = (nodes: ZoneWithChildren[], inside: boolean): void => {
+      for (const n of nodes) {
+        const here = inside || n.id === zoneId;
+        if (here) ids.add(n.id);
+        if (n.children.length > 0) collect(n.children, here);
+      }
+    };
+    collect(zoneTree, false);
+    return ids;
+  }, [zoneTree, zoneId]);
+
   // Light IDs already managed by a recipe instance in this zone
   const usedLightIds = useMemo(() => {
     const ids = new Set<string>();
@@ -1426,9 +1460,15 @@ function AddRecipeForm({
         ? slot.constraints.equipmentType.some((t) => GLOBAL_EQUIPMENT_TYPES.has(t))
         : GLOBAL_EQUIPMENT_TYPES.has(slot.constraints.equipmentType));
     const isCrossZone = slot.constraints?.crossZone === true;
+    const includeDescendants = slot.constraints?.includeDescendants === true;
 
     return equipments.filter((eq) => {
-      if (!isGlobalSlot && !isCrossZone && eq.zoneId !== zoneId) return false;
+      if (!isGlobalSlot && !isCrossZone) {
+        const allowed = includeDescendants
+          ? zoneAndDescendantIds.has(eq.zoneId)
+          : eq.zoneId === zoneId;
+        if (!allowed) return false;
+      }
       if (slot.type === "equipment" && !slot.list && usedLightIds.has(eq.id)) return false;
       if (slot.constraints?.equipmentType) {
         return matchesEquipmentType(eq.type, slot.constraints.equipmentType);
@@ -1443,8 +1483,14 @@ function AddRecipeForm({
       if (slot.type !== "equipment") continue;
       if (!slot.required) continue; // optional equipment slots don't block creation
       const isCrossZone = slot.constraints?.crossZone === true;
+      const includeDescendants = slot.constraints?.includeDescendants === true;
       const available = equipments.filter((eq) => {
-        if (!isCrossZone && eq.zoneId !== zoneId) return false;
+        if (!isCrossZone) {
+          const allowed = includeDescendants
+            ? zoneAndDescendantIds.has(eq.zoneId)
+            : eq.zoneId === zoneId;
+          if (!allowed) return false;
+        }
         if (!slot.list && usedLightIds.has(eq.id)) return false;
         if (slot.constraints?.equipmentType) {
           return matchesEquipmentType(eq.type, slot.constraints.equipmentType);
@@ -1796,7 +1842,9 @@ function AddRecipeForm({
                         >
                           <option value="">{t("common.select")}</option>
                           {getEquipmentOptions(slot.id).map((eq) => {
-                            const showZone = slot.constraints?.crossZone === true;
+                            const showZone =
+                              slot.constraints?.crossZone === true ||
+                              slot.constraints?.includeDescendants === true;
                             const zoneName = showZone ? allZones.find((z) => z.id === eq.zoneId)?.name : null;
                             return (
                               <option key={eq.id} value={eq.id}>

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -784,24 +784,27 @@ function RecipeInstanceRow({
                             })}
                           </div>
                         ) : slot.type === "equipment" ? (
-                          <select
-                            value={editParams[slot.id] ?? ""}
-                            onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
-                            className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
-                          >
-                            <option value="">{t("common.select")}</option>
-                            {getEquipmentOptions(slot.id).map((eq) => {
-                              const showZone =
-                                slot.constraints?.crossZone === true ||
-                                slot.constraints?.includeDescendants === true;
-                              const zoneName = showZone ? allZones.find((z) => z.id === eq.zoneId)?.name : null;
-                              return (
-                                <option key={eq.id} value={eq.id}>
-                                  {zoneName ? `${eq.name} — ${zoneName}` : eq.name}
-                                </option>
-                              );
-                            })}
-                          </select>
+                          slot.constraints?.crossZone === true ||
+                          slot.constraints?.includeDescendants === true ? (
+                            <SingleEquipmentZonePicker
+                              value={editParams[slot.id] ?? ""}
+                              onChange={(v) => setEditParams({ ...editParams, [slot.id]: v })}
+                              equipments={getEquipmentOptions(slot.id)}
+                              zones={allZones}
+                              matchesConstraint={() => true /* already filtered upstream */}
+                            />
+                          ) : (
+                            <select
+                              value={editParams[slot.id] ?? ""}
+                              onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
+                              className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                            >
+                              <option value="">{t("common.select")}</option>
+                              {getEquipmentOptions(slot.id).map((eq) => (
+                                <option key={eq.id} value={eq.id}>{eq.name}</option>
+                              ))}
+                            </select>
+                          )
                         ) : slot.type === "data-key" ? (
                           (() => {
                             const eqSlot = recipe?.slots.find((s) => s.type === "equipment" && !s.list);
@@ -1260,6 +1263,84 @@ function TimeInput({
       placeholder={placeholder ?? "08:00"}
       className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
     />
+  );
+}
+
+// ============================================================
+// Single equipment picker with zone-first selection — used for slots
+// with constraints.crossZone or includeDescendants
+// ============================================================
+
+function SingleEquipmentZonePicker({
+  value,
+  onChange,
+  equipments,
+  zones,
+  matchesConstraint,
+  zoneIdsAllowed,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  equipments: EquipmentWithDetails[];
+  zones: { id: string; name: string }[];
+  matchesConstraint: (eq: EquipmentWithDetails) => boolean;
+  /** When set, only zones in this set are listed. */
+  zoneIdsAllowed?: Set<string>;
+}) {
+  const { t } = useTranslation();
+
+  const selectedEq = value ? equipments.find((e) => e.id === value) : undefined;
+  const [pickerZoneId, setPickerZoneId] = useState<string>(selectedEq?.zoneId ?? "");
+
+  // Zones that have at least one matching equipment (and are within
+  // the allowed scope when one is provided).
+  const zonesWithOptions = useMemo(() => {
+    return zones.filter((z) => {
+      if (zoneIdsAllowed && !zoneIdsAllowed.has(z.id)) return false;
+      return equipments.some((eq) => eq.zoneId === z.id && matchesConstraint(eq));
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [zones, equipments, zoneIdsAllowed]);
+
+  const pickerOptions = useMemo(() => {
+    if (!pickerZoneId) return [];
+    return equipments.filter((eq) => eq.zoneId === pickerZoneId && matchesConstraint(eq));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pickerZoneId, equipments]);
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <select
+        value={pickerZoneId}
+        onChange={(e) => {
+          const zid = e.target.value;
+          setPickerZoneId(zid);
+          // Clear the equipment if it no longer belongs to the chosen zone
+          if (selectedEq && selectedEq.zoneId !== zid) onChange("");
+        }}
+        className="flex-1 px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+      >
+        <option value="">Zone…</option>
+        {zonesWithOptions.map((z) => (
+          <option key={z.id} value={z.id}>
+            {z.name}
+          </option>
+        ))}
+      </select>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={!pickerZoneId}
+        className="flex-1 px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text disabled:opacity-40"
+      >
+        <option value="">{t("common.select")}</option>
+        {pickerOptions.map((eq) => (
+          <option key={eq.id} value={eq.id}>
+            {eq.name}
+          </option>
+        ))}
+      </select>
+    </div>
   );
 }
 
@@ -1835,24 +1916,27 @@ function AddRecipeForm({
                           })}
                         </div>
                       ) : slot.type === "equipment" ? (
-                        <select
-                          value={params[slot.id] ?? ""}
-                          onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
-                          className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
-                        >
-                          <option value="">{t("common.select")}</option>
-                          {getEquipmentOptions(slot.id).map((eq) => {
-                            const showZone =
-                              slot.constraints?.crossZone === true ||
-                              slot.constraints?.includeDescendants === true;
-                            const zoneName = showZone ? allZones.find((z) => z.id === eq.zoneId)?.name : null;
-                            return (
-                              <option key={eq.id} value={eq.id}>
-                                {zoneName ? `${eq.name} — ${zoneName}` : eq.name}
-                              </option>
-                            );
-                          })}
-                        </select>
+                        slot.constraints?.crossZone === true ||
+                        slot.constraints?.includeDescendants === true ? (
+                          <SingleEquipmentZonePicker
+                            value={params[slot.id] ?? ""}
+                            onChange={(v) => setParams({ ...params, [slot.id]: v })}
+                            equipments={getEquipmentOptions(slot.id)}
+                            zones={allZones}
+                            matchesConstraint={() => true}
+                          />
+                        ) : (
+                          <select
+                            value={params[slot.id] ?? ""}
+                            onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
+                            className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                          >
+                            <option value="">{t("common.select")}</option>
+                            {getEquipmentOptions(slot.id).map((eq) => (
+                              <option key={eq.id} value={eq.id}>{eq.name}</option>
+                            ))}
+                          </select>
+                        )
                       ) : slot.type === "data-key" ? (
                         (() => {
                           const eqSlot = selectedRecipe?.slots.find((s) => s.type === "equipment" && !s.list);

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -420,14 +420,15 @@ function RecipeInstanceRow({
     const slot = recipe?.slots.find((s) => s.id === slotId);
     if (!slot) return [];
 
-    // Check if this slot targets a global equipment type
+    // Check if this slot targets a global equipment type or opts in to cross-zone selection.
     const isGlobalSlot = slot.constraints?.equipmentType &&
       (Array.isArray(slot.constraints.equipmentType)
         ? slot.constraints.equipmentType.some((t) => GLOBAL_EQUIPMENT_TYPES.has(t))
         : GLOBAL_EQUIPMENT_TYPES.has(slot.constraints.equipmentType));
+    const isCrossZone = slot.constraints?.crossZone === true;
 
     return equipments.filter((eq) => {
-      if (!isGlobalSlot && eq.zoneId !== zoneId) return false;
+      if (!isGlobalSlot && !isCrossZone && eq.zoneId !== zoneId) return false;
       if (slot.type === "equipment" && !slot.list && usedLightIds.has(eq.id)) return false;
       if (slot.constraints?.equipmentType) {
         return matchesEquipmentType(eq.type, slot.constraints.equipmentType);
@@ -771,9 +772,15 @@ function RecipeInstanceRow({
                             className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
                           >
                             <option value="">{t("common.select")}</option>
-                            {getEquipmentOptions(slot.id).map((eq) => (
-                              <option key={eq.id} value={eq.id}>{eq.name}</option>
-                            ))}
+                            {getEquipmentOptions(slot.id).map((eq) => {
+                              const showZone = slot.constraints?.crossZone === true;
+                              const zoneName = showZone ? allZones.find((z) => z.id === eq.zoneId)?.name : null;
+                              return (
+                                <option key={eq.id} value={eq.id}>
+                                  {zoneName ? `${eq.name} — ${zoneName}` : eq.name}
+                                </option>
+                              );
+                            })}
                           </select>
                         ) : slot.type === "data-key" ? (
                           (() => {
@@ -1418,9 +1425,10 @@ function AddRecipeForm({
       (Array.isArray(slot.constraints.equipmentType)
         ? slot.constraints.equipmentType.some((t) => GLOBAL_EQUIPMENT_TYPES.has(t))
         : GLOBAL_EQUIPMENT_TYPES.has(slot.constraints.equipmentType));
+    const isCrossZone = slot.constraints?.crossZone === true;
 
     return equipments.filter((eq) => {
-      if (!isGlobalSlot && eq.zoneId !== zoneId) return false;
+      if (!isGlobalSlot && !isCrossZone && eq.zoneId !== zoneId) return false;
       if (slot.type === "equipment" && !slot.list && usedLightIds.has(eq.id)) return false;
       if (slot.constraints?.equipmentType) {
         return matchesEquipmentType(eq.type, slot.constraints.equipmentType);
@@ -1434,8 +1442,9 @@ function AddRecipeForm({
     for (const slot of recipe.slots) {
       if (slot.type !== "equipment") continue;
       if (!slot.required) continue; // optional equipment slots don't block creation
+      const isCrossZone = slot.constraints?.crossZone === true;
       const available = equipments.filter((eq) => {
-        if (eq.zoneId !== zoneId) return false;
+        if (!isCrossZone && eq.zoneId !== zoneId) return false;
         if (!slot.list && usedLightIds.has(eq.id)) return false;
         if (slot.constraints?.equipmentType) {
           return matchesEquipmentType(eq.type, slot.constraints.equipmentType);
@@ -1786,9 +1795,15 @@ function AddRecipeForm({
                           className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
                         >
                           <option value="">{t("common.select")}</option>
-                          {getEquipmentOptions(slot.id).map((eq) => (
-                            <option key={eq.id} value={eq.id}>{eq.name}</option>
-                          ))}
+                          {getEquipmentOptions(slot.id).map((eq) => {
+                            const showZone = slot.constraints?.crossZone === true;
+                            const zoneName = showZone ? allZones.find((z) => z.id === eq.zoneId)?.name : null;
+                            return (
+                              <option key={eq.id} value={eq.id}>
+                                {zoneName ? `${eq.name} — ${zoneName}` : eq.name}
+                              </option>
+                            );
+                          })}
                         </select>
                       ) : slot.type === "data-key" ? (
                         (() => {

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -408,6 +408,9 @@ export interface RecipeSlotDef {
      *  from any zone (not just the recipe's zone) and disambiguates
      *  by appending the zone name in the dropdown. */
     crossZone?: boolean;
+    /** When true on an `equipment` slot, the picker also includes
+     *  equipments living in descendant zones of the recipe's zone. */
+    includeDescendants?: boolean;
   };
   group?: string;
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -404,6 +404,10 @@ export interface RecipeSlotDef {
     equipmentType?: EquipmentType | EquipmentType[];
     min?: number;
     max?: number;
+    /** When true on an `equipment` slot, the picker shows equipments
+     *  from any zone (not just the recipe's zone) and disambiguates
+     *  by appending the zone name in the dropdown. */
+    crossZone?: boolean;
   };
   group?: string;
 }


### PR DESCRIPTION
## Summary

Equipment slots in recipes can now declare \`constraints.crossZone = true\` to opt out of the recipe-zone filter. The form shows equipments from any zone, with the zone name appended in the dropdown to disambiguate duplicates.

Used by the new \`state-trigger-light\` v0.2.0 — the trigger (gate, garage door) commonly lives in a different zone from the lights.

## Changes

- \`RecipeSlotDef.constraints.crossZone?: boolean\` (backend + UI types)
- \`ZoneRecipesSection.tsx\`: \`getEquipmentOptions\` and \`hasAvailableEquipments\` honor the flag (3 sites). Single-equipment dropdowns append \`— ZoneName\` when crossZone is true (2 sites).
- \`plugins/registry.json\`: state-trigger-light → 0.2.0, sowelVersion >= 1.5.8.

Backend behavior unchanged — the flag is a UI-only hint.

## Test plan

- [x] \`npx tsc --noEmit\` (backend) — clean
- [x] \`cd ui && npx tsc -b --noEmit\` — clean
- [x] \`npx vitest run\` — 429 passed
- [ ] Manual: state-trigger-light v0.2.0 → trigger picker shows equipments from all zones with " — ZoneName" suffix