### PR TITLE
fix(energy): pastel palette + rounded bars on by-usage chart

### DIFF
--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -708,19 +708,18 @@ async function queryMainConsumptionPoints(
   return points;
 }
 
-/** Deterministic vivid palette for submeter colors. Aligned with the
- *  Sowel design system (primary, accent, active) plus the in-chart
- *  conventions already used by the consumption chart (HP/HC blues,
- *  autoconso green). Picked for distinct, lively bars. */
+/** Deterministic pastel palette for submeter colors. Medium saturation,
+ *  modern dashboard feel — readable on light background, comfortable
+ *  next to the brighter HP/HC/autoconso bars of the total chart. */
 const SUBMETER_PALETTE = [
-  "#4F7BE8", // vivid blue (matches HP_COLOR in EnergyBarChart)
-  "#D4963F", // amber — design system accent
-  "#6BCB77", // green (matches AUTOCONSO_COLOR)
-  "#E15A5A", // coral
-  "#9C7DD9", // violet
-  "#4FBDD0", // bright teal
-  "#E89A4F", // orange
-  "#FACC15", // yellow — design system active
+  "#60A5FA", // soft blue
+  "#34D399", // emerald
+  "#F87171", // soft red
+  "#A78BFA", // lavender
+  "#22D3EE", // cyan
+  "#FB7185", // coral pink
+  "#FBBF24", // soft amber
+  "#818CF8", // pale indigo
 ];
 
 function pickPaletteColor(index: number): string {

--- a/ui/src/components/energy/EnergyByUsageChart.tsx
+++ b/ui/src/components/energy/EnergyByUsageChart.tsx
@@ -18,8 +18,27 @@ interface Props {
   height?: number;
 }
 
-const OTHER_COLOR = "#94A3B8";
+const OTHER_COLOR = "#CBD5E1";
 const OTHER_KEY = "__other__";
+
+/** SVG path for a rectangle with only top corners rounded — same helper
+ *  as EnergyBarChart so the topmost segment of a stack matches the
+ *  rounded look of the total view. */
+function roundedTopRect(x: number, y: number, w: number, h: number, r: number): string {
+  const radius = Math.min(r, h, w / 2);
+  return `M${x},${y + h} L${x},${y + radius} Q${x},${y} ${x + radius},${y} L${x + w - radius},${y} Q${x + w},${y} ${x + w},${y + radius} L${x + w},${y + h}Z`;
+}
+
+/** Returns the id of the topmost non-zero series in a datum's stack.
+ *  Series array is rendered bottom→top, so the topmost is the LAST
+ *  entry with value > 0. */
+function topmostSeriesIdInStack(datum: Datum, series: Series[]): string | null {
+  for (let i = series.length - 1; i >= 0; i--) {
+    const v = datum[series[i].id];
+    if (typeof v === "number" && v > 0) return series[i].id;
+  }
+  return null;
+}
 
 interface Series {
   id: string;
@@ -203,7 +222,20 @@ export function EnergyByUsageChart({ data, period, date, height = 300 }: Props) 
             }}
           />
           {seriesWithI18n.map((s) => (
-            <Bar key={s.id} dataKey={s.id} stackId="usage" fill={s.color} name={s.name} radius={[0, 0, 0, 0]} />
+            <Bar
+              key={s.id}
+              dataKey={s.id}
+              stackId="usage"
+              fill={s.color}
+              name={s.name}
+              shape={(props: { x?: number; y?: number; width?: number; height?: number; payload?: Datum }) => {
+                const { x = 0, y = 0, width: w = 0, height: h = 0, payload } = props;
+                if (h <= 0) return <g />;
+                const isTop = payload ? topmostSeriesIdInStack(payload, seriesWithI18n) === s.id : false;
+                if (isTop) return <path d={roundedTopRect(x, y, w, h, 4)} fill={s.color} />;
+                return <rect x={x} y={y} width={w} height={h} fill={s.color} />;
+              }}
+            />
           ))}
         </BarChart>
       </ResponsiveContainer>


### PR DESCRIPTION
## Summary

Two visual fixes for the **Consumption > By usage** chart:

- **Rounded top corners** on the topmost non-zero stacked segment, matching the look of the total-view chart (`roundedTopRect` helper, same as `EnergyBarChart.tsx`). Previously every segment was a flat rect, which felt inconsistent.
- **Pastel palette** replacing the previous vivid one. The amber `#D4963F` was particularly harsh ("triste/moche" per user feedback) and the gray `#94A3B8` "Other" felt sad. New palette: medium saturation pastels (blue/emerald/red/lavender/cyan/coral pink/amber/indigo) + soft slate `#CBD5E1` for "Other".

## Changes

- `src/api/routes/energy.ts` — `SUBMETER_PALETTE` retuned to pastels
- `ui/src/components/energy/EnergyByUsageChart.tsx`:
  - `OTHER_COLOR` → `#CBD5E1`
  - Added `roundedTopRect()` and `topmostSeriesIdInStack()` helpers
  - Each `<Bar>` now uses a custom `shape` that draws a rounded-top path for the topmost non-zero segment and a plain rect otherwise

## Test plan

- [x] `npx tsc --noEmit` — backend, 0 errors
- [x] `cd ui && npx tsc -b --noEmit` — UI, 0 errors
- [x] `npx vitest run` — 429 tests pass
- [x] `npx eslint` — 0 errors (2 unrelated pre-existing warnings)
- [ ] Visual check in dev: top corners rounded, palette pleasant