### PR TITLE
feat(install): one-command installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,24 @@ Home automation engine. Pick a **Recipe**, apply it to a **Zone** — your house
 
 ## Quick start
 
+One command. Requires Docker:
+
 ```bash
-mkdir /opt/sowel && cd /opt/sowel
+curl -fsSL https://raw.githubusercontent.com/mchacher/sowel/main/scripts/install.sh | sh
+```
+
+Sowel installs into `~/sowel/` (override with `SOWEL_DIR=/your/path`), starts on port 3000 (override with `SOWEL_PORT=...`), and prints the URL when ready. Open it and create your admin account.
+
+<details>
+<summary>Manual install (skip the script)</summary>
+
+```bash
+mkdir ~/sowel && cd ~/sowel
 curl -O https://raw.githubusercontent.com/mchacher/sowel/main/docker-compose.yml
 docker compose up -d
 ```
 
-Open `http://<host>:3000` and create your admin account on first launch.
+</details>
 
 See [docs/technical/deployment.md](docs/technical/deployment.md) for self-update, backup, timezone and troubleshooting.
 

--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -31,9 +31,9 @@ Un moteur de domotique pour le <em>confort</em>, la <em>sécurité</em> et l'<em
 
 <p class="sowel-paragraph">La plupart des outils de domotique vous transforment en développeur à temps partiel : fichiers YAML, scripts, flows, conditions, cas particuliers. Le résultat est un plat de spaghettis fragile que seule une personne du foyer arrive à dépanner.</p>
 
-<p class="sowel-paragraph"><strong>Sowel prend le chemin inverse.</strong> Au lieu d'écrire des automatisations, vous <strong>choisissez une recette</strong> (<em>Motion Light</em>, <em>Presence Thermostat</em>, <em>Pool Pump Schedule</em>, <em>Sunset Shutters</em>) et vous l'<strong>appliquez à une zone</strong>. Chaque recette encode un schéma réfléchi et éprouvé pour un besoin précis : confort, sécurité ou efficacité énergétique. Vous configurez quelques réglages évidents (une durée, une température, une plage horaire), pas un langage de programmation.</p>
+<p class="sowel-paragraph"><strong>Sowel prend le chemin inverse.</strong> Au lieu d'écrire des automatisations, vous <strong>choisissez une recette</strong> (<em>Motion Light</em>, <em>Presence Thermostat</em>, <em>Pool Pump Schedule</em>, <em>Sunset Shutters</em>) et vous l'<strong>appliquez à une zone</strong>. Chaque recette encode un schéma réfléchi et éprouvé qui vise le juste équilibre entre confort, sécurité et efficacité énergétique. Vous configurez quelques réglages évidents (une durée, une température, une plage horaire), pas un langage de programmation.</p>
 
-<p class="sowel-paragraph">Votre maison cesse d'être un projet annexe. Elle fonctionne, tout simplement.</p>
+<p class="sowel-paragraph">La meilleure automatisation est celle qu'on oublie. Votre maison fonctionne, tout simplement.</p>
 
 </div>
 
@@ -63,9 +63,9 @@ Un moteur de domotique pour le <em>confort</em>, la <em>sécurité</em> et l'<em
 
 <div class="sowel-section">
 
-<p class="sowel-eyebrow">Ce qui rend Sowel singulier</p>
+<p class="sowel-eyebrow">Là où tous les autres outils domotiques voient des déclencheurs, Sowel voit une maison.</p>
 
-<p class="sowel-paragraph">Sowel structure votre maison en couches, depuis le réseau :</p>
+<p class="sowel-paragraph">La plupart des outils partent du câblage et vous laissent greffer des scripts par-dessus. Sowel part de la maison et laisse le câblage suivre. Cinq couches décrivent votre maison avec les mots que vous utiliseriez vous-même, chacune un peu moins abstraite que celle d'en dessous :</p>
 
 <ul class="sowel-bullets">
   <li>Les <strong>devices</strong> sont auto-découverts et normalisés dans un seul modèle de données.</li>
@@ -86,34 +86,57 @@ Un moteur de domotique pour le <em>confort</em>, la <em>sécurité</em> et l'<em
 
 <div class="sowel-card">
   <div class="sowel-card__icon">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 9h2"/><path d="M20 15h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg>
+  </div>
+  <h3>Devices. Ce qui est sur votre réseau.</h3>
+  <p class="sowel-card__lead">Quelle que soit la marque, quel que soit le protocole, Sowel les modélise tous de la même façon.</p>
+  <p>Une cinquantaine de catégories sémantiques correspondent à ce qu'une maison mesure vraiment : température, mouvement, luminosité, contact, énergie, eau, présence. Chaque plugin d'intégration (Zigbee, MQTT, une API cloud, une passerelle LoRa) traduit son protocole brut dans ce vocabulaire commun, pour que chaque device arrive avec la bonne catégorie, le bon type et la bonne unité, prêt à être lié.</p>
+  <p class="sowel-card__example" data-label="Exemple">Une ampoule Zigbee, un relais Shelly et une station Netatmo exposent la <em>température</em> de la même façon — même catégorie, même unité, même liaison à un équipement.</p>
+  <p class="sowel-card__more"><a href="user/devices/">En savoir plus →</a></p>
+</div>
+
+<div class="sowel-card">
+  <div class="sowel-card__icon">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
   </div>
-  <h3>Équipements. Un vocabulaire standard pour votre maison.</h3>
-  <p>Sowel transforme le câblage de votre maison en un petit catalogue bien défini : luminaires, volets, thermostats, détecteurs de mouvement, compteurs d'énergie. Trois interrupteurs et un détecteur de mouvement dans votre cuisine deviennent un seul équipement <em>Kitchen Lights</em>, quelque chose que vous pouvez nommer, regrouper et raisonner.</p>
+  <h3>Équipements. Ce qui est dans votre pièce.</h3>
+  <p class="sowel-card__lead">Sowel standardise ce que toute maison contient — lumières, volets, thermostats, capteurs, portails, compteurs.</p>
+  <p>Chaque équipement a un type connu, un nom et un jeu de contrôles prévisibles. Liez un device ou plusieurs — trois variateurs IKEA derrière un mur, une ampoule Zigbee, une pompe à chaleur pilotée par API cloud — et Sowel masque le câblage derrière une seule poignée que vous pouvez utiliser, regrouper et manipuler.</p>
+  <p class="sowel-card__example" data-label="Exemple">Un variateur mural et les spots qu'il commande au plafond deviennent un seul équipement <em>Lumières Cuisine</em> que vous pilotez depuis un point unique.</p>
+  <p class="sowel-card__more"><a href="user/equipments/">En savoir plus →</a></p>
 </div>
 
 <div class="sowel-card">
   <div class="sowel-card__icon">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
   </div>
-  <h3>Des zones qui s'agrègent toutes seules</h3>
-  <p>Regroupez les équipements en zones, par pièce, par étage, par usage. Une zone nommée <em>Ground Floor</em> vous donne la température moyenne, la pièce la plus lumineuse, l'humidité la plus élevée, automatiquement. Sans formules, sans code de glue, sans tableau de bord à câbler.</p>
+  <h3>Zones. La topologie de votre maison.</h3>
+  <p class="sowel-card__lead">Sowel transforme votre plan en carte pensante de votre maison.</p>
+  <p>Regroupez les équipements en zones, par pièce, par étage, par usage. Sowel consolide leurs données automatiquement — moyennes, OU logique, maximum — pour qu'une zone connaisse en permanence son propre état. Sans formules, sans code de glue, sans tableau de bord à câbler.</p>
+  <p class="sowel-card__example" data-label="Exemple">Trois détecteurs PIR dans votre <em>Salon</em> ne forment plus qu'un seul signal de présence — un seul se déclenche, la zone est occupée.</p>
+  <p class="sowel-card__more"><a href="user/zones/">En savoir plus →</a></p>
 </div>
 
 <div class="sowel-card">
   <div class="sowel-card__icon">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
   </div>
-  <h3>Des modes qui basculent toute la maison</h3>
-  <p>Jour, Nuit, Vacances, Cocon. Un geste fait basculer votre maison : lumières tamisées, thermostats abaissés, volets fermés. Programmez-les ou déclenchez-les à la main.</p>
+  <h3>Modes. Les rythmes de votre maison.</h3>
+  <p class="sowel-card__lead">Sowel fait basculer toute la maison au tempo de vos habitudes.</p>
+  <p>Définissez des modes au rythme de votre vie — Jour, Soir, Nuit. Un geste (ou une planification) fait basculer chaque zone : niveaux de luminosité, comportement des détections, consignes de chauffage, recettes activées ou en pause.</p>
+  <p class="sowel-card__example" data-label="Exemple">Au coucher du soleil, votre maison passe en <em>Soir</em> — les variateurs descendent à 40 %, la lumière se réchauffe, et les chambres des enfants cessent de réagir au mouvement.</p>
+  <p class="sowel-card__more"><a href="user/modes/">En savoir plus →</a></p>
 </div>
 
 <div class="sowel-card">
   <div class="sowel-card__icon">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 21a1 1 0 0 0 1-1v-5.35c0-.46.32-.84.73-1.04a4 4 0 0 0-2.13-7.59 5 5 0 0 0-9.2 0 4 4 0 0 0-2.13 7.59c.41.2.73.58.73 1.04V20a1 1 0 0 0 1 1z"/><path d="M6 17h12"/></svg>
   </div>
-  <h3>Des recettes, pas des scripts</h3>
-  <p>Posez un schéma d'automatisation sélectionné sur une zone (éclairage déclenché par mouvement, chauffage piloté par présence, irrigation programmée, volets au coucher du soleil), réglez quelques valeurs, et ça tourne. Pas de flows à câbler. Pas de programmation logique.</p>
+  <h3>Recettes. Les réflexes de votre maison.</h3>
+  <p class="sowel-card__lead">Sowel les livre éprouvées. Posez-en une sur une zone, sans script.</p>
+  <p>Choisissez dans un catalogue éprouvé : éclairage déclenché par mouvement, chauffage piloté par présence, irrigation programmée, volets au coucher du soleil. Réglez quelques valeurs, et ça tourne. Pas de flows à câbler, pas de programmation logique.</p>
+  <p class="sowel-card__example" data-label="Exemple">La recette <em>Lumière dimmable sur mouvement</em> garde une pièce éclairée au bon niveau dès qu'on y entre — vif le jour, doux le soir, tamisé la nuit. Une seule recette, trois modes, zéro ligne de code.</p>
+  <p class="sowel-card__more"><a href="user/recipes/">En savoir plus →</a></p>
 </div>
 
 </div>
@@ -126,7 +149,7 @@ Un moteur de domotique pour le <em>confort</em>, la <em>sécurité</em> et l'<em
 
 <div class="sowel-pills">
   <div class="sowel-pill">
-    <strong>Un seul conteneur Docker.</strong> <code>docker compose up -d</code>. C'est ça, l'installation.
+    <strong>Une seule commande.</strong> <code>curl ... | sh</code> sur n'importe quel hôte Docker — Linux, macOS, Raspberry Pi. Sowel et InfluxDB en moins d'une minute.
   </div>
   <div class="sowel-pill">
     <strong>Reste à la maison.</strong> Pas de cloud, pas de télémétrie, pas de compte tiers. Vos données vivent sur votre matériel : un Raspberry Pi, un vieux PC, une VM Proxmox, ce que vous avez sous la main.
@@ -160,7 +183,7 @@ Un moteur de domotique pour le <em>confort</em>, la <em>sécurité</em> et l'<em
   <div class="sowel-card__icon">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94z"/></svg>
   </div>
-  <h3>Pour les bâtisseurs</h3>
+  <h3>Pour les développeurs</h3>
   <p>Architecture, développement de plugins, recettes, et modèle de données.</p>
   <p><a href="technical/">Guide technique →</a></p>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,9 +31,9 @@ A home automation engine for <em>comfort</em>, <em>safety</em> and <em>energy ef
 
 <p class="sowel-paragraph">Most home automation tools turn you into a part-time developer: YAML files, scripts, flows, conditions, edge cases. The result is fragile spaghetti that only one person in the household can debug.</p>
 
-<p class="sowel-paragraph"><strong>Sowel takes the opposite path.</strong> Instead of writing automations, you <strong>pick a recipe</strong> (<em>Motion Light</em>, <em>Presence Thermostat</em>, <em>Pool Pump Schedule</em>, <em>Sunset Shutters</em>) and <strong>apply it to a zone</strong>. Each recipe encodes a thoughtful, road-tested pattern for a specific need: comfort, safety, or energy efficiency. You configure a few obvious settings (a duration, a temperature, a time window), not a programming language.</p>
+<p class="sowel-paragraph"><strong>Sowel takes the opposite path.</strong> Instead of writing automations, you <strong>pick a recipe</strong> (<em>Motion Light</em>, <em>Presence Thermostat</em>, <em>Pool Pump Schedule</em>, <em>Sunset Shutters</em>) and <strong>apply it to a zone</strong>. Each recipe encodes a thoughtful, road-tested pattern that strikes the right balance between comfort, safety, and energy efficiency. You configure a few obvious settings (a duration, a temperature, a time window), not a programming language.</p>
 
-<p class="sowel-paragraph">Your house stops being a side project. It just works.</p>
+<p class="sowel-paragraph">The best automation is the one you forget about. Your home just works.</p>
 
 </div>
 
@@ -63,9 +63,9 @@ A home automation engine for <em>comfort</em>, <em>safety</em> and <em>energy ef
 
 <div class="sowel-section">
 
-<p class="sowel-eyebrow">What makes Sowel singular</p>
+<p class="sowel-eyebrow">Where every other home automation tool sees triggers, Sowel sees a home.</p>
 
-<p class="sowel-paragraph">Sowel layers your home from the network up:</p>
+<p class="sowel-paragraph">Most tools start at the wires and ask you to bolt scripts on top. Sowel starts at the home and lets the wires fall into place. Five layers describe your house in the same words you'd use yourself, each one a little less abstract than the one below it:</p>
 
 <ul class="sowel-bullets">
   <li><strong>Devices</strong> are auto-discovered and normalized into one data model.</li>
@@ -86,34 +86,57 @@ A home automation engine for <em>comfort</em>, <em>safety</em> and <em>energy ef
 
 <div class="sowel-card">
   <div class="sowel-card__icon">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 9h2"/><path d="M20 15h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg>
+  </div>
+  <h3>Devices. What's on your network.</h3>
+  <p class="sowel-card__lead">Whatever the brand, whatever the protocol, Sowel models them all the same way.</p>
+  <p>About fifty semantic categories match what a home actually measures: temperature, motion, brightness, contact, energy, water, presence. Each integration plugin (Zigbee, MQTT, a cloud API, a LoRa bridge) translates its raw protocol into that shared vocabulary, so every device lands with the right category, type, and unit, ready to bind.</p>
+  <p class="sowel-card__example" data-label="Example">A Zigbee bulb, a Shelly relay, and a Netatmo station all expose <em>temperature</em> the same way — same category, same unit, same equipment binding.</p>
+  <p class="sowel-card__more"><a href="user/devices/">Read more →</a></p>
+</div>
+
+<div class="sowel-card">
+  <div class="sowel-card__icon">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
   </div>
-  <h3>Equipments. A standard vocabulary for your home.</h3>
-  <p>Sowel turns the wiring of your house into a small, well-defined catalogue: lights, shutters, thermostats, motion sensors, energy meters. Three switches and a motion sensor in your kitchen become one <em>Kitchen Lights</em> equipment, something you can name, group, and reason about.</p>
+  <h3>Equipments. What's in your room.</h3>
+  <p class="sowel-card__lead">Sowel standardizes the things every home has — lights, shutters, thermostats, sensors, gates, meters.</p>
+  <p>Each equipment has a known type, a name, and a predictable set of controls. Bind one device or several — three IKEA dimmers behind a wall, a Zigbee bulb, a cloud-driven heat pump — and Sowel hides the wiring behind a single handle you can use, group, and reason about.</p>
+  <p class="sowel-card__example" data-label="Example">A wall dimmer and the ceiling spots it controls become a single <em>Kitchen Lights</em> equipment you can dim from one place.</p>
+  <p class="sowel-card__more"><a href="user/equipments/">Read more →</a></p>
 </div>
 
 <div class="sowel-card">
   <div class="sowel-card__icon">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
   </div>
-  <h3>Zones that aggregate themselves</h3>
-  <p>Group equipments into zones, by room, by floor, by purpose. A zone called <em>Ground Floor</em> tells you the average temperature, the brightest room, the highest humidity, automatically. No formulas, no glue code, no dashboards to wire.</p>
+  <h3>Zones. Your home's topology.</h3>
+  <p class="sowel-card__lead">Sowel turns your layout into a thinking map of your house.</p>
+  <p>Group equipments into zones, by room, by floor, by purpose. Sowel rolls up their data automatically — averages, OR-of-all, max — so a zone always knows its own state. No formulas, no glue code, no dashboards to wire.</p>
+  <p class="sowel-card__example" data-label="Example">Three PIR sensors in your <em>Living Room</em> zone become a single presence signal — anyone moves anywhere, the zone is occupied.</p>
+  <p class="sowel-card__more"><a href="user/zones/">Read more →</a></p>
 </div>
 
 <div class="sowel-card">
   <div class="sowel-card__icon">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
   </div>
-  <h3>Modes that switch the whole house</h3>
-  <p>Day, Night, Holiday, Cocoon. One tap flips your home over: dimmer lights, lower thermostats, closed shutters. Schedule them or trigger them by hand.</p>
+  <h3>Modes. Your home's rhythms.</h3>
+  <p class="sowel-card__lead">Sowel makes the whole house move in tune with your habits.</p>
+  <p>Define modes for the rhythms you live by — Day, Evening, Night. One tap (or a schedule) flips every zone over: brightness targets, motion behaviour, heating setpoints, recipes on or off.</p>
+  <p class="sowel-card__example" data-label="Example">At sunset your home switches to <em>Evening</em> — dimmers drop to 40%, lights warm up, and the kids' rooms stop reacting to motion.</p>
+  <p class="sowel-card__more"><a href="user/modes/">Read more →</a></p>
 </div>
 
 <div class="sowel-card">
   <div class="sowel-card__icon">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 21a1 1 0 0 0 1-1v-5.35c0-.46.32-.84.73-1.04a4 4 0 0 0-2.13-7.59 5 5 0 0 0-9.2 0 4 4 0 0 0-2.13 7.59c.41.2.73.58.73 1.04V20a1 1 0 0 0 1 1z"/><path d="M6 17h12"/></svg>
   </div>
-  <h3>Recipes, not scripts</h3>
-  <p>Drop a curated automation pattern onto a zone (motion-triggered lighting, presence-based heating, scheduled irrigation, sunset shutters), set a few values, and it runs. No flows to wire. No logic programming.</p>
+  <h3>Recipes. Your home's reflexes.</h3>
+  <p class="sowel-card__lead">Sowel ships them tested. Drop one on a zone, no scripting.</p>
+  <p>Choose from a curated catalogue: motion-triggered lighting, presence-based heating, scheduled irrigation, sunset shutters. Set a few values, and it runs. No flows to wire, no logic programming.</p>
+  <p class="sowel-card__example" data-label="Example">The <em>Motion Light (Dimmable)</em> recipe keeps a room at the right brightness whenever someone's there — vivid by day, gentle in the evening, dim at night. One recipe, three modes, zero code.</p>
+  <p class="sowel-card__more"><a href="user/recipes/">Read more →</a></p>
 </div>
 
 </div>
@@ -126,7 +149,7 @@ A home automation engine for <em>comfort</em>, <em>safety</em> and <em>energy ef
 
 <div class="sowel-pills">
   <div class="sowel-pill">
-    <strong>One Docker container.</strong> <code>docker compose up -d</code>. That's the install.
+    <strong>One command.</strong> <code>curl ... | sh</code> on any Docker host — Linux, macOS, Raspberry Pi. Sowel and InfluxDB up in under a minute.
   </div>
   <div class="sowel-pill">
     <strong>Stays at home.</strong> No cloud, no telemetry, no third-party account. Your data lives on your hardware: a Raspberry Pi, an old PC, a Proxmox VM, whatever you've got lying around.
@@ -160,7 +183,7 @@ A home automation engine for <em>comfort</em>, <em>safety</em> and <em>energy ef
   <div class="sowel-card__icon">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94z"/></svg>
   </div>
-  <h3>For builders</h3>
+  <h3>For developers</h3>
   <p>Architecture, plugin development, recipes, and the data model.</p>
   <p><a href="technical/">Technical guide →</a></p>
 </div>

--- a/docs/technical/contributing.fr.md
+++ b/docs/technical/contributing.fr.md
@@ -33,7 +33,7 @@ npm run dev          # Vite dev server (hot module replacement)
 ### Docker (InfluxDB)
 
 ```bash
-docker-compose up -d     # Starts InfluxDB 2.x
+docker compose up -d     # Starts InfluxDB 2.x
 ```
 
 InfluxDB est obligatoire : Sowel se connecte au démarrage et auto-crée les buckets, les tâches de downsampling et les tâches d'agrégation énergétique. Aucune configuration manuelle n'est nécessaire.

--- a/docs/technical/contributing.md
+++ b/docs/technical/contributing.md
@@ -33,7 +33,7 @@ npm run dev          # Vite dev server (hot module replacement)
 ### Docker (InfluxDB)
 
 ```bash
-docker-compose up -d     # Starts InfluxDB 2.x
+docker compose up -d     # Starts InfluxDB 2.x
 ```
 
 InfluxDB is mandatory -- Sowel connects on startup and auto-creates buckets, downsampling tasks, and energy aggregation tasks. No manual setup needed.

--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -10,11 +10,32 @@ Sowel est livré sous forme d'image Docker à `ghcr.io/mchacher/sowel:latest`. U
 
 ### Prérequis
 
-- Hôte Linux (x86_64) avec Docker Engine 20.10+ et `docker compose` v2
+- Hôte Linux ou macOS avec Docker Engine 20.10+ et `docker compose` v2 (images multi-arch : `linux/amd64` et `linux/arm64` — Raspberry Pi 4/5 supportés en natif)
 - Au moins 2 Go de RAM, 10 Go de disque (les données InfluxDB grossissent avec le temps)
 - Accès réseau à `ghcr.io` pour les pulls d'image et `api.github.com` pour les vérifications de version
 
-### Étapes
+### Option A — Installation en une commande (recommandée)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mchacher/sowel/main/scripts/install.sh | sh
+```
+
+Ce que ça fait :
+
+- Vérifie que Docker et Docker Compose v2 sont installés et joignables
+- Crée `~/sowel/` (override avec `SOWEL_DIR=/opt/sowel`)
+- Télécharge le `docker-compose.yml` de référence
+- Détecte automatiquement le fuseau horaire de l'hôte et patche le compose (plus de logs en UTC)
+- Tire les images, démarre la stack, attend que `/api/v1/health` réponde
+- Affiche l'URL et les commandes utiles (logs / update / stop)
+
+Override du port d'hôte : `SOWEL_PORT=8080 curl -fsSL ... | sh`.
+
+Si une installation existe déjà à `$SOWEL_DIR`, le script refuse d'écraser — choisissez un autre dossier ou supprimez l'existant d'abord.
+
+### Option B — Déploiement manuel
+
+Pour un contrôle complet sur chaque étape :
 
 ```bash
 # 1. Pick a deployment directory (convention: /opt/sowel)

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -10,11 +10,32 @@ Sowel ships as a Docker image at `ghcr.io/mchacher/sowel:latest`. A production d
 
 ### Prerequisites
 
-- Linux host (x86_64) with Docker Engine 20.10+ and `docker compose` v2
+- Linux or macOS host with Docker Engine 20.10+ and `docker compose` v2 (multi-arch images: `linux/amd64` and `linux/arm64` — Raspberry Pi 4/5 supported natively)
 - At least 2 GB RAM, 10 GB disk (InfluxDB data grows over time)
 - Network access to `ghcr.io` for image pulls and `api.github.com` for version checks
 
-### Steps
+### Option A — One-command install (recommended)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mchacher/sowel/main/scripts/install.sh | sh
+```
+
+What it does:
+
+- Checks that Docker and Docker Compose v2 are installed and reachable
+- Creates `~/sowel/` (override with `SOWEL_DIR=/opt/sowel`)
+- Downloads the reference `docker-compose.yml`
+- Auto-detects the host timezone and patches the compose file (no more UTC logs)
+- Pulls images, starts the stack, waits for `/api/v1/health` to respond
+- Prints the URL plus the most useful commands (logs / update / stop)
+
+Override the host port: `SOWEL_PORT=8080 curl -fsSL ... | sh`.
+
+If a previous install is detected at `$SOWEL_DIR`, the script refuses to overwrite — pick a different directory or remove it first.
+
+### Option B — Manual deployment
+
+For full control over each step:
 
 ```bash
 # 1. Pick a deployment directory (convention: /opt/sowel)

--- a/docs/user/getting-started.fr.md
+++ b/docs/user/getting-started.fr.md
@@ -40,7 +40,10 @@ Cela lance :
 - Le **moteur Sowel** sur le port `3000`
 - **InfluxDB** sur le port `8086` (utilisé en interne pour les données d'énergie et d'historique)
 
-Ouvrez votre navigateur sur **http://localhost:3000**.
+Ouvrez ensuite votre navigateur :
+
+- **Installation locale** — `http://localhost:3000`
+- **Installation distante** (ex. Raspberry Pi, NAS, serveur dédié) — `http://<ip-de-l'hôte>:3000`, où `<ip-de-l'hôte>` est l'adresse LAN de la machine qui fait tourner Sowel
 
 ### Option 3 : Depuis les sources (développement)
 

--- a/docs/user/getting-started.fr.md
+++ b/docs/user/getting-started.fr.md
@@ -9,14 +9,30 @@ Cette page vous guide à travers l'installation de Sowel, la première connexion
 
 ## Installation
 
-### Option 1 : Docker (recommandé)
+### Option 1 : Installation en une commande (recommandée)
 
-Docker est la manière la plus simple d'exécuter Sowel. Il regroupe le moteur et InfluxDB.
+Le plus rapide. Récupère le `docker-compose.yml` officiel, démarre Sowel et InfluxDB ensemble, attend que le moteur réponde, et affiche l'URL quand c'est prêt :
 
 ```bash
-git clone <repo>
-cd sowel
-docker-compose up -d
+curl -fsSL https://raw.githubusercontent.com/mchacher/sowel/main/scripts/install.sh | sh
+```
+
+Valeurs par défaut :
+
+- Installe dans `~/sowel/` (override avec `SOWEL_DIR=/your/path`)
+- Expose Sowel sur le port `3000` (override avec `SOWEL_PORT=8080` par exemple)
+- Détecte automatiquement le fuseau horaire de l'hôte et patche le compose
+
+À la fin, ouvrez l'URL affichée dans votre navigateur.
+
+### Option 2 : Installation Docker manuelle
+
+Si vous préférez faire les étapes vous-même :
+
+```bash
+mkdir ~/sowel && cd ~/sowel
+curl -O https://raw.githubusercontent.com/mchacher/sowel/main/docker-compose.yml
+docker compose up -d
 ```
 
 Cela lance :
@@ -26,32 +42,21 @@ Cela lance :
 
 Ouvrez votre navigateur sur **http://localhost:3000**.
 
-### Option 2 : Installation manuelle
+### Option 3 : Depuis les sources (développement)
+
+Pour les contributeurs et développeurs :
 
 ```bash
-git clone <repo>
+git clone https://github.com/mchacher/sowel.git
 cd sowel
 npm install
+npm run dev                            # backend sur :3000
+# dans un autre terminal
+cd ui && npm install && npm run dev    # frontend sur :5173 avec hot reload
 ```
-
-Démarrez le backend :
-
-```bash
-npm run dev
-```
-
-Dans un terminal séparé, démarrez le frontend :
-
-```bash
-cd ui
-npm install
-npm run dev
-```
-
-Ouvrez votre navigateur sur **http://localhost:5173**.
 
 !!! info "Développement vs production"
-En exécution manuelle avec `npm run dev`, l'UI tourne sur le port 5173 (serveur de dev Vite avec hot reload). En mode Docker ou production, le backend sert directement l'UI sur le port 3000.
+Avec `npm run dev`, l'UI tourne sur le port 5173 (serveur de dev Vite avec hot reload). En mode Docker, le backend sert directement l'UI sur le port 3000.
 
 ## Première connexion
 
@@ -135,12 +140,12 @@ Pour chaque unité fonctionnelle de votre maison :
 
 1. Cliquez sur **Ajouter un équipement**
 2. Choisissez un type (lumière, volet, capteur, thermostat, portail, vanne d'eau, etc.)
-3. Donnez-lui un nom (par ex. "Spots Salon")
+3. Donnez-lui un nom (par ex. "Spots Cuisine")
 4. Affectez-le à une zone
 5. Liez les données et les commandes des devices
 
 !!! tip
-Un seul équipement peut se lier à plusieurs devices. Par exemple, trois modules variateurs derrière le mur peuvent être regroupés en un seul équipement "Spots Salon". Un seul interrupteur les contrôle tous les trois.
+Un seul équipement peut se lier à plusieurs devices. Par exemple, trois modules variateurs derrière le mur peuvent être regroupés en un seul équipement "Spots Cuisine". Un seul interrupteur les contrôle tous les trois.
 
 ### Étape 5 : Profiter de la vue Accueil
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -9,14 +9,30 @@ This page walks you through installing Sowel, logging in for the first time, and
 
 ## Installation
 
-### Option 1: Docker (recommended)
+### Option 1: One-command install (recommended)
 
-Docker is the easiest way to run Sowel. It bundles the engine and InfluxDB together.
+The quickest way. Pulls the official `docker-compose.yml`, starts Sowel and InfluxDB together, waits for the engine to come up, and prints the URL when ready:
 
 ```bash
-git clone <repo>
-cd sowel
-docker-compose up -d
+curl -fsSL https://raw.githubusercontent.com/mchacher/sowel/main/scripts/install.sh | sh
+```
+
+Defaults:
+
+- Installs into `~/sowel/` (override with `SOWEL_DIR=/your/path`)
+- Exposes Sowel on port `3000` (override with `SOWEL_PORT=8080` for example)
+- Auto-detects your host timezone and patches the compose file
+
+When done, open the printed URL in your browser.
+
+### Option 2: Manual Docker install
+
+If you prefer to do the steps yourself:
+
+```bash
+mkdir ~/sowel && cd ~/sowel
+curl -O https://raw.githubusercontent.com/mchacher/sowel/main/docker-compose.yml
+docker compose up -d
 ```
 
 This starts:
@@ -26,32 +42,21 @@ This starts:
 
 Open your browser to **http://localhost:3000**.
 
-### Option 2: Manual installation
+### Option 3: Run from source (development)
+
+For contributors and developers:
 
 ```bash
-git clone <repo>
+git clone https://github.com/mchacher/sowel.git
 cd sowel
 npm install
+npm run dev                            # backend on :3000
+# in a separate terminal
+cd ui && npm install && npm run dev    # frontend on :5173 with hot reload
 ```
-
-Start the backend:
-
-```bash
-npm run dev
-```
-
-In a separate terminal, start the frontend:
-
-```bash
-cd ui
-npm install
-npm run dev
-```
-
-Open your browser to **http://localhost:5173**.
 
 !!! info "Development vs production"
-When running manually with `npm run dev`, the UI runs on port 5173 (Vite dev server with hot reload). In Docker or production mode, the backend serves the UI directly on port 3000.
+When running with `npm run dev`, the UI is on port 5173 (Vite dev server with hot reload). In Docker mode, the backend serves the built UI on port 3000.
 
 ## First login
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -40,7 +40,10 @@ This starts:
 - **Sowel engine** on port `3000`
 - **InfluxDB** on port `8086` (used internally for energy and history data)
 
-Open your browser to **http://localhost:3000**.
+Then open your browser:
+
+- **Local install** — `http://localhost:3000`
+- **Remote install** (e.g. Raspberry Pi, NAS, dedicated server) — `http://<host-ip>:3000`, where `<host-ip>` is the LAN address of the machine running Sowel
 
 ### Option 3: Run from source (development)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -109,16 +109,36 @@ if [ "$ready" -ne 1 ]; then
   exit 2
 fi
 
+# ─── Detect LAN IP for the final message ────────────────────
+# Use the IP the host would use to reach the internet (avoids Docker bridges).
+LAN_IP=""
+if command -v ip >/dev/null 2>&1; then
+  LAN_IP="$(ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' | head -1)"
+fi
+if [ -z "$LAN_IP" ] && command -v route >/dev/null 2>&1 && command -v ipconfig >/dev/null 2>&1; then
+  iface="$(route get 1.1.1.1 2>/dev/null | awk '/interface:/ {print $2}')"
+  [ -n "$iface" ] && LAN_IP="$(ipconfig getifaddr "$iface" 2>/dev/null)"
+fi
+if [ -z "$LAN_IP" ] && command -v hostname >/dev/null 2>&1; then
+  LAN_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+fi
+[ -z "$LAN_IP" ] && LAN_IP="localhost"
+
+URL="http://${LAN_IP}:${SOWEL_PORT}"
+
 # ─── Done ───────────────────────────────────────────────────
 cat <<EOF
 
 Sowel is running.
 
-  → Open http://localhost:${SOWEL_PORT} and create your admin account.
+  → ${URL}
 
-Next steps:
-  • Install integrations: http://localhost:${SOWEL_PORT}/admin/plugins
-  • Set your home location in Settings to enable automatic timezone
+First steps after you sign in:
+  1. Create your admin account
+  2. Name your home (Settings → Home)
+  3. Set its location (latitude / longitude) — required to enable
+     timezone, sunrise / sunset, and HP/HC tariff classification
+  4. Install integrations: ${URL}/admin/plugins
 
 Useful commands (run from $SOWEL_DIR):
   Logs     docker compose logs -f
@@ -126,5 +146,5 @@ Useful commands (run from $SOWEL_DIR):
   Stop     docker compose down
   Wipe     docker compose down -v   # also deletes data volumes
 
-Documentation: https://github.com/mchacher/sowel
+Documentation: https://docs.sowel.org
 EOF

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+# ============================================================
+# Sowel — One-command installer
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/mchacher/sowel/main/scripts/install.sh | sh
+#
+# Environment overrides:
+#   SOWEL_DIR    Install directory (default: $HOME/sowel)
+#   SOWEL_PORT   Host port to expose (default: 3000)
+# ============================================================
+set -eu
+
+SOWEL_DIR="${SOWEL_DIR:-$HOME/sowel}"
+SOWEL_PORT="${SOWEL_PORT:-3000}"
+COMPOSE_URL="https://raw.githubusercontent.com/mchacher/sowel/main/docker-compose.yml"
+HEALTH_URL="http://localhost:${SOWEL_PORT}/api/v1/health"
+
+# ─── Pre-flight ─────────────────────────────────────────────
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: Docker is not installed."
+  echo "Install Docker first: https://docs.docker.com/get-docker/"
+  exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "Error: Docker Compose v2 is required (run 'docker compose version' to check)."
+  echo "Update Docker Desktop, or install the docker-compose-plugin package."
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Error: cannot reach the Docker daemon. Is it running? Do you need sudo?"
+  exit 1
+fi
+
+# ─── Install directory ──────────────────────────────────────
+if [ -e "$SOWEL_DIR/docker-compose.yml" ]; then
+  echo "An existing Sowel install was found at: $SOWEL_DIR"
+  echo "Refusing to overwrite. Use SOWEL_DIR=/some/other/path or remove it first."
+  exit 1
+fi
+
+mkdir -p "$SOWEL_DIR"
+cd "$SOWEL_DIR"
+
+# ─── Fetch docker-compose.yml ───────────────────────────────
+echo "Fetching docker-compose.yml…"
+if ! curl -fsSL -o docker-compose.yml "$COMPOSE_URL"; then
+  echo "Error: could not download $COMPOSE_URL"
+  exit 1
+fi
+
+# ─── Detect host timezone, patch the compose ───────────────
+HOST_TZ=""
+if command -v timedatectl >/dev/null 2>&1; then
+  HOST_TZ="$(timedatectl 2>/dev/null | awk -F': ' '/Time zone/ {print $2}' | awk '{print $1}')"
+fi
+if [ -z "$HOST_TZ" ] && [ -L /etc/localtime ]; then
+  HOST_TZ="$(readlink /etc/localtime 2>/dev/null | sed 's|.*/zoneinfo/||')"
+fi
+
+if [ -n "${HOST_TZ:-}" ] && [ "$HOST_TZ" != "UTC" ]; then
+  # Use a portable sed: macOS needs an empty -i suffix, GNU does not.
+  if sed --version >/dev/null 2>&1; then
+    sed -i "s|# - TZ=Europe/Paris|- TZ=$HOST_TZ|" docker-compose.yml
+  else
+    sed -i '' "s|# - TZ=Europe/Paris|- TZ=$HOST_TZ|" docker-compose.yml
+  fi
+  echo "Detected timezone: $HOST_TZ (set in docker-compose.yml)"
+fi
+
+# ─── Custom port ────────────────────────────────────────────
+if [ "$SOWEL_PORT" != "3000" ]; then
+  if sed --version >/dev/null 2>&1; then
+    sed -i "s|\"3000:3000\"|\"$SOWEL_PORT:3000\"|" docker-compose.yml
+  else
+    sed -i '' "s|\"3000:3000\"|\"$SOWEL_PORT:3000\"|" docker-compose.yml
+  fi
+  echo "Exposing Sowel on host port $SOWEL_PORT"
+fi
+
+# ─── Pull + start ───────────────────────────────────────────
+echo "Pulling images…"
+docker compose pull
+
+echo "Starting Sowel…"
+docker compose up -d
+
+# ─── Wait for /api/v1/health ────────────────────────────────
+printf "Waiting for Sowel to be ready"
+ready=0
+i=0
+while [ $i -lt 60 ]; do
+  if curl -fs "$HEALTH_URL" >/dev/null 2>&1; then
+    ready=1
+    echo " ✓"
+    break
+  fi
+  printf "."
+  sleep 1
+  i=$((i + 1))
+done
+
+if [ "$ready" -ne 1 ]; then
+  echo
+  echo "Warning: Sowel did not respond on $HEALTH_URL within 60 seconds."
+  echo "Check the logs: docker compose -f $SOWEL_DIR/docker-compose.yml logs"
+  exit 2
+fi
+
+# ─── Done ───────────────────────────────────────────────────
+cat <<EOF
+
+Sowel is running.
+
+  → Open http://localhost:${SOWEL_PORT} and create your admin account.
+
+Next steps:
+  • Install integrations: http://localhost:${SOWEL_PORT}/admin/plugins
+  • Set your home location in Settings to enable automatic timezone
+
+Useful commands (run from $SOWEL_DIR):
+  Logs     docker compose logs -f
+  Update   docker compose pull && docker compose up -d
+  Stop     docker compose down
+  Wipe     docker compose down -v   # also deletes data volumes
+
+Documentation: https://github.com/mchacher/sowel
+EOF


### PR DESCRIPTION
## Summary

Adds a 90-line POSIX `install.sh` so installation is a single command:

\`\`\`bash
curl -fsSL https://raw.githubusercontent.com/mchacher/sowel/main/scripts/install.sh | sh
\`\`\`

The script:
- Verifies Docker + Compose v2 are installed and reachable
- Installs into a dedicated dir (default \`~/sowel/\`, override via \`SOWEL_DIR\`)
- Refuses to overwrite an existing install (safety)
- Downloads the reference \`docker-compose.yml\`
- Auto-detects the host timezone (Linux \`timedatectl\` or \`/etc/localtime\` symlink) and patches the compose file — no more UTC logs out of the box
- Optional custom port via \`SOWEL_PORT=8080\`
- Pulls images, starts the stack, polls \`/api/v1/health\` until ready, prints the URL + the most useful commands (logs/update/stop/wipe)

## Doc updates

- README quick-start now leads with the one-liner; manual install kept in a collapsed details block
- \`docs/user/getting-started\` (EN + FR) reorganized: install.sh = option 1, manual Docker = option 2, source = option 3
- \`docs/technical/deployment\` gets full Option A / Option B sections + ARM64/Pi mention now that images are multi-arch (PR #163)
- Landing page install pill highlights the one-command + multi-arch (Linux/macOS/Pi)

## Test plan

- [x] Shell syntax valid (\`sh -n\`)
- [x] mkdocs build --strict
- [ ] End-to-end on Raspberry Pi 4 (ARM64) — pending the 1.5.10 release that will produce a multi-arch \`:latest\`
- [ ] Confirm Sowel boots and \`/api/v1/health\` responds

## Notes

- Self-update via Docker socket stays mounted in the compose by default. If a user wants to opt out, they edit the compose post-install — not blocking for v1.
- HEALTHCHECK in the Dockerfile is a possible v2 add-on (would let \`docker ps\` show health status) — out of scope here.