### PR TITLE
ci(release): multi-arch (amd64 + arm64) Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,46 @@ on:
   workflow_dispatch:
     inputs:
       test_tag:
-        description: "Tag suffix for test images (e.g. ci-test). Will push :<test_tag> and :<test_tag>-arm64."
+        description: "Tag suffix for test images (e.g. ci-test). Pushes :<test_tag> and :<test_tag>-arm64. Does NOT touch :latest."
         required: false
         default: "ci-test"
+      restore_latest_from:
+        description: "If set (e.g. 1.5.9), the workflow skips builds and only repoints :latest to :<this version>."
+        required: false
+        default: ""
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # ── Restore :latest tag (manual recovery only) ───────────
+  # Triggered only via workflow_dispatch with restore_latest_from set.
+  # Useful if a test run accidentally overwrote :latest.
+  restore-latest:
+    if: github.event_name == 'workflow_dispatch' && inputs.restore_latest_from != ''
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Repoint :latest to :${{ inputs.restore_latest_from }}
+        env:
+          REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          FROM: ${{ inputs.restore_latest_from }}
+        run: |
+          docker buildx imagetools create --tag ${REPO}:latest ${REPO}:${FROM}
+
   # ── CI checks ─────────────────────────────────────────────
   ci:
+    if: github.event_name != 'workflow_dispatch' || inputs.restore_latest_from == ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,15 +103,30 @@ jobs:
             echo "is_release=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Compute image tags
+        id: tags
+        env:
+          REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          V: ${{ steps.version.outputs.version }}
+          IS_RELEASE: ${{ steps.version.outputs.is_release }}
+        run: |
+          tags="${REPO}:${V}"
+          if [[ "$IS_RELEASE" == "true" ]]; then
+            tags="${tags}"$'\n'"${REPO}:latest"
+          fi
+          {
+            echo 'list<<EOF'
+            echo "$tags"
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
       - name: Build and push (amd64)
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ steps.tags.outputs.list }}
           cache-from: type=gha,scope=amd64
           cache-to: type=gha,scope=amd64,mode=max
 
@@ -97,7 +141,7 @@ jobs:
 
   # ── Docker build (arm64, async, non-blocking) ────────────
   # Runs after the amd64 release is published, then promotes the main
-  # tags (:VERSION, :latest) to a multi-arch manifest combining both.
+  # tags to a multi-arch manifest combining both architectures.
   # Failure here does NOT fail the release — amd64 image stays valid,
   # the main tags just remain amd64-only until the next release.
   docker-arm64:
@@ -149,6 +193,9 @@ jobs:
         env:
           REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           V: ${{ steps.version.outputs.version }}
+          IS_RELEASE: ${{ steps.version.outputs.is_release }}
         run: |
-          docker buildx imagetools create --tag ${REPO}:${V}     ${REPO}:${V}     ${REPO}:${V}-arm64
-          docker buildx imagetools create --tag ${REPO}:latest   ${REPO}:latest   ${REPO}:latest-arm64
+          docker buildx imagetools create --tag ${REPO}:${V} ${REPO}:${V} ${REPO}:${V}-arm64
+          if [[ "$IS_RELEASE" == "true" ]]; then
+            docker buildx imagetools create --tag ${REPO}:latest ${REPO}:latest ${REPO}:latest-arm64
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      test_tag:
+        description: "Tag suffix for test images (e.g. ci-test). Will push :<test_tag> and :<test_tag>-arm64."
+        required: false
+        default: "ci-test"
 
 env:
   REGISTRY: ghcr.io
@@ -37,7 +43,7 @@ jobs:
           npm run lint
           npx tsc -b --noEmit
 
-  # ── Docker build + push ───────────────────────────────────
+  # ── Docker build + push (amd64, priority) ────────────────
   docker:
     needs: ci
     runs-on: ubuntu-latest
@@ -57,11 +63,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version from tag
+      - name: Resolve version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ inputs.test_tag }}" >> $GITHUB_OUTPUT
+            echo "is_release=false" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Build and push Docker image
+      - name: Build and push (amd64)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -70,13 +83,72 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=amd64
+          cache-to: type=gha,scope=amd64,mode=max
 
       - name: Create GitHub Release
+        if: steps.version.outputs.is_release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create ${{ github.ref_name }} \
             --title "Sowel ${{ steps.version.outputs.version }}" \
             --generate-notes
+
+  # ── Docker build (arm64, async, non-blocking) ────────────
+  # Runs after the amd64 release is published, then promotes the main
+  # tags (:VERSION, :latest) to a multi-arch manifest combining both.
+  # Failure here does NOT fail the release — amd64 image stays valid,
+  # the main tags just remain amd64-only until the next release.
+  docker-arm64:
+    needs: docker
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ inputs.test_tag }}" >> $GITHUB_OUTPUT
+            echo "is_release=false" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-arm64
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-arm64
+          cache-from: type=gha,scope=arm64
+          cache-to: type=gha,scope=arm64,mode=max
+
+      - name: Promote tags to multi-arch manifest
+        env:
+          REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          V: ${{ steps.version.outputs.version }}
+        run: |
+          docker buildx imagetools create --tag ${REPO}:${V}     ${REPO}:${V}     ${REPO}:${V}-arm64
+          docker buildx imagetools create --tag ${REPO}:latest   ${REPO}:latest   ${REPO}:latest-arm64


### PR DESCRIPTION
## Summary
- amd64 build stays the priority path, unchanged in timing — release is published at T+8-10 min as before
- New `docker-arm64` job runs after, builds for `linux/arm64` via QEMU, pushes to `:VERSION-arm64` and `:latest-arm64`, then promotes `:VERSION` and `:latest` to multi-arch manifests combining both architectures
- `continue-on-error: true` on the arm64 job — a failure there doesn't poison the amd64 release

## Why
ARM users (Raspberry Pi, Apple Silicon dev boxes, AWS Graviton) currently can't pull `ghcr.io/mchacher/sowel:latest`. After merge, the next release tag will produce a multi-arch image natively pullable on both architectures.

## What's also in this PR
- `workflow_dispatch` trigger to allow manual test runs without cutting a real release. Test runs only push to a `:<test_tag>` (default `ci-test`) and never touch `:latest`.
- New `restore-latest` job (manual recovery): if `:latest` ever gets corrupted, run the workflow with `restore_latest_from=<version>` to repoint it to a known-good `:VERSION` tag without rebuilding.

## Test plan

The pipeline was exercised twice on this branch via `workflow_dispatch`:

- [x] Full multi-arch build: ci → docker (amd64, 2m46s) → docker-arm64 (10m24s, QEMU). Multi-arch manifest verified on `ghcr.io/mchacher/sowel:ci-test`.
- [x] Restore-latest action: triggered with `restore_latest_from=1.5.9`. Other jobs correctly skipped, `:latest` repointed to 1.5.9 digest.
- [x] YAML syntax validated.

## Cost
Sowel is a public repository — GitHub Actions minutes are unlimited. Per-release wall clock for arm64 image availability: ~T+20-25 min (vs T+8-10 min for amd64).

## After merge
Cleanup of test tags polluting the registry (cosmetic, can be done via Settings > Packages):
- `:ci-test`
- `:ci-test-arm64`
- `:latest-arm64` (created during the original test before the `:latest` protection fix)