### PR TITLE
chore(registry): bump polytropic_master to 1.0.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -337,7 +337,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-polytropic-master",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "tags": ["pool", "heat-pump", "modbus", "polytropic"],
     "i18n": {
       "fr": {


### PR DESCRIPTION
## Summary
Bumps the polytropic_master plugin entry in `plugins/registry.json` from 1.0.0 → 1.0.1 so running Sowel engines can detect the available update via PackageManager.

## Why
The 1.0.1 release of [sowel-plugin-polytropic-master](https://github.com/mchacher/sowel-plugin-polytropic-master/releases/tag/v1.0.1) fixes a Modbus connection-state bug where the plugin failed to reconnect after a network blip (router reboot, gateway restart) — observed in production with 769 consecutive `PortNotOpenError` and no recovery.

Sowel's "available version" is read from this registry file, not from GitHub releases, so without this commit running engines will keep showing 1.0.0 as the latest available.

## Test plan
- [x] JSON valid
- [ ] After merge: trigger "Refresh registry" on the running engine (or wait for next 1h cache TTL) — `polytropic_master` should show update 1.0.0 → 1.0.1 available