### PR TITLE
docs: French translation

### DIFF
--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -1,0 +1,172 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
+<div class="sowel-hero">
+
+<svg class="sowel-logo" xmlns="http://www.w3.org/2000/svg" viewBox="25 15 150 155" aria-label="Logo Sowel">
+  <path class="house"     d="M100 30 L160 90 Q165 95 160 100 L160 150 Q160 158 152 158 L48 158 Q40 158 40 150 L40 100 Q35 95 40 90 Z"/>
+  <path class="smile"     d="M75 115 Q100 140 125 115"/>
+  <path class="left-eye"  d="M78 95 Q83 87 88 95"/>
+  <path class="right-eye" d="M112 95 Q117 87 122 95"/>
+</svg>
+
+<h1 class="sowel-wordmark">Sowel</h1>
+
+<p class="sowel-lede"><strong>Ne programmez pas votre maison. <em>Appliquez-lui des recettes.</em></strong><br/>
+Un moteur de domotique pour le <em>confort</em>, la <em>sécurité</em> et l'<em>efficacité énergétique</em>, sans écrire une seule ligne de code.</p>
+
+<p class="sowel-cta">
+  <a class="md-button md-button--primary" href="user/getting-started/">Commencer <span class="md-icon md-icon--arrow">→</span></a>
+  <a class="md-button" href="https://github.com/mchacher/sowel">Voir sur GitHub</a>
+</p>
+
+</div>
+
+<div class="sowel-section">
+
+<p class="sowel-eyebrow">Une autre façon d'automatiser votre maison</p>
+
+<p class="sowel-paragraph">La plupart des outils de domotique vous transforment en développeur à temps partiel : fichiers YAML, scripts, flows, conditions, cas particuliers. Le résultat est un plat de spaghettis fragile que seule une personne du foyer arrive à dépanner.</p>
+
+<p class="sowel-paragraph"><strong>Sowel prend le chemin inverse.</strong> Au lieu d'écrire des automatisations, vous <strong>choisissez une recette</strong> (<em>Motion Light</em>, <em>Presence Thermostat</em>, <em>Pool Pump Schedule</em>, <em>Sunset Shutters</em>) et vous l'<strong>appliquez à une zone</strong>. Chaque recette encode un schéma réfléchi et éprouvé pour un besoin précis : confort, sécurité ou efficacité énergétique. Vous configurez quelques réglages évidents (une durée, une température, une plage horaire), pas un langage de programmation.</p>
+
+<p class="sowel-paragraph">Votre maison cesse d'être un projet annexe. Elle fonctionne, tout simplement.</p>
+
+</div>
+
+<div class="sowel-section">
+
+<div class="sowel-story">
+
+<p class="sowel-eyebrow">Une petite histoire</p>
+
+<p class="sowel-paragraph">Prenez <em>Constant Light</em>. Une cuisine éclairée à une luminosité confortable toute la journée. Pour bien faire, il faut plusieurs détecteurs de mouvement qui prolongent le même minuteur sans se contrarier, une cible de luminosité qui s'adapte au lux naturel entrant par la fenêtre, et des exemptions pour les repas, la nuit, ou quand quelqu'un appuie sur l'interrupteur.</p>
+
+<p class="sowel-paragraph">Ou prenez <em>Solar EV Charging</em>. Le chargeur doit monter en puissance exactement au rythme du surplus produit par vos panneaux, et redescendre dès qu'un nuage passe ou que le lave-vaisselle démarre. Le calcul tient sur une ligne ; l'orchestration, non.</p>
+
+<ul class="sowel-bullets">
+  <li>plusieurs entrées qui doivent rester synchronisées (capteurs, compteurs, plannings)</li>
+  <li>des décisions en temps réel qui suivent les mesures live, pas des instantanés</li>
+  <li>des replis sûrs pour chaque cas particulier (capteur hors ligne, coupure réseau, surcharge utilisateur)</li>
+</ul>
+
+<p class="sowel-paragraph">Chaque règle prise isolément est triviale. Le difficile, ce sont les <strong>combinaisons</strong>. Les règles à la IFTTT s'effondrent dès le premier chevauchement. Les automatisations faites maison se déboguent pendant une semaine, puis accumulent en silence des cas tordus que personne n'ose toucher.</p>
+
+<p class="sowel-paragraph"><strong>Sowel encode cette complexité une fois pour toutes</strong>, éprouvée sur le terrain, et la livre sous forme de recette. Posez-la sur une zone, passez à la suite.</p>
+
+</div>
+
+</div>
+
+<div class="sowel-section">
+
+<p class="sowel-eyebrow">Ce qui rend Sowel singulier</p>
+
+<p class="sowel-paragraph">Sowel structure votre maison en couches, depuis le réseau :</p>
+
+<ul class="sowel-bullets">
+  <li>Les <strong>devices</strong> sont auto-découverts et normalisés dans un seul modèle de données.</li>
+  <li>Les <strong>équipements</strong> nomment ce que ces devices font réellement.</li>
+  <li>Les <strong>zones</strong> regroupent les équipements par espace, avec des métriques agrégées automatiquement.</li>
+  <li>Les <strong>modes</strong> font basculer toute la maison d'un seul geste.</li>
+  <li>Les <strong>recettes</strong> la font fonctionner toute seule.</li>
+</ul>
+
+<p class="sowel-paragraph">Et la cerise sur le gâteau :</p>
+
+<ul class="sowel-bullets">
+  <li>Les intégrations et les recettes sont livrées comme des <strong>plugins</strong>, distribués depuis GitHub : <em>Zigbee2MQTT</em>, <em>Netatmo</em>, <em>Shelly</em>, <em>Panasonic Comfort Cloud</em>, <em>prévisions météo</em>, et bien d'autres. Installez ce dont vous avez besoin, ignorez le reste.</li>
+  <li>Tout repose sur une <strong>API et un bus d'événements</strong> typés et compacts, donc étendre Sowel se fait en un seul fichier TypeScript, pas avec un fork.</li>
+</ul>
+
+<div class="sowel-cards">
+
+<div class="sowel-card">
+  <div class="sowel-card__icon">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+  </div>
+  <h3>Équipements. Un vocabulaire standard pour votre maison.</h3>
+  <p>Sowel transforme le câblage de votre maison en un petit catalogue bien défini : luminaires, volets, thermostats, détecteurs de mouvement, compteurs d'énergie. Trois interrupteurs et un détecteur de mouvement dans votre cuisine deviennent un seul équipement <em>Kitchen Lights</em>, quelque chose que vous pouvez nommer, regrouper et raisonner.</p>
+</div>
+
+<div class="sowel-card">
+  <div class="sowel-card__icon">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+  </div>
+  <h3>Des zones qui s'agrègent toutes seules</h3>
+  <p>Regroupez les équipements en zones, par pièce, par étage, par usage. Une zone nommée <em>Ground Floor</em> vous donne la température moyenne, la pièce la plus lumineuse, l'humidité la plus élevée, automatiquement. Sans formules, sans code de glue, sans tableau de bord à câbler.</p>
+</div>
+
+<div class="sowel-card">
+  <div class="sowel-card__icon">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+  </div>
+  <h3>Des modes qui basculent toute la maison</h3>
+  <p>Jour, Nuit, Vacances, Cocon. Un geste fait basculer votre maison : lumières tamisées, thermostats abaissés, volets fermés. Programmez-les ou déclenchez-les à la main.</p>
+</div>
+
+<div class="sowel-card">
+  <div class="sowel-card__icon">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 21a1 1 0 0 0 1-1v-5.35c0-.46.32-.84.73-1.04a4 4 0 0 0-2.13-7.59 5 5 0 0 0-9.2 0 4 4 0 0 0-2.13 7.59c.41.2.73.58.73 1.04V20a1 1 0 0 0 1 1z"/><path d="M6 17h12"/></svg>
+  </div>
+  <h3>Des recettes, pas des scripts</h3>
+  <p>Posez un schéma d'automatisation sélectionné sur une zone (éclairage déclenché par mouvement, chauffage piloté par présence, irrigation programmée, volets au coucher du soleil), réglez quelques valeurs, et ça tourne. Pas de flows à câbler. Pas de programmation logique.</p>
+</div>
+
+</div>
+
+</div>
+
+<div class="sowel-section">
+
+<p class="sowel-eyebrow">Déployez en quelques minutes. À vous dès le premier jour.</p>
+
+<div class="sowel-pills">
+  <div class="sowel-pill">
+    <strong>Un seul conteneur Docker.</strong> <code>docker compose up -d</code>. C'est ça, l'installation.
+  </div>
+  <div class="sowel-pill">
+    <strong>Reste à la maison.</strong> Pas de cloud, pas de télémétrie, pas de compte tiers. Vos données vivent sur votre matériel : un Raspberry Pi, un vieux PC, une VM Proxmox, ce que vous avez sous la main.
+  </div>
+  <div class="sowel-pill">
+    <strong>Branchez ce que vous avez.</strong> Zigbee, Panasonic, Netatmo, Shelly, Legrand, tout ce qui parle MQTT. Installez les intégrations comme vous installez des applications, ignorez ce dont vous n'avez pas besoin.
+  </div>
+  <div class="sowel-pill">
+    <strong>Auto-mise à jour.</strong> Les plugins et le moteur se mettent à jour depuis GitHub. Pas de SSH, pas de bidouille, pas de redémarrage programmé à 3 h du matin.
+  </div>
+</div>
+
+</div>
+
+<div class="sowel-section">
+
+<p class="sowel-eyebrow">Faites le tour</p>
+
+<div class="sowel-cards sowel-cards--two">
+
+<div class="sowel-card">
+  <div class="sowel-card__icon">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+  </div>
+  <h3>Pour les utilisateurs</h3>
+  <p>Configurez votre maison, paramétrez vos équipements, et appliquez vos premières recettes.</p>
+  <p><a href="user/getting-started/">Guide utilisateur →</a></p>
+</div>
+
+<div class="sowel-card">
+  <div class="sowel-card__icon">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94z"/></svg>
+  </div>
+  <h3>Pour les bâtisseurs</h3>
+  <p>Architecture, développement de plugins, recettes, et modèle de données.</p>
+  <p><a href="technical/">Guide technique →</a></p>
+</div>
+
+</div>
+
+</div>
+
+<p class="sowel-foot">Sowel est distribué sous licence <a href="https://github.com/mchacher/sowel/blob/main/LICENSE">AGPL-3.0</a> · <a href="https://github.com/mchacher/sowel">GitHub</a></p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ A home automation engine for <em>comfort</em>, <em>safety</em> and <em>energy ef
 <p class="sowel-paragraph">And the cherry on top:</p>
 
 <ul class="sowel-bullets">
-  <li>Integrations and recipes ship as <strong>first-class plugins</strong>, distributed from GitHub: <em>Zigbee2MQTT</em>, <em>Netatmo</em>, <em>Shelly</em>, <em>Panasonic Comfort Cloud</em>, <em>weather forecasts</em>, and many more. Install what you need, ignore the rest.</li>
+  <li>Integrations and recipes ship as <strong>plugins</strong>, distributed from GitHub: <em>Zigbee2MQTT</em>, <em>Netatmo</em>, <em>Shelly</em>, <em>Panasonic Comfort Cloud</em>, <em>weather forecasts</em>, and many more. Install what you need, ignore the rest.</li>
   <li>Everything sits on a small, typed <strong>API and event bus</strong>, so extending Sowel is a single TypeScript file, not a fork.</li>
 </ul>
 

--- a/docs/specs-index.fr.md
+++ b/docs/specs-index.fr.md
@@ -1,0 +1,169 @@
+# Index des specs Sowel
+
+Ce fichier sert d'aide à la navigation sur `specs/`. Chaque spec sous `specs/XXX-name/` contient typiquement trois fichiers : `spec.md` (exigences + critères d'acceptation), `architecture.md` (design technique), `plan.md` (étapes d'implémentation).
+
+**Utilisez cet index pour récupérer rapidement le contexte** : parcourez les descriptions, trouvez la spec pertinente, puis lisez le dossier complet pour les détails.
+
+Les specs sont regroupées par thème et annotées d'un statut :
+
+- ✅ **active** : implémentée et en production
+- 🔁 **superseded** : remplacée par une spec ultérieure (suivez la flèche)
+- 🟡 **partial** : implémentée, mais le périmètre a évolué
+
+---
+
+## Fondations (V0.x) : moteur central
+
+| #   | Title                                  | Status                    | Résumé                                                                                         |
+| --- | -------------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------- |
+| 001 | V0.1 MQTT devices                      | ✅                        | Première intégration avec le bridge Zigbee2MQTT. Auto-découverte de devices brute via MQTT.    |
+| 002 | V0.1 UI scaffolding devices            | ✅                        | Frontend React initial avec liste de devices.                                                  |
+| 003 | V0.2 Zones                             | ✅                        | Zones imbriquables hiérarchiquement. Structure parent-enfant en arbre.                         |
+| 004 | V0.3 Equipments                        | ✅                        | Équipements user-facing qui se lient aux devices via des clés de données.                      |
+| 005 | V0.5 UI restructuring                  | ✅                        | Refonte de la navigation (home, zones, équipements, devices, admin).                           |
+| 006 | V0.6 Sensor equipments                 | ✅                        | Types de capteurs température, humidité, mouvement, luminance.                                 |
+| 007 | V0.7 Zone aggregation                  | ✅                        | Calcul auto des métriques de zone depuis les données d'équipement (motion=OR, temp=AVG, etc.). |
+| 008 | Shutter equipments                     | ✅                        | Position + état + ordres de cover (ouvrir/fermer/stop).                                        |
+| 009 | V0.8 Recipes                           | ✅                        | Moteur d'automatisation avec slots typés. Premières recettes intégrées.                        |
+| 010 | V0.9 Modes                             | ✅                        | États nommés au niveau zone (Day/Night/Away) avec impacts.                                     |
+| 011 | V0.10a Integration plugin architecture | 🔁 superseded by 040, 053 | Interface plugin initiale pour les intégrations.                                               |
+
+## V0.10 : intégrations natives (la plupart sont maintenant 🔁 externalisées en plugins)
+
+| #   | Title                          | Status                | Résumé                                                                               |
+| --- | ------------------------------ | --------------------- | ------------------------------------------------------------------------------------ |
+| 012 | V0.10b Panasonic Comfort Cloud | 🔁 → 050              | Polling de l'API cloud des climatiseurs Panasonic (maintenant un plugin).            |
+| 013 | V0.10c MCZ Maestro             | 🔁 → 049              | Intégration Socket.IO du poêle à granulés MCZ (maintenant un plugin).                |
+| 014 | V0.10d Netatmo Home+Control    | 🔁 → 048a, 048b, 048c | Intégration Netatmo HC (séparée maintenant en 3 plugins : weather, control, energy). |
+
+## V0.11 : logging, backup, UX volets
+
+| #   | Title                           | Status             | Résumé                                                                          |
+| --- | ------------------------------- | ------------------ | ------------------------------------------------------------------------------- |
+| 015 | V0.11 Logging system            | ✅                 | Logging structuré pino, ring buffer, tagging par module, viewer de logs UI.     |
+| 016 | V0.8b Motion Light enhancements | ✅                 | Affinements de la recette motion-light (créneaux horaires, override, fallback). |
+| 017 | V0.11b Backup hardening         | 🔁 → 046, 058, 060 | Premier système de backup (export/import).                                      |
+| 018 | Recipes roadmap                 | ✅ (meta)          | Document roadmap pour les recettes prévues.                                     |
+| 019 | V0.8c Switch light              | ✅                 | Recette switch-light (bascule à l'appui sur bouton).                            |
+| 020 | V0.8e Presence thermostat       | ✅                 | Logique de consigne thermostat basée sur la présence avec cocoon.               |
+| 021 | V0.8f Zone commands             | ✅                 | Batching d'ordres au niveau zone (allShuttersOpen/Close, allLightsOn/Off).      |
+
+## UX et tableau de bord
+
+| #   | Title                              | Status   | Résumé                                                                                                                                                                                            |
+| --- | ---------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 022 | Dark mode                          | ✅       | Dark mode basé sur la classe Tailwind avec préférence utilisateur.                                                                                                                                |
+| 023 | Sunrise / sunset                   | ✅       | Sunlight manager basé sur SunCalc avec réglages d'offset.                                                                                                                                         |
+| 024 | Motion light split                 | ✅       | Séparation de motion-light en variantes basique et dimmable.                                                                                                                                      |
+| 025 | V0.13 History (InfluxDB)           | ✅       | Historique en série temporelle pour les données numériques de devices.                                                                                                                            |
+| 026 | V0.8 Cocoon thermostat             | ✅       | Logique cocoon au coucher pour le thermostat de présence.                                                                                                                                         |
+| 027 | V0.8 Presence heater               | ✅       | Recette de radiateur basée sur la présence (éco/confort).                                                                                                                                         |
+| 028 | MQTT publishers                    | ✅       | Manager de publisher MQTT sortant (mappings d'événements vers topics). v1.2.6 : option `onChangeOnly`, publication seulement au changement de valeur pour ne pas inonder les afficheurs externes. |
+| 029 | MQTT brokers                       | ✅       | Support multi-broker pour les publishers MQTT.                                                                                                                                                    |
+| 030 | Logging audit                      | ✅       | Stratégie consolidée des niveaux de log et taxonomie des modules.                                                                                                                                 |
+| 031 | Notification publishers            | ✅       | Canaux de notification Telegram / webhook / FCM / ntfy.                                                                                                                                           |
+| 032 | State watch recipe                 | ✅       | Surveillance générique de clé de donnée avec recette d'alarme.                                                                                                                                    |
+| 033 | Dashboard widgets                  | ✅       | Widgets de zone personnalisables sur le tableau de bord.                                                                                                                                          |
+| 034 | Progressive Web App                | ✅       | Manifest PWA, service worker (`NetworkOnly` pour /api/), bandeau offline.                                                                                                                         |
+| 035 | Energy dashboard                   | ✅       | Ventilation jour/semaine/mois/année avec classification HP/HC.                                                                                                                                    |
+| 036 | Order dispatch error handling      | ✅       | Fallback gracieux quand la publication d'un ordre échoue.                                                                                                                                         |
+| 037 | Panasonic CC connection resilience | 🔁 → 050 | Logique de reconnexion pour Panasonic Comfort Cloud.                                                                                                                                              |
+| 038 | MCZ connection resilience          | 🔁 → 049 | Logique de reconnexion pour MCZ Maestro.                                                                                                                                                          |
+| 039 | Integrations page redesign         | ✅       | Page intégrations unifiée (liste, configuration, statut).                                                                                                                                         |
+
+## Système de plugins V2 (crucial, architecture actuelle)
+
+| #   | Title                      | Status               | Résumé                                                                 |
+| --- | -------------------------- | -------------------- | ---------------------------------------------------------------------- |
+| 040 | Plugin engine              | 🟡 superseded by 053 | Première génération de moteur de plugins (install depuis zip local).   |
+| 041 | Weather forecast plugin    | ✅                   | Plugin de prévisions météo basé sur Open-Meteo (exemple de référence). |
+| 042 | Weather forecast equipment | ✅                   | Type d'équipement pour l'affichage des données de prévision.           |
+| 043 | Plugin update              | ✅                   | Mise à jour de plugin in-place depuis une release GitHub.              |
+| 044 | Plugin SmartThings         | ✅                   | Plugin Samsung SmartThings (polling + ordres).                         |
+| 045 | Plugin SmartThings OAuth   | ✅                   | Flux OAuth2 pour l'authentification SmartThings.                       |
+| 046 | Backup v2                  | 🔁 → 058, 060        | Format de backup révisé (inclut le line protocol InfluxDB).            |
+| 047 | Prebuilt plugins           | ✅                   | Distribution de plugins via les releases GitHub (tarball).             |
+
+## V1.0 : externalisation de toutes les intégrations en plugins
+
+| #    | Title                       | Status | Résumé                                                                                                                                                         |
+| ---- | --------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 048a | Plugin Netatmo Weather      | ✅     | Intégration Netatmo Weather Station externalisée.                                                                                                              |
+| 048b | Plugin Legrand Control      | ✅     | Legrand Home+Control externalisé (lumières/volets/prises).                                                                                                     |
+| 048c | Plugin Legrand Energy       | ✅     | Suivi énergétique Legrand externalisé (compteurs NLPC).                                                                                                        |
+| 049  | Plugin MCZ Maestro          | ✅     | Intégration MCZ Maestro externalisée.                                                                                                                          |
+| 050  | Plugin Panasonic CC         | ✅     | Intégration Panasonic Comfort Cloud externalisée.                                                                                                              |
+| 051  | Plugin LoRa2MQTT            | ✅     | Bridge LoRa2MQTT en tant que plugin.                                                                                                                           |
+| 052  | Plugin Zigbee2MQTT          | ✅     | Zigbee2MQTT en tant que plugin (la dernière intégration native à être externalisée).                                                                           |
+| 053  | **Package manager**         | ✅     | **Refactor majeur** : le service `PackageManager` gère tous les paquets (intégrations + recettes). Distribution basée sur GitHub avec `plugins/registry.json`. |
+| 054  | Recipe packages             | ✅     | Recettes externalisées en tant que paquets (même modèle de distribution que les plugins).                                                                      |
+| 055  | Versioning + CI/CD + Docker | ✅     | Workflow de release GitHub Actions, `scripts/release.sh`, image ghcr.io, tags semver. Introduit en v1.0.0.                                                     |
+
+## V1.0+ : auto-update et déploiement
+
+| #   | Title                                           | Status   | Résumé                                                                                                                                                                                                                                                                                                                                                                  |
+| --- | ----------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 057 | Self-update UI                                  | 🔁 → 060 | Premier auto-update via l'UI (avait une race condition).                                                                                                                                                                                                                                                                                                                |
+| 058 | Backup completeness                             | ✅       | Auto-téléchargement des plugins manquants au démarrage ; scan dynamique des fichiers de données ; restauration FK-safe.                                                                                                                                                                                                                                                 |
+| 059 | Remote registry + backup fix                    | ✅       | Récupération de `plugins/registry.json` à distance avec cache + fallback local. InfluxDB ensureBuckets avant restauration.                                                                                                                                                                                                                                              |
+| 060 | **Self-update helper + detection improvements** | ✅       | **Architecture actuelle d'auto-update** : pattern de container helper (spawn `docker:25-cli` qui survit à la mort de sowel), backup pré-update auto dans `data/backups/` (rotation, conserve 3), poll de version 1 h, push WebSocket de update.available, bouton "Check for updates", détection `composeManaged`.                                                       |
+| 061 | **Timezone from home location**                 | ✅       | Auto-dérivation de `process.env.TZ` depuis `home.latitude`/`home.longitude` via `tz-lookup` au boot (s'exécute avant `createLogger()` pour éviter le caching TZ V8). Endpoints `GET /system/timezone` + `POST /system/restart` (container helper). UI : TZ dans Réglages, `CurrentTimePill` dans le header, `RestartToast` au changement de localisation.               |
+| 062 | Water valve equipment                           | ✅       | Nouveau type d'équipement `water_valve` avec icône custom de vanne, famille de widget `water`, agrégation de zone (open/total + somme de débit), pastille de zone, widget tableau de bord (close-all), et carte de détail avec toggle + arrosage minuté. Cible les SONOFF SWV et vannes connectées similaires. Base pour une future recette d'auto-arrosage (spec 063). |
+
+## Refactoring du dispatch d'ordre (migration progressive)
+
+| #   | Title                             | Status  | Résumé                                                                                                                                                           |
+| --- | --------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 067 | Order dispatch — core + lora2mqtt | ✅      | Nouvelle signature `executeOrder(device, orderKey, value)` avec rétro-compat v1. Première migration : lora2mqtt v2.0.0. Résolution d'enum insensible à la casse. |
+| 068 | Order dispatch — zigbee2mqtt      | ✅      | Migration du plugin z2m vers v2.0.0 (apiVersion 2). Support des payloads composites préservé.                                                                    |
+| 069 | Order dispatch — legrand-control  | Planned | Migration de legrand-control (IDs API cloud stockés en mémoire du plugin).                                                                                       |
+| 070 | Order dispatch — panasonic-cc     | Planned | Migration de panasonic-cc (guid/param stockés en mémoire du plugin).                                                                                             |
+| 071 | Order dispatch — mcz-maestro      | Planned | Migration de mcz-maestro (commandId stocké en mémoire du plugin).                                                                                                |
+| 072 | Order dispatch — netatmo-security | Planned | Migration de netatmo-security (paramètre unique : monitoring).                                                                                                   |
+| 073 | Order dispatch — smartthings      | Planned | Migration de smartthings (noms de commande stockés en mémoire du plugin).                                                                                        |
+| 074 | Order dispatch — cleanup          | Planned | Suppression de la rétro-compat v1. Suppression de la colonne `dispatch_config` de `device_orders`.                                                               |
+
+---
+
+## Équipements piscine
+
+| #   | Title                       | Status | Résumé                                                                                            |
+| --- | --------------------------- | ------ | ------------------------------------------------------------------------------------------------- |
+| 081 | Pool equipments             | ✅     | Types `pool_pump`, `pool_cover` avec liaison basée sur des candidats pour les relais multi-canaux |
+| 082 | Pool pump schedule          | ✅     | Plugin de recette avec 3 créneaux on/off journaliers                                              |
+| 083 | Pool heat pump (Polytropic) | ✅     | Type `pool_heat_pump` + plugin d'intégration Modbus (Polytropic Master Inverter)                  |
+
+## Refactor énergétique Shelly (multi-itérations)
+
+| #   | Title                                 | Status   | Résumé                                                                                                                              |
+| --- | ------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| 084 | Shelly energy — overview              | Planned  | Principes directeurs pour la migration en 4 itérations de Legrand vers Shelly Pro 3EM                                               |
+| 085 | Iteration 1 — shelly-em plugin (live) | Planned  | Plugin Sowel : `act_power` live et compteurs par canal, en parallèle de Legrand                                                     |
+| 086 | Iteration 2 — Shelly drives roles     | Planned  | Promotion des canaux Shelly en `main_energy_meter` + `energy_production_meter`, retrait de Legrand                                  |
+| 087 | Iteration 3 — energydata-stack        | Rejected | Remplacé par l'archive native du Shelly Pro 3EM (60 j in-device) ; voir 088 pour le correctif réel                                  |
+| 088 | Iteration 4 — Shelly gap backfill     | Planned  | Le plugin interroge la RPC `EM1Data.GetData` au boot et toutes les heures pour rejouer les minutes manquantes dans le pipeline live |
+
+## V1.5 : graphique par usage, bascules MQTT, recette state-trigger
+
+| #   | Title                        | Status | Résumé                                                                                                                                                                                                                                                                                                                                     |
+| --- | ---------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 090 | MQTT mapping enable/disable  | ✅     | Flag `enabled` par mapping sur les publishers MQTT, en complément de la bascule au niveau publisher. Icône power-off UI + opacité réduite sur les lignes désactivées. Permet à l'utilisateur de mettre en sourdine un seul mapping (source saisonnière) sans perdre sa configuration.                                                      |
+| 091 | By-usage consumption chart   | ✅     | Nouvel endpoint `GET /energy/by-usage` et bascule Total / Par usage sur la page Énergie qui rend une ventilation empilée par sous-compteur `energy_meter` + un résidu "Other" (`compteur principal - Σ sous-compteurs`).                                                                                                                   |
+| 092 | State-triggered light recipe | ✅     | Nouveau plugin de recette externe `state-trigger-light` (dans `plugins/registry.json`). Allume les lumières pour une durée fixe quand l'alias `state` d'un équipement surveillé transite vers une valeur cible. Filtre nightOnly optionnel via le sunlight manager. Introduit les contraintes de slot `crossZone` et `includeDescendants`. |
+
+---
+
+## Comment utiliser cet index après une perte de contexte
+
+1. **Trouvez le thème** dont vous avez besoin via les en-têtes de section ci-dessus
+2. **Ouvrez `specs/XXX-name/spec.md`** pour les exigences et critères d'acceptation
+3. **Ouvrez `specs/XXX-name/architecture.md`** pour le design technique, les changements de modèle de données, l'impact au niveau fichier
+4. **Ouvrez `specs/XXX-name/plan.md`** pour les étapes d'implémentation
+
+Pour l'architecture actuelle basée sur les plugins, commencez par la **spec 053** (PackageManager), c'est la racine de tout ce qui touche aux plugins.
+
+Pour l'auto-update, commencez par la **spec 060**, elle remplace la spec 057 et est le design actuel.
+
+Pour la vue d'ensemble du système, voir [technical/architecture.md](technical/architecture.md).
+
+Pour l'exploitation production (déploiement, backup, auto-update, logs), voir [technical/deployment.md](technical/deployment.md).

--- a/docs/technical/api-reference.fr.md
+++ b/docs/technical/api-reference.fr.md
@@ -1,0 +1,446 @@
+# Référence API
+
+Sowel expose une API REST sous `/api/v1/` et un endpoint WebSocket à `/ws`. Tous les endpoints requièrent une authentification, sauf mention contraire. Les réponses sont en JSON.
+
+**Base URL** : `http://<host>:3000`
+
+**Authentification** : passez un token d'accès JWT en header `Authorization: Bearer <token>`, ou un token d'API en `Authorization: Bearer swl_<token>`.
+
+---
+
+## Sommaire
+
+- [Authentication](#authentication)
+- [Current User (Me)](#current-user-me)
+- [Users (Admin)](#users-admin)
+- [Devices](#devices)
+- [Equipments](#equipments)
+- [Zones](#zones)
+- [Modes](#modes)
+- [Calendar](#calendar)
+- [Recipes](#recipes)
+- [Dashboard](#dashboard)
+- [Charts](#charts)
+- [Energy](#energy)
+- [History](#history)
+- [Integrations (Admin)](#integrations-admin)
+- [Plugins (Admin)](#plugins-admin)
+- [Settings (Admin)](#settings-admin)
+- [MQTT Brokers](#mqtt-brokers)
+- [MQTT Publishers](#mqtt-publishers)
+- [Notification Publishers](#notification-publishers)
+- [Button Actions](#button-actions)
+- [Logs (Admin)](#logs-admin)
+- [Backup (Admin)](#backup-admin)
+- [Health](#health)
+- [WebSocket](#websocket)
+
+---
+
+## Authentication
+
+Endpoints publics, aucune auth requise pour `status` et `setup`.
+
+| Method | Path                   | Description                                                                                                                                         |
+| ------ | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET`  | `/api/v1/auth/status`  | Vérifie si le setup au premier démarrage est requis. Retourne `{ setupRequired: boolean }`.                                                         |
+| `POST` | `/api/v1/auth/setup`   | Crée le premier utilisateur admin (premier démarrage uniquement). Body : `{ username, password, displayName, language? }`. Retourne les tokens JWT. |
+| `POST` | `/api/v1/auth/login`   | Authentification. Body : `{ username, password }`. Retourne `{ accessToken, refreshToken }`. Limité : 10 req/min.                                   |
+| `POST` | `/api/v1/auth/refresh` | Rafraîchit le token d'accès. Body : `{ refreshToken }`. Retourne une nouvelle paire de tokens.                                                      |
+| `POST` | `/api/v1/auth/logout`  | Invalide le refresh token. Body : `{ refreshToken }`. Retourne 204.                                                                                 |
+
+---
+
+## Current User (Me)
+
+Profil et tokens de l'utilisateur authentifié.
+
+| Method   | Path                     | Description                                                                                          |
+| -------- | ------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/v1/me`             | Récupère le profil de l'utilisateur courant.                                                         |
+| `PUT`    | `/api/v1/me`             | Met à jour le nom d'affichage. Body : `{ displayName }`.                                             |
+| `PUT`    | `/api/v1/me/preferences` | Met à jour les préférences (langue, thème, etc.). Body : `{ preferences }`.                          |
+| `PUT`    | `/api/v1/me/password`    | Change le mot de passe. Body : `{ currentPassword, newPassword }`.                                   |
+| `GET`    | `/api/v1/me/tokens`      | Liste les tokens d'API personnels.                                                                   |
+| `POST`   | `/api/v1/me/tokens`      | Crée un token d'API. Body : `{ name, expiresAt? }`. Retourne la chaîne de token (affichée une fois). |
+| `DELETE` | `/api/v1/me/tokens/:id`  | Révoque un token d'API. Retourne 204.                                                                |
+
+---
+
+## Users (Admin)
+
+Toutes les routes de gestion des utilisateurs nécessitent le rôle admin.
+
+| Method   | Path                | Description                                                                                         |
+| -------- | ------------------- | --------------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/v1/users`     | Liste tous les utilisateurs.                                                                        |
+| `POST`   | `/api/v1/users`     | Crée un utilisateur. Body : `{ username, password, displayName, role }`.                            |
+| `PUT`    | `/api/v1/users/:id` | Met à jour un utilisateur. Body : `{ displayName?, role?, enabled? }`.                              |
+| `DELETE` | `/api/v1/users/:id` | Supprime un utilisateur. Impossible de se supprimer ou de supprimer le dernier admin. Retourne 204. |
+
+---
+
+## Devices
+
+| Method   | Path                      | Description                                                                                 |
+| -------- | ------------------------- | ------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/v1/devices`         | Liste tous les devices avec leurs données et ordres courants.                               |
+| `GET`    | `/api/v1/devices/:id`     | Récupère un device avec données et ordres.                                                  |
+| `PUT`    | `/api/v1/devices/:id`     | Met à jour un device. Body : `{ name?, zoneId? }`.                                          |
+| `DELETE` | `/api/v1/devices/:id`     | Supprime un device. Retourne 204.                                                           |
+| `GET`    | `/api/v1/devices/suggest` | Suggère les devices compatibles avec un type d'équipement. Query : `?type=<equipmentType>`. |
+| `GET`    | `/api/v1/devices/:id/raw` | Récupère les données expose brutes de l'intégration pour un device.                         |
+
+---
+
+## Equipments
+
+| Method   | Path                                   | Description                                                                                                                                             |
+| -------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/v1/equipments`                   | Liste tous les équipements avec leurs liaisons et données courantes.                                                                                    |
+| `GET`    | `/api/v1/equipments/:id`               | Récupère un équipement avec liaisons et données courantes.                                                                                              |
+| `POST`   | `/api/v1/equipments`                   | Crée un équipement. Body : `{ name, type, zoneId, icon?, description?, deviceIds? }`. Si `deviceIds` est fourni, des liaisons automatiques sont créées. |
+| `PUT`    | `/api/v1/equipments/:id`               | Met à jour un équipement. Body : `{ name?, type?, zoneId?, icon?, description?, enabled? }`.                                                            |
+| `DELETE` | `/api/v1/equipments/:id`               | Supprime un équipement. Retourne 204.                                                                                                                   |
+| `POST`   | `/api/v1/equipments/:id/orders/:alias` | Exécute un ordre d'équipement. Body : `{ value }`.                                                                                                      |
+
+### Data Bindings
+
+| Method   | Path                                              | Description                                              |
+| -------- | ------------------------------------------------- | -------------------------------------------------------- |
+| `POST`   | `/api/v1/equipments/:id/data-bindings`            | Ajoute un DataBinding. Body : `{ deviceDataId, alias }`. |
+| `DELETE` | `/api/v1/equipments/:id/data-bindings/:bindingId` | Supprime un DataBinding. Retourne 204.                   |
+
+### Order Bindings
+
+| Method   | Path                                               | Description                                                |
+| -------- | -------------------------------------------------- | ---------------------------------------------------------- |
+| `POST`   | `/api/v1/equipments/:id/order-bindings`            | Ajoute un OrderBinding. Body : `{ deviceOrderId, alias }`. |
+| `DELETE` | `/api/v1/equipments/:id/order-bindings/:bindingId` | Supprime un OrderBinding. Retourne 204.                    |
+
+---
+
+## Zones
+
+| Method   | Path                                 | Description                                                                                        |
+| -------- | ------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/v1/zones`                      | Liste toutes les zones en arborescence.                                                            |
+| `GET`    | `/api/v1/zones/:id`                  | Récupère une zone avec ses enfants.                                                                |
+| `POST`   | `/api/v1/zones`                      | Crée une zone. Body : `{ name, parentId?, icon?, description?, displayOrder? }`.                   |
+| `PUT`    | `/api/v1/zones/:id`                  | Met à jour une zone. Body : `{ name?, parentId?, icon?, description?, displayOrder? }`.            |
+| `DELETE` | `/api/v1/zones/:id`                  | Supprime une zone. Retourne 204.                                                                   |
+| `PUT`    | `/api/v1/zones/reorder`              | Réordonne des zones de même niveau. Body : `{ parentId, orderedIds }`. Retourne 204.               |
+| `GET`    | `/api/v1/zones/aggregation`          | Récupère les données agrégées de toutes les zones (température, mouvement, lightsOn, etc.).        |
+| `POST`   | `/api/v1/zones/:id/orders/:orderKey` | Exécute un ordre au niveau zone (par ex. `allLightsOff`, `allShuttersClose`). Body : `{ value? }`. |
+
+---
+
+## Modes
+
+| Method   | Path                                      | Description                                                  |
+| -------- | ----------------------------------------- | ------------------------------------------------------------ |
+| `GET`    | `/api/v1/modes`                           | Liste tous les modes avec détails.                           |
+| `GET`    | `/api/v1/modes/:id`                       | Récupère un mode avec impacts et état.                       |
+| `POST`   | `/api/v1/modes`                           | Crée un mode. Body : `{ name, icon?, description? }`.        |
+| `PUT`    | `/api/v1/modes/:id`                       | Met à jour un mode. Body : `{ name?, icon?, description? }`. |
+| `DELETE` | `/api/v1/modes/:id`                       | Supprime un mode. Retourne 204.                              |
+| `POST`   | `/api/v1/modes/:id/activate`              | Active le mode.                                              |
+| `POST`   | `/api/v1/modes/:id/deactivate`            | Désactive le mode.                                           |
+| `POST`   | `/api/v1/modes/:id/apply-to-zone/:zoneId` | Applique les impacts du mode à une zone spécifique.          |
+
+### Zone Mode Impacts
+
+| Method   | Path                                 | Description                                                                         |
+| -------- | ------------------------------------ | ----------------------------------------------------------------------------------- |
+| `GET`    | `/api/v1/zones/:zoneId/mode-impacts` | Récupère les impacts de mode d'une zone.                                            |
+| `PUT`    | `/api/v1/modes/:id/impacts/:zoneId`  | Définit les actions d'impact de zone. Body : `{ actions: ZoneModeImpactAction[] }`. |
+| `DELETE` | `/api/v1/modes/:id/impacts/:zoneId`  | Supprime un impact de zone. Retourne 204.                                           |
+
+### Mode Triggers
+
+| Method | Path                         | Description                                              |
+| ------ | ---------------------------- | -------------------------------------------------------- |
+| `GET`  | `/api/v1/modes/:id/triggers` | Récupère les liaisons de bouton qui déclenchent ce mode. |
+
+---
+
+## Calendar
+
+| Method   | Path                                  | Description                                                     |
+| -------- | ------------------------------------- | --------------------------------------------------------------- |
+| `GET`    | `/api/v1/calendar/profiles`           | Liste tous les profils de calendrier.                           |
+| `GET`    | `/api/v1/calendar/active`             | Récupère le profil actif et ses créneaux.                       |
+| `PUT`    | `/api/v1/calendar/active`             | Définit le profil actif. Body : `{ profileId }`.                |
+| `GET`    | `/api/v1/calendar/profiles/:id/slots` | Liste les créneaux d'un profil.                                 |
+| `POST`   | `/api/v1/calendar/profiles/:id/slots` | Ajoute un créneau. Body : `{ days, time, modeActions }`.        |
+| `PUT`    | `/api/v1/calendar/slots/:slotId`      | Met à jour un créneau. Body : `{ days?, time?, modeActions? }`. |
+| `DELETE` | `/api/v1/calendar/slots/:slotId`      | Supprime un créneau. Retourne 204.                              |
+
+---
+
+## Recipes
+
+### Recipe Definitions
+
+| Method | Path                        | Description                                              |
+| ------ | --------------------------- | -------------------------------------------------------- |
+| `GET`  | `/api/v1/recipes`           | Liste les définitions de recettes disponibles (modèles). |
+| `GET`  | `/api/v1/recipes/:recipeId` | Récupère une définition de recette avec slots et i18n.   |
+
+### Recipe Instances
+
+| Method   | Path                                   | Description                                                              |
+| -------- | -------------------------------------- | ------------------------------------------------------------------------ |
+| `GET`    | `/api/v1/recipe-instances`             | Liste toutes les instances de recettes actives.                          |
+| `POST`   | `/api/v1/recipe-instances`             | Crée une instance. Body : `{ recipeId, params }`.                        |
+| `PUT`    | `/api/v1/recipe-instances/:id`         | Met à jour les params de l'instance. Body : `{ params }`.                |
+| `DELETE` | `/api/v1/recipe-instances/:id`         | Arrête et supprime l'instance. Retourne 204.                             |
+| `POST`   | `/api/v1/recipe-instances/:id/enable`  | Active une instance désactivée.                                          |
+| `POST`   | `/api/v1/recipe-instances/:id/disable` | Désactive (met en pause) une instance en cours.                          |
+| `POST`   | `/api/v1/recipe-instances/:id/actions` | Envoie une action à une recette en cours. Body : `{ action, payload? }`. |
+| `GET`    | `/api/v1/recipe-instances/:id/log`     | Récupère le journal d'exécution. Query : `?limit=50`.                    |
+
+---
+
+## Dashboard
+
+| Method   | Path                              | Description                                                                                         |
+| -------- | --------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/v1/dashboard/widgets`       | Liste tous les widgets du tableau de bord, ordonnés par display order.                              |
+| `POST`   | `/api/v1/dashboard/widgets`       | Crée un widget (admin). Body : `{ type, equipmentId?, zoneId?, family?, label?, icon? }`.           |
+| `PATCH`  | `/api/v1/dashboard/widgets/:id`   | Met à jour le label, l'icône ou la config d'un widget (admin). Body : `{ label?, icon?, config? }`. |
+| `DELETE` | `/api/v1/dashboard/widgets/:id`   | Supprime un widget (admin). Retourne 204.                                                           |
+| `PUT`    | `/api/v1/dashboard/widgets/order` | Réordonne les widgets (admin). Body : `{ order: string[] }`.                                        |
+
+---
+
+## Charts
+
+| Method   | Path                 | Description                                           |
+| -------- | -------------------- | ----------------------------------------------------- |
+| `GET`    | `/api/v1/charts`     | Liste les configurations de graphiques sauvegardées.  |
+| `GET`    | `/api/v1/charts/:id` | Récupère une configuration de graphique.              |
+| `POST`   | `/api/v1/charts`     | Crée un graphique. Body : `{ name, config }`.         |
+| `PUT`    | `/api/v1/charts/:id` | Met à jour un graphique. Body : `{ name?, config? }`. |
+| `DELETE` | `/api/v1/charts/:id` | Supprime un graphique. Retourne 204.                  |
+
+---
+
+## Energy
+
+| Method | Path                             | Description                                                                                                                                                                                                                                                                                   |
+| ------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET`  | `/api/v1/energy/status`          | Statut du module énergie (disponibilité, sources, tarif configuré).                                                                                                                                                                                                                           |
+| `GET`  | `/api/v1/energy/history`         | Interroge l'historique d'énergie. Query : `?period=day&date=2026-01-15`. Périodes : `day`, `week`, `month`, `year`. Retourne la ventilation HP/HC et les données de production.                                                                                                               |
+| `GET`  | `/api/v1/energy/by-usage`        | Séries temporelles de consommation par sous-compteur pour les mêmes buckets de période que `/energy/history`. Query : `?period=day&date=2026-01-15`. Retourne une série par sous-compteur `energy_meter` plus un résidu `other` (`max(0, total - Σ submeters)`) et les totaux par équipement. |
+| `GET`  | `/api/v1/settings/energy/tariff` | Récupère la configuration tarifaire (grilles HP/HC et prix).                                                                                                                                                                                                                                  |
+| `PUT`  | `/api/v1/settings/energy/tariff` | Met à jour la configuration tarifaire. Body : `{ schedules, prices }`.                                                                                                                                                                                                                        |
+
+---
+
+## History
+
+| Method | Path                                               | Description                                                                                                                    |
+| ------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `GET`  | `/api/v1/history/status`                           | Statut du module historique (connexion, nombre de bindings historisés, stats).                                                 |
+| `GET`  | `/api/v1/history/retention`                        | Statut de rétention et de downsampling pour tous les buckets/tâches InfluxDB.                                                  |
+| `GET`  | `/api/v1/history/bindings/:equipmentId`            | Liste les réglages d'historisation des data bindings d'un équipement.                                                          |
+| `PUT`  | `/api/v1/history/bindings/:equipmentId/:bindingId` | Définit le flag d'historisation. Body : `{ historize }` (null, 0 ou 1).                                                        |
+| `GET`  | `/api/v1/history/sparkline/zone/:zoneId/:category` | Données de sparkline 24 h au niveau zone (par ex. tendance de température).                                                    |
+| `GET`  | `/api/v1/history/sparkline/:equipmentId/:alias`    | Données de sparkline 24 h au niveau équipement.                                                                                |
+| `GET`  | `/api/v1/history/:equipmentId`                     | Liste les alias historisés pour un équipement.                                                                                 |
+| `GET`  | `/api/v1/history/:equipmentId/:alias`              | Interroge les données de série temporelle. Query : `?from=-24h&to=&aggregation=auto`. Agrégations : `raw`, `1h`, `1d`, `auto`. |
+
+---
+
+## Integrations (Admin)
+
+Routes admin uniquement pour gérer les plugins d'intégration de devices.
+
+| Method | Path                               | Description                                                               |
+| ------ | ---------------------------------- | ------------------------------------------------------------------------- |
+| `GET`  | `/api/v1/integrations`             | Liste toutes les intégrations avec statut, réglages et nombre de devices. |
+| `POST` | `/api/v1/integrations/:id/start`   | Démarre une intégration.                                                  |
+| `POST` | `/api/v1/integrations/:id/stop`    | Arrête une intégration.                                                   |
+| `POST` | `/api/v1/integrations/:id/restart` | Redémarre une intégration (stop + start).                                 |
+| `POST` | `/api/v1/integrations/:id/refresh` | Force un refresh des données (intégrations en polling uniquement).        |
+
+---
+
+## Plugins (Admin)
+
+Routes admin uniquement pour la gestion des plugins tiers.
+
+| Method | Path                            | Description                                                         |
+| ------ | ------------------------------- | ------------------------------------------------------------------- |
+| `GET`  | `/api/v1/plugins`               | Liste les plugins installés.                                        |
+| `GET`  | `/api/v1/plugins/store`         | Liste les plugins disponibles depuis le registre.                   |
+| `POST` | `/api/v1/plugins/install`       | Installe depuis GitHub. Body : `{ repo }` (par ex. `"owner/repo"`). |
+| `POST` | `/api/v1/plugins/:id/uninstall` | Désinstalle un plugin.                                              |
+| `POST` | `/api/v1/plugins/:id/enable`    | Active un plugin (le charge et le démarre).                         |
+| `POST` | `/api/v1/plugins/:id/disable`   | Désactive un plugin (le stoppe et le décharge).                     |
+
+---
+
+## Settings (Admin)
+
+Stockage clé-valeur des réglages admin (utilisé pour les configs d'intégration, les réglages maison, etc.).
+
+| Method | Path               | Description                                                                 |
+| ------ | ------------------ | --------------------------------------------------------------------------- |
+| `GET`  | `/api/v1/settings` | Récupère tous les réglages.                                                 |
+| `PUT`  | `/api/v1/settings` | Met à jour les réglages. Body : objet clé-valeur `{ "key": "value", ... }`. |
+
+---
+
+## MQTT Brokers
+
+Brokers MQTT externes pour la publication sortante.
+
+| Method   | Path                       | Description                                                           |
+| -------- | -------------------------- | --------------------------------------------------------------------- |
+| `GET`    | `/api/v1/mqtt-brokers`     | Liste tous les brokers MQTT.                                          |
+| `POST`   | `/api/v1/mqtt-brokers`     | Crée un broker. Body : `{ name, url, username?, password? }`.         |
+| `PUT`    | `/api/v1/mqtt-brokers/:id` | Met à jour un broker. Body : `{ name?, url?, username?, password? }`. |
+| `DELETE` | `/api/v1/mqtt-brokers/:id` | Supprime un broker. Retourne 204.                                     |
+
+---
+
+## MQTT Publishers
+
+Publishers MQTT sortants qui poussent les données Sowel vers des brokers externes. Chaque publisher cible un seul topic MQTT et peut avoir plusieurs mappings de données (sources équipement, zone, ou recette). Quand `onChangeOnly` est activé, le publisher ne publie que lorsqu'une valeur change réellement, utile pour ne pas inonder les afficheurs externes de heartbeats périodiques.
+
+Chaque mapping porte son propre flag `enabled` (par défaut `true`). Les mappings désactivés sont ignorés en publication live, dans le snapshot initial et dans le bouton manuel "Test", de sorte qu'une source saisonnière peut être mise en sourdine sans perdre son câblage source/clé. Le flag `enabled` au niveau du publisher l'emporte toujours : si le publisher est éteint, tous ses mappings le sont aussi, indépendamment de leur flag par mapping.
+
+| Method   | Path                                              | Description                                                                                                                                                                |
+| -------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/v1/mqtt-publishers`                         | Liste tous les publishers avec leurs mappings.                                                                                                                             |
+| `GET`    | `/api/v1/mqtt-publishers/:id`                     | Récupère un publisher avec ses mappings.                                                                                                                                   |
+| `POST`   | `/api/v1/mqtt-publishers`                         | Crée un publisher. Body : `{ name, brokerId, topic, enabled?, onChangeOnly? }`.                                                                                            |
+| `PUT`    | `/api/v1/mqtt-publishers/:id`                     | Met à jour un publisher. Body : `{ name?, brokerId?, topic?, enabled?, onChangeOnly? }`.                                                                                   |
+| `DELETE` | `/api/v1/mqtt-publishers/:id`                     | Supprime un publisher. Retourne 204.                                                                                                                                       |
+| `POST`   | `/api/v1/mqtt-publishers/:id/test`                | Test : publie un snapshot.                                                                                                                                                 |
+| `POST`   | `/api/v1/mqtt-publishers/:id/mappings`            | Ajoute un mapping de données. Body : `{ publishKey, sourceType, sourceId, sourceKey, enabled? }`. `enabled` par défaut à `true` si omis.                                   |
+| `PUT`    | `/api/v1/mqtt-publishers/:id/mappings/:mappingId` | Met à jour un mapping. Accepte `{ publishKey?, sourceType?, sourceId?, sourceKey?, enabled? }`. Le flag `enabled` bascule la publication on/off sans supprimer le mapping. |
+| `DELETE` | `/api/v1/mqtt-publishers/:id/mappings/:mappingId` | Supprime un mapping. Retourne 204.                                                                                                                                         |
+
+---
+
+## Notification Publishers
+
+Notifications push (actuellement Telegram) déclenchées par des changements de données.
+
+| Method   | Path                                                      | Description                                                                                             |
+| -------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/v1/notification-publishers`                         | Liste tous les notification publishers avec leurs mappings.                                             |
+| `GET`    | `/api/v1/notification-publishers/:id`                     | Récupère un publisher avec ses mappings.                                                                |
+| `POST`   | `/api/v1/notification-publishers`                         | Crée un publisher. Body : `{ name, channelType, channelConfig, enabled? }`.                             |
+| `PUT`    | `/api/v1/notification-publishers/:id`                     | Met à jour un publisher.                                                                                |
+| `DELETE` | `/api/v1/notification-publishers/:id`                     | Supprime un publisher. Retourne 204.                                                                    |
+| `POST`   | `/api/v1/notification-publishers/:id/test-channel`        | Teste le canal de notification (envoie un message de test).                                             |
+| `POST`   | `/api/v1/notification-publishers/:id/test`                | Teste le publisher complet (déclenche les mappings).                                                    |
+| `POST`   | `/api/v1/notification-publishers/:id/mappings`            | Ajoute un mapping de déclenchement. Body : `{ message, sourceType, sourceId, sourceKey, throttleMs? }`. |
+| `PUT`    | `/api/v1/notification-publishers/:id/mappings/:mappingId` | Met à jour un mapping.                                                                                  |
+| `DELETE` | `/api/v1/notification-publishers/:id/mappings/:mappingId` | Supprime un mapping. Retourne 204.                                                                      |
+
+---
+
+## Button Actions
+
+Mappe les appuis sur des boutons physiques (boutons Zigbee, etc.) à des actions (activation de mode, ordres d'équipement, basculement de recette).
+
+| Method   | Path                                                | Description                                                                                                                                         |
+| -------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/v1/equipments/:id/action-bindings`            | Liste les action bindings d'un équipement bouton.                                                                                                   |
+| `POST`   | `/api/v1/equipments/:id/action-bindings`            | Crée une liaison. Body : `{ actionValue, effectType, config }`. Types d'effet : `mode_activate`, `mode_toggle`, `equipment_order`, `recipe_toggle`. |
+| `PUT`    | `/api/v1/equipments/:id/action-bindings/:bindingId` | Met à jour une liaison.                                                                                                                             |
+| `DELETE` | `/api/v1/equipments/:id/action-bindings/:bindingId` | Supprime une liaison. Retourne 204.                                                                                                                 |
+
+---
+
+## Logs (Admin)
+
+Accès aux logs admin uniquement depuis le ring buffer en mémoire.
+
+| Method | Path                 | Description                                                                                                                                                              |
+| ------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `GET`  | `/api/v1/logs`       | Interroge les logs. Query : `?limit=100&level=error&module=mqtt&search=text&since=ISO`. Retourne les entrées, la capacité, le niveau courant et les modules disponibles. |
+| `GET`  | `/api/v1/logs/level` | Récupère le niveau de log runtime courant.                                                                                                                               |
+| `PUT`  | `/api/v1/logs/level` | Change le niveau de log runtime. Body : `{ level }`. Valides : `debug`, `info`, `warn`, `error`, `fatal`, `silent`.                                                      |
+
+---
+
+## Backup (Admin)
+
+Backup et restauration complète de la configuration, admin uniquement.
+
+| Method | Path             | Description                                                                                                                 |
+| ------ | ---------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `GET`  | `/api/v1/backup` | Exporte la configuration complète. Retourne un ZIP (JSON SQLite + CSV InfluxDB) ou JSON s'il n'y a pas de données InfluxDB. |
+| `POST` | `/api/v1/backup` | Restaure la configuration depuis un backup JSON. Body : payload de backup avec `{ version: 1, tables }`.                    |
+
+---
+
+## Health
+
+Aucune authentification requise.
+
+| Method | Path             | Description                                                                                                                              |
+| ------ | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET`  | `/api/v1/health` | Vérification de santé du système. Retourne le statut, l'uptime, les statuts d'intégration, le nombre de devices et la version du moteur. |
+
+---
+
+## WebSocket
+
+**Endpoint** : `ws://<host>:3000/ws?token=<jwt_or_api_token>`
+
+L'authentification est passée via le paramètre de query `token`. Les tokens JWT et les tokens d'API (préfixe `swl_`) sont tous deux acceptés.
+
+### Connexion
+
+À la connexion, le serveur envoie un message de bienvenue :
+
+```json
+{ "type": "connected", "message": "Connected to Sowel engine", "version": "0.1.0" }
+```
+
+Les clients sont automatiquement abonnés au topic `system`.
+
+### S'abonner aux topics
+
+Envoyez un message JSON pour vous abonner à des topics supplémentaires :
+
+```json
+{ "type": "subscribe", "topics": ["devices", "equipments", "zones", "modes", "recipes"] }
+```
+
+**Topics disponibles** : `devices`, `equipments`, `zones`, `modes`, `recipes`, `calendar`, `mqtt-publishers`, `system`, `logs`.
+
+Le topic `system` est toujours inclus, indépendamment de l'abonnement.
+
+### Livraison des événements
+
+Les événements sont batchés toutes les 200 ms et envoyés sous forme de tableau JSON. Les événements de données à haute fréquence sont dédupliqués par batch, seule la dernière valeur par device/équipement/clé de zone est envoyée.
+
+```json
+[
+  { "type": "device.data.updated", "deviceId": "...", "key": "temperature", "value": 22.5 },
+  { "type": "equipment.data.changed", "equipmentId": "...", "alias": "state", "value": "ON" },
+  { "type": "zone.data.changed", "zoneId": "...", "key": "temperature", "value": 21.8 }
+]
+```
+
+### Streaming de logs
+
+Quand on est abonné au topic `logs`, les entrées de log sont streamées individuellement (non batchées) :
+
+```json
+{
+  "type": "log.entry",
+  "level": "info",
+  "module": "devices",
+  "msg": "Device discovered",
+  "time": 1700000000
+}
+```

--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -1,0 +1,528 @@
+# Vue d'ensemble de l'architecture
+
+Ce document décrit l'architecture technique de Sowel : la stack technique, la structure du projet, le pipeline réactif, les concepts métier clés, et le design system.
+
+---
+
+## Stack technique
+
+### Backend
+
+| Technologie                  | Rôle                                                 |
+| ---------------------------- | ---------------------------------------------------- |
+| **Node.js 20+**              | Runtime                                              |
+| **TypeScript** (strict mode) | Langage                                              |
+| **Fastify**                  | Framework HTTP                                       |
+| **SQLite** (better-sqlite3)  | Base de données principale (API synchrone, mode WAL) |
+| **InfluxDB 2.x**             | Stockage de séries temporelles (historique, énergie) |
+| **ws**                       | Serveur WebSocket                                    |
+| **mqtt.js**                  | Client MQTT pour les intégrations device             |
+| **pino**                     | Logs JSON structurés                                 |
+
+### Frontend
+
+| Technologie      | Rôle                                                          |
+| ---------------- | ------------------------------------------------------------- |
+| **React 18+**    | Framework UI                                                  |
+| **TypeScript**   | Langage                                                       |
+| **Vite**         | Build tool et serveur de développement                        |
+| **Tailwind CSS** | Styling (utility classes uniquement, pas de CSS personnalisé) |
+| **Zustand**      | Gestion d'état                                                |
+| **Lucide React** | Bibliothèque d'icônes (stroke 1.5px)                          |
+
+### Infrastructure
+
+| Technologie                 | Rôle                              |
+| --------------------------- | --------------------------------- |
+| **Docker + docker-compose** | Déploiement conteneurisé          |
+| **PM2**                     | Gestion de processus (production) |
+
+---
+
+## Concepts métier clés
+
+| Terme         | Rôle                                                                                                                                     |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Device**    | Matériel physique, auto-découvert depuis les intégrations. Expose des Data brutes et des Orders.                                         |
+| **Equipment** | Unité fonctionnelle visible par l'utilisateur. Se lie à un ou plusieurs Devices. Peut avoir des Data calculées et dispatcher des Orders. |
+| **Zone**      | Regroupement spatial (arbre imbriquable). Auto-agrège les Data des Equipments (motion=OR, temperature=AVG, lightsOn=COUNT, etc.).        |
+| **Scenario**  | Règle d'automatisation : trigger(s) -> condition(s) -> action(s).                                                                        |
+| **Recipe**    | Modèle de Scenario réutilisable avec slots de paramètres typés.                                                                          |
+| **Mode**      | État nommé (par ex. "Night", "Away") avec impacts au niveau zone. Activable manuellement, par calendrier, ou par appui sur un bouton.    |
+
+**Principe directeur** : un Device est ce qui est sur le réseau. Un Equipment est ce qui est dans la pièce.
+
+---
+
+## Pipeline réactif
+
+Le flux de données central est entièrement piloté par les événements. Chaque message d'intégration se propage à travers toute la stack :
+
+```
+Integration message (MQTT, cloud API poll, etc.)
+  -> Integration Plugin (receives + parses)
+    -> Device Manager (updates DeviceData)
+      -> Event Bus: "device.data.updated"
+        -> Equipment Manager (re-evaluates bindings + computed Data)
+          -> Event Bus: "equipment.data.changed"
+            -> Zone Manager (re-evaluates aggregations)
+              -> Event Bus: "zone.data.changed"
+                -> Recipe Engine (evaluates triggers -> conditions -> actions)
+                  -> Actions may emit Orders -> Integration Plugin -> device
+            -> MQTT Publish Service (outbound to external brokers, with optional on-change filter)
+            -> Notification Publish Service (Telegram, etc.)
+            -> WebSocket pushes to UI clients
+```
+
+### Event Bus
+
+Le bus d'événements est un `EventEmitter` typé qui utilise les unions discriminées TypeScript (type `EngineEvent`). C'est la colonne vertébrale qui relie tous les managers. Règles clés :
+
+- Tous les handlers doivent être non bloquants et ne jamais lever d'exception.
+- Les événements sont batchés (intervalle de 200 ms) avant d'être envoyés aux clients WebSocket.
+- Les événements de données à haute fréquence (`device.data.updated`, `equipment.data.changed`, `zone.data.changed`) sont dédupliqués par batch : seule la dernière valeur par clé est envoyée.
+
+### Types d'événements
+
+| Event                             | Payload                                              | Quand                    |
+| --------------------------------- | ---------------------------------------------------- | ------------------------ |
+| `device.discovered`               | `device: Device`                                     | Nouveau device trouvé    |
+| `device.removed`                  | `deviceId, deviceName`                               | Device supprimé          |
+| `device.status_changed`           | `deviceId, deviceName, status`                       | Online/offline           |
+| `device.data.updated`             | `deviceId, deviceName, dataId, key, value, previous` | Changement de propriété  |
+| `equipment.data.changed`          | `equipmentId, key, value, previous`                  | Donnée liée modifiée     |
+| `equipment.order.executed`        | `equipmentId, orderAlias, value`                     | Ordre dispatché          |
+| `zone.data.changed`               | `zoneId, key, value, previous`                       | Donnée agrégée modifiée  |
+| `system.started`                  | --                                                   | Démarrage moteur terminé |
+| `system.integration.connected`    | `integrationId`                                      | Intégration connectée    |
+| `system.integration.disconnected` | `integrationId`                                      | Intégration déconnectée  |
+| `settings.changed`                | `keys`                                               | Réglages mis à jour      |
+| `mode.activated`                  | mode details                                         | Mode activé              |
+| `mode.deactivated`                | mode details                                         | Mode désactivé           |
+| `recipe.state_changed`            | instance details                                     | État de recette modifié  |
+
+---
+
+## Structure du projet
+
+```
+sowel/
+├── src/
+│   ├── index.ts                 # Entry point
+│   ├── config.ts                # Env config loading
+│   ├── core/                    # event-bus, database (SQLite), influx, logger, settings-manager
+│   ├── integrations/            # Integration plugins (zigbee2mqtt, panasonic-cc, mcz-maestro, ...)
+│   ├── plugins/                 # Plugin manager (third-party plugin loading)
+│   ├── devices/                 # Device manager, auto-discovery, category inference
+│   ├── equipments/              # Equipment manager, bindings, computed engine, order dispatcher
+│   ├── energy/                  # Energy aggregator, tariff classifier (HP/HC)
+│   ├── zones/                   # Zone manager, auto-aggregation engine
+│   ├── modes/                   # Mode manager, calendar manager
+│   ├── recipes/                 # Recipe engine, built-in recipes (motion-light, switch-light)
+│   ├── buttons/                 # Button action bindings (physical button -> mode/order)
+│   ├── charts/                  # Saved chart configurations
+│   ├── history/                 # InfluxDB history writer and query helpers
+│   ├── mqtt-publishers/         # Outbound MQTT publishing (broker manager, publisher manager, on-change filter)
+│   ├── notifications/           # Notification channels (Telegram, etc.)
+│   ├── ai/                      # LLM integration (Claude/OpenAI/Ollama) -- V1.0+
+│   ├── auth/                    # JWT + API tokens, middleware, first-run setup
+│   ├── users/                   # User CRUD, preferences
+│   ├── api/                     # Fastify server, WebSocket handler, route files
+│   │   ├── server.ts            # Server setup and route registration
+│   │   ├── websocket.ts         # WebSocket handler with topic subscriptions
+│   │   └── routes/              # One file per domain (auth, devices, zones, etc.)
+│   └── shared/                  # types.ts (all interfaces), constants.ts
+├── ui/                          # React frontend (separate Vite project)
+│   └── src/
+│       ├── store/               # Zustand stores (devices, equipments, zones, WebSocket)
+│       ├── components/          # By domain: dashboard/, devices/, equipments/, zones/, scenarios/
+│       ├── pages/               # Dashboard, Devices, Equipments, Zones, Scenarios, Settings
+│       └── i18n/                # Internationalization (en.json, fr.json)
+├── plugins/                     # Third-party plugin install directory
+├── recipes/                     # Built-in Recipe JSON templates
+├── migrations/                  # SQLite migration SQL files
+├── specs/                       # Feature specifications (XXX-version-name/)
+└── scripts/                     # Maintenance & diagnostic scripts
+    ├── energy/                  # InfluxDB energy backfill, diagnostic, admin
+    └── logs/                    # Log retrieval via API
+```
+
+---
+
+## Architecture Plugin V2 (actuelle)
+
+Depuis la spec 053, **toutes les intégrations et recettes sont des plugins** distribués via GitHub. Plus rien n'est intégré nativement, une installation Sowel fraîche n'a aucun plugin et les télécharge à la demande depuis un registre.
+
+### Services centraux
+
+| Service                 | Fichier                                    | Rôle                                                                                                                                                                                                                                                           |
+| ----------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PackageManager**      | `src/packages/package-manager.ts`          | Télécharge, installe, met à jour et supprime les packages (intégrations + recettes). Récupère les manifests depuis les releases GitHub. Tient l'état en base dans la table `plugins`.                                                                          |
+| **PluginLoader**        | `src/plugins/plugin-loader.ts`             | Loader spécifique aux intégrations. Importe l'entrée JS du plugin (`dist/index.js`), appelle `createPlugin`, enregistre dans `IntegrationRegistry`. Auto-télécharge les fichiers du plugin au démarrage si manquants (par ex. après restauration d'un backup). |
+| **RecipeLoader**        | `src/recipes/recipe-loader.ts`             | Loader spécifique aux recettes. Même modèle que PluginLoader mais pour les paquets de recettes.                                                                                                                                                                |
+| **IntegrationRegistry** | `src/integrations/integration-registry.ts` | Registre runtime des intégrations connectées. Gère les start/stop avec staggering (pour éviter les appels simultanés aux APIs cloud).                                                                                                                          |
+
+### Modèle de distribution
+
+Les plugins vivent dans des repos GitHub séparés (par ex. `mchacher/sowel-plugin-zigbee2mqtt`). Chaque release embarque un tarball pré-compilé. Le **registre**, la liste des packages disponibles, est récupéré depuis :
+
+- **Distant** : `https://raw.githubusercontent.com/mchacher/sowel/main/plugins/registry.json` (TTL de cache 1 h)
+- **Fallback** : `plugins/registry.json` local livré dans l'image Docker
+
+Flux d'installation :
+
+1. L'utilisateur clique sur "Installer" dans l'UI Admin → Plugins
+2. PackageManager appelle l'API releases GitHub du repo du plugin
+3. Télécharge le tarball de la dernière release et le manifest
+4. Extrait dans `plugins/<id>/` sur le volume `sowel-plugins`
+5. Insère une ligne dans la table SQLite `plugins`
+6. PluginLoader importe l'entrée et enregistre l'intégration
+
+Le `plugins/registry.json` sur `main` est la source de vérité pour la liste officielle. N'importe quel utilisateur peut pointer vers son propre fork.
+
+### Format du manifest plugin
+
+Chaque plugin embarque un `manifest.json` avec `id`, `type` (`integration` ou `recipe`), `name`, `description`, `icon` (nom Lucide), `author`, `repo`, `version`, `tags`. Voir [plugin-development.md](plugin-development.md) pour la spec complète.
+
+### Cycle de vie d'une intégration
+
+1. **Load** : `PluginLoader.loadAll()` parcourt la table `plugins`, importe chaque entrée activée, appelle `createPlugin(deps)`, enregistre dans `IntegrationRegistry`.
+2. **Start** : `IntegrationRegistry.startAll()` démarre les plugins séquentiellement avec de petits délais. Le `start()` de chaque plugin se connecte, découvre les devices, démarre le polling.
+3. **Runtime** : le plugin pousse les données via `deviceManager.updateDeviceData()`. Les ordres sortent via `plugin.executeOrder()`.
+4. **Stop** : `stop()` annule les timers, ferme les connexions.
+5. **Update** : Unload → `PackageManager.updateFiles()` → reload.
+6. **Uninstall** : Unload → `PackageManager.removeFiles()`.
+
+Les réglages d'intégration sont stockés en SQLite dans `settings` sous `integration.<id>.<key>`, configurés depuis l'UI.
+
+### Écosystème actuel des plugins officiels
+
+| Plugin                  | Repo                                          | Type        |
+| ----------------------- | --------------------------------------------- | ----------- |
+| `zigbee2mqtt`           | `mchacher/sowel-plugin-zigbee2mqtt`           | integration |
+| `lora2mqtt`             | `mchacher/sowel-plugin-lora2mqtt`             | integration |
+| `panasonic_cc`          | `mchacher/sowel-plugin-panasonic-cc`          | integration |
+| `mcz_maestro`           | `mchacher/sowel-plugin-mcz-maestro`           | integration |
+| `legrand_control`       | `mchacher/sowel-plugin-legrand-control`       | integration |
+| `legrand_energy`        | `mchacher/sowel-plugin-legrand-energy`        | integration |
+| `netatmo_weather`       | `mchacher/sowel-plugin-netatmo-weather`       | integration |
+| `netatmo-security`      | `mchacher/sowel-plugin-netatmo-security`      | integration |
+| `weather-forecast`      | `mchacher/sowel-plugin-weather-forecast`      | integration |
+| `smartthings`           | `mchacher/sowel-plugin-smartthings`           | integration |
+| `motion-light`          | `mchacher/sowel-recipe-motion-light`          | recipe      |
+| `motion-light-dimmable` | `mchacher/sowel-recipe-motion-light-dimmable` | recipe      |
+| `switch-light`          | `mchacher/sowel-recipe-switch-light`          | recipe      |
+| `presence-heater`       | `mchacher/sowel-recipe-presence-heater`       | recipe      |
+| `presence-thermostat`   | `mchacher/sowel-recipe-presence-thermostat`   | recipe      |
+| `state-watch`           | `mchacher/sowel-recipe-state-watch`           | recipe      |
+| `state-trigger-light`   | `mchacher/sowel-recipe-state-trigger-light`   | recipe      |
+
+La liste live est dans `plugins/registry.json` à la racine du repo.
+
+---
+
+## Architecture base de données
+
+### SQLite
+
+- **Bibliothèque** : `better-sqlite3` avec API volontairement synchrone (rapide, pas de surcharge de callbacks).
+- **Mode WAL** : `PRAGMA journal_mode=WAL` pour la lecture/écriture concurrente.
+- **Migrations** : fichiers SQL dans `migrations/` exécutés automatiquement au démarrage.
+- **Transactions** : utilisées pour les opérations en lot.
+- **IDs** : UUID v4 via `crypto.randomUUID()`.
+- **Dates** : format ISO 8601 partout.
+
+### InfluxDB
+
+Les données d'énergie et d'historique transitent dans un pipeline multi-buckets :
+
+```
+sowel (raw)              -- 7-day retention  -- raw data points
+  | task: sowel-energy-sum-hourly (every: 1h, lookback: -7h)
+sowel-energy-hourly      -- 2-year retention -- hourly sums
+  | task: sowel-energy-sum-daily (every: 1d, lookback: -2d)
+sowel-energy-daily       -- 10-year retention -- daily sums
+```
+
+Des buckets downsamplés supplémentaires (`sowel-hourly`, `sowel-daily`) existent pour les séries temporelles non énergétiques.
+
+InfluxDB est obligatoire : Sowel se connecte au démarrage et auto-crée les buckets, les tâches de downsampling, et les tâches d'agrégation énergétique.
+
+---
+
+## Authentification et autorisation
+
+- **Mots de passe** : bcrypt (cost 12).
+- **JWT** : HS256 via `jsonwebtoken`. TTL access token : 15 min. TTL refresh token : 30 jours.
+- **Tokens d'API** : préfixe `swl_`, hash SHA-256 stocké, généré via `crypto.randomBytes(32)`. Préfixes legacy `wch_` et `cbl_` aussi acceptés.
+- **Middleware d'auth** : tente d'abord le décodage JWT, puis le lookup de token d'API.
+- **Rôles** : `admin` > `standard` > `viewer` (permissions hiérarchiques).
+- **Setup au premier démarrage** : `POST /api/v1/auth/setup` crée le premier utilisateur admin.
+
+---
+
+## Architecture frontend
+
+### Gestion d'état
+
+- Stores **Zustand** par domaine : devices, equipments, zones, modes, recipes, etc.
+- Les stores sont mis à jour en temps réel par les événements **WebSocket**.
+- WebSocket auto-reconnect avec récupération d'état (incrémentale ou complète).
+
+### Styling
+
+- **Tailwind CSS utility classes uniquement**, pas de fichiers CSS personnalisés.
+- Design responsive **mobile-first** (breakpoints : 640 px, 1024 px).
+- **Dark mode** via la stratégie `class` de Tailwind, indispensable pour un usage de tableau de bord la nuit.
+
+### Internationalisation
+
+- Anglais et français pris en charge.
+- Fichiers de locale : `ui/src/i18n/locales/en.json`, `ui/src/i18n/locales/fr.json`.
+- Les traductions de recettes voyagent avec la classe de la recette (voir le champ `i18n`), pas dans les fichiers de locale de la plateforme.
+
+---
+
+## Design system
+
+| Propriété                 | Valeur                                                       |
+| ------------------------- | ------------------------------------------------------------ |
+| **Police body**           | Inter                                                        |
+| **Police mono**           | JetBrains Mono (valeurs, logs)                               |
+| **Couleur primaire**      | `#1A4F6E` (ocean blue), hover : `#13405A`, light : `#E6F0F6` |
+| **Couleur accent**        | `#D4963F` (amber), hover : `#BB8232`                         |
+| **Espacement de base**    | 4px                                                          |
+| **Border radius**         | 6px (boutons), 10px (cartes), 14px (modales)                 |
+| **Taille de police body** | 14px (tableau de bord dense)                                 |
+| **Valeurs de données**    | 28px (lisibles d'un coup d'œil)                              |
+| **Icônes**                | Lucide React, stroke 1.5px                                   |
+
+---
+
+## Backup et restauration
+
+Les backups capturent l'état complet du système dans une seule archive ZIP et le restaurent atomiquement.
+
+### Service
+
+`BackupManager` dans `src/backup/backup-manager.ts` est le service central. Il est appelé par :
+
+- **Routes HTTP** `GET/POST /api/v1/backup` (export/import manuel)
+- **UpdateManager** (backup automatique pré-update, voir la section auto-update)
+- **Routes de backup local** `GET /api/v1/backup/local`, `POST /api/v1/backup/restore-local`
+
+### Format d'archive
+
+Un ZIP de backup contient :
+
+| Entrée                    | Contenu                                                                                                          |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `sowel-backup.json`       | Export SQLite en JSON, structuré par table (format version 2)                                                    |
+| `influx-raw.lp`           | Données InfluxDB brutes en line protocol (7 derniers jours)                                                      |
+| `influx-hourly.lp`        | Données horaires downsamplées (90 derniers jours)                                                                |
+| `influx-daily.lp`         | Données journalières downsamplées (5 dernières années)                                                           |
+| `influx-energy-hourly.lp` | Sommes énergétiques horaires (2 dernières années)                                                                |
+| `influx-energy-daily.lp`  | Sommes énergétiques journalières (10 dernières années)                                                           |
+| `data/*`                  | Tous les fichiers non DB de `data/` (secrets de tokens, etc.), scannés dynamiquement, hors `.db`, `.pid`, `.log` |
+
+L'export JSON SQLite couvre une liste sélectionnée de tables (constante `BACKUP_TABLES` dans `backup-manager.ts`) dans l'ordre des dépendances (parents d'abord pour la restauration).
+
+### Backups locaux (data/backups/)
+
+Distinct de l'export manuel, `BackupManager.exportToFile()` écrit les backups dans `data/backups/sowel-backup-<name>.zip` sur le volume persistant. Utilisé par :
+
+- **UpdateManager** avant tout self-update : `data/backups/sowel-backup-pre-v<version>-<timestamp>.zip`
+- **Rotation** via `rotateLocalBackups(keep)`, conserve uniquement les N fichiers les plus récents
+
+L'UI (Admin → Backup) liste les backups locaux et propose une restauration en un clic via `POST /api/v1/backup/restore-local { filename }`.
+
+### Flux de restauration
+
+1. Valide la structure du ZIP et le schéma JSON
+2. Désactive les contraintes FK (hors transaction, limitation SQLite)
+3. Supprime toutes les lignes en ordre inverse des dépendances (enfants d'abord)
+4. Insère les nouvelles lignes en ordre parent-first
+5. Exécute `PRAGMA foreign_key_check`, abandonne la transaction si violations
+6. S'assure que les buckets InfluxDB existent (`influxClient.ensureBuckets()` et `ensureEnergyBuckets()`)
+7. POST chaque fichier `.lp` vers InfluxDB `/api/v2/write` par batches de 5000 lignes
+8. Restaure les fichiers de données dynamiques
+9. Répond `restartRequired: true`, l'utilisateur doit redémarrer Sowel pour recharger l'état
+
+Voir la spec 060 pour le dernier design de backup et `src/backup/backup-manager.ts` pour l'implémentation.
+
+---
+
+## Auto-update (spec 060)
+
+Sowel peut se mettre à jour depuis l'UI quand il tourne sous `docker compose`. Le design contourne le paradoxe "le processus se tue lui-même" via un pattern de container helper (similaire à Watchtower).
+
+### Détection
+
+`VersionChecker` dans `src/core/version-checker.ts` interroge `https://api.github.com/repos/mchacher/sowel/releases/latest` toutes les heures (et aussi à T+10s après le boot). Quand un semver plus récent est trouvé, il émet `system.update.available` sur l'EventBus, qui est diffusé aux clients UI via WebSocket. L'UI affiche un badge en temps réel. Un bouton manuel "Check now" appelle `POST /api/v1/system/version/check` qui force un poll immédiat.
+
+`GET /api/v1/system/version` retourne `{ current, latest, updateAvailable, releaseUrl, dockerAvailable, composeManaged }`. `composeManaged` est dérivé des labels du conteneur en cours (`com.docker.compose.*`) ; s'ils sont absents, l'auto-update est désactivé avec un tooltip.
+
+### Flux de mise à jour
+
+`UpdateManager` dans `src/core/update-manager.ts` orchestre la mise à jour :
+
+1. **Backup pré-update** via `backupManager.exportToFile()` → `data/backups/sowel-backup-pre-v<X>-<ts>.zip`
+2. **Rotation des backups** (conserve les 3 plus récents)
+3. **Détection du contexte compose** depuis les labels du conteneur courant : `com.docker.compose.project.working_dir`, `com.docker.compose.project`, `com.docker.compose.service`
+4. **Spawn d'un container helper** via dockerode :
+   - Image : `docker:25-cli` (intègre `docker compose`)
+   - Mounts : `/var/run/docker.sock` + le compose working dir comme `/workdir`
+   - Cmd : `sh -c "sleep 5 && docker compose pull <service> && docker compose up -d <service>"`
+   - `AutoRemove: true`
+5. **Retour immédiat de l'API**, le helper survit à la mort de Sowel
+6. **L'UI affiche un overlay** ("Updating...") pendant le swap, poll `/system/version` toutes les 3 s
+7. **Au changement de version** → `window.location.reload()`
+
+Pourquoi un helper ? Appeler `dockerode.stop()` sur le conteneur en cours depuis le processus en cours tue le runtime Node via SIGTERM avant que la séquence remove/create/start puisse s'exécuter. Le helper est un processus séparé dans un conteneur séparé qui survit au swap.
+
+**Prérequis sur l'hôte** :
+
+- `/var/run/docker.sock` monté dans le conteneur sowel
+- Le compose working dir doit être accessible depuis le système de fichiers de l'hôte (n'importe quel chemin de bind mount fonctionne, Sowel le lit depuis les labels du conteneur)
+- `docker compose up` doit utiliser un nom de fichier standard `docker-compose.yml` / `compose.yml` (les noms non standards nécessitent `-f`, pas géré actuellement)
+
+---
+
+## CI/CD et releases (spec 055)
+
+### Workflow GitHub Actions
+
+`.github/workflows/release.yml` se déclenche sur les tags poussés correspondant à `v*`. Il exécute :
+
+1. **job ci** : typecheck, lint, tests (backend + UI)
+2. **job docker** : build l'image `linux/amd64` avec Buildx, pousse vers `ghcr.io/mchacher/sowel:<version>` et `:latest`, puis crée une GitHub Release avec des notes auto-générées
+
+Le build Docker est **amd64-only** (spec simplifiée en avril 2026 pour des builds environ 3x plus rapides ; arm64 abandonné car aucun utilisateur ne tourne sur des hôtes Linux Apple Silicon en production).
+
+### Script de release
+
+`scripts/release.sh <version>` :
+
+1. Valide le format semver et un working tree propre
+2. Bump les versions de `package.json` + `ui/package.json`
+3. Lance la validation complète (`npm run validate`)
+4. Commit `release: vX.Y.Z`, tag `vX.Y.Z`, push vers origin
+5. GitHub Actions prend le relais
+
+Une skill Claude Code emballe ça dans `.claude/skills/sowel-release/SKILL.md`.
+
+### Image Docker (`Dockerfile`)
+
+Build multi-étages :
+
+1. **backend-build** : Node 20, `tsc` backend
+2. **ui-build** : Node 20, build Vite UI
+3. **runtime** : Debian Trixie (pour Python 3.13), Node 20 installé via NodeSource, Python 3.13 + venv pour les plugins qui en ont besoin (par ex. Panasonic CC), `better-sqlite3` recompilé pour la plateforme
+
+L'image runtime fait environ 950 Mo non compressée (environ 210 Mo de contenu). L'exigence Python 3.13 vient du plugin Panasonic CC qui a besoin d'une syntaxe f-string indisponible en Python 3.11.
+
+---
+
+## Logging
+
+### Stratégie
+
+Logs JSON structurés pino avec sortie multistream (voir `src/core/logger.ts`) :
+
+- **Ring buffer** : buffer circulaire en mémoire pour le viewer de logs de l'UI (capture toujours au niveau debug)
+- **stdout** : JSON brut en production (capté par les Docker logs), pino-pretty en développement
+- **Transport fichier** : en production uniquement, via `pino-roll` vers `data/logs/sowel-N.log`, rotation journalière, conserve 14 fichiers
+
+### Emplacement des fichiers de log
+
+`/app/data/logs/sowel-<N>.log` à l'intérieur du conteneur (sur le volume `sowel-data`). **Survit à la recréation du conteneur**, indispensable pour l'investigation post-incident après une auto-mise à jour.
+
+Exemple de récupération :
+
+```bash
+docker exec sowel sh -c 'cat /app/data/logs/sowel.6.log | grep -E "2026-04-11T07:" | grep error'
+```
+
+### Conseils sur les niveaux de log
+
+| Niveau  | Usage                                                              |
+| ------- | ------------------------------------------------------------------ |
+| `fatal` | Crash de processus imminent                                        |
+| `error` | Opération échouée, le moteur continue (toujours avec `{ err }`)    |
+| `warn`  | Dégradation auto-réparable (reconnexion, données obsolètes)        |
+| `info`  | Événements métier significatifs, un par opération                  |
+| `debug` | Détail de dépannage pour les développeurs                          |
+| `trace` | Chemin chaud à haut volume (chaque événement, chaque message MQTT) |
+
+Conventions :
+
+- Chaque module crée un child logger avec `{ module: "module-name" }`
+- Contexte structuré comme premier argument objet : `logger.info({ deviceId, status }, "Device status changed")`
+- Mots de passe/tokens/secrets sont auto-redactés par la config pino
+- **N'utilisez jamais `console.*`**, ça contourne le ring buffer, la rotation des fichiers et la redaction
+
+### Helpers de récupération
+
+- **Depuis l'UI** : page Admin → Logs (lit le ring buffer)
+- **Via API** : `GET /api/v1/logs?module=X&level=Y&limit=N` (ring buffer uniquement, perdu au redémarrage)
+- **Depuis le fichier** : `docker exec` dans `/app/data/logs/sowel-*.log` (persistant)
+- **Script helper** : `scripts/logs/fetch-logs.py <module> <level> <limit>` avec les variables d'env `SOWEL_URL` + `SOWEL_PASSWORD`
+
+---
+
+## Gestion des fuseaux horaires (spec 061)
+
+La logique backend de Sowel dépend fortement de l'heure locale : créneaux cron du calendrier (`croner`), classification tarifaire HP/HC énergie, frontières de jour énergétique, affichage des levers/couchers de soleil, notifications. Tout utilise les méthodes natives `Date` qui dépendent de `process.env.TZ`.
+
+### Stratégie de détection
+
+Au démarrage, `src/core/timezone.ts` détermine le fuseau horaire avec cette priorité :
+
+1. **Variable d'env `TZ`** : si elle est définie dans `docker-compose.yml` ou dans l'env de l'hôte, Sowel la respecte (l'override explicite l'emporte)
+2. **`home.latitude` / `home.longitude`** : si elles sont configurées dans les Réglages, Sowel les passe à `tz-lookup` pour dériver le nom IANA du fuseau (par ex. `Europe/Paris`)
+3. **Fallback UTC** : avec un log WARN bruyant invitant l'utilisateur à configurer une localisation maison
+
+`process.env.TZ` est défini **avant `createLogger()`** dans `src/index.ts`. C'est crucial : le premier appel `new Date()` de pino met en cache le TZ dans V8, et les changements de `process.env.TZ` après ça n'ont aucun effet sur les méthodes `Date.prototype` déjà chargées. Voir la séquence de boot dans `src/index.ts`.
+
+### Redémarrage requis après changement de localisation
+
+Node met le TZ en cache à la première utilisation. Si l'utilisateur change `home.latitude` / `home.longitude` dans les Réglages au runtime :
+
+1. La route des réglages logge un warn et émet `system.restart_required` sur l'EventBus
+2. L'UI reçoit l'événement via WebSocket et affiche `RestartToast` avec un bouton "Redémarrer maintenant"
+3. Cliquer sur le bouton appelle `POST /api/v1/system/restart` qui spawne un container helper `docker:25-cli` (même pattern que la spec 060 self-update) qui exécute `docker compose up -d sowel`
+4. Le helper survit à la mort de Sowel et recrée le conteneur, qui prend la nouvelle env et ré-exécute `detectTimezone()` avec les nouvelles coordonnées
+5. L'`UpdateOverlay` existant recharge l'UI à la reconnexion WS
+
+### Exposition du TZ dans l'UI
+
+- `GET /api/v1/system/timezone` retourne `{ tz, source, offsetHours }` à tout utilisateur authentifié
+- `ui/src/store/useTimezone.ts` met le résultat en cache dans un store Zustand, fetché une fois au montage de l'app depuis `AppLayout.tsx`
+- La section Réglages → Maison affiche le TZ en lecture seule avec son label de source (auto / env / fallback)
+- La `CurrentTimePill` dans le bandeau d'en-tête affiche l'heure de la **maison** (pas l'heure locale du navigateur), calculée via `Intl.DateTimeFormat(undefined, { timeZone: tz, ... })`, utile quand on accède à Sowel depuis un appareil dans un autre fuseau
+
+Voir la spec 061 sur [github.com/mchacher/sowel/tree/main/specs/061-timezone-from-home-location](https://github.com/mchacher/sowel/tree/main/specs/061-timezone-from-home-location).
+
+---
+
+## Variables d'environnement
+
+Tous les réglages sont optionnels avec des valeurs par défaut raisonnables, Sowel tourne sans configuration prête à l'emploi. Surchargez via `.env` au besoin :
+
+| Variable          | Défaut                         | Notes                                                                                      |
+| ----------------- | ------------------------------ | ------------------------------------------------------------------------------------------ |
+| `SQLITE_PATH`     | `./data/sowel.db`              | Chemin de la base SQLite                                                                   |
+| `API_PORT`        | `3000`                         | Port du serveur HTTP                                                                       |
+| `API_HOST`        | `0.0.0.0`                      | Adresse de bind                                                                            |
+| `JWT_SECRET`      | auto-généré                    | Persisté dans `data/.jwt-secret` au premier lancement                                      |
+| `JWT_ACCESS_TTL`  | `900`                          | TTL de l'access token en secondes (15 min)                                                 |
+| `JWT_REFRESH_TTL` | `2592000`                      | TTL du refresh token en secondes (30 jours)                                                |
+| `LOG_LEVEL`       | `info`                         | Niveau de log pino                                                                         |
+| `CORS_ORIGINS`    | `*`                            | Origines autorisées séparées par des virgules                                              |
+| `INFLUX_URL`      | `http://localhost:8086`        | URL InfluxDB 2.x                                                                           |
+| `INFLUX_TOKEN`    | auto-généré                    | Persisté dans `data/.influx-token` au premier lancement                                    |
+| `INFLUX_ORG`      | `sowel`                        | Organisation InfluxDB                                                                      |
+| `INFLUX_BUCKET`   | `sowel`                        | Bucket principal InfluxDB                                                                  |
+| `TZ`              | défaut système (UTC en Docker) | Fuseau IANA. À fixer explicitement dans docker-compose pour fiabiliser la logique horaire. |
+
+Les réglages d'intégration (MQTT, identifiants cloud, intervalles de polling) sont configurés depuis l'UI, pas depuis `.env`.

--- a/docs/technical/contributing.fr.md
+++ b/docs/technical/contributing.fr.md
@@ -1,0 +1,267 @@
+# Contribuer à Sowel
+
+Ce guide couvre tout ce qu'un contributeur doit savoir pour mettre en place l'environnement de développement, suivre les conventions du projet et soumettre des changements.
+
+---
+
+## Mise en place du dev
+
+### Prérequis
+
+- **Node.js 20+**
+- **npm** (livré avec Node.js)
+- **Docker + docker-compose** (pour InfluxDB)
+- **Git**
+
+### Backend
+
+```bash
+git clone <repo-url>
+cd sowel
+npm install
+npm run dev          # Development with hot reload (ts-node + nodemon)
+```
+
+### Frontend
+
+```bash
+cd ui
+npm install
+npm run dev          # Vite dev server (hot module replacement)
+```
+
+### Docker (InfluxDB)
+
+```bash
+docker-compose up -d     # Starts InfluxDB 2.x
+```
+
+InfluxDB est obligatoire : Sowel se connecte au démarrage et auto-crée les buckets, les tâches de downsampling et les tâches d'agrégation énergétique. Aucune configuration manuelle n'est nécessaire.
+
+### Build
+
+```bash
+# Backend: TypeScript compilation
+npm run build
+
+# Frontend: production build
+cd ui && npm run build
+
+# Start production
+npm start
+```
+
+### Tests
+
+```bash
+npm test                          # Run all tests
+npm test -- --grep "pattern"      # Run specific tests
+```
+
+Les tests utilisent Vitest avec des bases SQLite en mémoire et de faux timers.
+
+---
+
+## Workflow Git
+
+### Stratégie de branches
+
+- **Feature branches obligatoires** : tout développement non trivial (nouvelle fonctionnalité, refactoring, changements multi-fichiers) doit se faire sur une branche dédiée, pas directement sur `main`.
+- Utilisez des noms de branche descriptifs : `feat/gate-abstraction`, `fix/rate-limit`, `refactor/influxdb-mandatory-core`.
+- Les petits correctifs isolés (typo, changement de config sur une ligne) peuvent aller directement sur `main`.
+
+### Pull Requests
+
+- **Le merge d'une PR exige une approbation explicite de l'utilisateur** : ne mergez jamais une pull request sans validation explicite du mainteneur.
+- Créez la PR, présentez-la, et attendez l'approbation avant de merger.
+- Gardez les PRs ciblées : une fonctionnalité ou un correctif par PR.
+
+### Messages de commit
+
+Suivez le style conventional commits :
+
+```
+feat(devices): add auto-discovery for Netatmo HC
+fix(energy): correct HP/HC timestamp offset
+refactor(core): make InfluxDB mandatory
+docs(api): update endpoint documentation
+```
+
+---
+
+## Conventions de code
+
+### TypeScript
+
+- Le **strict mode** est activé sur tout le projet.
+- Tous les types sont définis dans `src/shared/types.ts` et partagés entre les modules backend.
+- Utilisez les unions discriminées TypeScript pour l'Event Bus typé (type `EngineEvent`).
+- Exécutez toujours `npx tsc --noEmit` avant de committer pour attraper les erreurs de type.
+
+### IDs et données
+
+- UUID v4 pour tous les IDs d'entité : `crypto.randomUUID()`.
+- Toutes les dates en format ISO 8601.
+- Toutes les interfaces vivent dans `src/shared/types.ts`.
+
+### Base de données
+
+- SQLite via l'API synchrone de `better-sqlite3`, volontairement synchrone, très rapide.
+- Mode WAL : `PRAGMA journal_mode=WAL`.
+- Migrations dans le répertoire `migrations/`, exécutées automatiquement au démarrage.
+- Utilisez les transactions pour les opérations en lot.
+- Les fichiers de migration suivent le pattern de nommage `NNN_description.sql` (par ex. `033_plugins.sql`).
+
+### Event Bus
+
+- `EventEmitter` typé avec union discriminée TypeScript (type `EngineEvent`).
+- Tous les handlers doivent être **non bloquants** et **ne jamais lever d'exception**.
+- Wrappez toute la logique de handler dans try/catch avec logging.
+
+### Intégrations
+
+- Chaque source de device implémente l'interface `IntegrationPlugin`.
+- Les plugins s'enregistrent dans `IntegrationRegistry` qui gère le cycle de vie (start/stop/reconnect).
+- Les intégrations basées sur MQTT utilisent `mqtt.js` avec `connectAsync` pour async/await.
+- Les intégrations cloud utilisent du polling avec des intervalles configurables.
+- Tous les handlers de message/événement ne doivent jamais lever d'exception, wrappez en try/catch avec logging.
+- Les réglages stockés en SQLite dans la table `settings` sous `integration.<id>.<key>`, configurables depuis l'UI.
+
+### Authentification
+
+- bcrypt (cost 12) pour les mots de passe, `jsonwebtoken` (HS256) pour les JWT.
+- Tokens d'API : préfixe `swl_`, hash SHA-256 stocké, généré via `crypto.randomBytes(32)`.
+- Middleware d'auth : essaie d'abord le décodage JWT, puis le lookup de token d'API.
+- Rôles : `admin` > `standard` > `viewer` (permissions hiérarchiques).
+
+### Moteur d'expressions
+
+- Parser d'expressions sûr (PAS `eval`), à envisager `expr-eval` ou un parseur maison.
+- Références : `binding.<alias>`, `equipment.<id>.<key>`, `zone.<zoneId>.<key>`.
+- Opérateurs : `OR`, `AND`, `NOT`, `AVG`, `MIN`, `MAX`, `SUM`, `IF`, `THRESHOLD`.
+
+### Frontend
+
+- Stores **Zustand** mis à jour par les événements WebSocket.
+- WebSocket auto-reconnect avec récupération d'état (incrémental ou complet).
+- **Tailwind CSS utility classes uniquement**, pas de fichiers CSS personnalisés.
+- Design responsive **mobile-first** (breakpoints : 640 px, 1024 px).
+- **Dark mode** via la stratégie `class` de Tailwind.
+- **Icônes** : Lucide React, stroke 1.5px.
+
+---
+
+## Règles de logging
+
+Logs JSON structurés via pino (par défaut Fastify) avec multistream : ring buffer (UI), pino-pretty (dev), JSON stdout + fichiers pino-roll (prod).
+
+### Niveaux de log
+
+| Niveau    | Usage                                                         | Visible en prod   | Exemples                                                                                     |
+| --------- | ------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------- |
+| **fatal** | Le processus est sur le point de crasher, irrécupérable       | Oui               | Exception non capturée, corruption de base                                                   |
+| **error** | Opération échouée, le moteur continue. Demande attention      | Oui               | Poll d'intégration échoué, erreur de dispatch d'ordre, erreur d'exécution de recette         |
+| **warn**  | Situation inattendue, gérée proprement                        | Oui               | MQTT en reconnexion, device offline, retry de refresh de token, nettoyage de device obsolète |
+| **info**  | Événements métier significatifs, un par opération             | Oui               | Démarrage/arrêt moteur, device découvert/supprimé, CRUD d'équipement, mode activé            |
+| **debug** | Détail opérationnel pour le dépannage                         | Non (dev/UI seul) | Évaluation de binding, étapes d'agrégation, migration appliquée, config chargée              |
+| **trace** | Données de chemin chaud à haut volume, debugging profond seul | Non (dev/UI seul) | Chaque émission d'event bus, chaque message MQTT, chaque mise à jour de point de donnée      |
+
+### Règles d'attribution de niveau
+
+- **info = tableau de bord admin** : un opérateur qui lit les logs info doit comprendre _ce qui s'est passé_ sans se noyer. Un log par opération métier, pas par item traité.
+- **debug = session développeur** : assez détaillé pour tracer un problème spécifique. Un humain peut lire ces logs sur un module pendant une session de debug.
+- **trace = mode replay** : permet de reproduire les transitions d'état exactes. Volume élevé, jamais activé en production.
+- **error inclut toujours `{ err }`** : passez l'objet Error en contexte structuré, par ex. `logger.error({ err }, "Poll failed")`.
+- **warn = auto-réparation** : le système a géré, mais des warnings répétés signalent une dégradation.
+- **N'utilisez jamais `console.log/error/warn`** : utilisez toujours le logger pino structuré. Les appels console contournent le ring buffer, la rotation des fichiers et la redaction.
+
+### Que mettre où (par domaine)
+
+| Domaine          | info                                               | debug                                            | trace                           |
+| ---------------- | -------------------------------------------------- | ------------------------------------------------ | ------------------------------- |
+| **MQTT**         | Connecté, déconnecté, en reconnexion               | Souscrit à un topic, résultat de publication     | Chaque message reçu             |
+| **Devices**      | Découvert, supprimé, statut changé                 | Donnée auto-créée, catégorie inférée             | Chaque mise à jour de donnée    |
+| **Equipments**   | CRUD, ordre dispatché                              | Évaluation de binding, résultat de computed data | Chaque réévaluation de binding  |
+| **Zones**        | CRUD, résumé d'agrégation                          | Champs d'agrégation calculés individuellement    | Chaque déclencheur d'agrégation |
+| **Modes**        | Activé, désactivé, CRUD                            | Chaque action d'impact exécutée                  | --                              |
+| **Recipes**      | Instance créée/supprimée, activée/désactivée       | Étapes d'exécution, évaluation de trigger        | --                              |
+| **Integrations** | Démarré, stoppé, connecté, poll terminé            | Détails de cycle de poll, résultats d'appel API  | Réponses API brutes             |
+| **Auth**         | Login utilisateur, token créé, mot de passe changé | Validation JWT, décisions du middleware          | --                              |
+| **API**          | Serveur en écoute, route enregistrée               | Détails de traitement de requête                 | Chaque requête/réponse          |
+| **WebSocket**    | Client connecté/déconnecté                         | Souscription topic, message envoyé               | Chaque frame                    |
+| **Event Bus**    | --                                                 | --                                               | Chaque événement émis           |
+| **Database**     | DB ouverte, migration appliquée                    | Exécution de requête, changements de schéma      | --                              |
+
+### Conventions du logger
+
+- **Nom de propriété** : utilisez `this.logger` dans les classes, `logger` dans les fonctions standalone. Jamais `this.log`, `log`, ou `console`.
+- **Child loggers** : chaque module crée un child logger avec `{ module: "module-name" }` pour le filtrage.
+- **Contexte structuré** : passez les données comme premier argument objet, le message comme second : `logger.info({ deviceId, status }, "Device status changed")`.
+- **Données sensibles** : auto-redactées par la config pino (mots de passe, tokens, secrets, clés d'API). Ne loggez jamais des credentials manuellement.
+- **Pas d'interpolation de chaîne dans les messages** : utilisez `logger.info({ count }, "Devices discovered")` plutôt que ``logger.info(`Discovered ${count} devices`)``.
+
+---
+
+## Référence du design system
+
+Quand vous ajoutez ou modifiez des composants UI, suivez ces design tokens :
+
+| Propriété                 | Valeur                                                       |
+| ------------------------- | ------------------------------------------------------------ |
+| **Police body**           | Inter                                                        |
+| **Police mono**           | JetBrains Mono (valeurs, logs)                               |
+| **Couleur primaire**      | `#1A4F6E` (ocean blue), hover : `#13405A`, light : `#E6F0F6` |
+| **Couleur accent**        | `#D4963F` (amber), hover : `#BB8232`                         |
+| **Espacement de base**    | 4px                                                          |
+| **Border radius**         | 6px (boutons), 10px (cartes), 14px (modales)                 |
+| **Taille de police body** | 14px (tableau de bord dense)                                 |
+| **Valeurs de données**    | 28px (lisibles d'un coup d'œil)                              |
+| **Icônes**                | Lucide React, stroke 1.5px                                   |
+
+---
+
+## Variables d'environnement
+
+Tous les réglages sont optionnels avec des valeurs par défaut raisonnables, Sowel tourne sans configuration. Surchargez via `.env` au besoin :
+
+| Variable          | Défaut                  | Notes                                                   |
+| ----------------- | ----------------------- | ------------------------------------------------------- |
+| `SQLITE_PATH`     | `./data/sowel.db`       | Chemin de la base SQLite                                |
+| `API_PORT`        | `3000`                  | Port du serveur HTTP                                    |
+| `API_HOST`        | `0.0.0.0`               | Adresse de bind                                         |
+| `JWT_SECRET`      | auto-généré             | Persisté dans `data/.jwt-secret` au premier lancement   |
+| `JWT_ACCESS_TTL`  | `900`                   | TTL de l'access token en secondes (15 min)              |
+| `JWT_REFRESH_TTL` | `2592000`               | TTL du refresh token en secondes (30 jours)             |
+| `LOG_LEVEL`       | `info`                  | Niveau de log pino                                      |
+| `CORS_ORIGINS`    | `*`                     | Origines autorisées séparées par des virgules           |
+| `INFLUX_URL`      | `http://localhost:8086` | URL InfluxDB 2.x                                        |
+| `INFLUX_TOKEN`    | auto-généré             | Persisté dans `data/.influx-token` au premier lancement |
+| `INFLUX_ORG`      | `sowel`                 | Organisation InfluxDB                                   |
+| `INFLUX_BUCKET`   | `sowel`                 | Bucket principal InfluxDB                               |
+
+Les réglages d'intégration (MQTT, identifiants cloud, intervalles de polling) sont configurés depuis l'UI (Administration > Intégrations), pas depuis `.env`.
+
+---
+
+## Structure du projet
+
+Pour un schéma complet de la structure du projet et des détails d'architecture, voir [Vue d'ensemble de l'architecture](architecture.md).
+
+---
+
+## Roadmap de développement
+
+V0.1 Devices -> V0.2 Zones -> V0.3 Equipments+Bindings -> V0.4 UI Home -> V0.5 Sensors -> V0.6 Zone Aggregation -> V0.7 Shutters -> V0.8 Recipes -> V0.9 Modes+Calendar -> V0.10 Integration Plugins (Z2M, Panasonic CC, MCZ Maestro, Netatmo HC) -> V0.11 Logging -> V0.12 Computed Data -> V0.13 History (InfluxDB) -> V1.0+ AI Assistant
+
+---
+
+## Checklist avant soumission
+
+- [ ] `npx tsc --noEmit` passe (backend)
+- [ ] `cd ui && npx tsc --noEmit` passe (frontend, si modifié)
+- [ ] `npm test` passe
+- [ ] Aucun appel `console.log`, utilisez le logger pino
+- [ ] Logging structuré avec les bons niveaux (voir règles ci-dessus)
+- [ ] Migrations ajoutées si changement de schéma
+- [ ] Branche feature avec un nom descriptif
+- [ ] La description de PR explique le "pourquoi"

--- a/docs/technical/data-model.fr.md
+++ b/docs/technical/data-model.fr.md
@@ -1,0 +1,830 @@
+# Sowel : Modèle de données
+
+> Version : 1.0, 2026-02-19
+>
+> Ce document est la référence du modèle de données central de Sowel. Il décrit l'architecture en trois couches (Topologie -> Fonctionnel -> Physique), toutes les entités, leurs relations et les règles d'agrégation.
+
+---
+
+## 1. Architecture en trois couches
+
+Sowel sépare les responsabilités en trois couches distinctes :
+
+```
++-------------------------------------------------------------+
+|  LAYER 1 -- TOPOLOGY (Zones)                                |
+|  Spatial structure of the home                               |
+|  Hierarchical: Home -> Floor -> Room                         |
+|  Aggregates data automatically from child Equipments         |
++-------------------------------------------------------------+
+|  LAYER 2 -- FUNCTIONAL (Equipments + Groups)                 |
+|  What the user sees and controls                             |
+|  Placed IN a Zone, optionally IN a Group                     |
+|  Binds to one or more physical Devices                       |
++-------------------------------------------------------------+
+|  LAYER 3 -- PHYSICAL (Devices)                               |
+|  Hardware discovered from integrations                       |
+|  Auto-discovered, raw data and commands                      |
+|  Never directly manipulated by the end user                  |
++-------------------------------------------------------------+
+```
+
+**Principe directeur** : un Device est ce qui est sur le réseau. Un Equipment est ce qui est dans la pièce.
+
+---
+
+## 2. Diagramme entité-relation
+
+```
+Zone (hierarchy: parent -> children)
+ |
+ +-- EquipmentGroup (optional functional grouping)
+ |    +-- Equipment*
+ |
+ +-- Equipment (functional unit, user-facing)
+      +-- DataBinding --> DeviceData (on a Device)
+      +-- OrderBinding --> DeviceOrder (on a Device)
+      +-- [V0.5] ComputedData (expression-based virtual data)
+
+Device (physical, auto-discovered)
+ +-- DeviceData (readable properties: temperature, state, brightness...)
+ +-- DeviceOrder (writable commands: set brightness, turn on...)
+```
+
+---
+
+## 3. Zone
+
+Une **Zone** représente une aire spatiale dans la maison. Les zones forment une **hiérarchie en arbre**.
+
+### 3.1 Interface
+
+```typescript
+interface Zone {
+  id: string; // UUID v4
+  name: string; // "Salon", "Etage 1", "Maison"
+  parentId: string | null; // null = root zone
+  icon?: string; // Lucide icon name: "home", "sofa", "bed"
+  description?: string; // "Piece principale, 35m2"
+  displayOrder: number; // Sort order among siblings (0-based)
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+}
+```
+
+### 3.2 Hiérarchie
+
+Les zones sont imbriquables sur n'importe quelle profondeur. Structure typique :
+
+```
+Maison                    (root, parentId: null)
++-- RDC                   (floor, parentId: Maison)
+|   +-- Salon             (room, parentId: RDC)
+|   +-- Cuisine           (room, parentId: RDC)
+|   +-- Entree            (room, parentId: RDC)
+|   +-- WC                (room, parentId: RDC)
++-- Etage                 (floor, parentId: Maison)
+|   +-- Chambre Parentale (room, parentId: Etage)
+|   +-- Chambre Enfant    (room, parentId: Etage)
+|   +-- Salle de Bain     (room, parentId: Etage)
+|   +-- Couloir           (room, parentId: Etage)
++-- Exterieur             (area, parentId: Maison)
+    +-- Jardin            (area, parentId: Exterieur)
+    +-- Garage            (area, parentId: Exterieur)
+```
+
+### 3.3 Données agrégées de zone
+
+Le moteur **calcule automatiquement** les données agrégées de chaque Zone à partir des Equipments qu'elle contient. Aucune configuration manuelle requise, c'est une fonctionnalité centrale.
+
+L'agrégation est **récursive** : une Zone parent agrège ses propres Equipments plus toutes les Zones enfants.
+
+| Attribute                | Type           | Règle d'agrégation | Source (DataCategory) | Description                                                   |
+| ------------------------ | -------------- | ------------------ | --------------------- | ------------------------------------------------------------- |
+| `temperature`            | number \| null | AVG                | `temperature`         | Température moyenne de la zone                                |
+| `humidity`               | number \| null | AVG                | `humidity`            | Humidité moyenne                                              |
+| `pressure`               | number \| null | AVG                | `pressure`            | Pression atmosphérique moyenne                                |
+| `luminosity`             | number \| null | AVG                | `luminosity`          | Luminosité moyenne (lux)                                      |
+| `co2`                    | number \| null | AVG                | `co2`                 | Niveau de CO2 moyen (ppm)                                     |
+| `voc`                    | number \| null | AVG                | `voc`                 | Niveau de COV moyen (ppb)                                     |
+| `motion`                 | boolean        | OR                 | `motion`              | true si AU MOINS UN capteur de mouvement détecte du mouvement |
+| `presence`               | boolean        | OR + timeout       | `motion`              | true si du mouvement détecté dans un timeout configurable     |
+| `openDoors`              | number         | COUNT (open)       | `contact_door`        | Nombre de contacts de porte ouverts                           |
+| `openWindows`            | number         | COUNT (open)       | `contact_window`      | Nombre de contacts de fenêtre ouverts                         |
+| `waterLeak`              | boolean        | OR                 | `water_leak`          | true si AU MOINS UN capteur de fuite d'eau se déclenche       |
+| `smoke`                  | boolean        | OR                 | `smoke`               | true si AU MOINS UN détecteur de fumée se déclenche           |
+| `lightsOn`               | number         | COUNT (on)         | `light_state`         | Nombre de lumières allumées                                   |
+| `lightsTotal`            | number         | COUNT (all)        | `light_state`         | Nombre total d'équipements lumière                            |
+| `averageBrightness`      | number \| null | AVG (on only)      | `light_brightness`    | Luminosité moyenne des lumières allumées                      |
+| `shuttersOpen`           | number         | COUNT (open)       | `shutter_position`    | Nombre de volets ouverts                                      |
+| `shuttersTotal`          | number         | COUNT (all)        | `shutter_position`    | Nombre total de volets                                        |
+| `averageShutterPosition` | number \| null | AVG                | `shutter_position`    | Position moyenne des volets (%)                               |
+| `totalPower`             | number         | SUM                | `power`               | Puissance instantanée totale (W)                              |
+| `totalEnergy`            | number         | SUM                | `energy`              | Consommation d'énergie totale (kWh)                           |
+| `heatingActive`          | boolean        | OR                 | thermostat equipments | true si un thermostat chauffe activement                      |
+| `targetTemperature`      | number \| null | AVG                | thermostat equipments | Consigne de température cible moyenne                         |
+
+> **Note** : cette liste évoluera. De nouveaux attributs agrégés peuvent être ajoutés à mesure que de nouveaux types d'Equipment et DataCategories sont introduits.
+
+### 3.4 Auto-ordres de zone
+
+Les zones exposent des commandes en lot qui agissent sur tous les Equipments de la zone (et des zones enfants récursivement) :
+
+| Order              | Effet                                              |
+| ------------------ | -------------------------------------------------- |
+| `allOff`           | Éteint TOUS les Equipments contrôlables de la Zone |
+| `allLightsOff`     | Éteint tous les Equipments de type lumière         |
+| `allLightsOn`      | Allume tous les Equipments de type lumière         |
+| `allShuttersOpen`  | Ouvre tous les volets                              |
+| `allShuttersClose` | Ferme tous les volets                              |
+
+### 3.5 Schéma SQLite
+
+```sql
+CREATE TABLE zones (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  parent_id TEXT REFERENCES zones(id) ON DELETE SET NULL,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+---
+
+## 4. Equipment Group
+
+Un **EquipmentGroup** est un regroupement fonctionnel d'Equipments au sein d'une Zone. Il permet de contrôler et de surveiller un sous-ensemble d'équipements ensemble.
+
+### 4.1 Interface
+
+```typescript
+interface EquipmentGroup {
+  id: string; // UUID v4
+  name: string; // "Volets Sud", "Eclairage Ambiance"
+  zoneId: string; // FK -> Zone (a group belongs to exactly one zone)
+  icon?: string; // Lucide icon name
+  description?: string;
+  displayOrder: number; // Sort order within the zone
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+}
+```
+
+### 4.2 Objectif et exemples
+
+```
+Salon (Zone)
++-- Group "Volets Sud"
+|   +-- Volet Baie Vitree          (Equipment: shutter)
+|   +-- Volet Porte Fenetre        (Equipment: shutter)
++-- Group "Volets Nord"
+|   +-- Volet Fenetre Nord         (Equipment: shutter)
++-- Group "Eclairage Ambiance"
+|   +-- Spots Plafond              (Equipment: dimmer)
+|   +-- Lampe Canape               (Equipment: dimmer)
++-- Detection Salon                (Equipment: motion_sensor, no group)
++-- Temperature Salon              (Equipment: sensor, no group)
+```
+
+**Comportements clés :**
+
+- Un Equipment appartient à **au plus un** Group (optionnel, via `groupId`)
+- Un Group appartient à exactement une Zone
+- Les Groups ont leurs propres données agrégées (mêmes règles que les Zones, périmètre = membres du groupe)
+- Les Groups peuvent recevoir des ordres en lot (par ex., "fermer tous les volets de Volets Sud")
+
+### 4.3 Données agrégées de groupe
+
+Les Groups calculent les données agrégées avec les **mêmes règles** que les Zones (section 3.3), mais limitées aux Equipments membres du groupe. Cela permet :
+
+- "Position moyenne des volets de Volets Sud" vs "Position moyenne des volets de Volets Nord"
+- "Nombre de lumières allumées dans Eclairage Ambiance" vs comptage à l'échelle de la zone
+
+### 4.4 Schéma SQLite
+
+```sql
+CREATE TABLE equipment_groups (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+---
+
+## 5. Equipment
+
+Un **Equipment** est l'unité fonctionnelle visible par l'utilisateur. C'est l'entité primaire avec laquelle l'utilisateur interagit dans l'UI, les scénarios et les commandes vocales.
+
+### 5.1 Interface
+
+```typescript
+type EquipmentType =
+  | "light" // on/off light
+  | "dimmer" // dimmable light
+  | "color_light" // color-capable light
+  | "shutter" // cover, blind, shutter
+  | "thermostat" // heating/cooling control
+  | "lock" // door lock
+  | "alarm" // alarm system
+  | "sensor" // generic sensor (temp, humidity...)
+  | "motion_sensor" // motion detector
+  | "contact_sensor" // door/window contact
+  | "media_player" // media device
+  | "camera" // surveillance camera
+  | "switch" // on/off switch or plug
+  | "water_valve" // smart irrigation valve (toggle + timed watering)
+  | "generic"; // anything else
+
+interface Equipment {
+  id: string; // UUID v4
+  name: string; // "Spots Salon", "Volet Baie Vitree"
+  zoneId: string; // FK -> Zone (where the equipment functions)
+  groupId: string | null; // FK -> EquipmentGroup (optional)
+  type: EquipmentType; // Semantic type, drives UI rendering & aggregation
+  icon?: string; // Lucide icon name (overrides type default)
+  description?: string;
+  enabled: boolean; // Disabled equipments are ignored by the engine
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+}
+```
+
+### 5.2 Equipment vs Device
+
+|                      | Device                                 | Equipment                           |
+| -------------------- | -------------------------------------- | ----------------------------------- |
+| **Nature**           | Matériel physique                      | Abstraction fonctionnelle           |
+| **Découverte**       | Auto-découvert depuis les intégrations | Créé manuellement par l'utilisateur |
+| **Identité**         | ID spécifique à l'intégration          | Nom choisi par l'utilisateur        |
+| **Localisation**     | Où il est installé physiquement        | Où il est utilisé fonctionnellement |
+| **Cardinalité**      | 1 Device -> N Equipments possible      | 1 Equipment -> N Devices possible   |
+| **Interaction user** | Jamais (couche technique)              | Toujours (interface principale)     |
+
+**Exemples :**
+
+- 1 Device -> 1 Equipment : capteur de température Aqara -> "Temperature Salon"
+- 1 Device -> N Equipments : module double relais -> "Lumiere Cuisine" + "Lumiere Cellier"
+- N Devices -> 1 Equipment : 3 capteurs PIR -> "Detection Salon" (via computed data, V0.5)
+
+---
+
+## 6. Data Binding
+
+Un **DataBinding** mappe une propriété Device Data vers un alias au niveau Equipment.
+
+### 6.1 Interface
+
+```typescript
+interface DataBinding {
+  id: string; // UUID v4
+  equipmentId: string; // FK -> Equipment
+  deviceDataId: string; // FK -> DeviceData
+  alias: string; // Equipment-level name: "state", "brightness", "temperature"
+}
+```
+
+### 6.2 Comment ça marche
+
+```
+Device "Variateur #1"
++-- DeviceData: key="state", value="ON"        <--+
++-- DeviceData: key="brightness", value=180    <---+-- DataBinding
++-- DeviceData: key="linkquality", value=85        |
+                                                   |
+Equipment "Spots Salon"                            |
++-- Data alias "state" ----------------------------+ (bound to DeviceData "state")
++-- Data alias "brightness" -----------------------  (bound to DeviceData "brightness")
++-- [not bound to linkquality -- it's a technical metric, not user-facing]
+```
+
+### 6.3 Contraintes
+
+- `UNIQUE(equipment_id, alias)`, chaque alias est unique par Equipment
+- Quand le DeviceData change, l'alias lié de l'Equipment reflète la nouvelle valeur immédiatement
+- L'alias est utilisé dans les expressions, l'affichage UI, l'agrégation de zone et les conditions de Scenario
+
+### 6.4 Schéma SQLite
+
+```sql
+CREATE TABLE data_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  device_data_id TEXT NOT NULL REFERENCES device_data(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL,
+  UNIQUE(equipment_id, alias)
+);
+```
+
+---
+
+## 7. Order Binding
+
+Un **OrderBinding** mappe un Device Order vers un alias de commande au niveau Equipment.
+
+### 7.1 Interface
+
+```typescript
+interface OrderBinding {
+  id: string; // UUID v4
+  equipmentId: string; // FK -> Equipment
+  deviceOrderId: string; // FK -> DeviceOrder
+  alias: string; // Equipment-level command: "turn_on", "set_brightness"
+}
+```
+
+### 7.2 Comment ça marche
+
+Quand un Equipment Order est exécuté :
+
+```
+User clicks "Turn On" on Equipment "Spots Salon"
+  -> API: POST /equipments/:id/orders/turn_on { value: true }
+    -> Equipment Manager finds OrderBinding alias="turn_on"
+      -> Resolves to DeviceOrder
+        -> Integration Plugin dispatches command to device
+```
+
+### 7.3 Dispatch multi-devices
+
+Un Equipment peut avoir plusieurs OrderBindings avec **le même alias** pointant vers des Devices différents. Cela permet de contrôler plusieurs devices avec une seule commande :
+
+```
+Equipment "Eclairage Cuisine"
++-- OrderBinding: alias="turn_on" -> DeviceOrder on Relais #1
++-- OrderBinding: alias="turn_on" -> DeviceOrder on Relais #2
+```
+
+L'exécution de `turn_on` dispatche vers les DEUX relais en parallèle.
+
+**Note sur la contrainte du schéma :** pour le dispatch multi-devices, la contrainte UNIQUE est sur `(equipment_id, alias, device_order_id)`, pas seulement `(equipment_id, alias)`.
+
+### 7.4 Schéma SQLite
+
+```sql
+CREATE TABLE order_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  device_order_id TEXT NOT NULL REFERENCES device_orders(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL,
+  UNIQUE(equipment_id, alias, device_order_id)
+);
+```
+
+---
+
+## 8. Device (Couche 3, physique)
+
+Les Devices sont auto-découverts depuis les intégrations configurées (Zigbee2MQTT, Panasonic CC, MCZ Maestro, Netatmo HC, etc.). Ils sont documentés ici par souci de complétude.
+
+### 8.1 Interface
+
+```typescript
+interface Device {
+  id: string; // UUID v4
+  mqttBaseTopic: string; // Integration-specific topic or identifier
+  mqttName: string; // Integration-specific name or ID
+  name: string; // User-editable display name
+  manufacturer?: string; // "Aqara", "IKEA", "Panasonic", "MCZ"
+  model?: string; // "MCCGQ11LM", "CS-Z25VKEW", etc.
+  ieeeAddress?: string; // Hardware address (Zigbee IEEE, serial, etc.)
+  source: DeviceSource; // "zigbee2mqtt" | "panasonic_cc" | "mcz_maestro" | "netatmo_hc" | ...
+  status: DeviceStatus; // "online" | "offline" | "unknown"
+  lastSeen: string | null; // ISO 8601
+  rawExpose?: unknown; // Raw integration-specific metadata
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### 8.2 DeviceData
+
+```typescript
+interface DeviceData {
+  id: string;
+  deviceId: string; // FK -> Device
+  key: string; // Property name: "temperature", "state", "brightness"
+  type: DataType; // "boolean" | "number" | "enum" | "text" | "json"
+  category: DataCategory; // Semantic category for aggregation rules
+  value: unknown; // Current value
+  unit?: string; // "C", "%", "lx", "W"
+  lastUpdated: string | null;
+}
+```
+
+### 8.3 DeviceOrder
+
+```typescript
+interface DeviceOrder {
+  id: string;
+  deviceId: string; // FK -> Device
+  key: string; // "state", "brightness", "position"
+  type: DataType;
+  mqttSetTopic: string; // MQTT topic to publish to
+  payloadKey: string; // Key in the JSON payload
+  min?: number; // For numeric: minimum value
+  max?: number; // For numeric: maximum value
+  enumValues?: string[]; // For enum: allowed values
+  unit?: string;
+}
+```
+
+---
+
+## 9. Computed Data (V0.5)
+
+> **Différé en V0.5**, documenté ici dans le cadre du modèle de données complet.
+
+Une **ComputedData** est un point de donnée virtuel sur un Equipment dont la valeur est dérivée d'une expression sur d'autres sources de données.
+
+### 9.1 Interface
+
+```typescript
+interface ComputedData {
+  id: string; // UUID v4
+  equipmentId: string; // FK -> Equipment
+  key: string; // "state", "average_temperature", "motion"
+  type: DataType;
+  category: DataCategory; // Used by Zone aggregation
+  expression: string; // Computation expression
+  value: unknown; // Current computed value
+}
+```
+
+### 9.2 Langage d'expression
+
+```
+// Boolean
+OR(binding.motion_1, binding.motion_2)
+AND(binding.door, binding.window)
+NOT(binding.occupancy)
+
+// Numeric
+AVG(binding.temp_1, binding.temp_2)
+MIN(binding.temp_1, binding.temp_2)
+MAX(binding.temp_1, binding.temp_2)
+SUM(binding.power_1, binding.power_2)
+
+// Conditional
+IF(binding.brightness > 0, "on", "off")
+THRESHOLD(binding.temperature, 19, "cold", "ok")
+
+// References
+binding.<alias>                        -> DataBinding on the same Equipment
+equipment.<equipmentId>.<alias>        -> Data on another Equipment
+zone.<zoneId>.<key>                    -> Zone aggregated Data
+```
+
+---
+
+## 10. Flux de données réactif
+
+Le pipeline complet piloté par les événements :
+
+```
+Integration event (MQTT message, cloud API poll, etc.)
+  |
+  v
+Integration Plugin (receives + parses)
+  |
+  v
+Device Manager (updates DeviceData)
+  |
+  +--> Event: "device.data.updated"
+  |
+  v
+Equipment Manager
+  +-- Updates bound Equipment Data (via DataBindings)
+  +-- [V0.5] Re-evaluates ComputedData expressions
+  |
+  +--> Event: "equipment.data.changed"
+  |
+  v
+Zone Aggregator
+  +-- Re-computes Zone aggregated data
+  +-- Re-computes Group aggregated data
+  +-- Propagates up the zone hierarchy (recursive)
+  |
+  +--> Event: "zone.data.changed"
+  |
+  v
+Scenario Engine (V0.7)
+  +-- Evaluates triggers
+  +-- Checks conditions
+  +-- Executes actions
+  |
+  +--> Actions may dispatch Equipment/Zone Orders -> Integration Plugin -> device
+  |
+  v
+WebSocket Server
+  +-- Broadcasts all events to connected UI clients
+```
+
+---
+
+## 11. Événements de l'Event Bus
+
+Tous les événements sont typés via les unions discriminées TypeScript.
+
+### Événements système
+
+| Event                      | Payload         | Quand                    |
+| -------------------------- | --------------- | ------------------------ |
+| `system.started`           | --              | Démarrage moteur terminé |
+| `system.mqtt.connected`    | --              | Broker MQTT connecté     |
+| `system.mqtt.disconnected` | --              | Broker MQTT perdu        |
+| `system.error`             | `error: string` | Erreur non récupérable   |
+
+### Événements Device (V0.1)
+
+| Event                   | Payload                                              | Quand                   |
+| ----------------------- | ---------------------------------------------------- | ----------------------- |
+| `device.discovered`     | `device: Device`                                     | Nouveau device trouvé   |
+| `device.removed`        | `deviceId, deviceName`                               | Device supprimé         |
+| `device.status_changed` | `deviceId, deviceName, status`                       | Online/offline          |
+| `device.data.updated`   | `deviceId, deviceName, dataId, key, value, previous` | Changement de propriété |
+
+### Événements Equipment (V0.3)
+
+| Event                      | Payload                             | Quand                |
+| -------------------------- | ----------------------------------- | -------------------- |
+| `equipment.data.changed`   | `equipmentId, key, value, previous` | Donnée liée modifiée |
+| `equipment.order.executed` | `equipmentId, orderAlias, value`    | Ordre dispatché      |
+
+### Événements Zone (V0.3+)
+
+| Event               | Payload                        | Quand                   |
+| ------------------- | ------------------------------ | ----------------------- |
+| `zone.data.changed` | `zoneId, key, value, previous` | Donnée agrégée modifiée |
+
+---
+
+## 12. Schéma SQLite complet
+
+```sql
+-- ============================================================
+-- ZONES (V0.2)
+-- ============================================================
+CREATE TABLE zones (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  parent_id TEXT REFERENCES zones(id) ON DELETE SET NULL,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- ============================================================
+-- EQUIPMENT GROUPS (V0.2)
+-- ============================================================
+CREATE TABLE equipment_groups (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- ============================================================
+-- DEVICES (V0.1 -- existing)
+-- ============================================================
+CREATE TABLE devices (
+  id TEXT PRIMARY KEY,
+  mqtt_base_topic TEXT NOT NULL UNIQUE,
+  mqtt_name TEXT NOT NULL,
+  name TEXT NOT NULL,
+  manufacturer TEXT,
+  model TEXT,
+  ieee_address TEXT,
+  source TEXT NOT NULL,  -- integration source: 'zigbee2mqtt', 'panasonic_cc', 'mcz_maestro', 'netatmo_hc', ...
+  status TEXT NOT NULL DEFAULT 'unknown',
+  last_seen DATETIME,
+  raw_expose JSON,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE device_data (
+  id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  type TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'generic',
+  value TEXT,
+  unit TEXT,
+  last_updated DATETIME,
+  UNIQUE(device_id, key)
+);
+
+CREATE TABLE device_orders (
+  id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  type TEXT NOT NULL,
+  mqtt_set_topic TEXT NOT NULL,
+  payload_key TEXT NOT NULL,
+  min_value REAL,
+  max_value REAL,
+  enum_values JSON,
+  unit TEXT,
+  UNIQUE(device_id, key)
+);
+
+-- ============================================================
+-- EQUIPMENTS (V0.3)
+-- ============================================================
+CREATE TABLE equipments (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+  group_id TEXT REFERENCES equipment_groups(id) ON DELETE SET NULL,
+  type TEXT NOT NULL DEFAULT 'generic',
+  icon TEXT,
+  description TEXT,
+  enabled INTEGER DEFAULT 1,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE data_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  device_data_id TEXT NOT NULL REFERENCES device_data(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL,
+  UNIQUE(equipment_id, alias)
+);
+
+CREATE TABLE order_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  device_order_id TEXT NOT NULL REFERENCES device_orders(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL,
+  UNIQUE(equipment_id, alias, device_order_id)
+);
+
+-- ============================================================
+-- COMPUTED DATA (V0.5)
+-- ============================================================
+CREATE TABLE computed_data (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  type TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'generic',
+  expression TEXT NOT NULL,
+  value TEXT,
+  UNIQUE(equipment_id, key)
+);
+
+-- ============================================================
+-- INTERNAL RULES (V0.5)
+-- ============================================================
+CREATE TABLE internal_rules (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  condition_expr TEXT NOT NULL,
+  action_expr TEXT NOT NULL,
+  enabled INTEGER DEFAULT 1
+);
+
+-- ============================================================
+-- RECIPES (V0.8)
+-- ============================================================
+CREATE TABLE recipe_instances (
+  id TEXT PRIMARY KEY,
+  recipe_id TEXT NOT NULL,
+  params JSON NOT NULL DEFAULT '{}',
+  enabled INTEGER DEFAULT 1,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE recipe_state (
+  instance_id TEXT NOT NULL REFERENCES recipe_instances(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  value TEXT,
+  PRIMARY KEY (instance_id, key)
+);
+
+CREATE TABLE recipe_log (
+  id TEXT PRIMARY KEY,
+  instance_id TEXT NOT NULL REFERENCES recipe_instances(id) ON DELETE CASCADE,
+  level TEXT NOT NULL DEFAULT 'info',
+  message TEXT NOT NULL,
+  data JSON,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- ============================================================
+-- USERS & AUTH
+-- ============================================================
+CREATE TABLE users (
+  id TEXT PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  display_name TEXT NOT NULL,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'standard',
+  preferences JSON DEFAULT '{}',
+  enabled INTEGER DEFAULT 1,
+  last_login_at DATETIME,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE api_tokens (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  token_hash TEXT NOT NULL,
+  last_used_at DATETIME,
+  expires_at DATETIME,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE refresh_tokens (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_hash TEXT NOT NULL,
+  expires_at DATETIME NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- ============================================================
+-- SETTINGS (key-value store for integration config)
+-- ============================================================
+CREATE TABLE settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+---
+
+## 13. Récapitulatif des endpoints API
+
+### Zones (V0.2)
+
+| Method | Route               | Description                                          |
+| ------ | ------------------- | ---------------------------------------------------- |
+| GET    | `/api/v1/zones`     | Liste toutes les zones (structure arborescente)      |
+| GET    | `/api/v1/zones/:id` | Récupère une zone avec données agrégées              |
+| POST   | `/api/v1/zones`     | Crée une zone                                        |
+| PUT    | `/api/v1/zones/:id` | Met à jour une zone                                  |
+| DELETE | `/api/v1/zones/:id` | Supprime une zone (sans enfants ni équipements liés) |
+
+### Equipment Groups (V0.2)
+
+| Method | Route                          | Description                  |
+| ------ | ------------------------------ | ---------------------------- |
+| GET    | `/api/v1/zones/:zoneId/groups` | Liste les groupes d'une zone |
+| POST   | `/api/v1/zones/:zoneId/groups` | Crée un groupe dans une zone |
+| PUT    | `/api/v1/groups/:id`           | Met à jour un groupe         |
+| DELETE | `/api/v1/groups/:id`           | Supprime un groupe           |
+
+### Equipments (V0.3)
+
+| Method | Route                                  | Description                                               |
+| ------ | -------------------------------------- | --------------------------------------------------------- |
+| GET    | `/api/v1/equipments`                   | Liste tous les équipements                                |
+| GET    | `/api/v1/equipments/:id`               | Récupère un équipement avec liaisons et données courantes |
+| POST   | `/api/v1/equipments`                   | Crée un équipement                                        |
+| PUT    | `/api/v1/equipments/:id`               | Met à jour un équipement                                  |
+| DELETE | `/api/v1/equipments/:id`               | Supprime un équipement                                    |
+| POST   | `/api/v1/equipments/:id/orders/:alias` | Exécute un ordre d'équipement                             |
+
+### Zone Orders (V0.3+)
+
+| Method | Route                                 | Description                                               |
+| ------ | ------------------------------------- | --------------------------------------------------------- |
+| POST   | `/api/v1/zones/:id/orders/:orderKey`  | Exécute un auto-ordre de zone (allOff, allLightsOff, ...) |
+| POST   | `/api/v1/groups/:id/orders/:orderKey` | Exécute un ordre de groupe                                |
+
+Pour la référence complète de l'API, voir [Référence API](api-reference.md).
+
+---
+
+## 14. Roadmap d'implémentation
+
+| Version   | Entités implémentées                                                  |
+| --------- | --------------------------------------------------------------------- |
+| **V0.1**  | Device, DeviceData, DeviceOrder                                       |
+| **V0.2**  | Zone, EquipmentGroup (CRUD + UI)                                      |
+| **V0.3**  | Equipment, DataBinding, OrderBinding (CRUD + exécution d'ordres + UI) |
+| **V0.5**  | ComputedData, InternalRule                                            |
+| **V0.3+** | Moteur d'agrégation de zone, auto-ordres de zone                      |

--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -1,0 +1,390 @@
+# Guide de déploiement
+
+Ce guide couvre le déploiement, la mise à jour, la sauvegarde et le dépannage de Sowel en production.
+
+---
+
+## Déploiement initial
+
+Sowel est livré sous forme d'image Docker à `ghcr.io/mchacher/sowel:latest`. Un déploiement de production se compose de deux conteneurs (`sowel` + `sowel-influxdb`) orchestrés par `docker compose`.
+
+### Prérequis
+
+- Hôte Linux (x86_64) avec Docker Engine 20.10+ et `docker compose` v2
+- Au moins 2 Go de RAM, 10 Go de disque (les données InfluxDB grossissent avec le temps)
+- Accès réseau à `ghcr.io` pour les pulls d'image et `api.github.com` pour les vérifications de version
+
+### Étapes
+
+```bash
+# 1. Pick a deployment directory (convention: /opt/sowel)
+sudo mkdir -p /opt/sowel
+sudo chown $USER:$USER /opt/sowel
+cd /opt/sowel
+
+# 2. Download the reference docker-compose.yml
+curl -O https://raw.githubusercontent.com/mchacher/sowel/main/docker-compose.yml
+
+# 3. Optional: set your timezone (recommended — fixes calendar scheduling,
+#    HP/HC tariff classification, sunrise/sunset display)
+#    Edit docker-compose.yml and uncomment / add:
+#      - TZ=Europe/Paris
+
+# 4. Launch
+docker compose up -d
+
+# 5. Check containers are up
+docker compose ps
+
+# 6. Open the UI and create the first admin
+open http://<host>:3000
+```
+
+Au premier boot, Sowel :
+
+- Crée sa base SQLite à `/app/data/sowel.db` (sur le volume `sowel-data`)
+- Génère un secret JWT persistant (`data/.jwt-secret`) et un token admin InfluxDB
+- Attend que vous créiez le premier admin via l'écran de setup de l'UI
+
+### Volumes
+
+| Volume          | Mount                | Contenu                                                        |
+| --------------- | -------------------- | -------------------------------------------------------------- |
+| `sowel-data`    | `/app/data`          | Base SQLite, logs, secrets, backups, fichiers de données       |
+| `sowel-plugins` | `/app/plugins`       | Fichiers de plugins installés (`dist/`, `manifest.json`, etc.) |
+| `influxdb-data` | `/var/lib/influxdb2` | Stockage de séries temporelles                                 |
+
+Ce sont des **volumes Docker nommés**, persistants à travers les recréations de conteneurs. Ce sont eux qui font fonctionner l'auto-update et le backup/restore : les données stateful survivent.
+
+### Bind requis sur l'hôte
+
+Pour que l'**auto-update** (spec 060) fonctionne, le socket Docker doit être monté :
+
+```yaml
+services:
+  sowel:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+Sans cela, le bouton "Update now" dans l'UI est désactivé.
+
+---
+
+## Exploitation
+
+### Vérifier le statut
+
+```bash
+docker compose ps
+docker logs -f sowel          # live logs from stdout
+docker logs --tail 100 sowel  # last 100 lines
+```
+
+Ou via l'API :
+
+```bash
+curl -s http://localhost:3000/api/v1/health | jq
+```
+
+### Redémarrer
+
+```bash
+docker compose restart sowel
+```
+
+Le ring buffer est en mémoire, le redémarrage le vide. Le log fichier (`data/logs/sowel-N.log`) survit.
+
+### Stop / start
+
+```bash
+docker compose stop
+docker compose start
+```
+
+### Reconstruire le conteneur (sans changement d'image)
+
+```bash
+docker compose up -d --force-recreate sowel
+```
+
+---
+
+## Mises à jour
+
+Sowel prend en charge **deux chemins** : auto-update depuis l'UI (facile) et mise à jour manuelle via compose (fallback).
+
+### Chemin 1 : auto-update depuis l'UI (préféré)
+
+1. Connectez-vous en admin
+2. Ouvrez les réglages / le badge de version. Si une mise à jour est disponible, un badge affiche "vX.Y.Z"
+3. Cliquez sur le badge → confirmez dans la modale
+4. Sowel crée un backup automatique, puis spawne un container helper qui fait le swap
+5. L'UI affiche un overlay "Update in progress"
+6. Après environ 30 à 90 secondes, la page se recharge sur la nouvelle version
+
+**Prérequis** :
+
+- Tourner sous `docker compose` (Sowel le détecte via les labels du conteneur)
+- `/var/run/docker.sock` monté dans le conteneur sowel
+- `docker-compose.yml` dans un répertoire bind-monté ou accessible sur l'hôte
+
+Si un prérequis manque, le bouton Update est désactivé avec un tooltip qui explique quoi faire.
+
+### Chemin 2 : mise à jour manuelle via docker compose (fallback)
+
+```bash
+cd /opt/sowel
+docker compose pull sowel   # fetch the latest image from ghcr.io
+docker compose up -d sowel  # recreate the container
+```
+
+Sowel redémarre, les migrations s'exécutent automatiquement, les plugins sont auto-téléchargés s'ils sont manquants (spec 058), et l'UI reprend.
+
+**À utiliser quand** :
+
+- L'UI d'auto-update est désactivée (pas de socket Docker, déploiement non-compose)
+- Mise à jour à travers une version qui contient elle-même un bug d'auto-update (par ex. depuis v1.0.6, qui avait la race condition corrigée en v1.0.7)
+- Vous voulez épingler une version spécifique. Modifiez `docker-compose.yml` en `ghcr.io/mchacher/sowel:1.0.7` avant le `pull`
+
+---
+
+## Backup et restauration
+
+Les backups capturent SQLite, les données InfluxDB et tous les fichiers `data/*` dynamiques dans un seul ZIP.
+
+### Backup manuel (export)
+
+**Depuis l'UI** : Admin → Backup → "Télécharger un backup". Le navigateur télécharge un fichier `sowel-backup-<date>.zip`.
+
+**Depuis l'API** :
+
+```bash
+TOKEN=$(curl -s http://<host>:3000/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  --data-raw '{"username":"admin","password":"<pwd>"}' | jq -r .accessToken)
+
+curl -s http://<host>:3000/api/v1/backup \
+  -H "Authorization: Bearer $TOKEN" \
+  -o sowel-backup.zip
+```
+
+### Backups pré-update automatiques (locaux)
+
+Avant chaque auto-update, Sowel crée un backup dans `data/backups/sowel-backup-pre-v<version>-<timestamp>.zip`. Les trois plus récents sont conservés ; les plus anciens sont rotés.
+
+**Lister les backups locaux** :
+
+- Depuis l'UI : Admin → Backup → section "Backups locaux"
+- Via l'API : `GET /api/v1/backup/local`
+
+**Restaurer un backup local** :
+
+- Depuis l'UI : cliquez sur "Restaurer" à côté du backup dans la liste
+- Via l'API : `POST /api/v1/backup/restore-local { "filename": "sowel-backup-pre-v1.0.7-2026-04-11T08-28-45.zip" }`
+
+### Restauration manuelle (import)
+
+**Depuis l'UI** : Admin → Backup → "Charger un backup".
+
+**Depuis l'API** :
+
+```bash
+curl -s -X POST http://<host>:3000/api/v1/backup \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "file=@sowel-backup.zip"
+```
+
+Après restauration, Sowel renvoie `{ restartRequired: true }`. Vous devez redémarrer le conteneur pour que l'état restauré prenne pleinement effet :
+
+```bash
+docker compose restart sowel
+```
+
+### Contenu de l'archive
+
+Voir la section "Backup et restauration" dans [architecture.md](architecture.md) pour le format complet.
+
+---
+
+## Accès aux logs
+
+### Trois sources
+
+| Source                                              | Rétention                                       | Cas d'usage                                                                               |
+| --------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **Ring buffer** (mémoire)                           | Perdu au redémarrage                            | Tail live via UI Admin → Logs                                                             |
+| **stdout Docker**                                   | Par conteneur (perdu à la recréation)           | `docker logs sowel`                                                                       |
+| **Fichiers `pino-roll`** sur le volume `sowel-data` | 14 fichiers journaliers, survit à la recréation | **Investigation post-incident**, la seule source qui survit aux recréations d'auto-update |
+
+### Accéder aux logs fichiers
+
+```bash
+# List files
+docker exec sowel ls -la /app/data/logs/
+
+# View today's log
+docker exec sowel cat /app/data/logs/sowel.6.log
+
+# Grep errors/warns in a time window
+docker exec sowel sh -c 'cat /app/data/logs/sowel.6.log | grep -E "2026-04-11T07:" | grep -E "\"level\":\"(error|warn)\""'
+```
+
+### Via le script helper
+
+Depuis le repo (sur votre machine de dev) :
+
+```bash
+SOWEL_URL=http://<host>:3000 SOWEL_PASSWORD='<pwd>' \
+  python3 scripts/logs/fetch-logs.py "" error 100
+
+# Filter by module
+SOWEL_URL=http://<host>:3000 SOWEL_PASSWORD='<pwd>' \
+  python3 scripts/logs/fetch-logs.py recipe-manager debug 50
+```
+
+Cela interroge le **ring buffer** via l'API, donc seulement les logs depuis le dernier redémarrage.
+
+### Augmenter temporairement le niveau de log
+
+```bash
+curl -s -X PUT http://<host>:3000/api/v1/logs/level \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"level":"debug"}'
+```
+
+Cela n'affecte que le ring buffer (toujours à debug par défaut). Le transport fichier est au niveau racine défini via la variable d'env `LOG_LEVEL`.
+
+---
+
+## Vérification de version
+
+```bash
+TOKEN=$(curl -s -X POST http://<host>:3000/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  --data-raw '{"username":"admin","password":"<pwd>"}' | jq -r .accessToken)
+
+curl -s http://<host>:3000/api/v1/system/version \
+  -H "Authorization: Bearer $TOKEN" | jq
+```
+
+Réponse attendue :
+
+```json
+{
+  "current": "1.0.8",
+  "latest": "1.0.8",
+  "updateAvailable": false,
+  "releaseUrl": "https://github.com/mchacher/sowel/releases/tag/v1.0.8",
+  "dockerAvailable": true,
+  "composeManaged": true
+}
+```
+
+Forcer un poll GitHub frais :
+
+```bash
+curl -s -X POST http://<host>:3000/api/v1/system/version/check \
+  -H "Authorization: Bearer $TOKEN" | jq
+```
+
+---
+
+## Dépannage
+
+### Le conteneur redémarre en boucle
+
+```bash
+docker logs --tail 50 sowel
+```
+
+Causes courantes :
+
+- Erreur de migration de base de données, cherchez `migration failed` dans les logs
+- `/var/run/docker.sock` manquant alors que l'auto-update est activé, devrait simplement warn, pas crasher
+- InfluxDB non joignable, vérifiez que `sowel-influxdb` tourne
+
+### L'intégration ne se connecte pas
+
+1. Vérifiez le statut dans UI Admin → Intégrations ou via `GET /api/v1/integrations`
+2. Vérifiez les logs pour le module plugin spécifique : `plugin:<id>`
+3. Vérifiez que les réglages sont configurés sous `integration.<id>.*` dans la table `settings`
+
+### L'auto-update échoue
+
+Symptômes : clic sur "Update", overlay affiché, mais la page ne recharge jamais. Le conteneur reste sur l'ancienne version.
+
+Récupération :
+
+```bash
+cd /opt/sowel
+docker compose up -d  # recreates the current container if helper failed mid-way
+# Or manual upgrade:
+docker compose pull && docker compose up -d
+```
+
+Investigation :
+
+- Les logs du conteneur helper sont **perdus** si `AutoRemove: true` (défaut actuel, spec 060)
+- Vérifiez les logs propres de sowel juste avant le spawn du helper, `Update helper spawned` est la dernière ligne avant le swap
+- Si sowel n'est jamais revenu, vérifiez `docker ps -a` pour voir si le conteneur est en Exited
+
+### Base de données corrompue
+
+SQLite est en mode WAL, sûr en cas d'arrêts brutaux dans la plupart des cas. En cas de corruption :
+
+```bash
+# Stop sowel
+docker compose stop sowel
+
+# Backup the corrupted DB
+docker run --rm -v /opt/sowel_sowel-data:/data alpine cp /data/sowel.db /data/sowel.db.broken
+
+# Restore from the most recent local backup
+docker run --rm -v /opt/sowel_sowel-data:/data alpine ls /data/backups/
+
+# Then use the restore flow (see above)
+```
+
+### Bucket InfluxDB manquant après restauration
+
+Si vous restaurez sur une machine fraîche, InfluxDB peut ne pas encore avoir de buckets. Le flux de restauration actuel (spec 059) appelle `ensureBuckets()` et `ensureEnergyBuckets()` avant d'écrire les données, donc cela devrait être automatique. Sinon, vérifiez les logs `sowel-influxdb`.
+
+### Logique horaire cassée (volets à la mauvaise heure, HP/HC erroné)
+
+Le conteneur démarre par défaut en UTC. Définissez `TZ=Europe/Paris` (ou votre fuseau) dans `docker-compose.yml` puis redémarrez. Voir [architecture.md § Gestion des fuseaux horaires](architecture.md#gestion-des-fuseaux-horaires-spec-061) et la spec 061 sur [github.com/mchacher/sowel/tree/main/specs/061-timezone-from-home-location](https://github.com/mchacher/sowel/tree/main/specs/061-timezone-from-home-location).
+
+---
+
+## Référence production : déploiement actuel
+
+Le déploiement production du mainteneur (au 2026-04-11) :
+
+- **Hôte** : VM Proxmox `sowelox` (Linux, x86_64, 8 Go RAM)
+- **Chemin** : `/opt/sowel/`
+- **Accès** : LAN `http://192.168.0.230:3000`
+- **Conteneurs** : `sowel` + `sowel-influxdb`
+- **Fuseau** : `TZ=Europe/Paris` explicitement défini dans le compose (workaround en attendant la spec 061)
+- **Version actuelle** : suivie via `git log specs/060-self-update-helper-and-detection/` et `docker logs sowel | grep "Sowel engine started"`
+- **Backups** : locaux dans `data/backups/` (auto), téléchargements manuels sur le Mac du mainteneur
+- **MQTT** : `mosquitto` externe tournant sur la même VM (pas dans le compose), utilisé par les plugins `zigbee2mqtt` et `lora2mqtt`
+- **Zigbee2MQTT** : daemon externe sur sowelox, pas géré par Sowel lui-même
+
+Le graphe de connectivité :
+
+```
+         Internet
+            |
+     Cloudflare Tunnel
+            |
+     sowelox (Linux VM)
+     +-- docker: sowel           (port 3000)
+     +-- docker: sowel-influxdb
+     +-- docker: mosquitto       (MQTT broker, 1883)
+     +-- systemd: zigbee2mqtt   (reads Zigbee coordinator USB)
+     +-- systemd: lora2mqtt     (reads LoRa dongle USB)
+     +-- systemd: cloudflared   (tunnel)
+```
+
+Voir le fichier de mémoire `reference_sowel_access.md` pour les identifiants SSH / API.

--- a/docs/technical/index.fr.md
+++ b/docs/technical/index.fr.md
@@ -1,0 +1,39 @@
+# Guide technique
+
+Cette section couvre l'architecture, les APIs, le développement et l'exploitation de Sowel.
+
+## Vue d'ensemble
+
+Sowel suit un **pipeline réactif piloté par les événements** :
+
+```
+Integration message (MQTT, cloud API poll, plugin)
+  → Integration Plugin (receives + parses)
+    → Device Manager (updates DeviceData)
+      → Event Bus: "device.data.updated"
+        → Equipment Manager (re-evaluates bindings + computed Data)
+          → Event Bus: "equipment.data.changed"
+            → Zone Manager (re-evaluates aggregations)
+              → Event Bus: "zone.data.changed"
+                → Recipe Engine (triggers → conditions → actions)
+                  → Actions may emit Orders → Integration Plugin → device
+            → WebSocket pushes to UI clients
+```
+
+Depuis la spec 053, **tout est plugin** : les intégrations et les recettes sont distribuées depuis GitHub via le service `PackageManager`. Il n'y a plus aucune intégration intégrée dans `src/`.
+
+## Sections
+
+| Section                                            | Description                                                        |
+| -------------------------------------------------- | ------------------------------------------------------------------ |
+| [Architecture](architecture.md)                    | Conception système, plugin V2, auto-update, backup, CI/CD, logs    |
+| [Déploiement](deployment.md)                       | Déploiement en production, mises à jour, backup/restore, dépannage |
+| [Référence API](api-reference.md)                  | Endpoints REST et événements WebSocket                             |
+| [Développement de plugins](plugin-development.md)  | Comment créer des intégrations plugin tierces                      |
+| [Développement de recettes](recipe-development.md) | Comment créer des paquets de recettes d'automatisation             |
+| [Modèle de données](data-model.md)                 | Schéma SQLite, types TypeScript, événements du bus                 |
+| [Contribuer](contributing.md)                      | Mise en place de l'environnement, conventions et workflow          |
+
+## Index des specs
+
+Pour une liste chronologique de chaque spec avec un résumé d'une ligne et son statut, voir [../specs-index.md](../specs-index.md).

--- a/docs/technical/plugin-development.fr.md
+++ b/docs/technical/plugin-development.fr.md
@@ -1,0 +1,1049 @@
+# Guide de développement de plugins Sowel
+
+Ce guide explique comment créer un plugin tiers pour Sowel. Un plugin est une intégration autonome qui peut être installée, activée, désactivée et supprimée au runtime sans redémarrer le moteur Sowel.
+
+Le plugin `sowel-plugin-weather-forecast` est utilisé comme exemple de référence tout au long de ce document.
+
+---
+
+## Sommaire
+
+1. [Vue d'ensemble](#vue-densemble)
+2. [Structure d'un plugin](#structure-dun-plugin)
+3. [Schéma du manifest](#schema-du-manifest)
+4. [Référence de l'API PluginDeps](#reference-de-lapi-plugindeps)
+5. [Interface IntegrationPlugin](#interface-integrationplugin)
+6. [Créer un plugin pas à pas](#creer-un-plugin-pas-a-pas)
+7. [Découverte de devices](#decouverte-de-devices)
+8. [Mises à jour de données device](#mises-a-jour-de-donnees-device)
+9. [Exécution d'ordres](#execution-dordres)
+10. [Réglages](#reglages)
+11. [Publication et versioning](#publication-et-versioning)
+12. [Dépannage](#depannage)
+
+---
+
+## Vue d'ensemble
+
+Un plugin Sowel est un package Node.js ESM (ECMAScript Module) qui exporte une fonction usine `createPlugin`. Au chargement, Sowel injecte un objet `PluginDeps` qui donne accès aux services centraux (logs, event bus, gestion des devices, settings). Le plugin utilise ces dépendances pour découvrir des devices, pousser des mises à jour de données, et traiter des ordres, exactement comme les intégrations historiques.
+
+Les plugins vivent dans le répertoire `plugins/` à la racine de Sowel. Chaque plugin a son propre sous-répertoire qui contient un `manifest.json` et le JavaScript compilé dans `dist/`.
+
+**Cycle de vie :**
+
+1. Sowel lit la table `plugins` de la base au démarrage
+2. Pour chaque plugin activé, Sowel importe dynamiquement `plugins/<id>/dist/index.js` (ESM)
+3. La fonction usine `createPlugin` exportée reçoit `PluginDeps` et retourne une instance d'`IntegrationPlugin`
+4. Sowel enregistre le plugin auprès de l'`IntegrationRegistry`
+5. Si le plugin est configuré (`isConfigured()` renvoie true), Sowel appelle `plugin.start()`
+6. À la désactivation/désinstallation, Sowel appelle `plugin.stop()` et le retire du registre
+
+---
+
+## Structure d'un plugin
+
+```
+sowel-plugin-my-device/
+  manifest.json          # Plugin metadata (required)
+  package.json           # Node.js package descriptor ("type": "module")
+  tsconfig.json          # TypeScript config (module: "NodeNext")
+  dist/
+    index.js             # Compiled entry point (ESM)
+    index.js.map         # Source map (optional)
+  src/
+    index.ts             # TypeScript source (not loaded by Sowel)
+```
+
+**Règles clés :**
+
+- Le point d'entrée est toujours `dist/index.js`, c'est codé en dur dans le plugin loader
+- Utilisez le **format ESM** (`export { createPlugin }`), Sowel utilise un `import()` dynamique pour charger les plugins
+- Définissez `"type": "module"` dans `package.json`
+- Définissez `"module": "NodeNext"` et `"moduleResolution": "NodeNext"` dans `tsconfig.json`
+- Le répertoire `src/` est pour le développement uniquement, Sowel ne le lit jamais
+- Les `node_modules/` propres au plugin sont isolés des dépendances de Sowel
+
+---
+
+## Schéma du manifest
+
+Le fichier `manifest.json` décrit le plugin à Sowel. Il vit à la racine du répertoire du plugin.
+
+**Exemple** (depuis `sowel-plugin-weather-forecast`) :
+
+```json
+{
+  "id": "weather-forecast",
+  "name": "Weather Forecast",
+  "version": "0.2.0",
+  "description": "Weather forecast via Open-Meteo API (free, no API key)",
+  "icon": "CloudSun",
+  "author": "mchacher",
+  "sowelVersion": ">=0.10.0",
+  "settings": [
+    {
+      "key": "polling_interval",
+      "label": "Polling interval (minutes)",
+      "type": "number",
+      "required": false,
+      "defaultValue": "30",
+      "placeholder": "Min 15, default 30"
+    }
+  ]
+}
+```
+
+### Référence des champs
+
+| Champ          | Type                    | Requis | Description                                                                                                                                |
+| -------------- | ----------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`           | string                  | Oui    | Identifiant unique du plugin. Minuscules avec tirets (par ex. `weather-forecast`). Doit correspondre au nom du répertoire sous `plugins/`. |
+| `name`         | string                  | Oui    | Nom d'affichage lisible présenté dans l'UI.                                                                                                |
+| `version`      | string                  | Oui    | Version SemVer (par ex. `0.2.0`). **Doit être mise à jour à chaque release.** Voir [Versioning](#versioning).                              |
+| `description`  | string                  | Oui    | Courte description (une phrase) affichée dans le store de plugins et la page intégrations.                                                 |
+| `icon`         | string                  | Oui    | Nom d'icône Lucide (par ex. `CloudSun`, `Camera`). Utilisé dans l'UI pour la carte d'intégration.                                          |
+| `author`       | string                  | Non    | Nom de l'auteur ou organisation.                                                                                                           |
+| `sowelVersion` | string                  | Non    | Plage SemVer des versions Sowel compatibles (par ex. `>=0.10.0`).                                                                          |
+| `settings`     | IntegrationSettingDef[] | Non    | Tableau de définitions de réglages pour le formulaire de configuration UI. Voir [Réglages](#reglages).                                     |
+
+**Champs qui n'existent PAS dans le manifest :** `entry`, `integrationId`, `license`, `repository`. Ne les incluez pas.
+
+---
+
+## Référence de l'API PluginDeps
+
+Quand Sowel charge un plugin, il passe un objet `PluginDeps` à la fonction usine `createPlugin`. C'est la porte d'entrée du plugin vers tous les services centraux Sowel.
+
+```typescript
+interface PluginDeps {
+  logger: Logger;
+  eventBus: EventBus;
+  settingsManager: SettingsManager;
+  deviceManager: DeviceManager;
+  pluginDir: string;
+}
+```
+
+### `logger`
+
+Un child logger pino préconfiguré avec `{ module: "plugin:<pluginId>" }`. Utilisez-le pour tous les logs, n'utilisez jamais `console.log`.
+
+```typescript
+deps.logger.info({ deviceCount: 5 }, "Devices discovered");
+deps.logger.debug({ response }, "API response received");
+deps.logger.error({ err }, "Poll failed");
+```
+
+**Conseils par niveau :**
+
+| Niveau  | Usage                                                                 |
+| ------- | --------------------------------------------------------------------- |
+| `info`  | Événements significatifs : connecté, devices découverts, poll terminé |
+| `debug` | Détails opérationnels : réponses d'API, étapes intermédiaires         |
+| `trace` | Données à haut volume : chaque message, chaque point de données       |
+| `error` | Opération échouée, incluez toujours `{ err }` avec l'objet Error      |
+| `warn`  | Inattendu mais géré : retry, fallback, récupérable                    |
+
+### `eventBus`
+
+L'event emitter typé. Les plugins émettent typiquement des événements de cycle de vie d'intégration :
+
+```typescript
+deps.eventBus.emit({ type: "system.integration.connected", integrationId: "my-plugin" });
+deps.eventBus.emit({ type: "system.integration.disconnected", integrationId: "my-plugin" });
+```
+
+### `settingsManager`
+
+Lit et écrit les réglages stockés dans la table SQLite `settings`. Les réglages utilisent une **clé complète** avec le préfixe `integration.<pluginId>.`.
+
+```typescript
+// Read a setting -- returns string | undefined
+const interval = deps.settingsManager.get("integration.weather-forecast.polling_interval");
+
+// Read a global Sowel setting (no prefix)
+const lat = deps.settingsManager.get("home.latitude");
+
+// Write a setting
+deps.settingsManager.set("integration.weather-forecast.last_poll", Date.now().toString());
+```
+
+**Important :** `get()` prend la **clé complète** (par ex. `integration.weather-forecast.polling_interval`) et retourne `string | undefined` (pas null). Les réglages déclarés dans le tableau `settings` de votre manifest sont automatiquement namespacés par Sowel sous `integration.<pluginId>.<key>`.
+
+**Méthodes :**
+
+| Méthode       | Signature                                    | Description                                       |
+| ------------- | -------------------------------------------- | ------------------------------------------------- |
+| `get`         | `(key: string) => string \| undefined`       | Récupère un réglage par sa clé complète           |
+| `set`         | `(key: string, value: string) => void`       | Définit un réglage                                |
+| `getByPrefix` | `(prefix: string) => Record<string, string>` | Récupère tous les réglages commençant par préfixe |
+| `setMany`     | `(entries: Record<string, string>) => void`  | Définit plusieurs réglages d'un coup              |
+
+### `deviceManager`
+
+Gère les devices découverts par votre plugin. Deux méthodes principales sont utilisées :
+
+| Méthode               | Signature                                                                                   | Description                                           |
+| --------------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `upsertFromDiscovery` | `(integrationId: string, source: string, discovered: DiscoveredDevice) => void`             | Crée ou met à jour un device depuis la découverte     |
+| `updateDeviceData`    | `(integrationId: string, sourceDeviceId: string, payload: Record<string, unknown>) => void` | Pousse de nouvelles valeurs de données pour un device |
+
+Voir [Découverte de devices](#decouverte-de-devices) et [Mises à jour de données device](#mises-a-jour-de-donnees-device) pour l'usage détaillé.
+
+### `pluginDir`
+
+Chemin absolu vers le répertoire installé du plugin (par ex. `/app/plugins/weather-forecast`). Utilisez-le pour lire des fichiers locaux ou stocker des données spécifiques au plugin.
+
+```typescript
+import { resolve } from "node:path";
+const cachePath = resolve(deps.pluginDir, "cache.json");
+```
+
+**Note :** il n'y a pas de `mqttConnector` dans `PluginDeps`. Si votre plugin a besoin de MQTT, utilisez le package npm `mqtt` directement comme dépendance du plugin.
+
+---
+
+## Interface IntegrationPlugin
+
+La fonction usine `createPlugin` doit retourner un objet qui implémente l'interface `IntegrationPlugin` :
+
+```typescript
+interface IntegrationPlugin {
+  readonly id: string; // Unique integration ID (must match manifest.id)
+  readonly name: string; // Human-readable name
+  readonly description: string; // Short description for the UI
+  readonly icon: string; // Lucide icon name
+
+  getStatus(): IntegrationStatus;
+  isConfigured(): boolean;
+  getSettingsSchema(): IntegrationSettingDef[];
+  start(options?: { pollOffset?: number }): Promise<void>;
+  stop(): Promise<void>;
+  executeOrder(
+    device: Device,
+    dispatchConfig: Record<string, unknown>,
+    value: unknown,
+  ): Promise<void>;
+  refresh?(): Promise<void>;
+  getPollingInfo?(): { lastPollAt: string; intervalMs: number } | null;
+}
+
+type IntegrationStatus = "connected" | "disconnected" | "not_configured" | "error";
+```
+
+### Référence des méthodes
+
+| Méthode               | Requise | Description                                                                                                        |
+| --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| `getStatus()`         | Oui     | Retourne le statut de connexion courant. Retournez `"not_configured"` si `isConfigured()` est false.               |
+| `isConfigured()`      | Oui     | Retourne true si tous les réglages requis sont présents. Sowel n'appelle `start()` que si c'est true.              |
+| `getSettingsSchema()` | Oui     | Retourne la définition du formulaire de réglages (identique au champ `settings` du manifest).                      |
+| `start(options?)`     | Oui     | Démarre l'intégration. `pollOffset` est fourni par Sowel pour étaler plusieurs plugins en polling.                 |
+| `stop()`              | Oui     | Arrêt propre : annule les timers, ferme les connexions.                                                            |
+| `executeOrder()`      | Oui     | Exécute une commande sur un device. Levez une erreur si le plugin ne supporte pas les ordres.                      |
+| `refresh()`           | Non     | Force un rafraîchissement immédiat (par ex. re-poll de l'API cloud). Appelé depuis le bouton refresh de l'UI.      |
+| `getPollingInfo()`    | Non     | Retourne le timestamp du dernier poll et l'intervalle. Affiché dans l'UI intégrations pour les plugins en polling. |
+
+---
+
+## Créer un plugin pas à pas
+
+### 1. Initialiser le projet
+
+```bash
+mkdir sowel-plugin-my-device
+cd sowel-plugin-my-device
+npm init -y
+npm install -D typescript
+```
+
+Modifiez `package.json`, définissez `"type": "module"` :
+
+```json
+{
+  "name": "sowel-plugin-my-device",
+  "version": "0.1.0",
+  "description": "Sowel plugin: My Device integration",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0"
+  }
+}
+```
+
+### 2. Configurer TypeScript
+
+Créez `tsconfig.json`, utilisez le format module `NodeNext` :
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+```
+
+### 3. Définir les interfaces de types locales
+
+Les plugins **n'importent pas** depuis le code source de Sowel. À la place, définissez des interfaces locales qui correspondent à la forme de `PluginDeps`. Cela maintient le plugin entièrement découplé.
+
+```typescript
+// src/index.ts -- local type definitions
+
+interface Logger {
+  child(bindings: Record<string, unknown>): Logger;
+  info(obj: Record<string, unknown>, msg: string): void;
+  info(msg: string): void;
+  warn(obj: Record<string, unknown>, msg: string): void;
+  warn(msg: string): void;
+  error(obj: Record<string, unknown>, msg: string): void;
+  error(msg: string): void;
+  debug(obj: Record<string, unknown>, msg: string): void;
+  debug(msg: string): void;
+}
+
+interface EventBus {
+  emit(event: unknown): void;
+}
+
+interface SettingsManager {
+  get(key: string): string | undefined;
+  set(key: string, value: string): void;
+}
+
+interface DiscoveredDevice {
+  ieeeAddress?: string;
+  friendlyName: string;
+  manufacturer?: string;
+  model?: string;
+  data: {
+    key: string;
+    type: string;
+    category: string;
+    unit?: string;
+  }[];
+  orders: {
+    key: string;
+    type: string;
+    dispatchConfig: Record<string, unknown>;
+    min?: number;
+    max?: number;
+    enumValues?: string[];
+    unit?: string;
+  }[];
+}
+
+interface DeviceManager {
+  upsertFromDiscovery(integrationId: string, source: string, discovered: DiscoveredDevice): void;
+  updateDeviceData(
+    integrationId: string,
+    sourceDeviceId: string,
+    payload: Record<string, unknown>,
+  ): void;
+}
+
+interface Device {
+  id: string;
+  integrationId: string;
+  sourceDeviceId: string;
+  name: string;
+  manufacturer?: string;
+  model?: string;
+}
+
+interface PluginDeps {
+  logger: Logger;
+  eventBus: EventBus;
+  settingsManager: SettingsManager;
+  deviceManager: DeviceManager;
+  pluginDir: string;
+}
+
+type IntegrationStatus = "connected" | "disconnected" | "not_configured" | "error";
+
+interface IntegrationSettingDef {
+  key: string;
+  label: string;
+  type: "text" | "password" | "number" | "boolean";
+  required: boolean;
+  placeholder?: string;
+  defaultValue?: string;
+}
+
+interface IntegrationPlugin {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly icon: string;
+  getStatus(): IntegrationStatus;
+  isConfigured(): boolean;
+  getSettingsSchema(): IntegrationSettingDef[];
+  start(options?: { pollOffset?: number }): Promise<void>;
+  stop(): Promise<void>;
+  executeOrder(
+    device: Device,
+    dispatchConfig: Record<string, unknown>,
+    value: unknown,
+  ): Promise<void>;
+  refresh?(): Promise<void>;
+  getPollingInfo?(): { lastPollAt: string; intervalMs: number } | null;
+}
+```
+
+### 4. Implémenter le plugin
+
+Sous les définitions de types, implémentez votre classe de plugin et exportez l'usine :
+
+```typescript
+const PLUGIN_ID = "my-device";
+const SETTINGS_PREFIX = `integration.${PLUGIN_ID}.`;
+const SOURCE_DEVICE_ID = "My Device"; // Must match friendlyName in DiscoveredDevice
+
+class MyDevicePlugin implements IntegrationPlugin {
+  readonly id = PLUGIN_ID;
+  readonly name = "My Device";
+  readonly description = "Integration with My Device API";
+  readonly icon = "Cpu";
+
+  private logger: Logger;
+  private settingsManager: SettingsManager;
+  private deviceManager: DeviceManager;
+  private eventBus: EventBus;
+
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastPollAt: string | null = null;
+  private pollIntervalMs = 300_000;
+  private status: IntegrationStatus = "disconnected";
+
+  constructor(deps: PluginDeps) {
+    this.logger = deps.logger.child({ module: PLUGIN_ID });
+    this.settingsManager = deps.settingsManager;
+    this.deviceManager = deps.deviceManager;
+    this.eventBus = deps.eventBus;
+  }
+
+  getStatus(): IntegrationStatus {
+    if (!this.isConfigured()) return "not_configured";
+    return this.status;
+  }
+
+  isConfigured(): boolean {
+    return !!this.settingsManager.get(`${SETTINGS_PREFIX}api_url`);
+  }
+
+  getSettingsSchema(): IntegrationSettingDef[] {
+    return [
+      {
+        key: "api_url",
+        label: "API URL",
+        type: "text",
+        required: true,
+        placeholder: "http://192.168.1.50/api",
+      },
+      {
+        key: "polling_interval",
+        label: "Polling interval (seconds)",
+        type: "number",
+        required: false,
+        defaultValue: "300",
+      },
+    ];
+  }
+
+  getPollingInfo(): { lastPollAt: string; intervalMs: number } | null {
+    return { lastPollAt: this.lastPollAt ?? "", intervalMs: this.pollIntervalMs };
+  }
+
+  async start(options?: { pollOffset?: number }): Promise<void> {
+    if (!this.isConfigured()) {
+      this.status = "not_configured";
+      return;
+    }
+
+    // Read polling interval from settings
+    const rawInterval = parseInt(
+      this.settingsManager.get(`${SETTINGS_PREFIX}polling_interval`) ?? "300",
+      10,
+    );
+    this.pollIntervalMs = Math.max(60_000, (isNaN(rawInterval) ? 300 : rawInterval) * 1000);
+
+    await this.poll();
+    this.schedulePoll(options?.pollOffset ?? 0);
+
+    this.status = "connected";
+    this.eventBus.emit({ type: "system.integration.connected", integrationId: this.id });
+    this.logger.info({ pollIntervalMs: this.pollIntervalMs }, "Plugin started");
+  }
+
+  async stop(): Promise<void> {
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.status = "disconnected";
+    this.eventBus.emit({ type: "system.integration.disconnected", integrationId: this.id });
+    this.logger.info("Plugin stopped");
+  }
+
+  async executeOrder(
+    _device: Device,
+    _dispatchConfig: Record<string, unknown>,
+    _value: unknown,
+  ): Promise<void> {
+    throw new Error("My Device plugin does not support orders");
+  }
+
+  async refresh(): Promise<void> {
+    await this.poll();
+  }
+
+  // --- Polling ---
+
+  private async poll(): Promise<void> {
+    try {
+      // 1. Fetch data from your API
+      // const data = await this.fetchData();
+
+      // 2. Upsert device definition
+      this.deviceManager.upsertFromDiscovery(PLUGIN_ID, PLUGIN_ID, {
+        friendlyName: SOURCE_DEVICE_ID,
+        manufacturer: "My Company",
+        model: "Sensor v2",
+        data: [
+          { key: "temperature", type: "number", category: "temperature", unit: "C" },
+          { key: "humidity", type: "number", category: "humidity", unit: "%" },
+        ],
+        orders: [],
+      });
+
+      // 3. Update device data values
+      this.deviceManager.updateDeviceData(PLUGIN_ID, SOURCE_DEVICE_ID, {
+        temperature: 21.5,
+        humidity: 45,
+      });
+
+      this.lastPollAt = new Date().toISOString();
+      this.logger.info("Poll complete");
+    } catch (err) {
+      this.logger.error({ err }, "Poll failed");
+      throw err;
+    }
+  }
+
+  private schedulePoll(offsetMs: number): void {
+    if (this.pollTimer) clearTimeout(this.pollTimer);
+    const delay = offsetMs > 0 ? offsetMs : this.pollIntervalMs;
+    this.pollTimer = setTimeout(async () => {
+      try {
+        await this.poll();
+      } catch {
+        /* already logged */
+      }
+      this.schedulePoll(0);
+    }, delay);
+  }
+}
+
+// ============================================================
+// Plugin factory -- this is the entry point Sowel calls
+// ============================================================
+
+export function createPlugin(deps: PluginDeps): IntegrationPlugin {
+  return new MyDevicePlugin(deps);
+}
+```
+
+### 5. Build
+
+```bash
+npx tsc
+```
+
+Cela produit `dist/index.js` (ESM) prêt à être chargé par Sowel.
+
+### 6. Créer le manifest
+
+Créez `manifest.json` à la racine du plugin :
+
+```json
+{
+  "id": "my-device",
+  "name": "My Device",
+  "version": "0.1.0",
+  "description": "Integration with My Device API",
+  "icon": "Cpu",
+  "author": "Your Name",
+  "sowelVersion": ">=0.10.0",
+  "settings": [
+    {
+      "key": "api_url",
+      "label": "API URL",
+      "type": "text",
+      "required": true,
+      "placeholder": "http://192.168.1.50/api"
+    },
+    {
+      "key": "polling_interval",
+      "label": "Polling interval (seconds)",
+      "type": "number",
+      "required": false,
+      "defaultValue": "300"
+    }
+  ]
+}
+```
+
+### 7. Tester localement
+
+Faites un symlink du répertoire du plugin dans le `plugins/` de Sowel :
+
+```bash
+# From the Sowel root
+ln -s /path/to/sowel-plugin-my-device plugins/my-device
+```
+
+Puis enregistrez-le manuellement dans la base (Sowel auto-charge depuis la table `plugins`) :
+
+```bash
+# Using the Sowel API to install from a local path, or manually:
+sqlite3 data/sowel.db "INSERT INTO plugins (id, version, enabled, installed_at, manifest) VALUES ('my-device', '0.1.0', 1, datetime('now'), readfile('plugins/my-device/manifest.json'));"
+```
+
+Démarrez Sowel, il va détecter et charger le plugin automatiquement. Vérifiez les logs pour la sortie de votre plugin :
+
+```
+[info] plugin:my-device -- Plugin started
+```
+
+---
+
+## Découverte de devices
+
+Quand votre plugin détecte des devices (depuis une API, MQTT, ou un scan local), enregistrez-les avec `deviceManager.upsertFromDiscovery()`.
+
+### Signature
+
+```typescript
+deviceManager.upsertFromDiscovery(
+  integrationId: string,     // Your plugin ID (e.g. "weather-forecast")
+  source: string,            // Device source identifier (typically your plugin ID)
+  discovered: DiscoveredDevice,
+): void;
+```
+
+### Format DiscoveredDevice
+
+```typescript
+interface DiscoveredDevice {
+  ieeeAddress?: string; // Optional hardware address (for Zigbee devices)
+  friendlyName: string; // Unique device name -- used as sourceDeviceId for data updates
+  manufacturer?: string; // Device manufacturer
+  model?: string; // Device model
+  data: {
+    // Data points this device exposes
+    key: string; // Data point key (e.g. "temperature", "j1_condition")
+    type: string; // "number" | "boolean" | "text" | "enum"
+    category: string; // "temperature" | "humidity" | "motion" | "battery" | etc.
+    unit?: string; // Unit of measurement (e.g. "C", "%", "km/h")
+  }[];
+  orders: {
+    // Commands this device accepts
+    key: string; // Order key (e.g. "set_monitoring")
+    type: string; // Value type: "boolean" | "number" | "enum" | "text"
+    dispatchConfig: Record<string, unknown>; // Integration-specific config for order dispatch
+    min?: number; // For numeric orders: minimum value
+    max?: number; // For numeric orders: maximum value
+    enumValues?: string[]; // For enum orders: allowed values
+    unit?: string; // Unit (e.g. "C")
+  }[];
+}
+```
+
+### Exemple (depuis weather-forecast)
+
+```typescript
+const WEATHER_DISCOVERED_DEVICE: DiscoveredDevice = {
+  friendlyName: "Weather Forecast",
+  manufacturer: "Open-Meteo",
+  model: "Forecast API",
+  data: [
+    { key: "j1_condition", type: "enum", category: "weather_condition" },
+    { key: "j1_temp_min", type: "number", category: "temperature", unit: "C" },
+    { key: "j1_temp_max", type: "number", category: "temperature", unit: "C" },
+    { key: "j1_rain_prob", type: "number", category: "rain", unit: "%" },
+    { key: "j1_wind_gusts", type: "number", category: "wind", unit: "km/h" },
+    // ... j2 through j5
+  ],
+  orders: [],
+};
+
+// Call during poll
+this.deviceManager.upsertFromDiscovery(PLUGIN_ID, SOURCE_DEVICE_ID, WEATHER_DISCOVERED_DEVICE);
+```
+
+**Important :**
+
+- `friendlyName` devient le `source_device_id` dans la base. Il doit correspondre à l'argument `sourceDeviceId` utilisé dans `updateDeviceData()`.
+- Appelez `upsertFromDiscovery()` à chaque cycle de poll, c'est idempotent (créé au premier appel, met à jour les métadonnées aux suivants).
+- Incluez tous les data points et ordres dans la définition `DiscoveredDevice`. Les entrées de données/ordres obsolètes qui ne sont pas dans la découverte courante sont nettoyées automatiquement.
+
+---
+
+## Mises à jour de données device
+
+Après la découverte de devices, poussez les mises à jour de données quand de nouvelles valeurs arrivent. Utilisez `deviceManager.updateDeviceData()`.
+
+### Signature
+
+```typescript
+deviceManager.updateDeviceData(
+  integrationId: string,                // Your plugin ID (e.g. "weather-forecast")
+  sourceDeviceId: string,               // Must match friendlyName from upsertFromDiscovery
+  payload: Record<string, unknown>,     // Flat key-value map of data points
+): void;
+```
+
+### Exemple (depuis weather-forecast)
+
+```typescript
+const payload: Record<string, unknown> = {
+  j1_condition: "rainy",
+  j1_temp_min: 8.2,
+  j1_temp_max: 14.5,
+  j1_rain_prob: 75,
+  j1_wind_gusts: 42,
+  // ... j2 through j5
+};
+
+this.deviceManager.updateDeviceData(PLUGIN_ID, SOURCE_DEVICE_ID, payload);
+```
+
+**Critique :** le paramètre `sourceDeviceId` doit correspondre exactement au `friendlyName` utilisé dans `upsertFromDiscovery()`. C'est ainsi que Sowel retrouve le device dans la base. Dans le plugin weather-forecast, les deux sont définis à `"Weather Forecast"`.
+
+Le payload est un **`Record<string, unknown>` plat**, les clés sont les noms de data points, les valeurs sont les valeurs brutes (number, boolean, string). Ce n'est pas un objet imbriqué avec labels ou unités, ceux-ci sont définis une seule fois dans `upsertFromDiscovery()`.
+
+Cela déclenche le pipeline réactif :
+
+1. Les données du device sont mises à jour dans SQLite
+2. L'événement `device.data.updated` est émis
+3. Les liaisons d'équipements sont réévaluées
+4. Les agrégations de zones sont mises à jour
+5. Les triggers de scénarios sont vérifiés
+6. L'UI reçoit un push WebSocket
+
+---
+
+## Exécution d'ordres
+
+Quand un utilisateur ou un scénario envoie une commande à un device géré par votre plugin, Sowel appelle `executeOrder()` sur l'instance de votre plugin.
+
+### Signature
+
+```typescript
+executeOrder(
+  device: Device,                             // The target device object
+  dispatchConfig: Record<string, unknown>,    // Integration-specific config from the order definition
+  value: unknown,                             // The value to set
+): Promise<void>;
+```
+
+### Exemple
+
+```typescript
+async executeOrder(
+  device: Device,
+  dispatchConfig: Record<string, unknown>,
+  value: unknown,
+): Promise<void> {
+  const action = dispatchConfig.action as string;
+
+  switch (action) {
+    case "set_monitoring":
+      await this.api.setMonitoring(device.sourceDeviceId, value as boolean);
+      break;
+    default:
+      this.logger.warn({ action }, "Unknown order action");
+  }
+}
+```
+
+**Flux d'un ordre :**
+
+1. L'utilisateur appuie sur un bouton dans l'UI ou une action de scénario se déclenche
+2. L'équipement dispatche l'ordre vers le device lié
+3. Sowel route l'ordre vers l'intégration propriétaire du device
+4. La méthode `executeOrder()` du plugin est appelée avec l'objet Device complet, le `dispatchConfig` issu de la définition d'ordre, et la valeur
+5. Le plugin envoie la commande au device physique
+6. Au prochain poll (ou refresh immédiat), le nouvel état est reflété
+
+**Important — plugins basés sur MQTT** : ne figez pas le réglage `base_topic` dans `dispatchConfig.topic` pendant la découverte. À la place, stockez seulement le suffixe relatif au device (par ex. `topicSuffix: "garage/set"`) et résolvez le topic complet au runtime dans `executeOrder()` en utilisant le réglage `base_topic` courant. Cela garantit que les ordres restent corrects si l'utilisateur change le base topic. Utilisez `dispatchConfig.topic` comme fallback pour la rétrocompatibilité avec les entrées DB existantes.
+
+Si votre plugin ne supporte pas les ordres (par ex. un plugin météo en lecture seule), levez une erreur :
+
+```typescript
+async executeOrder(): Promise<void> {
+  throw new Error("Weather Forecast plugin does not support orders");
+}
+```
+
+---
+
+## Réglages
+
+Les plugins déclarent leurs réglages dans `manifest.json` et retournent le même schéma depuis `getSettingsSchema()`. Sowel rend automatiquement un formulaire de configuration dans l'UI.
+
+### Schéma de définition d'un réglage
+
+```typescript
+interface IntegrationSettingDef {
+  key: string; // Setting key (without prefix). Stored as "integration.<pluginId>.<key>"
+  label: string; // Display label in the UI
+  type: string; // One of: "text", "password", "number", "boolean"
+  required: boolean; // If true, must be filled before the plugin can start
+  placeholder?: string; // Placeholder text in the input field
+  defaultValue?: string; // Default value (always a string, even for numbers)
+}
+```
+
+### Exemple (depuis netatmo-security)
+
+```json
+{
+  "settings": [
+    {
+      "key": "client_id",
+      "label": "Client ID",
+      "type": "text",
+      "required": true,
+      "placeholder": "From dev.netatmo.com"
+    },
+    {
+      "key": "client_secret",
+      "label": "Client Secret",
+      "type": "password",
+      "required": true
+    },
+    {
+      "key": "refresh_token",
+      "label": "Refresh Token",
+      "type": "password",
+      "required": true,
+      "placeholder": "With camera scopes"
+    },
+    {
+      "key": "polling_interval",
+      "label": "Polling interval (seconds)",
+      "type": "number",
+      "required": false,
+      "defaultValue": "300",
+      "placeholder": "Min 180, default 300"
+    }
+  ]
+}
+```
+
+### Lire les réglages au runtime
+
+Les réglages sont stockés avec la clé complète `integration.<pluginId>.<key>` :
+
+```typescript
+const SETTINGS_PREFIX = `integration.${PLUGIN_ID}.`;
+
+// Read a plugin-specific setting
+const interval = this.settingsManager.get(`${SETTINGS_PREFIX}polling_interval`);
+// Returns "300" (string) or undefined if not set
+
+// Read a global Sowel setting (no prefix)
+const lat = this.settingsManager.get("home.latitude");
+
+// Write a setting
+this.settingsManager.set(`${SETTINGS_PREFIX}last_token_refresh`, Date.now().toString());
+```
+
+**Notes importantes :**
+
+- `get()` retourne toujours `string | undefined`, parsez les nombres avec `parseInt()` / `parseFloat()`
+- Le `defaultValue` du schéma de réglages est uniquement pour l'affichage UI, gérez toujours undefined dans le code
+- Utilisez le type `"password"` pour les secrets, l'UI masque ces valeurs
+- Il n'y a pas de types `"select"`, `"string"` ou `"secret"`. Les types valides sont : `"text"`, `"password"`, `"number"`, `"boolean"`
+
+---
+
+## Publication et versioning
+
+### Créer un tarball de release
+
+Les plugins sont installés depuis des tarballs de release GitHub. Le tarball **doit inclure** `dist/` (JS compilé) et **doit exclure** `src/` et `node_modules/`.
+
+```bash
+# Build first
+npm run build
+
+# Create the release tarball
+tar -czf sowel-plugin-my-device-0.1.0.tar.gz \
+  manifest.json \
+  package.json \
+  dist/
+```
+
+Si votre plugin a des dépendances de production (listées dans `dependencies`, pas `devDependencies`), incluez aussi `package.json` pour que Sowel puisse exécuter `npm install --production` après extraction. S'il n'y a pas de dépendances runtime, `package.json` est quand même recommandé mais `node_modules/` ne doit pas être inclus.
+
+### Créer une release GitHub
+
+```bash
+gh release create v0.1.0 \
+  sowel-plugin-my-device-0.1.0.tar.gz \
+  --title "v0.1.0" \
+  --notes "Initial release"
+```
+
+**Flux d'installation :** quand un utilisateur clique sur "Installer" dans le store de plugins Sowel, Sowel :
+
+1. Récupère la dernière release depuis l'API GitHub
+2. Préfère un asset `.tar.gz` uploadé (qui inclut `dist/`), retombe sur le tarball source GitHub
+3. Extrait dans `plugins/<id>/`
+4. Exécute `npm install --production` si `package.json` existe
+5. Si `dist/` est manquant mais que `tsconfig.json` existe, tente `npx tsc` pour build depuis les sources
+6. Enregistre le plugin dans la base et le charge
+
+Bonne pratique : **uploadez toujours un tarball pré-compilé** comme asset de release. Cela évite à l'instance Sowel de l'utilisateur d'avoir besoin de TypeScript installé.
+
+### Mettre à jour un plugin
+
+Quand une version plus récente est disponible dans `registry.json` par rapport à la version installée, Sowel affiche un indicateur de mise à jour dans l'UI (badge sidebar, pastille header, et un bouton "Update" sur la carte du plugin).
+
+**Flux de mise à jour** (déclenché par un clic sur "Update") :
+
+1. Stoppe le plugin en cours
+2. Télécharge la dernière release depuis GitHub (même logique que l'install)
+3. Remplace les fichiers du plugin dans `plugins/<id>/`
+4. Exécute `npm install` et build si nécessaire
+5. Met à jour la version et le manifest dans la base
+6. Redémarre le plugin s'il était activé
+
+**Ce qui est préservé :** tous les réglages du plugin, les devices découverts, les liaisons d'équipement, et la configuration d'historisation. La mise à jour ne remplace que le code du plugin, elle ne touche pas la base.
+
+**Ce qui change :** les fichiers du plugin dans `plugins/<id>/` et la version enregistrée dans la table `plugins`.
+
+### S'enregistrer dans le store de plugins
+
+Pour que votre plugin apparaisse dans le store de plugins Sowel, soumettez une PR sur le repo Sowel ajoutant une entrée à `plugins/registry.json` :
+
+```json
+{
+  "id": "my-device",
+  "type": "integration",
+  "name": "My Device",
+  "description": "Integration with My Device API",
+  "icon": "Cpu",
+  "author": "Your Name",
+  "repo": "yourname/sowel-plugin-my-device",
+  "version": "0.1.0",
+  "tags": ["sensor", "api"]
+}
+```
+
+#### Schéma d'entrée du registre
+
+| Champ         | Type     | Requis | Description                                                                               |
+| ------------- | -------- | ------ | ----------------------------------------------------------------------------------------- |
+| `id`          | string   | Oui    | Doit correspondre à l'`id` du `manifest.json` du plugin                                   |
+| `type`        | string   | Oui    | `integration` ou `recipe`, route vers PluginLoader ou RecipeLoader au moment de l'install |
+| `name`        | string   | Oui    | Nom affiché dans le store                                                                 |
+| `description` | string   | Oui    | Courte description                                                                        |
+| `icon`        | string   | Oui    | Nom d'icône Lucide                                                                        |
+| `author`      | string   | Oui    | Nom de l'auteur                                                                           |
+| `repo`        | string   | Oui    | Chemin GitHub `owner/repo` (utilisé pour récupérer les releases)                          |
+| `version`     | string   | Non    | Dernière version disponible (affichée dans l'onglet "Available" du store)                 |
+| `tags`        | string[] | Oui    | Tags cherchables (par ex. `["camera", "security"]`)                                       |
+
+#### Récupération du registre distant
+
+Depuis la spec 059, Sowel récupère `plugins/registry.json` depuis `https://raw.githubusercontent.com/mchacher/sowel/main/plugins/registry.json` avec un cache d'une heure, retombant sur le fichier local livré dans l'image Docker. Cela signifie :
+
+- **Publier une nouvelle version d'un plugin** ne nécessite que la mise à jour de `plugins/registry.json` sur `main`, pas besoin de release Sowel
+- Les **forks privés** peuvent pointer Sowel vers leur propre registre en changeant `REGISTRY_URL` dans `package-manager.ts`
+- Les **plugins sont re-téléchargés automatiquement** au démarrage du conteneur si leur répertoire est manquant (par ex. après une restauration de backup, spec 058)
+
+### Versioning
+
+Il y a **deux endroits** où la version compte, et ils ont des objectifs différents :
+
+1. **`manifest.json` (dans le repo du plugin)** : le champ `version` ici est lu lors de l'installation du plugin. Il est stocké dans la base de Sowel et affiché dans l'**onglet "Installed"** de l'UI Plugins.
+
+2. **`plugins/registry.json` (dans le repo Sowel)** : le champ `version` ici est affiché dans l'**onglet "Store"** de l'UI Plugins, montrant aux utilisateurs quelle version est disponible à l'installation.
+
+**Règles :**
+
+- Mettez à jour la version dans `manifest.json` à **chaque release**. C'est ainsi que Sowel sait quelle version est installée.
+- Mettez à jour la version dans `plugins/registry.json` du repo Sowel quand vous publiez une nouvelle release. C'est ainsi que les utilisateurs voient qu'une mise à jour est disponible : Sowel compare la version installée (depuis le manifest) à la version du registre et affiche un badge de mise à jour si elles diffèrent.
+- Gardez les deux versions en phase. Si `manifest.json` dit `0.2.0` mais `registry.json` dit `0.1.0`, le store affichera une version périmée.
+- La version dans le tag de release (par ex. `v0.2.0`) doit correspondre à `manifest.json`.
+
+### Convention de nommage des releases
+
+- Tag git : `v0.2.0` (SemVer avec préfixe `v`)
+- Asset tarball : `sowel-plugin-<id>-<version>.tar.gz`
+- La `version` dans le `manifest.json` du tarball doit correspondre au tag de release
+
+---
+
+## Dépannage
+
+**Le plugin n'est pas détecté :**
+
+- Vérifiez que `plugins/<id>/manifest.json` existe et est un JSON valide
+- Vérifiez que le champ `id` correspond au nom du répertoire
+- Vérifiez la table `plugins` dans SQLite, le plugin doit avoir une ligne avec `enabled = 1`
+
+**Le plugin échoue au chargement :**
+
+- Assurez-vous que `dist/index.js` existe et exporte une fonction `createPlugin`
+- Consultez les logs Sowel pour les entrées `plugin:<id>`
+- Vérifiez que le plugin utilise ESM (`export function createPlugin` ou `export { createPlugin }`)
+- Le loader vérifie aussi `mod.default?.createPlugin` en fallback
+
+**Le plugin se charge mais ne démarre pas :**
+
+- Vérifiez que `isConfigured()` renvoie true, Sowel saute `start()` quand c'est false
+- Vérifiez que tous les réglages requis sont configurés dans l'UI (Administration > Intégrations)
+
+**Les devices n'apparaissent pas :**
+
+- Vérifiez que `integrationId` dans `upsertFromDiscovery()` correspond à l'`id` de votre plugin
+- Vérifiez que `friendlyName` est non vide et unique
+- Cherchez les erreurs dans les logs du device manager
+
+**Les mises à jour de données ne fonctionnent pas :**
+
+- Vérifiez que `sourceDeviceId` dans `updateDeviceData()` correspond exactement au `friendlyName` utilisé dans `upsertFromDiscovery()`
+- Vérifiez que les clés du payload correspondent aux clés déclarées dans le tableau `DiscoveredDevice.data`
+
+**Les ordres ne sont pas reçus :**
+
+- Vérifiez que votre plugin implémente `executeOrder()` avec la bonne signature : `(device: Device, dispatchConfig: Record<string, unknown>, value: unknown)`
+- Vérifiez que le tableau `orders` du device inclut la définition d'ordre avec un `dispatchConfig`
+- Cherchez les événements de dispatch d'ordre dans les logs
+
+---
+
+## Référence
+
+- [Architecture Sowel](architecture.md) : vue d'ensemble de l'architecture technique
+- [Plugin Weather Forecast](https://github.com/mchacher/sowel-plugin-weather-forecast) : exemple complet et fonctionnel
+- [Plugin Netatmo Security](https://github.com/mchacher/sowel-plugin-netatmo-security) : plugin avec OAuth et ordres

--- a/docs/technical/recipe-development.fr.md
+++ b/docs/technical/recipe-development.fr.md
@@ -1,0 +1,250 @@
+# Guide de développement de recettes
+
+Comment créer une nouvelle recette pour Sowel.
+
+## Architecture
+
+Une recette est un modèle d'automatisation réutilisable. Les utilisateurs instancient les recettes avec des paramètres (slots) pour créer des instances d'automatisation en cours d'exécution. Les recettes sont enregistrées au démarrage du moteur et exposées via l'API REST.
+
+```
+Recipe class (definition)
+  -> RecipeManager.register()
+    -> GET /api/v1/recipes -> UI shows available recipes
+      -> User creates instance with params
+        -> RecipeManager.createInstance() -> validate() -> start()
+          -> Recipe subscribes to EventBus events and reacts
+```
+
+## Créer une recette
+
+### 1. Créer le fichier
+
+Créez `src/recipes/<recipe-name>.ts` qui étend la classe de base `Recipe` :
+
+```typescript
+import type { RecipeSlotDef, RecipeLangPack } from "../shared/types.js";
+import { Recipe, type RecipeContext } from "./engine/recipe.js";
+
+export class MyRecipe extends Recipe {
+  readonly id = "my-recipe";
+  readonly name = "My Recipe"; // English (fallback)
+  readonly description = "What it does"; // English (fallback)
+  readonly slots: RecipeSlotDef[] = [
+    // ...see Slots section below
+  ];
+  override readonly i18n: Record<string, RecipeLangPack> = {
+    // ...see Translations section below
+  };
+
+  validate(params: Record<string, unknown>, ctx: RecipeContext): void {
+    // Throw if params are invalid
+  }
+
+  start(params: Record<string, unknown>, ctx: RecipeContext): void {
+    // Subscribe to events, start timers
+  }
+
+  stop(): void {
+    // Unsubscribe events, clear timers (must be idempotent)
+  }
+}
+```
+
+### 2. Enregistrer dans index.ts
+
+```typescript
+import { MyRecipe } from "./recipes/my-recipe.js";
+// ...
+recipeManager.register(MyRecipe);
+```
+
+### 3. Écrire des tests
+
+Créez `src/recipes/<recipe-name>.test.ts`. Suivez le pattern de `motion-light.test.ts` :
+
+- SQLite en mémoire avec migrations
+- Faux timers (`vi.useFakeTimers()`)
+- Mock du registry d'intégrations capturant les publications MQTT
+- Test de la validation, du traitement des événements, du comportement des timers, du nettoyage
+
+## Slots
+
+Les slots définissent les paramètres que les utilisateurs configurent à la création d'une instance.
+
+```typescript
+interface RecipeSlotDef {
+  id: string; // Unique within recipe (e.g. "lights", "timeout")
+  name: string; // English label (fallback)
+  description: string; // English description (fallback)
+  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean";
+  required: boolean;
+  list?: boolean; // Allow multiple values (equipment lists)
+  defaultValue?: unknown;
+  constraints?: {
+    equipmentType?: EquipmentType | EquipmentType[]; // Filter equipment selector
+    min?: number;
+    max?: number;
+    crossZone?: boolean; // Allow picking equipments from any zone
+    includeDescendants?: boolean; // Widen candidates to descendant zones
+  };
+}
+```
+
+### Portée d'un slot equipment : `crossZone` et `includeDescendants`
+
+Par défaut, le picker d'un slot `equipment` est filtré sur les équipements qui vivent dans la `zone` de la recette. Deux contraintes élargissent cet ensemble :
+
+| Contrainte           | Effet                                                                                                                                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `crossZone`          | Permet à l'utilisateur de choisir un équipement depuis **n'importe quelle** zone du système. Utile pour des triggers comme "le portail" qui appartient sémantiquement à une zone différente de l'action.      |
+| `includeDescendants` | Élargit l'ensemble candidat à la zone de la recette **plus toutes les zones descendantes**. Utile quand les actionneurs (par ex. les lumières) vivent dans des sous-zones plutôt que directement dans `zone`. |
+
+Les deux flags sont indépendants : `crossZone` ignore complètement la portée de zone, alors que `includeDescendants` conserve la portée enracinée à la zone mais inclut récursivement les enfants. Un picker avec les deux activés se comporte comme `crossZone` seul.
+
+```typescript
+slots: RecipeSlotDef[] = [
+  { id: "zone", name: "Zone", description: "...", type: "zone", required: true },
+  {
+    id: "trigger",
+    name: "Trigger equipment",
+    description: "Equipment whose state change fires the recipe",
+    type: "equipment",
+    required: true,
+    constraints: { crossZone: true }, // can be in another zone
+  },
+  {
+    id: "lights",
+    name: "Lights",
+    description: "Lights to turn on",
+    type: "equipment",
+    required: true,
+    list: true,
+    constraints: {
+      equipmentType: ["light_onoff", "light_dimmable"],
+      includeDescendants: true, // lights may live in subzones of `zone`
+    },
+  },
+];
+```
+
+**Patterns courants de slot :**
+
+| Slot type   | Contrôle UI       | Format de valeur                      |
+| ----------- | ----------------- | ------------------------------------- |
+| `zone`      | Auto-rempli       | UUID de zone                          |
+| `equipment` | Liste/cases       | UUID d'équipement (ou UUID[] si list) |
+| `duration`  | Numérique + min   | `"10m"`, `"30s"`, `"1h"`              |
+| `number`    | Saisie numérique  | Valeur numérique                      |
+| `time`      | Sélecteur d'heure | Chaîne `"HH:MM"` (24 h)               |
+| `boolean`   | Bascule           | `true` / `false`                      |
+
+## Traductions (i18n)
+
+Les traductions voyagent avec la recette, pas dans les fichiers de locale de la plateforme. Cela permet de hot-loader des recettes sans modifier `fr.json`/`en.json`.
+
+### Comment ça marche
+
+Chaque recette définit un record `i18n` qui mappe les codes de langue à des noms, descriptions et libellés de slot traduits :
+
+```typescript
+override readonly i18n: Record<string, RecipeLangPack> = {
+  fr: {
+    name: "Ma recette",
+    description: "Ce qu'elle fait",
+    slots: {
+      lights: { name: "Lumieres", description: "Lumieres a controler" },
+      timeout: { name: "Delai", description: "Delai avant extinction" },
+    },
+  },
+  // Add more languages as needed
+};
+```
+
+### Définitions de types
+
+```typescript
+interface RecipeLangPack {
+  name: string;
+  description: string;
+  slots?: Record<string, RecipeSlotI18n>; // Keyed by slot id
+}
+
+interface RecipeSlotI18n {
+  name: string;
+  description: string;
+}
+```
+
+### Résolution dans l'UI
+
+Le frontend utilise des helpers depuis `ui/src/lib/recipe-i18n.ts` :
+
+```typescript
+recipeName(recipe, lang); // Recipe name with fallback
+recipeDescription(recipe, lang); // Recipe description with fallback
+recipeSlotName(recipe, slot, lang); // Slot name with fallback
+recipeSlotDescription(recipe, slot, lang); // Slot description with fallback
+```
+
+Chaîne de fallback : `i18n[lang].name -> recipe.name` (anglais embarqué dans la classe).
+
+### Ajouter une nouvelle langue
+
+Ajoutez une nouvelle clé au record `i18n` dans la classe de votre recette. Aucun fichier de plateforme à modifier.
+
+## RecipeContext
+
+L'objet `ctx` injecté dans `validate()` et `start()` fournit :
+
+| Propriété          | Type               | Usage                                                                                 |
+| ------------------ | ------------------ | ------------------------------------------------------------------------------------- |
+| `eventBus`         | `EventBus`         | S'abonner aux événements typés                                                        |
+| `equipmentManager` | `EquipmentManager` | Interroger l'état d'un équipement, exécuter des ordres                                |
+| `zoneManager`      | `ZoneManager`      | Interroger les définitions de zones                                                   |
+| `zoneAggregator`   | `ZoneAggregator`   | Interroger les données agrégées de zone                                               |
+| `state`            | `RecipeStateStore` | Persister un état clé-valeur (survit au redémarrage, auto-notifie l'UI sur mutations) |
+| `log(msg, level?)` | fonction           | Écrire dans le journal d'exécution de la recette                                      |
+
+## Helpers partagés
+
+Utilitaires réutilisables dans `src/recipes/engine/` :
+
+| Module             | Exporte                                                                        |
+| ------------------ | ------------------------------------------------------------------------------ |
+| `duration.ts`      | `parseDuration(value)`, `formatDuration(ms)`                                   |
+| `light-helpers.ts` | `isAnyLightOn()`, `turnOnLights()`, `turnOffLights()`, `setLightsBrightness()` |
+
+## Événements de l'Event Bus
+
+Événements clés auxquels les recettes s'abonnent typiquement :
+
+| Event                    | Payload                                                   |
+| ------------------------ | --------------------------------------------------------- |
+| `zone.data.changed`      | `{ zoneId, aggregatedData: { motion, luminosity, ... } }` |
+| `equipment.data.changed` | `{ equipmentId, alias, value, category }`                 |
+
+## Cycle de vie
+
+1. **Enregistrement** : `recipeManager.register(MyRecipe)`, crée une instance d'exemple pour extraire les métadonnées
+2. **Instanciation** : l'utilisateur crée via l'API → `validate()` → persisté en SQLite → `start()`
+3. **Restauration** : au redémarrage moteur, les instances activées sont chargées depuis la DB et `start()` est appelé
+4. **Mise à jour** : `stop()` → mise à jour des params en DB → `validate()` → `start()` avec les nouveaux params
+5. **Suppression** : `stop()` → retiré de la DB (cascade sur state + logs)
+
+## Recettes existantes
+
+| ID             | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| `motion-light` | Allume les lumières au mouvement, les éteint après un délai            |
+| `switch-light` | Bascule les lumières à l'appui sur bouton, timer de sécurité optionnel |
+
+## Checklist
+
+- [ ] La classe Recipe étend `Recipe` avec id, name, description, slots, i18n
+- [ ] `validate()` vérifie tous les params, lève une erreur si invalide
+- [ ] `start()` s'abonne aux événements, stocke les unsubs
+- [ ] `stop()` annule tous les timers et désabonne (idempotent)
+- [ ] Enregistré dans `src/index.ts`
+- [ ] Tests écrits et passants
+- [ ] `npx tsc --noEmit` passe
+- [ ] Traductions françaises dans le record `i18n`

--- a/docs/user/dashboard.fr.md
+++ b/docs/user/dashboard.fr.md
@@ -1,0 +1,79 @@
+# Tableau de bord
+
+Le Tableau de bord est votre écran d'accueil personnalisé : une grille de widgets configurable qui affiche les informations et les contrôles les plus importants pour vous.
+
+## Vue d'ensemble
+
+Contrairement à la vue Accueil (organisée par zones), le Tableau de bord vous laisse choisir exactement ce que vous voulez voir, peu importe la pièce ou le type d'équipement. Vous pouvez placer les lumières de votre salon à côté de la température extérieure et du portail de garage, le tout sur un même écran.
+
+## Types de widgets
+
+### Widget d'équipement
+
+Affiche un équipement unique avec son état courant et ses contrôles rapides.
+
+- **Lumières** : interrupteur, curseur de luminosité (pour les lumières variables)
+- **Volets** : affichage de la position avec contrôles ouvrir/fermer
+- **Capteurs** : valeurs actuelles avec icônes et unités appropriées
+- **Thermostats** : affichage de température avec indicateur de mode
+- **Interrupteurs** : badge d'état on/off
+
+### Widget de zone
+
+Affiche les données agrégées d'une zone entière. Vous choisissez quelle **famille** de données afficher :
+
+| Famille       | Ce qui est affiché                                                          |
+| ------------- | --------------------------------------------------------------------------- |
+| **Lumières**  | Nombre de lumières allumées / total, avec une action rapide "tout éteindre" |
+| **Volets**    | Nombre de volets ouverts / total, position moyenne                          |
+| **Chauffage** | Température moyenne, statut de chauffage                                    |
+| **Capteurs**  | Température, humidité, statut de mouvement                                  |
+
+Les widgets de zone vous donnent une vue d'ensemble rapide d'une pièce sans voir les détails de chaque équipement.
+
+## Ajouter des widgets
+
+1. Entrez en **mode édition** en cliquant sur l'icône crayon en haut à droite du Tableau de bord
+2. Cliquez sur le bouton **+** qui apparaît
+3. Dans la fenêtre, choisissez entre :
+   - **Équipement** : parcourez et sélectionnez n'importe quel équipement
+   - **Zone** : sélectionnez une zone et une famille de données
+
+Le widget apparaît à la fin de votre grille.
+
+## Personnaliser les widgets
+
+### Réorganiser
+
+En mode édition, glissez-déposez les widgets pour les réorganiser. L'ordre est enregistré automatiquement.
+
+### Étiquettes et icônes personnalisées
+
+Chaque widget peut avoir une étiquette et une icône personnalisées qui remplacent le nom par défaut de l'équipement ou de la zone. C'est utile pour mettre des noms plus courts sur le tableau de bord.
+
+### Configuration des widgets de capteur
+
+Pour les widgets d'équipements capteurs, vous pouvez choisir quelles liaisons de données afficher. Par défaut, toutes les liaisons sont affichées. Si un capteur remonte température, humidité et pression mais que seule la température vous intéresse, vous pouvez masquer les autres.
+
+### Supprimer des widgets
+
+En mode édition, cliquez sur le bouton de suppression d'un widget pour le retirer du tableau de bord.
+
+## Mode édition
+
+Le mode édition se bascule avec l'icône crayon dans l'en-tête du tableau de bord. Quand il est actif :
+
+- Un bouton **+** apparaît pour ajouter de nouveaux widgets
+- Chaque widget affiche un bouton **suppression**
+- Les widgets peuvent être **glissés** pour être réordonnés
+- Cliquez sur la **coche** pour quitter le mode édition et enregistrer
+
+!!! tip
+Le tableau de bord est personnel : chaque utilisateur a sa propre disposition de widgets. Les utilisateurs admin et les utilisateurs réguliers voient leur propre tableau de bord.
+
+## Astuces
+
+- **Restez concentré** : le tableau de bord fonctionne mieux avec 6 à 12 widgets. Trop de widgets réduisent la valeur d'un coup d'œil.
+- **Utilisez les widgets de zone pour l'aperçu** : un widget "Capteurs" de zone pour chaque étage vous donne la température de toute la maison en un coup d'œil.
+- **Utilisez les widgets d'équipement pour le contrôle** : mettez les lumières et volets que vous utilisez le plus sur le tableau de bord pour un accès en un seul geste.
+- **Adapté au mobile** : sur mobile, les widgets s'empilent en une seule colonne. Placez vos widgets les plus importants en haut.

--- a/docs/user/energy.fr.md
+++ b/docs/user/energy.fr.md
@@ -1,0 +1,161 @@
+# Suivi énergétique
+
+Sowel intègre un suivi énergétique qui mesure la consommation électrique de votre maison dans le temps. Il prend en charge la classification tarifaire HP/HC (heures pleines/heures creuses) et le suivi de l'autoconsommation pour la production solaire.
+
+## Vue d'ensemble
+
+Le suivi énergétique fonctionne via un pipeline :
+
+1. Un **équipement compteur d'énergie** (par ex. module Netatmo Energy sur votre disjoncteur principal) remonte les données de consommation
+2. Sowel écrit ces données dans **InfluxDB**, une base de données de séries temporelles
+3. InfluxDB agrège automatiquement les données en résumés horaires et journaliers
+4. La **page Énergie** dans l'UI affiche les graphiques et les totaux
+
+## Prérequis
+
+- Un device de compteur d'énergie connecté à l'une de vos intégrations (par ex. Netatmo Home Control)
+- Un équipement de type **main_energy_meter** configuré dans Sowel
+- InfluxDB en service (inclus dans la configuration Docker)
+
+!!! info "InfluxDB est automatique"
+InfluxDB est obligatoire et démarre avec Sowel. Au premier lancement, Sowel crée automatiquement les buckets requis, les tâches de downsampling et les tâches d'agrégation énergétique. Aucune configuration manuelle d'InfluxDB n'est nécessaire.
+
+## Configurer le suivi énergétique
+
+### Étape 1 : connecter votre intégration énergie
+
+Assurez-vous que votre source de données énergie est configurée dans **Administration > Intégrations**. Pour Netatmo, cela signifie configurer l'intégration Netatmo Home Control avec vos identifiants OAuth.
+
+### Étape 2 : créer l'équipement énergie
+
+Allez dans **Administration > Équipements** et créez un équipement :
+
+- **Type** : Compteur d'énergie principal
+- **Zone** : affectez-le à une zone pertinente (par ex. Maison ou Local technique)
+- **Liez** à votre device compteur d'énergie
+
+Une fois lié, Sowel commence à enregistrer les données d'énergie dans InfluxDB.
+
+### Étape 3 : (facultatif) configurer les tarifs HP/HC
+
+Si votre contrat d'électricité utilise des heures pleines (HP) et creuses (HC), configurez la grille tarifaire afin que Sowel puisse répartir votre consommation en conséquence.
+
+Allez dans **Réglages > Configuration tarifaire** :
+
+1. Définissez votre grille tarifaire : quelles heures sont HP et lesquelles sont HC
+2. Vous pouvez définir des grilles différentes selon les jours de la semaine
+3. Optionnellement, saisissez vos prix HP et HC par kWh
+
+**Exemple : tarif HP/HC français standard**
+
+| Heures        | Tarif        |
+| ------------- | ------------ |
+| 06:00 à 22:00 | HP (pleines) |
+| 22:00 à 06:00 | HC (creuses) |
+
+!!! tip
+Si aucun tarif n'est configuré, toute la consommation est classée HP par défaut. La page Énergie fonctionne quand même, vous ne verrez juste pas la ventilation HP/HC.
+
+### Étape 4 : (facultatif) configurer des sous-compteurs pour une ventilation par usage
+
+Vous pouvez ajouter des **équipements sous-compteurs** de type `energy_meter` sur des circuits dédiés (pompe à chaleur, piscine, borne VE, etc.) pour répartir ce que mesure votre compteur principal en usages nommés.
+
+Pour configurer un sous-compteur :
+
+1. Liez un compteur d'énergie ou une prise mesurée Zigbee/Wi-Fi au circuit pertinent.
+2. Allez dans **Administration > Équipements** et créez un équipement de type **Compteur d'énergie**.
+3. Liez-le à la donnée `energy` (Wh) du device.
+
+Une fois qu'au moins un sous-compteur est configuré, la page Énergie affiche un bouton **Total / Par usage**. La vue "Par usage" rend un graphique en barres empilées avec une pile par sous-compteur, plus une pile **Autre** pour le résidu non capturé par un sous-compteur (c'est-à-dire `compteur principal - somme des sous-compteurs`).
+
+### Étape 5 : (facultatif) configurer le suivi de production
+
+Si vous avez des panneaux solaires, créez un équipement de type **energy_production_meter** et liez-le au device de votre compteur de production. Sowel suivra alors :
+
+- **Consommation réseau** : énergie tirée du réseau
+- **Autoconsommation** : énergie produite et consommée localement
+- **Consommation totale** : réseau + autoconsommation
+
+## Utiliser la page Énergie
+
+Naviguez vers **Énergie** dans la barre latérale. La page affiche :
+
+### Sélecteur de période
+
+Basculez entre différentes vues temporelles :
+
+| Période   | Ce qui est affiché                                       |
+| --------- | -------------------------------------------------------- |
+| **Jour**  | Barres de consommation horaires pour un jour choisi      |
+| **Mois**  | Barres de consommation journalières pour un mois choisi  |
+| **Année** | Barres de consommation mensuelles pour une année choisie |
+
+Utilisez les flèches de navigation pour vous déplacer entre les dates.
+
+### Graphique de consommation
+
+Un graphique en barres qui montre la consommation d'énergie sur la période sélectionnée. Chaque barre est codée par couleur :
+
+- **Bleu** : consommation réseau
+- **Bleu clair** : portion en heures creuses (HC), si HP/HC est configuré
+- **Vert** : autoconsommation, si le suivi de production est configuré
+
+#### Bouton Total / Par usage
+
+Si vous avez configuré au moins un sous-compteur (voir [Étape 4](#etape-4-facultatif-configurer-des-sous-compteurs-pour-une-ventilation-par-usage)), un bouton **Total / Par usage** apparaît au-dessus du graphique :
+
+- **Total** : la vue HP/HC/production standard décrite plus haut
+- **Par usage** : un graphique en barres empilées avec une couleur par sous-compteur (par ex. PAC, Piscine) plus un résidu **Autre** qui représente ce que le compteur principal a vu mais qu'aucun sous-compteur n'a comptabilisé
+
+Le bouton est masqué quand aucun sous-compteur n'est configuré. Les widgets de totaux (HP/HC, autoconsommation) conservent leurs valeurs entre les deux vues.
+
+### Totaux
+
+Sous le graphique, vous voyez les totaux récapitulatifs :
+
+- **Consommation réseau** en kWh
+- **Répartition HP / HC** en kWh (si le tarif est configuré)
+- **Autoconsommation** en kWh (si la production est suivie)
+- **Consommation totale** en kWh
+
+### Page Production
+
+Si vous avez configuré la production solaire, un onglet **Production** apparaît, qui affiche :
+
+- Graphique en barres de production (même sélecteur de période que la consommation)
+- Totaux de production
+- Ratio d'autoconsommation
+
+## Pipeline de données
+
+Comprendre le flux des données aide au dépannage :
+
+```
+Energy meter device
+  --> 30-minute energy readings
+    --> InfluxDB "sowel" bucket (7-day retention, raw data)
+      --> Hourly aggregation task
+        --> InfluxDB "sowel-energy-hourly" bucket (2-year retention)
+          --> Daily aggregation task
+            --> InfluxDB "sowel-energy-daily" bucket (10-year retention)
+```
+
+- **Vue Jour** : pour les jours récents (moins d'une semaine), le graphique interroge les données brutes pour une précision en temps réel. Pour les jours plus anciens, il utilise le bucket horaire.
+- **Vue Mois/Année** : utilise le bucket journalier pour des requêtes efficaces sur de longues périodes.
+
+## Dépannage
+
+### Aucune donnée n'apparaît sur la page Énergie
+
+1. Vérifiez que votre intégration énergie est connectée (indicateur vert dans Intégrations)
+2. Vérifiez que l'équipement énergie existe et est lié à un device
+3. Patientez le temps d'au moins un cycle de polling (typiquement 30 minutes pour Netatmo)
+4. Consultez les logs pour des messages d'erreur liés à l'énergie ou à InfluxDB
+
+### La répartition HP/HC affiche tout en HP
+
+Cela signifie qu'aucune grille tarifaire n'est configurée. Allez dans **Réglages > Configuration tarifaire** et définissez vos heures HP/HC.
+
+### Des données anciennes manquent
+
+Les données de plus de 7 jours ne sont disponibles que si la tâche d'agrégation horaire s'est exécutée correctement. Vérifiez qu'InfluxDB tourne et que Sowel a créé les tâches d'agrégation (cela se fait automatiquement au démarrage).

--- a/docs/user/equipments.fr.md
+++ b/docs/user/equipments.fr.md
@@ -1,0 +1,258 @@
+# Équipements
+
+Les équipements sont le concept central de Sowel. Un équipement est une **unité fonctionnelle** avec laquelle vous interagissez au quotidien : "Spots Salon", "Volets Chambre", "Capteur Cuisine".
+
+**Un device est ce qui est sur le réseau, un équipement est ce qui est dans la pièce.** Vous ne pensez jamais au module variateur Zigbee installé derrière le mur, vous pensez aux lumières de votre salon.
+
+## Créer un équipement
+
+Allez dans **Administration > Équipements** et cliquez sur **Ajouter un équipement**.
+
+### Étape 1 : Informations de base
+
+| Champ       | Obligatoire | Description                                                                             |
+| ----------- | ----------- | --------------------------------------------------------------------------------------- |
+| Type        | Oui         | La catégorie de l'équipement (voir [Types d'équipements](#types-dequipements) plus bas) |
+| Nom         | Oui         | Un nom parlant comme "Spots Salon" ou "Capteur Cuisine"                                 |
+| Zone        | Oui         | À quelle pièce ou zone cet équipement appartient                                        |
+| Description | Non         | Une note pour vous-même                                                                 |
+
+!!! info "Le type ne peut pas être modifié après création"
+Choisissez le type avec soin, il détermine quels devices sont compatibles et comment l'équipement est affiché.
+
+### Étape 2 : Sélectionner les devices
+
+Cliquez sur **Suivant : Sélectionner les devices** pour voir la liste des devices compatibles. Sowel filtre automatiquement les devices selon le type d'équipement.
+
+- Sélectionnez un ou plusieurs devices
+- Cliquez sur **Créer**
+
+**C'est tout.** Sowel crée automatiquement toutes les liaisons de données et de commandes. Chaque valeur que le device expose (température, humidité, batterie...) devient immédiatement disponible sur l'équipement.
+
+!!! tip "Vous pouvez ignorer la sélection de device"
+Vous pouvez créer un équipement sans device et en lier un plus tard depuis la page de détail.
+
+### Liaison multi-devices
+
+Un seul équipement peut se lier à **plusieurs devices**. C'est une des fonctionnalités les plus puissantes de Sowel.
+
+**Exemple :** Trois modules variateurs IKEA séparés alimentent les spots de votre salon. Créez un seul équipement "Spots Salon" et liez les trois. Un seul interrupteur allume les trois. Un seul curseur les variégradue tous les trois.
+
+---
+
+## Types d'équipements
+
+### Lumières
+
+#### Lumière (On/Off)
+
+Contrôle simple on/off d'une lumière.
+
+- **Contrôles :** Bascule ON/OFF
+- **Données attendues :** état (on/off)
+
+#### Lumière (Variateur)
+
+Lumière à luminosité réglable.
+
+- **Contrôles :** Bascule ON/OFF + curseur de luminosité
+- **Données attendues :** état, niveau de luminosité
+
+#### Lumière (Couleur)
+
+Lumière à couleur réglable, avec température de couleur en option.
+
+- **Contrôles :** Bascule + curseur de luminosité + contrôles de couleur
+- **Données attendues :** état, luminosité, couleur, température de couleur
+
+---
+
+### Volets
+
+#### Volet
+
+Volet roulant motorisé, store ou volet.
+
+- **Contrôles :** Boutons Ouvrir / Stop / Fermer, affichage de la position
+- **Données attendues :** position (0 % = fermé, 100 % = ouvert)
+
+---
+
+### Climatisation
+
+#### Thermostat
+
+Contrôle de chauffage ou de climatisation : climatiseur, poêle à granulés, pompe à chaleur.
+
+- **Contrôles :** Affichage de la température, ajustement de la consigne (+/-), allumage/extinction
+- **Données attendues :** température courante, consigne cible, état d'alimentation
+- **Données additionnelles** (selon le device) : mode de fonctionnement, vitesse du ventilateur, mode éco
+
+#### Radiateur
+
+Radiateur électrique individuel piloté par relais fil pilote.
+
+- **Contrôles :** Bascule Confort / Éco
+- **Données attendues :** état du relais (ON = éco, OFF = confort)
+
+---
+
+### Accès
+
+#### Portail
+
+Portail, portail coulissant, ou porte de garage.
+
+- **Contrôles :** Bouton Ouvrir/Fermer avec indicateur d'état
+- **Données attendues :** état du portail (ouvert, fermé, en ouverture, en fermeture)
+
+!!! tip "Icône du tableau de bord"
+Vous pouvez choisir une icône spécifique pour les portails sur le tableau de bord : portail standard, portail coulissant, ou porte de garage.
+
+---
+
+### Capteurs
+
+#### Capteur
+
+Capteur générique qui affiche une ou plusieurs valeurs mesurées. Sowel adapte l'affichage automatiquement selon ce que le device expose.
+
+- **Contrôles :** Affichage en lecture seule avec icônes et unités appropriées
+- **Données typiques :** température, humidité, pression, CO2, COV, luminosité, bruit, batterie
+- **Capteurs booléens :** mouvement (Mouvement/Calme), contact (Ouvert/Fermé), fuite d'eau, fumée
+
+#### Station météo
+
+Capteur météo extérieur qui fournit les conditions actuelles.
+
+- **Contrôles :** Affichage multi-valeurs
+- **Données typiques :** température, humidité, pression, pluie, vent, bruit, batterie
+
+#### Prévision météo
+
+Prévision météo sur plusieurs jours depuis une intégration API (par ex. plugin Open-Meteo).
+
+- **Contrôles :** Cartes de prévisions jour par jour avec icônes des conditions
+- **Données par jour (J+1 à J+5) :** condition météo, températures min/max, probabilité de pluie, rafales de vent
+
+#### Bouton / Télécommande
+
+Bouton physique ou télécommande. Pas piloté directement, utilisé comme déclencheur d'automatisations.
+
+- **Données :** événements d'action (appui simple, double appui, appui long)
+- **Usage :** Déclencher des [recettes](../technical/recipe-development.md) ou basculer des [modes](modes.md)
+
+---
+
+### Énergie
+
+#### Compteur d'énergie
+
+Suit la consommation d'énergie d'un circuit ou d'un device spécifique. Souvent utilisé comme **sous-compteur** sur une ligne dédiée (pompe à chaleur, piscine, borne VE) pour alimenter la [ventilation par usage](energy.md#bouton-total-par-usage) sur la page Énergie.
+
+- **Contrôles :** Affichage de la puissance (W) et de l'énergie quotidienne (Wh/kWh)
+- **Données attendues :** énergie cumulée (Wh)
+
+#### Compteur d'énergie principal
+
+Le compteur principal du réseau de votre maison. Un seul autorisé par système.
+
+- **Contrôles :** Identique au compteur d'énergie, plus alimentation de la page [Suivi énergétique](energy.md)
+- **Données attendues :** puissance, énergie (avec classification tarifaire HP/HC)
+
+#### Compteur d'énergie de production
+
+Panneau solaire ou autre source de production. Un seul autorisé par système.
+
+- **Contrôles :** Affichage de la production avec calcul d'autoconsommation
+- **Données attendues :** puissance de production, production cumulée
+
+---
+
+### Multimédia
+
+#### Lecteur multimédia
+
+TV, barre de son, ou appareil multimédia (par ex. TV Samsung SmartThings).
+
+- **Contrôles :** Allumage/extinction, volume, mute, sélecteur de source d'entrée
+- **Données attendues :** état d'alimentation, niveau de volume, mute, source d'entrée courante, mode image
+- **Ordres :** allumer/éteindre, régler le volume, basculer mute, changer de source d'entrée
+
+---
+
+### Électroménager
+
+#### Appareil électroménager
+
+Appareil électroménager connecté tel que lave-linge, sèche-linge ou lave-vaisselle (par ex. Samsung SmartThings Washer).
+
+- **Contrôles :** Affichage de statut en lecture seule
+- **Données attendues :** état d'alimentation, état de fonctionnement (prêt/en cours/en pause), phase courante (lavage/rinçage/essorage), progression (%), temps restant, consommation d'énergie
+
+!!! tip "Notification de fin de cycle"
+Utilisez une recette de surveillance d'état pour être notifié quand l'état de fonctionnement passe de `running` à `ready`.
+
+---
+
+### Eau
+
+#### Vanne d'eau
+
+Vanne d'arrosage connectée pour le jardin. Conçue pour des devices comme la SONOFF SWV qui exposent `state`, `flow`, et les propriétés `irrigation_*`.
+
+- **Contrôles :** Bascule ON/OFF, action minutée "Arroser pendant X min" qui ouvre la vanne et laisse le firmware du device la refermer automatiquement après la durée configurée
+- **Métriques live affichées si liées :** débit (m³/h), batterie, statut device (normal / manque d'eau / fuite)
+- **Alias standards :** `state`, `flow`, `battery`, `status`, `duration`, `cycles`, `interval`, `capacity`, `autoCloseOnShortage`, seul `state` est requis, l'UI s'adapte à ce qui est lié
+- **Agrégation de zone :** compte les vannes ouvertes/totales et somme le débit live sur l'arbre des zones
+- **Base pour** de futures recettes d'arrosage automatique (planification consciente de la pluie)
+
+### Autre
+
+#### Interrupteur / Prise
+
+Simple interrupteur on/off ou prise connectée.
+
+- **Contrôles :** Bascule ON/OFF avec badge d'état
+- **Données attendues :** état (on/off)
+
+---
+
+## Gérer les équipements
+
+### Page de détail
+
+Cliquez sur n'importe quel équipement pour voir sa page de détail :
+
+- **Données live** : toutes les valeurs sont mises à jour en temps réel via WebSocket
+- **Contrôles** : contrôles interactifs adaptés au type d'équipement
+- **Graphique d'historique** : tendances des données dans le temps (si l'historisation est activée)
+- **Configuration** : devices liés, liaisons de données, liaisons d'ordres
+
+### Changer le device
+
+Depuis la page de détail, cliquez sur **Changer de device** pour relier l'équipement à un ou plusieurs devices différents. Sowel supprime toutes les liaisons existantes et les recrée automatiquement à partir des nouveaux devices.
+
+### Historisation
+
+Chaque valeur de donnée est historisée vers InfluxDB par défaut, selon sa catégorie (température, humidité, puissance...). Depuis la page de détail, vous pouvez surcharger ce comportement par liaison :
+
+- **Défaut** : suit la règle de la catégorie
+- **Forcer ON** : toujours historiser cette valeur
+- **Forcer OFF** : ne jamais historiser cette valeur
+
+### Désactiver un équipement
+
+Un équipement désactivé :
+
+- N'apparaît pas dans la vue Accueil
+- Est exclu de l'[agrégation de zone](zones.md)
+- Ne déclenche pas les recettes ni les impacts de mode
+- Reste consultable et modifiable
+
+### Supprimer un équipement
+
+La suppression retire l'équipement de Sowel. Les devices sous-jacents ne sont **pas** affectés, ils restent disponibles pour de nouveaux équipements.
+
+!!! warning
+Supprimer un équipement supprime également toutes les instances de recettes et impacts de mode qui le référencent.

--- a/docs/user/getting-started.fr.md
+++ b/docs/user/getting-started.fr.md
@@ -1,0 +1,203 @@
+# Premiers pas
+
+Cette page vous guide à travers l'installation de Sowel, la première connexion, et la configuration de votre maison.
+
+## Prérequis
+
+- **Docker** (recommandé) ou **Node.js 20+** pour une installation manuelle
+- Au moins une intégration prise en charge :
+  - **Zigbee2MQTT** avec un broker MQTT (Mosquitto ou équivalent)
+  - Compte **Panasonic Comfort Cloud** (pour les climatiseurs)
+  - Compte **MCZ Maestro** (pour les poêles à granulés)
+  - **Netatmo Weather** (pour les stations météo)
+  - **Legrand Energy / Control** (pour le suivi énergétique, les lumières, les volets)
+  - **LoRa2MQTT** (pour les devices LoRa via un pont lora2mqtt)
+
+## Installation
+
+### Option 1 : Docker (recommandé)
+
+Docker est la manière la plus simple d'exécuter Sowel. Il regroupe le moteur et InfluxDB.
+
+```bash
+git clone <repo>
+cd sowel
+docker-compose up -d
+```
+
+Cela lance :
+
+- Le **moteur Sowel** sur le port `3000`
+- **InfluxDB** sur le port `8086` (utilisé en interne pour les données d'énergie et d'historique)
+
+Ouvrez votre navigateur sur **http://localhost:3000**.
+
+### Option 2 : Installation manuelle
+
+```bash
+git clone <repo>
+cd sowel
+npm install
+```
+
+Démarrez le backend :
+
+```bash
+npm run dev
+```
+
+Dans un terminal séparé, démarrez le frontend :
+
+```bash
+cd ui
+npm install
+npm run dev
+```
+
+Ouvrez votre navigateur sur **http://localhost:5173**.
+
+!!! info "Développement vs production"
+En exécution manuelle avec `npm run dev`, l'UI tourne sur le port 5173 (serveur de dev Vite avec hot reload). En mode Docker ou production, le backend sert directement l'UI sur le port 3000.
+
+## Première connexion
+
+À la première ouverture de Sowel, une **page de configuration** apparaît. Créez votre compte administrateur :
+
+1. Choisissez un nom d'utilisateur
+2. Définissez un mot de passe
+3. Saisissez un nom d'affichage
+
+Une fois le premier compte créé, l'écran de connexion vous accueille :
+
+![Écran de connexion](../screenshots/getting-started-login.png)
+
+Cela crée le premier compte administrateur. Vous pourrez ajouter d'autres utilisateurs plus tard depuis les Réglages.
+
+!!! warning
+Il n'existe aucun mécanisme de récupération de mot de passe. Assurez-vous de bien retenir vos identifiants admin.
+
+## Configuration initiale
+
+Après la connexion, suivez ces étapes pour configurer votre maison.
+
+### Étape 1 : Configurer les intégrations
+
+Allez dans **Administration > Intégrations** dans la barre latérale.
+
+![Page intégrations](../screenshots/getting-started-integrations.png)
+
+Chaque intégration possède son propre panneau de réglages. Cliquez sur une intégration pour la déplier et configurer la connexion. Réglages courants :
+
+| Intégration                 | À configurer                                                        |
+| --------------------------- | ------------------------------------------------------------------- |
+| **Zigbee2MQTT**             | URL du broker MQTT (par ex. `mqtt://localhost:1883`), topic de base |
+| **Panasonic Comfort Cloud** | Email et mot de passe de votre compte Panasonic                     |
+| **MCZ Maestro**             | Email et mot de passe de votre compte MCZ                           |
+| **Netatmo Weather**         | Identifiants OAuth (client ID, client secret, tokens)               |
+| **Legrand Energy/Control**  | Identifiants OAuth (client ID, client secret, tokens)               |
+| **LoRa2MQTT**               | URL du broker MQTT, topic de base                                   |
+
+Chaque intégration affiche un **indicateur de statut de connexion** (vert = connecté). Vous pouvez démarrer/arrêter les intégrations et déclencher un rafraîchissement manuel sans redémarrer le moteur.
+
+!!! tip
+Les réglages d'intégration sont stockés dans la base de données, pas dans des fichiers d'environnement. Vous configurez tout depuis l'UI.
+
+### Étape 2 : Vérifier la découverte des devices
+
+Allez dans **Administration > Devices**.
+
+![Page devices](../screenshots/getting-started-devices.png)
+
+Une fois qu'une intégration est connectée, les devices apparaissent automatiquement. Le tableau affiche :
+
+- Le nom du device et l'intégration source (Z2M, LORA2MQTT, MCZ, etc.)
+- Le fabricant et le modèle
+- Le statut de connexion (point vert = en ligne)
+- Le lien à l'équipement (s'il est déjà affecté)
+
+Utilisez les onglets d'intégration en haut pour filtrer par source. Si les devices n'apparaissent pas, vérifiez que votre intégration est connectée (indicateur vert) et que les devices sont appairés à votre coordinateur ou enregistrés sur votre compte cloud.
+
+### Étape 3 : Créer la topologie de vos zones
+
+Allez dans **Administration > Topologie**.
+
+![Page zones](../screenshots/getting-started-zones.png)
+
+Construisez la structure spatiale de votre maison sous forme d'arbre imbriquable. Une configuration typique :
+
+```
+Home
+  Ground Floor
+    Living Room
+    Kitchen
+    Hallway
+  First Floor
+    Master Bedroom
+    Kids Room
+    Bathroom
+  Outdoor
+    Garden
+    Garage
+```
+
+Utilisez le bouton **+ Ajouter une zone** pour créer des zones, et les boutons fléchés pour les réordonner. Les zones peuvent être imbriquées sur n'importe quelle profondeur. L'arbre des zones apparaît dans la barre latérale Accueil pour la navigation quotidienne.
+
+### Étape 4 : Créer les équipements
+
+Allez dans **Administration > Équipements**.
+
+Pour chaque unité fonctionnelle de votre maison :
+
+1. Cliquez sur **Ajouter un équipement**
+2. Choisissez un type (lumière, volet, capteur, thermostat, portail, vanne d'eau, etc.)
+3. Donnez-lui un nom (par ex. "Spots Salon")
+4. Affectez-le à une zone
+5. Liez les données et les commandes des devices
+
+!!! tip
+Un seul équipement peut se lier à plusieurs devices. Par exemple, trois modules variateurs derrière le mur peuvent être regroupés en un seul équipement "Spots Salon". Un seul interrupteur les contrôle tous les trois.
+
+### Étape 5 : Profiter de la vue Accueil
+
+Allez sur **Accueil** dans la barre latérale.
+
+![Vue accueil](../screenshots/getting-started-home.png)
+
+L'arbre des zones apparaît à gauche. Cliquez sur n'importe quelle zone pour voir :
+
+- **L'état agrégé** : température, humidité, luminosité, mouvement, nombre de lumières, position des volets
+- **Les commandes de zone** : actions groupées (toutes lumières on/off, tous volets ouverts/fermés)
+- **Les cartes d'équipement** : groupées par type (Thermostat, Énergie, Météo, etc.) avec contrôles intégrés
+- **Les comportements** : recettes et modes configurés pour cette zone
+
+### Étape 6 : Personnaliser le tableau de bord
+
+Allez sur **Tableau de bord** et cliquez sur **Éditer**.
+
+![Tableau de bord](../screenshots/getting-started-dashboard.png)
+
+Ajoutez des widgets pour les équipements et zones que vous utilisez le plus. Les widgets se mettent à jour en temps réel via WebSocket. Vous pouvez les réordonner par glisser-déposer, les renommer, et personnaliser leurs icônes.
+
+Votre maison est maintenant configurée. À partir de là, vous pouvez :
+
+- [Personnaliser votre tableau de bord](dashboard.md) avec plus de widgets
+- [Configurer des modes](modes.md) pour différents scénarios (Confort, Absence, Nuit)
+- [Suivre la consommation d'énergie](energy.md)
+
+## Variables d'environnement
+
+Sowel fonctionne d'emblée avec des valeurs par défaut raisonnables. Pour une configuration avancée, vous pouvez définir des variables d'environnement dans un fichier `.env` à la racine du projet :
+
+| Variable        | Défaut                  | Description                                      |
+| --------------- | ----------------------- | ------------------------------------------------ |
+| `SQLITE_PATH`   | `./data/sowel.db`       | Emplacement du fichier de base de données        |
+| `API_PORT`      | `3000`                  | Port du serveur HTTP                             |
+| `API_HOST`      | `0.0.0.0`               | Adresse de bind                                  |
+| `LOG_LEVEL`     | `info`                  | Niveau de log (`debug`, `info`, `warn`, `error`) |
+| `CORS_ORIGINS`  | `*`                     | Origines CORS autorisées                         |
+| `INFLUX_URL`    | `http://localhost:8086` | URL InfluxDB                                     |
+| `INFLUX_ORG`    | `sowel`                 | Organisation InfluxDB                            |
+| `INFLUX_BUCKET` | `sowel`                 | Bucket principal InfluxDB                        |
+
+!!! note
+`JWT_SECRET` et `INFLUX_TOKEN` sont auto-générés au premier lancement et persistés dans le répertoire `data/`. Vous n'avez pas besoin de les définir manuellement.

--- a/docs/user/index.fr.md
+++ b/docs/user/index.fr.md
@@ -1,0 +1,59 @@
+# Guide utilisateur
+
+Bienvenue dans le guide utilisateur Sowel. Cette documentation couvre tout ce dont vous avez besoin pour installer, configurer et utiliser Sowel au quotidien.
+
+## Qu'est-ce que Sowel ?
+
+Sowel est un moteur de domotique qui apporte de la **structure** à votre maison connectée. Au lieu de gérer des centaines de devices individuels, Sowel organise votre maison en trois couches claires :
+
+- **Devices** : le matériel physique sur votre réseau (capteurs, interrupteurs, variateurs, thermostats). Découverts automatiquement depuis vos intégrations.
+- **Équipements** : les unités fonctionnelles avec lesquelles vous interagissez vraiment ("Spots Salon", "Volets Chambre"). Chaque équipement se lie à un ou plusieurs devices.
+- **Zones** : la structure spatiale de votre maison (Maison > Étage > Pièce). Les zones agrègent automatiquement les données de leurs équipements.
+
+Cette séparation vous permet de penser en termes de _pièces et de fonctions_, pas en termes d'adresses Zigbee et de topics MQTT.
+
+## Que peut faire Sowel ?
+
+| Fonctionnalité          | Description                                                                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Auto-découverte**     | Les devices apparaissent automatiquement depuis les intégrations configurées (Zigbee2MQTT, Panasonic CC, MCZ Maestro, Netatmo, et bien d'autres) |
+| **Agrégation de zones** | État de la pièce en temps réel : température, mouvement, nombre de lumières, position des volets, tout calculé automatiquement                   |
+| **Tableau de bord**     | Tableau de bord personnalisable basé sur des widgets pour l'usage quotidien                                                                      |
+| **Recettes**            | Modèles d'automatisation prêts à l'emploi : choisissez une zone, choisissez une lumière, réglez un délai, c'est fini                             |
+| **Modes**               | Profils de fonctionnement nommés (Confort, Absence, Nuit) avec impacts par zone et planification calendaire                                      |
+| **Suivi énergétique**   | Suivez la consommation avec ventilation HP/HC et autoconsommation                                                                                |
+| **Accès distant**       | Accès sécurisé depuis n'importe où via Cloudflare Tunnel                                                                                         |
+
+## Sections du guide
+
+<div class="grid cards" markdown>
+
+- **[Premiers pas](getting-started.md)**
+
+  Installation, première connexion et configuration initiale.
+
+- **[Équipements](equipments.md)**
+
+  Création et gestion des équipements, liaison aux devices, types d'équipements.
+
+- **[Tableau de bord](dashboard.md)**
+
+  Widgets, personnalisation, mode édition.
+
+- **[Zones](zones.md)**
+
+  Création de zones, affectation des équipements, agrégation automatique.
+
+- **[Modes](modes.md)**
+
+  Profils de fonctionnement, impacts, planification calendaire.
+
+- **[Suivi énergétique](energy.md)**
+
+  Suivi de la consommation, tarifs HP/HC, autoconsommation.
+
+- **[Accès distant](remote-access.md)**
+
+  Accès sécurisé depuis l'extérieur de votre réseau domestique.
+
+</div>

--- a/docs/user/modes.fr.md
+++ b/docs/user/modes.fr.md
@@ -1,0 +1,138 @@
+# Modes
+
+Les modes sont des **profils de fonctionnement nommés** pour votre maison. Un mode représente un état de vie : "Confort", "Absence", "Nuit", "Éco", et il définit ce qui se passe dans chaque pièce quand le mode est activé.
+
+## Comprendre les modes
+
+Voyez les modes comme des préréglages pour toute votre maison. Au lieu d'éteindre manuellement les lumières, fermer les volets et baisser le chauffage en partant, vous activez le mode "Absence" et tout se fait d'un coup.
+
+**Exemples de modes** :
+
+| Mode        | Description                                         |
+| ----------- | --------------------------------------------------- |
+| **Confort** | Chauffage allumé, lumières chaudes et lumineuses    |
+| **Nuit**    | Lumières tamisées, volets fermés, chauffage abaissé |
+| **Absence** | Tout éteint, sécurité activée                       |
+| **Éco**     | Chauffage réduit, lumières seulement si nécessaire  |
+
+Un seul mode peut être actif à la fois. L'activation d'un nouveau mode désactive le précédent.
+
+## Créer un mode
+
+Allez dans **Administration > Modes** et cliquez sur **Ajouter un mode**.
+
+1. Saisissez un **nom** (par ex. "Nuit")
+2. Ajoutez une **description** facultative
+
+Le mode est créé mais n'a aucun effet pour l'instant. Ensuite, vous devez définir des **impacts** : ce qui se passe dans chaque zone quand le mode s'active.
+
+## Définir les impacts
+
+Un impact est ce qui se passe dans une zone précise quand le mode est activé. Allez dans la page de détail du mode, puis configurez les impacts par zone.
+
+### Types d'impacts
+
+Chaque impact peut contenir une ou plusieurs **actions** :
+
+**Actions d'ordre** : envoyer une commande à un équipement :
+
+- Éteindre les lumières du salon
+- Fermer les volets de la chambre
+- Régler le thermostat à 18 °C
+
+**Actions de bascule de recette** : activer ou désactiver une recette :
+
+- Désactiver la lumière déclenchée par mouvement dans la chambre (pour qu'elle ne s'allume pas la nuit)
+- Activer une recette d'économie d'énergie en mode Éco
+
+### Exemple : mode Nuit
+
+| Zone            | Actions                                      |
+| --------------- | -------------------------------------------- |
+| Living Room     | Toutes lumières éteintes, volets fermés      |
+| Kitchen         | Toutes lumières éteintes                     |
+| Master Bedroom  | Luminosité à 20 %, volets fermés             |
+| Hallway         | Désactiver la recette de lumière à mouvement |
+| Toute la maison | Régler le thermostat à 18 °C                 |
+
+## Activer les modes
+
+Il existe trois façons d'activer un mode :
+
+### Activation manuelle
+
+Depuis la vue **Accueil** ou **Administration > Modes**, appuyez sur le bouton d'activation du mode. Le mode prend effet immédiatement.
+
+### Déclencheurs par événement
+
+Un mode peut être déclenché par un événement de device, typiquement un appui sur un bouton.
+
+**Exemple** : vous avez un bouton Zigbee sur votre table de chevet. Configurez-le comme déclencheur du mode "Nuit" : un appui sur le bouton, et toute la maison bascule en configuration nuit.
+
+Pour ajouter un déclencheur d'événement :
+
+1. Ouvrez la page de détail du mode
+2. Ajoutez un déclencheur
+3. Sélectionnez l'équipement (par ex. votre bouton)
+4. Sélectionnez l'alias de donnée (par ex. "action")
+5. Réglez la valeur de déclenchement (par ex. "toggle" ou "single press")
+
+!!! tip
+Un seul bouton peut déclencher différents modes pour différentes actions. Par exemple : appui simple pour "Nuit", double appui pour "Absence".
+
+### Planification calendaire
+
+Les modes peuvent être activés automatiquement selon une grille hebdomadaire. Voir [Planification calendaire](#planification-calendaire) ci-dessous.
+
+## Planification calendaire
+
+Le calendrier gère des **profils hebdomadaires** d'activation automatique de modes. C'est ainsi que vous automatisez votre routine quotidienne.
+
+### Profils
+
+Un profil est une grille hebdomadaire nommée. Vous pourriez avoir :
+
+- **Semaine** : votre routine régulière du lundi au vendredi
+- **Week-end** : une grille différente pour samedi et dimanche
+- **Vacances** : grille relâchée quand vous êtes à la maison toute la journée
+
+Un seul profil est actif à la fois. Basculez d'un profil à l'autre en un seul geste.
+
+### Créneaux horaires
+
+Chaque profil contient des créneaux horaires. Un créneau définit :
+
+- **Jour(s)** : quels jours de la semaine (lun, mar, mer, etc.)
+- **Heure** : à quelle heure le mode s'active
+- **Mode(s)** : quel(s) mode(s) activer
+
+**Exemple : profil Semaine**
+
+| Jours   | Heure | Mode    |
+| ------- | ----- | ------- |
+| Lun-Ven | 07:00 | Confort |
+| Lun-Ven | 09:00 | Absence |
+| Lun-Ven | 18:00 | Confort |
+| Lun-Ven | 22:30 | Nuit    |
+| Sam-Dim | 09:00 | Confort |
+| Sam-Dim | 23:00 | Nuit    |
+
+### Gérer le calendrier
+
+Allez dans **Administration > Calendrier** :
+
+1. Créez ou sélectionnez un profil
+2. Ajoutez des créneaux (jour + heure + mode)
+3. Définissez le profil comme actif
+
+Les créneaux du profil actif s'exécutent automatiquement. Quand un créneau horaire est atteint, le mode spécifié est activé.
+
+!!! info
+L'activation manuelle d'un mode est toujours prioritaire. Si vous activez un mode manuellement, il reste actif jusqu'au prochain créneau du calendrier ou jusqu'à ce que vous le changiez à la main.
+
+## Astuces
+
+- **Commencez simple** : démarrez avec 2 ou 3 modes (Confort, Nuit, Absence) et étoffez ensuite.
+- **Utilisez les zones intelligemment** : toutes les zones n'ont pas besoin d'un impact pour chaque mode. Définissez des impacts uniquement là où le mode doit réellement changer quelque chose.
+- **Combinez avec les recettes** : les modes peuvent activer/désactiver des recettes. C'est puissant : par exemple, désactiver les lumières à détection de mouvement dans les chambres en mode Nuit pour que les mouvements n'allument pas les lumières.
+- **Calendrier pour la routine, boutons pour les exceptions** : utilisez le calendrier pour votre routine quotidienne et les déclencheurs par bouton pour les changements ponctuels.

--- a/docs/user/remote-access.fr.md
+++ b/docs/user/remote-access.fr.md
@@ -1,0 +1,175 @@
+# Accès distant
+
+Sowel peut être consulté de manière sécurisée depuis l'extérieur de votre réseau domestique grâce à un **Cloudflare Tunnel**. Cette approche ne nécessite aucune redirection de port et n'expose pas votre réseau local.
+
+## Comment ça marche
+
+```
+Your phone/laptop (HTTPS)
+  --> Cloudflare Edge (SSL termination, DDoS protection)
+    --> Cloudflare Tunnel (outbound connection from your server)
+      --> localhost:3000 (Sowel backend serving API + UI)
+```
+
+Le Cloudflare Tunnel crée une connexion **sortante** depuis votre serveur domestique vers le réseau edge de Cloudflare. Cela signifie :
+
+- Aucun port entrant à ouvrir sur votre routeur
+- Tout le trafic est chiffré en HTTPS
+- Cloudflare fournit une protection anti-DDoS
+- Le plan Cloudflare gratuit (Zero Trust) suffit
+
+## Prérequis
+
+- Un **compte Cloudflare** (le plan gratuit fonctionne)
+- Un **nom de domaine** géré par le DNS Cloudflare (vous pouvez en enregistrer un via Cloudflare ou transférer un domaine existant)
+- **cloudflared** installé sur la machine qui exécute Sowel
+
+## Mise en place
+
+### Étape 1 : installer cloudflared
+
+Sur macOS :
+
+```bash
+brew install cloudflared
+```
+
+Sur Linux (Debian/Ubuntu) :
+
+```bash
+curl -L --output cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+sudo dpkg -i cloudflared.deb
+```
+
+### Étape 2 : s'authentifier auprès de Cloudflare
+
+```bash
+cloudflared tunnel login
+```
+
+Cela ouvre une fenêtre de navigateur où vous autorisez cloudflared à accéder à votre compte Cloudflare.
+
+### Étape 3 : créer un tunnel
+
+```bash
+cloudflared tunnel create sowel
+```
+
+Cela crée un tunnel et génère un fichier d'identifiants.
+
+### Étape 4 : configurer le tunnel
+
+Créez un fichier de configuration dans `~/.cloudflared/config.yml` :
+
+```yaml
+tunnel: sowel
+credentials-file: /path/to/credentials.json
+
+ingress:
+  - hostname: app.yourdomain.com
+    service: http://localhost:3000
+  - service: http_status:404
+```
+
+Remplacez `app.yourdomain.com` par votre sous-domaine réel et mettez à jour le chemin du fichier d'identifiants.
+
+### Étape 5 : créer les enregistrements DNS
+
+```bash
+cloudflared tunnel route dns sowel app.yourdomain.com
+```
+
+Cela crée un enregistrement CNAME dans le DNS Cloudflare pointant votre sous-domaine vers le tunnel.
+
+### Étape 6 : lancer le tunnel
+
+Pour tester :
+
+```bash
+cloudflared tunnel run sowel
+```
+
+En production, installez-le comme service système :
+
+```bash
+sudo cloudflared service install
+```
+
+Cela crée un service système (LaunchDaemon sur macOS, systemd sur Linux) qui démarre le tunnel automatiquement au boot.
+
+## Gestion
+
+### Vérifier l'état du tunnel
+
+Sur macOS :
+
+```bash
+sudo launchctl list | grep cloudflare
+```
+
+Sur Linux :
+
+```bash
+sudo systemctl status cloudflared
+```
+
+### Redémarrer le tunnel
+
+Sur macOS :
+
+```bash
+sudo launchctl stop com.cloudflare.cloudflared
+sudo launchctl start com.cloudflare.cloudflared
+```
+
+Sur Linux :
+
+```bash
+sudo systemctl restart cloudflared
+```
+
+### Désinstaller le tunnel
+
+```bash
+sudo cloudflared service uninstall
+```
+
+### Tableau de bord Cloudflare
+
+Gérez votre tunnel depuis l'interface web Cloudflare :
+
+- **Zero Trust dashboard** : [https://one.dash.cloudflare.com](https://one.dash.cloudflare.com), statut du tunnel, politiques d'accès
+- **Gestion DNS** : tableau de bord Cloudflare > votre domaine > DNS, pour vérifier les enregistrements
+
+## Fichiers statiques de l'UI
+
+Le backend Sowel (Fastify sur le port 3000) sert l'UI compilée depuis le répertoire `ui-dist/`. Quand vous accédez à Sowel à distance, vous utilisez cette version pré-compilée du frontend.
+
+### Reconstruire l'UI pour l'accès distant
+
+Si vous modifiez l'UI et voulez que les changements soient visibles à distance :
+
+```bash
+cd ui && npm run build && cp -r dist ../ui-dist
+```
+
+!!! info
+Cela n'est nécessaire que lorsque le code de l'UI change. En développement local, utilisez `localhost:5173` (serveur de dev Vite) pour le hot reload. L'URL distante sert toujours la version compilée depuis `ui-dist/`.
+
+## Accès local vs distant
+
+| Usage               | URL                          | Notes                                 |
+| ------------------- | ---------------------------- | ------------------------------------- |
+| Développement local | `http://localhost:5173`      | Serveur de dev Vite avec hot reload   |
+| Production locale   | `http://localhost:3000`      | Le backend sert l'UI compilée         |
+| Accès distant       | `https://app.yourdomain.com` | Cloudflare Tunnel vers localhost:3000 |
+
+## Considérations de sécurité
+
+!!! warning
+Assurez-vous d'utiliser un mot de passe fort pour votre compte admin Sowel. Toute personne disposant de l'URL distante peut atteindre votre page de connexion.
+
+- Tout le trafic distant est chiffré (HTTPS via Cloudflare)
+- L'authentification JWT intégrée à Sowel protège tous les endpoints d'API
+- Envisagez d'ajouter des politiques [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/) pour une couche d'authentification supplémentaire (par ex. codes uniques par email)
+- Des tokens d'API peuvent être créés depuis les Réglages pour des intégrations externes nécessitant un accès programmatique

--- a/docs/user/zones.fr.md
+++ b/docs/user/zones.fr.md
@@ -1,0 +1,109 @@
+# Zones
+
+Les zones représentent la **structure spatiale** de votre maison. Elles organisent vos équipements en pièces, étages et espaces, et elles calculent automatiquement un statut en temps réel pour chaque espace.
+
+## Créer des zones
+
+Allez dans **Administration > Zones**.
+
+### Construire votre arbre de zones
+
+Les zones forment une hiérarchie (structure arborescente). Une configuration typique :
+
+```
+Home
+  Ground Floor
+    Living Room
+    Kitchen
+    Hallway
+    Bathroom
+  First Floor
+    Master Bedroom
+    Kids Room
+    Office
+  Outdoor
+    Garden
+    Terrace
+    Garage
+```
+
+Pour créer une zone :
+
+1. Cliquez sur **Ajouter une zone**
+2. Saisissez un nom
+3. Sélectionnez une zone parent (ou aucune pour une zone racine)
+
+Vous pouvez imbriquer les zones sur n'importe quelle profondeur, mais 2 à 3 niveaux suffisent généralement (Maison > Étage > Pièce).
+
+### Réorganiser les zones
+
+Les zones ont un ordre d'affichage qui contrôle leur apparition dans la barre latérale. Vous pouvez réordonner les zones d'un même parent en les glissant dans la liste.
+
+### Modifier et supprimer
+
+- Cliquez sur une zone pour modifier son nom ou la déplacer vers un autre parent
+- La suppression retire la zone et **désaffecte** ses équipements (ils ne sont pas supprimés)
+
+!!! warning
+Vous ne pouvez pas supprimer une zone qui a des zones enfants. Supprimez ou déplacez d'abord les enfants.
+
+## Agrégation de zone
+
+C'est l'une des fonctionnalités les plus puissantes de Sowel. Chaque zone calcule automatiquement des **données agrégées** à partir des équipements qu'elle contient. Aucune configuration n'est nécessaire.
+
+### Ce qui est agrégé
+
+| Donnée                          | Logique                                          | Exemple                                    |
+| ------------------------------- | ------------------------------------------------ | ------------------------------------------ |
+| **Température**                 | Moyenne de tous les capteurs de température      | 21,5 °C (moyenne de 2 capteurs Aqara)      |
+| **Humidité**                    | Moyenne de tous les capteurs d'humidité          | 45 %                                       |
+| **Luminosité**                  | Moyenne de tous les capteurs de lumière          | 320 lx                                     |
+| **Mouvement**                   | OU sur tous les capteurs de mouvement            | "Mouvement" si un PIR détecte une présence |
+| **Durée de mouvement**          | Temps écoulé depuis le dernier changement d'état | "Calme depuis 15 min"                      |
+| **Lumières allumées**           | Nombre de lumières actives                       | 2 / 5 lumières allumées                    |
+| **Volets ouverts**              | Nombre de volets ouverts                         | 1 / 3 volets ouverts                       |
+| **Position moyenne des volets** | Position moyenne sur tous les volets             | 65 %                                       |
+| **Portes ouvertes**             | Nombre de contacts de porte ouverts              | 1 porte ouverte                            |
+| **Fenêtres ouvertes**           | Nombre de contacts de fenêtre ouverts            | 2 fenêtres ouvertes                        |
+| **Fuite d'eau**                 | OU sur tous les capteurs de fuite                | Alerte si un capteur détecte de l'eau      |
+| **Fumée**                       | OU sur tous les capteurs de fumée                | Alerte si un capteur détecte de la fumée   |
+
+### Agrégation récursive
+
+L'agrégation est **récursive** : une zone parent fusionne automatiquement les données de toutes ses zones enfants.
+
+**Exemple** : la zone "First Floor" agrège les données de Master Bedroom, Kids Room et Office. S'il y a du mouvement dans l'une de ces pièces, le First Floor affiche "Mouvement". La température affichée est la moyenne sur les trois pièces.
+
+Cela signifie que vous pouvez jeter un œil à une zone d'étage et connaître le statut global sans vérifier chaque pièce individuellement.
+
+### Comment cela apparaît dans l'UI
+
+Dans la vue **Accueil**, chaque zone affiche un **bandeau d'état** avec les données agrégées présentées sous forme de pastilles colorées :
+
+- Pastille **Température** (par ex. "21,5 °C")
+- Pastille **Humidité** (par ex. "45 %")
+- Pastille **Mouvement** avec durée ("Mouvement" ou "Calme 15 min")
+- Pastille de comptage **Lumières** (par ex. "2/5")
+- Pastille de comptage **Volets** (par ex. "1/3")
+- Pastilles **Alerte** pour portes/fenêtres ouvertes, fuites d'eau, fumée
+
+Sous le bandeau, les équipements sont regroupés par type (Lumières, Volets, Capteurs) avec des contrôles intégrés.
+
+## Ordres de zone
+
+Chaque zone expose des ordres automatiques que vous pouvez utiliser depuis l'UI ou dans les automatisations :
+
+| Ordre                        | Effet                                                         |
+| ---------------------------- | ------------------------------------------------------------- |
+| **Tout éteindre**            | Éteint tous les équipements de la zone (et des zones enfants) |
+| **Toutes lumières éteintes** | Éteint tous les équipements lumière de la zone                |
+| **Toutes lumières allumées** | Allume tous les équipements lumière de la zone                |
+
+Ils sont disponibles dans la vue Accueil, dans l'API, et comme actions dans les recettes et les modes.
+
+## Astuces
+
+- **Calquez la disposition physique** : les zones doivent refléter la façon dont vous pensez votre maison. Si vous dites "le salon", ça doit être une zone.
+- **N'imbriquez pas trop** : deux ou trois niveaux (Maison > Étage > Pièce) suffisent en général. Les arbres trop profonds sont moins faciles à parcourir.
+- **Zones extérieures** : créez une zone "Outdoor" pour les capteurs du jardin, le portail et tout équipement extérieur.
+- **L'agrégation crée la valeur** : plus vous affectez de capteurs et d'équipements aux zones, plus le statut agrégé est riche. Même un seul capteur de température dans une pièce rend le bandeau de zone utile.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,11 +64,35 @@ markdown_extensions:
 
 plugins:
   - search
-  # - i18n:  # Uncomment when adding French translation
-  #     default_language: en
-  #     languages:
-  #       en: English
-  #       fr: Français
+  - i18n:
+      docs_structure: suffix
+      languages:
+        - locale: en
+          default: true
+          name: English
+          build: true
+        - locale: fr
+          name: Français
+          build: true
+          nav_translations:
+            Home: Accueil
+            Technical Guide: Guide technique
+            Architecture: Architecture
+            Deployment: Déploiement
+            API Reference: Référence API
+            Plugin Development: Développement de plugins
+            Recipe Development: Développement de recettes
+            Data Model: Modèle de données
+            Contributing: Contribuer
+            Specs Index: Index des specs
+            User Guide: Guide utilisateur
+            Getting Started: Premiers pas
+            Equipments: Équipements
+            Dashboard: Tableau de bord
+            Zones & Rooms: Zones et pièces
+            Modes & Calendar: Modes et calendrier
+            Energy Monitoring: Suivi énergétique
+            Remote Access: Accès distant
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary

- Adds full French translation of the Sowel documentation site under the `mkdocs-static-i18n` plugin in suffix mode (`*.fr.md`)
- Configures `mkdocs.yml` with `en` (default) and `fr` languages, plus `nav_translations` for the sidebar
- Translates the landing page (preserving all HTML/SVG/class markup), 8 user-guide pages, 8 technical pages, and the specs index

## Files added (18 `.fr.md`)

- `docs/index.fr.md` — landing page (hero, story, cards, pills, "Take a tour")
- `docs/specs-index.fr.md` — prose translated, spec numbers/titles kept English
- `docs/user/{index,getting-started,equipments,dashboard,zones,modes,energy,remote-access}.fr.md`
- `docs/technical/{index,architecture,deployment,api-reference,plugin-development,recipe-development,data-model,contributing}.fr.md`

## Translation rules applied

- Tone: chaleureux, à la deuxième personne ("vous")
- Proper nouns kept in English: Sowel, Zigbee2MQTT, Netatmo, Shelly, Panasonic, MQTT, Docker, GitHub, Raspberry Pi, Proxmox
- Recipe / integration product names kept in English (italicized on first mention): _Motion Light_, _Presence Thermostat_, _Pool Pump Schedule_, _Sunset Shutters_, _Constant Light_, _Solar EV Charging_, _Kitchen Lights_, _Ground Floor_
- Code blocks, JSON/YAML, type signatures, identifiers, file paths, CLI commands, and event/type/key column entries preserved verbatim
- Domain terms ("device", "equipment", "zone", "mode", "recipe") kept in English in technical pages where they refer to engine concepts; translated to "équipement"/"recette" in user-facing prose where natural

## Pages skipped (out of scope, as instructed)

- `docs/sowel-spec.md` (legacy)
- `docs/_legacy/*` (legacy)
- No CSS, no `extra.css` changes

## Validation

- `mkdocs build --strict` passes (only the pre-existing `architecture.md#timezone-handling` anchor warning, present on `main`)
- Both languages render: `site/index.html` (en) and `site/fr/index.html` (fr) generated; the Material language switcher exposes "English" and "Français" entries for every page

## Test plan

- [ ] `mkdocs serve` and switch to "Français" in the header — every page should serve French content
- [ ] Spot-check a long page (architecture, deployment, plugin-development) for code-block fidelity
- [ ] Spot-check the landing page in both languages — hero buttons, cards, pills should align