### PR TITLE
docs: doc session cleanup (landing fix + equipments tables + data-model split)

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -368,6 +368,47 @@
   font-weight: 700;
 }
 
+.sowel-card__lead {
+  font-size: 0.74rem;
+  font-weight: 600;
+  line-height: 1.45;
+  color: var(--md-default-fg-color);
+  margin: 0 0 0.5rem;
+}
+
+.sowel-card__more {
+  margin-top: 0.55rem;
+  margin-bottom: 0;
+  font-size: 0.7rem;
+}
+
+.sowel-card__example {
+  position: relative;
+  margin-top: 0.7rem;
+  padding: 0.55rem 0.75rem 0.6rem 0.85rem;
+  background: color-mix(in srgb, var(--md-default-fg-color) 6%, transparent);
+  border-left: 2px solid color-mix(in srgb, var(--md-default-fg-color) 25%, transparent);
+  border-radius: 0 6px 6px 0;
+  font-size: 0.7rem;
+  line-height: 1.55;
+  color: var(--md-default-fg-color);
+}
+.sowel-card__example::before {
+  content: attr(data-label);
+  display: block;
+  font-family: var(--sowel-display);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--md-default-fg-color) 55%, transparent);
+  margin-bottom: 0.15rem;
+}
+[data-md-color-scheme="slate"] .sowel-card__example {
+  background: color-mix(in srgb, var(--md-default-fg-color) 10%, transparent);
+  border-left-color: color-mix(in srgb, var(--md-default-fg-color) 30%, transparent);
+}
+
 /* ============================================================
    Landing-page hero
    ============================================================ */

--- a/docs/technical/data-model.fr.md
+++ b/docs/technical/data-model.fr.md
@@ -62,7 +62,7 @@ Une **Zone** représente une aire spatiale dans la maison. Les zones forment une
 ```typescript
 interface Zone {
   id: string; // UUID v4
-  name: string; // "Salon", "Etage 1", "Maison"
+  name: string; // "Cuisine", "Etage 1", "Maison"
   parentId: string | null; // null = root zone
   icon?: string; // Lucide icon name: "home", "sofa", "bed"
   description?: string; // "Piece principale, 35m2"
@@ -79,7 +79,7 @@ Les zones sont imbriquables sur n'importe quelle profondeur. Structure typique :
 ```
 Maison                    (root, parentId: null)
 +-- RDC                   (floor, parentId: Maison)
-|   +-- Salon             (room, parentId: RDC)
+|   +-- Cuisine             (room, parentId: RDC)
 |   +-- Cuisine           (room, parentId: RDC)
 |   +-- Entree            (room, parentId: RDC)
 |   +-- WC                (room, parentId: RDC)
@@ -177,7 +177,7 @@ interface EquipmentGroup {
 ### 4.2 Objectif et exemples
 
 ```
-Salon (Zone)
+Cuisine (Zone)
 +-- Group "Volets Sud"
 |   +-- Volet Baie Vitree          (Equipment: shutter)
 |   +-- Volet Porte Fenetre        (Equipment: shutter)
@@ -186,8 +186,8 @@ Salon (Zone)
 +-- Group "Eclairage Ambiance"
 |   +-- Spots Plafond              (Equipment: dimmer)
 |   +-- Lampe Canape               (Equipment: dimmer)
-+-- Detection Salon                (Equipment: motion_sensor, no group)
-+-- Temperature Salon              (Equipment: sensor, no group)
++-- Detection Cuisine                (Equipment: motion_sensor, no group)
++-- Temperature Cuisine              (Equipment: sensor, no group)
 ```
 
 **Comportements clés :**
@@ -247,7 +247,7 @@ type EquipmentType =
 
 interface Equipment {
   id: string; // UUID v4
-  name: string; // "Spots Salon", "Volet Baie Vitree"
+  name: string; // "Spots Cuisine", "Volet Baie Vitree"
   zoneId: string; // FK -> Zone (where the equipment functions)
   groupId: string | null; // FK -> EquipmentGroup (optional)
   type: EquipmentType; // Semantic type, drives UI rendering & aggregation
@@ -272,9 +272,9 @@ interface Equipment {
 
 **Exemples :**
 
-- 1 Device -> 1 Equipment : capteur de température Aqara -> "Temperature Salon"
+- 1 Device -> 1 Equipment : capteur de température Aqara -> "Temperature Cuisine"
 - 1 Device -> N Equipments : module double relais -> "Lumiere Cuisine" + "Lumiere Cellier"
-- N Devices -> 1 Equipment : 3 capteurs PIR -> "Detection Salon" (via computed data, V0.5)
+- N Devices -> 1 Equipment : 3 capteurs PIR -> "Detection Cuisine" (via computed data, V0.5)
 
 ---
 
@@ -301,7 +301,7 @@ Device "Variateur #1"
 +-- DeviceData: key="brightness", value=180    <---+-- DataBinding
 +-- DeviceData: key="linkquality", value=85        |
                                                    |
-Equipment "Spots Salon"                            |
+Equipment "Spots Cuisine"                            |
 +-- Data alias "state" ----------------------------+ (bound to DeviceData "state")
 +-- Data alias "brightness" -----------------------  (bound to DeviceData "brightness")
 +-- [not bound to linkquality -- it's a technical metric, not user-facing]
@@ -347,7 +347,7 @@ interface OrderBinding {
 Quand un Equipment Order est exécuté :
 
 ```
-User clicks "Turn On" on Equipment "Spots Salon"
+User clicks "Turn On" on Equipment "Spots Cuisine"
   -> API: POST /equipments/:id/orders/turn_on { value: true }
     -> Equipment Manager finds OrderBinding alias="turn_on"
       -> Resolves to DeviceOrder

--- a/docs/technical/data-model.md
+++ b/docs/technical/data-model.md
@@ -1,31 +1,43 @@
 # Sowel -- Data Model
 
-> Version: 1.0 -- 2026-02-19
+> Version: 2.0 -- 2026-05-10
 >
-> This document is the reference for Sowel's core data model. It describes the three-layer architecture (Topology -> Functional -> Physical), all entities, their relationships, and the aggregation rules.
+> This index covers the cross-cutting parts of Sowel's data model: the three-layer architecture, the entity relationship diagram, the plugin distribution layer, the reactive data flow, the event bus events, and the API surface.
+>
+> Per-entity details are split across five focused pages aligned with the core concepts:
+>
+> - [Devices](data-model/devices.md) -- physical layer, normalized data model
+> - [Equipments](data-model/equipments.md) -- functional units, bindings, computed data
+> - [Zones](data-model/zones.md) -- spatial topology, aggregation rules, auto-orders
+> - [Modes](data-model/modes.md) -- orchestration, button bindings, calendar scheduling
+> - [Recipes](data-model/recipes.md) -- automation templates, instances, runtime helpers
 
 ---
 
 ## 1. Three-Layer Architecture
 
-Sowel separates concerns into three distinct layers:
+Sowel separates concerns into three distinct layers, with orchestration entities (Modes, Recipes, Calendars) operating across them.
 
 ```
 +-------------------------------------------------------------+
+|  ORCHESTRATION                                              |
+|  Modes  --  Recipes  --  Calendars  --  Buttons             |
+|  Cross-cutting state machines that drive Equipments / Zones |
++-------------------------------------------------------------+
 |  LAYER 1 -- TOPOLOGY (Zones)                                |
-|  Spatial structure of the home                               |
-|  Hierarchical: Home -> Floor -> Room                         |
-|  Aggregates data automatically from child Equipments         |
+|  Spatial structure of the home                              |
+|  Hierarchical: Home -> Floor -> Room                        |
+|  Aggregates data automatically from child Equipments        |
 +-------------------------------------------------------------+
-|  LAYER 2 -- FUNCTIONAL (Equipments + Groups)                 |
-|  What the user sees and controls                             |
-|  Placed IN a Zone, optionally IN a Group                     |
-|  Binds to one or more physical Devices                       |
+|  LAYER 2 -- FUNCTIONAL (Equipments)                         |
+|  What the user sees and controls                            |
+|  Placed IN a Zone                                           |
+|  Binds to one or more physical Devices                      |
 +-------------------------------------------------------------+
-|  LAYER 3 -- PHYSICAL (Devices)                               |
-|  Hardware discovered from integrations                       |
-|  Auto-discovered, raw data and commands                      |
-|  Never directly manipulated by the end user                  |
+|  LAYER 3 -- PHYSICAL (Devices)                              |
+|  Hardware discovered from integration plugins               |
+|  Auto-discovered, raw data and orders                       |
+|  Never directly manipulated by the end user                 |
 +-------------------------------------------------------------+
 ```
 
@@ -33,798 +45,305 @@ Sowel separates concerns into three distinct layers:
 
 ---
 
+---
+
 ## 2. Entity Relationship Diagram
 
 ```
+Plugin (PackageType: integration | recipe)
+ +-- (integration) discovers --> Device
+ +-- (recipe)      registers --> RecipeDefinition
+
 Zone (hierarchy: parent -> children)
  |
- +-- EquipmentGroup (optional functional grouping)
- |    +-- Equipment*
- |
  +-- Equipment (functional unit, user-facing)
-      +-- DataBinding --> DeviceData (on a Device)
-      +-- OrderBinding --> DeviceOrder (on a Device)
-      +-- [V0.5] ComputedData (expression-based virtual data)
+      +-- DataBinding  --> DeviceData  (readable, alias-named)
+      +-- OrderBinding --> DeviceOrder (writable, alias-named)
+      +-- ComputedDataEntry (provider-supplied, no DB row)
 
-Device (physical, auto-discovered)
- +-- DeviceData (readable properties: temperature, state, brightness...)
- +-- DeviceOrder (writable commands: set brightness, turn on...)
+Device (physical, auto-discovered, optional zoneId)
+ +-- DeviceData  (readable properties)
+ +-- DeviceOrder (writable commands)
+
+Mode --< ZoneModeImpact >-- Zone
+                            |
+                            actions: order | recipe_toggle | recipe_params
+
+RecipeInstance --(params)--> RecipeDefinition (from a recipe plugin)
+ +-- RecipeState (key/value store, persisted)
+ +-- RecipeLog  (event log)
+
+CalendarProfile --< CalendarSlot (cron-scheduled mode changes)
+
+ButtonActionBinding (Equipment.action -> mode/order/recipe/zone-order)
 ```
 
 ---
 
-## 3. Zone
+## 3. Plugin
 
-A **Zone** represents a spatial area in the home. Zones form a **tree hierarchy**.
+Since spec 053, **everything that ships out of band is a plugin** -- both integrations and recipes. The PackageManager downloads them from GitHub and the appropriate loader (PluginLoader for integrations, RecipeLoader for recipes) instantiates them at runtime.
 
-### 3.1 Interface
+### 3.1 Interfaces
 
 ```typescript
-interface Zone {
-  id: string; // UUID v4
-  name: string; // "Salon", "Etage 1", "Maison"
-  parentId: string | null; // null = root zone
-  icon?: string; // Lucide icon name: "home", "sofa", "bed"
-  description?: string; // "Piece principale, 35m2"
-  displayOrder: number; // Sort order among siblings (0-based)
-  createdAt: string; // ISO 8601
-  updatedAt: string; // ISO 8601
+type PackageType = "integration" | "recipe";
+
+interface PluginManifest {
+  id: string; // unique plugin id, used in DB and registry
+  name: string;
+  version: string; // semver
+  description: string;
+  icon: string; // Lucide icon name
+  repo: string; // GitHub owner/repo -- required for backup/restore reinstall
+  type?: PackageType; // defaults to "integration"
+  author?: string;
+  sowelVersion?: string; // minimum compatible Sowel version
+  settings?: IntegrationSettingDef[];
+}
+
+interface InstalledPackage {
+  manifest: PluginManifest;
+  enabled: boolean;
+  installedAt: string;
+  type: PackageType;
+}
+
+interface PluginInfo extends Omit<InstalledPackage, "type"> {
+  status: IntegrationStatus; // connected | disconnected | error | not_configured
+  deviceCount: number;
+  offlineDeviceCount: number;
+  latestVersion?: string; // populated when registry has a newer version
 }
 ```
 
-### 3.2 Hierarchy
-
-Zones are nestable to any depth. Typical structure:
-
-```
-Maison                    (root, parentId: null)
-+-- RDC                   (floor, parentId: Maison)
-|   +-- Salon             (room, parentId: RDC)
-|   +-- Cuisine           (room, parentId: RDC)
-|   +-- Entree            (room, parentId: RDC)
-|   +-- WC                (room, parentId: RDC)
-+-- Etage                 (floor, parentId: Maison)
-|   +-- Chambre Parentale (room, parentId: Etage)
-|   +-- Chambre Enfant    (room, parentId: Etage)
-|   +-- Salle de Bain     (room, parentId: Etage)
-|   +-- Couloir           (room, parentId: Etage)
-+-- Exterieur             (area, parentId: Maison)
-    +-- Jardin            (area, parentId: Exterieur)
-    +-- Garage            (area, parentId: Exterieur)
-```
-
-### 3.3 Zone Aggregated Data
-
-The engine **automatically computes** aggregated data for each Zone based on the Equipments it contains. No manual configuration required -- this is a core feature.
-
-Aggregation is **recursive**: a parent Zone aggregates its own Equipments plus all children Zones.
-
-| Attribute                | Type           | Aggregation Rule | Source (DataCategory) | Description                                         |
-| ------------------------ | -------------- | ---------------- | --------------------- | --------------------------------------------------- |
-| `temperature`            | number \| null | AVG              | `temperature`         | Average temperature in the zone                     |
-| `humidity`               | number \| null | AVG              | `humidity`            | Average humidity                                    |
-| `pressure`               | number \| null | AVG              | `pressure`            | Average atmospheric pressure                        |
-| `luminosity`             | number \| null | AVG              | `luminosity`          | Average luminosity (lux)                            |
-| `co2`                    | number \| null | AVG              | `co2`                 | Average CO2 level (ppm)                             |
-| `voc`                    | number \| null | AVG              | `voc`                 | Average VOC level (ppb)                             |
-| `motion`                 | boolean        | OR               | `motion`              | true if ANY motion sensor detects movement          |
-| `presence`               | boolean        | OR + timeout     | `motion`              | true if motion detected within configurable timeout |
-| `openDoors`              | number         | COUNT (open)     | `contact_door`        | Number of open door contacts                        |
-| `openWindows`            | number         | COUNT (open)     | `contact_window`      | Number of open window contacts                      |
-| `waterLeak`              | boolean        | OR               | `water_leak`          | true if ANY water leak sensor triggers              |
-| `smoke`                  | boolean        | OR               | `smoke`               | true if ANY smoke detector triggers                 |
-| `lightsOn`               | number         | COUNT (on)       | `light_state`         | Number of lights turned on                          |
-| `lightsTotal`            | number         | COUNT (all)      | `light_state`         | Total number of light equipments                    |
-| `averageBrightness`      | number \| null | AVG (on only)    | `light_brightness`    | Average brightness of lights that are on            |
-| `shuttersOpen`           | number         | COUNT (open)     | `shutter_position`    | Number of open shutters                             |
-| `shuttersTotal`          | number         | COUNT (all)      | `shutter_position`    | Total number of shutters                            |
-| `averageShutterPosition` | number \| null | AVG              | `shutter_position`    | Average shutter position (%)                        |
-| `totalPower`             | number         | SUM              | `power`               | Total instantaneous power (W)                       |
-| `totalEnergy`            | number         | SUM              | `energy`              | Total energy consumption (kWh)                      |
-| `heatingActive`          | boolean        | OR               | thermostat equipments | true if any thermostat is actively heating          |
-| `targetTemperature`      | number \| null | AVG              | thermostat equipments | Average target temperature setpoint                 |
-
-> **Note**: This list will evolve. New aggregated attributes can be added as new Equipment types and DataCategories are introduced.
-
-### 3.4 Zone Auto-Orders
-
-Zones expose bulk commands that act on all Equipments within the zone (and child zones recursively):
-
-| Order              | Effect                                           |
-| ------------------ | ------------------------------------------------ |
-| `allOff`           | Turn off ALL controllable Equipments in the Zone |
-| `allLightsOff`     | Turn off all light-type Equipments               |
-| `allLightsOn`      | Turn on all light-type Equipments                |
-| `allShuttersOpen`  | Open all shutters                                |
-| `allShuttersClose` | Close all shutters                               |
-
-### 3.5 SQLite Schema
+### 3.2 SQLite Schema
 
 ```sql
-CREATE TABLE zones (
-  id TEXT PRIMARY KEY,
-  name TEXT NOT NULL,
-  parent_id TEXT REFERENCES zones(id) ON DELETE SET NULL,
-  icon TEXT,
-  description TEXT,
-  display_order INTEGER DEFAULT 0,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE plugins (
+  id TEXT PRIMARY KEY,                    -- manifest.id
+  version TEXT NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  installed_at TEXT NOT NULL DEFAULT (datetime('now')),
+  manifest TEXT NOT NULL,                 -- JSON: full PluginManifest
+  type TEXT NOT NULL DEFAULT 'integration'
 );
 ```
 
----
-
-## 4. Equipment Group
-
-An **EquipmentGroup** is a functional grouping of Equipments within a Zone. It allows controlling and monitoring a subset of equipments together.
-
-### 4.1 Interface
-
-```typescript
-interface EquipmentGroup {
-  id: string; // UUID v4
-  name: string; // "Volets Sud", "Eclairage Ambiance"
-  zoneId: string; // FK -> Zone (a group belongs to exactly one zone)
-  icon?: string; // Lucide icon name
-  description?: string;
-  displayOrder: number; // Sort order within the zone
-  createdAt: string; // ISO 8601
-  updatedAt: string; // ISO 8601
-}
-```
-
-### 4.2 Purpose & Examples
-
-```
-Salon (Zone)
-+-- Group "Volets Sud"
-|   +-- Volet Baie Vitree          (Equipment: shutter)
-|   +-- Volet Porte Fenetre        (Equipment: shutter)
-+-- Group "Volets Nord"
-|   +-- Volet Fenetre Nord         (Equipment: shutter)
-+-- Group "Eclairage Ambiance"
-|   +-- Spots Plafond              (Equipment: dimmer)
-|   +-- Lampe Canape               (Equipment: dimmer)
-+-- Detection Salon                (Equipment: motion_sensor, no group)
-+-- Temperature Salon              (Equipment: sensor, no group)
-```
-
-**Key behaviors:**
-
-- An Equipment belongs to **at most one** Group (optional, via `groupId`)
-- A Group belongs to exactly one Zone
-- Groups have their own aggregated data (same rules as Zones, scoped to group members)
-- Groups can receive bulk orders (e.g., "close all shutters in Volets Sud")
-
-### 4.3 Group Aggregated Data
-
-Groups compute aggregated data using the **same rules** as Zones (section 3.3), but scoped to the group's member Equipments only. This allows:
-
-- "Average shutter position of Volets Sud" vs "Average shutter position of Volets Nord"
-- "Number of lights on in Eclairage Ambiance" vs zone-wide count
-
-### 4.4 SQLite Schema
-
-```sql
-CREATE TABLE equipment_groups (
-  id TEXT PRIMARY KEY,
-  name TEXT NOT NULL,
-  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
-  icon TEXT,
-  description TEXT,
-  display_order INTEGER DEFAULT 0,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
-```
+Integration settings are stored in the generic `settings` table under keys like `integration.<id>.<settingKey>`.
 
 ---
 
-## 5. Equipment
-
-An **Equipment** is the user-facing functional unit. It's the primary entity users interact with in the UI, scenarios, and voice commands.
-
-### 5.1 Interface
-
-```typescript
-type EquipmentType =
-  | "light" // on/off light
-  | "dimmer" // dimmable light
-  | "color_light" // color-capable light
-  | "shutter" // cover, blind, shutter
-  | "thermostat" // heating/cooling control
-  | "lock" // door lock
-  | "alarm" // alarm system
-  | "sensor" // generic sensor (temp, humidity...)
-  | "motion_sensor" // motion detector
-  | "contact_sensor" // door/window contact
-  | "media_player" // media device
-  | "camera" // surveillance camera
-  | "switch" // on/off switch or plug
-  | "water_valve" // smart irrigation valve (toggle + timed watering)
-  | "generic"; // anything else
-
-interface Equipment {
-  id: string; // UUID v4
-  name: string; // "Spots Salon", "Volet Baie Vitree"
-  zoneId: string; // FK -> Zone (where the equipment functions)
-  groupId: string | null; // FK -> EquipmentGroup (optional)
-  type: EquipmentType; // Semantic type, drives UI rendering & aggregation
-  icon?: string; // Lucide icon name (overrides type default)
-  description?: string;
-  enabled: boolean; // Disabled equipments are ignored by the engine
-  createdAt: string; // ISO 8601
-  updatedAt: string; // ISO 8601
-}
-```
-
-### 5.2 Equipment vs Device
-
-|                      | Device                            | Equipment                         |
-| -------------------- | --------------------------------- | --------------------------------- |
-| **Nature**           | Physical hardware                 | Functional abstraction            |
-| **Discovery**        | Auto-discovered from integrations | Manually created by user          |
-| **Identity**         | Integration-specific ID           | User-chosen name                  |
-| **Location**         | Where physically installed        | Where functionally used           |
-| **Cardinality**      | 1 Device -> N Equipments possible | 1 Equipment -> N Devices possible |
-| **User interaction** | Never (technical layer)           | Always (primary interface)        |
-
-**Examples:**
-
-- 1 Device -> 1 Equipment: Aqara temperature sensor -> "Temperature Salon"
-- 1 Device -> N Equipments: Double relay module -> "Lumiere Cuisine" + "Lumiere Cellier"
-- N Devices -> 1 Equipment: 3 PIR sensors -> "Detection Salon" (via computed data, V0.5)
-
 ---
 
-## 6. Data Binding
-
-A **DataBinding** maps a Device Data property to an Equipment-level alias.
-
-### 6.1 Interface
-
-```typescript
-interface DataBinding {
-  id: string; // UUID v4
-  equipmentId: string; // FK -> Equipment
-  deviceDataId: string; // FK -> DeviceData
-  alias: string; // Equipment-level name: "state", "brightness", "temperature"
-}
-```
-
-### 6.2 How It Works
-
-```
-Device "Variateur #1"
-+-- DeviceData: key="state", value="ON"        <--+
-+-- DeviceData: key="brightness", value=180    <---+-- DataBinding
-+-- DeviceData: key="linkquality", value=85        |
-                                                   |
-Equipment "Spots Salon"                            |
-+-- Data alias "state" ----------------------------+ (bound to DeviceData "state")
-+-- Data alias "brightness" -----------------------  (bound to DeviceData "brightness")
-+-- [not bound to linkquality -- it's a technical metric, not user-facing]
-```
-
-### 6.3 Constraints
-
-- `UNIQUE(equipment_id, alias)` -- each alias is unique per Equipment
-- When DeviceData changes, the Equipment's bound alias reflects the new value immediately
-- The alias is used in expressions, UI display, Zone aggregation, and Scenario conditions
-
-### 6.4 SQLite Schema
-
-```sql
-CREATE TABLE data_bindings (
-  id TEXT PRIMARY KEY,
-  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
-  device_data_id TEXT NOT NULL REFERENCES device_data(id) ON DELETE CASCADE,
-  alias TEXT NOT NULL,
-  UNIQUE(equipment_id, alias)
-);
-```
-
----
-
-## 7. Order Binding
-
-An **OrderBinding** maps a Device Order to an Equipment-level command alias.
-
-### 7.1 Interface
-
-```typescript
-interface OrderBinding {
-  id: string; // UUID v4
-  equipmentId: string; // FK -> Equipment
-  deviceOrderId: string; // FK -> DeviceOrder
-  alias: string; // Equipment-level command: "turn_on", "set_brightness"
-}
-```
-
-### 7.2 How It Works
-
-When an Equipment Order is executed:
-
-```
-User clicks "Turn On" on Equipment "Spots Salon"
-  -> API: POST /equipments/:id/orders/turn_on { value: true }
-    -> Equipment Manager finds OrderBinding alias="turn_on"
-      -> Resolves to DeviceOrder
-        -> Integration Plugin dispatches command to device
-```
-
-### 7.3 Multi-Device Dispatch
-
-An Equipment can have multiple OrderBindings with the **same alias** pointing to different Devices. This enables controlling multiple devices with a single command:
-
-```
-Equipment "Eclairage Cuisine"
-+-- OrderBinding: alias="turn_on" -> DeviceOrder on Relais #1
-+-- OrderBinding: alias="turn_on" -> DeviceOrder on Relais #2
-```
-
-Executing `turn_on` dispatches to BOTH relays in parallel.
-
-**Schema constraint note:** For multi-device dispatch, the UNIQUE constraint is on `(equipment_id, alias, device_order_id)` -- not just `(equipment_id, alias)`.
-
-### 7.4 SQLite Schema
-
-```sql
-CREATE TABLE order_bindings (
-  id TEXT PRIMARY KEY,
-  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
-  device_order_id TEXT NOT NULL REFERENCES device_orders(id) ON DELETE CASCADE,
-  alias TEXT NOT NULL,
-  UNIQUE(equipment_id, alias, device_order_id)
-);
-```
-
----
-
-## 8. Device (Layer 3 -- Physical)
-
-Devices are auto-discovered from configured integrations (Zigbee2MQTT, Panasonic CC, MCZ Maestro, Netatmo HC, etc.). They are documented here for completeness.
-
-### 8.1 Interface
-
-```typescript
-interface Device {
-  id: string; // UUID v4
-  mqttBaseTopic: string; // Integration-specific topic or identifier
-  mqttName: string; // Integration-specific name or ID
-  name: string; // User-editable display name
-  manufacturer?: string; // "Aqara", "IKEA", "Panasonic", "MCZ"
-  model?: string; // "MCCGQ11LM", "CS-Z25VKEW", etc.
-  ieeeAddress?: string; // Hardware address (Zigbee IEEE, serial, etc.)
-  source: DeviceSource; // "zigbee2mqtt" | "panasonic_cc" | "mcz_maestro" | "netatmo_hc" | ...
-  status: DeviceStatus; // "online" | "offline" | "unknown"
-  lastSeen: string | null; // ISO 8601
-  rawExpose?: unknown; // Raw integration-specific metadata
-  createdAt: string;
-  updatedAt: string;
-}
-```
-
-### 8.2 DeviceData
-
-```typescript
-interface DeviceData {
-  id: string;
-  deviceId: string; // FK -> Device
-  key: string; // Property name: "temperature", "state", "brightness"
-  type: DataType; // "boolean" | "number" | "enum" | "text" | "json"
-  category: DataCategory; // Semantic category for aggregation rules
-  value: unknown; // Current value
-  unit?: string; // "C", "%", "lx", "W"
-  lastUpdated: string | null;
-}
-```
-
-### 8.3 DeviceOrder
-
-```typescript
-interface DeviceOrder {
-  id: string;
-  deviceId: string; // FK -> Device
-  key: string; // "state", "brightness", "position"
-  type: DataType;
-  mqttSetTopic: string; // MQTT topic to publish to
-  payloadKey: string; // Key in the JSON payload
-  min?: number; // For numeric: minimum value
-  max?: number; // For numeric: maximum value
-  enumValues?: string[]; // For enum: allowed values
-  unit?: string;
-}
-```
-
----
-
-## 9. Computed Data (V0.5)
-
-> **Deferred to V0.5** -- documented here as part of the complete data model.
-
-A **ComputedData** is a virtual data point on an Equipment whose value is derived from an expression over other data sources.
-
-### 9.1 Interface
-
-```typescript
-interface ComputedData {
-  id: string; // UUID v4
-  equipmentId: string; // FK -> Equipment
-  key: string; // "state", "average_temperature", "motion"
-  type: DataType;
-  category: DataCategory; // Used by Zone aggregation
-  expression: string; // Computation expression
-  value: unknown; // Current computed value
-}
-```
-
-### 9.2 Expression Language
-
-```
-// Boolean
-OR(binding.motion_1, binding.motion_2)
-AND(binding.door, binding.window)
-NOT(binding.occupancy)
-
-// Numeric
-AVG(binding.temp_1, binding.temp_2)
-MIN(binding.temp_1, binding.temp_2)
-MAX(binding.temp_1, binding.temp_2)
-SUM(binding.power_1, binding.power_2)
-
-// Conditional
-IF(binding.brightness > 0, "on", "off")
-THRESHOLD(binding.temperature, 19, "cold", "ok")
-
-// References
-binding.<alias>                        -> DataBinding on the same Equipment
-equipment.<equipmentId>.<alias>        -> Data on another Equipment
-zone.<zoneId>.<key>                    -> Zone aggregated Data
-```
-
----
-
-## 10. Reactive Data Flow
+## 4. Reactive Data Flow
 
 The complete event-driven pipeline:
 
 ```
-Integration event (MQTT message, cloud API poll, etc.)
+Integration message (MQTT, cloud API poll, etc.)
   |
   v
 Integration Plugin (receives + parses)
   |
   v
-Device Manager (updates DeviceData)
+Device Manager (updates DeviceData, persists, emits)
   |
   +--> Event: "device.data.updated"
   |
   v
 Equipment Manager
-  +-- Updates bound Equipment Data (via DataBindings)
-  +-- [V0.5] Re-evaluates ComputedData expressions
+  +-- Updates bound aliases via DataBindings
+  +-- Pulls ComputedDataEntry from registered providers (energy, pool, ...)
   |
   +--> Event: "equipment.data.changed"
   |
+  +--> Button Action Manager (if alias=="action")
+  |     +-- Dispatches: mode activate/toggle, equipment order, recipe toggle, zone order
+  |
   v
 Zone Aggregator
-  +-- Re-computes Zone aggregated data
-  +-- Re-computes Group aggregated data
-  +-- Propagates up the zone hierarchy (recursive)
+  +-- Recomputes Zone aggregated data, propagates up the tree
   |
   +--> Event: "zone.data.changed"
   |
   v
-Scenario Engine (V0.7)
-  +-- Evaluates triggers
-  +-- Checks conditions
-  +-- Executes actions
+Recipe Engine
+  +-- Each running RecipeInstance reacts via its createInstance() handle
+  +-- May emit equipment orders (back into the equipment manager)
   |
-  +--> Actions may dispatch Equipment/Zone Orders -> Integration Plugin -> device
+  +--> Events: "recipe.instance.state.changed" / ".error"
   |
   v
-WebSocket Server
-  +-- Broadcasts all events to connected UI clients
+Side effects (parallel, all subscribe to the bus)
+  +-- WebSocket Server                 -> pushes events to UI clients
+  +-- History Writer                   -> writes points to InfluxDB
+  +-- MQTT Publishers                  -> emit on configured outbound topics
+  +-- Notification Publishers          -> Telegram/webhook on threshold
+
+Mode/Calendar/Button paths:
+  CalendarManager (cron)  -> ModeManager.activate/deactivate
+  ButtonActionBinding     -> ModeManager / EquipmentManager / RecipeManager / Zone order
+  ModeManager.activate    -> equipment orders + recipe toggles + recipe param updates
 ```
 
 ---
 
-## 11. Event Bus Events
+## 5. Event Bus Events
 
-All events are typed via TypeScript discriminated unions.
+All events are typed via `EngineEvent`, a TypeScript discriminated union. Handlers must never throw (wrap in try/catch + structured log).
 
-### System Events
+### System
 
-| Event                      | Payload         | When                  |
-| -------------------------- | --------------- | --------------------- |
-| `system.started`           | --              | Engine boot complete  |
-| `system.mqtt.connected`    | --              | MQTT broker connected |
-| `system.mqtt.disconnected` | --              | MQTT broker lost      |
-| `system.error`             | `error: string` | Unrecoverable error   |
+| Event                             | Payload                           |
+| --------------------------------- | --------------------------------- |
+| `system.started`                  | --                                |
+| `system.integration.connected`    | `integrationId`                   |
+| `system.integration.disconnected` | `integrationId`                   |
+| `system.error`                    | `error`                           |
+| `system.alarm.raised`             | `alarmId, level, source, message` |
+| `system.alarm.resolved`           | `alarmId, source, message`        |
+| `system.update.available`         | `current, latest, releaseUrl`     |
+| `system.update.progress`          | `step, message`                   |
+| `system.update.error`             | `error`                           |
+| `system.restart_required`         | `reason`                          |
 
-### Device Events (V0.1)
+### Device
 
-| Event                   | Payload                                              | When             |
-| ----------------------- | ---------------------------------------------------- | ---------------- |
-| `device.discovered`     | `device: Device`                                     | New device found |
-| `device.removed`        | `deviceId, deviceName`                               | Device deleted   |
-| `device.status_changed` | `deviceId, deviceName, status`                       | Online/offline   |
-| `device.data.updated`   | `deviceId, deviceName, dataId, key, value, previous` | Property change  |
+| Event                   | Payload                                                                           |
+| ----------------------- | --------------------------------------------------------------------------------- |
+| `device.discovered`     | `device: Device`                                                                  |
+| `device.removed`        | `deviceId, deviceName`                                                            |
+| `device.status_changed` | `deviceId, deviceName, status`                                                    |
+| `device.data.updated`   | `deviceId, deviceName, dataId, key, value, previous, timestamp, sourceTimestamp?` |
+| `device.heartbeat`      | `deviceId, timestamp`                                                             |
 
-### Equipment Events (V0.3)
+### Zone
 
-| Event                      | Payload                             | When               |
-| -------------------------- | ----------------------------------- | ------------------ |
-| `equipment.data.changed`   | `equipmentId, key, value, previous` | Bound data changed |
-| `equipment.order.executed` | `equipmentId, orderAlias, value`    | Order dispatched   |
+| Event               | Payload                                      |
+| ------------------- | -------------------------------------------- |
+| `zone.created`      | `zone: Zone`                                 |
+| `zone.updated`      | `zone: Zone`                                 |
+| `zone.removed`      | `zoneId, zoneName`                           |
+| `zone.data.changed` | `zoneId, aggregatedData: ZoneAggregatedData` |
 
-### Zone Events (V0.3+)
+### Equipment
 
-| Event               | Payload                        | When                    |
-| ------------------- | ------------------------------ | ----------------------- |
-| `zone.data.changed` | `zoneId, key, value, previous` | Aggregated data changed |
+| Event                      | Payload                                                 |
+| -------------------------- | ------------------------------------------------------- |
+| `equipment.created`        | `equipment: Equipment`                                  |
+| `equipment.updated`        | `equipment: Equipment`                                  |
+| `equipment.removed`        | `equipmentId, equipmentName, zoneId`                    |
+| `equipment.data.changed`   | `equipmentId, alias, value, previous, sourceTimestamp?` |
+| `equipment.order.executed` | `equipmentId, orderAlias, value`                        |
+| `equipment.order.failed`   | `equipmentId, orderAlias, value, error`                 |
 
----
+### Recipe
 
-## 12. Complete SQLite Schema
+| Event                           | Payload                       |
+| ------------------------------- | ----------------------------- |
+| `recipe.instance.created`       | `instanceId, recipeId`        |
+| `recipe.instance.removed`       | `instanceId, recipeId`        |
+| `recipe.instance.started`       | `instanceId, recipeId`        |
+| `recipe.instance.stopped`       | `instanceId, recipeId`        |
+| `recipe.instance.state.changed` | `instanceId, recipeId`        |
+| `recipe.instance.error`         | `instanceId, recipeId, error` |
 
-```sql
--- ============================================================
--- ZONES (V0.2)
--- ============================================================
-CREATE TABLE zones (
-  id TEXT PRIMARY KEY,
-  name TEXT NOT NULL,
-  parent_id TEXT REFERENCES zones(id) ON DELETE SET NULL,
-  icon TEXT,
-  description TEXT,
-  display_order INTEGER DEFAULT 0,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
+### Mode / Calendar / Sunlight / Settings
 
--- ============================================================
--- EQUIPMENT GROUPS (V0.2)
--- ============================================================
-CREATE TABLE equipment_groups (
-  id TEXT PRIMARY KEY,
-  name TEXT NOT NULL,
-  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
-  icon TEXT,
-  description TEXT,
-  display_order INTEGER DEFAULT 0,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
+| Event                      | Payload                  |
+| -------------------------- | ------------------------ |
+| `mode.created`             | `mode: Mode`             |
+| `mode.updated`             | `mode: Mode`             |
+| `mode.removed`             | `modeId, modeName`       |
+| `mode.activated`           | `modeId, modeName`       |
+| `mode.deactivated`         | `modeId, modeName`       |
+| `calendar.profile.changed` | `profileId, profileName` |
+| `sunlight.changed`         | --                       |
+| `settings.changed`         | `keys: string[]`         |
 
--- ============================================================
--- DEVICES (V0.1 -- existing)
--- ============================================================
-CREATE TABLE devices (
-  id TEXT PRIMARY KEY,
-  mqtt_base_topic TEXT NOT NULL UNIQUE,
-  mqtt_name TEXT NOT NULL,
-  name TEXT NOT NULL,
-  manufacturer TEXT,
-  model TEXT,
-  ieee_address TEXT,
-  source TEXT NOT NULL,  -- integration source: 'zigbee2mqtt', 'panasonic_cc', 'mcz_maestro', 'netatmo_hc', ...
-  status TEXT NOT NULL DEFAULT 'unknown',
-  last_seen DATETIME,
-  raw_expose JSON,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
+### MQTT / Notification publishers
 
-CREATE TABLE device_data (
-  id TEXT PRIMARY KEY,
-  device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
-  key TEXT NOT NULL,
-  type TEXT NOT NULL,
-  category TEXT NOT NULL DEFAULT 'generic',
-  value TEXT,
-  unit TEXT,
-  last_updated DATETIME,
-  UNIQUE(device_id, key)
-);
-
-CREATE TABLE device_orders (
-  id TEXT PRIMARY KEY,
-  device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
-  key TEXT NOT NULL,
-  type TEXT NOT NULL,
-  mqtt_set_topic TEXT NOT NULL,
-  payload_key TEXT NOT NULL,
-  min_value REAL,
-  max_value REAL,
-  enum_values JSON,
-  unit TEXT,
-  UNIQUE(device_id, key)
-);
-
--- ============================================================
--- EQUIPMENTS (V0.3)
--- ============================================================
-CREATE TABLE equipments (
-  id TEXT PRIMARY KEY,
-  name TEXT NOT NULL,
-  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
-  group_id TEXT REFERENCES equipment_groups(id) ON DELETE SET NULL,
-  type TEXT NOT NULL DEFAULT 'generic',
-  icon TEXT,
-  description TEXT,
-  enabled INTEGER DEFAULT 1,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TABLE data_bindings (
-  id TEXT PRIMARY KEY,
-  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
-  device_data_id TEXT NOT NULL REFERENCES device_data(id) ON DELETE CASCADE,
-  alias TEXT NOT NULL,
-  UNIQUE(equipment_id, alias)
-);
-
-CREATE TABLE order_bindings (
-  id TEXT PRIMARY KEY,
-  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
-  device_order_id TEXT NOT NULL REFERENCES device_orders(id) ON DELETE CASCADE,
-  alias TEXT NOT NULL,
-  UNIQUE(equipment_id, alias, device_order_id)
-);
-
--- ============================================================
--- COMPUTED DATA (V0.5)
--- ============================================================
-CREATE TABLE computed_data (
-  id TEXT PRIMARY KEY,
-  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
-  key TEXT NOT NULL,
-  type TEXT NOT NULL,
-  category TEXT NOT NULL DEFAULT 'generic',
-  expression TEXT NOT NULL,
-  value TEXT,
-  UNIQUE(equipment_id, key)
-);
-
--- ============================================================
--- INTERNAL RULES (V0.5)
--- ============================================================
-CREATE TABLE internal_rules (
-  id TEXT PRIMARY KEY,
-  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
-  name TEXT NOT NULL,
-  condition_expr TEXT NOT NULL,
-  action_expr TEXT NOT NULL,
-  enabled INTEGER DEFAULT 1
-);
-
--- ============================================================
--- RECIPES (V0.8)
--- ============================================================
-CREATE TABLE recipe_instances (
-  id TEXT PRIMARY KEY,
-  recipe_id TEXT NOT NULL,
-  params JSON NOT NULL DEFAULT '{}',
-  enabled INTEGER DEFAULT 1,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TABLE recipe_state (
-  instance_id TEXT NOT NULL REFERENCES recipe_instances(id) ON DELETE CASCADE,
-  key TEXT NOT NULL,
-  value TEXT,
-  PRIMARY KEY (instance_id, key)
-);
-
-CREATE TABLE recipe_log (
-  id TEXT PRIMARY KEY,
-  instance_id TEXT NOT NULL REFERENCES recipe_instances(id) ON DELETE CASCADE,
-  level TEXT NOT NULL DEFAULT 'info',
-  message TEXT NOT NULL,
-  data JSON,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
-
--- ============================================================
--- USERS & AUTH
--- ============================================================
-CREATE TABLE users (
-  id TEXT PRIMARY KEY,
-  username TEXT UNIQUE NOT NULL,
-  display_name TEXT NOT NULL,
-  password_hash TEXT NOT NULL,
-  role TEXT NOT NULL DEFAULT 'standard',
-  preferences JSON DEFAULT '{}',
-  enabled INTEGER DEFAULT 1,
-  last_login_at DATETIME,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TABLE api_tokens (
-  id TEXT PRIMARY KEY,
-  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  name TEXT NOT NULL,
-  token_hash TEXT NOT NULL,
-  last_used_at DATETIME,
-  expires_at DATETIME,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TABLE refresh_tokens (
-  id TEXT PRIMARY KEY,
-  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  token_hash TEXT NOT NULL,
-  expires_at DATETIME NOT NULL,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
-
--- ============================================================
--- SETTINGS (key-value store for integration config)
--- ============================================================
-CREATE TABLE settings (
-  key TEXT PRIMARY KEY,
-  value TEXT NOT NULL,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
-```
+| Event                                         | Payload                                              |
+| --------------------------------------------- | ---------------------------------------------------- |
+| `mqtt-broker.created` / `.updated`            | `broker: MqttBroker`                                 |
+| `mqtt-broker.removed`                         | `brokerId`                                           |
+| `mqtt-publisher.created` / `.updated`         | `publisher: MqttPublisher`                           |
+| `mqtt-publisher.removed`                      | `publisherId, publisherName`                         |
+| `mqtt-publisher.mapping.created`              | `publisherId, mapping: MqttPublisherMapping`         |
+| `mqtt-publisher.mapping.removed`              | `publisherId, mappingId`                             |
+| `notification-publisher.created` / `.updated` | `publisher: NotificationPublisher`                   |
+| `notification-publisher.removed`              | `publisherId, publisherName`                         |
+| `notification-publisher.mapping.created`      | `publisherId, mapping: NotificationPublisherMapping` |
+| `notification-publisher.mapping.removed`      | `publisherId, mappingId`                             |
 
 ---
 
-## 13. API Endpoints Summary
+## 6. API Endpoints Summary
 
-### Zones (V0.2)
+This is a non-exhaustive index. See [API Reference](api-reference.md) for the full surface.
 
-| Method | Route               | Description                                    |
-| ------ | ------------------- | ---------------------------------------------- |
-| GET    | `/api/v1/zones`     | List all zones (tree structure)                |
-| GET    | `/api/v1/zones/:id` | Get zone with aggregated data                  |
-| POST   | `/api/v1/zones`     | Create zone                                    |
-| PUT    | `/api/v1/zones/:id` | Update zone                                    |
-| DELETE | `/api/v1/zones/:id` | Delete zone (must have no children/equipments) |
+### Zones
 
-### Equipment Groups (V0.2)
+| Method | Route                                | Description                     |
+| ------ | ------------------------------------ | ------------------------------- |
+| GET    | `/api/v1/zones`                      | List all zones (tree structure) |
+| GET    | `/api/v1/zones/:id`                  | Get zone with aggregated data   |
+| POST   | `/api/v1/zones`                      | Create zone                     |
+| PUT    | `/api/v1/zones/:id`                  | Update zone                     |
+| DELETE | `/api/v1/zones/:id`                  | Delete zone                     |
+| POST   | `/api/v1/zones/:id/orders/:orderKey` | Execute zone-level bulk order   |
 
-| Method | Route                          | Description            |
-| ------ | ------------------------------ | ---------------------- |
-| GET    | `/api/v1/zones/:zoneId/groups` | List groups in a zone  |
-| POST   | `/api/v1/zones/:zoneId/groups` | Create group in a zone |
-| PUT    | `/api/v1/groups/:id`           | Update group           |
-| DELETE | `/api/v1/groups/:id`           | Delete group           |
+### Equipments
 
-### Equipments (V0.3)
+| Method | Route                                  | Description                        |
+| ------ | -------------------------------------- | ---------------------------------- |
+| GET    | `/api/v1/equipments`                   | List all equipments                |
+| GET    | `/api/v1/equipments/:id`               | Get equipment with bindings + data |
+| POST   | `/api/v1/equipments`                   | Create equipment                   |
+| PUT    | `/api/v1/equipments/:id`               | Update equipment                   |
+| DELETE | `/api/v1/equipments/:id`               | Delete equipment                   |
+| POST   | `/api/v1/equipments/:id/orders/:alias` | Execute an equipment order         |
 
-| Method | Route                                  | Description                                  |
-| ------ | -------------------------------------- | -------------------------------------------- |
-| GET    | `/api/v1/equipments`                   | List all equipments                          |
-| GET    | `/api/v1/equipments/:id`               | Get equipment with bindings and current data |
-| POST   | `/api/v1/equipments`                   | Create equipment                             |
-| PUT    | `/api/v1/equipments/:id`               | Update equipment                             |
-| DELETE | `/api/v1/equipments/:id`               | Delete equipment                             |
-| POST   | `/api/v1/equipments/:id/orders/:alias` | Execute an equipment order                   |
+### Devices, Plugins, History
 
-### Zone Orders (V0.3+)
+| Method | Route                     | Description                             |
+| ------ | ------------------------- | --------------------------------------- |
+| GET    | `/api/v1/devices`         | List discovered devices                 |
+| GET    | `/api/v1/devices/:id`     | Device with data + orders               |
+| GET    | `/api/v1/integrations`    | Runtime integration status              |
+| GET    | `/api/v1/plugins`         | Installed plugins (manifest + status)   |
+| POST   | `/api/v1/plugins/install` | Install a plugin from registry / GitHub |
+| DELETE | `/api/v1/plugins/:id`     | Uninstall plugin                        |
+| GET    | `/api/v1/history`         | Time-series history query               |
 
-| Method | Route                                 | Description                                       |
-| ------ | ------------------------------------- | ------------------------------------------------- |
-| POST   | `/api/v1/zones/:id/orders/:orderKey`  | Execute zone auto-order (allOff, allLightsOff...) |
-| POST   | `/api/v1/groups/:id/orders/:orderKey` | Execute group order                               |
+### Modes / Recipes / Calendar / Buttons
 
-For the complete API reference, see [API Reference](api-reference.md).
+| Method | Route                                    | Description                       |
+| ------ | ---------------------------------------- | --------------------------------- |
+| GET    | `/api/v1/modes`                          | List modes                        |
+| POST   | `/api/v1/modes`                          | Create mode                       |
+| POST   | `/api/v1/modes/:id/activate`             | Activate a mode (apply impacts)   |
+| POST   | `/api/v1/modes/:id/deactivate`           | Deactivate a mode                 |
+| PUT    | `/api/v1/modes/:id/zones/:zoneId/impact` | Set the zone-impact for a mode    |
+| GET    | `/api/v1/recipes`                        | List available recipe definitions |
+| POST   | `/api/v1/recipes/:recipeId/instances`    | Create a recipe instance          |
+| GET    | `/api/v1/recipes/instances/:id`          | Get instance + recent log         |
+| GET    | `/api/v1/calendar/profiles`              | List calendar profiles            |
+| PUT    | `/api/v1/calendar/active`                | Switch active profile             |
+| POST   | `/api/v1/calendar/profiles/:id/slots`    | Add a scheduling slot             |
+| GET    | `/api/v1/button-actions`                 | List button bindings              |
+| POST   | `/api/v1/button-actions`                 | Create a button binding           |
 
----
+### MQTT / Notifications / Dashboard / Charts
 
-## 14. Implementation Roadmap
+| Method | Route                                 | Description                         |
+| ------ | ------------------------------------- | ----------------------------------- |
+| \*     | `/api/v1/mqtt-brokers/...`            | CRUD MQTT brokers                   |
+| \*     | `/api/v1/mqtt-publishers/...`         | CRUD MQTT publishers + mappings     |
+| \*     | `/api/v1/notification-publishers/...` | CRUD notification publishers        |
+| \*     | `/api/v1/dashboard/...`               | Dashboard widgets                   |
+| \*     | `/api/v1/charts/...`                  | Saved chart configs                 |
+| \*     | `/api/v1/energy/...`                  | Energy dashboard, history, by-usage |
 
-| Version   | Entities Implemented                                               |
-| --------- | ------------------------------------------------------------------ |
-| **V0.1**  | Device, DeviceData, DeviceOrder                                    |
-| **V0.2**  | Zone, EquipmentGroup (CRUD + UI)                                   |
-| **V0.3**  | Equipment, DataBinding, OrderBinding (CRUD + Order execution + UI) |
-| **V0.5**  | ComputedData, InternalRule                                         |
-| **V0.3+** | Zone aggregation engine, Zone auto-orders                          |
+For the complete and authoritative reference, see [API Reference](api-reference.md).

--- a/docs/technical/data-model/devices.md
+++ b/docs/technical/data-model/devices.md
@@ -1,0 +1,204 @@
+# Devices
+
+> **Layer 3 -- Physical**: hardware discovered from integration plugins, with their raw data and orders. Never directly manipulated by the end user.
+>
+> See also: [Equipments](equipments.md) for the user-facing layer that binds to devices.
+
+## Device
+
+Devices are auto-discovered by integration plugins. They are documented here for completeness; users do not create them manually.
+
+### 1 Interface
+
+```typescript
+type DeviceSource =
+  | "zigbee2mqtt"
+  | "lora2mqtt"
+  | "tasmota"
+  | "esphome"
+  | "shelly"
+  | "custom_mqtt"
+  | "panasonic_cc"
+  | "mcz_maestro"
+  | "netatmo_hc";
+
+type DeviceStatus = "online" | "offline" | "unknown";
+
+interface Device {
+  id: string; // UUID v4 (Sowel-internal)
+  integrationId: string; // Plugin id that owns this device (e.g. "zigbee2mqtt")
+  sourceDeviceId: string; // Plugin-side stable id (e.g. friendly_name, serial)
+  name: string; // User-editable display name
+  manufacturer?: string;
+  model?: string;
+  ieeeAddress?: string; // Hardware address (Zigbee IEEE, MAC, etc.)
+  zoneId: string | null; // Optional placement (used by integrations for context)
+  source: DeviceSource;
+  status: DeviceStatus;
+  lastSeen: string | null; // ISO 8601
+  rawExpose?: unknown; // Raw plugin-specific metadata
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+The pair `(integrationId, sourceDeviceId)` is unique across all devices and is the natural key used by plugins on rediscovery.
+
+### 2 DeviceData
+
+```typescript
+interface DeviceData {
+  id: string;
+  deviceId: string;
+  key: string; // Plugin-side property name
+  type: DataType;
+  category: DataCategory; // Drives binding suggestions and aggregation
+  value: unknown;
+  unit?: string;
+  lastUpdated: string | null;
+}
+```
+
+### 3 DeviceOrder
+
+```typescript
+interface DeviceOrder {
+  id: string;
+  deviceId: string;
+  key: string; // Plugin-side command name
+  type: DataType;
+  category?: OrderCategory; // Semantic category, drives equipment-level aliasing
+  min?: number;
+  max?: number;
+  enumValues?: string[];
+  unit?: string;
+}
+```
+
+> **Note**: earlier versions exposed MQTT-specific fields (`mqttSetTopic`, `payloadKey`, `dispatch_config`) on `DeviceOrder`. These are no longer part of the runtime API. Migration `004_drop_dispatch_config.sql` deprecated them; the underlying SQLite columns remain (SQLite cannot drop columns without rebuilding the table) but are ignored. Order delivery is now fully delegated to the integration plugin via `IntegrationPlugin.executeOrder()`.
+
+### 4 DataType / DataCategory / OrderCategory
+
+```typescript
+type DataType = "boolean" | "number" | "enum" | "text" | "json";
+
+type DataCategory =
+  | "motion"
+  | "temperature"
+  | "humidity"
+  | "pressure"
+  | "luminosity"
+  | "contact_door"
+  | "contact_window"
+  | "light_state"
+  | "light_brightness"
+  | "light_color_temp"
+  | "light_color"
+  | "shutter_position"
+  | "lock_state"
+  | "battery"
+  | "power"
+  | "energy"
+  | "voltage"
+  | "current"
+  | "water_leak"
+  | "smoke"
+  | "co2"
+  | "voc"
+  | "noise"
+  | "rain"
+  | "wind"
+  | "action"
+  | "gate_state"
+  | "cover_state"
+  | "runtime_daily"
+  | "weather_condition"
+  | "uv"
+  | "solar_radiation"
+  | "setpoint"
+  | "temperature_outdoor"
+  | "humidity_outdoor"
+  | "media_volume"
+  | "media_mute"
+  | "media_input"
+  | "appliance_state"
+  | "pool_water_temperature"
+  | "pool_temperature_setpoint"
+  | "generic";
+
+type OrderCategory =
+  | "light_toggle"
+  | "set_brightness"
+  | "set_color_temp"
+  | "set_color"
+  | "shutter_move"
+  | "set_shutter_position"
+  | "toggle_power"
+  | "set_setpoint"
+  | "gate_trigger"
+  | "valve_toggle"
+  | "toggle_mute"
+  | "set_input"
+  | "pool_pump_toggle"
+  | "pool_cover_move"
+  | "pool_cover_position"
+  | "set_pool_temperature_setpoint";
+```
+
+### 5 SQLite Schema
+
+```sql
+CREATE TABLE devices (
+  id TEXT PRIMARY KEY,
+  mqtt_base_topic TEXT,        -- legacy, kept for migration compatibility
+  mqtt_name TEXT,              -- legacy, kept for migration compatibility
+  name TEXT NOT NULL,
+  manufacturer TEXT,
+  model TEXT,
+  ieee_address TEXT,
+  zone_id TEXT,
+  source TEXT NOT NULL DEFAULT 'zigbee2mqtt',
+  status TEXT NOT NULL DEFAULT 'unknown',
+  last_seen DATETIME,
+  raw_expose JSON,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  integration_id TEXT NOT NULL DEFAULT '',
+  source_device_id TEXT NOT NULL DEFAULT ''
+);
+CREATE UNIQUE INDEX idx_devices_integration_source
+  ON devices(integration_id, source_device_id);
+
+CREATE TABLE device_data (
+  id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  type TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'generic',
+  unit TEXT,
+  value TEXT,
+  last_updated DATETIME,
+  last_changed TEXT,
+  enum_values JSON,
+  UNIQUE(device_id, key)
+);
+
+CREATE TABLE device_orders (
+  id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  type TEXT NOT NULL,
+  category TEXT,
+  min_value REAL,
+  max_value REAL,
+  enum_values JSON,
+  unit TEXT,
+  -- Legacy columns kept for backward compatibility (ignored at runtime):
+  mqtt_set_topic TEXT,
+  payload_key TEXT,
+  dispatch_config JSON NOT NULL DEFAULT '{}',
+  UNIQUE(device_id, key)
+);
+```
+
+---

--- a/docs/technical/data-model/equipments.md
+++ b/docs/technical/data-model/equipments.md
@@ -1,0 +1,250 @@
+# Equipments
+
+> **Layer 2 -- Functional**: the user-facing functional units. Each equipment lives in a Zone and binds to one or more physical Devices through aliases.
+>
+> See also: [Devices](devices.md) for the physical layer underneath.
+
+## Equipment
+
+An **Equipment** is the user-facing functional unit. It is the primary entity users interact with in the UI, recipes, and external integrations (MQTT publishers, notifications).
+
+### 1 Interface
+
+```typescript
+type EquipmentType =
+  | "light_onoff"
+  | "light_dimmable"
+  | "light_color"
+  | "shutter"
+  | "switch"
+  | "sensor"
+  | "button"
+  | "thermostat"
+  | "weather"
+  | "weather_forecast"
+  | "gate"
+  | "heater"
+  | "energy_meter"
+  | "main_energy_meter"
+  | "energy_production_meter"
+  | "media_player"
+  | "appliance"
+  | "water_valve"
+  | "pool_pump"
+  | "pool_cover"
+  | "pool_heat_pump";
+
+interface Equipment {
+  id: string; // UUID v4
+  name: string;
+  zoneId: string; // FK -> Zone (where the equipment functions)
+  type: EquipmentType; // Drives UI rendering, aggregation, valid orders
+  icon?: string; // Lucide icon name (overrides type default)
+  description?: string;
+  enabled: boolean; // Disabled equipments are ignored by the engine
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### 2 Equipment vs Device
+
+|                      | Device                              | Equipment                         |
+| -------------------- | ----------------------------------- | --------------------------------- |
+| **Nature**           | Physical hardware                   | Functional abstraction            |
+| **Discovery**        | Auto-discovered from a plugin       | Manually created by user          |
+| **Identity**         | `(integrationId, sourceDeviceId)`   | UUID + user-chosen name           |
+| **Location**         | Optional `zoneId` (where installed) | Required `zoneId` (where used)    |
+| **Cardinality**      | 1 Device -> N Equipments possible   | 1 Equipment -> N Devices possible |
+| **User interaction** | Never (technical layer)             | Always (primary interface)        |
+
+**Examples:**
+
+- 1 Device -> 1 Equipment: Aqara temperature sensor -> "Temperature Cuisine"
+- 1 Device -> N Equipments: Double relay -> "Lumiere Cuisine" + "Lumiere Cellier"
+- N Devices -> 1 Equipment: 3 PIR sensors -> "Detection Cuisine" (via multiple `motion`-aliased DataBindings)
+
+### 3 Equipment with details
+
+```typescript
+interface EquipmentWithDetails extends Equipment {
+  dataBindings: DataBindingWithValue[];
+  orderBindings: OrderBindingWithDetails[];
+  /** Provider-supplied virtual data (e.g. energy aggregator cumuls). */
+  computedData?: ComputedDataEntry[];
+}
+```
+
+### 4 SQLite Schema
+
+```sql
+CREATE TABLE equipments (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+  type TEXT NOT NULL DEFAULT 'generic',
+  icon TEXT,
+  description TEXT,
+  enabled INTEGER DEFAULT 1,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+---
+
+## Data Binding
+
+A **DataBinding** maps a `DeviceData` row to an Equipment-level alias. The alias is the stable name used in the UI, recipes, and history queries.
+
+### 1 Interface
+
+```typescript
+interface DataBinding {
+  id: string;
+  equipmentId: string; // FK -> Equipment
+  deviceDataId: string; // FK -> DeviceData
+  alias: string; // Equipment-level name: "state", "brightness", "temperature"
+  /** NULL = follow category default. 1 = force historize ON. 0 = force OFF. */
+  historize?: number | null;
+}
+
+interface DataBindingWithValue extends DataBinding {
+  deviceId: string;
+  deviceName: string;
+  key: string;
+  type: DataType;
+  category: DataCategory;
+  value: unknown;
+  unit?: string;
+  enumValues?: string[];
+  lastUpdated: string | null;
+  lastChanged: string | null;
+  historize?: number | null;
+}
+```
+
+### 2 How It Works
+
+```
+Device "Variateur #1"
++-- DeviceData: key="state",       category=light_state       <--+
++-- DeviceData: key="brightness",  category=light_brightness  <--+ DataBinding
++-- DeviceData: key="linkquality", category=generic              |
+                                                                  |
+Equipment "Spots Cuisine"                                         |
++-- alias "state"      ----------------------------------------- +
++-- alias "brightness" -----------------------------------------
+```
+
+### 3 Constraints
+
+- `UNIQUE(equipment_id, alias)` -- each alias is unique per Equipment.
+- When `DeviceData.value` changes, the bound alias reflects the new value immediately and `equipment.data.changed` is emitted.
+- The alias is used in zone aggregation (looked up by `category`), recipe slots, MQTT publisher mappings, notification mappings, history queries, and chart series.
+
+### 4 Historization control
+
+Each binding may override the default historization decision per category. Resolution order: explicit `historize` override -> alias name default -> category default. `effectiveOn` is exposed via `HistoryBindingState`.
+
+### 5 SQLite Schema
+
+```sql
+CREATE TABLE data_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  device_data_id TEXT NOT NULL REFERENCES device_data(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL,
+  historize INTEGER DEFAULT NULL,
+  UNIQUE(equipment_id, alias)
+);
+```
+
+---
+
+## Order Binding
+
+An **OrderBinding** maps a `DeviceOrder` to an Equipment-level command alias.
+
+### 1 Interface
+
+```typescript
+interface OrderBinding {
+  id: string;
+  equipmentId: string;
+  deviceOrderId: string;
+  alias: string; // Equipment-level command: "turn_on", "set_brightness"
+}
+
+interface OrderBindingWithDetails extends OrderBinding {
+  deviceId: string;
+  deviceName: string;
+  key: string;
+  type: DataType;
+  category?: OrderCategory;
+  min?: number;
+  max?: number;
+  enumValues?: string[];
+  unit?: string;
+}
+```
+
+### 2 Multi-Device Dispatch
+
+An Equipment can have multiple OrderBindings sharing the **same alias** but pointing to different Devices. Executing the alias dispatches to all of them in parallel:
+
+```
+Equipment "Eclairage Cuisine"
++-- OrderBinding alias="state" -> DeviceOrder on Relais #1
++-- OrderBinding alias="state" -> DeviceOrder on Relais #2
+```
+
+<!-- MISMATCH: src/shared/types.ts comments suggested UNIQUE(equipment_id, alias, device_order_id) for multi-dispatch, but the live migration 001_initial.sql declares UNIQUE(equipment_id, alias). Multi-device dispatch in the current code is achieved by EquipmentManager iterating bindings and matching the alias across multiple device orders -- not by storing multiple rows with the same alias. Verify before relying on multi-row dispatch. -->
+
+### 3 Per-binding category override
+
+Migration `006_pool_runtime_and_category_override.sql` added `category_override` so an Equipment of type `pool_pump` can re-tag a generic relay's `toggle_power` order as `pool_pump_toggle` without touching the device definition. Effective category is `COALESCE(order_bindings.category_override, device_orders.category)`.
+
+### 4 SQLite Schema
+
+```sql
+CREATE TABLE order_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  device_order_id TEXT NOT NULL REFERENCES device_orders(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL,
+  category_override TEXT,
+  UNIQUE(equipment_id, alias)
+);
+```
+
+---
+
+## Computed Data
+
+Sowel does **not** persist computed data in a SQLite table. There is no expression language, and no `computed_data` table. Instead, the EquipmentManager exposes a **provider registry** that internal modules use to attach virtual data points to an Equipment at read time:
+
+```typescript
+interface ComputedDataEntry {
+  alias: string;
+  value: unknown;
+  unit?: string;
+  category?: DataCategory;
+  lastUpdated: string | null;
+}
+
+type ComputedDataProvider = (equipmentId: string) => ComputedDataEntry[];
+```
+
+Current providers in the codebase:
+
+- **Energy aggregator** (`src/energy/energy-aggregator.ts`) -- exposes daily/monthly cumuls on `main_energy_meter` and `energy_production_meter` equipments.
+- **Power submeter integrator** (`src/energy/power-submeter-integrator.ts`) -- integrates instantaneous power into Wh on `energy_meter` equipments without an energy counter (state persisted in `submeter_integrator_state`).
+- **Pool runtime tracker** (`src/equipments/pool-runtime-tracker.ts`) -- daily ON-time of `pool_pump` equipments (state in `pool_runtime_state`).
+- **Pool water temperature tracker** (`src/equipments/pool-water-temp-tracker.ts`) -- last active water temperature on `pool_heat_pump` (state in `pool_water_temp_state`).
+
+Computed entries appear in `EquipmentWithDetails.computedData` and can be referenced from MQTT publishers, notifications, and chart series like any other binding alias.
+
+> **Removed from the data model**: the legacy expression language (`OR()`, `AVG()`, `IF()`, `binding.<alias>`, etc.) and the `internal_rules` table mentioned in earlier versions of this document. They were never implemented. Automation logic now lives in **Recipes** (section 10).
+
+---

--- a/docs/technical/data-model/modes.md
+++ b/docs/technical/data-model/modes.md
@@ -1,0 +1,162 @@
+# Modes
+
+> **Orchestration**: cross-cutting state machines that flip the whole house in one gesture. This page also covers their two companion entities -- Button Action Bindings (one-tap triggers) and Calendar (scheduled mode changes).
+
+## Mode
+
+A **Mode** is a named state (e.g. "Day", "Night", "Away", "Vacances") that, when activated, applies a configured set of **impacts** across one or more zones.
+
+### 1 Interfaces
+
+```typescript
+interface Mode {
+  id: string;
+  name: string;
+  icon?: string;
+  description?: string;
+  active: boolean; // Persisted -- restored on engine restart
+  createdAt: string;
+  updatedAt: string;
+}
+
+type ZoneModeImpactAction =
+  | { type: "order"; equipmentId: string; orderAlias: string; value: unknown }
+  | { type: "recipe_toggle"; instanceId: string; enabled: boolean }
+  | { type: "recipe_params"; instanceId: string; params: Record<string, unknown> };
+
+interface ZoneModeImpact {
+  id: string;
+  modeId: string;
+  zoneId: string;
+  actions: ZoneModeImpactAction[]; // Stored as JSON in the row
+}
+
+interface ModeWithDetails extends Mode {
+  impacts: ZoneModeImpact[];
+}
+```
+
+### 2 Behavior
+
+- Modes are **not exclusive by default** -- multiple modes can be active simultaneously. Mutual exclusion (e.g. Day vs Night) is enforced at the policy level (calendar configuration, button bindings).
+- On `activateMode(id)`, the manager iterates all `ZoneModeImpact` rows for the mode and applies each action: dispatching equipment orders, toggling recipe instances, or updating recipe instance params.
+- `applyModeToZone(modeId, zoneId)` re-runs the impact for a single zone without changing the active flag (useful for "re-apply current mode" on a specific room).
+- Action errors are logged but never abort the rest of the impact set.
+
+### 3 SQLite Schema
+
+```sql
+CREATE TABLE modes (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  icon TEXT,
+  description TEXT,
+  active INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE zone_mode_impacts (
+  id TEXT PRIMARY KEY,
+  mode_id TEXT NOT NULL REFERENCES modes(id) ON DELETE CASCADE,
+  zone_id TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+  actions TEXT NOT NULL              -- JSON: ZoneModeImpactAction[]
+);
+CREATE UNIQUE INDEX idx_zone_mode_impacts_unique ON zone_mode_impacts(mode_id, zone_id);
+```
+
+---
+
+## Button Action Binding
+
+A **ButtonActionBinding** wires a Zigbee button (or any Equipment of type `button` whose data binding alias is `action`) to a high-level effect. When the bound `action` value fires, the engine executes the configured effect.
+
+```typescript
+type ButtonEffectType =
+  | "mode_activate" // config: { modeId }
+  | "mode_toggle" // config: { modeOnId, modeOffId } (mutually exclusive pair)
+  | "equipment_order" // config: { equipmentId, orderAlias, value }
+  | "recipe_toggle" // config: { instanceId }
+  | "zone_order"; // config: { zoneId, orderKey, value? }
+
+interface ButtonActionBinding {
+  id: string;
+  equipmentId: string; // FK -> Equipment of type "button"
+  actionValue: string; // Match against the equipment's action alias value
+  effectType: ButtonEffectType;
+  config: Record<string, unknown>; // Shape depends on effectType (see above)
+  createdAt: string;
+}
+```
+
+The manager subscribes to `equipment.data.changed` events with `alias === "action"` and dispatches the matching binding.
+
+### SQLite Schema
+
+```sql
+CREATE TABLE button_action_bindings (
+  id TEXT PRIMARY KEY,
+  equipment_id TEXT NOT NULL REFERENCES equipments(id) ON DELETE CASCADE,
+  action_value TEXT NOT NULL,
+  effect_type TEXT NOT NULL,
+  config TEXT NOT NULL DEFAULT '{}',     -- JSON
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+---
+
+## Calendar (Mode Scheduling)
+
+Calendars schedule mode activations/deactivations on a recurring weekly basis. Two profiles are seeded at first run: **Travail** and **Vacances**. Only one profile is **active** at a time (key `calendar.activeProfileId` in the `settings` table).
+
+```typescript
+interface CalendarProfile {
+  id: string;
+  name: string;
+  builtIn: boolean;
+  createdAt: string;
+}
+
+interface CalendarModeAction {
+  modeId: string;
+  action: "on" | "off";
+}
+
+interface CalendarSlot {
+  id: string;
+  profileId: string;
+  days: number[]; // 0=Sunday..6=Saturday
+  time: string; // "HH:MM" (local time)
+  modeActions: CalendarModeAction[]; // Multiple modes can be flipped at the same slot
+}
+```
+
+`CalendarManager` uses `croner` to schedule every slot of the active profile. On profile change, all crons are torn down and rebuilt. Slot firing calls `ModeManager.activateMode` / `deactivateMode` and emits `calendar.profile.changed` when the active profile itself is changed.
+
+### SQLite Schema
+
+```sql
+CREATE TABLE calendar_profiles (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  built_in INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+-- Seeded:
+--   ('travail', 'Travail', 1)
+--   ('vacances', 'Vacances', 1)
+
+CREATE TABLE calendar_slots (
+  id TEXT PRIMARY KEY,
+  profile_id TEXT NOT NULL REFERENCES calendar_profiles(id) ON DELETE CASCADE,
+  days TEXT NOT NULL,           -- JSON: number[]
+  time TEXT NOT NULL,           -- "HH:MM"
+  mode_ids TEXT NOT NULL,       -- legacy column, kept for back-compat (JSON)
+  mode_actions TEXT             -- JSON: CalendarModeAction[]
+);
+```
+
+<!-- MISMATCH: the legacy `mode_ids` column is still required by the schema (NOT NULL) but is not part of the runtime CalendarSlot interface; new code reads `mode_actions` only. Inserts must keep filling `mode_ids` with a JSON array (commonly the modeIds extracted from modeActions) until a future migration drops it. -->
+
+---

--- a/docs/technical/data-model/recipes.md
+++ b/docs/technical/data-model/recipes.md
@@ -1,0 +1,128 @@
+# Recipes
+
+> **Orchestration**: reusable automation templates distributed as plugins. Users instantiate a recipe by filling in its typed slots; the engine runs the resulting `RecipeInstance`.
+>
+> See also: [Plugin](../data-model.md#3-plugin) in the data-model index for how recipes are distributed and loaded.
+
+## Recipe
+
+A **Recipe** is a reusable automation template, distributed as a plugin (PackageType `recipe`). Users instantiate a recipe by filling in its **slots** (typed parameters); the engine then runs the resulting `RecipeInstance`.
+
+### 1 Definition (provided by the recipe package)
+
+```typescript
+interface RecipeSlotDef {
+  id: string;
+  name: string;
+  description: string;
+  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean" | "text" | "data-key";
+  required: boolean;
+  list?: boolean;
+  defaultValue?: unknown;
+  constraints?: {
+    equipmentType?: EquipmentType | EquipmentType[];
+    min?: number;
+    max?: number;
+    crossZone?: boolean; // for `equipment` slots
+    includeDescendants?: boolean;
+  };
+  group?: string;
+}
+
+interface RecipeLangPack {
+  name: string;
+  description: string;
+  slots?: Record<string, { name: string; description: string }>;
+  groups?: Record<string, string>;
+}
+
+interface RecipeActionDef {
+  id: string;
+  type: "cycle";
+  stateKey: string;
+  options: { value: string; label: string }[];
+}
+
+interface RecipeDefinition {
+  id: string;
+  name: string;
+  description: string;
+  slots: RecipeSlotDef[];
+  actions?: RecipeActionDef[];
+  i18n?: Record<string, RecipeLangPack>;
+  validate(params: Record<string, unknown>, ctx: RecipeContext): void;
+  createInstance(params: Record<string, unknown>, ctx: RecipeContext): RecipeInstanceHandle;
+}
+
+interface RecipeInstanceHandle {
+  stop(): void;
+  onAction?(action: string, payload?: Record<string, unknown>): void;
+}
+```
+
+### 2 Instance, state, log
+
+```typescript
+interface RecipeInstance {
+  id: string;
+  recipeId: string; // matches a registered RecipeDefinition.id
+  params: Record<string, unknown>;
+  enabled: boolean;
+  createdAt: string;
+}
+
+interface RecipeLogEntry {
+  id: number;
+  instanceId: string;
+  timestamp: string;
+  message: string;
+  level: "info" | "warn" | "error";
+}
+```
+
+`recipe_state` is a per-instance key/value store (`RecipeStateStore`) used by the recipe code to persist arbitrary state across restarts (e.g. timer deadlines, counter values).
+
+### 3 Helpers exposed to recipe packages
+
+```typescript
+interface RecipeHelpers {
+  isAnyLightOn(lightIds: string[], ctx: RecipeContext): boolean;
+  turnOnLights(lightIds: string[], ctx: RecipeContext): string[];
+  turnOffLights(lightIds: string[], ctx: RecipeContext): string[];
+  setLightsBrightness(lightIds: string[], ctx: RecipeContext, brightness: number): string[];
+  parseDuration(value: unknown): number;
+  formatDuration(ms: number): string;
+}
+```
+
+### 4 SQLite Schema
+
+```sql
+CREATE TABLE recipe_instances (
+  id TEXT PRIMARY KEY,
+  recipe_id TEXT NOT NULL,
+  params JSON NOT NULL,
+  enabled INTEGER DEFAULT 1,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE recipe_state (
+  instance_id TEXT NOT NULL REFERENCES recipe_instances(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  value TEXT,
+  PRIMARY KEY (instance_id, key)
+);
+
+CREATE TABLE recipe_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  instance_id TEXT NOT NULL REFERENCES recipe_instances(id) ON DELETE CASCADE,
+  timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+  message TEXT NOT NULL,
+  level TEXT DEFAULT 'info'
+);
+CREATE INDEX idx_recipe_log_instance ON recipe_log(instance_id, timestamp DESC);
+```
+
+<!-- MISMATCH: types.ts uses level enum "info" | "warn" | "error" with no DB constraint; the SQLite column is plain TEXT defaulting to 'info'. -->
+
+---

--- a/docs/technical/data-model/zones.md
+++ b/docs/technical/data-model/zones.md
@@ -1,0 +1,111 @@
+# Zones
+
+> **Layer 1 -- Topology**: the spatial structure of the home. Zones form a tree hierarchy and aggregate equipment data automatically.
+
+## Zone
+
+A **Zone** represents a spatial area in the home. Zones form a **tree hierarchy**.
+
+### 1 Interface
+
+```typescript
+interface Zone {
+  id: string; // UUID v4
+  name: string; // "Cuisine", "Etage 1", "Maison"
+  parentId: string | null; // null = root zone
+  icon?: string; // Lucide icon name
+  description?: string;
+  displayOrder: number; // Sort order among siblings (0-based)
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+}
+
+interface ZoneWithChildren extends Zone {
+  children: ZoneWithChildren[];
+}
+```
+
+### 2 Hierarchy
+
+Zones are nestable to any depth. Typical structure:
+
+```
+Maison                    (root, parentId: null)
++-- RDC                   (floor, parentId: Maison)
+|   +-- Cuisine             (room, parentId: RDC)
+|   +-- Salon              (room, parentId: RDC)
+|   +-- Entree            (room, parentId: RDC)
++-- Etage                 (floor, parentId: Maison)
+|   +-- Chambre Parentale (room, parentId: Etage)
+|   +-- Salle de Bain     (room, parentId: Etage)
++-- Exterieur             (area, parentId: Maison)
+    +-- Jardin            (area, parentId: Exterieur)
+    +-- Garage            (area, parentId: Exterieur)
+```
+
+### 3 Zone Aggregated Data
+
+The engine **automatically computes** aggregated data for each Zone based on the Equipments it contains. Aggregation is **recursive**: a parent Zone aggregates its own Equipments plus all children Zones.
+
+```typescript
+interface ZoneAggregatedData {
+  temperature: number | null; // AVG of bindings with category=temperature
+  humidity: number | null; // AVG, category=humidity
+  luminosity: number | null; // AVG, category=luminosity
+  motion: boolean; // OR over category=motion
+  motionSensors: number; // COUNT of motion sensors in zone subtree
+  motionSince: string | null; // ISO timestamp of last motion edge
+  openDoors: number; // COUNT(open), category=contact_door
+  openWindows: number; // COUNT(open), category=contact_window
+  waterLeak: boolean; // OR, category=water_leak
+  smoke: boolean; // OR, category=smoke
+  lightsOn: number; // COUNT(on), category=light_state
+  lightsTotal: number; // COUNT(all light equipments)
+  shuttersOpen: number; // COUNT(open), category=shutter_position
+  shuttersTotal: number; // COUNT(all shutter equipments)
+  averageShutterPosition: number | null; // AVG of shutter_position (%)
+  waterValvesOpen: number;
+  waterValvesTotal: number;
+  waterFlowTotal: number | null; // SUM of current water flow (when supported)
+  sunrise: string | null; // From SunlightManager (computed from home location)
+  sunset: string | null;
+  isDaylight: boolean | null;
+}
+```
+
+> **Note**: aggregation rules are encoded in `src/zones/zone-aggregator.ts`. New attributes are added there as new EquipmentTypes and DataCategories appear (energy totals, CO2/VOC, etc. -- see roadmap entries in specs).
+
+### 4 Zone Auto-Orders
+
+Zones expose bulk commands that fan out to all Equipments of matching types within the zone subtree. The valid keys are defined in `EquipmentManager.ZONE_ORDERS`:
+
+| Order Key                | Target EquipmentTypes                    | OrderCategory dispatched | Value                  |
+| ------------------------ | ---------------------------------------- | ------------------------ | ---------------------- |
+| `allLightsOn`            | light_onoff, light_dimmable, light_color | `light_toggle`           | `"ON"`                 |
+| `allLightsOff`           | light_onoff, light_dimmable, light_color | `light_toggle`           | `"OFF"`                |
+| `allLightsBrightness`    | light_dimmable, light_color              | `set_brightness`         | from request body      |
+| `allShuttersOpen`        | shutter                                  | `shutter_move`           | `"OPEN"`               |
+| `allShuttersStop`        | shutter                                  | `shutter_move`           | `"STOP"`               |
+| `allShuttersClose`       | shutter                                  | `shutter_move`           | `"CLOSE"`              |
+| `allThermostatsPowerOn`  | thermostat                               | `toggle_power`           | `true`                 |
+| `allThermostatsPowerOff` | thermostat                               | `toggle_power`           | `false`                |
+| `allThermostatsSetpoint` | thermostat                               | `set_setpoint`           | from request body (°C) |
+
+### 5 SQLite Schema
+
+```sql
+CREATE TABLE zones (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  parent_id TEXT REFERENCES zones(id) ON DELETE SET NULL,
+  icon TEXT,
+  description TEXT,
+  display_order INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+> **Removed**: `EquipmentGroup` no longer exists. Earlier versions of this document described it; the entity and its table were removed before 1.0. Use Zones (with deeper nesting if needed) and bulk zone orders instead.
+
+---

--- a/docs/user/dashboard.fr.md
+++ b/docs/user/dashboard.fr.md
@@ -4,7 +4,7 @@ Le Tableau de bord est votre écran d'accueil personnalisé : une grille de widg
 
 ## Vue d'ensemble
 
-Contrairement à la vue Accueil (organisée par zones), le Tableau de bord vous laisse choisir exactement ce que vous voulez voir, peu importe la pièce ou le type d'équipement. Vous pouvez placer les lumières de votre salon à côté de la température extérieure et du portail de garage, le tout sur un même écran.
+Contrairement à la vue Accueil (organisée par zones), le Tableau de bord vous laisse choisir exactement ce que vous voulez voir, peu importe la pièce ou le type d'équipement. Vous pouvez placer les lumières de votre cuisine à côté de la température extérieure et du portail de garage, le tout sur un même écran.
 
 ## Types de widgets
 

--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -1,0 +1,117 @@
+# Devices
+
+Devices are everything wired to Sowel: a Zigbee bulb, a Shelly relay, a Netatmo weather station, a LoRa sensor, a Panasonic heat pump talking to a cloud API. Sowel auto-discovers them through **integration plugins** and turns them all into the same shape.
+
+**A Device is what's on the network. An [Equipment](equipments.md) is what's in the room.**
+
+You will rarely manipulate devices directly -- they are the technical layer that everything else in Sowel sits on top of. But understanding what Sowel does to them is what explains why the rest works without glue code.
+
+---
+
+## One data model for the whole house
+
+Every protocol describes its hardware differently. A Zigbee thermometer sends its temperature one way; a Netatmo cloud API sends it another; an ESPHome device sends it a third. If you have ever wired up a "smart home" by hand, you know the cost: every new device means new YAML, new templates, new nuance.
+
+Sowel takes the opposite path. It defines a **single, normalized data model**, and the plugins do the translation work.
+
+The data model is a closed list of about fifty **semantic categories** that match what a home actually measures:
+
+| Theme    | Categories                                                                          |
+| -------- | ----------------------------------------------------------------------------------- |
+| Climate  | `temperature`, `humidity`, `pressure`, `co2`, `voc`, `noise`                        |
+| Light    | `light_state`, `light_brightness`, `light_color_temp`, `light_color`, `luminosity`  |
+| Movement | `motion`, `contact_door`, `contact_window`                                          |
+| Energy   | `power`, `energy`, `voltage`, `current`                                             |
+| Safety   | `water_leak`, `smoke`, `lock_state`                                                 |
+| Outdoors | `temperature_outdoor`, `wind`, `rain`, `uv`, `solar_radiation`, `weather_condition` |
+| Pool     | `pool_water_temperature`, `pool_temperature_setpoint`                               |
+
+The full list lives in the [technical reference](../technical/data-model/devices.md).
+
+A `temperature` is always a number in °C. A `motion` is always a boolean. A `light_brightness` is always normalized to the same scale, regardless of whether the underlying device speaks 0--255 or 0--100.
+
+The consequence is simple: **the rest of Sowel doesn't care where the data comes from**. A zone that aggregates "average temperature" works whether the underlying sensors are Zigbee, LoRa, or a cloud API. A recipe that triggers on motion doesn't need to know which integration provided the signal.
+
+---
+
+## The translation is done by plugins
+
+Every integration ships as a **plugin** distributed from GitHub:
+
+- `sowel-plugin-zigbee2mqtt` -- Zigbee devices via the Zigbee2MQTT bridge
+- `sowel-plugin-shelly` -- Shelly relays and meters
+- `sowel-plugin-netatmo-hc` -- Netatmo Home Coach (weather, air quality)
+- `sowel-plugin-panasonic-cc` -- Panasonic heat pumps via Comfort Cloud
+- `sowel-plugin-mcz-maestro` -- MCZ pellet stoves
+- ... and so on
+
+Each plugin does three things:
+
+1. Connect to its data source (MQTT broker, cloud API, serial bridge, ...)
+2. Discover the devices it sees
+3. Translate every data point and every command into Sowel's shared vocabulary
+
+You install a plugin once, configure it in **Administration > Integrations**, and Sowel takes care of the rest. New devices that appear later are picked up automatically.
+
+!!! tip "Browse the plugin catalogue in-app"
+Open **Administration > Plugins** to see what is available, install with one click, and update from the same place.
+
+---
+
+## Auto-discovery and auto-typing
+
+When a plugin reports a device, Sowel reads what the plugin exposes and **automatically figures out**:
+
+- The right **category** for each data point (`temperature`, `light_brightness`, ...)
+- The right **type** (`number`, `boolean`, `enum`, `text`)
+- The right **unit** (°C, %, kWh, lx, ...)
+
+You write no schema. You configure no binding rules. A new device shows up in **Administration > Devices**, fully typed, ready to bind to an equipment.
+
+!!! info "What you actually do as a user"
+Most of the time, you never touch the devices page. You go straight to **Administration > Equipments**, click **Add Equipment**, choose a type ("Light (Dimmable)", "Motion Sensor", ...) -- and Sowel filters the device list to show only the compatible ones. Click. Done.
+
+---
+
+## Stable identity
+
+Each device gets a stable UUID generated from its `(integrationId, sourceDeviceId)` pair. The practical consequences:
+
+- **Re-pair a Zigbee device** and it keeps the same UUID -- your equipments and recipes stay bound to it.
+- **Migrate to a new Zigbee2MQTT instance** and, as long as the source device IDs are preserved, your home still works.
+- **Reinstall an integration plugin** and your devices come back with the same identities.
+
+This sounds boring until the day you have to do it.
+
+---
+
+## Why it matters
+
+Most home automation tools ask you to write rules against raw protocol-specific events:
+
+```yaml
+# A typical hand-rolled setup
+- alias: motion_kitchen_light
+  trigger:
+    platform: mqtt
+    topic: zigbee2mqtt/aqara_motion_kitchen
+    payload_path: $.occupancy
+  action: ...
+```
+
+That works -- until you replace the Aqara sensor with a Tuya one, add a second sensor, or split the kitchen into a zone with three motion points. Now you have multiple alias rules, MQTT topics in your code, and a maintenance burden that grows with your hardware.
+
+Sowel sits one layer above that. Recipes and zones reference **categories and aliases** (`motion`, `temperature`, `state`), not topics or vendor-specific identifiers. The plugin does the translation work once, and everything you build on top -- equipments, zones, recipes -- keeps working when the hardware changes.
+
+!!! example "Same data, three sources"
+A Zigbee bulb, a Shelly relay, and a Netatmo station all expose `temperature` the same way: same category, same unit, same equipment binding. Swap any one of them out -- nothing else needs to change.
+
+---
+
+## For developers
+
+If you are writing or extending an integration plugin, the technical reference is here:
+
+- [Devices -- technical reference](../technical/data-model/devices.md) -- full type signatures, schema, category list
+- [Plugin Development](../technical/plugin-development.md) -- writing a plugin, registering devices, exposing data and orders
+- [Architecture](../technical/architecture.md) -- where devices fit in the reactive pipeline

--- a/docs/user/equipments.fr.md
+++ b/docs/user/equipments.fr.md
@@ -1,8 +1,8 @@
 # Équipements
 
-Les équipements sont le concept central de Sowel. Un équipement est une **unité fonctionnelle** avec laquelle vous interagissez au quotidien : "Spots Salon", "Volets Chambre", "Capteur Cuisine".
+Les équipements sont le concept central de Sowel. Un équipement est une **unité fonctionnelle** avec laquelle vous interagissez au quotidien : "Spots Cuisine", "Volets Chambre", "Capteur Cuisine".
 
-**Un device est ce qui est sur le réseau, un équipement est ce qui est dans la pièce.** Vous ne pensez jamais au module variateur Zigbee installé derrière le mur, vous pensez aux lumières de votre salon.
+**Un device est ce qui est sur le réseau, un équipement est ce qui est dans la pièce.** Vous ne pensez jamais au module variateur Zigbee installé derrière le mur, vous pensez aux lumières de votre cuisine.
 
 ## Créer un équipement
 
@@ -13,7 +13,7 @@ Allez dans **Administration > Équipements** et cliquez sur **Ajouter un équipe
 | Champ       | Obligatoire | Description                                                                             |
 | ----------- | ----------- | --------------------------------------------------------------------------------------- |
 | Type        | Oui         | La catégorie de l'équipement (voir [Types d'équipements](#types-dequipements) plus bas) |
-| Nom         | Oui         | Un nom parlant comme "Spots Salon" ou "Capteur Cuisine"                                 |
+| Nom         | Oui         | Un nom parlant comme "Spots Cuisine" ou "Capteur Cuisine"                               |
 | Zone        | Oui         | À quelle pièce ou zone cet équipement appartient                                        |
 | Description | Non         | Une note pour vous-même                                                                 |
 
@@ -36,7 +36,7 @@ Vous pouvez créer un équipement sans device et en lier un plus tard depuis la 
 
 Un seul équipement peut se lier à **plusieurs devices**. C'est une des fonctionnalités les plus puissantes de Sowel.
 
-**Exemple :** Trois modules variateurs IKEA séparés alimentent les spots de votre salon. Créez un seul équipement "Spots Salon" et liez les trois. Un seul interrupteur allume les trois. Un seul curseur les variégradue tous les trois.
+**Exemple :** Trois modules variateurs IKEA séparés alimentent les spots de votre cuisine. Créez un seul équipement "Spots Cuisine" et liez les trois. Un seul interrupteur allume les trois. Un seul curseur les variégradue tous les trois.
 
 ---
 

--- a/docs/user/equipments.md
+++ b/docs/user/equipments.md
@@ -42,179 +42,99 @@ A single equipment can bind to **multiple devices**. This is one of Sowel's most
 
 ## Equipment types
 
+Sowel ships a closed catalogue of equipment types. Every equipment in your home is one of these, and the type drives both the UI controls and the expected data shape.
+
 ### Lights
 
-#### Light (On/Off)
-
-Simple on/off light control.
-
-- **Controls:** Toggle ON/OFF
-- **Expected data:** state (on/off)
-
-#### Light (Dimmable)
-
-Brightness-controllable light.
-
-- **Controls:** Toggle ON/OFF + brightness slider
-- **Expected data:** state, brightness level
-
-#### Light (Color)
-
-Color-capable light with optional color temperature.
-
-- **Controls:** Toggle + brightness slider + color controls
-- **Expected data:** state, brightness, color, color temperature
-
----
+| Type                 | Controls                             | Expected data                               |
+| -------------------- | ------------------------------------ | ------------------------------------------- |
+| **Light (On/Off)**   | Toggle ON/OFF                        | state (on/off)                              |
+| **Light (Dimmable)** | Toggle + brightness slider           | state, brightness                           |
+| **Light (Color)**    | Toggle + brightness + color controls | state, brightness, color, color temperature |
 
 ### Shutters
 
-#### Shutter
-
-Motorized roller blind, cover, or shutter.
-
-- **Controls:** Open / Stop / Close buttons, position display
-- **Expected data:** position (0% = closed, 100% = open)
-
----
+| Type        | Controls                               | Expected data                       |
+| ----------- | -------------------------------------- | ----------------------------------- |
+| **Shutter** | Open / Stop / Close + position display | position (0% = closed, 100% = open) |
 
 ### Climate
 
-#### Thermostat
+| Type           | Controls                                        | Expected data                                                            |
+| -------------- | ----------------------------------------------- | ------------------------------------------------------------------------ |
+| **Thermostat** | Temperature display, setpoint +/-, power on/off | current temperature, target setpoint, power state, optional mode/fan/eco |
+| **Heater**     | Comfort / Eco toggle                            | relay state (fil pilote: ON = eco, OFF = comfort)                        |
 
-Heating or cooling control -- air conditioning, pellet stove, heat pump.
-
-- **Controls:** Temperature display, setpoint adjustment (+/-), power on/off
-- **Expected data:** current temperature, target setpoint, power state
-- **Additional data** (depends on device): operating mode, fan speed, eco mode
-
-#### Heater
-
-Individual electric heater controlled via fil pilote relay.
-
-- **Controls:** Comfort / Eco toggle
-- **Expected data:** relay state (ON = eco, OFF = comfort)
-
----
+Thermostat covers air conditioning, pellet stoves, and heat pumps. Heater covers individual electric heaters wired through a fil-pilote relay.
 
 ### Access
 
-#### Gate
-
-Gate, sliding gate, or garage door.
-
-- **Controls:** Open/Close button with state indicator
-- **Expected data:** gate state (open, closed, opening, closing)
+| Type     | Controls                            | Expected data                               |
+| -------- | ----------------------------------- | ------------------------------------------- |
+| **Gate** | Open/Close button + state indicator | gate state (open, closed, opening, closing) |
 
 !!! tip "Dashboard icon"
 You can choose a specific icon for gates on the dashboard: standard gate, sliding gate, or garage door.
 
----
-
 ### Sensors
 
-#### Sensor
+| Type                 | Controls / Display                          | Expected data                                                                                             |
+| -------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Sensor**           | Read-only multi-value display, auto-adapted | temperature, humidity, pressure, CO2, VOC, luminosity, noise, battery, motion, contact, water leak, smoke |
+| **Weather Station**  | Multi-value display                         | temperature, humidity, pressure, rain, wind, noise, battery                                               |
+| **Weather Forecast** | Day-by-day forecast cards (J+1 to J+5)      | weather condition, temperature min/max, rain probability, wind gusts                                      |
+| **Button / Remote**  | Not directly controlled (used as trigger)   | action events (single press, double press, long press)                                                    |
 
-Generic sensor that displays one or more measured values. Sowel adapts the display automatically based on what the device exposes.
+The generic **Sensor** type adapts its display automatically. Boolean sensors (motion, contact, water leak, smoke) get appropriate badges; numeric sensors get values with the right unit and icon.
 
-- **Controls:** Read-only value display with appropriate icons and units
-- **Typical data:** temperature, humidity, pressure, CO2, VOC, luminosity, noise, battery
-- **Boolean sensors:** motion (Movement/Calm), contact (Open/Closed), water leak, smoke
-
-#### Weather Station
-
-Outdoor weather sensor providing current conditions.
-
-- **Controls:** Multi-value display
-- **Typical data:** temperature, humidity, pressure, rain, wind, noise, battery
-
-#### Weather Forecast
-
-Multi-day weather forecast from an API integration (e.g., Open-Meteo plugin).
-
-- **Controls:** Day-by-day forecast cards with condition icons
-- **Data per day (J+1 to J+5):** weather condition, temperature min/max, rain probability, wind gusts
-
-#### Button / Remote
-
-Physical button or remote control. Not directly controlled -- used as a trigger for automations.
-
-- **Data:** action events (single press, double press, long press)
-- **Usage:** Trigger [recipes](../technical/recipe-development.md) or toggle [modes](modes.md)
-
----
+Buttons are inputs only — bind them to a [recipe](recipes.md) action or a [mode](modes.md) toggle through **Administration > Buttons**.
 
 ### Energy
 
-#### Energy Meter
-
-Tracks energy consumption for a specific circuit or device. Often used as a **submeter** on a dedicated line (heat pump, pool, EV charger) to feed the [by-usage breakdown](energy.md#total-by-usage-toggle) on the Energy page.
-
-- **Controls:** Power (W) and daily energy (Wh/kWh) display
-- **Expected data:** cumulative energy (Wh)
-
-#### Main Energy Meter
-
-Your home's main grid meter. Only one allowed per system.
-
-- **Controls:** Same as energy meter, plus feeds the [Energy monitoring](energy.md) page
-- **Expected data:** power, energy (with HP/HC tariff classification)
-
-#### Energy Production Meter
-
-Solar panel or other production source. Only one allowed per system.
-
-- **Controls:** Production display with autoconsumption calculation
-- **Expected data:** production power, cumulative production
-
----
+| Type                        | Controls / Display                                    | Expected data                                    | Notes                                                                                                                  |
+| --------------------------- | ----------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| **Energy Meter**            | Power (W) and daily energy (Wh/kWh)                   | cumulative energy (Wh)                           | Submeter for a circuit (heat pump, pool, EV charger). Feeds the [by-usage breakdown](energy.md#total-by-usage-toggle). |
+| **Main Energy Meter**       | Same + drives the [Energy monitoring](energy.md) page | power, energy (with HP/HC tariff classification) | One allowed per system.                                                                                                |
+| **Energy Production Meter** | Production display + autoconsumption calculation      | production power, cumulative production          | One allowed per system.                                                                                                |
 
 ### Media
 
-#### Media Player
-
-TV, soundbar, or media device (e.g., Samsung SmartThings TV).
-
-- **Controls:** Power on/off, volume, mute, input source selector
-- **Expected data:** power state, volume level, mute, current input source, picture mode
-- **Orders:** power on/off, set volume, toggle mute, change input source
-
----
+| Type             | Controls                                 | Expected data                                                |
+| ---------------- | ---------------------------------------- | ------------------------------------------------------------ |
+| **Media Player** | Power on/off, volume, mute, input source | power state, volume level, mute, current input, picture mode |
 
 ### Appliances
 
-#### Appliance
-
-Smart home appliance such as a washing machine, dryer, or dishwasher (e.g., Samsung SmartThings Washer).
-
-- **Controls:** Read-only status display
-- **Expected data:** power state, operating state (ready/running/paused), current phase (wash/rinse/spin), progress (%), remaining time, energy consumption
+| Type          | Controls / Display       | Expected data                                                                                                 |
+| ------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| **Appliance** | Read-only status display | power state, operating state (ready/running/paused), current phase, progress (%), remaining time, energy used |
 
 !!! tip "End-of-cycle notification"
-Use a state-watch recipe to get notified when the operating state changes from `running` to `ready`.
-
----
+Use a `state-watch` recipe to get notified when the operating state changes from `running` to `ready`.
 
 ### Water
 
-#### Water valve
+| Type            | Controls                                                                 | Expected data                                                                    |
+| --------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| **Water Valve** | Toggle ON/OFF, "Water for X min" timed action (firmware-side auto-close) | state, flow rate (m³/h), battery, device status (normal / water shortage / leak) |
 
-Smart irrigation valve for garden watering. Designed for devices like the SONOFF SWV that expose `state`, `flow`, and `irrigation_*` properties.
+Designed for devices like the SONOFF SWV. Standard aliases: `state`, `flow`, `battery`, `status`, `duration`, `cycles`, `interval`, `capacity`, `autoCloseOnShortage`. Only `state` is required — the UI adapts to whichever are bound. Zones aggregate open/total valves and sum live flow across the tree.
 
-- **Controls:** Toggle ON/OFF, "Water for X min" timed action that opens the valve and lets the device firmware close it automatically after the configured duration
-- **Live metrics shown when bound:** flow rate (m³/h), battery, device status (normal / water shortage / leak)
-- **Standard aliases:** `state`, `flow`, `battery`, `status`, `duration`, `cycles`, `interval`, `capacity`, `autoCloseOnShortage` — only `state` is required, the UI adapts to which are bound
-- **Zone aggregation:** counts open/total valves and sums live flow across the zone tree
-- **Foundation for** future auto-watering recipes (rain-aware scheduling)
+### Pool
+
+| Type               | Controls                               | Expected data                                   |
+| ------------------ | -------------------------------------- | ----------------------------------------------- |
+| **Pool Pump**      | Toggle ON/OFF + daily runtime display  | pump state, daily runtime                       |
+| **Pool Cover**     | Open / Stop / Close + position display | cover position (0% = closed, 100% = open)       |
+| **Pool Heat Pump** | Power on/off, target water temperature | water temperature, target setpoint, power state |
+
+Pool equipments work with the **Pool Pump Schedule** recipe (daily runtime tied to water temperature) and feed the pool widgets on the dashboard.
 
 ### Other
 
-#### Switch / Plug
-
-Simple on/off switch or smart plug.
-
-- **Controls:** Toggle ON/OFF with state badge
-- **Expected data:** state (on/off)
+| Type              | Controls                    | Expected data  |
+| ----------------- | --------------------------- | -------------- |
+| **Switch / Plug** | Toggle ON/OFF + state badge | state (on/off) |
 
 ---
 
@@ -237,18 +157,23 @@ From the detail page, click **Change device** to rebind the equipment to differe
 
 Each data value is historized to InfluxDB by default based on its category (temperature, humidity, power...). From the detail page, you can override this per binding:
 
-- **Default** -- follows the category rule
-- **Force ON** -- always historize this value
-- **Force OFF** -- never historize this value
+| Setting       | Effect                      |
+| ------------- | --------------------------- |
+| **Default**   | Follows the category rule   |
+| **Force ON**  | Always historize this value |
+| **Force OFF** | Never historize this value  |
 
 ### Disabling an equipment
 
-A disabled equipment:
+A disabled equipment behaves as if it weren't there for the engine, while staying visible in the admin UI:
 
-- Does not appear in the Home view
-- Is excluded from [zone aggregation](zones.md)
-- Does not trigger recipes or mode impacts
-- Can still be viewed and edited
+| Where                        | Disabled equipment         |
+| ---------------------------- | -------------------------- |
+| Home view                    | Hidden                     |
+| [Zone aggregation](zones.md) | Excluded                   |
+| Recipes                      | Not triggered              |
+| Mode impacts                 | Skipped                    |
+| Administration > Equipments  | Still visible and editable |
 
 ### Deleting an equipment
 

--- a/docs/user/index.fr.md
+++ b/docs/user/index.fr.md
@@ -7,7 +7,7 @@ Bienvenue dans le guide utilisateur Sowel. Cette documentation couvre tout ce do
 Sowel est un moteur de domotique qui apporte de la **structure** à votre maison connectée. Au lieu de gérer des centaines de devices individuels, Sowel organise votre maison en trois couches claires :
 
 - **Devices** : le matériel physique sur votre réseau (capteurs, interrupteurs, variateurs, thermostats). Découverts automatiquement depuis vos intégrations.
-- **Équipements** : les unités fonctionnelles avec lesquelles vous interagissez vraiment ("Spots Salon", "Volets Chambre"). Chaque équipement se lie à un ou plusieurs devices.
+- **Équipements** : les unités fonctionnelles avec lesquelles vous interagissez vraiment ("Spots Cuisine", "Volets Chambre"). Chaque équipement se lie à un ou plusieurs devices.
 - **Zones** : la structure spatiale de votre maison (Maison > Étage > Pièce). Les zones agrègent automatiquement les données de leurs équipements.
 
 Cette séparation vous permet de penser en termes de _pièces et de fonctions_, pas en termes d'adresses Zigbee et de topics MQTT.

--- a/docs/user/modes.fr.md
+++ b/docs/user/modes.fr.md
@@ -36,7 +36,7 @@ Chaque impact peut contenir une ou plusieurs **actions** :
 
 **Actions d'ordre** : envoyer une commande à un équipement :
 
-- Éteindre les lumières du salon
+- Éteindre les lumières de la cuisine
 - Fermer les volets de la chambre
 - Régler le thermostat à 18 °C
 

--- a/docs/user/recipes.md
+++ b/docs/user/recipes.md
@@ -1,0 +1,125 @@
+# Recipes
+
+Recipes are Sowel's answer to home automation **without scripting**. Each recipe is a reusable automation template: a thoughtful, road-tested pattern -- "Motion Light", "Presence Heater", "Pool Pump Schedule" -- that you drop onto a zone, fill in a few values, and let run.
+
+You don't write code. You don't wire flows. You pick a recipe, configure its slots, and it works.
+
+---
+
+## What a recipe is
+
+A recipe has two parts:
+
+- A **definition** -- the template, written once by a recipe author and shipped as a plugin. It declares typed parameter **slots** (zone, equipments, durations, time windows, ...) and the behaviour to run when those slots are filled.
+- An **instance** -- your application of the template. Each instance runs independently, with its own parameters and its own state.
+
+You can have **multiple instances** of the same recipe. The same Motion Light pattern can run independently in your kitchen, your hallway, and your stairwell -- each with its own brightness setpoints and timeouts.
+
+!!! info "A recipe instance is more than a script"
+Behind the scenes, a recipe instance is a small running program that listens to the event bus, keeps state across restarts, and reacts in real time. You don't need to know any of that to use it.
+
+---
+
+## The catalogue
+
+Sowel ships several recipes through the official plugin registry. New ones land regularly.
+
+| Recipe                      | What it does                                                                                 |
+| --------------------------- | -------------------------------------------------------------------------------------------- |
+| **Motion Light**            | Turns lights on for a fixed duration when motion is detected                                 |
+| **Motion Light (Dimmable)** | Same, with brightness that adapts to time of day (3 brightness slots: day / evening / night) |
+| **Switch Light**            | Lights follow manual button presses -- toggle on/off, with optional max-on failsafe          |
+| **State-Triggered Light**   | Turns lights on when a watched equipment hits a target state (e.g. gate opens at night)      |
+| **Presence Heater**         | Heats a room only when occupied, with day/evening/night setpoints and an away setback        |
+| **Presence Thermostat**     | Same idea, for thermostats with a writable target temperature                                |
+| **Auto Watering**           | Schedules irrigation by zone, with rain skip and weather-aware reduction                     |
+| **Freecooling**             | Opens shutters or windows when outside is cooler than inside (and no rain in forecast)       |
+| **Pool Pump Schedule**      | Runs the pool pump for a daily duration tied to water temperature                            |
+| **State Watch**             | Monitors a data point and raises an alarm when it stays in a watched state too long          |
+
+Browse the full list in **Administration > Plugins > Recipe**.
+
+---
+
+## Applying a recipe
+
+Go to **Administration > Recipes** and click **Add Recipe**.
+
+### Step 1: Pick a pattern
+
+The catalogue shows everything installed locally. Each card displays the recipe name, what it does, and the parameters it needs.
+
+### Step 2: Fill the slots
+
+Slots are typed and validated. Depending on the recipe, you might be asked for:
+
+| Slot type   | Example                                                 |
+| ----------- | ------------------------------------------------------- |
+| `zone`      | The room or area the recipe applies to                  |
+| `equipment` | One or more equipments (filtered by required type)      |
+| `duration`  | How long lights stay on after motion (e.g. `2m`, `15m`) |
+| `time`      | A time of day (e.g. sunset, 22:00)                      |
+| `number`    | A brightness, a temperature, a threshold                |
+| `boolean`   | An on/off option                                        |
+
+Sowel only shows you devices and equipments that are **compatible** with the slot. You can't bind a thermostat to a "lights" slot.
+
+!!! tip "Most slots are pre-validated"
+If a slot looks empty or wrong, the **Save** button stays disabled and the recipe explains what's missing.
+
+### Step 3: Save and let it run
+
+The instance starts as soon as you save. Toggle it on/off from the recipe list anytime. Open the instance to see its **log** -- a per-instance trace of what it has done and why.
+
+---
+
+## How recipes interact with [modes](modes.md)
+
+Modes can flip recipes on or off as part of a single gesture. When you switch the house to **Night**, your "Motion Light" recipes can keep running but with the night brightness slot active; your "Auto Watering" can pause; your "Freecooling" can wake up.
+
+A mode impact on a zone can do three things to a recipe instance:
+
+- `recipe_toggle` -- enable or disable the instance
+- `recipe_params` -- update its parameters (e.g. switch the brightness target)
+- nothing -- leave it untouched
+
+This is the glue that lets a recipe template behave differently across day / evening / night without you maintaining three separate instances.
+
+---
+
+## Why a recipe is not a script
+
+In a typical hand-rolled setup, you write rules:
+
+```yaml
+- alias: kitchen_motion_light
+  trigger:
+    - platform: state
+      entity_id: binary_sensor.kitchen_motion
+      to: "on"
+  action:
+    - service: light.turn_on
+      target:
+        entity_id: light.kitchen_spots
+      data:
+        brightness_pct: 80
+```
+
+Now multiply this by every room, every time-of-day variation, every "but only if no one is sleeping", every "except during dinner". You end up with hundreds of YAML rules glued together with templates and conditions. Adding a new room means rewriting the rules.
+
+A recipe encodes the **complete pattern** -- including the edge cases that took the recipe author six months to get right. You set the brightness, the duration, the rooms; the recipe handles the rest. When you add a new room, you create a new instance of the same recipe -- not a new rule to maintain.
+
+!!! example "What you don't have to think about"
+Take **Motion Light (Dimmable)**. Out of the box, one recipe handles: multiple PIR sensors aggregated as a single signal, a brightness target that changes by time of day, manual brightness override detection (so dimming the light yourself doesn't get instantly overridden), a lux threshold (so it doesn't turn on at noon), button toggles to force-cancel, and recovery when the bridge reconnects after a Zigbee outage.
+
+    You'd have spent a weekend hand-rolling that. The recipe ships with it.
+
+---
+
+## For developers
+
+Want to write your own recipe?
+
+- [Recipe Development](../technical/recipe-development.md) -- writing a recipe plugin, declaring slots, accessing helpers
+- [Recipes -- technical reference](../technical/data-model/recipes.md) -- full type signatures (`RecipeDefinition`, `RecipeInstance`, `RecipeHelpers`) and runtime model
+- [Plugin Development](../technical/plugin-development.md) -- how plugins are packaged and distributed

--- a/docs/user/zones.fr.md
+++ b/docs/user/zones.fr.md
@@ -103,7 +103,7 @@ Ils sont disponibles dans la vue Accueil, dans l'API, et comme actions dans les 
 
 ## Astuces
 
-- **Calquez la disposition physique** : les zones doivent refléter la façon dont vous pensez votre maison. Si vous dites "le salon", ça doit être une zone.
+- **Calquez la disposition physique** : les zones doivent refléter la façon dont vous pensez votre maison. Si vous dites "la cuisine", ça doit être une zone.
 - **N'imbriquez pas trop** : deux ou trois niveaux (Maison > Étage > Pièce) suffisent en général. Les arbres trop profonds sont moins faciles à parcourir.
 - **Zones extérieures** : créez une zone "Outdoor" pour les capteurs du jardin, le portail et tout équipement extérieur.
 - **L'agrégation crée la valeur** : plus vous affectez de capteurs et d'équipements aux zones, plus le statut agrégé est riche. Même un seul capteur de température dans une pièce rend le bandeau de zone utile.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,7 +105,13 @@ nav:
     - API Reference: technical/api-reference.md
     - Plugin Development: technical/plugin-development.md
     - Recipe Development: technical/recipe-development.md
-    - Data Model: technical/data-model.md
+    - Data Model:
+      - technical/data-model.md
+      - Devices: technical/data-model/devices.md
+      - Equipments: technical/data-model/equipments.md
+      - Zones: technical/data-model/zones.md
+      - Modes: technical/data-model/modes.md
+      - Recipes: technical/data-model/recipes.md
     - Contributing: technical/contributing.md
     - Specs Index: specs-index.md
   - User Guide:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,10 +87,12 @@ plugins:
             Specs Index: Index des specs
             User Guide: Guide utilisateur
             Getting Started: Premiers pas
+            Devices: Devices
             Equipments: Équipements
             Dashboard: Tableau de bord
             Zones & Rooms: Zones et pièces
             Modes & Calendar: Modes et calendrier
+            Recipes: Recettes
             Energy Monitoring: Suivi énergétique
             Remote Access: Accès distant
 
@@ -109,10 +111,12 @@ nav:
   - User Guide:
     - user/index.md
     - Getting Started: user/getting-started.md
+    - Devices: user/devices.md
     - Equipments: user/equipments.md
     - Dashboard: user/dashboard.md
     - Zones & Rooms: user/zones.md
     - Modes & Calendar: user/modes.md
+    - Recipes: user/recipes.md
     - Energy Monitoring: user/energy.md
     - Remote Access: user/remote-access.md
 


### PR DESCRIPTION
## Summary

Doc session work that accumulated over the previous turn, now committed and structured. Four atomic commits:

1. **fix(docs): broken landing links** — `user/devices.md` + `user/recipes.md` were referenced by the landing cards but never committed (shipped as broken links via PR #164). Adds the two pages, the matching CSS classes (`.sowel-card__lead/__example/__more`), and the user-guide nav entries.
2. **docs(equipments)** — refactor the user guide into per-category tables. 10 tables (Lights / Shutters / Climate / Access / Sensors / Energy / Media / Appliances / Water / Pool / Other) replace the long H4 + bullets sequence. Adds the Pool category which was missing. Page goes from 259 → 190 lines.
3. **docs(data-model)** — full rewrite of `technical/data-model.md` against the current code (DataCategory enums, generic plugin Device/DeviceOrder, Mode/Recipe/Plugin/Button/Calendar sections added, V0.x roadmap removed). Then split into 6 files: a slim index + 5 sub-pages aligned with the landing cards. mkdocs nav updated.
4. **docs(fr)** — finish the Salon → Cuisine rename across the few French pages and `data-model.fr.md` legacy content that earlier sweeps had missed.

## Test plan

- [x] `mkdocs build --strict` clean (only the pre-existing INFO about `data-model.fr.md` not having the new `#3-plugin` anchor — expected, FR data-model retranslation is a separate PR)
- [x] Landing card "Read more →" links resolve (`/user/devices/`, `/user/recipes/`, etc.)
- [x] Per-category equipments tables render correctly (Light, Shutter, etc.)
- [x] Data-model sub-pages appear under "Data Model" in nav

## Out of scope (next PRs)

- Full retranslation of `data-model.fr.md` to mirror the new EN structure + 5 FR sub-pages
- French translation of `user/devices.md` and `user/recipes.md`
- Screenshots for the home name / lat/long step in `getting-started.md` (noted in `project_next_specs`)