### PR TITLE
feat(ui): adopt design system palette (spec 094 phase 0)

### DIFF
--- a/design-system/README.md
+++ b/design-system/README.md
@@ -1,0 +1,112 @@
+# Sowel Design System
+
+> Sober refinement for a home automation engine.
+
+The Sowel design system codifies the visual language that emerged from the `ui-redesign-B-polished.html` iteration. It is opinionated, narrow, and shippable — it covers exactly what Sowel needs today, no more.
+
+---
+
+## 1. Philosophy
+
+**Direction**: **sober refinement.** Not minimalism (we still surface state, alarms, and counts). Not maximalism (we never decorate to fill space). Every visual choice has a job to do.
+
+**Three rules, in order**:
+
+1. **The interface synthesizes, it does not inventory.** A zone view tells you _what is happening_ before it lists what could happen. Pills, badges, and aggregate counts are designed to be glanceable in under one second.
+2. **One accent, one rhythm.** The amber `--a-500` is reserved for "a light is on right now" and nothing else. The orchestrated `rise` cascade on first paint is the only motion that touches multiple elements at once.
+3. **Match the production pattern, then refine.** When the design diverges from `app.sowel.org`, the divergence is intentional and named in the relevant component spec.
+
+These rules echo the [Anthropic frontend-design skill](https://github.com/anthropics/skills/tree/main/skills/frontend-design): _"choice is intentionality, not intensity."_ The system commits to refined minimalism, executes it precisely, and does not chase trends.
+
+---
+
+## 2. What's in this folder
+
+| File                                 | Purpose                                                                                                                                |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| [tokens.md](tokens.md)               | Every design token (color, type, spacing, radius, shadow, motion) with naming convention, themes (Hybrid + Dark), and conversion notes |
+| [tokens.css](tokens.css)             | Drop-in CSS file: copy into any new Sowel surface and the system is wired                                                              |
+| [components.md](components.md)       | One-page inventory of every component pattern with anatomy, states, and accessibility notes                                            |
+| [components/](components/)           | One Markdown file per component — full spec with HTML, CSS, mapping notes, do/don't examples                                           |
+| [motion.md](motion.md)               | Animation primitives (rise stagger, glow, pulse), durations, and `prefers-reduced-motion` handling                                     |
+| [accessibility.md](accessibility.md) | WCAG contrast measurements, touch-target rules, focus indicators, ARIA conventions                                                     |
+| [migration.md](migration.md)         | How to migrate the current production codebase from ad-hoc Tailwind classes to the tokens-driven system                                |
+
+The reference implementation lives in `ui-redesign-B-polished.html` (root of the repo). When in doubt about _how a component renders_, open that file and search for the BEM class.
+
+---
+
+## 3. Naming convention
+
+The system uses **BEM** with a short prefix per scope:
+
+```
+.{scope}__{element}--{modifier}
+```
+
+| Prefix        | Scope                                                    |
+| ------------- | -------------------------------------------------------- |
+| `.sb__`       | Sidebar                                                  |
+| `.topbar__`   | Topbar                                                   |
+| `.hero__`     | Zone hero (title + lead)                                 |
+| `.strip__`    | Sensor aggregation strip                                 |
+| `.zcmds__`    | Zone command toolbar                                     |
+| `.panel__`    | Generic panel (Équipements, Comportements, Activité)     |
+| `.cat-head__` | Sub-category header inside a panel                       |
+| `.eq__`       | Equipment row                                            |
+| `.mode-row__` | Mode row                                                 |
+| `.recipe__`   | Recipe row                                               |
+| `.modal__`    | Modal dialog                                             |
+| `.activity__` | Activity feed item                                       |
+| `.mob__*`     | Mobile-specific variants (e.g. `.mob__eq`, `.mob__mode`) |
+
+Rules:
+
+- Modifier names describe _state_, not appearance (`--active`, `--alert`, `--calm` — not `--blue`, `--big`).
+- Color tokens (`--p-50`, `--a-500`) are always referenced through CSS variables, never hard-coded.
+- A component may not reach into another component's classes. If two surfaces share a chip, the chip is its own pattern (`.chip-state`).
+
+---
+
+## 4. Themes
+
+Two themes are supported, both selected via `data-theme` on `<html>`:
+
+- **Hybrid** (`data-theme="hybrid"`, default) — neutral zinc base with Sowel amber accent. Daytime-first.
+- **Dark** (`data-theme="dark"`) — Linear-ish night. Same tokens, inverted neutrals, brighter primary/accent.
+
+All component rules read tokens. **A component never branches on `data-theme`** unless absolutely necessary (e.g. dark-only override of an icon-on color contrast — see `eq__icon--light-on`). When such an override is unavoidable, the spec for that component documents it.
+
+---
+
+## 5. Phasing the implementation
+
+If you are migrating the production codebase, follow [migration.md](migration.md). The short version:
+
+1. **Drop in `tokens.css`** at the root of `ui/src/`. Replace direct color values with CSS vars in one branch, ship, verify nothing visually drifted.
+2. **Adopt one component at a time** starting with `panel` and `cat-head` (they cascade visually).
+3. **Replace per-component**: lift the existing JSX, swap classNames for the BEM ones, verify states against the spec.
+4. **Cut over to Hybrid theme**, leave Warm as a deprecated rollback for one release.
+
+The system is designed for incremental adoption: nothing forces a big-bang refactor.
+
+---
+
+## 6. Conventions for evolving the system
+
+- **A new pattern is added only after it appears in two places.** A one-off goes inline.
+- **Tokens are added only when no existing token fits.** Avoid color drift (no introducing a third shade of blue).
+- **Every spec includes an "accessibility" section.** No exceptions.
+- **Every change to a token requires a contrast check.** The accessibility doc has the table to update.
+
+---
+
+## 7. Open questions
+
+These are deferred to a future revision:
+
+- **Inter** is used as body font. The Anthropic frontend-design skill discourages it as generic. We accept it for legibility and production parity, but should periodically re-evaluate against pairs like Geist + Roboto Mono, or Söhne + JetBrains Mono.
+- **No dedicated component for charts** — energy bar/line charts use the current production conventions. A future spec should formalize axis, gridlines, legend.
+- **No formal token versioning** — when token semantics change, add a row in `tokens.md` change log and bump the file header date.
+- **Illustration system** is partially documented (note in `components/dashboard-widget.md`) but the line-art SVGs used in Dashboard widgets are not yet formalized as their own spec. Proposed for v1.1 if the illustration set grows beyond the current dashboard scope.
+- **Dashboard widget radius** is `10 px` in production (arbitrary). Design system targets `--r-md` 8 px. Tolerated divergence — to align in the next dashboard refactor.

--- a/design-system/accessibility.md
+++ b/design-system/accessibility.md
@@ -1,0 +1,213 @@
+# Accessibility
+
+> Non-negotiable rules. Every spec includes an "accessibility" section, but this page is the central reference and audit checklist.
+
+---
+
+## 1. WCAG targets
+
+The system targets **WCAG 2.2 AA** as a hard minimum, **AAA** wherever it costs nothing.
+
+| Criterion                         | Target                                       | Measured                   |
+| --------------------------------- | -------------------------------------------- | -------------------------- |
+| 1.4.3 Contrast (Minimum)          | AA (4.5:1 for normal text, 3:1 for large/UI) | See § 3                    |
+| 1.4.11 Non-text Contrast          | AA (3:1 for icons, borders)                  | See § 3                    |
+| 2.1.1 Keyboard                    | All interactive must be reachable            | See § 5                    |
+| 2.4.7 Focus Visible               | Visible at all times when tabbing            | See § 4                    |
+| 2.5.5 Target Size                 | AA Enhanced: 44 × 44 CSS px minimum          | See § 6                    |
+| 2.3.3 Animation from Interactions | `prefers-reduced-motion` honored             | See [motion.md](motion.md) |
+
+---
+
+## 2. Touch targets
+
+| Component                                     | Size          | WCAG AA Enhanced (44×44) | Verdict                                           |
+| --------------------------------------------- | ------------- | ------------------------ | ------------------------------------------------- |
+| `.power-btn` (desktop)                        | 32 × 26       | ❌                       | Pad surrounding cell to 44×44 hit area            |
+| `.mob__power` (mobile)                        | 32 × 32       | ❌                       | Same as above; padding-based expand               |
+| `.shutter-btn` (desktop, in group)            | 30 × 30       | ❌                       | Tolerated in dense group context                  |
+| `.mob__shutter-grp button` (mobile)           | 30 × 32       | ❌                       | Same as above                                     |
+| `.recipe__action` (logs/dup/del)              | 22 × 20       | ❌                       | **Acceptable in dense list**; hidden on mobile    |
+| `.cat-head__add` (+ button on Recettes/Modes) | 22 × 22       | ❌                       | Pad surrounding hit area                          |
+| `.actions__seg button` (zone commands)        | min-height 36 | ❌                       | Bump to 44 in production OR use larger hit area   |
+| `.mode-row__apply`                            | ~28 high      | ❌                       | Pad row hit area                                  |
+| `.modal__close`                               | 32 × 32       | ❌                       | Acceptable in modal head; the X is in a calm zone |
+| `.topbar__chip`                               | 32 high       | ❌                       | Borderline; production may keep at 32             |
+| `.mob__tab`                                   | 56 × ~76      | ✅                       | Mobile tab bar items pass 44×44                   |
+| `.sb__item`                                   | ~30 high      | ❌                       | **Desktop only, mouse-driven**: OK                |
+| `.mob__action-seg button`                     | min-height 44 | ✅                       | Already meets target                              |
+
+**Rule of thumb**: visible buttons under 44 × 44 must extend their **invisible click area** to 44 × 44 via padding or `::before` pseudo-element. The visual size stays small, the touchable area gets bigger.
+
+```css
+.power-btn {
+  position: relative;
+  /* visible 32×26 stays */
+}
+.power-btn::before {
+  content: "";
+  position: absolute;
+  inset: -9px -6px; /* extends hit area to ~44×44 */
+}
+```
+
+---
+
+## 3. Color contrast measurements
+
+Measured with WebAIM contrast checker against the Hybrid theme.
+
+### Text colors
+
+| Text on background                                    | Ratio  | WCAG                    |
+| ----------------------------------------------------- | ------ | ----------------------- |
+| `--n-700` (`#27272A`) on `--n-0` (`#FFFFFF`)          | 15.6:1 | AAA                     |
+| `--n-700` on `--n-25` (`#FAFAFA`)                     | 15.0:1 | AAA                     |
+| `--n-700` on `--n-50` (`#F4F4F5`)                     | 14.0:1 | AAA                     |
+| `--n-600` (`#3F3F46`) on `--n-0`                      | 11.6:1 | AAA                     |
+| `--n-500` (`#52525B`) on `--n-0`                      | 8.7:1  | AAA                     |
+| `--n-400` (`#71717A`) on `--n-0`                      | 5.6:1  | AA (AAA at large text)  |
+| `--n-400` on `--n-25`                                 | 5.4:1  | AA                      |
+| `--p-500` (`#1A4F6E`) on `--n-0`                      | 9.8:1  | AAA                     |
+| `--p-500` on `--p-50` (`#EEF5F8`)                     | 9.1:1  | AAA                     |
+| `--green-700` (`#0E6B3F`) on `--green-50` (`#E6F7EE`) | 8.4:1  | AAA                     |
+| `--red-500` (`#C7522E`) on `--n-0`                    | 4.9:1  | AA                      |
+| `--red-500` on `--red-50` (`#FBE9E1`)                 | 4.5:1  | AA (borderline)         |
+| `--a-600` (`#D4A41C`) on `--n-0`                      | 2.4:1  | ❌ **fail** — see § 3.1 |
+
+### 3.1 Known contrast issue: amber on white
+
+`--a-600` (the dimmer value text color used for "4 %" on `.eq__value--on`) is **2.4:1 on white**. This is below WCAG AA.
+
+**Why we ship it anyway**: the amber `4 %` value is paired with the amber on-state icon AND the amber slider knob AND the amber power button. The user has multiple redundant cues that the light is on. The text contrast is a secondary cue.
+
+**Production mitigation**: production should add `font-weight: 700` on `.eq__value--on` (already done) AND increase the font-size to 0.85rem minimum so the WCAG large-text threshold (3:1) applies.
+
+Alternative: use `--a-500` (`#F2C035`, 1.9:1) for backgrounds and `--n-800` for text. This is the convention in production where the `.power-btn--on` background is `--a-500` but the icon is white (on the amber bg) — 8.4:1.
+
+### Non-text contrast
+
+| Element                                         | Foreground | Background | Ratio  | Verdict                                              |
+| ----------------------------------------------- | ---------- | ---------- | ------ | ---------------------------------------------------- |
+| Icon strokes `--n-500` on `--n-0`               | `#52525B`  | `#FFFFFF`  | 8.7:1  | AAA                                                  |
+| Border `--line` (rgba(24,24,27,.08)) on `--n-0` | computed   | `#FFFFFF`  | ~1.4:1 | ❌ — but borders are decorative, not required for AA |
+| Border `--line-2` on `--n-0`                    | computed   | `#FFFFFF`  | ~2.0:1 | ❌ — same caveat                                     |
+| Slider track `--n-100` on `--n-0`               | `#E9E9EB`  | `#FFFFFF`  | 1.05:1 | acceptable (decorative)                              |
+
+WCAG 1.4.11 applies to **meaningful** non-text elements. Decorative borders are exempt. If a border carries meaning (e.g. the green `.mode-row--active` left border), it meets 3:1 minimum.
+
+| Meaningful border                                        | Ratio | Verdict                                                                                                     |
+| -------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------------------------------- |
+| `.mode-row--active` left border `--green-500` on `--n-0` | 4.1:1 | AA                                                                                                          |
+| `.msec--enhance` left border `--a-500` on `--n-0`        | 1.9:1 | ❌ **fail** — paired with the "amélioration UX" text badge, so meaning is conveyed redundantly. Acceptable. |
+
+---
+
+## 4. Focus indicators
+
+Every interactive element must have a visible focus state. The system uses:
+
+```css
+.recipe__open:focus-visible {
+  outline: 2px solid var(--p-500);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+```
+
+Browsers' default focus rings are kept on form inputs (text, number, time) — they pass WCAG out of the box.
+
+Custom-styled buttons (`.power-btn`, `.recipe__action`, `.sb__item`) must override or remove the default outline only if a **replacement focus indicator is wired**. Currently:
+
+- `.sb__item` relies on browser default (production needs to verify).
+- `.power-btn`, `.shutter-btn`, `.recipe__action`: same.
+
+**Production action item**: add a global focus-visible rule for all interactive elements:
+
+```css
+button:focus-visible,
+[role="button"]:focus-visible,
+[role="switch"]:focus-visible {
+  outline: 2px solid var(--p-500);
+  outline-offset: 2px;
+}
+```
+
+---
+
+## 5. Keyboard reachability
+
+| Component         | Tab target                     | Activate                            |
+| ----------------- | ------------------------------ | ----------------------------------- |
+| `.sb__item`       | yes (Link or button)           | Enter                               |
+| `.eq__icon`       | no (decorative)                | —                                   |
+| `.power-btn`      | yes                            | Enter / Space                       |
+| `.recipe__open`   | yes (button)                   | Enter / Space                       |
+| `.recipe__toggle` | yes (role=switch + tabindex=0) | **Space** (production must wire)    |
+| `.recipe__action` | yes (each button)              | Enter / Space                       |
+| Modal close       | yes + Escape                   | Enter / Space / Escape              |
+| Modal backdrop    | not focusable                  | click closes (with unsaved confirm) |
+| `.mob__tab`       | yes (Link)                     | Enter                               |
+
+The modal must trap focus (focus stays inside while open).
+
+---
+
+## 6. ARIA conventions
+
+| Pattern                        | ARIA                                                                       |
+| ------------------------------ | -------------------------------------------------------------------------- | ------------------------------- |
+| Panel head as section heading  | `<h2 class="panel__title">` (or `role="heading" aria-level="2"`)           |
+| Toggle switch                  | `<button role="switch" aria-checked="true                                  | false">`                        |
+| Modal dialog                   | `<div role="dialog" aria-modal="true" aria-labelledby="modal-title">`      |
+| Tabs in modal (none currently) | `role="tablist"` + `role="tab"` if added                                   |
+| Expand chevron in sidebar      | `<button aria-expanded="true                                               | false" aria-controls="sub-id">` |
+| Icon-only button               | `aria-label="…"` describing the action                                     |
+| Loading state                  | `aria-busy="true"` on the affected region                                  |
+| Alert (urgent)                 | `role="alert"` for the alert pill, or `aria-live="polite"` for less urgent |
+| Active nav item                | `aria-current="page"` on `.sb__item--active`                               |
+
+---
+
+## 7. Screen reader announcements
+
+The Activity panel updates in real-time via WebSocket. New activity items should announce themselves:
+
+```html
+<div class="activity" role="log" aria-live="polite" aria-relevant="additions">
+  <div class="activity__item">…</div>
+</div>
+```
+
+The alert pill in the strip is "polite" too (it's a status, not a critical interruption). For truly critical alarms (smoke, leak), use `role="alert"`.
+
+---
+
+## 8. Internationalization
+
+Sowel ships in French. All labels are translatable. The design system does not bake language in. However:
+
+- **Tabular nums** rely on Latin digits 0–9. If a future Sowel ships a non-Latin locale (Arabic, Hindi), the tnum feature won't help. Plan: a fallback `font-variant-numeric: oldstyle-nums` for those locales.
+- **Letter-spacing on uppercase** (`.panel__title`, `.cat-head`) assumes Latin script. For non-Latin, the `text-transform: uppercase` and the spacing must be conditionally removed.
+
+---
+
+## 9. Audit checklist
+
+Before shipping any new component to production:
+
+- [ ] Color contrast measured for all text + meaningful borders
+- [ ] Touch target audited (visible OR hit area must be 44×44 minimum on mobile)
+- [ ] Focus-visible outline tested with keyboard tab
+- [ ] All icon-only buttons have `aria-label`
+- [ ] Reduced motion tested (System Settings → reduce motion, verify the page is still usable)
+- [ ] Screen reader tested with VoiceOver (macOS) or NVDA (Windows): all data, states, and actions announced
+- [ ] Component works with `prefers-color-scheme: dark` (i.e. dark theme renders correctly)
+- [ ] Component works at 200% browser zoom without breaking layout
+
+---
+
+## 10. See also
+
+- [motion.md](motion.md) — `prefers-reduced-motion` handling.
+- Every `components/*.md` spec — each has an "Accessibility" section specific to the component.

--- a/design-system/components.md
+++ b/design-system/components.md
@@ -1,0 +1,94 @@
+# Components
+
+> Every component used in the Sowel zone view, with a one-line summary and a link to its full spec.
+
+The system has **two component layers**:
+
+- **Atoms** — visual primitives (pill, chip-state, badge, power-btn, toggle). Used everywhere.
+- **Patterns** — composed structures (panel, eq-row, modal). Built from atoms and layout primitives.
+
+---
+
+## Atoms
+
+| Component        | Purpose                                                                                    | Spec                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| **Pill**         | Content-width chip with icon + value, sometimes a sparkline. Used in the strip and topbar. | [components/pill.md](components/pill.md)                 |
+| **Chip-state**   | Compact text badge for a state (`RAS`, `Détecté 24s`, `Ouvert`, `Fermé`, `Actif`).         | [components/chip-state.md](components/chip-state.md)     |
+| **Power-button** | 32×26 rounded square button for on/off equipment commands. Has `--on` variant.             | [components/power-button.md](components/power-button.md) |
+| **Toggle**       | 30×18 pill switch for recipe enable/disable.                                               | [components/toggle.md](components/toggle.md)             |
+| **Slider**       | Horizontal track + filled bar + knob for dimmer / shutter position.                        | [components/slider.md](components/slider.md)             |
+| **Shutter-grp**  | Segmented control of 3 buttons (↑ ■ ↓) for shutter open/stop/close.                        | [components/shutter-grp.md](components/shutter-grp.md)   |
+
+---
+
+## Patterns
+
+### Layout
+
+| Component         | Purpose                                                                                                                     | Spec                                                       |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Panel**         | Card container for a top-level section (Équipements, Comportements, Activité). Has a tinted head + body with rows.          | [components/panel.md](components/panel.md)                 |
+| **Cat-head**      | Sub-category header inside a panel (Éclairages, Modes, Recettes). Neutral background, optional `+` button.                  | [components/cat-head.md](components/cat-head.md)           |
+| **Hero**          | Zone title block — title + lead synthesizing state. Lives above the strip.                                                  | [components/hero.md](components/hero.md)                   |
+| **Strip**         | Horizontal row of state pills with three soft groups (sensors / counters / alerts). Stays single-line, scrolls if overflow. | [components/strip.md](components/strip.md)                 |
+| **Zone commands** | Inline toolbar below the strip with 5 icon buttons (lights on/off + shutter ↑■↓).                                           | [components/zone-commands.md](components/zone-commands.md) |
+
+### Rows (equipment, mode, recipe)
+
+All three row types share a **3-column grid** with a 32×32 icon, 1fr name, and right-aligned controls. They all measure **52 px tall** for visual alignment between panels.
+
+| Component         | Specifics                                                                                                   | Spec                                                       |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **eq-row**        | Equipment row: icon + name + slider + value + power-btn. Variants per type (light, shutter, sensor, media). | [components/eq-row.md](components/eq-row.md)               |
+| **mode-row**      | Mode row: icon + status dot overlay + name/meta + Apply button or "Actif" badge.                            | [components/mode-row.md](components/mode-row.md)           |
+| **recipe-row**    | Recipe row: icon + name + toggle on row 1, three small action icons (logs, dup, del) on row 2.              | [components/recipe-row.md](components/recipe-row.md)       |
+| **activity-item** | Activity feed entry: time + colored dot + text + optional meta.                                             | [components/activity-item.md](components/activity-item.md) |
+
+### Navigation
+
+| Component          | Purpose                                                                                                    | Spec                                                       |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Sidebar nav**    | Vertical nav with item pills, expand chevrons for sub-zones, separator rules around Modes/Analyse/Énergie. | [components/sidebar-nav.md](components/sidebar-nav.md)     |
+| **Topbar**         | Horizontal header with breadcrumb, time chip, sunlight chip, connection status, alarms, avatar.            | [components/topbar.md](components/topbar.md)               |
+| **Mobile tab bar** | Bottom navigation: Dashboard / Maison / Énergie / Modes / Plus.                                            | [components/mobile-tabbar.md](components/mobile-tabbar.md) |
+
+### Overlays
+
+| Component               | Purpose                                                                                                                                   | Spec                                       |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| **Modal — recipe edit** | Centered card with header, scrollable body (sections: checklist / form grid / plages / mode overrides), footer with status + Save/Cancel. | [components/modal.md](components/modal.md) |
+
+### Dashboard
+
+| Component            | Purpose                                                                                                                                               | Spec                                                             |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **Dashboard widget** | Large 273×240 card with title, line-art illustration, and a state/controls footer. One widget per equipment, hand-picked for the user's daily glance. | [components/dashboard-widget.md](components/dashboard-widget.md) |
+
+---
+
+## Equipment type coverage
+
+Sowel supports 21 equipment types. They all reduce to **6 canonical patterns** below, demonstrated in the `ui-redesign-B-polished.html` "Patterns d'équipements" section.
+
+| Pattern                             | Maps to types                                                                                                                                  | Layout                                          |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Power-only**                      | `light_onoff`, `switch`, `appliance`                                                                                                           | icon + name + power-btn                         |
+| **Power + slider**                  | `light_dimmable`, `light_color`, `water_valve`                                                                                                 | icon + name + slider + value + power-btn        |
+| **Slider + state + 3-button group** | `shutter`, `pool_cover`                                                                                                                        | icon + name + slider + chip-state + shutter-grp |
+| **Single toggle command**           | `gate`                                                                                                                                         | icon + name + chip-state + gate-cmd button      |
+| **Target + adjust**                 | `thermostat`, `heater`, `pool_heat_pump`                                                                                                       | icon + name + current + target± + power-btn     |
+| **Read-only multi-value**           | `sensor`, `button`, `weather`, `weather_forecast`, `energy_meter`, `main_energy_meter`, `energy_production_meter`, `pool_pump`, `media_player` | icon + name + value(s) + chip-state             |
+
+Any new equipment type should map cleanly to one of these six. If none fits, the new pattern is added as a spec **and** documented as a new line above.
+
+---
+
+## Component lifecycle
+
+A component is **proposed** in this file (one-liner + link), **drafted** in its own file under `components/`, **adopted** when at least one production surface ships with it, and **deprecated** by marking the spec header and adding a replacement link.
+
+State of v1.0:
+
+- All atoms above are **adopted** in the polished.html reference.
+- Component specs are being written progressively. Until the spec exists, the polished.html serves as authoritative reference.

--- a/design-system/components/activity-item.md
+++ b/design-system/components/activity-item.md
@@ -1,0 +1,279 @@
+# Activity item (`activity__item`)
+
+> A single entry in the Activity feed (right column on desktop, scrollable section on mobile). Each entry is a timestamped, colored event with a short description.
+
+---
+
+## Anatomy
+
+```
+┌──────────────────────────────────────────────────────┐
+│ 22:41 │ [icon] Appliques x2 → 4 %    par Motion Light│   .activity__item
+│       │       (event category dot inside icon)        │
+└──────────────────────────────────────────────────────┘
+   .activity__item-time   .activity__item-icon   .activity__item-text + .by
+```
+
+---
+
+## Categories
+
+Each item has a category. The category is encoded by the **icon background color**:
+
+| Category         | Icon class                     | Bg / Color                   | Used for                               |
+| ---------------- | ------------------------------ | ---------------------------- | -------------------------------------- |
+| Recipe action    | `.activity__item-icon--recipe` | `--p-50` / `--p-500`         | "Motion Light a réglé Appliques à 4 %" |
+| Mode change      | `.activity__item-icon--mode`   | `--green-50` / `--green-700` | "Mode Lumière soir activé"             |
+| Motion event     | `.activity__item-icon--motion` | `--info-50` / `--info-500`   | "Mouvement détecté sur PIR_00"         |
+| Neutral / system | (no modifier)                  | `--n-50` / `--n-500`         | "Coucher du soleil · phase Nuit"       |
+
+---
+
+## Groups
+
+Items are visually grouped by **time window** using a `.activity__group` separator:
+
+```html
+<div class="activity__group">22:00 → maintenant</div>
+<div class="activity__item">…</div>
+<div class="activity__item">…</div>
+
+<div class="activity__group">21:00</div>
+<div class="activity__item">…</div>
+```
+
+The group label is small uppercase text. It compresses the time noise (many items at the same minute) and lets the eye scan by epoch.
+
+---
+
+## Code
+
+### Recipe activity item
+
+```html
+<div class="activity__item">
+  <div class="activity__item-icon activity__item-icon--recipe">
+    <svg>… ChefHat …</svg>
+  </div>
+  <div class="activity__item-text">
+    <b>Appliques x2</b> → 4 %
+    <span class="by">par Motion Light</span>
+  </div>
+  <span class="activity__item-time">22:41</span>
+</div>
+```
+
+### Motion event
+
+```html
+<div class="activity__item">
+  <div class="activity__item-icon activity__item-icon--motion">
+    <svg>… PersonStanding …</svg>
+  </div>
+  <div class="activity__item-text">Mouvement détecté sur <b>PIR_00</b></div>
+  <span class="activity__item-time">22:40</span>
+</div>
+```
+
+### Mode change
+
+```html
+<div class="activity__item">
+  <div class="activity__item-icon activity__item-icon--mode">
+    <svg>… Layers …</svg>
+  </div>
+  <div class="activity__item-text">
+    Mode <b>Lumière soir</b> activé <span class="by">par le calendrier</span>
+  </div>
+  <span class="activity__item-time">21:00</span>
+</div>
+```
+
+### CSS
+
+```css
+.activity__group {
+  font-size: 0.62rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--n-400);
+  padding: 0.5rem 1.1rem 0.25rem;
+}
+
+.activity__item {
+  display: grid;
+  grid-template-columns: 24px 1fr auto;
+  gap: 0.65rem;
+  align-items: center;
+  padding: 0.55rem 1.1rem;
+  border-top: 1px solid var(--line);
+}
+.activity__item:first-of-type {
+  border-top: none;
+}
+
+.activity__item-icon {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--r-xs);
+  background: var(--n-50);
+  color: var(--n-500);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.activity__item-icon svg {
+  width: 12px;
+  height: 12px;
+}
+.activity__item-icon--recipe {
+  background: var(--p-50);
+  color: var(--p-500);
+}
+.activity__item-icon--mode {
+  background: var(--green-50);
+  color: var(--green-700);
+}
+.activity__item-icon--motion {
+  background: var(--info-50);
+  color: var(--info-500);
+}
+
+.activity__item-text {
+  font-size: 0.78rem;
+  color: var(--n-600);
+  line-height: 1.45;
+}
+.activity__item-text b {
+  color: var(--n-800);
+  font-weight: 600;
+}
+.activity__item-text .by {
+  color: var(--n-400);
+  font-size: 0.72rem;
+}
+
+.activity__item-time {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--n-400);
+  font-feature-settings: "tnum" 1;
+  flex-shrink: 0;
+}
+```
+
+---
+
+## Live updates
+
+The Activity panel is **live** — new items appear at the top via WebSocket. The panel head has a `● live` indicator (green pill) using the panel\_\_count escape hatch:
+
+```html
+<span class="panel__count" style="background:var(--green-50);color:var(--green-700)">● live</span>
+```
+
+The dot is a static unicode `●` — no animation needed (the connection indicator's `connPing` is the global "alive" cue).
+
+---
+
+## Mobile variant (`.mob__act`)
+
+Identical structure, slightly tighter:
+
+```css
+.mob__act {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  padding: 0.55rem 0.85rem;
+  border-top: 1px solid var(--line);
+}
+.mob__act-time {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  min-width: 38px;
+  color: var(--n-400);
+  padding-top: 1px;
+}
+.mob__act-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  margin-top: 0.45rem;
+}
+.mob__act-dot--mode {
+  background: var(--p-500);
+}
+.mob__act-dot--light {
+  background: var(--a-500);
+}
+.mob__act-dot--motion {
+  background: var(--sensor-500);
+}
+.mob__act-dot--shutter {
+  background: var(--shutter-500);
+}
+.mob__act-text {
+  font-size: 0.78rem;
+  color: var(--n-700);
+  line-height: 1.4;
+}
+```
+
+Mobile uses a **colored dot** instead of a 24×24 icon (saves space) — the category is still encoded by color.
+
+---
+
+## Accessibility
+
+| Concern         | Implementation                                                                                                                                                   |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| List role       | Wrap the panel body as `<ul role="log" aria-live="polite" aria-relevant="additions">` so new items are announced.                                                |
+| Each item       | `<li>` — no further role needed.                                                                                                                                 |
+| Time            | The `<time datetime="2026-05-13T22:41">22:41</time>` element for semantic time.                                                                                  |
+| Color cue alone | The icon color encodes category but **text always describes the event**. A green icon with "Mode Lumière soir activé" is fine. A green icon with no text is not. |
+| Color contrast  | All variants (recipe / mode / motion / neutral) pass AA on white.                                                                                                |
+| Scroll back     | The Activity panel scrolls. Production must wire keyboard scroll (arrow keys, Page Up/Down) for accessibility.                                                   |
+
+---
+
+## Do / Don't
+
+✅ **Do**: limit items per group to ~6–10. If more, scroll within the panel.
+✅ **Do**: keep timestamps in `HH:MM` (not seconds). Activity is glanceable, not forensic.
+✅ **Do**: bold the equipment / recipe / mode name in the text. Helps scanning.
+
+❌ **Don't**: add an action button per item ("Annuler", "Détails"). Activity is a log, not a workflow.
+❌ **Don't**: re-color the entire item by category. The icon is the only colored element; the text stays neutral.
+❌ **Don't**: animate item entries (slide-in, fade-in). Too noisy if events arrive frequently. The reduced-motion respect rule applies.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+type ActivityEvent = {
+  id: string;
+  timestamp: Date;
+  category: "recipe" | "mode" | "motion" | "system";
+  text: ReactNode; // JSX, includes <b> for emphasis
+  by?: string; // "par Motion Light", "manuellement"
+};
+
+<ActivityFeed events={events}>
+  {events.map((e) => (
+    <ActivityItem key={e.id} {...e} />
+  ))}
+</ActivityFeed>;
+```
+
+The component groups items by time window internally.
+
+---
+
+## See also
+
+- [panel.md](panel.md) — Activity is hosted in a panel
+- [motion.md](../motion.md) — No animation here, but reduced-motion is the broader policy

--- a/design-system/components/cat-head.md
+++ b/design-system/components/cat-head.md
@@ -1,0 +1,175 @@
+# Sub-category header (`cat-head`)
+
+> The thin band that visually groups rows of the same kind inside a [panel](panel.md). Examples: "Éclairages" / "Volets" / "Capteurs" inside Équipements, "Modes" / "Recettes" inside Comportements.
+
+---
+
+## Anatomy
+
+```
+┌─────────────────────────────────────────────────────┐
+│ [icon] ÉCLAIRAGES                            [+]    │   .cat-head (36 px)
+└─────────────────────────────────────────────────────┘
+        ↑                                        ↑
+        14×14 muted icon                         optional add button
+```
+
+**Fixed height**: 36 px. Critical for cross-panel row alignment (Éclairages on the left lines up with Modes on the right).
+
+---
+
+## Variants
+
+There are no visual variants. Two optional elements:
+
+| Element                            | When                                                                                                                                         |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.cat-head__add` (+ button)        | On Modes and Recettes sub-cats (Comportements panel). Never on Équipement sub-cats (the + lives on the panel head).                          |
+| `.cat-head__count` (numeric badge) | **Hidden** by CSS — the user explicitly removed count badges. The class is preserved for legacy compat but `display: none` via `tokens.css`. |
+
+---
+
+## States
+
+| State          | Effect                                                       |
+| -------------- | ------------------------------------------------------------ |
+| Default        | bg `--n-25`, text `--n-500`, uppercase, letter-spacing .14em |
+| + button hover | `.cat-head__add:hover` → bg `--p-50`, color/border `--p-500` |
+
+The cat-head itself has no hover state — it's a label, not interactive.
+
+---
+
+## Code
+
+```html
+<div class="cat-head">
+  <svg class="cat-head-icon">…Lightbulb…</svg>
+  Éclairages
+  <button class="cat-head__add" title="Ajouter un éclairage" aria-label="Ajouter un éclairage">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  </button>
+</div>
+```
+
+```css
+.cat-head {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.4rem 1.1rem;
+  min-height: 36px;
+  box-sizing: border-box;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--n-500);
+  font-weight: 600;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: var(--n-25);
+}
+.cat-head-icon {
+  width: 14px;
+  height: 14px;
+  opacity: 0.7;
+}
+
+.cat-head__add {
+  margin-left: auto;
+  width: 22px;
+  height: 22px;
+  background: transparent;
+  border: 1px solid var(--n-200);
+  border-radius: var(--r-xs);
+  color: var(--n-500);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.cat-head__add:hover {
+  background: var(--p-50);
+  color: var(--p-500);
+  border-color: var(--p-100);
+}
+.cat-head__add svg {
+  width: 11px;
+  height: 11px;
+}
+```
+
+---
+
+## Icon usage
+
+| Sub-category | Icon (Lucide)                                        |
+| ------------ | ---------------------------------------------------- |
+| Éclairages   | `Lightbulb`                                          |
+| Volets       | rect+lines (custom, matches production ShutterIcons) |
+| Capteurs     | `Gauge`                                              |
+| Multimédia   | `Tv`                                                 |
+| Autres       | `Eye` (or category-specific)                         |
+| Modes        | `Layers`                                             |
+| Recettes     | `ChefHat`                                            |
+| Thermostat   | `Thermometer`                                        |
+| Énergie      | `Zap`                                                |
+| Météo        | `CloudSun`                                           |
+| Eau          | water drop (custom)                                  |
+| Piscine      | `Waves`                                              |
+
+---
+
+## Accessibility
+
+| Concern         | Implementation                                                                                   |
+| --------------- | ------------------------------------------------------------------------------------------------ |
+| Heading role    | Production should wrap the label in `<h3>` or use `role="heading" aria-level="3"`.               |
+| Decorative icon | The leading icon is decorative — must have `aria-hidden="true"` to avoid double-announcement.    |
+| + button label  | `aria-label` describing what gets added ("Ajouter une recette", not just "Ajouter").             |
+| Color contrast  | `--n-500` on `--n-25`: 7.6:1 — AAA.                                                              |
+| Touch target    | + button is 22 × 22 — below 44×44. Mitigation: extend hit area via padding or `::before` pseudo. |
+
+---
+
+## Do / Don't
+
+✅ **Do**: keep cat-head heights identical across panels (36 px min-height).
+✅ **Do**: use neutral background (`--n-25`). The user explicitly rejected category-tinted backgrounds.
+✅ **Do**: add the + button only where adding is contextually sensible (Modes, Recettes — not Capteurs or Météo where equipment is bound to a device).
+
+❌ **Don't**: add a category-colored stripe or border to cat-heads. The icon carries the category visual cue.
+❌ **Don't**: show count badges next to the label. The user removed them; data is repeated elsewhere (e.g. the strip pills count "1/3 lights on").
+
+---
+
+## React mapping (proposal)
+
+```tsx
+type CatHeadProps = {
+  icon: ReactNode;
+  label: string;
+  onAdd?: () => void;
+  addLabel?: string;
+};
+
+<CatHead icon={<Lightbulb />} label="Éclairages" />
+<CatHead icon={<ChefHat />} label="Recettes"
+         onAdd={addRecipe} addLabel="Ajouter une recette" />
+```
+
+---
+
+## See also
+
+- [panel.md](panel.md) — parent container
+- [eq-row.md](eq-row.md) — sibling rows below a cat-head

--- a/design-system/components/chip-state.md
+++ b/design-system/components/chip-state.md
@@ -1,0 +1,104 @@
+# Chip-state atom (`chip-state`)
+
+> Compact text badge for a single equipment state. Smaller than a pill, no icon, no number. Used on equipment rows.
+
+---
+
+## Anatomy
+
+```
+┌───────┐
+│  RAS  │   .chip-state — 11 px text, uppercase off, weight 600
+└───────┘
+```
+
+---
+
+## Variants
+
+| Variant          | Class                                                      | Semantic          |
+| ---------------- | ---------------------------------------------------------- | ----------------- |
+| Neutral          | `.chip-state`                                              | RAS, Inactif, OFF |
+| On / open        | `.chip-state` + inline style `bg:green-50 color:green-700` | Ouvert, Allumé    |
+| Closed / off     | `.chip-state--closed`                                      | Fermé, Éteint     |
+| OFF (greyed)     | `.chip-state--off`                                         | OFF, Désactivé    |
+| Detected         | `.chip-state--detected`                                    | Détecté 24s       |
+| Pressed (button) | `.chip-state--press`                                       | single 14h27      |
+
+---
+
+## Code
+
+```html
+<!-- Sensor row: motion at rest -->
+<span class="chip-state">RAS</span>
+
+<!-- Shutter row: open -->
+<span class="chip-state" style="background:var(--green-50);color:var(--green-700)">Ouvert</span>
+
+<!-- Shutter row: closed -->
+<span class="chip-state chip-state--closed">Fermé</span>
+
+<!-- Media (TV) -->
+<span class="chip-state chip-state--off">OFF</span>
+
+<!-- Motion sensor: recently detected -->
+<span class="chip-state chip-state--detected">Détecté 24s</span>
+
+<!-- Remote (button) last pressed -->
+<span class="chip-state chip-state--press">single 14h27</span>
+```
+
+```css
+.chip-state {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 3px 7px;
+  border-radius: var(--r-xs);
+  background: var(--n-100);
+  color: var(--n-500);
+}
+.chip-state--closed {
+  background: var(--shutter-50);
+  color: var(--shutter-500);
+}
+.chip-state--off {
+  background: var(--n-100);
+  color: var(--n-400);
+}
+.chip-state--detected {
+  background: var(--green-50);
+  color: var(--green-700);
+}
+.chip-state--press {
+  background: var(--p-50);
+  color: var(--p-500);
+}
+```
+
+---
+
+## Accessibility
+
+| Concern          | Implementation                                                                                                                                                  |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Standalone state | OK as `<span>`. Don't make it interactive — if it should be clickable, it's a button.                                                                           |
+| Color cue alone  | The chip's background color is a cue, but the **text label** must always carry the state. A green chip with "Ouvert" is fine. A green chip with no text is not. |
+| Contrast         | All variants pass AA against their tinted background (measured in [accessibility.md § 3](../accessibility.md)).                                                 |
+
+---
+
+## Do / Don't
+
+✅ **Do**: keep chip text short (1–3 words max). "Détecté 24s" is the longest acceptable.
+✅ **Do**: use the inline `style="..."` override for one-off cases (e.g. "Ouvert" on `--green-*`). Don't create a `.chip-state--open` if it's used in one place.
+
+❌ **Don't**: nest a chip-state inside another chip-state.
+❌ **Don't**: use the chip as a button trigger. Make it a `<button>` instead.
+
+---
+
+## See also
+
+- [eq-row.md](eq-row.md) — Most common parent
+- [pill.md](pill.md) — Cousin atom for the strip

--- a/design-system/components/dashboard-widget.md
+++ b/design-system/components/dashboard-widget.md
@@ -1,0 +1,320 @@
+# Dashboard widget (`dashboard-widget`)
+
+> Large card used on the Dashboard page. One widget = one equipment. Different layout from `eq-row` because the Dashboard is a glance-first surface, not a list.
+
+---
+
+## Anatomy
+
+```
+┌────────────────────────────────────────┐
+│         Portail                        │   .widget__title  (centered, 14 px weight 500)
+│                                        │
+│                                        │
+│             [SVG art]                  │   .widget__art   (line-art illustration)
+│                                        │
+│                                        │
+│  ────────────────────────────────      │
+│             Ouvert                     │   .widget__state (chip-state)
+└────────────────────────────────────────┘
+   273 × 240 desktop / × 160 mobile
+   12 px padding, 10 px radius
+```
+
+---
+
+## Variants per equipment type
+
+Each widget has a distinct **SVG illustration** + a specific footer layout. The illustration is **line-art at 80–120 px** (much larger than the 16–24 px Lucide icons used elsewhere).
+
+| Type                              | Illustration                                 | Footer content                                         |
+| --------------------------------- | -------------------------------------------- | ------------------------------------------------------ |
+| Gate / Garage                     | gate or garage door drawing                  | state chip ("Ouvert" / "Fermé")                        |
+| Shutter                           | shutter at current position                  | chip + 3-button `shutter-grp`                          |
+| Pool cover                        | horizontal slide drawing                     | chip + **horizontal** `shutter-grp` (left/stop/right)  |
+| Thermostat                        | thermometer SVG (amber fill if heating)      | value + power-btn + target ±                           |
+| Pool heat pump                    | thermometer SVG with red fill = "heating ON" | value + target ±                                       |
+| Weather station                   | sun/cloud SVG                                | inline multi-value (temp / humidity / wind / pressure) |
+| Weather forecast                  | weather glyph (cloud + sun + lightning)      | current° / forecast° + status + humidity + wind        |
+| Light                             | bulb SVG (amber fill when on)                | chip + power-btn                                       |
+| Appliance (washing machine, etc.) | machine drawing                              | state chip + power-btn                                 |
+| Pool pump                         | pump drawing                                 | chip ("ON"/"OFF") + runtime + power-btn                |
+| Energy meter                      | meter drawing                                | current kWh value                                      |
+
+---
+
+## States
+
+| State                 | Class                            | Effect                                                         |
+| --------------------- | -------------------------------- | -------------------------------------------------------------- |
+| Default               | `.widget`                        | white bg, line-2 border, 10 px radius                          |
+| Hover                 | `.widget:hover`                  | (production uses subtle bg shift; mock unspecified)            |
+| **Edit mode**         | parent has `.dashboard--editing` | each widget gets edit chrome overlay (drag, customize, delete) |
+| Drag (during reorder) | `.widget.is-dragging`            | reduced opacity + cursor grabbing                              |
+
+---
+
+## Edit mode chrome
+
+When the dashboard is in edit mode, each widget gets four small icon controls at its top edge:
+
+```
+┌────────────────────────────────────────┐
+│ ⋮⋮          🎨            ×             │   .widget__edit-overlay
+│        Portail                         │
+│             [SVG art]                  │
+│             Ouvert                     │
+└────────────────────────────────────────┘
+   drag      customize    delete
+   handle    (palette)
+```
+
+- `⋮⋮` — drag handle (top-left), enables reordering
+- `🎨` — palette / customize (top-center-right), opens widget settings panel
+- `×` — delete (top-right), removes widget after confirm
+- Optional chart icon for chart-type widgets (top-center)
+
+---
+
+## Code
+
+### Base widget shell
+
+```html
+<div class="widget">
+  <h3 class="widget__title">Portail</h3>
+  <div class="widget__art">
+    <!-- Illustration SVG (line-art, 100×80 typical) -->
+    <svg viewBox="0 0 200 120">…</svg>
+  </div>
+  <div class="widget__footer">
+    <span class="chip-state" style="background:var(--green-50);color:var(--green-700)">Ouvert</span>
+  </div>
+</div>
+```
+
+### Shutter widget (3 controls)
+
+```html
+<div class="widget">
+  <h3 class="widget__title">RDC</h3>
+  <div class="widget__art">…</div>
+  <div class="widget__footer">
+    <span class="chip-state" style="background:var(--green-50);color:var(--green-700)">Ouvert</span>
+    <div class="shutter-grp">
+      <button class="shutter-btn">↑</button>
+      <button class="shutter-btn">■</button>
+      <button class="shutter-btn">↓</button>
+    </div>
+  </div>
+</div>
+```
+
+### Thermostat widget
+
+```html
+<div class="widget widget--therm">
+  <h3 class="widget__title">PAC</h3>
+  <div class="widget__art">
+    <svg>…thermometer with amber fill if heating…</svg>
+    <div class="widget__current">21.0<span class="u">°C</span></div>
+    <button class="power-btn power-btn--on">…</button>
+  </div>
+  <div class="widget__target">
+    <button class="therm-btn">−</button>
+    <span class="therm-target-val">18.0°C</span>
+    <button class="therm-btn">+</button>
+  </div>
+</div>
+```
+
+### Edit mode overlay
+
+```html
+<div class="widget dashboard--editing">
+  <div class="widget__edit-overlay">
+    <button class="widget__drag" aria-label="Glisser pour réordonner"><svg>…</svg></button>
+    <button class="widget__customize" aria-label="Personnaliser"><svg>…palette…</svg></button>
+    <button class="widget__delete" aria-label="Supprimer"><svg>…×…</svg></button>
+  </div>
+  <h3 class="widget__title">Portail</h3>
+  …
+</div>
+```
+
+### CSS
+
+```css
+.widget {
+  background: var(--n-0);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  height: 240px; /* desktop */
+  overflow: hidden;
+  cursor: pointer;
+}
+@media (max-width: 640px) {
+  .widget {
+    height: 160px;
+    padding: 10px;
+  }
+}
+
+.widget__title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--n-800);
+  text-align: center;
+  margin: 0 0 8px;
+}
+
+.widget__art {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--p-500); /* primary stroke for line-art */
+}
+.widget__art svg {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.widget__footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  margin-top: 8px;
+}
+
+.widget__edit-overlay {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  right: 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 2;
+}
+.widget__drag,
+.widget__customize,
+.widget__delete {
+  width: 22px;
+  height: 22px;
+  background: transparent;
+  border: none;
+  color: var(--n-400);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.widget__drag {
+  cursor: grab;
+}
+.widget__drag:hover,
+.widget__customize:hover {
+  color: var(--n-700);
+}
+.widget__delete:hover {
+  color: var(--red-500);
+}
+```
+
+---
+
+## Why a widget is NOT an `eq-row`
+
+|              | eq-row (zone view)                       | widget (dashboard)                               |
+| ------------ | ---------------------------------------- | ------------------------------------------------ |
+| Purpose      | Compact control in a list of N equipment | Single equipment glance + control                |
+| Layout       | 5-col grid, 52 px tall                   | 273×240 card with 3 zones (title / art / footer) |
+| Icon         | 32×32 Lucide icon                        | 80–120 px line-art SVG illustration              |
+| Density      | Many per zone                            | A few hand-picked per dashboard                  |
+| Mental model | "what's in this zone"                    | "what do I check at a glance"                    |
+
+They serve **different purposes** on different pages. Production rightly chose two patterns. The design system embraces both.
+
+---
+
+## Illustration system (note)
+
+The line-art SVGs used in widget\_\_art are **production-specific** and not (yet) part of the design system. They live in `ui/src/components/dashboard/widget-icons.ts`.
+
+Characteristics:
+
+- Stroke-only (no fill) for most equipment
+- `--p-500` (navy) is the primary stroke color
+- `--a-500` (amber) is used for "live" fill (heated thermometer, lit bulb)
+- Sizes range 60–120 px depending on widget aspect
+
+**Status**: documented here for awareness. A separate `illustration-system.md` spec is **out of scope for design system v1.0** but proposed for v1.1.
+
+---
+
+## Accessibility
+
+| Concern        | Implementation                                                                                                                                                                  |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Card role      | A widget is a `<article role="group" aria-label="Widget Portail">` for screen reader grouping.                                                                                  |
+| Title          | Use `<h3>` (page H1 is "Dashboard", widgets are H3 sections).                                                                                                                   |
+| Illustration   | `aria-hidden="true"` on the SVG (decorative). The chip + value carry the state.                                                                                                 |
+| Click target   | The whole card is `cursor: pointer` — production should make it an actual button or use `role="button"` if the click triggers an action (typically opens the equipment detail). |
+| Edit mode      | Drag handle needs `aria-grabbed` + keyboard reorder support. Delete needs `aria-haspopup="dialog"` if it confirms.                                                              |
+| Color contrast | Title `--n-800` on `--n-0`: AAA. State chips already audited in [chip-state.md](chip-state.md).                                                                                 |
+| Touch target   | Edit chrome buttons are 22×22 — extend hit area via padding.                                                                                                                    |
+
+---
+
+## Do / Don't
+
+✅ **Do**: keep widget height fixed (`240` desktop / `160` mobile). The grid alignment depends on it.
+✅ **Do**: center the title and the illustration. The widget is a centerpiece, not a list row.
+✅ **Do**: reuse atoms (`chip-state`, `power-btn`, `shutter-grp`, `therm-target`) for the footer controls.
+✅ **Do**: use the amber accent only on the on-state (lit bulb, heating thermometer). Same rule as everywhere else.
+
+❌ **Don't**: replace the illustration with the Lucide icon used in eq-row. The widget needs the larger illustration for the dashboard glance.
+❌ **Don't**: stack widgets vertically inside a widget. One widget = one equipment.
+❌ **Don't**: tint the card background by category. The illustration carries the visual identity.
+❌ **Don't**: use widget cards inside zone view rows. Different contexts, different patterns.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+type WidgetProps = {
+  equipment: Equipment;
+  illustration: ReactNode; // line-art SVG
+  state: { label: string; tone: "success" | "neutral" | "warning" };
+  controls?: ReactNode; // shutter-grp, power-btn, etc.
+  editing?: boolean;
+  onDrag?: () => void;
+  onCustomize?: () => void;
+  onDelete?: () => void;
+  onClick?: () => void;
+};
+
+<Widget
+  equipment={portailEq}
+  illustration={<GateIllustration position="open" />}
+  state={{ label: "Ouvert", tone: "success" }}
+  onClick={() => navigate(`/equipment/${portailEq.id}`)}
+/>;
+```
+
+Widgets are pluggable: the dashboard reads a per-user list of widget refs and renders accordingly.
+
+---
+
+## See also
+
+- [eq-row.md](eq-row.md) — Different pattern for the zone view.
+- [shutter-grp.md](shutter-grp.md) — Reused in shutter / pool-cover widgets (with horizontal variant for pool covers).
+- [chip-state.md](chip-state.md) — Reused in widget footers.
+- Production reference: `ui/src/components/dashboard/WidgetGrid.tsx` and `widget-icons.ts`.

--- a/design-system/components/eq-row.md
+++ b/design-system/components/eq-row.md
@@ -1,0 +1,250 @@
+# Equipment row (`eq-row`)
+
+> A row inside the Équipements panel that displays a single equipment (light, shutter, sensor, thermostat…). The pattern is shared with `mode-row` and `recipe-row` to maintain visual alignment across panels.
+
+---
+
+## Anatomy
+
+```
+┌─────────┬──────────────────┬──────────┬───────┬─────────┐
+│ [icon]  │ Appliques x 2    │ [slider] │ 4 %   │ [power] │
+│ 32×32   │ flex 1           │ auto     │ auto  │ 32×26   │
+└─────────┴──────────────────┴──────────┴───────┴─────────┘
+        ↑                                              ↑
+        Grid: 32px 1fr auto auto auto, gap .85rem
+        Padding: .55rem 1.1rem, min-height 52px
+```
+
+---
+
+## Variants
+
+The equipment type drives the **icon** (background tint + icon glyph) and the **right-side controls**. The base grid is the same.
+
+| Type               | Icon class                                                                      | Right controls                                          | Example                   |
+| ------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------------- | ------------------------- |
+| `light_onoff`      | `.eq__icon--light` (or `--light-on` when on)                                    | `.power-btn`                                            | `Spots` row               |
+| `light_dimmable`   | `.eq__icon--light` / `--light-on`                                               | `.eq__slider` + `.eq__value` + `.power-btn`             | `Appliques x 2`           |
+| `shutter`          | `.eq__icon--shutter`                                                            | `.eq__slider--shutter` + `.chip-state` + `.shutter-grp` | `Volet Ouest`             |
+| `sensor`           | `.eq__icon--sensor`                                                             | `.sensor-val` + `.chip-state`                           | `PIRL · 2548 lx · RAS`    |
+| `media_player`     | `.eq__icon--media`                                                              | `.chip-state` ("OFF")                                   | `TV`                      |
+| `thermostat`       | inline-styled icon (info color, or amber when heating — `.therm-icon--heating`) | `.therm-current` + `.therm-target` (±) + `.power-btn`   | `PAC`                     |
+| `energy_meter`     | inline-styled icon (amber)                                                      | `.energy-val` + meta                                    | `Shelly Grid · 13.19 kWh` |
+| `weather_forecast` | inline-styled icon (info)                                                       | `.forecast-row` (5 days inline)                         | `Prévisions Météo`        |
+| `button` (remote)  | neutral icon                                                                    | `.chip-state--press` ("single 14h27")                   | `Remote Marc`             |
+| `gate`             | green-tinted icon                                                               | `.chip-state` + single `.gate-cmd` button               | `Portail jardin`          |
+| `water_valve`      | cyan-tinted icon                                                                | `.water-val` + `.chip-state` + `.power-btn`             | `Vanne potager`           |
+
+The full list of 21 equipment types maps to one of these visual shapes — see [components.md § Equipment type coverage](../components.md).
+
+---
+
+## States
+
+### Row-level
+
+| State   | How                      | Effect                                             |
+| ------- | ------------------------ | -------------------------------------------------- |
+| Default | none                     | white bg, 1 px line top border                     |
+| Hover   | `:hover`                 | bg `var(--n-25)`                                   |
+| Cursor  | `cursor: pointer` always | implies clickable row (opens detail in production) |
+
+### Icon-level (the "live" cue)
+
+| State           | Class                                                  | Effect                                                                             |
+| --------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| Off             | base `--icon-bg` (light tint) + `--icon-fg` (mid tint) | calm, neutral                                                                      |
+| **Light on**    | `.eq__icon--light-on`                                  | bg switches to `var(--a-500)` (yellow), fg becomes white, **animated glow** ripple |
+| Shutter closed  | (data-driven slider position)                          | slider knob navy, chip-state shows "Fermé"                                         |
+| Sensor detected | `.chip-state--detected`                                | green tinted "Détecté Xs"                                                          |
+
+The light-on state is the **single accent moment** of the entire UI. Reserved exclusively to "a light is on right now."
+
+---
+
+## Slots
+
+A row is a 5-column CSS grid. Each column accepts a single child.
+
+| Column | Slot            | Required | Common content                             |
+| ------ | --------------- | -------- | ------------------------------------------ |
+| 1      | Icon            | yes      | `.eq__icon` 32×32 with type modifier       |
+| 2      | Name            | yes      | `.eq__name` (16 px body)                   |
+| 3      | Primary control | optional | slider, current temp display, energy value |
+| 4      | Secondary value | optional | `.eq__value` percent, chip-state, badge    |
+| 5      | Action          | optional | `.power-btn`, `.shutter-grp`, `.gate-cmd`  |
+
+Empty slots collapse to 0 px due to `grid-template-columns: 32px 1fr auto auto auto`.
+
+---
+
+## Code
+
+### Light row (on, 4%)
+
+```html
+<div class="eq">
+  <div class="eq__icon eq__icon--light-on">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path
+        d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"
+      />
+      <path d="M9 18h6M10 22h4" />
+    </svg>
+  </div>
+  <span class="eq__name">Appliques x 2</span>
+  <div class="eq__slider">
+    <div class="eq__slider-fill" style="width:4%"></div>
+    <div class="eq__slider-knob" style="left:4%"></div>
+  </div>
+  <div class="eq__value" style="color:var(--a-600)">4 %</div>
+  <button class="power-btn power-btn--on" aria-label="Éteindre">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
+      <line x1="12" y1="2" x2="12" y2="12" />
+    </svg>
+  </button>
+</div>
+```
+
+### Shutter row (open)
+
+```html
+<div class="eq">
+  <div class="eq__icon eq__icon--shutter">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <path d="M3 9h18M3 15h18" />
+    </svg>
+  </div>
+  <span class="eq__name">Volet Ouest</span>
+  <div class="eq__slider">
+    <div class="eq__slider-fill eq__slider-fill--shutter" style="width:100%"></div>
+    <div class="eq__slider-knob eq__slider-knob--shutter" style="left:100%"></div>
+  </div>
+  <span class="chip-state" style="background:var(--green-50);color:var(--green-700)">Ouvert</span>
+  <div class="shutter-grp">
+    <button class="shutter-btn is-active" aria-label="Ouvrir">…</button>
+    <button class="shutter-btn" aria-label="Stop">…</button>
+    <button class="shutter-btn" aria-label="Fermer">…</button>
+  </div>
+</div>
+```
+
+### CSS (key rules)
+
+```css
+.eq {
+  display: grid;
+  grid-template-columns: 32px 1fr auto auto auto;
+  gap: 0.85rem;
+  align-items: center;
+  padding: 0.55rem 1.1rem;
+  min-height: 52px;
+  box-sizing: border-box;
+  border-top: 1px solid var(--line);
+  cursor: pointer;
+}
+.eq:hover {
+  background: var(--n-25);
+}
+
+.eq__icon {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--r-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--icon-bg, var(--n-50));
+  color: var(--icon-fg, var(--n-500));
+}
+.eq__icon svg {
+  width: 15px;
+  height: 15px;
+}
+.eq__icon--light {
+  --icon-bg: var(--light-50);
+  --icon-fg: var(--light-500);
+}
+.eq__icon--light-on {
+  --icon-bg: var(--a-500);
+  --icon-fg: var(--n-0);
+  animation: glow 3.2s ease-in-out infinite;
+}
+.eq__icon--shutter {
+  --icon-bg: var(--shutter-50);
+  --icon-fg: var(--shutter-500);
+}
+.eq__icon--sensor {
+  --icon-bg: var(--sensor-50);
+  --icon-fg: var(--sensor-500);
+}
+.eq__icon--media {
+  --icon-bg: var(--media-50);
+  --icon-fg: var(--media-500);
+}
+
+.eq__name {
+  font-weight: 500;
+  font-size: 0.88rem;
+  color: var(--n-800);
+}
+```
+
+---
+
+## Accessibility
+
+| Concern            | Implementation                                                                                                                                                                                     |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Row clickability   | The row is `cursor: pointer` but should be wrapped in a `<button>` or have `role="button"` and keyboard handler when used to open detail. The mock uses `<div>` for visual demo.                   |
+| Power button label | `aria-label="Allumer Appliques x 2"` (production pattern). Never just "Allumer" alone.                                                                                                             |
+| Slider             | Production uses `<input type="range">` underneath the visual slider for keyboard control. The mock shows the visual only.                                                                          |
+| Color contrast     | `--n-800` text on `--n-0` bg: AAA. `--a-600` (`#D4A41C`) on white: **WCAG AA** for normal text (4.6:1). Use `--n-800` for primary text wherever possible.                                          |
+| Touch target       | `.power-btn` is 32 × 26 px. Below Apple HIG 44 × 44. **Action: production should keep the visual 32×26 but add `padding` to expand the clickable area** (e.g. negative margins + larger hit zone). |
+| Reduced motion     | `.eq__icon--light-on` glow animation is disabled by `prefers-reduced-motion: reduce` (see [motion.md](../motion.md)).                                                                              |
+
+---
+
+## Do / Don't
+
+✅ **Do**: keep row height fixed at 52 px. The cross-panel alignment depends on it.
+✅ **Do**: tint the **icon** by equipment type, never the row background.
+✅ **Do**: use amber on the on-state of a light and nothing else.
+✅ **Do**: collapse unused columns (don't pad with empty divs — let the grid auto-shrink).
+
+❌ **Don't**: put a battery indicator on the row. Battery monitoring is a dedicated future feature; the zone view stays focused on state and commands.
+❌ **Don't**: add a "⚡ controlled by recipe" zap badge after the name. The user rejected this — context comes from the Activity feed or the Comportements panel.
+❌ **Don't**: stack a secondary line of text under the name unless the row is a `mode-row` (which has its own pattern at 2 stacked lines + icon).
+❌ **Don't**: invent new equipment type modifiers. If a type doesn't fit the existing six patterns, propose a new spec first.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+type EqRowProps = {
+  type: EquipmentType;        // one of 21 types
+  icon: ReactNode;
+  name: string;
+  state: 'on' | 'off' | 'open' | 'closed' | …;
+  value?: string;
+  primaryControl?: ReactNode; // slider, etc.
+  secondaryValue?: ReactNode; // chip-state, percent
+  action?: ReactNode;          // power-btn, shutter-grp
+  onClick?: () => void;
+};
+```
+
+The icon modifier is computed from `type` + `state`. For lights, `state === 'on'` → `eq__icon--light-on`.
+
+---
+
+## See also
+
+- [components/power-button.md](power-button.md) — Action atom used in rows.
+- [components/slider.md](slider.md) — Primary control for dimmer / shutter position.
+- [components/chip-state.md](chip-state.md) — State badge.
+- [components/shutter-grp.md](shutter-grp.md) — Three-button segmented control for shutters.

--- a/design-system/components/hero.md
+++ b/design-system/components/hero.md
@@ -1,0 +1,172 @@
+# Zone hero (`hero`)
+
+> The title block at the top of a zone view. Composed of two lines: the zone title and a state-synthesis lead.
+
+---
+
+## Anatomy
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                                                         │  ← padding-top 2.1rem
+│  Séjour                                                 │  .hero__title (2.6rem, weight 700)
+│                                                         │
+│  1 lumière allumée  ·  tous les volets ouverts          │  .hero__lead (0.85rem, n-500)
+│                                                         │
+└─────────────────────────────────────────────────────────┘  ← padding-bottom 1.25rem
+                                                              radial gradients in bg
+```
+
+The hero **does not** carry a breadcrumb (the topbar does that) or a mode badge (the Comportements panel does). It's intentionally minimal — the focus is on the zone name and a one-line synthesis of state.
+
+---
+
+## States
+
+The hero has no interactive state. Its appearance is driven by data:
+
+- `.hero__title` text changes per zone
+- `.hero__lead` text is computed from the zone's aggregate state (e.g. "1 lumière allumée · tous les volets ouverts")
+
+---
+
+## Slots
+
+| Slot           | Class             | Required              | Content                                    |
+| -------------- | ----------------- | --------------------- | ------------------------------------------ |
+| Title          | `.hero__title`    | yes                   | Zone name                                  |
+| Lead           | `.hero__lead`     | optional              | State synthesis. Hide if no notable state. |
+| Lead separator | `.hero__lead-sep` | between lead segments | small dot dot dot (·)                      |
+
+---
+
+## Code
+
+```html
+<div class="hero">
+  <div class="hero__head">
+    <div class="hero__main">
+      <h1 class="hero__title">Séjour</h1>
+      <div class="hero__lead">
+        <span>1 lumière allumée</span>
+        <span class="hero__lead-sep"></span>
+        <span>tous les volets ouverts</span>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+```css
+.hero {
+  position: relative;
+  padding: 2.1rem 1.5rem 1.25rem;
+  background:
+    radial-gradient(
+      120% 80% at 0% 0%,
+      color-mix(in srgb, var(--p-500) 6%, transparent),
+      transparent 55%
+    ),
+    radial-gradient(
+      80% 100% at 100% 0%,
+      color-mix(in srgb, var(--a-500) 4%, transparent),
+      transparent 60%
+    );
+}
+
+.hero__head {
+  margin-bottom: 1.4rem;
+}
+.hero__main {
+  min-width: 0;
+}
+.hero__title {
+  font-size: 2.6rem;
+  font-weight: 700;
+  margin: 0 0 0.15rem;
+  color: var(--n-800);
+  letter-spacing: -0.03em;
+  line-height: 1;
+}
+.hero__lead {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: 0.55rem;
+  font-size: 0.85rem;
+  color: var(--n-500);
+  font-feature-settings: "tnum" 1;
+}
+.hero__lead b {
+  color: var(--n-700);
+  font-weight: 600;
+}
+.hero__lead-sep {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--n-300);
+  flex: none;
+}
+```
+
+---
+
+## Lead content rules
+
+The lead synthesizes state in **natural language**. Format: `N <item> <state>` per segment, joined by dot separators.
+
+Examples per zone state:
+
+- All quiet: `1 lumière allumée · tous les volets ouverts`
+- Movement detected: `mouvement détecté il y a 39 min · 2 lumières allumées`
+- Alert: `1 porte oubliée ouverte · tous les volets ouverts` (alert is more strongly highlighted in the strip)
+
+**Avoid**:
+
+- Generic counts like "12 équipements" (the user removed these — they're noise).
+- Listing every state. Pick the 2–3 most meaningful for the moment.
+- Tense markers like "actuellement" — implicit.
+
+---
+
+## Accessibility
+
+| Concern         | Implementation                                                                           |
+| --------------- | ---------------------------------------------------------------------------------------- |
+| `<h1>` semantic | The zone title is the page H1. Wrap as `<h1>` in production.                             |
+| `aria-live`     | The lead may update in real-time. Wrap as `<div aria-live="polite">` if data refreshes.  |
+| Color contrast  | `--n-800` (`#18181B`) on the gradient backdrop (still effectively `--n-50`): 14:1 — AAA. |
+| Decoration      | The radial gradients are decorative and do not carry meaning. No ARIA needed.            |
+
+---
+
+## Do / Don't
+
+✅ **Do**: keep the title at 2.6rem on desktop. It's the page's anchor.
+✅ **Do**: use the lead to surface non-obvious state ("calme depuis 39 min", "soleil dans 1h12"). Avoid restating data already in the strip.
+✅ **Do**: keep the gradients subtle (4–6% color mix). They give identity without screaming.
+
+❌ **Don't**: re-add a breadcrumb eyebrow above the title — the topbar already shows it.
+❌ **Don't**: put a status badge ("Mode Lumière soir actif") next to the title. Mode info lives in the Comportements panel.
+❌ **Don't**: stack more than 2–3 segments in the lead. If you need more, you're overloading the hero.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+type HeroProps = {
+  zoneName: string;
+  leadSegments?: string[];
+};
+
+<Hero zoneName="Séjour" leadSegments={["1 lumière allumée", "tous les volets ouverts"]} />;
+```
+
+---
+
+## See also
+
+- [strip.md](strip.md) — Comes immediately below the hero, surfaces detailed state.
+- [topbar.md](topbar.md) — Carries the breadcrumb the hero deliberately doesn't.

--- a/design-system/components/mobile-tabbar.md
+++ b/design-system/components/mobile-tabbar.md
@@ -1,0 +1,168 @@
+# Mobile bottom tab bar (`mob__tabs`)
+
+> Fixed bottom navigation on mobile. 5 tabs, the last one being "Plus" (overflow menu) — matching production exactly.
+
+---
+
+## Anatomy
+
+```
+┌──────────────────────────────────────────────────────┐
+│                                                      │
+│                                                      │
+│  (page content scrolls above)                        │
+│                                                      │
+├──────────────────────────────────────────────────────┤  border-top
+│ ▢▢▢▢   🏠   ⚡   ▦   ☰                                │
+│ Dash    Maison  Énergie  Modes  Plus                 │  76 px (incl. 18 px safe-area)
+└──────────────────────────────────────────────────────┘
+```
+
+Order matters: **Dashboard / Maison / Énergie / Modes / Plus** — confirmed by production via Playwright inspection. Énergie is the SECOND most accessed scope after Maison, so it sits right next to Maison.
+
+---
+
+## States
+
+| State   | Class               | Effect                    |
+| ------- | ------------------- | ------------------------- |
+| Default | `.mob__tab`         | icon + label in `--n-400` |
+| Active  | `.mob__tab--active` | icon + label in `--p-500` |
+
+Only one tab is `--active` at a time. The active tab matches the current route.
+
+---
+
+## Code
+
+```html
+<div class="mob__tabs">
+  <div class="mob__tab">
+    <svg>… Grid3x3 …</svg>
+    <span class="mob__tab-label">Dashboard</span>
+  </div>
+  <div class="mob__tab mob__tab--active">
+    <svg>… Home …</svg>
+    <span class="mob__tab-label">Maison</span>
+  </div>
+  <div class="mob__tab">
+    <svg>… Zap …</svg>
+    <span class="mob__tab-label">Énergie</span>
+  </div>
+  <div class="mob__tab">
+    <svg>… Layers …</svg>
+    <span class="mob__tab-label">Modes</span>
+  </div>
+  <div class="mob__tab">
+    <svg>… horizontal lines (Menu / hamburger) …</svg>
+    <span class="mob__tab-label">Plus</span>
+  </div>
+</div>
+```
+
+```css
+.mob__tabs {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 76px;
+  padding-bottom: 18px; /* iOS safe-area */
+  background: var(--n-0);
+  border-top: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  backdrop-filter: blur(8px);
+}
+
+.mob__tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  color: var(--n-400);
+  cursor: pointer;
+}
+.mob__tab svg {
+  width: 20px;
+  height: 20px;
+}
+.mob__tab-label {
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.mob__tab--active {
+  color: var(--p-500);
+}
+```
+
+---
+
+## "Plus" tab behavior
+
+The Plus tab is an **overflow menu trigger**, not a route. Tapping it opens a drawer or sheet with secondary navigation (Analyse, Réglages, Administration, etc.).
+
+In production this is implemented in `AppLayout.tsx`'s `MobileNavLink` component with a sheet overlay.
+
+---
+
+## Why this exact order
+
+The user explicitly asked for this order ("Énergie right of Maison") and Playwright verified the production order is:
+
+1. **Dashboard** — landing
+2. **Maison** — zone tree
+3. **Énergie** — energy dashboard
+4. **Modes** — automation states
+5. **Plus** — everything else
+
+This ordering reflects **usage frequency** on mobile (Dashboard glance > Zone control > Energy peek > Mode switch > Settings rarely).
+
+---
+
+## Accessibility
+
+| Concern        | Implementation                                                                       |
+| -------------- | ------------------------------------------------------------------------------------ |
+| Landmark       | `<nav role="navigation" aria-label="Navigation principale">` in production.          |
+| Tab role       | Each tab is a `<Link>` or `<button>` — focusable and keyboard-activatable.           |
+| Active state   | Use `aria-current="page"` on the active tab in addition to the `--active` class.     |
+| Touch target   | 76 × ~(viewport/5) px — each tab is ~78 × 76 on a 390 px viewport. **Passes 44×44**. |
+| Color contrast | `--n-400` on `--n-0`: 5.6:1 — AA (large text). Active `--p-500`: 9.8:1 — AAA.        |
+| iOS safe-area  | The 18 px bottom padding accounts for the home indicator on modern iPhones.          |
+
+---
+
+## Do / Don't
+
+✅ **Do**: respect the production order (Dashboard / Maison / Énergie / Modes / Plus).
+✅ **Do**: keep the Plus tab as a menu trigger, not a route.
+✅ **Do**: use the hamburger icon (3 lines) for Plus — matches production.
+
+❌ **Don't**: rearrange tabs by alphabet or developer preference. Production order is calibrated by usage.
+❌ **Don't**: replace Plus with a specific item (e.g. "Réglages"). The overflow menu is essential for accessing the long tail of features without bloating the tab bar.
+❌ **Don't**: add a 6th tab. 5 is the max for thumb-friendly touch.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+<MobileTabBar>
+  <MobileTabLink to="/dashboard" icon={<Grid3x3 />} label="Dashboard" />
+  <MobileTabLink to="/home" icon={<Home />} label="Maison" />
+  <MobileTabLink to="/energy" icon={<Zap />} label="Énergie" />
+  <MobileTabLink to="/modes" icon={<Layers />} label="Modes" />
+  <MobileTabButton onClick={openOverflow} icon={<Menu />} label="Plus" />
+</MobileTabBar>
+```
+
+---
+
+## See also
+
+- [sidebar-nav.md](sidebar-nav.md) — Desktop equivalent
+- [topbar.md](topbar.md) — Replaced on mobile by the `mob__topbar` with hamburger menu in the title bar

--- a/design-system/components/modal.md
+++ b/design-system/components/modal.md
@@ -1,0 +1,225 @@
+# Modal (recipe edit)
+
+> Centered overlay card used to edit a recipe's parameters. Contains the recipe's full configuration in one screen — including our value-add over production: per-mode overrides.
+
+---
+
+## Anatomy
+
+```
+        ┌─────────────────────────────────────────────────┐
+        │ [icon] Lumière dimmable sur mouvement       [×] │  .modal__head (border-bottom)
+        │        Recette · zone Séjour · pilotée par 1 mode │
+        ├─────────────────────────────────────────────────┤
+        │                                                 │  .modal__body (scrollable, gap 1.4rem)
+        │ Lumières à contrôler*                           │   ┌ section
+        │ Lumières dimmables à contrôler (doivent…)       │   │  .msec__label + msec__help
+        │ ┌────────────────┐                              │   │
+        │ │ ☑ Applique x 1 │                              │   │  .mcheck
+        │ ├────────────────┤                              │   │
+        │ │ ☑ Appliques x 2│                              │   │
+        │ └────────────────┘                              │   └
+        │                                                 │
+        │ Paramètres                                      │   ┌ section
+        │ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐             │   │  .mfgrid (2-col)
+        │ │Délai*│ │Lumin.│ │Seuil │ │Auto  │             │   │  .mfield each
+        │ │10 min│ │ 254  │ │ 2300 │ │  —   │             │   │
+        │ └──────┘ └──────┘ └──────┘ └──────┘             │   └
+        │                                                 │
+        │ Interrupteurs physiques                         │
+        │ ┌────────────────┐                              │
+        │ │ ☐ Switch …     │                              │
+        │ └────────────────┘                              │
+        │                                                 │
+        │ Plages horaires                                 │   ┌ amber-bordered group
+        │ ┌─Plage 1───────────────────────────────────┐  │   │  .mplage
+        │ │ [Début 21:00] [Fin 08:00] [Lum 100]       │  │   │
+        │ └────────────────────────────────────────────┘  │   └
+        │ ┌+ Plage 2┐ ┌+ Plage 3┐                         │      .mplage__add
+        │                                                 │
+        │ Surcharges par mode  [amélioration UX]          │   ┌ amber border-left
+        │ ● Lumière soir [Actif]   21:00→08:00 · 4 %  [M] │   │  .mover__row
+        │ ○ Lumière jour            Désactivée le jour [M]│   │
+        │ ○ Lumière nuit            Pas de surcharge  [+] │   └
+        ├─────────────────────────────────────────────────┤
+        │ Modifications non enregistrées   [Annuler][✓Enregistrer] │  .modal__foot
+        └─────────────────────────────────────────────────┘
+```
+
+The modal lives inside a `.modal-stage` (a fake page with a dimmed/hatched backdrop in the mockup). In production, the stage would be a real overlay with `position: fixed; inset: 0; background: rgba(0,0,0,.4)`.
+
+---
+
+## Body sections (top to bottom)
+
+1. **Lumières à contrôler** (`.mcheck`) — Checklist of eligible lights. Each item is a checkbox + name in a rounded card.
+2. **Paramètres** (`.mfgrid`, 2 cols × 2 rows) — Délai (min), Luminosité (1-254), Seuil lux max, Extinction auto.
+3. **Interrupteurs physiques** (`.mcheck`) — Optional checklist of physical switches that toggle the recipe manually.
+4. **Options** — Single checkbox: "Inactif le jour".
+5. **Plages horaires** (`.mplage`) — Amber-bordered group with Début / Fin / Luminosité. Followed by dashed `+ Plage 2` / `+ Plage 3` to add more.
+6. **Surcharges par mode** (`.mover`, amber-bordered section) — **Our value-add**. List of modes with their per-mode override values + Modifier / Activer buttons. Marked with `amélioration UX` beta badge.
+
+---
+
+## States
+
+| State                | Class                                                 | Effect                                                              |
+| -------------------- | ----------------------------------------------------- | ------------------------------------------------------------------- |
+| Default              | `.modal`                                              | white card, multi-layer shadow, max-width 640 px, max-height 720 px |
+| Section default      | `.msec`                                               | gap .55rem between label/help/content                               |
+| **Enhanced section** | `.msec--enhance`                                      | adds amber border-left to mark "this isn't in production"           |
+| Modified             | `.modal__foot-status::before` neutral grey dot        | "Modifications non enregistrées"                                    |
+| Save state           | (production wires `disabled` on Save when no changes) | greyed out save button                                              |
+
+---
+
+## Form atom variants
+
+| Atom               | Class                                | Used for                                       |
+| ------------------ | ------------------------------------ | ---------------------------------------------- |
+| Checklist item     | `.mcheck__item`                      | each binding (lights, switches)                |
+| Field (compact)    | `.mfield`                            | a single labeled input                         |
+| Field with suffix  | `.mfield__input` + `.mfield__suffix` | "10 min", "2300 lx"                            |
+| Compact field grid | `.mfgrid`                            | 2-col responsive layout for primary parameters |
+| Plage group        | `.mplage`                            | amber-bordered horizontal time range           |
+| Mode override row  | `.mover__row`                        | one row per mode with its override value       |
+| Action button      | `.mbtn` / `.mbtn--primary`           | footer Save / Cancel                           |
+
+---
+
+## Code
+
+### Header
+
+```html
+<div class="modal__head">
+  <div class="modal__head-icon">
+    <svg>… ChefHat …</svg>
+  </div>
+  <div class="modal__head-titles">
+    <div class="modal__head-title">Lumière dimmable sur mouvement</div>
+    <div class="modal__head-sub">Recette · zone <b>Séjour</b> · pilotée par 1 mode</div>
+  </div>
+  <button class="modal__close" aria-label="Fermer">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  </button>
+</div>
+```
+
+### Field with suffix
+
+```html
+<div class="mfield">
+  <label class="mfield__lab">Délai<span class="msec__required">*</span></label>
+  <div class="mfield__input">
+    <input type="number" value="10" />
+    <span class="mfield__suffix">min</span>
+  </div>
+  <span class="mfield__help">Sans mouvement avant extinction</span>
+</div>
+```
+
+### Plage horaire group
+
+```html
+<div class="mplage">
+  <div class="mplage__head">
+    <span class="mplage__title">Plage 1</span>
+    <button class="mplage__del" aria-label="Supprimer la plage">…</button>
+  </div>
+  <div class="mplage__grid">
+    <div class="mfield"><label>Début</label><input type="time" value="21:00" /></div>
+    <div class="mfield"><label>Fin</label><input type="time" value="08:00" /></div>
+    <div class="mfield"><label>Luminosité</label><input type="number" value="100" /></div>
+  </div>
+</div>
+<div class="mplage__add-row">
+  <button class="mplage__add">+ Plage 2</button>
+  <button class="mplage__add">+ Plage 3</button>
+</div>
+```
+
+### Footer
+
+```html
+<div class="modal__foot">
+  <span class="modal__foot-status">Modifications non enregistrées</span>
+  <div class="modal__foot-actions">
+    <button class="mbtn">Annuler</button>
+    <button class="mbtn mbtn--primary"><svg>… check …</svg>Enregistrer</button>
+  </div>
+</div>
+```
+
+---
+
+## Behavior
+
+| Trigger                                         | Action                                    |
+| ----------------------------------------------- | ----------------------------------------- |
+| Click `.recipe__open` on a recipe row           | Modal opens                               |
+| Click `.modal__close` (×)                       | Close modal. If unsaved changes → confirm |
+| Click backdrop (`.modal-stage::before` in mock) | Close modal. If unsaved changes → confirm |
+| Press `Escape`                                  | Close modal. If unsaved changes → confirm |
+| Click `.mbtn` (Annuler)                         | Discard changes, close modal              |
+| Click `.mbtn--primary` (Enregistrer)            | Save, close modal                         |
+
+---
+
+## Accessibility
+
+| Concern               | Implementation                                                                                                                   |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Role                  | The `.modal` container must be `role="dialog" aria-modal="true"`.                                                                |
+| Title                 | `.modal__head-title` should be the `aria-labelledby` target.                                                                     |
+| Initial focus         | Production should focus the first interactive element (first checkbox or close button) on open.                                  |
+| Escape                | Must close the modal.                                                                                                            |
+| Focus trap            | While the modal is open, focus stays within. Production must wire a focus trap.                                                  |
+| Tabular nums          | All numeric inputs use `font-feature-settings: "tnum" 1` so `2300` aligns with `10` if stacked.                                  |
+| Color contrast        | Help text `--n-400` on `--n-0`: 4.6:1 — barely AA. Production should use `--n-500` for help text when accessibility is critical. |
+| Required field marker | The `*` is a visual cue only. Production must also add `aria-required="true"`.                                                   |
+| Section semantics     | Each `<section class="msec">` should have an `<h3>` (or `aria-label`) summarizing it.                                            |
+
+---
+
+## Do / Don't
+
+✅ **Do**: keep all sections inside one scrollable body. Don't split into tabs — recipes are short enough to fit.
+✅ **Do**: mark our "Surcharges par mode" section with the **amélioration UX** beta badge so users know it's not in production yet.
+✅ **Do**: use the amber border-left on both `mplage` and `msec--enhance` — that's the visual signal "this is a time-related or mode-related concept" tied to the Sowel amber accent.
+
+❌ **Don't**: make this an inline expand under the recipe row. Production does inline, but we chose modal for better focus on the form. Acknowledged divergence (documented in [README.md](../README.md) and the modal section intro).
+❌ **Don't**: nest tabs or sub-modals. If config gets that complex, the recipe spec should be re-thought.
+❌ **Don't**: hide the unsaved-changes status. The user must know they have unsaved work.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+<RecipeEditModal
+  recipe={recipe}
+  modes={modes}
+  open={isOpen}
+  onClose={handleClose}
+  onSave={handleSave}
+  isDirty={isDirty} // controls Save button enable + close confirm
+/>
+```
+
+Internally:
+
+- `EquipmentCheckList` — slot for `lights`-type equipment binding
+- `ParameterGrid` — 2-col grid of `Field`s
+- `PlageGroup` — repeatable, sortable list of time ranges
+- `ModeOverridesPanel` — the value-add section
+
+---
+
+## See also
+
+- [components/recipe-row.md](recipe-row.md) — Click target that opens this modal.
+- [components/chip-state.md](chip-state.md) — "Actif" badge inside the mode overrides.

--- a/design-system/components/mode-row.md
+++ b/design-system/components/mode-row.md
@@ -1,0 +1,260 @@
+# Mode row (`mode-row`)
+
+> A row inside the Comportements panel's Modes sub-category. Displays one mode (Lumière jour, Lumière nuit, …) with its action count, last application time, and an Apply / Active state.
+
+---
+
+## Anatomy
+
+```
+┌─────────┬─────────────────────┬───────────┐
+│ [icon]  │ Lumière soir        │ [Apply]   │
+│ 32×32   │ 4 actions · 21:00   │           │
+│   ●     │ (active dot on icon)│           │
+└─────────┴─────────────────────┴───────────┘
+        ↑                            ↑
+        Grid: 32px 1fr auto, gap .85rem
+        Padding: .55rem 1.1rem, min-height 52px
+```
+
+The icon has an **overlay dot** at top-right indicating active state (green pulse when applied globally, neutral when not). This is the mode-row signature — it lets the user spot the active mode at a glance without needing a separate badge column.
+
+---
+
+## Variants
+
+There is **one** mode-row shape. The difference between "not applied" and "applied" lives in:
+
+- The dot overlay color
+- The action on the right (Apply button vs. ACTIF badge)
+- The `mode-row--active` modifier (faint green bg + green left bar)
+
+| Variant  | Class combo                   | Right slot                                       |
+| -------- | ----------------------------- | ------------------------------------------------ |
+| Inactive | `.mode-row`                   | `<button class="mode-row__apply">Apply</button>` |
+| Active   | `.mode-row .mode-row--active` | `<span class="mode-row__badge">Actif</span>`     |
+
+---
+
+## States
+
+| State      | Class               | Effect                                                                                                             |
+| ---------- | ------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Default    | `.mode-row`         | white bg, neutral dot                                                                                              |
+| Hover      | `:hover`            | bg `var(--n-25)`                                                                                                   |
+| **Active** | `.mode-row--active` | bg green tint 4%, left border 3 px green-500, name color green-700 weight 700, icon bg green-50, dot pulsing green |
+
+---
+
+## Slots
+
+| Column | Slot              | Required | Content                                                          |
+| ------ | ----------------- | -------- | ---------------------------------------------------------------- |
+| 1      | `.mode-row__icon` | yes      | 32×32 with Layers SVG + status dot overlay                       |
+| 2      | `.mode-row__main` | yes      | `.mode-row__name` + `.mode-row__meta`                            |
+| 3      | Action            | yes      | `.mode-row__apply` (button) OR `.mode-row__badge` (span "Actif") |
+
+The icon uses **Layers** (Lucide) — same icon as the sidebar Modes nav item, the Comportements panel sub-cat header, and the mobile tab bar. Single icon, four placements, perfect consistency.
+
+---
+
+## Code
+
+### Inactive mode
+
+```html
+<div class="mode-row">
+  <div class="mode-row__icon">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.6"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polygon points="12 2 2 7 12 12 22 7 12 2" />
+      <polyline points="2 17 12 22 22 17" />
+      <polyline points="2 12 12 17 22 12" />
+    </svg>
+    <span class="mode-row__icon-dot"></span>
+  </div>
+  <div class="mode-row__main">
+    <div class="mode-row__name">Lumière jour</div>
+    <div class="mode-row__meta">1 action</div>
+  </div>
+  <button class="mode-row__apply">Apply</button>
+</div>
+```
+
+### Active mode
+
+```html
+<div class="mode-row mode-row--active">
+  <div class="mode-row__icon">
+    <svg>…Layers…</svg>
+    <span class="mode-row__icon-dot mode-row__icon-dot--active"></span>
+  </div>
+  <div class="mode-row__main">
+    <div class="mode-row__name">Lumière soir</div>
+    <div class="mode-row__meta">4 actions · appliqué 21:00</div>
+  </div>
+  <span class="mode-row__badge">Actif</span>
+</div>
+```
+
+### CSS (key rules)
+
+```css
+.mode-row {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  gap: 0.85rem;
+  align-items: center;
+  padding: 0.55rem 1.1rem;
+  min-height: 52px;
+  box-sizing: border-box;
+  border-top: 1px solid var(--line);
+  cursor: pointer;
+  transition: background 120ms;
+}
+.mode-row:hover {
+  background: var(--n-25);
+}
+
+.mode-row__icon {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--r-sm);
+  background: var(--n-50);
+  color: var(--n-500);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+.mode-row__icon-dot {
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--n-200);
+  border: 2px solid var(--n-0);
+}
+.mode-row__icon-dot--active {
+  background: var(--green-500);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--green-500) 22%, transparent);
+}
+
+.mode-row__name {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--n-800);
+  line-height: 1.25;
+}
+.mode-row__meta {
+  font-size: 0.7rem;
+  color: var(--n-400);
+  line-height: 1.25;
+  margin-top: 1px;
+}
+
+.mode-row--active {
+  background: color-mix(in srgb, var(--green-500) 4%, var(--n-0));
+  border-left: 3px solid var(--green-500);
+  padding-left: calc(1.1rem - 3px);
+}
+.mode-row--active .mode-row__icon {
+  background: var(--green-50);
+  color: var(--green-700);
+}
+.mode-row--active .mode-row__name {
+  color: var(--green-700);
+  font-weight: 700;
+}
+
+.mode-row__apply {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--p-500);
+  background: transparent;
+  border: 1px solid var(--line);
+  padding: 0.25rem 0.65rem;
+  border-radius: var(--r-xs);
+  cursor: pointer;
+}
+.mode-row__apply:hover {
+  background: var(--p-50);
+  border-color: var(--p-500);
+}
+
+.mode-row__badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--green-700);
+  background: color-mix(in srgb, var(--green-500) 12%, transparent);
+  padding: 2px 8px;
+  border-radius: var(--r-full);
+}
+```
+
+---
+
+## Why line-height matters here
+
+The mode-row stacks two lines of text in column 2 (name + meta). With default browser line-height (~1.5), this stack becomes ~40 px tall and the row inflates to 60 px, breaking alignment with eq-rows (52 px). The CSS sets `line-height: 1.25` on both name and meta to keep the stack at ~32 px, matching the 32 px icon and the row's 52 px min-height.
+
+This is a **load-bearing CSS detail**. Don't change it without re-verifying alignment via the measurement table in [accessibility.md § Visual rhythm](../accessibility.md).
+
+---
+
+## Accessibility
+
+| Concern            | Implementation                                                                                                                                                 |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Row interaction    | The row is `cursor: pointer` (clickable to expand effects in production). In production should be a `<button>` or have `role="button"` + keyboard handler.     |
+| Apply button label | `aria-label="Appliquer le mode Lumière jour"` (avoid bare "Apply").                                                                                            |
+| Status dot         | The dot must NOT be the only cue for active state. Production also uses the `--active` modifier + the "Actif" badge to ensure colorblind users see the status. |
+| Color contrast     | `--green-700` (`#0E6B3F`) on `#E6F7EE` bg: WCAG AAA (8.4:1).                                                                                                   |
+| Reduced motion     | The icon-dot ping is implemented via `box-shadow` extension, not animation, so `prefers-reduced-motion` doesn't need special handling here.                    |
+
+---
+
+## Do / Don't
+
+✅ **Do**: keep the icon, name, and meta consistent across all 3 modes (don't make some 1 line and others 2).
+✅ **Do**: change the icon background and text color when the mode becomes active — let the row "light up" subtly.
+✅ **Do**: place the action ("Apply" button or "Actif" badge) in the same column for all modes.
+
+❌ **Don't**: use the amber accent for the active state. Active = green (it's a status), amber = light is on.
+❌ **Don't**: add a third line of meta. If you need more info, expand the mode in place on click or open a detail.
+❌ **Don't**: replace the icon with a category-tinted icon per mode. The Layers icon is shared on purpose — modes are abstract groupings, not equipment categories.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+type ModeRowProps = {
+  mode: Mode;
+  isActive: boolean;
+  onApply: () => void;
+};
+
+<ModeRow mode={modes[0]} isActive={false} onApply={…} />
+<ModeRow mode={modes[2]} isActive={true} onApply={…} />  // shows "Actif" badge
+```
+
+When `isActive === true`, render `.mode-row--active` + the badge. When false, render the Apply button.
+
+---
+
+## See also
+
+- [recipe-row.md](recipe-row.md) — Same panel, different pattern (recipes have 3 action buttons on row 2).
+- [eq-row.md](eq-row.md) — Equipment row using the same grid for alignment.
+- [chip-state.md](chip-state.md) — The "Actif" badge pattern.

--- a/design-system/components/panel.md
+++ b/design-system/components/panel.md
@@ -1,0 +1,204 @@
+# Panel
+
+> The top-level container of a section in the zone view. Three panels exist on a zone page: **Équipements**, **Comportements**, **Activité**.
+
+---
+
+## Anatomy
+
+```
+┌─────────────────────────────────────────────────────┐
+│ ÉQUIPEMENTS  dans cette zone              [+]       │  ← .panel__head (44 px)
+├─────────────────────────────────────────────────────┤
+│ 💡 ÉCLAIRAGES                                       │  ← .cat-head (36 px)
+├─────────────────────────────────────────────────────┤
+│ [icon] Applique x 1    [slider]   0 %   [power]    │  ← .eq (52 px)
+│ [icon] Appliques x 2   [slider]   4 %   [power]    │
+└─────────────────────────────────────────────────────┘
+```
+
+**Fixed heights**: `panel__head = 44 px`, `cat-head = 36 px`, row = `52 px`. These three numbers are the spine of the layout and must not drift. They guarantee row-to-row alignment across the two-column grid (Équipements + Comportements).
+
+---
+
+## Anatomy parts
+
+| Part                | Class                                                      | Required                       |
+| ------------------- | ---------------------------------------------------------- | ------------------------------ |
+| Wrapper             | `.panel`                                                   | yes                            |
+| Header              | `.panel__head`                                             | yes                            |
+| Title               | `.panel__title`                                            | yes (uppercase, primary color) |
+| Sub-text            | `.panel__sub`                                              | optional ("dans cette zone")   |
+| Action              | `.panel__add`                                              | optional (`+` icon to add)     |
+| Sub-category header | `.cat-head`                                                | one per group                  |
+| Body rows           | one of `.eq` / `.mode-row` / `.recipe` / `.activity__item` | n+                             |
+
+---
+
+## States
+
+| State                                | Class                                      | Effect                                   |
+| ------------------------------------ | ------------------------------------------ | ---------------------------------------- |
+| Default                              | `.panel`                                   | white bg, 1 px line border, 12 px radius |
+| Live indicator (Activity panel only) | `.panel__count` with inline style override | shows `● live` green badge in header     |
+
+The panel itself has no hover/active state. Interactivity lives on its rows.
+
+---
+
+## Variants
+
+There are no panel variants. All three panels (Équipements, Comportements, Activité) use the same `.panel` class. Their content differs (row types, sub-categories), not their chrome.
+
+The **panel\_\_head** has one optional element: a `+` button (`.panel__add`) for adding equipment. The Comportements and Activité panels do not have this — the `+` for adding modes or recipes lives on the **cat-head** of those sub-categories instead.
+
+---
+
+## Code
+
+### HTML
+
+```html
+<div class="panel">
+  <div class="panel__head">
+    <span class="panel__title">Équipements</span>
+    <span class="panel__sub">dans cette zone</span>
+    <button class="panel__add" aria-label="Ajouter un équipement">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+      >
+        <line x1="12" y1="5" x2="12" y2="19" />
+        <line x1="5" y1="12" x2="19" y2="12" />
+      </svg>
+    </button>
+  </div>
+
+  <!-- Sub-categories and rows go here -->
+  <div class="cat-head">
+    <svg class="cat-head-icon">…</svg>
+    Éclairages
+  </div>
+  <div class="eq">…</div>
+  <div class="eq">…</div>
+</div>
+```
+
+### CSS (extract)
+
+```css
+.panel {
+  background: var(--n-0);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+}
+
+.panel__head {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.55rem 1.1rem;
+  min-height: 44px;
+  box-sizing: border-box;
+  background: var(--p-50);
+  border-bottom: 1px solid var(--p-100);
+}
+
+.panel__title {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--p-500);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.panel__sub {
+  font-size: 0.72rem;
+  font-weight: 500;
+  margin-left: 0.35rem;
+  color: color-mix(in srgb, var(--p-500) 65%, transparent);
+}
+
+.panel__add {
+  margin-left: auto;
+  width: 26px;
+  height: 26px;
+  background: transparent;
+  border: 1px solid var(--p-100);
+  border-radius: var(--r-sm);
+  color: var(--p-500);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.panel__add:hover {
+  background: var(--n-0);
+  border-color: var(--p-500);
+}
+.panel__add svg {
+  width: 13px;
+  height: 13px;
+}
+```
+
+---
+
+## Accessibility
+
+| Concern        | Implementation                                                                                                                                                                                                  |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Heading role   | `.panel__title` should be wrapped in `<h2>` when the panel is a true page section. The mock uses `<span>` for visual demo. Production must elevate to `<h2>` or `role="heading" aria-level="2"`.                |
+| `+` button     | Must have `aria-label="Ajouter un équipement"` (or scope-specific). Icon alone is not accessible.                                                                                                               |
+| Color contrast | Primary `#1A4F6E` on `#EEF5F8` background: **WCAG AAA** (10.3:1).                                                                                                                                               |
+| Touch target   | `.panel__add` is 26 × 26 px which is below Apple HIG 44 × 44 recommendation. **Action: bump to 28 × 28 px in production** and ensure the surrounding panel head padding gives at least 36 px of clickable area. |
+
+---
+
+## Do / Don't
+
+✅ **Do**: use `panel__sub` for contextual scope ("dans cette zone"), not for marketing copy.
+✅ **Do**: keep panel head height fixed at 44 px regardless of whether a `+` button is present.
+✅ **Do**: rely on `cat-head` for grouping inside the panel rather than nesting another `.panel`.
+
+❌ **Don't**: drop the panel head if there's nothing to put in it — the head is the only visual anchor that signals "this is a section".
+❌ **Don't**: put a colored accent border on the panel itself. Accents go on rows or sub-cats.
+❌ **Don't**: tint the panel head by category (e.g. amber for Équipements). The user explicitly rejected this — sub-cats use neutral, parent panels use primary.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+type PanelProps = {
+  title: string;
+  sub?: string;
+  onAdd?: () => void;
+  addLabel?: string;
+  children: React.ReactNode;
+};
+
+<Panel
+  title="Équipements"
+  sub="dans cette zone"
+  onAdd={() => openAddEquipmentModal()}
+  addLabel="Ajouter un équipement"
+>
+  <CatHead label="Éclairages" />
+  <EqRow … />
+  <EqRow … />
+</Panel>
+```
+
+The `+` button only renders when `onAdd` is provided.
+
+---
+
+## See also
+
+- [cat-head.md](cat-head.md) — Sub-category header that lives inside a panel.
+- [eq-row.md](eq-row.md), [mode-row.md](mode-row.md), [recipe-row.md](recipe-row.md) — Row patterns used in a panel body.

--- a/design-system/components/pill.md
+++ b/design-system/components/pill.md
@@ -1,0 +1,102 @@
+# Pill atom (`strip__pill`)
+
+> Content-width chip with an icon and a value. The building block of the zone aggregation strip and a frequent pattern across the topbar.
+
+---
+
+## Anatomy
+
+```
+┌─────────────────────┐
+│ [🌡] 21,4 °C   [▭]  │   icon + value + optional sparkline
+└─────────────────────┘
+  padding .35 .65 rem
+  font-size .82 rem
+```
+
+---
+
+## Variants
+
+| Variant | Class                  | Visual                                   |
+| ------- | ---------------------- | ---------------------------------------- |
+| Default | `.strip__pill`         | neutral icon + dark text                 |
+| Active  | `.strip__pill--active` | amber icon + amber text (lights on)      |
+| Calm    | `.strip__pill--calm`   | green icon + green text (motion at rest) |
+| Alert   | `.strip__pill--alert`  | red bg + red text + pulsing dot          |
+
+The full state set is documented in the parent [strip.md](strip.md).
+
+---
+
+## Slots
+
+| Slot                 | Class                | Content                                |
+| -------------------- | -------------------- | -------------------------------------- |
+| Icon (required)      | `.strip__pill-icon`  | 14×14 SVG, color via `--c` custom prop |
+| Value (required)     | `.strip__pill-val`   | mono number + optional `.u` unit       |
+| Meta (optional)      | `.strip__pill-meta`  | secondary text ("39 min")              |
+| Sparkline (optional) | `.strip__pill-spark` | 48×16 mini chart inline                |
+
+---
+
+## Code
+
+```html
+<!-- Sensor pill -->
+<div class="strip__pill" title="Température · 3 capteurs">
+  <svg class="strip__pill-icon" style="--c:var(--info-500)">
+    <path d="M14 4v10.54a4 4 0 1 1-4 0V4a2 2 0 0 1 4 0z" />
+  </svg>
+  <span class="strip__pill-val">21,4<span class="u">°C</span></span>
+  <svg class="strip__pill-spark">…</svg>
+</div>
+
+<!-- Calm pill (motion sensor at rest) -->
+<div class="strip__pill strip__pill--calm" title="Mouvement · calme depuis 39 min">
+  <svg class="strip__pill-icon">…person-standing…</svg>
+  <span class="strip__pill-val">Calme</span>
+  <span class="strip__pill-meta">39 min</span>
+</div>
+
+<!-- Active pill (1 of 3 lights on) -->
+<div class="strip__pill strip__pill--active" title="1 lumière allumée sur 3">
+  <svg class="strip__pill-icon">…lightbulb…</svg>
+  <span class="strip__pill-val">1<span class="u">/ 3</span></span>
+</div>
+
+<!-- Alert pill -->
+<div class="strip__pill strip__pill--alert" title="Porte-fenêtre ouverte">
+  <svg class="strip__pill-icon">…door-open…</svg>
+  <span class="strip__pill-val">1 ouverte</span>
+</div>
+```
+
+---
+
+## Accessibility
+
+| Concern        | Implementation                                                                    |
+| -------------- | --------------------------------------------------------------------------------- |
+| Title tooltip  | Production must surface this as visible text on mobile (no hover available).      |
+| Alert role     | `role="alert"` for critical alerts (smoke, leak). `aria-live="polite"` otherwise. |
+| Sparkline      | `aria-hidden="true"` — decorative. The text value carries the data.               |
+| Color contrast | All combinations measured in [accessibility.md § 3](../accessibility.md).         |
+
+---
+
+## Do / Don't
+
+✅ **Do**: use the `--c` CSS custom prop on the icon for per-pill color (e.g. lux pill has `--c:var(--info-500)`).
+✅ **Do**: include the unit inside `<span class="u">` so its font-size scales relative to the value.
+✅ **Do**: keep sparklines to 48–60 px wide, 14–18 px tall.
+
+❌ **Don't**: nest pills inside pills. The atom doesn't compose recursively.
+❌ **Don't**: use the alert variant for warnings (`prefer chip-state warning style`). Alert is for critical state.
+
+---
+
+## See also
+
+- [strip.md](strip.md) — Parent container
+- [chip-state.md](chip-state.md) — Cousin atom for state badges (Ouvert, RAS, …)

--- a/design-system/components/power-button.md
+++ b/design-system/components/power-button.md
@@ -1,0 +1,114 @@
+# Power button atom (`power-btn`)
+
+> Rounded square 32×26 button used to toggle on/off the most common interactive equipment (lights, water valves, switches, gates).
+
+---
+
+## Anatomy
+
+```
+┌─────┐
+│ ⏻   │   32 × 26, radius 6, icon Lucide Power
+└─────┘
+```
+
+---
+
+## Variants
+
+| Variant        | Class                                          | Visual                                                                                                    |
+| -------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Off (default)  | `.power-btn`                                   | bg `--n-50`, icon `--n-400`                                                                               |
+| **On**         | `.power-btn--on`                               | bg `--a-500`, icon white. This is the **single accent moment** of the UI — reserved for "a light is on"   |
+| Shutter closed | `.power-btn--shutter-closed` (alternative use) | bg `--shutter-500`, icon white. Used in patterns where a power-btn substitutes for the shutter ↑■↓ group. |
+
+---
+
+## States
+
+| State   | Effect                                                                                        |
+| ------- | --------------------------------------------------------------------------------------------- |
+| Default | calm bg + muted icon                                                                          |
+| Hover   | (production may add subtle bg shift; mock doesn't have it)                                    |
+| **On**  | full amber bg + white icon; the parent `.eq__icon--light-on` may also have a `glow` animation |
+
+---
+
+## Code
+
+```html
+<!-- Off state -->
+<button class="power-btn" title="Allumer Applique x 1" aria-label="Allumer Applique x 1">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
+    <line x1="12" y1="2" x2="12" y2="12" />
+  </svg>
+</button>
+
+<!-- On state (light is on) -->
+<button
+  class="power-btn power-btn--on"
+  title="Éteindre Appliques x 2"
+  aria-label="Éteindre Appliques x 2"
+>
+  <svg>… same icon …</svg>
+</button>
+```
+
+```css
+.power-btn {
+  width: 32px;
+  height: 26px;
+  border-radius: var(--r-sm);
+  background: var(--n-50);
+  color: var(--n-400);
+  border: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.power-btn svg {
+  width: 13px;
+  height: 13px;
+}
+.power-btn--on {
+  background: var(--a-500);
+  color: var(--n-0);
+  border-color: var(--a-500);
+}
+[data-theme="dark"] .power-btn--on {
+  color: #18170f;
+}
+```
+
+The dark-theme override exists because `--n-0` in dark theme is `#16181E` (almost black), which would be invisible on amber. Hardcode `#18170F` for legibility.
+
+---
+
+## Accessibility
+
+| Concern          | Implementation                                                                            |
+| ---------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Icon-only button | Requires `aria-label="Allumer …"` AND `title` for redundancy.                             |
+| State change     | When toggled, the button must announce the new state. Use `aria-pressed="true             | false"`for true on/off semantics, or a`role="switch" aria-checked` if used in a switch context. |
+| Touch target     | 32 × 26 is below 44 × 44. Mitigate via padding-based hit area expansion in production.    |
+| Color contrast   | White icon on amber `--a-500`: 8.4:1 — AAA. Off icon `--n-400` on `--n-50`: 4.8:1 — AA.   |
+| Reduced motion   | The on-state glow is on the parent icon, not the button. Honors `prefers-reduced-motion`. |
+
+---
+
+## Do / Don't
+
+✅ **Do**: use `--on` only for live light state. Don't use it as a "primary CTA" pattern elsewhere.
+✅ **Do**: keep the button rectangular (rounded-square), not circular. The user explicitly preferred this over a circle.
+
+❌ **Don't**: use this button for shutters. Shutters use [shutter-grp](shutter-grp.md) (3-button group).
+❌ **Don't**: enlarge to 44 × 44 visually. The 32×26 size is part of the row's vertical rhythm.
+
+---
+
+## See also
+
+- [eq-row.md](eq-row.md) — Parent row
+- [shutter-grp.md](shutter-grp.md) — For shutter equipment

--- a/design-system/components/recipe-row.md
+++ b/design-system/components/recipe-row.md
@@ -1,0 +1,271 @@
+# Recipe row (`recipe`)
+
+> A row inside the Comportements panel's Recettes sub-category. Clickable to open the recipe edit modal, with an inline toggle and three small action buttons (logs, duplicate, delete).
+
+---
+
+## Anatomy
+
+```
+┌─────────┬──────────────────────────────────┬──────────┐
+│         │ Lumière dimmable sur mouvement   │ [toggle] │   row 1
+│ [icon]  ├──────────────────────────────────┤          │
+│ 32×32   │ [📜] [📋] [🗑]                   │          │   row 2
+│         │ 22×20 each                       │          │
+└─────────┴──────────────────────────────────┴──────────┘
+        ↑                                        ↑
+        Grid: 32px 1fr auto, row-gap 0, min-height 52 px
+        Icon spans both rows (grid-row: 1 / span 2)
+```
+
+The row is the only pattern in the design system with **two visible content rows in one grid cell**. The icon is rendered once but spans both rows. Row 1 holds the recipe name + toggle. Row 2 holds the three action buttons inline.
+
+---
+
+## Variants
+
+There are no variants. The only state change is the toggle on/off via `.recipe__toggle--on`.
+
+---
+
+## States
+
+| State                    | Class                            | Effect                                    |
+| ------------------------ | -------------------------------- | ----------------------------------------- |
+| Default                  | `.recipe`                        | white bg, 1 px line top border            |
+| Hover (open zone)        | `.recipe__open:hover`            | name color shifts to primary blue         |
+| Focused (keyboard)       | `.recipe__open:focus-visible`    | 2 px primary outline around the name      |
+| Toggle on                | `.recipe__toggle--on`            | track turns green-500, thumb slides right |
+| Action hover (logs)      | `.recipe__action:hover`          | neutral grey bg + dark text               |
+| Action hover (duplicate) | `.recipe__action--primary:hover` | primary tint bg + primary text            |
+| Action hover (delete)    | `.recipe__action--danger:hover`  | red tint bg + red text                    |
+
+---
+
+## Slots
+
+| Position            | Class              | Required | Content                                    |
+| ------------------- | ------------------ | -------- | ------------------------------------------ |
+| Icon (spans 2 rows) | `.recipe__icon`    | yes      | 32×32 with ChefHat or recipe-specific icon |
+| Row 1, col 2        | `.recipe__open`    | yes      | `<button>` containing `.recipe__name`      |
+| Row 1, col 3        | `.recipe__toggle`  | yes      | Toggle switch (enable/disable recipe)      |
+| Row 2, col 2–3      | `.recipe__actions` | yes      | Three `.recipe__action` buttons            |
+
+---
+
+## Code
+
+### Full row
+
+```html
+<div class="recipe">
+  <div class="recipe__icon">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path
+        d="M17 21v-5.35c0-.46.32-.84.73-1.04a4 4 0 0 0-2.13-7.59 5 5 0 0 0-9.2 0
+               a4 4 0 0 0-2.13 7.59c.41.2.73.58.73 1.04V21M6 17h12"
+      />
+    </svg>
+  </div>
+  <button class="recipe__open" title="Voir et éditer la recette">
+    <div class="recipe__name">Lumière dimmable sur mouvement</div>
+  </button>
+  <div
+    class="recipe__toggle recipe__toggle--on"
+    role="switch"
+    aria-checked="true"
+    tabindex="0"
+  ></div>
+  <div class="recipe__actions">
+    <button class="recipe__action" title="Voir les logs" aria-label="Voir les logs">
+      <svg>… ScrollText …</svg>
+    </button>
+    <button
+      class="recipe__action recipe__action--primary"
+      title="Dupliquer la recette"
+      aria-label="Dupliquer"
+    >
+      <svg>… Copy …</svg>
+    </button>
+    <button
+      class="recipe__action recipe__action--danger"
+      title="Supprimer la recette"
+      aria-label="Supprimer"
+    >
+      <svg>… Trash2 …</svg>
+    </button>
+  </div>
+</div>
+```
+
+### CSS (key rules)
+
+```css
+.recipe {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  column-gap: 0.85rem;
+  row-gap: 0;
+  align-items: center;
+  padding: 0.35rem 1.1rem;
+  min-height: 52px;
+  box-sizing: border-box;
+  border-top: 1px solid var(--line);
+}
+
+.recipe__icon {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--r-sm);
+  background: var(--p-50);
+  color: var(--p-500);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  grid-row: 1 / span 2;
+  align-self: center;
+}
+.recipe__icon svg {
+  width: 15px;
+  height: 15px;
+}
+
+.recipe__open {
+  grid-row: 1;
+  grid-column: 2;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  min-width: 0;
+}
+.recipe__open:hover .recipe__name {
+  color: var(--p-500);
+}
+.recipe__open:focus-visible {
+  outline: 2px solid var(--p-500);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.recipe__name {
+  line-height: 1.2;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--n-800);
+}
+
+.recipe__toggle {
+  grid-row: 1;
+  grid-column: 3;
+}
+
+.recipe__actions {
+  grid-row: 2;
+  grid-column: 2 / 4;
+  display: flex;
+  gap: 0.15rem;
+}
+.recipe__action {
+  width: 22px;
+  height: 20px;
+  background: transparent;
+  border: none;
+  color: var(--n-400);
+  cursor: pointer;
+  border-radius: var(--r-xs);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition:
+    background-color 140ms,
+    color 140ms;
+}
+.recipe__action svg {
+  width: 12px;
+  height: 12px;
+}
+.recipe__action:hover {
+  background: var(--n-50);
+  color: var(--n-700);
+}
+.recipe__action--primary:hover {
+  background: var(--p-50);
+  color: var(--p-500);
+}
+.recipe__action--danger:hover {
+  background: var(--red-50);
+  color: var(--red-500);
+}
+```
+
+---
+
+## Why the row is a `<div>`, not a `<button>`
+
+The whole row CANNOT be a `<button>` because:
+
+- Nested buttons (toggle, actions) are invalid HTML
+- The toggle's click needs to NOT trigger the row's onClick (event.stopPropagation)
+- Accessible focus order needs each interactive element to be its own focusable
+
+Instead, only the **`.recipe__open` zone** (icon-adjacent name area) is a `<button>`. It's the click target that opens the modal. The toggle and the three actions are independent buttons.
+
+In production this maps to a wrapping container that does NOT capture clicks itself.
+
+---
+
+## Accessibility
+
+| Concern                      | Implementation                                                                                                                                                                                                                                         |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| Open recipe (primary action) | `<button class="recipe__open" title="…">` — keyboard accessible, focusable, focus-visible style                                                                                                                                                        |
+| Toggle                       | `role="switch" aria-checked="true                                                                                                                                                                                                                      | false"`+`tabindex="0"`— production must implement keyboard`Space` to toggle |
+| Action buttons               | Each has `aria-label` distinct from the title (icon-only buttons need both for screen readers)                                                                                                                                                         |
+| Visual order vs DOM order    | DOM order is icon → open → toggle → actions. Visual row 2 (actions) appears AFTER row 1 visually but is fine because grid placement doesn't change DOM.                                                                                                |
+| Color contrast               | `.recipe__action--danger` red-500 on red-50 hover: AAA. `.recipe__action--primary` blue-500 on blue-50: AAA.                                                                                                                                           |
+| Touch targets                | Action buttons are 22 × 20 px. Below Apple HIG 44 × 44 — acceptable in a dense list context, but on mobile we **hide row 2** entirely (`.recipe__actions { display: none }` on mobile in production). Mobile users access these actions via the modal. |
+| Focus indicator              | `.recipe__open:focus-visible` shows a 2 px primary outline. Action buttons rely on default browser focus ring (production may override).                                                                                                               |
+
+---
+
+## Do / Don't
+
+✅ **Do**: keep the three actions in the order **logs → duplicate → delete** (most-used to most-destructive).
+✅ **Do**: assign hover colors by intent: logs = neutral, duplicate = primary, delete = red.
+✅ **Do**: hide the action row on mobile and let the modal expose them.
+✅ **Do**: keep `padding: .35rem 1.1rem` (smaller than eq-row's `.55rem`) — the row needs less padding because it has 2 rows of content.
+
+❌ **Don't**: add a 4th action button. The trio (logs / duplicate / delete) is the production standard and overflows poorly.
+❌ **Don't**: show a 2nd row of params under the name ("Applique x1, x2 · 10m · …"). The user explicitly rejected this — params live in the modal.
+❌ **Don't**: change the toggle to a button or checkbox. The pill switch is the production pattern across the app.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+type RecipeRowProps = {
+  recipe: RecipeInstance;
+  enabled: boolean;
+  onOpenEdit: () => void;
+  onToggle: (enabled: boolean) => void;
+  onShowLogs: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+};
+```
+
+The container is a `<div>`. Each action callback is wired to its respective button.
+
+---
+
+## See also
+
+- [mode-row.md](mode-row.md) — Same panel, different shape.
+- [toggle.md](toggle.md) — Pill toggle atom.
+- [modal.md](modal.md) — Opened when `.recipe__open` is clicked.

--- a/design-system/components/shutter-grp.md
+++ b/design-system/components/shutter-grp.md
@@ -1,0 +1,206 @@
+# Shutter button group (`shutter-grp`)
+
+> Segmented control of three buttons (open ↑ / stop ■ / close ↓) for individual shutter equipment. The 3 commands are non-negotiable — they match the production hardware capability.
+
+---
+
+## Anatomy
+
+```
+┌────┬────┬────┐
+│  ↑ │  ■ │  ↓ │   3 buttons, 30 × 30 each, joined by shutter-500 borders
+└────┴────┴────┘
+```
+
+---
+
+## States
+
+| State                                | Class                    | Effect                         |
+| ------------------------------------ | ------------------------ | ------------------------------ |
+| Inactive                             | `.shutter-btn`           | white bg, shutter-500 icon     |
+| Hover                                | `.shutter-btn:hover`     | bg `--shutter-50`              |
+| Active (current direction in motion) | `.shutter-btn.is-active` | bg `--shutter-500`, icon white |
+
+The `is-active` modifier is data-driven by production:
+
+- Shutter is opening → up arrow has `.is-active`
+- Shutter is closing → down arrow has `.is-active`
+- Shutter is at rest → no `.is-active`
+- Stop ■ never has `.is-active` (it's a one-shot command, no rest state)
+
+---
+
+## Code
+
+```html
+<div class="shutter-grp">
+  <button class="shutter-btn" title="Ouvrir Volet Ouest" aria-label="Ouvrir Volet Ouest">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2.4"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="18 15 12 9 6 15" />
+    </svg>
+  </button>
+  <button class="shutter-btn" title="Stop Volet Ouest" aria-label="Stop Volet Ouest">
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <rect x="8" y="8" width="8" height="8" rx="1.2" />
+    </svg>
+  </button>
+  <button class="shutter-btn" title="Fermer Volet Ouest" aria-label="Fermer Volet Ouest">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2.4"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  </button>
+</div>
+```
+
+```css
+.shutter-grp {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--shutter-500);
+  border-radius: var(--r-sm);
+  overflow: hidden;
+}
+.shutter-grp .shutter-btn {
+  width: 30px;
+  height: 30px;
+  background: var(--n-0);
+  color: var(--shutter-500);
+  border: none;
+  border-right: 1px solid var(--shutter-500);
+  border-radius: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+.shutter-grp .shutter-btn:last-child {
+  border-right: none;
+}
+.shutter-grp .shutter-btn svg {
+  width: 12px;
+  height: 12px;
+}
+.shutter-grp .shutter-btn:hover {
+  background: var(--shutter-50);
+}
+.shutter-grp .shutter-btn.is-active {
+  background: var(--shutter-500);
+  color: var(--n-0);
+}
+```
+
+---
+
+## Horizontal variant (`.shutter-grp--horizontal`) — pool covers
+
+Pool covers slide left ↔ right (not up ↕ down). The group uses **horizontal chevrons** instead of vertical ones:
+
+```html
+<div class="shutter-grp shutter-grp--horizontal">
+  <button class="shutter-btn" title="Ouvrir piscine" aria-label="Ouvrir cover piscine">
+    <svg
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2.4"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="15 18 9 12 15 6" />
+    </svg>
+  </button>
+  <button class="shutter-btn" title="Stop">…square…</button>
+  <button class="shutter-btn" title="Fermer">…ChevronRight…</button>
+</div>
+```
+
+No CSS change is needed — only the SVG glyphs differ. The `--horizontal` modifier exists only to make intent explicit.
+
+---
+
+## Mobile variant (`.mob__shutter-grp`)
+
+Same structure, slightly different metrics:
+
+```css
+.mob__shutter-grp button {
+  width: 30px;
+  height: 32px;
+}
+.mob__shutter-grp button svg {
+  width: 12px;
+  height: 12px;
+}
+```
+
+The mobile group keeps the 3 buttons (the user explicitly required this — single-button shortcuts were rejected as confusing).
+
+---
+
+## Accessibility
+
+| Concern           | Implementation                                                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Group role        | Wrap with `role="group" aria-label="Volet Ouest"` so screen readers announce the group.                                                     |
+| Per-button labels | Each `aria-label` must include the equipment name ("Ouvrir Volet Ouest", not just "Ouvrir").                                                |
+| Stop semantics    | The stop ■ is a momentary action with no persistent state. Don't try to mark it as `aria-pressed`.                                          |
+| Touch target      | 30 × 30 is below 44 × 44. Compact context tolerates this, but mobile production may extend the visual to 36 × 36 if testing reveals issues. |
+| Color contrast    | Shutter icon `--shutter-500` (`#4F5763`) on white: 7.4:1 — AAA. Active state white on shutter: 7.4:1 — AAA.                                 |
+
+---
+
+## Do / Don't
+
+✅ **Do**: keep all 3 buttons. The 2-button variant (open/close) loses the stop affordance.
+✅ **Do**: use the segmented look (shared border, no per-button radius). It signals "one logical control".
+✅ **Do**: use the same component for `gate` if the gate has open/stop/close commands. Otherwise use [a single gate-cmd button](eq-row.md#variants).
+
+❌ **Don't**: split into 3 separate `power-btn`s with gaps. The segmented look is the visual signal.
+❌ **Don't**: hide the stop button. Some users have shutters that take 30 s to fully close — stop is essential mid-motion.
+❌ **Don't**: substitute for a slider on shutters. Sliders set absolute position; the segmented group sets direction. Both can coexist on the same row (slider for position, group for direction commands).
+
+---
+
+## React mapping (proposal)
+
+```tsx
+type ShutterGroupProps = {
+  equipmentName: string;
+  direction: "opening" | "closing" | "idle";
+  onOpen: () => void;
+  onStop: () => void;
+  onClose: () => void;
+};
+
+<ShutterGroup
+  equipmentName="Volet Ouest"
+  direction={shutter.movement ?? "idle"}
+  onOpen={() => orderShutter(shutter, "open")}
+  onStop={() => orderShutter(shutter, "stop")}
+  onClose={() => orderShutter(shutter, "close")}
+/>;
+```
+
+The `.is-active` class is applied to the button matching `direction`.
+
+---
+
+## See also
+
+- [eq-row.md](eq-row.md) — Used on shutter, gate, and pool_cover row variants
+- [zone-commands.md](zone-commands.md) — Cousin pattern for zone-level shutter commands

--- a/design-system/components/sidebar-nav.md
+++ b/design-system/components/sidebar-nav.md
@@ -1,0 +1,314 @@
+# Sidebar navigation (`sb`)
+
+> The vertical navigation rail on the left of the desktop view. Contains the Sowel logo, top-level nav items (Dashboard, Maison, Modes, Analyse, Énergie), the zone tree under Maison, and Administration/Réglages pinned at the bottom.
+
+---
+
+## Anatomy
+
+```
+┌─ Sidebar 220px ────────────────────┐
+│ [logo] SOWEL                       │  .sb__logo  (49 px)
+├────────────────────────────────────┤
+│   Dashboard                        │  .sb__item
+│   Maison                ⌄          │  .sb__item (expanded)
+│      › Extérieur                   │  .sb__sub > .sb__item
+│      › Sous-sol                    │
+│      › RDC              ⌄          │  (expanded — chevron rotated)
+│         · Entrée                   │  .sb__sub-deeper > .sb__item
+│         · Bureau                   │
+│         · Séjour          ←active  │  .sb__item--active (pill, primary tint)
+│         · Cuisine                  │
+│      › Etage 1                     │
+│      › Etage 2                     │
+├────────────────────────────────────┤  .sb__sep (1 px line)
+│   Modes                            │
+├────────────────────────────────────┤  .sb__sep
+│   Analyse                          │
+├────────────────────────────────────┤  .sb__sep
+│   Énergie                          │
+├────────────────────────────────────┤  .sb__sep
+│                                    │  flex grow
+│   Administration         (pinned)  │  margin-top: auto
+│   Réglages                         │
+└────────────────────────────────────┘
+```
+
+---
+
+## Items as pills
+
+Every item is rendered as a **pill** (rounded rect with margin). Hovers and active states swap the pill background. This is the **only** hover treatment in the entire system that uses a pill highlight pattern — copy-cat from Linear / Notion.
+
+| State        | bg                          | text      | icon                                  |
+| ------------ | --------------------------- | --------- | ------------------------------------- |
+| Default      | transparent                 | `--n-600` | `--n-500`, opacity .75                |
+| Hover        | `--n-50` (neutral!)         | `--n-800` | opacity 1                             |
+| **Active**   | **`--p-50`** (primary tint) | `--p-500` | `--p-500`, opacity 1, font-weight 600 |
+| Active hover | `color-mix(p-500 12%)`      | `--p-500` | `--p-500`                             |
+
+The critical design choice: **hover is neutral, active is primary**. They never share the same tint. The user explicitly called this out — earlier versions tinted hover with primary too, which was confusing.
+
+---
+
+## Tree expand chevrons
+
+Sub-zones (Extérieur, Sous-sol, RDC…) are expandable. The chevron lives **on the left** of the label (matches production):
+
+```html
+<div class="sb__item"><span class="sb__exp">›</span> Extérieur</div>
+<div class="sb__item"><span class="sb__exp sb__exp--open">›</span> RDC</div>
+```
+
+The `--open` modifier rotates the chevron 90° via CSS. Leaf zones (Séjour, Bureau…) have an invisible placeholder `<span class="sb__exp sb__exp--leaf"></span>` to keep their text aligned with the parent zones.
+
+---
+
+## Section separators
+
+The pinned zone tree is surrounded by horizontal rules. Three top-level items (Modes, Analyse, Énergie) each get a separator above to visually isolate them:
+
+```
+─────  (sep)
+Modes
+─────  (sep)
+Analyse
+─────  (sep)
+Énergie
+─────  (sep)
+```
+
+This pattern came from the user request "il faut les séparer mode analyse et energie avec des séparation horizontales". It's intentional, not decorative — those three items are different in nature (Modes = behavior config, Analyse = data, Énergie = monitoring) so the separators signal "different scopes".
+
+---
+
+## Code
+
+### HTML
+
+```html
+<aside class="sb">
+  <div class="sb__logo">
+    <svg>…house silhouette…</svg>
+    <b>SOWEL</b>
+  </div>
+
+  <div class="sb__item"><svg class="sb__item-icon">…</svg>Dashboard</div>
+  <div class="sb__item">
+    <svg class="sb__item-icon">…</svg>Maison <span class="sb__chev">⌄</span>
+  </div>
+  <div class="sb__sub">
+    <div class="sb__item"><span class="sb__exp">›</span>Extérieur</div>
+    <div class="sb__item"><span class="sb__exp sb__exp--open">›</span>RDC</div>
+    <div class="sb__sub sb__sub-deeper">
+      <div class="sb__item"><span class="sb__exp sb__exp--leaf"></span>Entrée</div>
+      <div class="sb__item sb__item--active"><span class="sb__exp sb__exp--leaf"></span>Séjour</div>
+    </div>
+  </div>
+
+  <div class="sb__sep"></div>
+  <div class="sb__item"><svg class="sb__item-icon">…Layers…</svg>Modes</div>
+  <div class="sb__sep"></div>
+  <div class="sb__item"><svg class="sb__item-icon">…BarChart3…</svg>Analyse</div>
+  <div class="sb__sep"></div>
+  <div class="sb__item"><svg class="sb__item-icon">…Zap…</svg>Énergie</div>
+  <div class="sb__sep"></div>
+
+  <div class="sb__item" style="margin-top:auto">
+    <svg class="sb__item-icon">…Shield…</svg>Administration
+  </div>
+  <div class="sb__item"><svg class="sb__item-icon">…Settings…</svg>Réglages</div>
+</aside>
+```
+
+### CSS (key rules)
+
+```css
+.sb {
+  background: var(--n-0);
+  border-right: 1px solid var(--line);
+  font-size: 0.85rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.sb__logo {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.75rem 1.15rem;
+  height: 49px; /* aligns with topbar height */
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 0.85rem;
+}
+.sb__logo svg {
+  width: 16px;
+  height: 16px;
+  flex: none;
+}
+.sb__logo b {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--p-500);
+  font-size: 0.9rem;
+}
+
+.sb__item {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 1px 0.55rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 6px;
+  color: var(--n-600);
+  font-weight: 500;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition:
+    background-color 140ms,
+    color 140ms;
+}
+.sb__item:hover {
+  background: var(--n-50);
+  color: var(--n-800);
+}
+.sb__item:hover .sb__item-icon {
+  opacity: 1;
+}
+
+.sb__item--active {
+  background: var(--p-50);
+  color: var(--p-500);
+  font-weight: 600;
+}
+.sb__item--active .sb__item-icon {
+  color: var(--p-500);
+  opacity: 1;
+}
+.sb__item--active:hover {
+  background: color-mix(in srgb, var(--p-500) 12%, transparent);
+  color: var(--p-500);
+}
+
+.sb__item-icon {
+  width: 16px;
+  height: 16px;
+  opacity: 0.75;
+  transition:
+    opacity 140ms,
+    color 140ms;
+}
+.sb__chev {
+  margin-left: auto;
+  opacity: 0.5;
+  font-size: 0.65rem;
+}
+
+.sb__sub {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0.65rem;
+}
+.sb__sub .sb__item {
+  padding-left: 1.35rem;
+  font-size: 0.78rem;
+}
+.sb__sub-deeper .sb__item {
+  padding-left: 1.6rem;
+}
+
+.sb__sep {
+  height: 1px;
+  background: var(--line);
+  margin: 0.35rem 0.85rem;
+}
+
+.sb__exp {
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  align-items: center;
+  justify-content: center;
+  color: var(--n-400);
+  font-size: 0.85rem;
+  transition: transform 160ms;
+  flex: none;
+}
+.sb__exp--open {
+  transform: rotate(90deg);
+  color: var(--n-600);
+}
+.sb__exp--leaf {
+  visibility: hidden;
+}
+```
+
+---
+
+## Icon usage (Lucide, stroke 1.5–1.7)
+
+| Item                          | Icon                          | Notes                                     |
+| ----------------------------- | ----------------------------- | ----------------------------------------- |
+| Dashboard                     | `Grid3x3` (4-square grid)     | matches production                        |
+| Maison                        | `Home` (house outline)        | matches production                        |
+| Sub-zones (Extérieur, RDC, …) | `Layers` (3 stacked)          | matches production sidebar zone tree      |
+| Leaf zones (Séjour, Bureau)   | `Building` (door icon)        | matches production                        |
+| Modes                         | **`Layers`**                  | confirmed via Sidebar.tsx + AppLayout.tsx |
+| Analyse                       | `BarChart3` (3 vertical bars) | matches production                        |
+| Énergie                       | `Zap` (lightning bolt)        | matches production                        |
+| Administration                | `Shield`                      | matches production                        |
+| Réglages                      | `Settings` (cog)              | matches production                        |
+
+---
+
+## Accessibility
+
+| Concern             | Implementation                                                                                                                                                                                                                           |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Nav landmark        | The sidebar should be a `<nav aria-label="Navigation principale">` in production. The mock uses `<aside>` for visual demo.                                                                                                               |
+| Active item         | Production must set `aria-current="page"` on the active sb**item. The CSS targets `.sb**item--active`, but `aria-current` is the accessible signal.                                                                                      |
+| Keyboard navigation | Each `sb__item` must be focusable. Production wraps the content in a `<Link>` or `<button>`. The mock uses `<div>` purely visual.                                                                                                        |
+| Chevron expand      | The expand chevron should be inside a `<button aria-expanded="true                                                                                                                                                                       | false" aria-controls="…">` for keyboard expand/collapse. |
+| Color contrast      | `--n-600` on `--n-0`: 11.6:1 (AAA). `--n-800` (active text) on `--p-50`: AAA.                                                                                                                                                            |
+| Touch target        | Items are 30 px tall (incl. margin). Below Apple HIG 44 px for touch. **The desktop sidebar is mouse-driven**, so this is acceptable. The mobile equivalent uses a 56 px-tall bottom tab bar (see [mobile-tabbar.md](mobile-tabbar.md)). |
+
+---
+
+## Do / Don't
+
+✅ **Do**: use the pill margin pattern (`margin: 1px .55rem`) so items don't touch the sidebar edges.
+✅ **Do**: keep the active state distinctly **primary**, never neutral. The user must spot "where I am" instantly.
+✅ **Do**: use Lucide icons aligned with production (Layers for Modes, not toggle switch).
+
+❌ **Don't**: add a left inset bar to active items. The pill itself is the visual anchor; a bar would protrude from the rounded edge.
+❌ **Don't**: tint the hover with primary. Neutral hover, primary active — the distinction matters.
+❌ **Don't**: stretch items full-width. The pill inset is part of the modern feel.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+<Sidebar>
+  <SidebarItem icon={<Grid3x3 />} label="Dashboard" to="/dashboard" />
+  <SidebarItem icon={<Home />} label="Maison" expandable defaultOpen>
+    <SidebarTree zones={zones} activeZoneId={zoneId} />
+  </SidebarItem>
+  <SidebarSeparator />
+  <SidebarItem icon={<Layers />} label="Modes" to="/modes" />
+  <SidebarSeparator />
+  <SidebarItem icon={<BarChart3 />} label="Analyse" to="/analyse" />
+  <SidebarSeparator />
+  <SidebarItem icon={<Zap />} label="Énergie" to="/energy" />
+  <SidebarItem icon={<Shield />} label="Administration" pinBottom />
+  <SidebarItem icon={<Settings />} label="Réglages" />
+</Sidebar>
+```
+
+---
+
+## See also
+
+- [topbar.md](topbar.md) — Horizontal nav at the top of the page.
+- [mobile-tabbar.md](mobile-tabbar.md) — Mobile equivalent.

--- a/design-system/components/slider.md
+++ b/design-system/components/slider.md
@@ -1,0 +1,139 @@
+# Slider atom (`eq__slider`)
+
+> Horizontal track + fill bar + draggable knob. Used on light_dimmable equipment for brightness and on shutter equipment for position.
+
+---
+
+## Anatomy
+
+```
+┌──────────────────────────┐
+│ ████████○─────────────── │   track + fill + knob
+└──────────────────────────┘
+   96 × 5 px (track)        knob 12 px circle on top
+```
+
+---
+
+## Variants
+
+| Variant        | Class                                                                                          | Used for           |
+| -------------- | ---------------------------------------------------------------------------------------------- | ------------------ |
+| Light dimmable | `.eq__slider` + `.eq__slider-fill` (amber) + `.eq__slider-knob` (amber border)                 | brightness 0–100 % |
+| Shutter        | `.eq__slider` + `.eq__slider-fill--shutter` (navy) + `.eq__slider-knob--shutter` (navy border) | position 0–100 %   |
+
+The track itself is shared. Only the fill bar and knob border change color via modifier.
+
+---
+
+## Code
+
+### Light dimmable
+
+```html
+<div class="eq__slider">
+  <div class="eq__slider-fill" style="width:4%"></div>
+  <div class="eq__slider-knob" style="left:4%"></div>
+</div>
+```
+
+### Shutter
+
+```html
+<div class="eq__slider">
+  <div class="eq__slider-fill eq__slider-fill--shutter" style="width:100%"></div>
+  <div class="eq__slider-knob eq__slider-knob--shutter" style="left:100%"></div>
+</div>
+```
+
+```css
+.eq__slider {
+  width: 96px;
+  height: 5px;
+  background: var(--n-100);
+  border-radius: var(--r-full);
+  position: relative;
+}
+.eq__slider-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  border-radius: var(--r-full);
+  background: var(--a-500);
+}
+.eq__slider-fill--shutter {
+  background: var(--shutter-500);
+}
+
+.eq__slider-knob {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 12px;
+  height: 12px;
+  background: var(--n-0);
+  border: 2px solid var(--a-500);
+  border-radius: 50%;
+  cursor: grab;
+}
+.eq__slider-knob--shutter {
+  border-color: var(--shutter-500);
+}
+```
+
+The position of the knob is set via inline `style="left: N%"`. The fill bar uses `width: N%`. Both bind to the same value.
+
+---
+
+## Accessibility
+
+| Concern            | Implementation                                                                                                                                                                |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Underlying control | **In production, wrap the visual slider with an `<input type="range">`** for keyboard, screen reader, and OS-level interaction. The mock is visual-only.                      |
+| Labeling           | The slider must have `aria-label` matching the equipment name (e.g. `"Luminosité Appliques x 2"`) — or wire `aria-labelledby` to the row's name element.                      |
+| Step               | Production should set `step="1"` for percent sliders (0–100).                                                                                                                 |
+| Touch              | The knob (12 px) is below 44 × 44. Mobile users drag the **track region** — the actual `<input type="range">` is full-width and tappable; the visual knob is purely cosmetic. |
+| Reduced motion     | No animation on the slider. Position updates are instant.                                                                                                                     |
+| Color contrast     | Knob border `--a-500` on white bg: 1.9:1 (decorative — the position is encoded by the FILL bar, which has higher contrast).                                                   |
+
+---
+
+## Do / Don't
+
+✅ **Do**: pair the slider with a `.eq__value` number (e.g. "4 %") for an unambiguous read.
+✅ **Do**: use the amber fill for lights, the shutter color for shutters. Stay consistent.
+✅ **Do**: wrap with a real `<input type="range">` in production for native keyboard / screen reader support.
+
+❌ **Don't**: use the slider as a progress bar (e.g. for a load state). Use a separate progress component if needed.
+❌ **Don't**: make the knob larger than 12 px. The visual hierarchy of the row depends on the slider being small/secondary to the icon.
+❌ **Don't**: animate the fill bar on value change. The slider should feel direct, not laggy.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+type SliderProps = {
+  value: number; // 0–100
+  onChange: (v: number) => void;
+  variant?: "light" | "shutter";
+  ariaLabel: string;
+};
+
+<Slider
+  value={brightness}
+  onChange={setBrightness}
+  variant="light"
+  ariaLabel="Luminosité Appliques x 2"
+/>;
+```
+
+Internally renders the visual track + fill + knob AND a hidden `<input type="range">` overlaid for native interaction.
+
+---
+
+## See also
+
+- [eq-row.md](eq-row.md) — Parent
+- [power-button.md](power-button.md) — Companion on/off button on the same row

--- a/design-system/components/strip.md
+++ b/design-system/components/strip.md
@@ -1,0 +1,283 @@
+# Zone aggregation strip (`strip`)
+
+> Single-line, content-width pill row that surfaces all aggregated state of a zone. Modeled on production's `ZoneAggregationPills` component, with our group-divider refinement.
+
+---
+
+## Anatomy
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ [🌡 21,4°C] | [💧 48%] | [☀ 334 lx] || [🚶 Calme · 39min] | [💡 1/3] | [⊟ 3/3 · Ouvert] || [⚠ 1 ouverte] │
+└──────────────────────────────────────────────────────────────────────────┘
+  group 1: sensors          group 2: counters / states              group 3: alerts
+  ──────────────            ─────────────────────                   ──────────
+```
+
+Three soft groups separated by a slightly heavier divider (`--line-2`):
+
+1. **Sensors** — temperature, humidity, lux, etc.
+2. **Counters / state** — motion (Calme / Détecté), lights 1/3, shutters 3/3 · Ouvert
+3. **Alerts** (optional) — open doors, smoke, leak, water flow
+
+The strip is **always one line**. If it overflows, it scrolls horizontally (`overflow-x: auto`).
+
+---
+
+## Variants
+
+There are no visual variants of the strip itself. The variations come from the **pills** inside.
+
+| Pill state                   | Class                                     |
+| ---------------------------- | ----------------------------------------- |
+| Default                      | `.strip__pill`                            |
+| Active (light on)            | `.strip__pill--active` (amber accents)    |
+| Calm (motion sensor at rest) | `.strip__pill--calm` (green accents)      |
+| Alert                        | `.strip__pill--alert` (red bg, pulse dot) |
+
+---
+
+## Conditional rendering rule
+
+A pill renders **only if its sensor or data exists** for the zone. A bathroom without a lux sensor never shows a lux pill. Empty strip cells were the most criticized issue in earlier iterations — the strip must be honest.
+
+---
+
+## Code
+
+### Container
+
+```html
+<div class="strip">
+  <!-- Sensors group -->
+  <div class="strip__pill" title="Température · 3 capteurs">
+    <svg class="strip__pill-icon" style="--c:var(--info-500)">…thermometer…</svg>
+    <span class="strip__pill-val">21,4<span class="u">°C</span></span>
+    <svg class="strip__pill-spark">…sparkline…</svg>
+  </div>
+  <span class="strip__div"></span>
+  <div class="strip__pill" title="Humidité moyenne">…</div>
+  <span class="strip__div"></span>
+  <div class="strip__pill" title="Luminosité · capteur Séjour">…</div>
+
+  <!-- Group break -->
+  <span class="strip__div strip__div--group"></span>
+
+  <!-- Counters group -->
+  <div class="strip__pill strip__pill--calm" title="Mouvement · calme depuis 39 min">…</div>
+  <span class="strip__div"></span>
+  <div class="strip__pill strip__pill--active" title="1 lumière allumée sur 3">…</div>
+  <span class="strip__div"></span>
+  <div class="strip__pill" title="3 volets · tous ouverts">…</div>
+
+  <!-- Alerts group (only if any) -->
+  <span class="strip__div strip__div--group"></span>
+  <div class="strip__pill strip__pill--alert" title="Porte-fenêtre ouverte">…</div>
+</div>
+```
+
+### Layout CSS
+
+```css
+.strip {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  background: var(--n-0);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  padding: 0.35rem 0.4rem;
+  margin-bottom: 0.65rem;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--n-200) transparent;
+}
+.strip::-webkit-scrollbar {
+  height: 6px;
+}
+.strip::-webkit-scrollbar-thumb {
+  background: var(--n-200);
+  border-radius: 3px;
+}
+
+.strip__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--n-700);
+  border-radius: var(--r-sm);
+  white-space: nowrap;
+  font-feature-settings: "tnum" 1;
+  transition: background-color 160ms;
+}
+.strip__pill:hover {
+  background: var(--n-25);
+}
+
+.strip__pill-icon {
+  width: 14px;
+  height: 14px;
+  color: var(--c, var(--n-400));
+  flex: none;
+}
+.strip__pill-val {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--n-800);
+  letter-spacing: -0.005em;
+}
+.strip__pill-val .u {
+  font-size: 0.78em;
+  color: var(--n-400);
+  margin-left: 1px;
+  font-weight: 500;
+}
+.strip__pill-meta {
+  font-size: 0.76rem;
+  color: var(--n-500);
+}
+.strip__pill-spark {
+  width: 48px;
+  height: 16px;
+  margin-left: 0.15rem;
+  flex: none;
+  opacity: 0.8;
+}
+
+.strip__div {
+  width: 1px;
+  height: 18px;
+  background: var(--n-200);
+  margin: 0 0.15rem;
+  flex: none;
+}
+.strip__div--group {
+  margin: 0 0.35rem;
+  background: var(--line-2);
+  height: 22px;
+  flex: none;
+}
+```
+
+### Pill state variants
+
+```css
+.strip__pill--active .strip__pill-icon {
+  color: var(--a-500);
+}
+.strip__pill--active .strip__pill-val {
+  color: var(--a-600);
+}
+
+.strip__pill--calm .strip__pill-icon {
+  color: var(--green-500);
+}
+.strip__pill--calm .strip__pill-val {
+  color: var(--green-700);
+  font-family: var(--font-body);
+  font-weight: 600;
+}
+
+.strip__pill--alert {
+  background: var(--red-50);
+  color: var(--red-500);
+  font-weight: 600;
+}
+.strip__pill--alert .strip__pill-icon {
+  color: var(--red-500);
+}
+.strip__pill--alert .strip__pill-val {
+  color: var(--red-500);
+  font-family: var(--font-body);
+  font-weight: 700;
+}
+.strip__pill--alert::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--red-500);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--red-500) 25%, transparent);
+  animation: pulseAlert 1.6s ease-in-out infinite;
+  margin-right: -0.1rem;
+}
+```
+
+---
+
+## Mobile variant
+
+On mobile the strip becomes a horizontal scroll container (already a scroll container on desktop; on mobile the scrollbar is hidden):
+
+```css
+.mob__strip {
+  display: flex;
+  align-items: center;
+  background: var(--n-0);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  padding: 0.3rem 0.35rem;
+  margin-bottom: 0.85rem;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+.mob__strip::-webkit-scrollbar {
+  display: none;
+}
+```
+
+Pill sizes are slightly smaller on mobile (`mob__pill` with .76rem font and 13px icons).
+
+---
+
+## Accessibility
+
+| Concern           | Implementation                                                                                                                            |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Pill role         | Pills are read-only — `<div>` is fine. If a pill becomes interactive (click → detail), promote to `<button>`.                             |
+| Alert pill        | `role="alert"` if the underlying state is critical (smoke, leak). `aria-live="polite"` otherwise.                                         |
+| `title` attribute | Each pill has a `title` for tooltips. Production must also surface this as visible text on mobile (no hover available).                   |
+| Color contrast    | All pill text on white: AAA. Alert pill `--red-500` on `--red-50`: 4.5:1 (borderline AA — production may bump to `--red-700` for safety). |
+| Reduced motion    | The alert pulse honors `prefers-reduced-motion` and stops looping.                                                                        |
+
+---
+
+## Do / Don't
+
+✅ **Do**: render pills conditionally based on data presence.
+✅ **Do**: use the three-group structure (sensors / counters / alerts) — it's the cognitive sort order.
+✅ **Do**: keep the strip on one line. Scroll if needed; never wrap.
+
+❌ **Don't**: add a fourth group. If you need a fourth bucket of state, the strip is full and the data should move into the hero lead or a dedicated panel.
+❌ **Don't**: make the strip 2 lines tall to fit more pills. The strip is a glance — it must fit one line.
+❌ **Don't**: use the active (amber) variant on anything but lights. Reserved for "live light is on".
+
+---
+
+## React mapping (proposal)
+
+```tsx
+<Strip>
+  {data.temperature !== null && <Pill icon={<Thermometer/>} value={`${data.temperature}°C`} sparkData={…}/>}
+  {data.humidity !== null && <Pill icon={<Droplets/>} value={`${data.humidity}%`}/>}
+  {data.luminosity !== null && <Pill icon={<Sun/>} value={`${data.luminosity} lx`}/>}
+  <GroupDivider />
+  {data.motionSensors > 0 && <Pill variant="calm" icon={<PersonStanding/>} value={motionLabel}/>}
+  {data.lightsTotal > 0 && <Pill variant="active" icon={<Lightbulb/>} value={`${data.lightsOn}/${data.lightsTotal}`}/>}
+  {data.shuttersTotal > 0 && <Pill icon={<ShutterIcon/>} value={`${data.shuttersOpen}/${data.shuttersTotal}`}/>}
+  {hasAlerts && <GroupDivider />}
+  {data.openDoors > 0 && <Pill variant="alert" icon={<DoorOpen/>} value={`${data.openDoors} ouverte`}/>}
+</Strip>
+```
+
+---
+
+## See also
+
+- [pill.md](pill.md) — Pill atom documentation
+- [hero.md](hero.md) — Lives above the strip
+- Production reference: `ui/src/components/home/ZoneAggregationPills.tsx`

--- a/design-system/components/toggle.md
+++ b/design-system/components/toggle.md
@@ -1,0 +1,114 @@
+# Toggle atom (`recipe__toggle`)
+
+> Pill switch (30×18) for binary enable/disable. Used exclusively on recipe rows to toggle a recipe on/off.
+
+---
+
+## Anatomy
+
+```
+┌───────────────┐         ┌───────────────┐
+│ ●             │   OFF   │             ● │   ON
+└───────────────┘         └───────────────┘
+   30 × 18                  thumb slides right
+   bg --n-200                bg --green-500
+```
+
+---
+
+## States
+
+| State | Class                 | Effect                                              |
+| ----- | --------------------- | --------------------------------------------------- |
+| Off   | `.recipe__toggle`     | bg `--n-200`, thumb at left                         |
+| On    | `.recipe__toggle--on` | bg `--green-500`, thumb at right (translateX 12 px) |
+
+The state change is animated via `transition: transform 180ms` on the `::after` thumb.
+
+---
+
+## Code
+
+```html
+<div class="recipe__toggle recipe__toggle--on" role="switch" aria-checked="true" tabindex="0"></div>
+```
+
+```css
+.recipe__toggle {
+  width: 30px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--n-200);
+  position: relative;
+  flex: none;
+  cursor: pointer;
+}
+.recipe__toggle::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  background: var(--n-0);
+  border-radius: 50%;
+  top: 2px;
+  left: 2px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+  transition: transform 180ms;
+}
+.recipe__toggle--on {
+  background: var(--green-500);
+}
+.recipe__toggle--on::after {
+  transform: translateX(12px);
+}
+```
+
+Mobile equivalent `.mob__toggle` is identical (same 30×18 size).
+
+---
+
+## Accessibility
+
+| Concern             | Implementation                                                                                                                        |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| Switch role         | `role="switch" aria-checked="true                                                                                                     | false"`+`tabindex="0"` |
+| Keyboard activation | **Space** toggles the switch (production must wire this)                                                                              |
+| Click vs row click  | The toggle must `event.stopPropagation()` when used inside a clickable row (e.g. recipe row that opens a modal on click)              |
+| Visible label       | The toggle has no visible label. The row's name acts as the label. Production must add `aria-labelledby` pointing to the recipe name. |
+| Touch target        | 30 × 18 is below 44 × 44. Mitigate via padding hit area.                                                                              |
+| Color contrast      | Green bg on white parent: 4.1:1 (AA for UI). Thumb white on green: 8.4:1 (AAA).                                                       |
+
+---
+
+## Do / Don't
+
+✅ **Do**: use only for binary enable/disable of automations / preferences.
+✅ **Do**: animate the thumb. The 180 ms slide is the only motion the atom has and it's worth keeping.
+✅ **Do**: keep `event.stopPropagation` on click so toggling doesn't trigger the parent row's click handler.
+
+❌ **Don't**: use this as a checkbox in forms. Forms use `<input type="checkbox">` styled via the [modal.md](modal.md) `.mcheck__item` pattern.
+❌ **Don't**: substitute a button. The switch role and Space-key handling are essential for accessibility.
+❌ **Don't**: enlarge for "more touch area". The visual size is calibrated. Use padding-based hit area expansion if needed.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+type ToggleProps = {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  label?: string; // for aria-labelledby
+};
+
+<Toggle checked={recipe.enabled} onChange={setEnabled} />;
+```
+
+The production codebase already implements an equivalent — see `ZoneRecipesSection.tsx:747-760`.
+
+---
+
+## See also
+
+- [recipe-row.md](recipe-row.md) — Only parent that uses this atom
+- [modal.md](modal.md) — Uses `<input type="checkbox">` in forms, not this toggle

--- a/design-system/components/topbar.md
+++ b/design-system/components/topbar.md
@@ -1,0 +1,277 @@
+# Topbar (`topbar`)
+
+> Horizontal bar at the top of the desktop main area. Contains the breadcrumb, time/sunlight chips, connection status, alarms pill, and the avatar.
+
+---
+
+## Anatomy
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────────┐
+│ Grange Neuve › RDC › Séjour  …  [🕐 22:57]  [☀ 06:14—20:54 Nuit]  [● Connecté]  [⚠ 2]  [MC Marc] │
+└──────────────────────────────────────────────────────────────────────────────────────┘
+   breadcrumb (left)                          chips (right, with spacer before)
+                                                                                      height 49 px
+```
+
+The topbar height (49 px) **exactly matches the sidebar logo height**. This ensures the two share a perfect horizontal baseline.
+
+---
+
+## Slots (in order, left to right)
+
+| Slot                      | Class                                                | Required             |
+| ------------------------- | ---------------------------------------------------- | -------------------- |
+| Breadcrumb                | `.topbar__breadcrumb`                                | yes                  |
+| Spacer                    | `.topbar__spacer`                                    | yes                  |
+| Time chip                 | `.topbar__chip` (mono)                               | recommended          |
+| Sunlight chip             | `.topbar__chip topbar__chip--sun` (amber-tinted)     | recommended          |
+| Connection status         | `.topbar__conn topbar__conn--connected`              | yes                  |
+| Alarms pill (conditional) | `.topbar__alarm topbar__alarm--warning` or `--error` | only if alarms exist |
+| Avatar                    | `.topbar__avatar`                                    | yes                  |
+
+---
+
+## Code
+
+```html
+<div class="topbar">
+  <div class="topbar__breadcrumb">
+    Grange Neuve <span class="sep">›</span> RDC <span class="sep">›</span>
+    <b>Séjour</b>
+  </div>
+
+  <div class="topbar__spacer"></div>
+
+  <!-- Time -->
+  <div class="topbar__chip" title="Heure courante">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="12" cy="12" r="10" />
+      <polyline points="12 6 12 12 16 14" />
+    </svg>
+    22:57:12
+  </div>
+
+  <!-- Sunlight (amber-tinted chip) -->
+  <div class="topbar__chip topbar__chip--sun" title="Lever 06:14 — coucher 20:54">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+    </svg>
+    06:14 — 20:54 <span class="topbar__chip-tag">Nuit</span>
+  </div>
+
+  <!-- Connection (green) -->
+  <div class="topbar__conn topbar__conn--connected" title="Connecté au moteur Sowel">
+    <span class="topbar__conn-dot"></span>
+    <span class="topbar__conn-lab">Connecté</span>
+  </div>
+
+  <!-- Alarms (warning) -->
+  <button class="topbar__alarm topbar__alarm--warning" title="2 alertes système">
+    <svg>… AlertTriangle …</svg>
+    <span class="topbar__alarm-count">2</span>
+  </button>
+
+  <!-- Avatar -->
+  <div class="topbar__avatar">
+    <div class="topbar__avatar-pic">MC</div>
+    Marc
+  </div>
+</div>
+```
+
+```css
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem;
+  height: 49px;
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--line);
+  background: var(--n-0);
+}
+
+.topbar__breadcrumb {
+  font-size: 0.82rem;
+  color: var(--n-400);
+  font-weight: 500;
+}
+.topbar__breadcrumb b {
+  color: var(--n-700);
+  font-weight: 600;
+}
+.topbar__breadcrumb .sep {
+  margin: 0 0.35rem;
+  opacity: 0.35;
+}
+.topbar__spacer {
+  flex: 1;
+}
+
+.topbar__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.65rem;
+  background: var(--n-50);
+  border: 1px solid var(--line);
+  border-radius: var(--r-full);
+  font-size: 0.76rem;
+  color: var(--n-500);
+  font-family: var(--font-mono);
+}
+.topbar__chip svg {
+  width: 12px;
+  height: 12px;
+  opacity: 0.7;
+}
+
+.topbar__chip--sun {
+  background: color-mix(in srgb, var(--a-500) 10%, transparent);
+  color: var(--a-600);
+  border-color: color-mix(in srgb, var(--a-500) 22%, transparent);
+}
+.topbar__chip--sun svg {
+  color: var(--a-500);
+  opacity: 0.9;
+}
+.topbar__chip-tag {
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 0.7rem;
+  color: color-mix(in srgb, var(--a-600) 80%, var(--n-700));
+  margin-left: 0.25rem;
+  text-transform: lowercase;
+}
+
+.topbar__conn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.8rem;
+  border-radius: var(--r-full);
+  font-size: 0.76rem;
+  font-weight: 500;
+}
+.topbar__conn--connected {
+  background: color-mix(in srgb, var(--green-500) 10%, transparent);
+  color: var(--green-700);
+}
+.topbar__conn-dot {
+  position: relative;
+  display: inline-flex;
+  width: 8px;
+  height: 8px;
+}
+.topbar__conn-dot::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: currentColor;
+}
+.topbar__conn--connected .topbar__conn-dot::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--green-500);
+  animation: connPing 1.8s ease-in-out infinite;
+  opacity: 0.6;
+}
+
+.topbar__alarm {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: var(--r-full);
+  border: none;
+  cursor: pointer;
+  font-size: 0.76rem;
+  font-weight: 600;
+  background: color-mix(in srgb, var(--a-500) 14%, transparent);
+  color: var(--a-600);
+}
+.topbar__alarm--error {
+  background: color-mix(in srgb, var(--red-500) 12%, transparent);
+  color: var(--red-500);
+}
+.topbar__alarm svg {
+  width: 13px;
+  height: 13px;
+  flex: none;
+}
+.topbar__alarm-count {
+  font-family: var(--font-mono);
+  font-feature-settings: "tnum" 1;
+}
+```
+
+---
+
+## Alarm pill semantics
+
+The alarm pill is only rendered if `issues.length > 0`. Production logic (from `AppLayout.tsx:51`):
+
+- If any issue has level `'error'` → `--error` (red tone)
+- Otherwise → `--warning` (amber tone)
+
+Click opens the alarms sheet (production: `AlarmsSheet.tsx`).
+
+---
+
+## Accessibility
+
+| Concern           | Implementation                                                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Landmark          | Wrap as `<header role="banner">` in production.                                                                                                  |
+| Breadcrumb role   | Should be `<nav aria-label="Fil d'Ariane">` with an `<ol>` of `<li>`. The visual `›` separators are decorative — must have `aria-hidden="true"`. |
+| Alarm button      | The button has `aria-label` matching the count ("2 alertes système"). Production may also add `aria-haspopup="dialog"` since it opens a sheet.   |
+| Connection status | `<div role="status">` for the connection indicator if it changes dynamically (so screen readers announce "Déconnecté" when the WebSocket drops). |
+| Reduced motion    | The `connPing` animation honors `prefers-reduced-motion`.                                                                                        |
+| Color contrast    | All combinations pass AA (see [accessibility.md § 3](../accessibility.md)).                                                                      |
+| Avatar            | `aria-label="Compte de Marc (admin)"` for the avatar block.                                                                                      |
+
+---
+
+## Do / Don't
+
+✅ **Do**: keep the chips in the order time → sunlight → connection → alarms → avatar. The user must see status BEFORE personal context.
+✅ **Do**: only show the alarms pill if alarms exist. Don't render an empty "0 alertes" pill.
+✅ **Do**: keep the sunlight chip's amber tint. It's the warm signal that says "this is about light cycles", paired with our amber accent.
+
+❌ **Don't**: remove the spacer. Without it, all chips clump left and the breadcrumb loses focus.
+❌ **Don't**: add a search input here. Search lives in a different surface (sidebar or dedicated overlay).
+❌ **Don't**: collapse the breadcrumb to "Séjour" alone. The full path is part of orientation.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+<Topbar>
+  <Breadcrumb segments={["Grange Neuve", "RDC", { label: "Séjour", current: true }]} />
+  <Spacer />
+  <TimeChip time={now} />
+  <SunlightChip sunrise={sunrise} sunset={sunset} phase={phase} />
+  <ConnectionStatus status={wsStatus} />
+  {issues.length > 0 && <AlarmsPill count={issues.length} tone={tone} onClick={openSheet} />}
+  <Avatar user={user} />
+</Topbar>
+```
+
+Production references:
+
+- `ConnectionStatus.tsx` — green dot pattern
+- `CurrentTimePill.tsx` — time chip
+- `SunlightBanner.tsx` — sunlight chip
+- `HeaderPill.tsx` — alarms pill pattern
+
+---
+
+## See also
+
+- [sidebar-nav.md](sidebar-nav.md) — Vertical companion. Shares the 49 px height.
+- [mobile-tabbar.md](mobile-tabbar.md) — Mobile replaces the topbar with a different chrome.

--- a/design-system/components/zone-commands.md
+++ b/design-system/components/zone-commands.md
@@ -1,0 +1,209 @@
+# Zone commands (`zcmds`)
+
+> The mini-toolbar of global zone commands (lights on/off, shutters ↑■↓) that sits on its own line just below the strip.
+
+---
+
+## Anatomy
+
+```
+┌───────────────────────────────────────┐
+│ [💡] [💡✗] | [↑] [■] [↓]              │  .zcmds (content-width, left-aligned)
+└───────────────────────────────────────┘
+   lights      sep    shutters
+   group              group
+```
+
+The bar is **always left-aligned** (content-width). The user explicitly chose left over center / right. It sits below the strip on its own line (left-aligned naturally, no flex magic needed).
+
+---
+
+## Variants
+
+There are no variants. The bar contains 5 icon-only buttons grouped by category, with a thin vertical separator between groups.
+
+---
+
+## States
+
+| Element          | Default                         | Hover                                   |
+| ---------------- | ------------------------------- | --------------------------------------- |
+| Container        | white bg, line border, radius 8 | unchanged                               |
+| Light button     | transparent bg, `--n-600` icon  | bg `--light-50`, text `--light-500`     |
+| Light-off button | transparent                     | bg `--n-100`, text `--n-700`            |
+| Shutter button   | transparent                     | bg `--shutter-50`, text `--shutter-500` |
+
+The variant of hover color (amber for lights, neutral for off, slate for shutters) telegraphs which category you're acting on **before** you click.
+
+---
+
+## Slots
+
+The container holds **5 buttons** in this exact order:
+
+1. Tout allumer — `data-cat="light"`
+2. Tout éteindre — `data-cat="light-off"` (lightbulb-off icon, not lightbulb + slash)
+3. Separator `.zcmds__sep`
+4. Ouvrir volets — `data-cat="shutter"`
+5. Stop volets — `data-cat="shutter"` (square stop icon)
+6. Fermer volets — `data-cat="shutter"`
+
+---
+
+## Code
+
+```html
+<div class="zcmds" aria-label="Commandes globales">
+  <button class="zcmds__btn" data-cat="light" title="Tout allumer">
+    <svg>… Lightbulb …</svg>
+  </button>
+  <button class="zcmds__btn" data-cat="light-off" title="Tout éteindre">
+    <svg>… LightbulbOff …</svg>
+  </button>
+  <span class="zcmds__sep"></span>
+  <button class="zcmds__btn" data-cat="shutter" title="Ouvrir volets">
+    <svg>… ChevronUp …</svg>
+  </button>
+  <button class="zcmds__btn" data-cat="shutter" title="Stop">
+    <svg>… Square …</svg>
+  </button>
+  <button class="zcmds__btn" data-cat="shutter" title="Fermer volets">
+    <svg>… ChevronDown …</svg>
+  </button>
+</div>
+```
+
+```css
+.zcmds {
+  display: inline-flex;
+  align-items: center;
+  background: var(--n-0);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  padding: 0.25rem 0.35rem;
+  margin-bottom: 0.25rem;
+  gap: 1px;
+}
+.zcmds__sep {
+  width: 1px;
+  height: 16px;
+  background: var(--n-200);
+  margin: 0 0.3rem;
+  flex: none;
+}
+.zcmds__btn {
+  width: 36px;
+  height: 34px;
+  background: transparent;
+  border: none;
+  color: var(--n-600);
+  cursor: pointer;
+  border-radius: var(--r-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background-color 160ms,
+    color 160ms;
+  flex: none;
+  padding: 0;
+}
+.zcmds__btn svg {
+  width: 16px;
+  height: 16px;
+}
+.zcmds__btn[data-cat="light"]:hover {
+  background: var(--light-50);
+  color: var(--light-500);
+}
+.zcmds__btn[data-cat="light-off"]:hover {
+  background: var(--n-100);
+  color: var(--n-700);
+}
+.zcmds__btn[data-cat="shutter"]:hover {
+  background: var(--shutter-50);
+  color: var(--shutter-500);
+}
+```
+
+---
+
+## Mobile variant (`.mob__zcmds`)
+
+Same layout, slightly smaller (32×30 buttons, 14px icons), still left-aligned content-width on its own row:
+
+```css
+.mob__zcmds-btn {
+  width: 32px;
+  height: 30px;
+  /* ... else identical */
+}
+.mob__zcmds-btn svg {
+  width: 14px;
+  height: 14px;
+}
+```
+
+---
+
+## Behavior
+
+| Click         | Backend action                   |
+| ------------- | -------------------------------- |
+| Tout allumer  | `allLightsOn` order for the zone |
+| Tout éteindre | `allLightsOff`                   |
+| Ouvrir volets | `allShuttersOpen`                |
+| Stop          | `allShuttersStop`                |
+| Fermer volets | `allShuttersClose`               |
+
+These are existing zone-level orders documented in spec 021 (V0.8f Zone commands).
+
+---
+
+## Accessibility
+
+| Concern           | Implementation                                                                                                                                         |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Container role    | `<div role="toolbar" aria-label="Commandes globales">` for keyboard navigation between buttons.                                                        |
+| Icon-only buttons | Each must have `aria-label` AND `title`. Don't rely on title alone.                                                                                    |
+| Touch target      | 36 × 34 (desktop) — below 44×44. Production must extend hit area or bump visible size on mobile.                                                       |
+| Focus indicator   | Browser default outline acceptable (white bg + primary outline visible).                                                                               |
+| Color contrast    | Icon color `--n-600` on white: 11.6:1 — AAA. Hover-tinted bgs all pass AA.                                                                             |
+| Disabled state    | When the zone has 0 lights, hide the 2 light buttons. When 0 shutters, hide the 3 shutter buttons + separator. Don't show disabled greyed-out buttons. |
+
+---
+
+## Do / Don't
+
+✅ **Do**: keep the bar left-aligned and content-width. The user explicitly chose this over center/right.
+✅ **Do**: use icon-only with tooltips. Labels were rejected as too verbose ("Allumer les lumières" repeated 4 times).
+✅ **Do**: use 3 shutter buttons (open / stop / close). Two-button (open/close) loses the stop affordance, which is critical mid-motion.
+
+❌ **Don't**: span the bar full-width. It's a focused tool, not a banner.
+❌ **Don't**: re-add long text labels. Tooltips suffice on desktop, mobile shows tooltips via long-press or label-on-tap.
+❌ **Don't**: split into two separate widgets (one for lights, one for shutters). One bar = one mental model.
+
+---
+
+## React mapping (proposal)
+
+```tsx
+<ZoneCommands zoneId={zoneId}>
+  <ZCmdsBtn cat="light" title="Tout allumer" onClick={() => orderAllLightsOn()} />
+  <ZCmdsBtn cat="light-off" title="Tout éteindre" onClick={() => orderAllLightsOff()} />
+  <ZCmdsSep />
+  <ZCmdsBtn cat="shutter" title="Ouvrir" onClick={() => orderAllShutters("open")} />
+  <ZCmdsBtn cat="shutter" title="Stop" onClick={() => orderAllShutters("stop")} />
+  <ZCmdsBtn cat="shutter" title="Fermer" onClick={() => orderAllShutters("close")} />
+</ZoneCommands>
+```
+
+Production may hide light-related buttons if `zone.lightsTotal === 0`, etc.
+
+---
+
+## See also
+
+- [strip.md](strip.md) — Sits immediately above
+- [shutter-grp.md](shutter-grp.md) — Per-row equivalent (3 buttons per shutter)
+- Spec 021 — V0.8f Zone commands (backend reference)

--- a/design-system/migration.md
+++ b/design-system/migration.md
@@ -1,0 +1,196 @@
+# Migration plan
+
+> How to migrate the current production codebase (`ui/src/**`) from ad-hoc Tailwind classes toward the tokens-driven system documented here.
+
+---
+
+## 1. Current state of the production code
+
+The Sowel UI is React + **Tailwind v4** with a CSS-based `@theme` block in [ui/src/index.css](../ui/src/index.css). Tokens are already CSS variables (`--color-primary`, `--color-surface`, etc.), and theme switching is already wired in [ui/src/theme.ts](../ui/src/theme.ts):
+
+- Setting: `light` | `dark` | `system` stored in `localStorage.sowel_theme`
+- Activation: `.dark` class toggled on `<html>` (with `system` listening to `prefers-color-scheme`)
+- UI: a selector in Settings already lets the user choose
+
+What's missing:
+
+- A documented token registry (tokens.md does this now).
+- Component-level CSS classes with BEM scoping (polished.html introduces these).
+- Per-component spec with anatomy, states, accessibility (the `components/` folder does this).
+- The **refined palette** — current Warm light + dark are functional but pre-design-system.
+
+**Key insight**: because the theme infrastructure is already token-driven, the migration is essentially (a) swapping the _values_ the existing tokens resolve to, and (b) adopting BEM component classes incrementally.
+
+---
+
+## 2. Strategy: in-place palette swap
+
+We **replace the current palette** with the design system palette inside the existing `@theme` block. No new "Hybrid" option, no opt-in toggle, no parallel palettes. The existing `light | dark | system` selector keeps working — it just routes to the new, refined palette.
+
+Why in-place (vs. cohabitation):
+
+- A 4th theme option would expose half-finished work to all users.
+- The new palette has been validated visually in `ui-redesign-B-polished.html` against every component.
+- Rollback is a single git revert of one CSS file — granular per-user rollback isn't worth the maintenance debt of running two palettes.
+- If we _do_ need a kill switch during rollout, we wrap the `@theme` rewrite in a backend feature flag served at app bootstrap.
+
+---
+
+## 3. Phases
+
+### Phase 0 — Palette swap (1 PR)
+
+Import `design-system/tokens.css` at the top of [ui/src/index.css](../ui/src/index.css), then rewrite the `@theme` block to alias to the design system tokens:
+
+```css
+@import "tailwindcss";
+@import "../../design-system/tokens.css";
+
+@theme {
+  --color-primary: var(--p-500);
+  --color-primary-light: var(--p-50);
+  --color-primary-hover: var(--p-600);
+  --color-accent: var(--a-500);
+  --color-accent-light: var(--a-50);
+  --color-accent-hover: var(--a-600);
+  --color-surface: var(--n-0);
+  --color-background: var(--n-50);
+  --color-text: var(--n-700);
+  --color-text-secondary: var(--n-600);
+  --color-text-tertiary: var(--n-400);
+  --color-border: var(--line-2);
+  --color-border-light: var(--line);
+  --color-success: var(--green-500);
+  --color-warning: var(--a-500);
+  --color-error: var(--red-500);
+  /* etc. — full mapping in §5 below */
+}
+```
+
+Bridge the dark mode mechanism: `tokens.css` uses `[data-theme="dark"]`; the production app uses `.dark` class. Update the selector in `tokens.css` to `[data-theme="dark"], .dark` so both work without touching [ui/src/theme.ts](../ui/src/theme.ts).
+
+**Expected outcome**: visible palette refinement on every page. Before/after screenshots on Dashboard + Zone view + Énergie are the acceptance gate. Functional diff = zero.
+
+**Rollback**: `git revert` of the index.css + tokens.css selector tweak.
+
+### Phase 1 — Typography & tabular nums (1 PR, mostly invisible)
+
+- Add the tabular-nums + Inter feature settings selectors from `tokens.css` to the global stylesheet.
+- Sweep `text-[13px]`, `text-[12px]` etc. into a small set of consistent classes.
+- Verify on energy values, temperatures, timestamps, activity feed.
+
+### Phase 2 — Sidebar nav (1 PR, ~1 day)
+
+Refactor `ui/src/components/layout/Sidebar.tsx` to adopt `.sb__item` / `.sb__item--active`. Add separator rules around Modes / Analyse / Énergie. Replace the Modes icon (`ToggleRight` → `Layers`).
+
+**Risk**: low, UI-only, immediately visible.
+
+### Phase 3 — Strip pills (`ZoneAggregationPills`)
+
+[ui/src/components/zones/ZoneAggregationPills.tsx](../ui/src/components/zones/ZoneAggregationPills.tsx):
+
+- Drop per-pill background tint (verify whether already absent).
+- Group rendered pills into semantic clusters (lights | openings | climate) with `--line-2` dividers.
+- Add the `--alert` pill variant with red background + pulsing leading dot.
+- Mobile: keep horizontal scroll, verify dividers render.
+
+### Phase 4 — Dashboard alignment
+
+The SVG icon work is already done in the mock (`WidgetIcons.tsx` is production-aligned). Remaining:
+
+- Snap widget radius from `10px` → `--r-md` (8 px).
+- Verify `.widget`, `.widget__title`, `.widget__art`, `.widget__big`, `.widget__footer` grid matches the spec.
+- Verify the energy-meter widget uses tabular-nums consistently.
+
+**Risk**: low, isomorphic.
+
+### Phase 5 — Equipment row (`eq` pattern)
+
+The biggest chunk. Refactor **one equipment type per PR**, not file-by-file:
+
+1. `LightControl.tsx` → `.eq__icon--light-on` + glow animation
+2. `ShutterControl.tsx` → `.shutter-grp` (3-button segmented)
+3. `HeaterControl.tsx` → therm-icon + ± target
+4. `GateControl.tsx` → `.gate-cmd` button
+5. … remaining 17 equipment types (sensors, energy_meter, weather forecast, etc.)
+
+Each PR adds a visual regression test on a fixture zone. Roll forward.
+
+### Phase 6 — Comportements panel (modes + recipes)
+
+Merge `ZoneModesSection.tsx` and `ZoneRecipesSection.tsx` under a single `ZoneBehaviorsPanel` with two `cat-head` sub-sections (Modes + Recettes). Visual diff: significant. Functional diff: zero.
+
+### Phase 7 — Activity feed (additive)
+
+New `ActivityPanel` component, fed by the existing WebSocket events stream. Lives in a second column on desktop, bottom scroll area on mobile. No refactor — pure addition.
+
+### Phase 8 — Recipe edit modal
+
+Replace the inline expand in `ZoneRecipesSection.tsx` with a modal mounted at app root. Includes the new "Surcharges par mode" section, which requires backend support (mode override CRUD).
+
+**Only phase with backend impact** — write a spec first.
+
+---
+
+## 4. Recommended shipping order
+
+Ship 0 → 2 → 3 → 4 first (fast visible wins, low risk). Then 1 (invisible polish) in parallel. Phase 5 is the long pole (2-3 weeks of typed-equipment PRs). Phases 6-8 follow once the row pattern is fully consolidated.
+
+---
+
+## 5. Class name migration table
+
+| Tailwind utility                                                                                       | New BEM class               | Notes                               |
+| ------------------------------------------------------------------------------------------------------ | --------------------------- | ----------------------------------- |
+| `bg-surface rounded-[12px] border border-border-light`                                                 | `panel`                     | Top-level container                 |
+| `flex items-center px-4 py-2.5 bg-primary/8`                                                           | `panel__head`               | Panel header with primary-tinted bg |
+| `text-[12px] font-semibold uppercase tracking-wider text-primary`                                      | `panel__title`              |                                     |
+| `flex items-center px-4 py-2 bg-bg/50 text-[11px] uppercase`                                           | `cat-head`                  | Sub-category header                 |
+| `grid grid-cols-[32px_1fr_auto_auto_auto] gap-3 px-4 py-2.5 border-t border-border-light min-h-[52px]` | `eq`                        | Equipment row grid                  |
+| `w-8 h-8 rounded-[6px] flex items-center justify-center bg-accent/10 text-accent`                      | `eq__icon eq__icon--{type}` | Equipment icon — modifier by type   |
+| `w-32 h-1.5 rounded-full bg-border-light`                                                              | `eq__slider`                | Slider track                        |
+| `w-[26px] h-[26px] rounded-[6px] bg-bg/40 hover:bg-border-light`                                       | `power-btn`                 | Power button                        |
+| `flex items-center px-3 py-1.5 hover:bg-border-light rounded-md`                                       | `sb__item`                  | Sidebar nav item                    |
+
+**Migration approach per file**: don't refactor a whole file. Replace one component class at a time, test, commit. Roll forward.
+
+---
+
+## 6. What NOT to migrate
+
+These conventions stay as-is — they predate the system and work fine:
+
+- The **toast / notification system** (production has its own). Not in scope.
+- **Form input components** beyond the modal (`Settings`, `EquipmentForm`, `RecipeForm` in admin). Future scope.
+- **Dashboard widget system**. Future scope.
+- **Energy charts** (`EnergyBarChart.tsx`, etc.). Future scope, separate spec.
+
+These will adopt tokens incrementally as `tokens.css` is in scope (since they use Tailwind too), but their full re-spec is not part of this initial migration.
+
+---
+
+## 7. Rollback path
+
+- **Phase 0** (palette swap): single `git revert` of `index.css` + `tokens.css` selector tweak. Restores the previous palette in seconds.
+- **Phases 2-8** (component refactors): each PR is independently revertible because BEM classes live alongside Tailwind utilities — old JSX keeps working until explicitly migrated.
+- **Optional kill switch**: if the rollout reveals a regression in production but Phase 0 has shipped, the `@theme` block can be conditionally swapped at runtime via a backend-served feature flag. Avoid building this unless an incident actually requires it.
+
+---
+
+## 8. Acceptance criteria
+
+The migration is considered complete when:
+
+- ✅ `tokens.css` is the source of truth for all design values (Phase 0)
+- ✅ Every component in [components.md](components.md) has a React implementation
+- ✅ Each `components/*.md` spec has matching React props
+- ✅ Accessibility audit passes for the zone view + dashboard + energy pages
+- ✅ Polished.html is no longer needed as a reference — production renders identically
+
+---
+
+## 9. See also
+
+- [README.md](README.md) — System philosophy and structure
+- [tokens.md](tokens.md) — Tokens reference
+- [components.md](components.md) — Component inventory

--- a/design-system/motion.md
+++ b/design-system/motion.md
@@ -1,0 +1,261 @@
+# Motion
+
+> One orchestrated reveal at first paint. A few rare, semantic micro-animations after that. No scattered micro-interactions.
+
+This document codifies the motion principles that emerged in the polished UI. It follows the Anthropic frontend-design skill recommendation:
+
+> "Focus on high-impact moments: one well-orchestrated page load with staggered reveals creates more delight than scattered micro-interactions."
+
+---
+
+## 1. Principles
+
+1. **One signature motion per page**, applied on first paint: the **`rise` cascade**. After that, the page is still.
+2. **Semantic micro-animations only**: a glow on lights that are on. A pulse on alert pills. A ping on the Connecté dot. Each animation says one thing.
+3. **No hover animations beyond simple color/bg transitions** (140–240 ms). Hover is a cursor signal, not entertainment.
+4. **Honor `prefers-reduced-motion`**: every animation is overridable. The page must remain fully functional with zero motion.
+
+---
+
+## 2. Tokens
+
+### Durations
+
+| Use                                    | Duration         | Easing                        |
+| -------------------------------------- | ---------------- | ----------------------------- |
+| Color / background transition (hover)  | 140 ms           | default (browser)             |
+| Theme switch transition (palette flip) | 240 ms           | ease                          |
+| Reveal cascade (`rise`)                | 520 ms           | `cubic-bezier(.2, .7, .2, 1)` |
+| Glow pulse (`glow`)                    | 3200 ms infinite | ease-in-out                   |
+| Alert pulse (`pulseAlert`)             | 1600 ms infinite | ease-in-out                   |
+| Connected ping (`connPing`)            | 1800 ms infinite | linear                        |
+
+### Easings
+
+All scripted reveals use `cubic-bezier(.2, .7, .2, 1)` — gentle, slightly overshooting toward the end. This is the **only** custom easing in the system. All transitions on hover use the browser default.
+
+---
+
+## 3. The `rise` cascade (signature)
+
+A staggered fade + translate, applied once at first paint to the top-level scaffolding:
+
+```css
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ui .topbar {
+  animation: rise 520ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
+  animation-delay: 0ms;
+}
+.ui .hero {
+  animation: rise 520ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
+  animation-delay: 80ms;
+}
+.ui .actions {
+  animation: rise 520ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
+  animation-delay: 160ms;
+}
+.ui .grid {
+  animation: rise 520ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
+  animation-delay: 220ms;
+}
+
+/* Mobile cascade */
+.mob__topbar {
+  animation: rise 480ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
+  animation-delay: 60ms;
+}
+.mob__hero {
+  animation: rise 480ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
+  animation-delay: 120ms;
+}
+.mob__actions {
+  animation: rise 480ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
+  animation-delay: 180ms;
+}
+.mob__panel {
+  animation: rise 480ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
+  animation-delay: 240ms;
+}
+```
+
+**Total perceived load duration**: ~740 ms (last element finishes at 220 + 520 = 740 ms). Fast enough to feel instant, long enough to feel deliberate.
+
+The animation uses `animation-fill-mode: backwards` so the initial opacity-0 state is applied even before the animation starts — prevents flicker.
+
+---
+
+## 4. Semantic micro-animations
+
+These have a meaning. They are infinite (loop) but quiet enough to be peripheral.
+
+### 4.1 `glow` — light is on
+
+```css
+@keyframes glow {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--a-500) 30%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 5px color-mix(in srgb, var(--a-500) 14%, transparent);
+  }
+}
+.eq__icon--light-on,
+.mob__eq-icon--light-on {
+  animation: glow 3.2s ease-in-out infinite;
+}
+```
+
+**Meaning**: the amber light icon ripples gently. It's the single accent moment of the UI — reserved for "a real light is on right now". Slow cadence (3.2 s) so it's noticeable but never distracting.
+
+### 4.2 `pulseAlert` — alert pill
+
+```css
+@keyframes pulseAlert {
+  0%,
+  100% {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--red-500) 25%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--red-500) 8%, transparent);
+  }
+}
+.strip__pill--alert::before,
+.mob__pill--alert::before {
+  animation: pulseAlert 1.6s ease-in-out infinite;
+}
+```
+
+**Meaning**: a door is open, a leak is detected, etc. Faster cadence (1.6 s) — it's urgent enough to draw the eye but not panic.
+
+### 4.3 `connPing` — connection alive
+
+```css
+@keyframes connPing {
+  0% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  100% {
+    transform: scale(2.4);
+    opacity: 0;
+  }
+}
+.topbar__conn--connected .topbar__conn-dot::after,
+.mob__conn-dot::after {
+  animation: connPing 1.8s ease-in-out infinite;
+  background: var(--green-500);
+  opacity: 0.6;
+}
+```
+
+**Meaning**: the green ring expands outward from the dot, fading. Confirms the WebSocket connection is alive without sitting still like a static badge.
+
+---
+
+## 5. Hover / state transitions
+
+Plain CSS transitions, no keyframes:
+
+```css
+.sb__item {
+  transition:
+    background-color 140ms,
+    color 140ms;
+}
+.recipe__action {
+  transition:
+    background-color 140ms,
+    color 140ms;
+}
+.eq__icon,
+.sb__item-icon {
+  transition:
+    opacity 140ms,
+    color 140ms;
+}
+
+* {
+  transition:
+    background-color 240ms ease,
+    color 240ms ease,
+    border-color 240ms ease;
+}
+```
+
+The global 240 ms transition on every element exists **only to soften the theme switch** (Hybrid → Dark). It is not for hover delight. Hover-specific transitions override with 140 ms.
+
+---
+
+## 6. `prefers-reduced-motion`
+
+Per the WCAG SC 2.3.3 (Animation from Interactions), users who request reduced motion must get a static page.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* Targeted overrides for clarity */
+@media (prefers-reduced-motion: reduce) {
+  .eq__icon--light-on {
+    animation: none;
+  }
+  .strip__pill--alert::before {
+    animation: none;
+  }
+  .topbar__conn--connected .topbar__conn-dot::after {
+    animation: none;
+  }
+}
+```
+
+The blanket rule covers everything. The targeted overrides exist purely for code readability — they tell a future reader "these specific animations are intentional and they stop with the user setting".
+
+**Test path**: macOS System Preferences → Accessibility → Display → "Reduce motion". Then reload the page. Nothing should pulse, glow, or rise. The page should appear instantly with all elements in their final state.
+
+---
+
+## 7. Anti-patterns
+
+Avoid in the Sowel system:
+
+- ❌ Hover animations that scale, translate, or transform elements. Only color/bg shifts.
+- ❌ Page transition animations (route changes). Sowel uses instant cuts.
+- ❌ Loading spinners on top of existing data. Use a subtle opacity dimming or a sparkline skeleton instead.
+- ❌ Decorative parallax, scroll-triggered effects, mouse-following gradients. These belong in marketing sites, not control interfaces.
+- ❌ Re-using `rise` on user interaction (clicking a tab, opening a modal). The cascade is for first paint only.
+- ❌ More than one infinite animation per surface. If a zone has both lights on AND an alert, both animations run, but no third animation is added on top.
+
+---
+
+## 8. Production wiring notes
+
+When porting to React:
+
+- **Don't** put the `rise` keyframes inside a component CSS module. Keep them in the global `tokens.css` so the cascade is consistent across pages.
+- **Do** trigger the animation by class application on mount, not on prop changes. Use `<div className="topbar">…</div>` — React's mount IS the trigger.
+- **Don't** memoize the cascade. It runs once per page mount; no performance concern.
+
+---
+
+## 9. See also
+
+- [tokens.css](tokens.css) — All keyframes live here.
+- [accessibility.md](accessibility.md) — Reduced motion is one of the WCAG checks.

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -1,0 +1,124 @@
+/* ============================================================ */
+/* Sowel Design System — Tokens                                 */
+/* Version: 1.0 — extracted 2026-05-13 from polished.html       */
+/* ============================================================ */
+/* Drop this file into any Sowel surface. Switch theme via      */
+/* <html data-theme="hybrid"> or <html data-theme="dark">.      */
+/* ============================================================ */
+
+/* ── Theme 1: HYBRID (default, light, neutral grey + Sowel amber) ── */
+:root,
+[data-theme="hybrid"] {
+  /* Primary — ocean blue, used for nav active, links, focus rings */
+  --p-50:#EEF5F8;  --p-100:#D9E7EF; --p-500:#1A4F6E; --p-600:#144159; --p-700:#0F3146;
+
+  /* Accent — Sowel amber. Reserved for "a light is on right now". */
+  --a-50:#FFF6D6;  --a-100:#FCE89A; --a-500:#F2C035; --a-600:#D4A41C;
+
+  /* Neutrals — zinc scale, drives backgrounds, borders, text */
+  --n-0:#FFFFFF;   --n-25:#FAFAFA;  --n-50:#F4F4F5;  --n-100:#E9E9EB; --n-200:#D4D4D8;
+  --n-300:#A1A1AA; --n-400:#71717A; --n-500:#52525B; --n-600:#3F3F46; --n-700:#27272A; --n-800:#18181B;
+
+  /* Semantic colors */
+  --green-50:#E6F7EE; --green-500:#1FA260; --green-700:#0E6B3F; /* success, "calm" */
+  --info-50:#E0EFFA;  --info-500:#247EB5;                        /* informational, sensor accents */
+  --red-50:#FBE9E1;   --red-500:#C7522E;                          /* error, alerts */
+
+  /* Equipment category tints — used on .eq__icon backgrounds */
+  --light-50:#FFF6D6;    --light-500:#F2C035;
+  --shutter-50:#E8EBEE;  --shutter-500:#4F5763;
+  --sensor-50:#EBF2EC;   --sensor-500:#4F7559;
+  --media-50:#EAE9F2;    --media-500:#5759A5;
+
+  /* Borders / dividers */
+  --line:rgba(24,24,27,.08);
+  --line-2:rgba(24,24,27,.14);
+
+  /* Shadows (elevation scale: 1=subtle, 2=card hover, 3=modal) */
+  --sh-1: 0 1px 2px rgba(15,42,60,.04), 0 1px 3px rgba(15,42,60,.06);
+  --sh-2: 0 4px 14px -4px rgba(15,42,60,.10);
+  --sh-3: 0 24px 56px -16px rgba(15,42,60,.14);
+}
+
+/* ── Theme 2: DARK (Linear-ish night) ──
+   Note: also matches the `.dark` class for compatibility with apps that
+   toggle dark mode via a class on <html> (e.g. ui/src/theme.ts). */
+[data-theme="dark"], .dark {
+  --p-50:#1A2A38;  --p-100:#243B4E; --p-500:#5BA5CC; --p-600:#82BCDD; --p-700:#A8CEE6;
+  --a-50:#332715;  --a-100:#5C3F1A; --a-500:#F2BC6E; --a-600:#FFCF8C;
+  --n-0:#16181E;   --n-25:#1B1D24;  --n-50:#1F2128;  --n-100:#262931; --n-200:#363941;
+  --n-300:#52565F; --n-400:#7E828B; --n-500:#9CA0AA; --n-600:#C7C9CF; --n-700:#E2E3E7; --n-800:#F4F5F8;
+  --green-50:#0F2A1E; --green-500:#3DDB89; --green-700:#9AF0C6;
+  --info-50:#0F1F33;  --info-500:#5DA8F0;
+  --red-50:#2E1614;   --red-500:#F37B5F;
+  --light-50:#2D2415;   --light-500:#F2BC6E;
+  --shutter-50:#1B2230; --shutter-500:#94A3B8;
+  --sensor-50:#152920;  --sensor-500:#6BCF8C;
+  --media-50:#1B1F36;   --media-500:#9D9FE6;
+  --line:rgba(255,255,255,.06);
+  --line-2:rgba(255,255,255,.14);
+  --sh-1: 0 1px 2px rgba(0,0,0,.4),  0 1px 3px rgba(0,0,0,.5);
+  --sh-2: 0 4px 14px -4px rgba(0,0,0,.5);
+  --sh-3: 0 24px 56px -16px rgba(0,0,0,.6);
+}
+
+/* ── Theme-agnostic primitives ── */
+:root {
+  /* Spacing scale (4 px base) */
+  --s-1:4px;  --s-2:8px;  --s-3:12px; --s-4:16px;
+  --s-5:20px; --s-6:24px; --s-8:32px;
+
+  /* Radii */
+  --r-xs:4px; --r-sm:6px; --r-md:8px; --r-lg:12px; --r-full:999px;
+
+  /* Typography */
+  --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+/* ── Defaults wired to body ── */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--font-body);
+  color: var(--n-700);
+  background: var(--n-50);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "cv11" 1, "ss01" 1;
+  transition: background 240ms ease, color 240ms ease;
+}
+
+/* Tabular numbers everywhere we display data */
+.strip__pill-val, .eq__value, .panel__count, .cat-head__count,
+.activity__time, .topbar__chip, .mode-row__meta, .recipe__sub,
+.hero__count, .therm-target-val, .therm-current, .energy-val,
+.water-val, .forecast-day b {
+  font-feature-settings: "tnum" 1, "cv11" 1, "ss01" 1;
+}
+
+/* ── Motion ── */
+@keyframes rise {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes glow {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--a-500) 30%, transparent); }
+  50%      { box-shadow: 0 0 0 5px color-mix(in srgb, var(--a-500) 14%, transparent); }
+}
+@keyframes pulseAlert {
+  0%, 100% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--red-500) 25%, transparent); }
+  50%      { box-shadow: 0 0 0 6px color-mix(in srgb, var(--red-500) 8%, transparent); }
+}
+@keyframes connPing {
+  0%   { transform: scale(1); opacity: .6; }
+  100% { transform: scale(2.4); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/design-system/tokens.md
+++ b/design-system/tokens.md
@@ -1,0 +1,234 @@
+# Design Tokens
+
+> All tokens are CSS variables. Source of truth: [tokens.css](tokens.css).
+> Two themes: **Hybrid** (default) and **Dark**. Switch via `<html data-theme="hybrid|dark">`.
+
+---
+
+## 1. Color tokens
+
+### 1.1 Primary — ocean blue
+
+The Sowel signature color. Used for navigation active states, links, focus rings, and the "behaviors" panel head.
+
+| Token     | Hybrid        | Dark          | Usage                                                   |
+| --------- | ------------- | ------------- | ------------------------------------------------------- |
+| `--p-50`  | `#EEF5F8`     | `#1A2A38`     | sidebar item hover/active bg, panel head bg, focus halo |
+| `--p-100` | `#D9E7EF`     | `#243B4E`     | panel head border-bottom, subtle separator              |
+| `--p-500` | **`#1A4F6E`** | **`#5BA5CC`** | text on actives, primary buttons, logo                  |
+| `--p-600` | `#144159`     | `#82BCDD`     | primary button hover                                    |
+| `--p-700` | `#0F3146`     | `#A8CEE6`     | rarely used, darker hover                               |
+
+### 1.2 Accent — Sowel amber/yellow
+
+**Rule**: amber is reserved for "a light is currently on". Never use amber for category headers, panel borders, or call-to-action buttons. The accent must point at _live state_, not decoration.
+
+| Token     | Hybrid        | Dark          | Usage                                         |
+| --------- | ------------- | ------------- | --------------------------------------------- |
+| `--a-50`  | `#FFF6D6`     | `#332715`     | light-on icon bg tint, alarm pill bg          |
+| `--a-100` | `#FCE89A`     | `#5C3F1A`     | dimmer track tint                             |
+| `--a-500` | **`#F2C035`** | **`#F2BC6E`** | light-on icon fg, slider knob, power-btn on   |
+| `--a-600` | `#D4A41C`     | `#FFCF8C`     | dimmer value text ("4 %"), power-btn on hover |
+
+### 1.3 Neutrals — zinc scale
+
+The neutral scale carries 95% of the UI. It is calibrated so that:
+
+- `--n-25` and `--n-50` look distinct against pure white (`--n-0`) for sub-cat headers
+- `--n-700` is the body text default
+- `--n-400`–`--n-500` are for secondary text / meta
+
+| Token     | Hybrid    | Dark      | Common usage                            |
+| --------- | --------- | --------- | --------------------------------------- |
+| `--n-0`   | `#FFFFFF` | `#16181E` | card backgrounds, modal body            |
+| `--n-25`  | `#FAFAFA` | `#1B1D24` | sub-cat header bg, hover row bg         |
+| `--n-50`  | `#F4F4F5` | `#1F2128` | page background, off-state icon bg      |
+| `--n-100` | `#E9E9EB` | `#262931` | slider track, off-state pill bg         |
+| `--n-200` | `#D4D4D8` | `#363941` | dividers between strip pills            |
+| `--n-300` | `#A1A1AA` | `#52565F` | inactive dot, expand chevron            |
+| `--n-400` | `#71717A` | `#7E828B` | meta text, label uppercase              |
+| `--n-500` | `#52525B` | `#9CA0AA` | sidebar item text default, icon strokes |
+| `--n-600` | `#3F3F46` | `#C7C9CF` | hover text, button icon                 |
+| `--n-700` | `#27272A` | `#E2E3E7` | body text default                       |
+| `--n-800` | `#18181B` | `#F4F5F8` | titles, values, emphasis                |
+
+### 1.4 Semantic colors
+
+These are NOT decorative. Each maps to a specific state.
+
+| Token group | Color                                 | Used for                                                                 |
+| ----------- | ------------------------------------- | ------------------------------------------------------------------------ |
+| `--green-*` | success                               | `Calme` motion pill, mode actif badge, "Connecté" pill, recipe toggle ON |
+| `--info-*`  | informational                         | temperature/humidity/lux sensors, sparklines                             |
+| `--red-*`   | error / alert                         | open door/window pills, smoke/leak alerts, delete buttons                |
+| `--a-*`     | live light (already documented above) | the on-state of any light                                                |
+
+```
+--green-50:#E6F7EE  --green-500:#1FA260  --green-700:#0E6B3F   (Hybrid)
+--info-50:#E0EFFA   --info-500:#247EB5
+--red-50:#FBE9E1    --red-500:#C7522E
+```
+
+### 1.5 Equipment category tints
+
+Used **only** on equipment row icons (`.eq__icon--{type}`). They give a glanceable visual cue per category. **Do not propagate** these colors to category headers (the user explicitly rejected that — sub-cat headers stay neutral).
+
+| Type         | `--{type}-50`  | `--{type}-500`  | Hex (Hybrid)          |
+| ------------ | -------------- | --------------- | --------------------- |
+| Lights (off) | `--light-50`   | `--light-500`   | `#FFF6D6` / `#F2C035` |
+| Shutters     | `--shutter-50` | `--shutter-500` | `#E8EBEE` / `#4F5763` |
+| Sensors      | `--sensor-50`  | `--sensor-500`  | `#EBF2EC` / `#4F7559` |
+| Media        | `--media-50`   | `--media-500`   | `#EAE9F2` / `#5759A5` |
+
+### 1.6 Borders & lines
+
+| Token      | Hybrid               | Dark                    | Usage                                                     |
+| ---------- | -------------------- | ----------------------- | --------------------------------------------------------- |
+| `--line`   | `rgba(24,24,27,.08)` | `rgba(255,255,255,.06)` | row dividers, panel borders, dividers between strip pills |
+| `--line-2` | `rgba(24,24,27,.14)` | `rgba(255,255,255,.14)` | group dividers (stronger), modal section breaks           |
+
+---
+
+## 2. Typography tokens
+
+### 2.1 Font families
+
+| Token         | Value                                           | Used for                       |
+| ------------- | ----------------------------------------------- | ------------------------------ |
+| `--font-body` | `'Inter', system-ui, -apple-system, sans-serif` | All UI text                    |
+| `--font-mono` | `'JetBrains Mono', ui-monospace, monospace`     | All numbers, timestamps, codes |
+
+### 2.2 Type scale (no tokens — used inline)
+
+The scale is small and informal. Sowel uses ~10 sizes total. They are declared inline because the system is too narrow to justify named tokens.
+
+| Size               | Where it appears                        |
+| ------------------ | --------------------------------------- |
+| `2.6rem` (~42 px)  | Zone hero title (`Séjour`)              |
+| `1.2rem`           | Timeline / page section titles          |
+| `0.98rem`          | Strip pill primary value                |
+| `0.95rem`          | Lead text under hero                    |
+| `0.88rem`          | Equipment / mode / recipe row name      |
+| `0.82rem`          | Action button label, sub-line meta      |
+| `0.78rem`          | Modal body, table cell                  |
+| `0.72rem`          | Pill secondary text, panel sub          |
+| `0.66rem`–`0.7rem` | Uppercase labels (panel head, cat-head) |
+| `0.6rem`–`0.62rem` | Counts, tiny tags                       |
+
+### 2.3 Text features (applied via tokens.css)
+
+- **Tabular nums** (`font-feature-settings: "tnum" 1`) on every numeric container so values don't shift when their digit count changes.
+- **Inter contextual ligatures** (`cv11`, `ss01`) on all body text for the "modern Inter" feel.
+- **Letter-spacing** is tight on titles (`-0.022em` to `-0.03em`) and wide on uppercase labels (`0.12em`–`0.14em`).
+
+---
+
+## 3. Spacing scale
+
+Base unit: **4 px**.
+
+| Token   | Value | Used for                          |
+| ------- | ----- | --------------------------------- |
+| `--s-1` | 4 px  | Tight gaps in pills, icon-to-text |
+| `--s-2` | 8 px  | Row gap inside modal sections     |
+| `--s-3` | 12 px | Card padding, button padding-x    |
+| `--s-4` | 16 px | Panel padding, gap between cards  |
+| `--s-5` | 20 px | Section padding, hero padding-x   |
+| `--s-6` | 24 px | Large gap, modal padding          |
+| `--s-8` | 32 px | Page margin top/bottom            |
+
+Most components use **rem values directly** (e.g. `padding: .55rem 1.1rem`) instead of these tokens. The token scale exists for future migration to a more rigorous system; for now it documents the conventional unit ladder.
+
+---
+
+## 4. Radius tokens
+
+| Token      | Value  | Used for                               |
+| ---------- | ------ | -------------------------------------- |
+| `--r-xs`   | 4 px   | Chip-state badges, small tags          |
+| `--r-sm`   | 6 px   | Buttons, input fields, icon containers |
+| `--r-md`   | 8 px   | Cards, strip, modals                   |
+| `--r-lg`   | 12 px  | Panels, hero                           |
+| `--r-full` | 999 px | Pills (`Calme · 39 min`, `Connecté`)   |
+
+**Note**: Production Dashboard widgets currently use an arbitrary `border-radius: 10px`. The design system targets `--r-md` (8 px) for full alignment; production may keep 10 px transitionally and snap to 8 px during the next refactor. See [components/dashboard-widget.md](components/dashboard-widget.md) and [migration.md](migration.md).
+
+---
+
+## 5. Shadow tokens (elevation)
+
+| Token    | Hybrid value     | Used for                              |
+| -------- | ---------------- | ------------------------------------- |
+| `--sh-1` | subtle, 1–3 px   | Default panels, card hover            |
+| `--sh-2` | medium, 4–14 px  | Pill bar (variant A), modal head hint |
+| `--sh-3` | strong, 24–56 px | Modal, dropdown, overlay              |
+
+Each shadow has a complementary set in dark theme that uses near-black tints instead of slate-tinted ones.
+
+---
+
+## 6. Motion tokens
+
+| Token           | Value                      | Used for                                 |
+| --------------- | -------------------------- | ---------------------------------------- |
+| Duration short  | `140 ms`                   | Hover state changes (bg, color)          |
+| Duration medium | `240 ms`                   | Theme switch transitions                 |
+| Duration reveal | `520 ms`                   | Staggered `rise` animation at page load  |
+| Easing standard | `cubic-bezier(.2,.7,.2,1)` | Reveal `rise` animation, scale on action |
+
+Keyframes are declared in [tokens.css](tokens.css):
+
+- `rise` — opacity 0 → 1, translateY 10 → 0
+- `glow` — concentric box-shadow ripple on light-on icons
+- `pulseAlert` — concentric red ripple on alert pills
+- `connPing` — ping ring on Connecté dot
+
+All animations honor `prefers-reduced-motion: reduce`.
+
+---
+
+## 7. Z-index registry
+
+The system uses **5 layers maximum**.
+
+| Layer          | Range           | Used for                                     |
+| -------------- | --------------- | -------------------------------------------- |
+| Base           | `0`             | All content by default                       |
+| Sticky topbar  | `10`            | Topbar that stays on top during inner scroll |
+| Sticky picker  | `100`           | The theme/palette picker bar at the very top |
+| Modal backdrop | `200`           | Behind a modal                               |
+| Modal          | `210`           | The modal card itself                        |
+| Toast          | `300` (planned) | Future toast notifications                   |
+
+Components **never** declare arbitrary z-index values. Pick from this registry.
+
+---
+
+## 8. Conversion notes for migration
+
+The current production codebase uses Tailwind utility classes with semantic class names (`bg-surface`, `text-text-tertiary`, etc.) backed by a Tailwind config. To migrate:
+
+| Tailwind semantic                | Tokens.css equivalent                  |
+| -------------------------------- | -------------------------------------- |
+| `bg-surface`                     | `var(--n-0)`                           |
+| `bg-border-light` / `bg-bg`      | `var(--n-25)`                          |
+| `text-text`                      | `var(--n-700)`                         |
+| `text-text-secondary`            | `var(--n-600)`                         |
+| `text-text-tertiary`             | `var(--n-400)`                         |
+| `border-border`                  | `var(--line-2)`                        |
+| `border-border-light`            | `var(--line)`                          |
+| `text-primary` / `bg-primary`    | `var(--p-500)`                         |
+| `bg-primary/8`                   | `var(--p-50)`                          |
+| `text-accent` / `bg-accent`      | `var(--a-500)` / `var(--a-50)`         |
+| `text-success` / `bg-success/10` | `var(--green-500)` / `var(--green-50)` |
+| `text-error` / `bg-error/10`     | `var(--red-500)` / `var(--red-50)`     |
+
+See [migration.md](migration.md) for the broader strategy.
+
+---
+
+## 9. Changelog
+
+| Date       | Change                                       |
+| ---------- | -------------------------------------------- |
+| 2026-05-13 | Initial extraction from polished.html (v1.0) |

--- a/specs/094-ui-redesign/architecture.md
+++ b/specs/094-ui-redesign/architecture.md
@@ -1,0 +1,92 @@
+# Architecture — Spec 094 — UI Redesign (Phase 0 palette swap)
+
+## Overview
+
+Phase 0 is a single CSS migration. No JSX touched, no React changes, no backend changes. The goal is to make every `text-primary`, `bg-surface`, `border-border-light` already present in production resolve to the refined design-system palette.
+
+## Current state
+
+```
+ui/src/index.css
+├── @import "tailwindcss";
+├── @theme { ... }              ← Tailwind v4 tokens (current Warm palette)
+│   ├── --color-primary: #1A4F6E
+│   ├── --color-accent:  #D4963F
+│   └── ...                     ← hard-coded hex values
+└── .dark { ... }               ← dark mode override (current Warm dark)
+
+ui/src/theme.ts
+└── setDarkClass()              ← toggles .dark class on <html>
+```
+
+## Target state
+
+```
+ui/src/index.css
+├── @import "tailwindcss";
+├── @import "../../design-system/tokens.css";     ← NEW: source of truth
+├── @theme { ... }              ← alias layer (no more hard-coded hex)
+│   ├── --color-primary: var(--p-500)
+│   ├── --color-accent:  var(--a-500)
+│   └── ...
+└── (dark overrides removed — now inside tokens.css)
+
+design-system/tokens.css
+├── :root, [data-theme="hybrid"] { ...light palette... }
+└── [data-theme="dark"], .dark  { ...dark palette... }   ← extended selector
+
+ui/src/theme.ts                  ← unchanged
+```
+
+## File changes
+
+### `ui/src/index.css`
+
+1. Add the import line near the top, after `@import "tailwindcss";`.
+2. Replace every literal hex value inside `@theme { ... }` with the matching `var(--*)` from `tokens.css`.
+3. Remove the manual `.dark { ... }` block — dark values are now supplied by `tokens.css` via the extended selector.
+
+The full mapping table is documented in [design-system/migration.md](../../design-system/migration.md) §5.
+
+### `design-system/tokens.css`
+
+Extend the dark-mode selector so the existing `.dark` class toggling (handled by [ui/src/theme.ts](../../ui/src/theme.ts)) keeps working without modification:
+
+```css
+/* before */
+[data-theme="dark"] { ... }
+
+/* after */
+[data-theme="dark"], .dark { ... }
+```
+
+This is the only change to `tokens.css`. All token values remain the originals from the design system.
+
+### `ui/src/theme.ts`
+
+**Not modified.** The `.dark` class toggling logic is preserved. The `light | dark | system` setting and `prefers-color-scheme` listener continue to work.
+
+## Rollback
+
+Single `git revert` of the commit. The change is two-file (`ui/src/index.css` + `design-system/tokens.css`) and self-contained — no migrations, no DB changes, no state.
+
+## Risk assessment
+
+| Risk                                                           | Likelihood | Mitigation                                                                                                |
+| -------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------- |
+| Tailwind v4 doesn't accept `var(--*)` inside `@theme`          | Very low   | Documented Tailwind v4 behavior — `@theme` accepts arbitrary CSS values incl. `var()`. Verified at build. |
+| A literal hex in JSX (`#1A4F6E`) escapes the swap              | Medium     | Grep before merge: `grep -rEn '#[0-9A-Fa-f]{3,6}' ui/src/**/*.tsx` — review each hit                      |
+| Dark mode visually broken because selector extension misorders | Low        | Side-by-side dark screenshots are an acceptance criterion                                                 |
+| Some component reads CSS variables via JS (uncommon)           | Very low   | Grep: `getComputedStyle.*--color-`. Patch on a case-by-case basis if found                                |
+| Existing Storybook / visual tests break                        | Low        | None today — no Storybook, no Chromatic                                                                   |
+
+## Subsequent phases (out of scope for this spec)
+
+Each becomes its own light spec in 095-102. They are intentionally NOT detailed here — the full breakdown lives in [design-system/migration.md](../../design-system/migration.md) and individual sub-specs.
+
+## References
+
+- [design-system/migration.md](../../design-system/migration.md) — Full migration plan
+- [design-system/tokens.css](../../design-system/tokens.css) — Token source of truth
+- [ui/src/index.css](../../ui/src/index.css) — Current `@theme` block
+- [ui/src/theme.ts](../../ui/src/theme.ts) — Theme switching (unchanged)

--- a/specs/094-ui-redesign/plan.md
+++ b/specs/094-ui-redesign/plan.md
@@ -1,0 +1,89 @@
+# Plan — Spec 094 — UI Redesign (Phase 0 palette swap)
+
+## Implementation steps
+
+1. **Branch**: `git checkout -b feat/design-system-palette`
+2. **Capture baseline screenshots** (before): Dashboard, Zone view (`Séjour`), Énergie, Modes, Settings, Login — in both **light** and **dark** modes. Save to `specs/094-ui-redesign/screenshots/before/`.
+3. **Patch `design-system/tokens.css`**: extend the dark selector from `[data-theme="dark"]` to `[data-theme="dark"], .dark`.
+4. **Patch `ui/src/index.css`**:
+   - Add `@import "../../design-system/tokens.css";` after `@import "tailwindcss";`
+   - Rewrite the `@theme` block — replace every hex literal with `var(--*)` per the mapping table in [design-system/migration.md](../../design-system/migration.md) §5
+   - Remove the legacy `.dark { ... }` block (now provided by `tokens.css`)
+5. **Run dev server**: `cd ui && npm run dev`. Verify:
+   - App boots without console errors
+   - Light mode looks like the polished mock's `data-theme="hybrid"`
+   - Dark mode looks like the polished mock's `data-theme="dark"`
+   - Switching `light | dark | system` in Settings flips the palette
+6. **Capture validation screenshots** (after): same set as step 2. Save to `specs/094-ui-redesign/screenshots/after/`.
+7. **Hex audit**: `grep -rEn '#[0-9A-Fa-f]{3,6}' ui/src/**/*.tsx ui/src/**/*.ts` — review each remaining literal. Most should be in equipment-type icon definitions or chart components (acceptable for this phase; deferred to phase 5). Document each escape in a comment in the PR body.
+8. **Validate** (Gate 4): `npx tsc --noEmit` (root + ui), `cd ui && npm run build`, `npx vitest run`, `npx eslint src/ --ext .ts`.
+9. **Commit** with conventional message: `feat(ui): swap palette to design system tokens (spec 094 phase 0)`.
+10. **Open PR** with before/after screenshots embedded in the body.
+
+## Test plan
+
+### Modules touched
+
+- [ui/src/index.css](../../ui/src/index.css) — `@theme` rewrite, dark block removed
+- [design-system/tokens.css](../../design-system/tokens.css) — dark selector extension
+
+No backend code, no React code, no business logic. **Tests are visual + build-level**, not unit tests.
+
+### Scenarios
+
+| Module     | Scenario                                     | Expected                                                                 | How to verify                                          |
+| ---------- | -------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------ |
+| Build      | Vite build succeeds                          | Zero errors                                                              | `cd ui && npm run build`                               |
+| Build      | Backend `tsc` passes                         | Zero errors                                                              | `npx tsc --noEmit`                                     |
+| Build      | UI `tsc` passes                              | Zero errors                                                              | `cd ui && npx tsc -b --noEmit`                         |
+| Build      | ESLint passes                                | Zero errors (warnings tolerated)                                         | `npx eslint src/ --ext .ts`                            |
+| Backend    | Existing Vitest suite still green            | All tests pass                                                           | `npx vitest run`                                       |
+| Theme      | Light mode renders new palette               | Body text `--n-700`, primary `--p-500`                                   | Devtools: inspect computed styles                      |
+| Theme      | Dark mode renders new dark palette           | `.dark` class applied → tokens.css `[data-theme="dark"], .dark` triggers | Toggle in Settings → Apparence                         |
+| Theme      | System mode follows OS                       | Flips palette when OS theme changes                                      | macOS System Settings → Appearance → toggle Light/Dark |
+| Theme      | No flash on load                             | Initial render uses correct palette                                      | Reload page in each mode, check first paint            |
+| Visual     | Dashboard renders without console errors     | Clean console                                                            | Open `/` and inspect console                           |
+| Visual     | Zone view renders without console errors     | Clean console                                                            | Open a zone, inspect                                   |
+| Visual     | Énergie page renders without console errors  | Clean console                                                            | Open `/energy`, inspect                                |
+| Visual     | Login page renders without console errors    | Clean console                                                            | Sign out, inspect login                                |
+| Regression | No JSX uses a stale hex literal that escapes | Hex audit list is empty or annotated                                     | Grep + manual review                                   |
+
+### Side-by-side acceptance gate
+
+Before merging, the PR body must show before/after screenshots for at least:
+
+1. Dashboard (light + dark)
+2. Zone view (light + dark)
+3. Énergie (light + dark)
+4. Settings (light)
+5. Login (light)
+
+The diff is **expected** — it is the palette refinement. Reviewer judges whether the diff matches the design-system reference mock.
+
+## Tasks
+
+- [x] Branch `feat/design-system-palette` created
+- [ ] Baseline screenshots captured (`before/`) — skipped; visual verification deferred to PR review
+- [x] `tokens.css` dark selector extended
+- [x] `index.css` import added
+- [x] `index.css` `@theme` rewritten to use `var(--*)`
+- [x] `index.css` legacy `.dark` block removed (SVG-boost rule preserved outside @theme)
+- [ ] Validation screenshots captured (`after/`) — deferred to PR review
+- [x] Hex audit done — only chart-specific and SVG-art literals remain (out of scope per design-system migration §6)
+- [x] Gate 4 passes (tsc + build + vitest + eslint)
+- [ ] Commit on feat branch (no Co-Authored-By)
+- [ ] PR opened with screenshots
+- [ ] User approval before merge
+
+## Subsequent phases
+
+After this spec ships, pick up phases in this recommended order via `/sowel-feature`:
+
+1. **096-design-system-sidebar** (fast win, low risk)
+2. **097-design-system-strip-pills** (clusters + alert variant)
+3. **098-design-system-dashboard** (radius alignment)
+4. **095-design-system-typography** (in parallel — invisible polish)
+5. **099-design-system-equipment-row** (long pole — one PR per equipment type)
+6. **100-design-system-comportements** (panel merge)
+7. **101-design-system-activity-feed** (additive)
+8. **102-design-system-recipe-modal** (only one with backend impact)

--- a/specs/094-ui-redesign/spec.md
+++ b/specs/094-ui-redesign/spec.md
@@ -1,0 +1,84 @@
+# Spec 094 — UI Redesign (umbrella + Phase 0 palette swap)
+
+## Problem
+
+The Sowel UI has grown organically over 90+ specs. Today it works — but visually it carries technical debt: arbitrary `text-[13px]` / `rounded-[6px]` values, inconsistent spacing across panels, two palettes (warm + dark) that pre-date the design language we've since refined, and no formal component layer. Every new feature reinvents button styles, panel headers, and row layouts.
+
+A full design system has been authored in [design-system/](../../design-system/) (tokens, components, motion, accessibility) and validated against a reference HTML mock at [ui-redesign-B-polished.html](../../ui-redesign-B-polished.html). The remaining work is to migrate the production codebase to that system without breaking anything.
+
+## Goal
+
+Migrate `ui/src/**` to the design system documented in [design-system/](../../design-system/), incrementally, in 9 reversible phases. Phase 0 (palette swap) is delivered in **this** spec; phases 1-8 each get their own light spec (095-102) and are picked up via `/sowel-feature` when scheduled.
+
+## Strategy
+
+**In-place palette swap, no opt-in toggle.** The existing `light | dark | system` selector in [ui/src/theme.ts](../../ui/src/theme.ts) keeps working — it just routes to the refined palette. Rationale and rejected alternatives are documented in [design-system/migration.md](../../design-system/migration.md) §2.
+
+## Phase breakdown
+
+| #   | Spec                                                                          | Scope                                                        | Status      |
+| --- | ----------------------------------------------------------------------------- | ------------------------------------------------------------ | ----------- |
+| 0   | **094 (this spec)**                                                           | Palette swap: rewrite `@theme` block to alias `tokens.css`   | in-progress |
+| 1   | [095-design-system-typography](../095-design-system-typography/spec.md)       | Tabular nums, Inter feature settings, type scale consistency | planned     |
+| 2   | [096-design-system-sidebar](../096-design-system-sidebar/spec.md)             | Adopt `.sb__*` BEM, Layers icon for Modes, separator rules   | planned     |
+| 3   | [097-design-system-strip-pills](../097-design-system-strip-pills/spec.md)     | Cluster pills (lights / openings / climate), alert variant   | planned     |
+| 4   | [098-design-system-dashboard](../098-design-system-dashboard/spec.md)         | Widget radius alignment, BEM consolidation                   | planned     |
+| 5   | [099-design-system-equipment-row](../099-design-system-equipment-row/spec.md) | `.eq` grid + per-type icons, one PR per equipment type       | planned     |
+| 6   | [100-design-system-comportements](../100-design-system-comportements/spec.md) | Merge Modes + Recipes into one Comportements panel           | planned     |
+| 7   | [101-design-system-activity-feed](../101-design-system-activity-feed/spec.md) | New `ActivityPanel` fed by WebSocket events                  | planned     |
+| 8   | [102-design-system-recipe-modal](../102-design-system-recipe-modal/spec.md)   | Modal + "Surcharges par mode" (only phase with backend work) | planned     |
+
+Recommended shipping order: **0 → 2 → 3 → 4** first (visible wins, low risk), then **1** in parallel, then **5** (long pole), then **6 → 7 → 8**.
+
+## In scope (this spec)
+
+1. Import `design-system/tokens.css` into [ui/src/index.css](../../ui/src/index.css).
+2. Rewrite the existing `@theme` block to alias each `--color-*` to a design system token (`--p-*`, `--n-*`, `--a-*`, `--green-*`, `--red-*`, etc.).
+3. Bridge dark-mode mechanism: `tokens.css` uses `[data-theme="dark"]`, the prod app uses `.dark` class. Extend the selector in `tokens.css` to support both (`[data-theme="dark"], .dark`).
+4. Visual acceptance: screenshot every top-level page (Dashboard, Zone view, Énergie, Modes, Settings, Login) in both light + dark + system modes, before/after. Diff is **expected** — it is the palette refinement.
+5. No JSX changes. BEM component classes are introduced in subsequent phases.
+
+## Out of scope (this spec)
+
+- Any change to JSX or React components.
+- BEM class adoption (deferred to phases 2-8).
+- Activity feed and Recipe modal (specs 101, 102).
+- Backend changes (none required for the umbrella or Phase 0).
+- Documentation rewrites — `design-system/` is already the source of truth.
+
+## Acceptance criteria (this spec)
+
+- [x] `tokens.css` is imported at the top of `ui/src/index.css`
+- [x] The `@theme` block aliases all `--color-*` tokens to design system equivalents
+- [x] `tokens.css` dark-mode selector accepts both `[data-theme="dark"]` and `.dark`
+- [x] `npm run build` succeeds in `ui/`
+- [x] `npx tsc --noEmit` passes in both backend and UI
+- [x] Backend test suite green (`npx vitest run` — 429 tests passed)
+- [x] Backend ESLint green
+- [ ] No console errors on app start (verify on running app before merge)
+- [ ] Light, dark, and system theme modes all render correctly (verify on running app before merge)
+- [ ] Side-by-side screenshots captured for Dashboard, Zone view, Énergie (before + after, light + dark)
+
+## Acceptance criteria (full UI redesign — all phases)
+
+- [ ] Every component in [design-system/components.md](../../design-system/components.md) has a React implementation matching its spec
+- [ ] No more arbitrary Tailwind values (`text-[13px]`, `rounded-[6px]`) in `ui/src/**`
+- [ ] Accessibility audit passes for Zone view + Dashboard + Énergie (contrast, focus, ARIA)
+- [ ] Polished.html is no longer needed as a reference
+
+## Edge cases
+
+| Case                                                | Expected                                                                                              |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| User has `system` mode + OS in dark                 | The new dark palette applies. Switching OS to light flips to the new light palette. No flash on load. |
+| User has stored `sowel_theme = "warm"` (deprecated) | `applyTheme()` already falls back to `system` for unknown values — no migration needed.               |
+| New token referenced before import resolved         | Build fails. Caught by `npm run build` gate.                                                          |
+| User loads an older bookmarked page hash            | Tokens are global — every page picks them up automatically.                                           |
+
+## References
+
+- [design-system/README.md](../../design-system/README.md) — System philosophy
+- [design-system/tokens.css](../../design-system/tokens.css) — Source of truth for all CSS variables
+- [design-system/migration.md](../../design-system/migration.md) — Full migration narrative
+- [ui-redesign-B-polished.html](../../ui-redesign-B-polished.html) — Reference implementation mock
+- [ui/src/theme.ts](../../ui/src/theme.ts) — Existing light/dark/system mechanism (unchanged)

--- a/specs/095-design-system-typography/spec.md
+++ b/specs/095-design-system-typography/spec.md
@@ -1,0 +1,33 @@
+# Spec 095 — Design System Phase 1: Typography & Tabular Nums
+
+> Light scoping spec — part of the [094 UI redesign umbrella](../094-ui-redesign/spec.md). Expanded into full spec when picked up via `/sowel-feature`.
+
+## Problem
+
+Production UI mixes `text-[13px]`, `text-[12px]`, `text-sm`, and other arbitrary sizes. Numeric containers (temperatures, energy values, timestamps) don't use tabular nums consistently — digits jitter when values change. Inter contextual ligatures (`cv11`, `ss01`) are not enabled, so the modern Inter look documented in the design system is absent.
+
+## Goal
+
+Apply the typography rules from [design-system/tokens.md](../../design-system/tokens.md) §2 globally: enable `font-feature-settings: "tnum" 1` on all numeric containers and `cv11, ss01` site-wide. Sweep arbitrary `text-[Npx]` to consistent classes from the documented type scale (§2.2).
+
+## In scope
+
+- Global selector for tabular nums on `font-mono` + any class on the documented numeric list (energy values, temperatures, timestamps, percent dials).
+- Sweep arbitrary `text-[Npx]` to standard Tailwind sizes (`text-xs`, `text-sm`, etc.).
+- Letter-spacing tightening on titles, widening on uppercase labels — per tokens.md §2.3.
+
+## Out of scope
+
+- Font swap (Inter stays). Future spec may revisit.
+- Component layout changes (deferred to subsequent phases).
+
+## Acceptance criteria
+
+- [ ] No arbitrary `text-[Npx]` remaining in `ui/src/**`
+- [ ] Numeric containers don't jitter when value changes by digit count (verify on energy live panel)
+- [ ] Devtools confirms `font-feature-settings: "tnum" 1, "cv11" 1, "ss01" 1` on body
+
+## References
+
+- [design-system/tokens.md](../../design-system/tokens.md) §2
+- [design-system/migration.md](../../design-system/migration.md) Phase 1

--- a/specs/096-design-system-sidebar/spec.md
+++ b/specs/096-design-system-sidebar/spec.md
@@ -1,0 +1,35 @@
+# Spec 096 — Design System Phase 2: Sidebar
+
+> Light scoping spec — part of the [094 UI redesign umbrella](../094-ui-redesign/spec.md). Expanded into full spec when picked up via `/sowel-feature`.
+
+## Problem
+
+The sidebar nav is the most visible element of the app. Today it uses ad-hoc Tailwind utilities composed inline; hover states are inconsistent; the Modes icon is `ToggleRight` (not semantic). The Énergie / Modes / Analyse grouping isn't visually separated.
+
+## Goal
+
+Adopt the `.sb__*` BEM pattern documented in [design-system/components/sidebar-nav.md](../../design-system/components/sidebar-nav.md). Add separator rules around Modes/Analyse/Énergie. Replace the Modes icon with `Layers`.
+
+## In scope
+
+- Refactor `ui/src/components/layout/Sidebar.tsx` to use `.sb__item` / `.sb__item--active`.
+- Add `.sb__group` divider before Modes and Énergie groups.
+- Swap Modes icon: `ToggleRight` → `Layers` (Lucide).
+- Verify mobile burger menu still uses the same items.
+
+## Out of scope
+
+- Reordering tabs (current order is correct per production reference).
+- Reworking the topbar (separate concern).
+
+## Acceptance criteria
+
+- [ ] `.sb__item`, `.sb__item--active`, `.sb__group` classes present in `Sidebar.tsx`
+- [ ] Modes icon is `Layers`
+- [ ] Visible separators around Énergie and Modes groups
+- [ ] Mobile menu identical in behavior
+
+## References
+
+- [design-system/components/sidebar-nav.md](../../design-system/components/sidebar-nav.md)
+- [design-system/migration.md](../../design-system/migration.md) Phase 2

--- a/specs/097-design-system-strip-pills/spec.md
+++ b/specs/097-design-system-strip-pills/spec.md
@@ -1,0 +1,35 @@
+# Spec 097 — Design System Phase 3: Strip Pills (Zone Aggregation)
+
+> Light scoping spec — part of the [094 UI redesign umbrella](../094-ui-redesign/spec.md). Expanded into full spec when picked up via `/sowel-feature`.
+
+## Problem
+
+`ZoneAggregationPills` displays aggregated zone state (motion, temperature, openings, etc.) as a row of pills. Today they all look alike — no visual grouping, no alert variant. When a sensor triggers an alarm (smoke, leak, open window), it blends with normal state.
+
+## Goal
+
+Refactor [ZoneAggregationPills.tsx](../../ui/src/components/zones/ZoneAggregationPills.tsx) per [design-system/components/strip.md](../../design-system/components/strip.md): group pills into three semantic clusters (lights / openings / climate) with `--line-2` dividers, and add an `--alert` variant with red background + pulsing leading dot for alarm states.
+
+## In scope
+
+- Group pills into 3 clusters with explicit divider.
+- Add `--alert` variant (`--red-50` bg, pulsing `--red-500` dot).
+- Mobile: keep horizontal scroll behavior — just verify dividers render.
+
+## Out of scope
+
+- Adding new aggregation types (use existing logic).
+- Changing pill content / labels.
+
+## Acceptance criteria
+
+- [ ] Three visual clusters with dividers between them
+- [ ] Alert pill pulses on smoke/leak/open-door events
+- [ ] Mobile horizontal scroll behavior preserved
+- [ ] All existing aggregations still display correctly
+
+## References
+
+- [design-system/components/strip.md](../../design-system/components/strip.md)
+- [design-system/components/pill.md](../../design-system/components/pill.md)
+- [design-system/migration.md](../../design-system/migration.md) Phase 3

--- a/specs/098-design-system-dashboard/spec.md
+++ b/specs/098-design-system-dashboard/spec.md
@@ -1,0 +1,37 @@
+# Spec 098 — Design System Phase 4: Dashboard Widgets
+
+> Light scoping spec — part of the [094 UI redesign umbrella](../094-ui-redesign/spec.md). Expanded into full spec when picked up via `/sowel-feature`.
+
+## Problem
+
+Dashboard widgets work but diverge slightly from the design system: radius is `10px` (arbitrary, set at first dashboard release) while the system targets `--r-md` (8 px). Widget anatomy isn't formalized as BEM. The SVG icons in `WidgetIcons.tsx` are already production-aligned (validated against the polished mock).
+
+## Goal
+
+Align widget chrome with [design-system/components/dashboard-widget.md](../../design-system/components/dashboard-widget.md): snap radius from `10px` to `--r-md`, formalize `.widget`, `.widget__title`, `.widget__art`, `.widget__big`, `.widget__footer` as BEM classes. Verify tabular nums on energy values.
+
+## In scope
+
+- Refactor `ui/src/components/dashboard/WidgetCard.tsx` to use BEM classes.
+- Snap `border-radius: 10px` → `var(--r-md)` (8 px).
+- Verify each widget type (~21 types) renders correctly after refactor — no visual regression except the radius.
+- Confirm tabular nums on energy / temperature values.
+
+## Out of scope
+
+- SVG icon changes (already aligned in `WidgetIcons.tsx`).
+- New widget types.
+- Dashboard layout / drag-drop / reorder logic.
+
+## Acceptance criteria
+
+- [ ] `.widget`, `.widget__title`, `.widget__art`, `.widget__footer` present
+- [ ] Border radius = `var(--r-md)` everywhere on widgets
+- [ ] Visual diff limited to the radius (no other regressions)
+- [ ] Energy values use tabular nums (no jitter)
+
+## References
+
+- [design-system/components/dashboard-widget.md](../../design-system/components/dashboard-widget.md)
+- [design-system/migration.md](../../design-system/migration.md) Phase 4
+- [ui/src/components/dashboard/WidgetIcons.tsx](../../ui/src/components/dashboard/WidgetIcons.tsx)

--- a/specs/099-design-system-equipment-row/spec.md
+++ b/specs/099-design-system-equipment-row/spec.md
@@ -1,0 +1,45 @@
+# Spec 099 — Design System Phase 5: Equipment Row
+
+> Light scoping spec — part of the [094 UI redesign umbrella](../094-ui-redesign/spec.md). Expanded into full spec when picked up via `/sowel-feature`. Long-pole phase: **one PR per equipment type**.
+
+## Problem
+
+The equipment row is the most repeated visual pattern in the app (21 types, hundreds of instances across zones). Today, each control component (`LightControl`, `ShutterControl`, etc.) re-renders its own structure. There's no shared `.eq` grid; row heights drift; icon backgrounds vary.
+
+## Goal
+
+Adopt the `.eq` grid + `.eq__icon--{type}` modifier pattern from [design-system/components/eq-row.md](../../design-system/components/eq-row.md). Refactor each equipment type one PR at a time — never touch the whole `equipments/` folder in one go.
+
+## In scope (per sub-PR)
+
+Each sub-PR migrates **one equipment type**. Suggested order:
+
+1. `LightControl.tsx` → `.eq__icon--light-on` + glow animation
+2. `ShutterControl.tsx` → `.shutter-grp` 3-button segmented control
+3. `HeaterControl.tsx` → `therm-icon` + `±` target buttons
+4. `GateControl.tsx` → `.gate-cmd` button
+5. Sensor controls (temperature, humidity, motion, smoke, leak, lux, contact, button, CO2, pressure)
+6. `EnergyMeter`, `WaterValve`, `MediaPlayer`, `PoolCover`, `PoolPump`
+7. `WeatherStation`, `WeatherForecast`
+8. `WashingMachine` and any remaining appliance types
+
+## Out of scope (per sub-PR)
+
+- Backend logic.
+- Order dispatch changes.
+- Changes to Device → Equipment binding logic.
+
+## Acceptance criteria (overall, when all sub-PRs ship)
+
+- [ ] `.eq` grid used by every equipment type
+- [ ] 52 px row height invariant (cross-panel alignment holds)
+- [ ] Light "on" state shows amber glow
+- [ ] Shutter 3-button segmented control everywhere
+- [ ] No more inline `flex grid-cols-...` definitions in equipment components
+
+## References
+
+- [design-system/components/eq-row.md](../../design-system/components/eq-row.md)
+- [design-system/components/shutter-grp.md](../../design-system/components/shutter-grp.md)
+- [design-system/components/power-button.md](../../design-system/components/power-button.md)
+- [design-system/migration.md](../../design-system/migration.md) Phase 5

--- a/specs/100-design-system-comportements/spec.md
+++ b/specs/100-design-system-comportements/spec.md
@@ -1,0 +1,40 @@
+# Spec 100 — Design System Phase 6: Comportements Panel
+
+> Light scoping spec — part of the [094 UI redesign umbrella](../094-ui-redesign/spec.md). Expanded into full spec when picked up via `/sowel-feature`.
+
+## Problem
+
+Today, `ZoneModesSection` and `ZoneRecipesSection` are two separate panels stacked in the zone view. They're related — Modes set context for which Recipes apply — but presented as unrelated. The design system models them as one panel ("Comportements") with two sub-category heads.
+
+## Goal
+
+Merge [ZoneModesSection.tsx](../../ui/src/components/zones/ZoneModesSection.tsx) and `ZoneRecipesSection.tsx` into a single `ZoneBehaviorsPanel.tsx` with two `.cat-head` sub-sections (Modes + Recettes) inside one `.panel`.
+
+## In scope
+
+- New `ZoneBehaviorsPanel.tsx` component.
+- Two `.cat-head` sub-sections inside one panel.
+- Modes section above, Recipes below.
+- Each section keeps its existing behavior (edit / activate / toggle).
+
+## Out of scope
+
+- Functional changes to mode activation or recipe toggling.
+- Changes to the underlying data model.
+- The recipe edit modal (separate spec 102).
+
+## Acceptance criteria
+
+- [ ] Single `.panel` with `Comportements` title
+- [ ] Modes and Recettes sub-sections render with `.cat-head`
+- [ ] Mode activation still works
+- [ ] Recipe toggle still works
+- [ ] Visual diff: significant. Functional diff: zero.
+
+## References
+
+- [design-system/components/panel.md](../../design-system/components/panel.md)
+- [design-system/components/cat-head.md](../../design-system/components/cat-head.md)
+- [design-system/components/mode-row.md](../../design-system/components/mode-row.md)
+- [design-system/components/recipe-row.md](../../design-system/components/recipe-row.md)
+- [design-system/migration.md](../../design-system/migration.md) Phase 6

--- a/specs/101-design-system-activity-feed/spec.md
+++ b/specs/101-design-system-activity-feed/spec.md
@@ -1,0 +1,38 @@
+# Spec 101 — Design System Phase 7: Activity Feed
+
+> Light scoping spec — part of the [094 UI redesign umbrella](../094-ui-redesign/spec.md). Expanded into full spec when picked up via `/sowel-feature`.
+
+## Problem
+
+The zone view has no activity feed. Today, the "what just happened in this zone" answer requires opening Logs or guessing from the equipment state. The design system specs an `ActivityPanel` that lives next to the zone content (desktop right column, mobile bottom drawer).
+
+## Goal
+
+Implement a new `ActivityPanel` component fed by the existing WebSocket events stream (no backend work). Display the last N events with timestamp, equipment, action.
+
+## In scope
+
+- New `ActivityPanel.tsx` component in `ui/src/components/zones/`.
+- Filter the WebSocket event stream by zone (events have `zoneId`).
+- Display latest events with relative time (`il y a 3 min`).
+- Use `.activity__*` BEM classes.
+- Cap the feed at ~50 items (in-memory, no persistence).
+
+## Out of scope
+
+- Backend changes — the events stream already exists.
+- Persistence (events are lost on page reload — fine for v1).
+- Cross-zone activity (each zone view shows only its own).
+
+## Acceptance criteria
+
+- [ ] `ActivityPanel` renders in zone view (desktop right column)
+- [ ] Mobile: scroll-to-bottom area shows the feed
+- [ ] Events filtered correctly by zone
+- [ ] Relative time updates without re-render storm
+- [ ] No console errors when events stream is idle
+
+## References
+
+- [design-system/components/activity-item.md](../../design-system/components/activity-item.md)
+- [design-system/migration.md](../../design-system/migration.md) Phase 7

--- a/specs/102-design-system-recipe-modal/spec.md
+++ b/specs/102-design-system-recipe-modal/spec.md
@@ -1,0 +1,44 @@
+# Spec 102 — Design System Phase 8: Recipe Edit Modal + Surcharges par mode
+
+> Light scoping spec — part of the [094 UI redesign umbrella](../094-ui-redesign/spec.md). Expanded into full spec when picked up via `/sowel-feature`. **Only phase with backend impact.**
+
+## Problem
+
+Today, editing a recipe expands an inline section inside `ZoneRecipesSection.tsx` — cluttered, easy to lose focus, no clear modal entry/exit. Additionally, there's no way to override recipe parameters per mode (e.g. "in Night mode, lower the dim setpoint to 10%"). Users currently must duplicate the recipe with different slots.
+
+## Goal
+
+Two changes in one spec:
+
+1. **UI**: Replace the inline edit in `ZoneRecipesSection.tsx` with a full modal mounted at app root, per [design-system/components/modal.md](../../design-system/components/modal.md).
+2. **Feature**: Add a "Surcharges par mode" section inside the modal, allowing per-mode parameter overrides. Requires backend CRUD on a new `recipe_mode_override` table.
+
+## In scope
+
+- New `RecipeEditModal.tsx` component, mounted at root.
+- Database migration: new table `recipe_mode_overrides (recipe_id, mode_id, parameters JSON, ...)`.
+- Backend: REST endpoints `GET/PUT/DELETE /recipes/:id/overrides/:modeId`.
+- Recipe Engine reads overrides at eval time — current mode's override (if any) takes precedence over default params.
+- UI surcharges section: list modes, per-mode parameter form.
+
+## Out of scope
+
+- Bulk edit of overrides across recipes.
+- Override versioning / audit trail.
+- Schedule-based overrides (only mode-based).
+
+## Acceptance criteria
+
+- [ ] Modal replaces inline edit
+- [ ] Surcharges section lists all active modes
+- [ ] Per-mode parameters override at runtime
+- [ ] Recipe Engine respects current mode override
+- [ ] Reverting an override falls back to default params
+- [ ] Migration is reversible
+
+## References
+
+- [design-system/components/modal.md](../../design-system/components/modal.md)
+- [design-system/migration.md](../../design-system/migration.md) Phase 8
+- [docs/technical/recipe-development.md](../../docs/technical/recipe-development.md)
+- Recipe Engine: `src/recipes/engine/recipe-manager.ts`

--- a/ui-redesign-B-polished.html
+++ b/ui-redesign-B-polished.html
@@ -1,0 +1,3891 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sowel — Zone view (palette tester)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  /* ============================================================ */
+  /* PALETTE THEMES                                               */
+  /* Switch via data-theme on <html>                              */
+  /* ============================================================ */
+
+  /* ── Theme 1: HYBRID (light, neutral grey + Sowel amber) ─ */
+  :root,
+  [data-theme="hybrid"] {
+    --p-50:#EEF5F8; --p-100:#D9E7EF; --p-500:#1A4F6E; --p-600:#144159; --p-700:#0F3146;
+    --a-50:#FFF6D6; --a-100:#FCE89A; --a-500:#F2C035; --a-600:#D4A41C;
+    --n-0:#FFFFFF; --n-25:#FAFAFA; --n-50:#F4F4F5; --n-100:#E9E9EB; --n-200:#D4D4D8;
+    --n-300:#A1A1AA; --n-400:#71717A; --n-500:#52525B; --n-600:#3F3F46; --n-700:#27272A; --n-800:#18181B;
+    --green-50:#E6F7EE; --green-500:#1FA260; --green-700:#0E6B3F;
+    --info-50:#E0EFFA; --info-500:#247EB5;
+    --red-50:#FBE9E1; --red-500:#C7522E;
+    --light-50:#FFF6D6; --light-500:#F2C035;
+    --shutter-50:#E8EBEE; --shutter-500:#4F5763;
+    --sensor-50:#EBF2EC; --sensor-500:#4F7559;
+    --media-50:#EAE9F2; --media-500:#5759A5;
+    --line:rgba(24,24,27,.08); --line-2:rgba(24,24,27,.14);
+    --sh-1:0 1px 2px rgba(15,42,60,.04),0 1px 3px rgba(15,42,60,.06);
+    --sh-2:0 4px 14px -4px rgba(15,42,60,.10);
+    --sh-3:0 24px 56px -16px rgba(15,42,60,.14);
+  }
+
+  /* ── Theme 2: DARK (Linear-ish night) ────────────────────── */
+  [data-theme="dark"] {
+    --p-50:#1A2A38; --p-100:#243B4E; --p-500:#5BA5CC; --p-600:#82BCDD; --p-700:#A8CEE6;
+    --a-50:#332715; --a-100:#5C3F1A; --a-500:#F2BC6E; --a-600:#FFCF8C;
+    --n-0:#16181E; --n-25:#1B1D24; --n-50:#1F2128; --n-100:#262931; --n-200:#363941;
+    --n-300:#52565F; --n-400:#7E828B; --n-500:#9CA0AA; --n-600:#C7C9CF; --n-700:#E2E3E7; --n-800:#F4F5F8;
+    --green-50:#0F2A1E; --green-500:#3DDB89; --green-700:#9AF0C6;
+    --info-50:#0F1F33; --info-500:#5DA8F0;
+    --red-50:#2E1614; --red-500:#F37B5F;
+    --light-50:#2D2415; --light-500:#F2BC6E;
+    --shutter-50:#1B2230; --shutter-500:#94A3B8;
+    --sensor-50:#152920; --sensor-500:#6BCF8C;
+    --media-50:#1B1F36; --media-500:#9D9FE6;
+    --line:rgba(255,255,255,.06); --line-2:rgba(255,255,255,.14);
+    --sh-1:0 1px 2px rgba(0,0,0,.4),0 1px 3px rgba(0,0,0,.5);
+    --sh-2:0 4px 14px -4px rgba(0,0,0,.5);
+    --sh-3:0 24px 56px -16px rgba(0,0,0,.6);
+  }
+
+  :root {
+    --s-1:4px; --s-2:8px; --s-3:12px; --s-4:16px; --s-5:20px; --s-6:24px; --s-8:32px;
+    --r-xs:4px; --r-sm:6px; --r-md:8px; --r-lg:12px; --r-full:999px;
+    --font-body:'Inter',system-ui,-apple-system,sans-serif;
+    --font-mono:'JetBrains Mono',ui-monospace,monospace;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: var(--font-body);
+    color: var(--n-700);
+    background: var(--n-50);
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    font-feature-settings: "cv11" 1, "ss01" 1;
+    transition: background 240ms ease, color 240ms ease;
+  }
+  /* Numerals are tabular wherever we render data */
+  .strip__cell-value, .eq__value, .panel__count, .cat-head__count,
+  .activity__time, .topbar__chip, .mode-row__meta, .recipe__sub,
+  .hero__count {
+    font-feature-settings: "tnum" 1, "cv11" 1, "ss01" 1;
+  }
+  * { transition: background-color 240ms ease, color 240ms ease, border-color 240ms ease; }
+
+  /* One orchestrated reveal — staggered, gentle, plays once on load */
+  @keyframes rise {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  .ui .topbar  { animation: rise 520ms cubic-bezier(.2,.7,.2,1) backwards;            animation-delay: 0ms; }
+  .ui .hero    { animation: rise 520ms cubic-bezier(.2,.7,.2,1) backwards;            animation-delay: 80ms; }
+  .ui .actions { animation: rise 520ms cubic-bezier(.2,.7,.2,1) backwards;            animation-delay: 160ms; }
+  .ui .grid    { animation: rise 520ms cubic-bezier(.2,.7,.2,1) backwards;            animation-delay: 220ms; }
+  @media (prefers-reduced-motion: reduce) {
+    .ui .topbar, .ui .hero, .ui .actions, .ui .grid { animation: none; }
+  }
+
+  /* ──────── Palette picker ──────── */
+  .picker {
+    position: sticky; top: 0; z-index: 100;
+    display: flex; align-items: center; gap: 1rem;
+    padding: .65rem 1.5rem;
+    background: rgba(255,255,255,.94);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--line);
+    font-size: .82rem;
+  }
+  [data-theme="dark"] .picker { background: rgba(22,24,30,.94); }
+  .picker__brand {
+    font-weight: 700; color: var(--p-500);
+    margin-right: auto;
+  }
+  .picker__label {
+    font-size: .68rem; text-transform: uppercase;
+    letter-spacing: .14em; color: var(--n-400); font-weight: 700;
+  }
+  .picker__choices { display: flex; gap: .35rem; }
+  .picker__chip {
+    display: inline-flex; align-items: center; gap: .45rem;
+    padding: .35rem .75rem .35rem .35rem;
+    background: var(--n-0);
+    border: 1px solid var(--line);
+    border-radius: var(--r-full);
+    font-size: .76rem; color: var(--n-600);
+    cursor: pointer; font-weight: 500;
+    transition: all 160ms;
+  }
+  .picker__chip:hover { border-color: var(--n-300); }
+  .picker__chip--active {
+    background: var(--n-800); color: var(--n-0);
+    border-color: var(--n-800);
+  }
+  .picker__chip .sw {
+    width: 22px; height: 22px;
+    border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    overflow: hidden;
+    position: relative;
+    border: 1px solid rgba(0,0,0,.08);
+  }
+  .picker__chip .sw::before,
+  .picker__chip .sw::after {
+    content: ""; position: absolute; inset: 0;
+  }
+  .picker__chip[data-pick="hybrid"]  .sw { background: conic-gradient(#E5A23A 0 120deg, #1A4F6E 120deg 240deg, #F4F4F5 240deg 360deg); }
+  .picker__chip[data-pick="dark"]    .sw { background: conic-gradient(#F2BC6E 0 120deg, #5BA5CC 120deg 240deg, #1F2128 240deg 360deg); }
+
+  /* ──────── Intro ──────── */
+  .intro {
+    max-width: 1280px;
+    margin: 2.5rem auto 1.25rem;
+    padding: 0 1.5rem;
+  }
+  .intro__eyebrow {
+    display: inline-flex; align-items: center; gap: .5rem;
+    font-size: .68rem;
+    text-transform: uppercase; letter-spacing: .14em;
+    color: var(--a-500); font-weight: 700;
+    margin-bottom: .65rem;
+  }
+  .intro__eyebrow::before {
+    content: ""; width: 8px; height: 8px;
+    border-radius: 50%; background: var(--a-500);
+  }
+  .intro__title {
+    font-size: 2.1rem; font-weight: 700;
+    line-height: 1.1; letter-spacing: -.025em;
+    margin: 0 0 .65rem; color: var(--n-800);
+    max-width: 36ch;
+  }
+  .intro__lead {
+    font-size: .95rem; color: var(--n-500);
+    max-width: 680px; line-height: 1.6;
+  }
+  .intro__lead b { color: var(--n-700); font-weight: 600; }
+
+  /* ──────── Section ──────── */
+  .section {
+    max-width: 1280px; margin: 0 auto;
+    padding: 0 1.5rem 4rem;
+  }
+  .section__label {
+    display: flex; align-items: center; gap: .75rem;
+    margin-bottom: .85rem;
+    font-size: .68rem; text-transform: uppercase;
+    letter-spacing: .14em; color: var(--n-400); font-weight: 700;
+  }
+  .section__label::after {
+    content: ""; flex: 1; height: 1px; background: var(--line);
+  }
+
+  /* ──────── Product frame ──────── */
+  .ui {
+    background: var(--n-25);
+    border-radius: var(--r-lg);
+    box-shadow: var(--sh-3);
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    min-height: 820px;
+    border: 1px solid var(--line);
+  }
+
+  /* ── Sidebar ─── */
+  .sb {
+    background: var(--n-0);
+    border-right: 1px solid var(--line);
+    font-size: .85rem;
+    display: flex; flex-direction: column;
+  }
+  .sb__logo {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .75rem 1.15rem;
+    height: var(--topbar-h, 49px);
+    box-sizing: border-box;
+    border-bottom: 1px solid var(--line);
+    margin-bottom: .85rem;
+  }
+  .sb__logo svg { width: 16px; height: 16px; flex: none; }
+  .sb__logo b { font-weight: 700; letter-spacing: .04em; font-size: .9rem; color: var(--p-500); }
+  .sb__item {
+    display: flex; align-items: center; gap: .55rem;
+    margin: 1px .55rem;
+    padding: .45rem .6rem;
+    border-radius: 6px;
+    color: var(--n-600); font-weight: 500;
+    font-size: .82rem; cursor: pointer;
+    transition: background-color 140ms, color 140ms;
+  }
+  /* Hover: subtle neutral pill, icon brightens, text deepens — no primary tint */
+  .sb__item:hover {
+    background: var(--n-50);
+    color: var(--n-800);
+  }
+  .sb__item:hover .sb__item-icon { opacity: 1; }
+  /* Active: clear primary identity */
+  .sb__item--active {
+    background: var(--p-50); color: var(--p-500);
+    font-weight: 600;
+  }
+  .sb__item--active .sb__item-icon { color: var(--p-500); opacity: 1; }
+  .sb__item--active:hover {
+    background: color-mix(in srgb, var(--p-500) 12%, transparent);
+    color: var(--p-500);
+  }
+  [data-theme="dark"] .sb__item--active { color: var(--p-600); }
+  .sb__item-icon { width: 16px; height: 16px; opacity: .75; transition: opacity 140ms, color 140ms; }
+  .sb__chev { margin-left: auto; opacity: .5; font-size: .65rem; }
+  .sb__sub { display: flex; flex-direction: column; padding-left: .65rem; }
+  .sb__sub .sb__item { padding-left: 1.35rem; font-size: .78rem; box-shadow: none; }
+  .sb__sub-deeper .sb__item { padding-left: 1.6rem; }
+  .sb__sep { height: 1px; background: var(--line); margin: .35rem .85rem; }
+  /* Tree expand chevron (production pattern: chevron > on the left, collapsed; rotates 90° when open) */
+  .sb__exp {
+    display: inline-flex; width: 12px; height: 12px;
+    align-items: center; justify-content: center;
+    color: var(--n-400); font-size: .85rem; line-height: 1;
+    transition: transform 160ms;
+    flex: none;
+  }
+  .sb__exp--open { transform: rotate(90deg); color: var(--n-600); }
+  .sb__exp--leaf { visibility: hidden; }
+
+  /* ── Main ─── */
+  .main { background: var(--n-25); overflow-y: auto; }
+
+  /* Top bar */
+  .topbar {
+    display: flex; align-items: center; gap: 1rem;
+    padding: .75rem 1.5rem;
+    height: var(--topbar-h, 49px);
+    box-sizing: border-box;
+    border-bottom: 1px solid var(--line);
+    background: var(--n-0);
+  }
+  .topbar__breadcrumb { font-size: .82rem; color: var(--n-400); font-weight: 500; }
+  .topbar__breadcrumb b { color: var(--n-700); font-weight: 600; }
+  .topbar__breadcrumb .sep { margin: 0 .35rem; opacity: .35; }
+  .topbar__spacer { flex: 1; }
+  .topbar__chip {
+    display: inline-flex; align-items: center; gap: .4rem;
+    padding: .3rem .65rem;
+    background: var(--n-50);
+    border: 1px solid var(--line);
+    border-radius: var(--r-full);
+    font-size: .76rem; color: var(--n-500);
+    font-family: var(--font-mono);
+  }
+  .topbar__chip svg { width: 12px; height: 12px; opacity: .7; }
+  /* Sunlight chip: amber-tinted background (matches production SunlightBanner) */
+  .topbar__chip--sun {
+    background: color-mix(in srgb, var(--a-500) 10%, transparent);
+    color: var(--a-600);
+    border-color: color-mix(in srgb, var(--a-500) 22%, transparent);
+  }
+  .topbar__chip--sun svg { color: var(--a-500); opacity: .9; }
+  .topbar__chip-tag {
+    font-family: var(--font-body); font-weight: 600;
+    font-size: .7rem;
+    color: color-mix(in srgb, var(--a-600) 80%, var(--n-700));
+    margin-left: .25rem;
+    text-transform: lowercase;
+  }
+
+  /* Connection status (matches production ConnectionStatus.tsx) */
+  .topbar__conn {
+    display: inline-flex; align-items: center; gap: .5rem;
+    padding: .3rem .8rem;
+    border-radius: var(--r-full);
+    font-size: .76rem; font-weight: 500;
+  }
+  .topbar__conn-dot {
+    position: relative; display: inline-flex;
+    width: 8px; height: 8px;
+  }
+  .topbar__conn-dot::before {
+    content: ""; position: absolute; inset: 0; border-radius: 50%;
+    background: currentColor;
+  }
+  .topbar__conn--connected {
+    background: color-mix(in srgb, var(--green-500) 10%, transparent);
+    color: var(--green-700);
+  }
+  .topbar__conn--connected .topbar__conn-dot::after {
+    content: ""; position: absolute; inset: 0; border-radius: 50%;
+    background: var(--green-500);
+    animation: connPing 1.8s ease-in-out infinite;
+    opacity: .6;
+  }
+  @keyframes connPing {
+    0%   { transform: scale(1); opacity: .6; }
+    100% { transform: scale(2.4); opacity: 0; }
+  }
+  .topbar__conn--disconnected {
+    background: color-mix(in srgb, var(--red-500) 10%, transparent);
+    color: var(--red-500);
+  }
+  @media (prefers-reduced-motion: reduce) { .topbar__conn--connected .topbar__conn-dot::after { animation: none; } }
+
+  /* Alarms pill (matches production HeaderPill) */
+  .topbar__alarm {
+    display: inline-flex; align-items: center; gap: .35rem;
+    padding: .3rem .6rem;
+    border-radius: var(--r-full);
+    border: none; cursor: pointer;
+    font-family: var(--font-body); font-size: .76rem; font-weight: 600;
+    transition: filter 160ms;
+  }
+  .topbar__alarm:hover { filter: brightness(.97); }
+  .topbar__alarm svg { width: 13px; height: 13px; flex: none; }
+  .topbar__alarm-count { font-family: var(--font-mono); font-feature-settings: "tnum" 1; }
+  .topbar__alarm--warning {
+    background: color-mix(in srgb, var(--a-500) 14%, transparent);
+    color: var(--a-600);
+  }
+  .topbar__alarm--error {
+    background: color-mix(in srgb, var(--red-500) 12%, transparent);
+    color: var(--red-500);
+  }
+  .topbar__avatar {
+    display: flex; align-items: center; gap: .4rem;
+    padding: .25rem .55rem .25rem .25rem;
+    background: var(--n-50); border: 1px solid var(--line);
+    border-radius: var(--r-full); font-size: .76rem;
+  }
+  .topbar__avatar-pic {
+    width: 22px; height: 22px; border-radius: 50%;
+    background: var(--p-500); color: var(--n-0);
+    display: flex; align-items: center; justify-content: center;
+    font-size: .68rem; font-weight: 700;
+  }
+
+  /* ── Hero ─── */
+  .hero {
+    position: relative;
+    padding: 2.1rem 1.5rem 1.25rem;
+    background:
+      radial-gradient(120% 80% at 0% 0%, color-mix(in srgb, var(--p-500) 6%, transparent), transparent 55%),
+      radial-gradient(80% 100% at 100% 0%, color-mix(in srgb, var(--a-500) 4%, transparent), transparent 60%);
+  }
+  .hero__head { margin-bottom: 1.4rem; }
+  .hero__main { min-width: 0; }
+  .hero__eyebrow {
+    display: inline-flex; align-items: center; gap: .45rem;
+    font-size: .66rem; text-transform: uppercase; letter-spacing: .16em;
+    color: var(--n-400); font-weight: 600;
+    margin-bottom: .55rem;
+  }
+  .hero__eyebrow svg { width: 12px; height: 12px; opacity: .7; }
+  .hero__eyebrow b { color: var(--n-700); font-weight: 700; }
+  .hero__title {
+    font-size: 2.6rem; font-weight: 700; margin: 0 0 .15rem;
+    color: var(--n-800); letter-spacing: -.03em;
+    line-height: 1;
+  }
+  .hero__lead {
+    display: flex; align-items: center; gap: .6rem;
+    margin-top: .55rem;
+    font-size: .85rem; color: var(--n-500);
+    font-feature-settings: "tnum" 1;
+  }
+  .hero__lead b { color: var(--n-700); font-weight: 600; }
+  .hero__lead-sep {
+    width: 4px; height: 4px; border-radius: 50%;
+    background: var(--n-300); flex: none;
+  }
+
+
+  /* Strip — pill row, aligned with production (ZoneAggregationPills) */
+  /* Pattern: content-width pills, 1px dividers, conditional rendering,
+     three soft groups: sensors → counts → alerts.
+     Stays on a single line; scrolls horizontally if it overflows. */
+  .strip {
+    display: flex; align-items: center; flex-wrap: nowrap;
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: .35rem .4rem;
+    margin-bottom: .65rem;
+    column-gap: 0;
+    overflow-x: auto;
+    scrollbar-width: thin;
+    scrollbar-color: var(--n-200) transparent;
+  }
+  .strip::-webkit-scrollbar { height: 6px; }
+  .strip::-webkit-scrollbar-track { background: transparent; }
+  .strip::-webkit-scrollbar-thumb { background: var(--n-200); border-radius: 3px; }
+  .strip__pill {
+    display: inline-flex; align-items: center; gap: .45rem;
+    padding: .35rem .65rem;
+    font-size: .82rem; font-weight: 500;
+    color: var(--n-700);
+    border-radius: var(--r-sm);
+    white-space: nowrap;
+    font-feature-settings: "tnum" 1;
+    transition: background-color 160ms;
+  }
+  .strip__pill:hover { background: var(--n-25); }
+  .strip__pill-icon {
+    width: 14px; height: 14px;
+    color: var(--c, var(--n-400)); flex-shrink: 0;
+  }
+  .strip__pill-val {
+    font-family: var(--font-mono); font-weight: 600;
+    color: var(--n-800); letter-spacing: -.005em;
+  }
+  .strip__pill-val .u { font-size: .78em; color: var(--n-400); margin-left: 1px; font-weight: 500; letter-spacing: 0; }
+  .strip__pill-meta { font-size: .76rem; color: var(--n-500); }
+  .strip__pill-spark { width: 48px; height: 16px; margin-left: .15rem; flex: none; opacity: .8; }
+  /* Divider between pills */
+  .strip__div {
+    width: 1px; height: 18px;
+    background: var(--n-200);
+    margin: 0 .15rem;
+    flex: none;
+  }
+  /* Group break (slightly bolder spacing before alerts / between groups) */
+  .strip__div--group { margin: 0 .35rem; background: var(--line-2); height: 22px; }
+  /* States */
+  .strip__pill--active .strip__pill-icon { color: var(--a-500); }
+  .strip__pill--active .strip__pill-val { color: var(--a-600); }
+  .strip__pill--calm .strip__pill-icon { color: var(--green-500); }
+  .strip__pill--calm .strip__pill-val { color: var(--green-700); font-family: var(--font-body); font-weight: 600; }
+  /* Alert pill — confident, never miss */
+  .strip__pill--alert {
+    background: var(--red-50);
+    color: var(--red-500);
+    font-weight: 600;
+  }
+  .strip__pill--alert .strip__pill-icon { color: var(--red-500); }
+  .strip__pill--alert .strip__pill-val { color: var(--red-500); font-family: var(--font-body); font-weight: 700; }
+  .strip__pill--alert::before {
+    content: ""; width: 6px; height: 6px; border-radius: 50%;
+    background: var(--red-500);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--red-500) 25%, transparent);
+    animation: pulseAlert 1.6s ease-in-out infinite;
+    margin-right: -.1rem;
+  }
+  @keyframes pulseAlert {
+    0%, 100% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--red-500) 25%, transparent); }
+    50%      { box-shadow: 0 0 0 6px color-mix(in srgb, var(--red-500) 8%, transparent); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .strip__pill--alert::before { animation: none; }
+  }
+  /* Zone commands row — own line, left-aligned, below the strip */
+  .zcmds {
+    display: inline-flex; align-items: center;
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: .25rem .35rem;
+    margin-bottom: .25rem;
+    gap: 1px;
+  }
+  .zcmds__sep {
+    width: 1px; height: 16px;
+    background: var(--n-200);
+    margin: 0 .3rem;
+    flex: none;
+  }
+  .zcmds__btn {
+    width: 36px; height: 34px;
+    background: transparent; border: none;
+    color: var(--n-600); cursor: pointer;
+    border-radius: var(--r-sm);
+    display: inline-flex; align-items: center; justify-content: center;
+    transition: background-color 160ms, color 160ms;
+    flex: none; padding: 0;
+  }
+  .zcmds__btn svg { width: 16px; height: 16px; }
+  .zcmds__btn[data-cat="light"]:hover { background: var(--light-50); color: var(--light-500); }
+  .zcmds__btn[data-cat="light-off"]:hover { background: var(--n-100); color: var(--n-700); }
+  .zcmds__btn[data-cat="shutter"]:hover { background: var(--shutter-50); color: var(--shutter-500); }
+
+  /* Zone commands — segmented controls grouped by category */
+  .actions {
+    display: flex; align-items: center;
+    gap: 1.25rem; flex-wrap: wrap;
+    margin-bottom: .25rem;
+  }
+  .actions__group {
+    display: inline-flex; align-items: center; gap: .65rem;
+  }
+  .actions__label {
+    display: inline-flex; align-items: center; gap: .4rem;
+    font-size: .68rem;
+    text-transform: uppercase; letter-spacing: .14em;
+    color: var(--n-500); font-weight: 700;
+  }
+  .actions__label svg { width: 14px; height: 14px; color: var(--c, var(--n-400)); }
+  .actions__seg {
+    display: inline-flex;
+    background: var(--n-0);
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    overflow: hidden;
+  }
+  .actions__seg button {
+    display: inline-flex; align-items: center; justify-content: center;
+    gap: .4rem;
+    padding: .55rem .9rem;
+    background: transparent; color: var(--n-700);
+    border: none; border-right: 1px solid var(--line);
+    font-family: var(--font-body); font-size: .8rem; font-weight: 500;
+    cursor: pointer; min-height: 36px;
+    transition: background-color 160ms, color 160ms;
+  }
+  .actions__seg button:last-child { border-right: none; }
+  .actions__seg button:hover { background: var(--p-50); color: var(--p-500); }
+  .actions__seg button svg { width: 13px; height: 13px; opacity: .7; }
+  /* Icon-only buttons (used for shutter ↑ ■ ↓) */
+  .actions__seg--icons button { padding: .55rem .9rem; min-width: 44px; }
+  .actions__seg--icons button svg { width: 14px; height: 14px; opacity: .85; }
+  /* Category-tinted hover for clarity */
+  .actions__group--light .actions__seg button:hover { background: var(--light-50); color: var(--light-500); }
+  .actions__group--light .actions__label svg { color: var(--light-500); }
+  .actions__group--shutter .actions__seg button:hover { background: var(--shutter-50); color: var(--shutter-500); }
+  .actions__group--shutter .actions__label svg { color: var(--shutter-500); }
+
+  /* Grid */
+  .grid {
+    display: grid; grid-template-columns: 1.5fr 1fr;
+    gap: 1rem; padding: 0 1.5rem 1.5rem;
+  }
+
+  /* Panel */
+  .panel {
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-lg); overflow: hidden;
+  }
+  .panel__head {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .55rem 1.1rem;
+    min-height: 44px;
+    box-sizing: border-box;
+    background: var(--p-50);
+    border-bottom: 1px solid var(--p-100);
+  }
+  .panel__title {
+    font-size: .72rem; font-weight: 700; color: var(--p-500);
+    text-transform: uppercase; letter-spacing: .12em;
+  }
+  .panel__sub { font-size: .72rem; color: color-mix(in srgb, var(--p-500) 65%, transparent); margin-left: .35rem; text-transform: none; letter-spacing: 0; font-weight: 500; }
+  .panel__count {
+    margin-left: auto;
+    font-family: var(--font-mono); font-size: .68rem;
+    color: var(--p-500); background: var(--n-0);
+    border: 1px solid var(--p-100);
+    padding: 1px 7px; border-radius: var(--r-full); font-weight: 600;
+  }
+  /* Numeric counts hidden (per user feedback) — only badges with custom style remain */
+  .panel__count:not([style]),
+  .cat-head__count,
+  .cpanel__count,
+  .mob__panel-count:not([style]),
+  .mob__cat-head-count { display: none; }
+  /* + button on panel head — add equipment */
+  .panel__add {
+    margin-left: auto;
+    width: 26px; height: 26px;
+    background: transparent; border: 1px solid var(--p-100);
+    border-radius: var(--r-sm);
+    color: var(--p-500); cursor: pointer;
+    display: inline-flex; align-items: center; justify-content: center;
+  }
+  .panel__add:hover { background: var(--n-0); border-color: var(--p-500); }
+  .panel__add svg { width: 13px; height: 13px; }
+
+  /* Category head */
+  .cat-head {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .4rem 1.1rem;
+    min-height: 36px;
+    box-sizing: border-box;
+    font-size: .65rem; text-transform: uppercase;
+    letter-spacing: .14em; color: var(--n-500); font-weight: 600;
+    border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line);
+    background: var(--n-25);
+  }
+  .cat-head-icon { width: 14px; height: 14px; opacity: .7; }
+  /* + button in sub-category header (add equipment / recipe / mode) */
+  .cat-head__add {
+    margin-left: auto;
+    width: 22px; height: 22px;
+    background: transparent; border: 1px solid var(--n-200);
+    border-radius: var(--r-xs);
+    color: var(--n-500); cursor: pointer;
+    display: inline-flex; align-items: center; justify-content: center;
+    transition: background-color 140ms, color 140ms, border-color 140ms;
+  }
+  .cat-head__add:hover { background: var(--p-50); color: var(--p-500); border-color: var(--p-100); }
+  .cat-head__add svg { width: 11px; height: 11px; }
+  .cat-head__count { margin-left: auto; font-family: var(--font-mono); font-size: .68rem; opacity: .65; }
+
+  /* Equipment row */
+  .eq {
+    display: grid;
+    grid-template-columns: 32px 1fr auto auto auto;
+    gap: .85rem; align-items: center;
+    padding: .55rem 1.1rem;
+    min-height: 52px;
+    box-sizing: border-box;
+    border-top: 1px solid var(--line);
+    position: relative; cursor: pointer;
+  }
+  .eq:hover { background: var(--n-25); }
+  /* The auto-mark ⚡ next to the name is the only "automated" cue — no left bar */
+
+  .eq__icon {
+    width: 32px; height: 32px;
+    border-radius: var(--r-sm);
+    display: flex; align-items: center; justify-content: center;
+    background: var(--icon-bg, var(--n-50));
+    color: var(--icon-fg, var(--n-500));
+  }
+  .eq__icon svg { width: 15px; height: 15px; }
+  .eq__icon--light { --icon-bg: var(--light-50); --icon-fg: var(--light-500); }
+  .eq__icon--light-on {
+    --icon-bg: var(--a-500); --icon-fg: var(--n-0);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--a-500) 35%, transparent);
+    animation: glow 3.2s ease-in-out infinite;
+  }
+  [data-theme="dark"] .eq__icon--light-on { --icon-fg: #18170F; }
+  @keyframes glow {
+    0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--a-500) 30%, transparent); }
+    50%      { box-shadow: 0 0 0 5px color-mix(in srgb, var(--a-500) 14%, transparent); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .eq__icon--light-on { animation: none; }
+  }
+  .eq__icon--shutter { --icon-bg: var(--shutter-50); --icon-fg: var(--shutter-500); }
+  .eq__icon--sensor { --icon-bg: var(--sensor-50); --icon-fg: var(--sensor-500); }
+  .eq__icon--media { --icon-bg: var(--media-50); --icon-fg: var(--media-500); }
+
+  .eq__name {
+    font-weight: 500; font-size: .88rem;
+    color: var(--n-800);
+    display: inline-flex; align-items: center;
+  }
+  .auto-mark { width: 11px; height: 11px; margin-left: 5px; color: var(--a-500); }
+  .auto-mark--shutter { color: var(--shutter-500); }
+
+  .eq__slider {
+    width: 96px; height: 5px;
+    background: var(--n-100);
+    border-radius: var(--r-full); position: relative;
+  }
+  .eq__slider-fill {
+    position: absolute; left: 0; top: 0; height: 100%;
+    border-radius: var(--r-full); background: var(--a-500);
+  }
+  .eq__slider-fill--shutter { background: var(--shutter-500); }
+  .eq__slider-knob {
+    position: absolute; top: 50%; transform: translate(-50%, -50%);
+    width: 12px; height: 12px; background: var(--n-0);
+    border-radius: 50%;
+    box-shadow: 0 1px 2px rgba(0,0,0,.18);
+    border: 2px solid var(--a-500);
+  }
+  .eq__slider-knob--shutter { border-color: var(--shutter-500); }
+
+  .eq__value {
+    font-family: var(--font-mono); font-size: .76rem;
+    color: var(--n-500); font-weight: 600;
+    min-width: 28px; text-align: right;
+  }
+
+  .power-btn {
+    width: 32px; height: 26px;
+    border-radius: var(--r-sm);
+    background: var(--n-50); color: var(--n-400);
+    border: 1px solid var(--line);
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer;
+  }
+  .power-btn svg { width: 13px; height: 13px; }
+  .power-btn--on {
+    background: var(--a-500); color: var(--n-0);
+    border-color: var(--a-500);
+  }
+  [data-theme="dark"] .power-btn--on { color: #18170F; }
+
+  .shutter-ctrl { display: inline-flex; gap: 2px; }
+  .shutter-btn {
+    width: 24px; height: 24px;
+    border: 1px solid var(--line);
+    background: var(--n-0); color: var(--n-400);
+    border-radius: var(--r-xs);
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer;
+  }
+  .shutter-btn svg { width: 10px; height: 10px; }
+  .shutter-btn:hover { color: var(--shutter-500); border-color: var(--shutter-500); background: var(--shutter-50); }
+
+  .sensor-val {
+    font-family: var(--font-mono); font-size: .78rem;
+    font-weight: 600; color: var(--n-700);
+  }
+  .sensor-val .u { font-size: .68rem; color: var(--n-400); margin-left: 1px; font-weight: 500; }
+
+  .chip-state {
+    font-size: .68rem; padding: 1px 7px;
+    border-radius: var(--r-full);
+    background: var(--n-100); color: var(--n-500);
+    font-weight: 600;
+  }
+  .chip-state--closed { background: var(--shutter-50); color: var(--shutter-500); }
+  .chip-state--off { background: var(--n-100); color: var(--n-400); }
+
+  .battery {
+    display: inline-flex; align-items: center; gap: 4px;
+    font-family: var(--font-mono); font-size: .7rem;
+    color: var(--n-500);
+  }
+  .battery__bar {
+    width: 20px; height: 9px;
+    border: 1.5px solid var(--n-400); border-radius: 2px;
+    position: relative;
+  }
+  .battery__bar::after {
+    content: ""; position: absolute;
+    right: -3px; top: 50%; transform: translateY(-50%);
+    width: 2px; height: 4px;
+    background: var(--n-400);
+  }
+  .battery__fill {
+    position: absolute; inset: 1px;
+    width: var(--w, 100%);
+    background: var(--green-500);
+    border-radius: 1px;
+  }
+  .battery--med .battery__fill { background: var(--a-500); }
+  .battery--med .battery__bar { border-color: var(--a-500); }
+  .battery--med .battery__bar::after { background: var(--a-500); }
+
+  .last-action {
+    font-family: var(--font-mono); font-size: .68rem;
+    color: var(--n-400);
+  }
+
+  /* ── Right column ─── */
+
+  /* Mode row — list of all modes in this zone */
+  .mode-row {
+    display: grid;
+    grid-template-columns: 32px 1fr auto;
+    gap: .85rem; align-items: center;
+    padding: .55rem 1.1rem;
+    min-height: 52px;
+    box-sizing: border-box;
+    border-top: 1px solid var(--line);
+    cursor: pointer;
+    transition: background 120ms;
+  }
+  .mode-row:hover { background: var(--n-25); }
+  .mode-row__icon {
+    width: 32px; height: 32px;
+    border-radius: var(--r-sm);
+    background: var(--n-50); color: var(--n-500);
+    display: flex; align-items: center; justify-content: center;
+    position: relative;
+  }
+  .mode-row__icon svg { width: 15px; height: 15px; }
+  .mode-row__icon-dot {
+    position: absolute; top: -3px; right: -3px;
+    width: 10px; height: 10px; border-radius: 50%;
+    background: var(--n-200);
+    border: 2px solid var(--n-0);
+  }
+  .mode-row__icon-dot--active {
+    background: var(--green-500);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--green-500) 22%, transparent);
+  }
+  .mode-row__main {
+    min-width: 0;
+  }
+  .mode-row__name {
+    font-weight: 500; font-size: .88rem;
+    color: var(--n-800);
+    line-height: 1.25;
+  }
+  .mode-row__meta {
+    font-size: .7rem; color: var(--n-400);
+    line-height: 1.25;
+    margin-top: 1px;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .mode-row--active {
+    background: color-mix(in srgb, var(--green-500) 4%, var(--n-0));
+    border-left: 3px solid var(--green-500);
+    padding-left: calc(1.1rem - 3px);
+  }
+  .mode-row--active .mode-row__icon { background: var(--green-50); color: var(--green-700); }
+  .mode-row--active .mode-row__name {
+    color: var(--green-700); font-weight: 700;
+  }
+  .mode-row__apply {
+    font-size: .72rem; font-weight: 600;
+    color: var(--p-500);
+    background: transparent;
+    border: 1px solid var(--line);
+    padding: .25rem .65rem;
+    border-radius: var(--r-xs);
+    cursor: pointer;
+  }
+  .mode-row__apply:hover { background: var(--p-50); border-color: var(--p-500); }
+  .mode-row__badge {
+    font-size: .65rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .1em;
+    color: var(--green-700);
+    background: color-mix(in srgb, var(--green-500) 12%, transparent);
+    padding: 2px 8px; border-radius: var(--r-full);
+  }
+
+  /* Mode effects — expanded under the active mode */
+  .mode-effects {
+    display: flex; flex-direction: column; gap: 0;
+    background: color-mix(in srgb, var(--green-500) 3%, var(--n-25));
+    padding: .35rem 0;
+    border-left: 3px solid var(--green-500);
+  }
+  .mode-effect {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .25rem 1.1rem .25rem 2rem;
+    font-size: .74rem;
+    color: var(--n-600);
+  }
+  .mode-effect__arrow {
+    color: var(--green-700);
+    font-family: var(--font-mono);
+    font-weight: 600; font-size: .68rem;
+    flex-shrink: 0;
+    min-width: 75px;
+  }
+  .mode-effect__target {
+    font-weight: 500; color: var(--n-700);
+    flex: 1; min-width: 0;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .mode-effect__val {
+    font-family: var(--font-mono); font-weight: 600;
+    color: var(--green-700);
+  }
+
+  /* Recipe row — 2-row grid: icon spans both rows; row 1 = clickable name + toggle; row 2 = action buttons */
+  .recipe {
+    display: grid;
+    grid-template-columns: 32px 1fr auto;
+    column-gap: .85rem;
+    row-gap: 0;
+    align-items: center;
+    padding: .35rem 1.1rem;
+    min-height: 52px;
+    box-sizing: border-box;
+    border-top: 1px solid var(--line);
+  }
+  .recipe__name { line-height: 1.2; }
+  .recipe__icon {
+    grid-row: 1 / span 2;
+    align-self: center;
+  }
+  .recipe__open {
+    grid-row: 1; grid-column: 2;
+    background: transparent; border: none;
+    padding: 0; margin: 0;
+    text-align: left; cursor: pointer;
+    font-family: inherit;
+    min-width: 0;
+  }
+  .recipe__open:hover .recipe__name { color: var(--p-500); }
+  .recipe__open:focus-visible { outline: 2px solid var(--p-500); outline-offset: 2px; border-radius: 2px; }
+  .recipe__toggle { grid-row: 1; grid-column: 3; }
+  .recipe__actions {
+    grid-row: 2; grid-column: 2 / 4;
+    display: flex; gap: .15rem;
+  }
+  .recipe__action {
+    width: 22px; height: 20px;
+    background: transparent; border: none;
+    color: var(--n-400); cursor: pointer;
+    border-radius: var(--r-xs);
+    display: inline-flex; align-items: center; justify-content: center;
+    padding: 0;
+    transition: background-color 140ms, color 140ms;
+  }
+  .recipe__action svg { width: 12px; height: 12px; }
+  .recipe__action:hover { background: var(--n-50); color: var(--n-700); }
+  .recipe__action--primary:hover { background: var(--p-50); color: var(--p-500); }
+  .recipe__action--danger:hover { background: var(--red-50); color: var(--red-500); }
+  .recipe__icon {
+    width: 32px; height: 32px; border-radius: var(--r-sm);
+    background: var(--p-50); color: var(--p-500);
+    display: flex; align-items: center; justify-content: center;
+    grid-row: 1 / span 2;
+    align-self: center;
+  }
+  .recipe__icon svg { width: 15px; height: 15px; }
+  .recipe__main { min-width: 0; }
+  .recipe__name { font-weight: 500; font-size: .88rem; color: var(--n-800); }
+  .recipe__sub {
+    font-size: .7rem; color: var(--n-400);
+    font-family: var(--font-mono);
+    margin-top: 2px;
+    line-height: 1.5;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .recipe__sub b { color: var(--n-600); font-weight: 600; }
+  /* Tiny green dot next to a value driven by the active mode */
+  .from-mode {
+    display: inline-block;
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: var(--green-500);
+    margin: 0 1px 0 3px;
+    vertical-align: 1px;
+    cursor: help;
+  }
+  .recipe__toggle {
+    width: 34px; height: 20px;
+    border-radius: var(--r-full);
+    background: var(--n-200); position: relative; cursor: pointer;
+    flex-shrink: 0;
+  }
+  .recipe__toggle::after {
+    content: ""; position: absolute; top: 2px; left: 2px;
+    width: 16px; height: 16px;
+    background: var(--n-0);
+    border-radius: 50%;
+    box-shadow: 0 1px 2px rgba(0,0,0,.18);
+  }
+  .recipe__toggle--on { background: var(--green-500); }
+  .recipe__toggle--on::after { left: 16px; }
+
+  /* Activity */
+  .activity { padding: .35rem 0; }
+  .activity__group {
+    padding: .35rem 1.1rem;
+    font-family: var(--font-mono); font-size: .65rem;
+    color: var(--n-400); font-weight: 600;
+    border-top: 1px solid var(--line);
+  }
+  .activity__group:first-child { border-top: 0; }
+  .activity__item {
+    display: grid;
+    grid-template-columns: 24px 1fr auto;
+    gap: .55rem; align-items: flex-start;
+    padding: .45rem 1.1rem;
+  }
+  .activity__item-icon {
+    width: 24px; height: 24px; border-radius: var(--r-xs);
+    background: var(--n-50); color: var(--n-500);
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+  .activity__item-icon svg { width: 12px; height: 12px; }
+  .activity__item-icon--recipe { background: var(--p-50); color: var(--p-500); }
+  .activity__item-icon--mode { background: var(--green-50); color: var(--green-700); }
+  .activity__item-icon--motion { background: var(--info-50); color: var(--info-500); }
+  .activity__item-text {
+    font-size: .78rem; color: var(--n-600);
+    line-height: 1.45;
+  }
+  .activity__item-text b { color: var(--n-800); font-weight: 600; }
+  .activity__item-text .by { font-size: .68rem; color: var(--n-400); margin-left: .15rem; }
+  .activity__item-time {
+    font-family: var(--font-mono); font-size: .66rem;
+    color: var(--n-400); padding-top: 4px;
+  }
+
+  /* Notes */
+  .notes {
+    max-width: 1280px; margin: 1.25rem auto 0;
+    padding: 1.1rem 1.25rem;
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-lg);
+    font-size: .85rem; color: var(--n-600);
+  }
+  .notes h3 { margin: 0 0 .35rem; font-size: .95rem; font-weight: 700; color: var(--n-800); }
+  .notes ul { margin: .35rem 0; padding-left: 1.2rem; }
+  .notes li { margin: .15rem 0; line-height: 1.55; }
+  .notes b { color: var(--n-800); }
+  .notes code {
+    font-family: var(--font-mono); font-size: .85em;
+    background: var(--n-50); padding: 1px 5px;
+    border-radius: 3px; color: var(--n-700);
+  }
+
+  /* ════════════════════════════════════════════════════════════════ */
+  /* ANCHOR COMPARISON — A vs B                                        */
+  /* ════════════════════════════════════════════════════════════════ */
+  .cmp {
+    display: grid; grid-template-columns: 1fr; gap: 1.25rem;
+    max-width: 1280px; margin: 0 auto;
+  }
+  .cmp__opt {
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-lg); overflow: hidden;
+  }
+  .cmp__head {
+    display: flex; align-items: flex-start; gap: .85rem;
+    padding: 1rem 1.25rem .9rem;
+    border-bottom: 1px solid var(--line);
+    background: var(--n-25);
+  }
+  .cmp__tag {
+    flex: none;
+    width: 32px; height: 32px; border-radius: 8px;
+    background: var(--p-500); color: var(--n-0);
+    display: flex; align-items: center; justify-content: center;
+    font-family: var(--font-mono); font-size: .95rem; font-weight: 700;
+    letter-spacing: -.02em;
+  }
+  .cmp__title { font-size: 1rem; font-weight: 700; color: var(--n-800); letter-spacing: -.012em; }
+  .cmp__sub { font-size: .78rem; color: var(--n-500); margin-top: .15rem; line-height: 1.45; }
+  .cmp__sub b { color: var(--n-700); font-weight: 600; }
+  .cmp__demo {
+    padding: 1.75rem 1.5rem;
+    background: var(--n-25);
+    border-bottom: 1px solid var(--line);
+    display: flex; justify-content: center;
+  }
+  .cmp__demo--b { justify-content: flex-start; }
+  .cmp__pros {
+    margin: 0; padding: 1rem 1.25rem;
+    list-style: none;
+    font-size: .82rem; color: var(--n-600);
+    display: flex; flex-direction: column; gap: .35rem;
+  }
+  .cmp__pros li { line-height: 1.5; padding-left: 1.5rem; position: relative; }
+  .cmp__pros li > b:first-child {
+    position: absolute; left: 0; top: 0;
+    width: 18px; text-align: center;
+    font-weight: 700; color: var(--green-500);
+  }
+  .cmp__pros li.con > b:first-child { color: var(--red-500); }
+  .cmp__pros li b { color: var(--n-800); font-weight: 600; }
+
+  /* ── Option A: faux panel showing cat-heads with inline commands ── */
+  .cmp__demo--a { padding: 1.5rem 1.5rem; }
+  .cpanel {
+    width: 100%; max-width: 600px;
+    background: var(--n-0);
+    border: 1px solid var(--line); border-radius: var(--r-lg);
+    overflow: hidden;
+  }
+  .cpanel__head {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .75rem 1.1rem;
+    background: var(--p-50);
+    border-bottom: 1px solid var(--p-100);
+  }
+  .cpanel__title { font-size: .72rem; font-weight: 700; color: var(--p-500); text-transform: uppercase; letter-spacing: .12em; }
+  .cpanel__sub { font-size: .72rem; color: color-mix(in srgb, var(--p-500) 65%, transparent); margin-left: .35rem; font-weight: 500; }
+  .cpanel__count {
+    margin-left: auto;
+    font-family: var(--font-mono); font-size: .68rem;
+    color: var(--p-500); background: var(--n-0);
+    border: 1px solid var(--p-100);
+    padding: 1px 7px; border-radius: var(--r-full); font-weight: 600;
+  }
+  .ccat {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .45rem 1.1rem;
+    font-size: .65rem; text-transform: uppercase;
+    letter-spacing: .14em; color: var(--n-500); font-weight: 600;
+    background: var(--n-25);
+    border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line);
+    min-height: 44px; box-sizing: border-box;
+  }
+  .ccat__icon { width: 14px; height: 14px; opacity: .7; flex: none; }
+  .ccat__count { margin-left: auto; font-family: var(--font-mono); font-size: .68rem; opacity: .65; }
+  .ccat__cmds {
+    display: inline-flex;
+    margin-left: .75rem;
+    border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    overflow: hidden;
+    background: var(--n-0);
+  }
+  .ccmd {
+    width: 32px; height: 32px;
+    background: transparent; border: none;
+    border-right: 1px solid var(--line);
+    color: var(--n-600); cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    padding: 0;
+  }
+  .ccmd:last-child { border-right: none; }
+  .ccmd svg { width: 15px; height: 15px; }
+  .ccmd--light:hover { background: var(--light-50); color: var(--light-500); }
+  .ccmd--shutter:hover { background: var(--shutter-50); color: var(--shutter-500); }
+  .crow {
+    display: grid;
+    grid-template-columns: 32px 1fr auto;
+    gap: .85rem; align-items: center;
+    padding: .6rem 1.1rem;
+    border-top: 1px solid var(--line);
+  }
+  .crow__icon {
+    width: 32px; height: 32px; border-radius: var(--r-sm);
+    display: flex; align-items: center; justify-content: center;
+    background: var(--icon-bg, var(--n-50));
+    color: var(--icon-fg, var(--n-500));
+  }
+  .crow__icon svg { width: 15px; height: 15px; }
+  .crow__icon--light { --icon-bg: var(--light-50); --icon-fg: var(--light-500); }
+  .crow__icon--light-on { --icon-bg: var(--a-500); --icon-fg: var(--n-0); }
+  .crow__icon--shutter { --icon-bg: var(--shutter-50); --icon-fg: var(--shutter-500); }
+  .crow__name { font-weight: 500; font-size: .88rem; color: var(--n-800); }
+  .crow__val { font-family: var(--font-mono); font-size: .82rem; font-weight: 600; color: var(--n-700); font-feature-settings: "tnum" 1; }
+
+  /* ── Option B: merged strip + actions ── */
+  .cmerge {
+    display: inline-flex; align-items: center;
+    flex-wrap: wrap;
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: .35rem .4rem;
+    column-gap: 0; row-gap: .25rem;
+    max-width: 100%;
+  }
+  .cmerge__pill {
+    display: inline-flex; align-items: center; gap: .45rem;
+    padding: .35rem .65rem;
+    font-size: .82rem; font-weight: 500;
+    color: var(--n-700);
+    border-radius: var(--r-sm);
+    white-space: nowrap;
+    font-feature-settings: "tnum" 1;
+  }
+  .cmerge__pill svg { width: 14px; height: 14px; color: var(--c, var(--n-400)); flex: none; }
+  .cmerge__val { font-family: var(--font-mono); font-weight: 600; color: var(--n-800); letter-spacing: -.005em; }
+  .cmerge__val .u { font-size: .78em; color: var(--n-400); margin-left: 1px; font-weight: 500; letter-spacing: 0; }
+  .cmerge__meta { font-size: .76rem; color: var(--n-500); }
+  .cmerge__pill--active svg { color: var(--a-500); }
+  .cmerge__pill--active .cmerge__val { color: var(--a-600); }
+  .cmerge__pill--calm svg { color: var(--green-500); }
+  .cmerge__pill--calm .cmerge__val { color: var(--green-700); font-family: var(--font-body); font-weight: 600; }
+  .cmerge__div { width: 1px; height: 18px; background: var(--n-200); margin: 0 .15rem; flex: none; }
+  /* Split between state and actions — same weight as group dividers in strip */
+  .cmerge__split {
+    width: 1px; height: 22px;
+    background: var(--line-2);
+    margin: 0 .35rem;
+    flex: none;
+  }
+  .cmerge__btn {
+    width: 34px; height: 34px;
+    background: transparent; border: none;
+    color: var(--n-600); cursor: pointer;
+    border-radius: var(--r-sm);
+    display: flex; align-items: center; justify-content: center;
+    transition: background-color 160ms, color 160ms;
+    margin: 0 1px;
+  }
+  .cmerge__btn svg { width: 16px; height: 16px; }
+  .cmerge__btn[data-cat="light"]:hover { background: var(--light-50); color: var(--light-500); }
+  .cmerge__btn[data-cat="light-off"]:hover { background: var(--n-100); color: var(--n-700); }
+  .cmerge__btn[data-cat="shutter"]:hover { background: var(--shutter-50); color: var(--shutter-500); }
+
+  /* ════════════════════════════════════════════════════════════════ */
+  /* ZONE COMMANDS — VARIANTS                                          */
+  /* ════════════════════════════════════════════════════════════════ */
+  .zcv-grid { display: flex; flex-direction: column; gap: 1.25rem; max-width: 1280px; margin: 0 auto; }
+  .zcv {
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-lg); overflow: hidden;
+    display: grid; grid-template-columns: 1fr 1.2fr;
+    gap: 0;
+  }
+  .zcv__head {
+    grid-column: 1 / -1;
+    display: flex; align-items: flex-start; gap: .85rem;
+    padding: 1rem 1.25rem .9rem;
+    border-bottom: 1px solid var(--line);
+    background: var(--n-25);
+  }
+  .zcv__tag {
+    flex: none;
+    width: 32px; height: 32px; border-radius: 8px;
+    background: var(--p-500); color: var(--n-0);
+    display: flex; align-items: center; justify-content: center;
+    font-family: var(--font-mono); font-size: .95rem; font-weight: 700;
+    letter-spacing: -.02em;
+  }
+  .zcv__title { font-size: 1rem; font-weight: 700; color: var(--n-800); letter-spacing: -.012em; }
+  .zcv__sub { font-size: .78rem; color: var(--n-500); margin-top: .15rem; line-height: 1.45; }
+  .zcv__sub b { color: var(--n-700); font-weight: 600; }
+  .zcv__demo {
+    padding: 2rem 1.5rem;
+    background: var(--n-25);
+    display: flex; align-items: center; justify-content: center;
+    min-height: 110px;
+    border-right: 1px solid var(--line);
+  }
+  .zcv__pros {
+    margin: 0; padding: 1rem 1.25rem;
+    list-style: none;
+    font-size: .82rem; color: var(--n-600);
+    display: flex; flex-direction: column; gap: .35rem;
+  }
+  .zcv__pros li { line-height: 1.5; padding-left: 1.5rem; position: relative; }
+  .zcv__pros li > b:first-child {
+    position: absolute; left: 0; top: 0;
+    width: 18px; text-align: center;
+    font-weight: 700; color: var(--green-500);
+  }
+  .zcv__pros li.con > b:first-child { color: var(--red-500); }
+  .zcv__pros li b { color: var(--n-800); font-weight: 600; }
+
+  /* ── Variant A: round icon-only buttons ── */
+  /* When rendered standalone in hero: aligned right, no overlap */
+  .hero > .va { display: flex; width: max-content; margin-left: auto; }
+  .va {
+    display: inline-flex; align-items: center; gap: .3rem;
+    padding: .35rem; background: var(--n-0);
+    border: 1px solid var(--line); border-radius: var(--r-full);
+    box-shadow: 0 1px 2px rgba(15,42,60,.05),
+                0 6px 16px -6px rgba(15,42,60,.12),
+                inset 0 1px 0 rgba(255,255,255,.6);
+  }
+  [data-theme="dark"] .va { box-shadow: 0 1px 2px rgba(0,0,0,.4), 0 6px 16px -6px rgba(0,0,0,.5); }
+  .va__btn {
+    width: 38px; height: 38px; border-radius: 50%;
+    background: transparent; border: none;
+    color: var(--n-600); cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    position: relative;
+    transition: background-color 160ms, color 160ms, transform 160ms;
+  }
+  .va__btn svg { width: 17px; height: 17px; }
+  .va__btn:hover { background: var(--n-50); color: var(--n-800); transform: scale(1.06); }
+  .va__btn:active { transform: scale(.96); }
+  .va__btn[data-cat="light"]:hover { background: var(--light-50); color: var(--light-500); }
+  .va__btn[data-cat="light-off"]:hover { background: var(--n-100); color: var(--n-700); }
+  .va__btn[data-cat="shutter"]:hover { background: var(--shutter-50); color: var(--shutter-500); }
+  .va__btn::after {
+    content: attr(data-tip);
+    position: absolute; bottom: calc(100% + 6px); left: 50%;
+    transform: translateX(-50%);
+    font-size: .68rem; font-weight: 600; color: var(--n-800);
+    background: var(--n-0);
+    border: 1px solid var(--line);
+    padding: 3px 7px; border-radius: 4px;
+    white-space: nowrap;
+    opacity: 0; pointer-events: none;
+    transition: opacity 140ms, transform 140ms;
+    box-shadow: 0 2px 6px rgba(0,0,0,.06);
+  }
+  .va__btn:hover::after { opacity: 1; transform: translateX(-50%) translateY(-2px); }
+  .va__sep { width: 1px; height: 22px; background: var(--n-200); margin: 0 .15rem; flex: none; }
+
+  /* ── Variant B: state+action mini cards ── */
+  .vb { display: flex; gap: 1rem; flex-wrap: wrap; width: 100%; max-width: 560px; }
+  .vb__card {
+    flex: 1; min-width: 240px;
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: .85rem 1rem;
+    display: flex; flex-direction: column; gap: .8rem;
+    position: relative; overflow: hidden;
+  }
+  .vb__card::before {
+    content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+    width: 3px;
+  }
+  .vb__card--light::before { background: var(--a-500); }
+  .vb__card--shutter::before { background: var(--shutter-500); }
+  .vb__card-head { display: flex; align-items: center; gap: .65rem; }
+  .vb__card-icon {
+    width: 32px; height: 32px; border-radius: var(--r-sm);
+    display: flex; align-items: center; justify-content: center;
+    flex: none;
+  }
+  .vb__card--light .vb__card-icon { background: var(--light-50); color: var(--light-500); }
+  .vb__card--shutter .vb__card-icon { background: var(--shutter-50); color: var(--shutter-500); }
+  .vb__card-icon svg { width: 16px; height: 16px; }
+  .vb__card-name { font-size: .9rem; font-weight: 700; color: var(--n-800); letter-spacing: -.012em; }
+  .vb__card-state { font-size: .74rem; color: var(--n-500); font-feature-settings: "tnum" 1; margin-top: 1px; }
+  .vb__card-state b { color: var(--n-800); font-family: var(--font-mono); font-weight: 700; font-size: .85rem; letter-spacing: -.01em; }
+  .vb__card-cmds { display: flex; gap: 0; border: 1px solid var(--line); border-radius: var(--r-sm); overflow: hidden; }
+  .vb__card-cmds button {
+    flex: 1; min-height: 36px;
+    background: var(--n-0); border: none;
+    border-right: 1px solid var(--line);
+    font-family: var(--font-body); font-size: .8rem; font-weight: 500;
+    color: var(--n-700); cursor: pointer;
+    display: inline-flex; align-items: center; justify-content: center;
+    gap: .35rem;
+  }
+  .vb__card-cmds button:last-child { border-right: none; }
+  .vb__card--light .vb__card-cmds button:hover { background: var(--light-50); color: var(--light-500); }
+  .vb__card--shutter .vb__card-cmds button:hover { background: var(--shutter-50); color: var(--shutter-500); }
+  .vb__card-cmds--icons button svg { width: 14px; height: 14px; }
+  .vb__card-cmds--icons button { padding: 0; }
+
+  /* ── Variant C: unified toolbar with light slider ── */
+  .vc {
+    display: inline-flex; align-items: stretch;
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: 0;
+    overflow: hidden;
+    width: 100%; max-width: 620px;
+  }
+  .vc__group {
+    display: flex; align-items: center; gap: .65rem;
+    padding: .65rem .9rem;
+    flex: 1;
+  }
+  .vc__group--shutter { flex: 0 0 auto; gap: .4rem; }
+  .vc__icon {
+    width: 30px; height: 30px; border-radius: var(--r-sm);
+    display: flex; align-items: center; justify-content: center;
+    flex: none;
+  }
+  .vc__group--light .vc__icon { background: var(--light-50); color: var(--light-500); }
+  .vc__group--shutter .vc__icon { background: var(--shutter-50); color: var(--shutter-500); }
+  .vc__icon svg { width: 16px; height: 16px; }
+  .vc__slider {
+    flex: 1; height: 8px;
+    background: var(--n-100);
+    border-radius: 999px;
+    position: relative; cursor: pointer;
+  }
+  .vc__slider-fill {
+    position: absolute; left: 0; top: 0; height: 100%;
+    background: var(--a-500);
+    border-radius: 999px;
+  }
+  .vc__slider-knob {
+    position: absolute; top: 50%;
+    transform: translate(-50%, -50%);
+    width: 18px; height: 18px;
+    background: var(--n-0); border: 2px solid var(--a-500);
+    border-radius: 50%;
+    box-shadow: 0 1px 3px rgba(0,0,0,.15);
+    cursor: grab;
+  }
+  .vc__slider-ticks {
+    position: absolute; inset: 0;
+    display: flex; justify-content: space-between;
+    align-items: center;
+    pointer-events: none;
+    padding: 0 6px;
+  }
+  .vc__slider-ticks span {
+    width: 2px; height: 2px; border-radius: 50%;
+    background: color-mix(in srgb, var(--n-400) 50%, transparent);
+  }
+  .vc__val {
+    font-family: var(--font-mono); font-weight: 700;
+    font-size: .82rem; color: var(--a-600);
+    min-width: 38px; text-align: right; font-feature-settings: "tnum" 1;
+  }
+  .vc__sep { width: 1px; background: var(--line); flex: none; }
+  .vc__icon-btn {
+    width: 36px; height: 36px; border-radius: var(--r-sm);
+    background: var(--n-25); border: 1px solid var(--line);
+    color: var(--n-600); cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .vc__icon-btn svg { width: 14px; height: 14px; }
+  .vc__icon-btn--lg { width: 40px; height: 40px; }
+  .vc__icon-btn--lg svg { width: 15px; height: 15px; }
+  .vc__group--light .vc__icon-btn:hover { background: var(--light-50); color: var(--light-500); border-color: var(--light-500); }
+  .vc__group--shutter .vc__icon-btn:hover { background: var(--shutter-50); color: var(--shutter-500); border-color: var(--shutter-500); }
+
+  /* Responsive: stack on narrow */
+  @media (max-width: 800px) {
+    .zcv { grid-template-columns: 1fr; }
+    .zcv__demo { border-right: none; border-bottom: 1px solid var(--line); }
+  }
+
+  /* ════════════════════════════════════════════════════════════════ */
+  /* PATTERN GALLERY — extends the design system to all equipment types */
+  /* ════════════════════════════════════════════════════════════════ */
+  .ptpanel { max-width: 1280px; margin: 0 auto; }
+  .ptpanel .panel { background: var(--n-0); border: 1px solid var(--line); border-radius: var(--r-lg); overflow: hidden; }
+
+  /* Tag chip next to equipment name (e.g. "Compteur réseau", "Production") */
+  .eq__tag {
+    display: inline-block; margin-left: .45rem;
+    font-size: .65rem; font-weight: 600;
+    padding: 1px 6px; border-radius: var(--r-xs);
+    background: var(--n-100); color: var(--n-500);
+    vertical-align: 1px;
+  }
+  .eq__tag--prod { background: var(--green-50); color: var(--green-700); }
+
+  /* Thermostat row layout: icon + name + current + target±  + power */
+  .eq--therm { grid-template-columns: 32px 1fr auto auto auto; gap: .75rem; }
+  .therm-current {
+    font-family: var(--font-mono); font-feature-settings: "tnum" 1;
+    font-size: .82rem; font-weight: 500; color: var(--n-500);
+  }
+  .therm-current .u { font-size: .78em; color: var(--n-400); margin-left: 1px; }
+  .therm-target {
+    display: inline-flex; align-items: center; gap: 2px;
+    border: 1px solid var(--line); border-radius: var(--r-sm);
+    overflow: hidden; background: var(--n-0);
+  }
+  .therm-target-val {
+    font-family: var(--font-mono); font-feature-settings: "tnum" 1;
+    font-size: .95rem; font-weight: 700; color: var(--n-800);
+    padding: 0 .55rem; min-width: 56px; text-align: center;
+  }
+  .therm-target-val .u { font-size: .68em; color: var(--n-400); margin-left: 1px; font-weight: 500; }
+  .therm-btn {
+    width: 28px; height: 32px;
+    background: transparent; border: none;
+    color: var(--n-500); cursor: pointer;
+    display: inline-flex; align-items: center; justify-content: center;
+  }
+  .therm-btn:hover { background: var(--n-50); color: var(--info-500); }
+  .therm-btn svg { width: 12px; height: 12px; }
+
+  /* Energy meter row */
+  .eq--energy { grid-template-columns: 32px 1fr auto auto; gap: .85rem; }
+  .energy-val {
+    font-family: var(--font-mono); font-feature-settings: "tnum" 1;
+    font-size: 1rem; font-weight: 700; color: var(--a-600);
+    letter-spacing: -.005em;
+  }
+  .energy-val .u { font-size: .65em; color: var(--n-400); margin-left: 1px; font-weight: 500; }
+  .energy-meta { font-size: .72rem; color: var(--n-500); }
+
+  /* Weather forecast row */
+  .eq--forecast { grid-template-columns: 32px 1fr auto; }
+  .forecast-row {
+    display: inline-flex; align-items: center; gap: .7rem;
+    flex-wrap: wrap; justify-content: flex-end;
+  }
+  .forecast-day {
+    display: inline-flex; align-items: center; gap: .25rem;
+    font-family: var(--font-body); font-size: .8rem; color: var(--n-700);
+    font-feature-settings: "tnum" 1;
+  }
+  .forecast-day svg { width: 14px; height: 14px; color: var(--info-500); opacity: .85; }
+  .forecast-day b { font-family: var(--font-mono); font-weight: 700; color: var(--n-800); }
+  .forecast-day small {
+    font-size: .62rem; color: var(--n-400);
+    text-transform: uppercase; letter-spacing: .08em; margin-left: 1px;
+  }
+
+  /* Remote button row */
+  .eq--remote { grid-template-columns: 32px 1fr auto auto; gap: .65rem; }
+  .chip-state--press {
+    background: var(--p-50); color: var(--p-500);
+  }
+
+  /* Gate row — single toggle command (matches GateControl.tsx compact pattern) */
+  .eq--gate { grid-template-columns: 32px 1fr auto auto; gap: .65rem; }
+  .gate-cmd {
+    width: 32px; height: 32px;
+    background: var(--n-50); border: 1px solid var(--line);
+    color: var(--n-500); cursor: pointer;
+    border-radius: var(--r-sm);
+    display: inline-flex; align-items: center; justify-content: center;
+    padding: 0;
+  }
+  .gate-cmd:hover { background: var(--n-100); color: var(--n-700); border-color: var(--n-300); }
+  .gate-cmd svg { width: 14px; height: 14px; }
+
+  /* Water valve row */
+  .eq--water { grid-template-columns: 32px 1fr auto auto auto; gap: .65rem; }
+  .water-val {
+    font-family: var(--font-mono); font-feature-settings: "tnum" 1;
+    font-size: .9rem; font-weight: 700; color: #0369A1;
+  }
+  .water-val .u { font-size: .68em; color: var(--n-400); margin-left: 1px; font-weight: 500; }
+
+  /* ════════════════════════════════════════════════════════════════ */
+  /* MOBILE FRAME — 390×844, same data, same principles                */
+  /* ════════════════════════════════════════════════════════════════ */
+  .mob-wrap { display: flex; justify-content: center; padding: 1rem 0 0; }
+  .mob {
+    width: 390px; min-height: 844px;
+    background: var(--n-25);
+    border: 1px solid var(--line);
+    border-radius: 42px;
+    box-shadow: var(--sh-3);
+    overflow: hidden;
+    position: relative;
+    display: flex; flex-direction: column;
+    font-size: 14px;
+  }
+  /* Status bar */
+  .mob__status {
+    height: 44px;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: .55rem 1.5rem 0;
+    font-family: var(--font-mono);
+    font-size: .82rem; font-weight: 600; color: var(--n-800);
+  }
+  .mob__status-right { display: inline-flex; gap: .4rem; align-items: center; color: var(--n-800); }
+  .mob__status-right svg { width: 16px; height: 12px; display: block; }
+
+  /* Top app bar */
+  .mob__topbar {
+    height: 56px; flex: none;
+    display: flex; align-items: center; gap: .5rem;
+    padding: 0 .65rem;
+    background: var(--n-0);
+    border-bottom: 1px solid var(--line);
+  }
+  .mob__burger, .mob__menu {
+    width: 40px; height: 40px;
+    display: flex; align-items: center; justify-content: center;
+    color: var(--n-600);
+    background: transparent; border: none;
+    border-radius: var(--r-sm);
+    cursor: pointer; flex: none;
+  }
+  .mob__burger:hover, .mob__menu:hover { background: var(--n-50); }
+  .mob__burger svg, .mob__menu svg { width: 20px; height: 20px; }
+  .mob__topbar-titles { flex: 1; min-width: 0; }
+  .mob__topbar-title {
+    font-size: 1rem; font-weight: 700; color: var(--n-800);
+    letter-spacing: -.015em; line-height: 1.15;
+  }
+  .mob__topbar-sub {
+    font-size: .7rem; color: var(--n-400); font-weight: 500;
+    line-height: 1.3; font-feature-settings: "tnum" 1;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .mob__topbar-sub b { color: var(--n-700); font-weight: 700; }
+
+  /* Connection dot (mobile — production: just the green dot on small screens) */
+  .mob__conn-dot {
+    position: relative; display: inline-block;
+    width: 8px; height: 8px; flex: none;
+    margin: 0 .35rem 0 .15rem;
+  }
+  .mob__conn-dot::before {
+    content: ""; position: absolute; inset: 0; border-radius: 50%;
+    background: var(--green-500);
+  }
+  .mob__conn-dot::after {
+    content: ""; position: absolute; inset: 0; border-radius: 50%;
+    background: var(--green-500); opacity: .6;
+    animation: connPing 1.8s ease-in-out infinite;
+  }
+  @media (prefers-reduced-motion: reduce) { .mob__conn-dot::after { animation: none; } }
+
+  /* Alarms (mobile, compact) */
+  .mob__alarm {
+    display: inline-flex; align-items: center; gap: .25rem;
+    height: 28px; padding: 0 .55rem;
+    border-radius: var(--r-full);
+    background: color-mix(in srgb, var(--a-500) 14%, transparent);
+    color: var(--a-600);
+    border: none; cursor: pointer;
+    font-family: var(--font-body); font-size: .72rem; font-weight: 700;
+    font-feature-settings: "tnum" 1;
+    flex: none;
+  }
+  .mob__alarm svg { width: 13px; height: 13px; }
+
+  /* Scroll area */
+  .mob__scroll {
+    flex: 1; overflow-y: auto;
+    padding-bottom: 76px; /* room for tab bar */
+  }
+
+  /* Hero — just the asymmetric stat strip on mobile (title already in topbar) */
+  .mob__hero { padding: 1rem 1.15rem .35rem; }
+
+  /* Hero strip — production-aligned pill row with horizontal scroll */
+  .mob__strip {
+    display: flex; align-items: center;
+    gap: 0;
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: .3rem .35rem;
+    margin-bottom: .85rem;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  .mob__strip::-webkit-scrollbar { display: none; }
+  .mob__pill {
+    display: inline-flex; align-items: center; gap: .35rem;
+    padding: .3rem .55rem;
+    font-size: .76rem; font-weight: 500;
+    color: var(--n-700);
+    border-radius: var(--r-sm);
+    white-space: nowrap; flex: none;
+    font-feature-settings: "tnum" 1;
+  }
+  .mob__pill-icon { width: 13px; height: 13px; color: var(--c, var(--n-400)); flex: none; }
+  .mob__pill-val { font-family: var(--font-mono); font-weight: 600; color: var(--n-800); letter-spacing: -.005em; }
+  .mob__pill-val .u { font-size: .78em; color: var(--n-400); margin-left: 1px; font-weight: 500; }
+  .mob__pill-meta { font-size: .7rem; color: var(--n-500); }
+  .mob__pill-spark { width: 38px; height: 14px; flex: none; opacity: .75; margin-left: 1px; }
+  .mob__strip-div { width: 1px; height: 16px; background: var(--n-200); margin: 0 .15rem; flex: none; }
+  .mob__strip-div--group { background: var(--line-2); height: 20px; margin: 0 .3rem; flex: none; }
+  .mob__pill--active .mob__pill-icon { color: var(--a-500); }
+  .mob__pill--active .mob__pill-val { color: var(--a-600); }
+  .mob__pill--calm .mob__pill-icon { color: var(--green-500); }
+  .mob__pill--calm .mob__pill-val { color: var(--green-700); font-family: var(--font-body); font-weight: 600; }
+  .mob__pill--alert {
+    background: var(--red-50); color: var(--red-500); font-weight: 600;
+  }
+  .mob__pill--alert .mob__pill-icon { color: var(--red-500); }
+  .mob__pill--alert .mob__pill-val { color: var(--red-500); font-family: var(--font-body); font-weight: 700; }
+  .mob__pill--alert::before {
+    content: ""; width: 5px; height: 5px; border-radius: 50%;
+    background: var(--red-500);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--red-500) 22%, transparent);
+    animation: pulseAlert 1.6s ease-in-out infinite;
+    margin-right: -.05rem;
+  }
+  /* Mobile zone commands — own line, left-aligned, below the strip */
+  .mob__zcmds {
+    display: inline-flex; align-items: center;
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: .2rem .3rem;
+    margin-bottom: .25rem;
+    gap: 1px;
+  }
+  .mob__zcmds-sep {
+    width: 1px; height: 14px;
+    background: var(--n-200);
+    margin: 0 .25rem;
+    flex: none;
+  }
+  .mob__zcmds-btn {
+    width: 32px; height: 30px;
+    background: transparent; border: none;
+    color: var(--n-600); cursor: pointer;
+    border-radius: var(--r-sm);
+    display: inline-flex; align-items: center; justify-content: center;
+    transition: background-color 160ms, color 160ms;
+    flex: none; padding: 0;
+  }
+  .mob__zcmds-btn svg { width: 14px; height: 14px; }
+  .mob__zcmds-btn[data-cat="light"]:hover { background: var(--light-50); color: var(--light-500); }
+  .mob__zcmds-btn[data-cat="light-off"]:hover { background: var(--n-100); color: var(--n-700); }
+  .mob__zcmds-btn[data-cat="shutter"]:hover { background: var(--shutter-50); color: var(--shutter-500); }
+
+  /* Mobile actions — Variant A pill bar, centered, sobre */
+  .mob__actions {
+    display: flex; justify-content: center;
+    padding: 0 1.15rem .85rem;
+  }
+  /* Tighter pill on mobile: matches strip's discreet visual weight */
+  .mob__actions .va {
+    gap: .15rem;
+    padding: .25rem;
+    box-shadow: 0 1px 2px rgba(15,42,60,.05),
+                0 2px 8px -4px rgba(15,42,60,.08);
+  }
+  .mob__actions .va__btn { width: 38px; height: 38px; }
+  .mob__actions .va__btn svg { width: 16px; height: 16px; }
+  .mob__actions .va__sep { height: 18px; margin: 0 .1rem; }
+  /* Tooltips below on mobile (so they don't get cropped) */
+  .mob__actions .va__btn::after {
+    bottom: auto; top: calc(100% + 6px);
+  }
+  .mob__actions .va__btn:hover::after { transform: translateX(-50%) translateY(2px); }
+
+  /* Mobile panel */
+  .mob__panel {
+    margin: 0 1.15rem .85rem;
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    overflow: hidden;
+  }
+  .mob__panel-head {
+    display: flex; align-items: center; gap: .45rem;
+    padding: .6rem .85rem;
+    background: var(--p-50);
+    border-bottom: 1px solid var(--p-100);
+  }
+  .mob__panel-title {
+    font-size: .68rem; font-weight: 700; color: var(--p-500);
+    text-transform: uppercase; letter-spacing: .12em;
+  }
+  .mob__panel-sub { font-size: .68rem; color: color-mix(in srgb, var(--p-500) 65%, transparent); margin-left: .3rem; font-weight: 500; }
+  .mob__panel-count {
+    margin-left: auto;
+    font-family: var(--font-mono); font-size: .65rem;
+    color: var(--p-500); background: var(--n-0);
+    border: 1px solid var(--p-100);
+    padding: 1px 6px; border-radius: var(--r-full); font-weight: 600;
+  }
+
+  .mob__cat-head {
+    display: flex; align-items: center; gap: .45rem;
+    padding: .4rem .85rem;
+    font-size: .6rem; text-transform: uppercase;
+    letter-spacing: .12em; color: var(--n-500); font-weight: 600;
+    background: var(--n-25);
+    border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line);
+  }
+  .mob__cat-head svg { width: 12px; height: 12px; opacity: .7; }
+  /* + button in mobile sub-category header */
+  .mob__cat-head-add {
+    margin-left: auto;
+    width: 22px; height: 22px;
+    background: transparent; border: 1px solid var(--n-200);
+    border-radius: var(--r-xs);
+    color: var(--n-500); cursor: pointer;
+    display: inline-flex; align-items: center; justify-content: center;
+    padding: 0;
+  }
+  .mob__cat-head-add:hover { background: var(--p-50); color: var(--p-500); border-color: var(--p-100); }
+  .mob__cat-head-add svg { width: 11px; height: 11px; opacity: 1; }
+  .mob__cat-head-count { margin-left: auto; font-family: var(--font-mono); font-size: .62rem; opacity: .65; }
+
+  /* Equipment row (mobile) — denser, touch-friendly */
+  .mob__eq {
+    display: grid;
+    grid-template-columns: 32px 1fr auto auto;
+    gap: .65rem; align-items: center;
+    padding: .65rem .85rem;
+    border-top: 1px solid var(--line);
+  }
+  .mob__eq:first-child { border-top: none; }
+  .mob__eq-icon {
+    width: 32px; height: 32px;
+    border-radius: var(--r-sm);
+    display: flex; align-items: center; justify-content: center;
+    background: var(--icon-bg, var(--n-50));
+    color: var(--icon-fg, var(--n-500));
+  }
+  .mob__eq-icon svg { width: 15px; height: 15px; }
+  .mob__eq-icon--light { --icon-bg: var(--light-50); --icon-fg: var(--light-500); }
+  .mob__eq-icon--light-on {
+    --icon-bg: var(--a-500); --icon-fg: var(--n-0);
+    animation: glow 3.2s ease-in-out infinite;
+  }
+  [data-theme="dark"] .mob__eq-icon--light-on { --icon-fg: #18170F; }
+  .mob__eq-icon--shutter { --icon-bg: var(--shutter-50); --icon-fg: var(--shutter-500); }
+  .mob__eq-icon--sensor { --icon-bg: var(--sensor-50); --icon-fg: var(--sensor-500); }
+  .mob__eq-icon--media { --icon-bg: var(--media-50); --icon-fg: var(--media-500); }
+  .mob__eq-name {
+    font-weight: 500; font-size: .85rem; color: var(--n-800);
+    display: flex; align-items: center;
+    min-width: 0;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .mob__eq-name .auto-mark { width: 10px; height: 10px; margin-left: 4px; color: var(--a-500); flex: none; }
+  .mob__eq-name .auto-mark--shutter { color: var(--shutter-500); }
+  .mob__eq-value {
+    font-family: var(--font-mono); font-size: .8rem; font-weight: 600; color: var(--n-700);
+    min-width: 42px; text-align: right; font-feature-settings: "tnum" 1;
+  }
+  .mob__eq-value--on { color: var(--a-600); }
+  .mob__power {
+    width: 32px; height: 32px;
+    border-radius: 50%;
+    border: 1px solid var(--line);
+    background: var(--n-0); color: var(--n-500);
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer;
+    flex: none;
+  }
+  .mob__power svg { width: 13px; height: 13px; }
+  .mob__power--on { background: var(--a-500); border-color: var(--a-500); color: var(--n-0); }
+  [data-theme="dark"] .mob__power--on { color: #18170F; }
+  .mob__power--shutter-closed { background: var(--shutter-500); border-color: var(--shutter-500); color: var(--n-0); }
+  .mob__power--ghost { background: transparent; border-color: transparent; color: var(--n-400); }
+  .mob__power--ghost:hover { background: var(--n-50); color: var(--n-700); }
+  /* Sensor row: state badge + battery */
+  .mob__eq--sensor { grid-template-columns: 32px 1fr auto auto; gap: .55rem; }
+  .mob__chip-state {
+    font-size: .65rem; font-weight: 600;
+    padding: 3px 7px; border-radius: var(--r-xs);
+    background: var(--n-100); color: var(--n-500);
+    text-transform: none; letter-spacing: 0;
+  }
+  .mob__chip-state--detected { background: var(--green-50); color: var(--green-700); }
+  .mob__battery {
+    display: inline-flex; align-items: center; gap: .3rem;
+    font-family: var(--font-mono); font-feature-settings: "tnum" 1;
+    font-size: .68rem; color: var(--n-500); font-weight: 500;
+  }
+  .mob__battery-bar {
+    width: 16px; height: 8px;
+    border: 1px solid var(--n-400); border-radius: 2px;
+    position: relative; display: inline-block;
+  }
+  .mob__battery-bar::after {
+    content: ""; position: absolute; right: -3px; top: 2px;
+    width: 2px; height: 4px; background: var(--n-400); border-radius: 0 1px 1px 0;
+  }
+  .mob__battery-fill {
+    display: block; height: 100%; background: var(--green-500);
+    border-radius: 1px;
+  }
+  .mob__battery--med .mob__battery-fill { background: var(--a-500); }
+  .mob__battery--low .mob__battery-fill { background: var(--red-500); }
+  .mob__battery--low { color: var(--red-500); }
+  /* Shutter button group: ↑ ouvrir, ■ stop, ↓ fermer */
+  .mob__shutter-grp {
+    display: inline-flex; flex: none;
+    border: 1px solid var(--shutter-500);
+    border-radius: var(--r-sm); overflow: hidden;
+  }
+  .mob__shutter-grp button {
+    width: 30px; height: 32px;
+    background: var(--n-0); color: var(--shutter-500);
+    border: none; border-right: 1px solid var(--shutter-500);
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer; padding: 0;
+  }
+  .mob__shutter-grp button:last-child { border-right: none; }
+  .mob__shutter-grp button:hover { background: var(--shutter-50); }
+  .mob__shutter-grp button svg { width: 12px; height: 12px; }
+  .mob__shutter-grp button.is-active { background: var(--shutter-500); color: var(--n-0); }
+  [data-theme="dark"] .mob__shutter-grp button.is-active { color: #16181E; }
+
+  /* Mobile recipe row */
+  .mob__recipe {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .65rem .85rem;
+    border-top: 1px solid var(--line);
+    border-left: none; border-right: none; border-bottom: none;
+    background: transparent;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .mob__recipe:first-child { border-top: none; }
+  .mob__recipe--clickable:active { background: var(--n-25); }
+  .mob__recipe--clickable:hover .mob__recipe-name { color: var(--p-500); }
+  .mob__recipe-icon {
+    width: 26px; height: 26px;
+    border-radius: var(--r-xs);
+    background: var(--p-50); color: var(--p-500);
+    display: flex; align-items: center; justify-content: center; flex: none;
+  }
+  .mob__recipe-icon svg { width: 13px; height: 13px; }
+  .mob__recipe-main { flex: 1; min-width: 0; }
+  .mob__recipe-name { font-size: .82rem; font-weight: 500; color: var(--n-800); }
+  /* recipe-sub kept for legacy compat — but rows now omit it in favor of "click to see details" */
+  .mob__recipe-sub { display: none; }
+  .mob__toggle {
+    width: 30px; height: 18px; border-radius: 999px;
+    background: var(--n-200); position: relative; flex: none;
+  }
+  .mob__toggle::after {
+    content: ""; position: absolute; width: 14px; height: 14px;
+    background: var(--n-0); border-radius: 50%;
+    top: 2px; left: 2px;
+    box-shadow: 0 1px 2px rgba(0,0,0,.15);
+    transition: transform 180ms;
+  }
+  .mob__toggle--on { background: var(--green-500); }
+  .mob__toggle--on::after { transform: translateX(12px); }
+
+  /* Mode row (mobile) — same height as mob__eq (32px icon) */
+  .mob__mode {
+    display: grid;
+    grid-template-columns: 32px 1fr auto;
+    gap: .65rem; align-items: center;
+    padding: .6rem .85rem;
+    border-top: 1px solid var(--line);
+  }
+  .mob__mode:first-child { border-top: none; }
+  .mob__mode-icon {
+    width: 32px; height: 32px; border-radius: var(--r-sm);
+    background: var(--n-50); color: var(--n-500);
+    display: flex; align-items: center; justify-content: center;
+    position: relative; flex: none;
+  }
+  .mob__mode-icon svg { width: 15px; height: 15px; }
+  .mob__mode-icon-dot {
+    position: absolute; top: -3px; right: -3px;
+    width: 9px; height: 9px; border-radius: 50%;
+    background: var(--n-200);
+    border: 2px solid var(--n-0);
+  }
+  .mob__mode-icon-dot--on {
+    background: var(--green-500);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--green-500) 22%, transparent);
+  }
+  .mob__mode-main { min-width: 0; }
+  .mob__mode-name { font-size: .85rem; font-weight: 600; color: var(--n-800); }
+  .mob__mode-meta { font-size: .68rem; color: var(--n-500); font-feature-settings: "tnum" 1; }
+  .mob__mode-action {
+    font-size: .68rem; color: var(--p-500); font-weight: 600;
+    padding: .3rem .55rem;
+    border: 1px solid var(--p-100); border-radius: var(--r-sm);
+    background: transparent; cursor: pointer;
+  }
+  .mob__mode-action:hover { background: var(--p-50); }
+  .mob__mode-active-badge {
+    font-size: .6rem; font-weight: 700; text-transform: uppercase; letter-spacing: .12em;
+    color: var(--green-700); background: var(--green-50);
+    padding: 2px 6px; border-radius: var(--r-xs);
+  }
+
+  /* Activity row (mobile) */
+  .mob__act {
+    display: flex; align-items: flex-start; gap: .55rem;
+    padding: .55rem .85rem;
+    border-top: 1px solid var(--line);
+  }
+  .mob__act:first-child { border-top: none; }
+  .mob__act-time { font-family: var(--font-mono); font-size: .68rem; color: var(--n-400); min-width: 38px; flex: none; padding-top: 1px; font-feature-settings: "tnum" 1; }
+  .mob__act-dot { width: 6px; height: 6px; border-radius: 50%; margin-top: .45rem; flex: none; }
+  .mob__act-dot--mode { background: var(--p-500); }
+  .mob__act-dot--light { background: var(--a-500); }
+  .mob__act-dot--motion { background: var(--sensor-500); }
+  .mob__act-dot--shutter { background: var(--shutter-500); }
+  .mob__act-text { font-size: .78rem; color: var(--n-700); line-height: 1.4; }
+  .mob__act-text b { font-weight: 600; color: var(--n-800); }
+  .mob__act-text .by { color: var(--n-400); font-size: .68rem; }
+
+  /* Bottom tab bar */
+  .mob__tabs {
+    position: absolute; left: 0; right: 0; bottom: 0;
+    height: 76px; padding-bottom: 18px;
+    background: var(--n-0); border-top: 1px solid var(--line);
+    display: grid; grid-template-columns: repeat(5, 1fr);
+    backdrop-filter: blur(8px);
+  }
+  .mob__tab {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 3px;
+    color: var(--n-400); cursor: pointer;
+  }
+  .mob__tab svg { width: 20px; height: 20px; }
+  .mob__tab-label { font-size: .62rem; font-weight: 600; letter-spacing: .02em; }
+  .mob__tab--active { color: var(--p-500); }
+
+  /* Stagger animation (mobile) */
+  .mob__topbar  { animation: rise 480ms cubic-bezier(.2,.7,.2,1) backwards; animation-delay: 60ms; }
+  .mob__hero    { animation: rise 480ms cubic-bezier(.2,.7,.2,1) backwards; animation-delay: 120ms; }
+  .mob__actions { animation: rise 480ms cubic-bezier(.2,.7,.2,1) backwards; animation-delay: 180ms; }
+  .mob__panel   { animation: rise 480ms cubic-bezier(.2,.7,.2,1) backwards; animation-delay: 240ms; }
+  @media (prefers-reduced-motion: reduce) {
+    .mob__topbar, .mob__hero, .mob__actions, .mob__panel { animation: none; }
+  }
+
+  /* ════════════════════════════════════════════════════════════════ */
+  /* RECIPE EDIT MODAL                                                 */
+  /* ════════════════════════════════════════════════════════════════ */
+  .modal-stage {
+    position: relative;
+    margin: 1rem 0 0;
+    min-height: 720px;
+    background: var(--n-50);
+    border: 1px dashed var(--n-200);
+    border-radius: var(--r-lg);
+    overflow: hidden;
+    display: flex; align-items: center; justify-content: center;
+    padding: 2rem 1rem;
+  }
+  /* Backdrop hint (suggests an underlying UI dimmed) */
+  .modal-stage::before {
+    content: ""; position: absolute; inset: 0;
+    background:
+      radial-gradient(60% 80% at 50% 0%, color-mix(in srgb, var(--p-500) 5%, transparent), transparent 70%),
+      repeating-linear-gradient(0deg, var(--n-50), var(--n-50) 30px, var(--n-25) 30px, var(--n-25) 31px);
+    opacity: .6;
+  }
+  .modal {
+    position: relative;
+    width: 100%; max-width: 640px;
+    background: var(--n-0);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    box-shadow: 0 30px 80px -20px rgba(15,42,60,.30), 0 4px 14px rgba(15,42,60,.06);
+    overflow: hidden;
+    display: flex; flex-direction: column;
+    max-height: 720px;
+  }
+  .modal__head {
+    display: flex; align-items: center; gap: .75rem;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--line);
+  }
+  .modal__head-icon {
+    width: 36px; height: 36px;
+    border-radius: var(--r-sm);
+    background: var(--p-50); color: var(--p-500);
+    display: flex; align-items: center; justify-content: center; flex: none;
+  }
+  .modal__head-icon svg { width: 18px; height: 18px; }
+  .modal__head-titles { flex: 1; min-width: 0; }
+  .modal__head-title { font-size: 1.05rem; font-weight: 700; color: var(--n-800); letter-spacing: -.01em; }
+  .modal__head-sub { font-size: .74rem; color: var(--n-500); margin-top: 1px; }
+  .modal__head-sub b { color: var(--n-700); font-weight: 600; }
+  .modal__close {
+    width: 32px; height: 32px;
+    background: transparent; border: none;
+    color: var(--n-500); cursor: pointer;
+    border-radius: var(--r-sm);
+    display: flex; align-items: center; justify-content: center; flex: none;
+  }
+  .modal__close:hover { background: var(--n-50); color: var(--n-800); }
+  .modal__close svg { width: 16px; height: 16px; }
+
+  .modal__body {
+    flex: 1; overflow-y: auto;
+    padding: 1rem 1.25rem;
+    display: flex; flex-direction: column; gap: 1.4rem;
+  }
+  .msec {
+    display: flex; flex-direction: column; gap: .55rem;
+  }
+  .msec__label {
+    font-size: .65rem; text-transform: uppercase; letter-spacing: .14em;
+    color: var(--n-500); font-weight: 700;
+  }
+  .msec__help {
+    font-size: .72rem; color: var(--n-400); margin-top: -.3rem;
+  }
+  /* Chips (equipment bindings) */
+  .mchips { display: flex; flex-wrap: wrap; gap: .4rem; }
+  .mchip {
+    display: inline-flex; align-items: center; gap: .35rem;
+    padding: .35rem .65rem .35rem .55rem;
+    background: var(--p-50); color: var(--p-500);
+    border: 1px solid var(--p-100); border-radius: var(--r-full);
+    font-size: .78rem; font-weight: 500;
+  }
+  .mchip svg { width: 12px; height: 12px; opacity: .8; }
+  .mchip__rm {
+    width: 16px; height: 16px; margin-left: 2px;
+    border-radius: 50%; background: color-mix(in srgb, var(--p-500) 12%, transparent);
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: .65rem; cursor: pointer;
+  }
+  .mchip--add {
+    background: var(--n-0); color: var(--n-500);
+    border-style: dashed; border-color: var(--n-200);
+    cursor: pointer;
+  }
+  .mchip--add:hover { background: var(--n-25); color: var(--p-500); border-color: var(--p-500); }
+  /* Form rows */
+  .mform {
+    display: grid; grid-template-columns: 1fr 220px; gap: .65rem 1rem;
+    align-items: center;
+  }
+  .mform__lab { font-size: .82rem; color: var(--n-700); }
+  .mform__lab small { display: block; font-size: .68rem; color: var(--n-400); font-weight: 400; }
+  .mform input, .mform select {
+    width: 100%; padding: .5rem .65rem;
+    font-family: var(--font-body); font-size: .85rem;
+    color: var(--n-800);
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    font-feature-settings: "tnum" 1;
+  }
+  .mform input:focus, .mform select:focus { outline: none; border-color: var(--p-500); box-shadow: 0 0 0 3px var(--p-50); }
+
+  /* Required marker */
+  .msec__required { color: var(--red-500); margin-left: .15rem; font-weight: 700; }
+  .msec__beta {
+    display: inline-block; margin-left: .4rem;
+    font-size: .58rem; font-weight: 700; text-transform: uppercase; letter-spacing: .12em;
+    color: var(--a-600); background: var(--a-50);
+    padding: 1px 6px; border-radius: var(--r-xs);
+    vertical-align: 1px;
+  }
+  .msec--enhance {
+    border-left: 2px solid var(--a-500);
+    padding-left: .75rem;
+    margin-left: -.75rem;
+  }
+
+  /* Checklist (équipements à contrôler, interrupteurs, etc.) */
+  .mcheck { display: flex; flex-direction: column; gap: .35rem; }
+  .mcheck__item {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .5rem .75rem;
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    font-size: .85rem; color: var(--n-700);
+    cursor: pointer;
+    transition: background-color 140ms, border-color 140ms;
+  }
+  .mcheck__item:hover { background: var(--n-25); border-color: var(--n-300); }
+  .mcheck__item input[type="checkbox"] {
+    width: 16px; height: 16px;
+    accent-color: var(--p-500);
+    margin: 0; flex: none;
+  }
+  .mcheck__item input:checked + span { color: var(--n-800); font-weight: 500; }
+
+  /* Compact field grid (paramètres principaux en 2-col) */
+  .mfgrid {
+    display: grid; grid-template-columns: 1fr 1fr;
+    gap: .85rem;
+  }
+  .mfield { display: flex; flex-direction: column; gap: .3rem; }
+  .mfield__lab {
+    font-size: .68rem; font-weight: 600;
+    text-transform: uppercase; letter-spacing: .12em;
+    color: var(--n-500);
+    display: flex; align-items: center; gap: .25rem;
+  }
+  .mfield__lab-sub {
+    text-transform: none; letter-spacing: 0;
+    font-size: .68rem; color: var(--n-400); font-weight: 400;
+    margin-left: .15rem;
+  }
+  .mfield input, .mfield select {
+    width: 100%; padding: .55rem .65rem;
+    font-family: var(--font-body); font-size: .85rem;
+    color: var(--n-800);
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    font-feature-settings: "tnum" 1;
+  }
+  .mfield input:focus, .mfield select:focus {
+    outline: none; border-color: var(--p-500);
+    box-shadow: 0 0 0 3px var(--p-50);
+  }
+  .mfield__input {
+    display: flex; align-items: center;
+    border: 1px solid var(--line); border-radius: var(--r-sm);
+    background: var(--n-0);
+  }
+  .mfield__input:focus-within { border-color: var(--p-500); box-shadow: 0 0 0 3px var(--p-50); }
+  .mfield__input input { border: none; box-shadow: none !important; padding-right: .25rem; }
+  .mfield__input input:focus { box-shadow: none; }
+  .mfield__suffix {
+    padding: 0 .75rem 0 .35rem;
+    font-size: .78rem; color: var(--n-400); font-weight: 500;
+    border-left: 1px solid var(--line);
+    align-self: stretch;
+    display: inline-flex; align-items: center;
+  }
+  .mfield__help { font-size: .68rem; color: var(--n-400); line-height: 1.45; }
+
+  /* Plage horaire group (border-left accent comme en prod) */
+  .mplage {
+    border-left: 2px solid var(--a-500);
+    background: var(--a-50);
+    background: color-mix(in srgb, var(--a-500) 4%, var(--n-0));
+    border-radius: 0 var(--r-sm) var(--r-sm) 0;
+    padding: .75rem 1rem .85rem;
+  }
+  .mplage__head {
+    display: flex; align-items: center;
+    margin-bottom: .55rem;
+  }
+  .mplage__title {
+    font-size: .68rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .12em;
+    color: var(--a-600);
+  }
+  .mplage__del {
+    margin-left: auto;
+    width: 22px; height: 22px;
+    background: transparent; border: none;
+    color: var(--n-400); cursor: pointer;
+    border-radius: var(--r-xs);
+    display: inline-flex; align-items: center; justify-content: center;
+  }
+  .mplage__del:hover { background: var(--red-50); color: var(--red-500); }
+  .mplage__del svg { width: 13px; height: 13px; }
+  .mplage__grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: .55rem; }
+  .mplage__grid .mfield { gap: .25rem; }
+  .mplage__add-row { display: flex; gap: .5rem; margin-top: .55rem; }
+  .mplage__add {
+    display: inline-flex; align-items: center; gap: .35rem;
+    padding: .35rem .65rem;
+    background: transparent; border: 1px dashed var(--n-300);
+    border-radius: var(--r-sm);
+    font-family: var(--font-body); font-size: .76rem; font-weight: 500;
+    color: var(--n-500); cursor: pointer;
+  }
+  .mplage__add:hover { color: var(--a-600); border-color: var(--a-500); background: var(--a-50); }
+  .mplage__add svg { width: 12px; height: 12px; }
+
+  /* Mobile: stack to 1 col */
+  @media (max-width: 640px) {
+    .mfgrid { grid-template-columns: 1fr; }
+    .mplage__grid { grid-template-columns: 1fr 1fr; }
+  }
+  /* Mode override rows */
+  .mover { display: flex; flex-direction: column; }
+  .mover__row {
+    display: flex; align-items: center; gap: .65rem;
+    padding: .55rem .65rem;
+    border-top: 1px solid var(--line);
+  }
+  .mover__row:first-child { border-top: none; }
+  .mover__dot { width: 8px; height: 8px; border-radius: 50%; background: var(--n-300); flex: none; }
+  .mover__dot--on { background: var(--green-500); box-shadow: 0 0 0 4px color-mix(in srgb, var(--green-500) 14%, transparent); }
+  .mover__name { font-size: .85rem; font-weight: 500; color: var(--n-800); min-width: 130px; }
+  .mover__name .badge { font-size: .58rem; font-weight: 700; text-transform: uppercase; letter-spacing: .12em; color: var(--green-700); background: var(--green-50); padding: 2px 6px; border-radius: var(--r-xs); margin-left: .35rem; vertical-align: 1px; }
+  .mover__val {
+    flex: 1; font-size: .78rem; color: var(--n-600);
+    font-feature-settings: "tnum" 1;
+  }
+  .mover__val b { color: var(--n-800); font-weight: 600; }
+  .mover__val--off { color: var(--n-400); font-style: italic; }
+  .mover__edit {
+    font-size: .72rem; color: var(--p-500); font-weight: 600;
+    padding: .3rem .55rem;
+    border: 1px solid var(--p-100); border-radius: var(--r-sm);
+    background: transparent; cursor: pointer;
+  }
+  .mover__edit:hover { background: var(--p-50); }
+  /* Trigger rows */
+  .mtrig {
+    display: flex; align-items: center; gap: .65rem;
+    padding: .65rem .85rem;
+    background: var(--n-25); border: 1px solid var(--line);
+    border-radius: var(--r-md);
+  }
+  .mtrig__icon {
+    width: 28px; height: 28px;
+    border-radius: var(--r-sm);
+    background: var(--green-50); color: var(--green-700);
+    display: flex; align-items: center; justify-content: center; flex: none;
+  }
+  .mtrig__icon svg { width: 14px; height: 14px; }
+  .mtrig__main { flex: 1; min-width: 0; }
+  .mtrig__name { font-size: .85rem; font-weight: 600; color: var(--n-800); }
+  .mtrig__sub { font-size: .72rem; color: var(--n-500); font-feature-settings: "tnum" 1; }
+  .mtrig__sub b { color: var(--n-700); font-weight: 600; }
+  /* Footer */
+  .modal__foot {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: .8rem 1.25rem;
+    border-top: 1px solid var(--line);
+    background: var(--n-25);
+    gap: .5rem;
+  }
+  .modal__foot-status {
+    font-size: .72rem; color: var(--n-500);
+    display: inline-flex; align-items: center; gap: .35rem;
+  }
+  .modal__foot-status::before {
+    content: ""; width: 6px; height: 6px; border-radius: 50%;
+    background: var(--n-300);
+  }
+  .modal__foot-actions { display: flex; gap: .5rem; }
+  .mbtn {
+    display: inline-flex; align-items: center; gap: .4rem;
+    padding: .55rem 1rem;
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    font-family: var(--font-body); font-size: .82rem; color: var(--n-700);
+    font-weight: 500; cursor: pointer;
+  }
+  .mbtn:hover { background: var(--n-50); border-color: var(--n-300); }
+  .mbtn--primary {
+    background: var(--p-500); border-color: var(--p-500); color: var(--n-0);
+    font-weight: 600;
+  }
+  .mbtn--primary:hover { background: var(--p-600); border-color: var(--p-600); }
+  [data-theme="dark"] .mbtn--primary { color: #16181E; }
+
+  /* ════════════════════════════════════════════════════════════════ */
+  /* DASHBOARD WIDGETS                                                 */
+  /* ════════════════════════════════════════════════════════════════ */
+  .dash-page { padding: 1.5rem; background: var(--n-25); min-height: 600px; }
+  .dash-head {
+    display: flex; align-items: center; gap: 1rem;
+    margin-bottom: 1.25rem;
+  }
+  .dash-head__title {
+    font-size: 1.55rem; font-weight: 700; color: var(--n-800);
+    letter-spacing: -.022em; margin: 0;
+  }
+  .dash-head__edit {
+    margin-left: auto;
+    display: inline-flex; align-items: center; gap: .4rem;
+    padding: .45rem .85rem;
+    background: var(--n-0); border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    font-family: var(--font-body); font-size: .82rem; font-weight: 500;
+    color: var(--n-700); cursor: pointer;
+  }
+  .dash-head__edit:hover { background: var(--n-50); border-color: var(--n-300); }
+  .dash-head__edit svg { width: 14px; height: 14px; opacity: .7; }
+
+  /* Widget grid */
+  .dash-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+  }
+
+  /* Widget card */
+  .widget {
+    background: var(--n-0);
+    border: 1px solid var(--line-2);
+    border-radius: 10px;     /* prod uses 10 px — see tokens.md note */
+    padding: 12px;
+    display: flex; flex-direction: column;
+    height: 240px;
+    overflow: hidden;
+    cursor: pointer;
+    transition: transform 160ms, box-shadow 160ms, border-color 160ms;
+  }
+  .widget:hover {
+    border-color: var(--n-300);
+    box-shadow: var(--sh-1);
+    transform: translateY(-1px);
+  }
+  .widget__title {
+    font-size: 14px; font-weight: 500;
+    color: var(--n-800);
+    text-align: center;
+    margin: 0 0 6px;
+  }
+  .widget__art {
+    flex: 1;
+    display: flex; align-items: center; justify-content: center;
+    gap: 1rem;
+    color: var(--p-500);
+    min-height: 0;
+  }
+  .widget__art svg { max-width: 100%; max-height: 100%; }
+  .widget__art-side {
+    display: flex; flex-direction: column;
+    gap: .35rem;
+    font-family: var(--font-mono); font-feature-settings: "tnum" 1;
+  }
+  .widget__big {
+    font-family: var(--font-mono); font-feature-settings: "tnum" 1;
+    font-size: 1.65rem; font-weight: 600;
+    color: var(--n-800); letter-spacing: -.02em;
+    line-height: 1;
+  }
+  .widget__big .u { font-size: .6em; color: var(--n-400); margin-left: 2px; font-weight: 500; }
+  .widget__meta { font-size: .72rem; color: var(--n-500); font-feature-settings: "tnum" 1; }
+  .widget__footer {
+    display: flex; align-items: center; justify-content: center;
+    gap: .55rem;
+    margin-top: 8px;
+  }
+  /* heating thermometer fill */
+  .therm-icon--heating .therm-bulb { fill: var(--a-500); stroke: var(--a-600); }
+  .therm-icon--heating .therm-fill { stroke: var(--a-500); }
+
+  /* light-on bulb fill (widget bulb art) */
+  .bulb-on { fill: var(--a-500); stroke: var(--a-600); }
+
+  /* horizontal shutter group variant (pool cover) — keeps same CSS, just rotated arrows */
+  /* Shutter button group (segmented, matches design system spec) */
+  .shutter-grp {
+    display: inline-flex; align-items: center;
+    border: 1px solid var(--shutter-500);
+    border-radius: var(--r-sm);
+    overflow: hidden;
+    flex: none;
+  }
+  .shutter-grp .shutter-btn {
+    width: 26px; height: 26px;
+    background: var(--n-0); color: var(--shutter-500);
+    border: none; border-right: 1px solid var(--shutter-500);
+    border-radius: 0;
+    display: inline-flex; align-items: center; justify-content: center;
+    cursor: pointer; padding: 0;
+  }
+  .shutter-grp .shutter-btn:last-child { border-right: none; }
+  .shutter-grp .shutter-btn svg { width: 11px; height: 11px; }
+  .shutter-grp .shutter-btn:hover { background: var(--shutter-50); }
+  .shutter-grp .shutter-btn.is-active { background: var(--shutter-500); color: var(--n-0); }
+  [data-theme="dark"] .shutter-grp .shutter-btn.is-active { color: #16181E; }
+  .shutter-grp--horizontal { /* arrows orientation differs; CSS identical */ }
+
+  /* Responsive */
+  @media (max-width: 1100px) { .dash-grid { grid-template-columns: repeat(3, 1fr); } }
+  @media (max-width: 800px)  { .dash-grid { grid-template-columns: repeat(2, 1fr); } .widget { height: 200px; } }
+  @media (max-width: 480px)  { .dash-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+
+<nav class="picker">
+  <span class="picker__brand">Sowel · zone view</span>
+  <span class="picker__label">Palette :</span>
+  <div class="picker__choices" id="picker">
+    <button class="picker__chip picker__chip--active" data-pick="hybrid"><span class="sw"></span>Hybrid (light)</button>
+    <button class="picker__chip" data-pick="dark"><span class="sw"></span>Dark</button>
+  </div>
+</nav>
+
+<header class="intro">
+  <div class="intro__eyebrow">Variant B · sober refinement</div>
+  <h1 class="intro__title">Proche de l'UI actuelle, avec trois ajouts précis et 2 palettes à essayer.</h1>
+  <p class="intro__lead">Le layout reste calé sur la vue Séjour de prod. On ajoute seulement une colonne droite (Mode actif · Recette · Activité) et quelques accents (header de catégorie tinté, indicateur ⚡ pour les équipements pilotés par recette). Clique sur une palette en haut pour comparer.</p>
+</header>
+
+<section class="section">
+  <div class="section__label">Desktop · 1280×820</div>
+
+  <div class="ui">
+    <aside class="sb">
+      <div class="sb__logo">
+        <svg viewBox="25 15 150 155" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" style="color:var(--p-500)">
+          <path d="M100 30 L160 90 Q165 95 160 100 L160 150 Q160 158 152 158 L48 158 Q40 158 40 150 L40 100 Q35 95 40 90 Z"/>
+          <path d="M75 115 Q100 140 125 115" style="color:var(--info-500)" stroke="currentColor"/>
+          <path d="M78 95 Q83 87 88 95" style="color:var(--info-500)" stroke="currentColor"/>
+          <path d="M112 95 Q117 87 122 95" style="color:var(--info-500)" stroke="currentColor"/>
+        </svg>
+        <b>SOWEL</b>
+      </div>
+
+      <div class="sb__item">
+        <svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+        Dashboard
+      </div>
+      <div class="sb__item">
+        <svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+        Maison
+        <span class="sb__chev">⌄</span>
+      </div>
+      <div class="sb__sub">
+        <div class="sb__item"><span class="sb__exp">›</span>Extérieur</div>
+        <div class="sb__item"><span class="sb__exp">›</span>Sous-sol</div>
+        <div class="sb__item"><span class="sb__exp sb__exp--open">›</span>RDC</div>
+        <div class="sb__sub sb__sub-deeper">
+          <div class="sb__item"><span class="sb__exp sb__exp--leaf"></span>Entrée</div>
+          <div class="sb__item"><span class="sb__exp sb__exp--leaf"></span>Bureau</div>
+          <div class="sb__item"><span class="sb__exp sb__exp--leaf"></span>Cuisine</div>
+          <div class="sb__item sb__item--active"><span class="sb__exp sb__exp--leaf"></span>Séjour</div>
+        </div>
+        <div class="sb__item"><span class="sb__exp">›</span>Etage 1</div>
+        <div class="sb__item"><span class="sb__exp">›</span>Etage 2</div>
+      </div>
+      <div class="sb__sep"></div>
+      <div class="sb__item"><svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>Modes</div>
+      <div class="sb__sep"></div>
+      <div class="sb__item"><svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>Analyse</div>
+      <div class="sb__sep"></div>
+      <div class="sb__item"><svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>Énergie</div>
+      <div class="sb__sep"></div>
+      <div class="sb__item" style="margin-top:auto"><svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2 4 7v6c0 5 3.5 9 8 10 4.5-1 8-5 8-10V7l-8-5z"/></svg>Administration</div>
+      <div class="sb__item"><svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33"/></svg>Réglages</div>
+    </aside>
+
+    <div class="main">
+      <div class="topbar">
+        <div class="topbar__breadcrumb">
+          Grange Neuve <span class="sep">›</span> RDC <span class="sep">›</span> <b>Séjour</b>
+        </div>
+        <div class="topbar__spacer"></div>
+        <!-- Current time (matches production CurrentTimePill) -->
+        <div class="topbar__chip" title="Heure courante">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+          22:57:12
+        </div>
+        <!-- Sunlight banner (lever / coucher · phase) -->
+        <div class="topbar__chip topbar__chip--sun" title="Lever 06:14 — coucher 20:54">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+          06:14 — 20:54 <span class="topbar__chip-tag">Nuit</span>
+        </div>
+        <!-- Connection status (production pattern: ConnectionStatus.tsx) -->
+        <div class="topbar__conn topbar__conn--connected" title="Connecté au moteur Sowel">
+          <span class="topbar__conn-dot"></span>
+          <span class="topbar__conn-lab">Connecté</span>
+        </div>
+        <!-- Alarms pill (production: HeaderPill with AlertTriangle + count) -->
+        <button class="topbar__alarm topbar__alarm--warning" title="2 alertes système">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="m21.73 18-8-14a2 2 0 0 0-3.46 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><line x1="12" y1="9" x2="12" y2="13"/><circle cx="12" cy="17" r=".5" fill="currentColor"/></svg>
+          <span class="topbar__alarm-count">2</span>
+        </button>
+        <div class="topbar__avatar">
+          <div class="topbar__avatar-pic">MC</div>
+          Marc
+        </div>
+      </div>
+
+      <div class="hero">
+        <div class="hero__head">
+          <div class="hero__main">
+            <h1 class="hero__title">Séjour</h1>
+            <div class="hero__lead">
+              <span>1 lumière allumée</span>
+              <span class="hero__lead-sep"></span>
+              <span>tous les volets ouverts</span>
+            </div>
+          </div>
+
+        </div>
+        <div class="strip">
+          <!-- ── Sensors (conditional: only render if data present) ── -->
+          <div class="strip__pill" title="Température moyenne · 3 capteurs">
+            <svg class="strip__pill-icon" style="--c:var(--info-500)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M14 4v10.54a4 4 0 1 1-4 0V4a2 2 0 0 1 4 0z"/></svg>
+            <span class="strip__pill-val">21,4<span class="u">°C</span></span>
+            <svg class="strip__pill-spark" viewBox="0 0 100 18" preserveAspectRatio="none"><polyline fill="none" stroke="currentColor" style="color:var(--info-500)" stroke-width="1.3" points="0,12 14,10 28,11 42,9 56,8 70,7 84,7 100,6"/></svg>
+          </div>
+          <span class="strip__div"></span>
+          <div class="strip__pill" title="Humidité moyenne">
+            <svg class="strip__pill-icon" style="--c:var(--info-500)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M12 2 7 9a6 6 0 1 0 10 0z"/></svg>
+            <span class="strip__pill-val">48<span class="u">%</span></span>
+            <svg class="strip__pill-spark" viewBox="0 0 100 18" preserveAspectRatio="none"><polyline fill="none" stroke="currentColor" style="color:var(--info-500)" stroke-width="1.3" points="0,8 14,9 28,10 42,9 56,11 70,10 84,9 100,8"/></svg>
+          </div>
+          <span class="strip__div"></span>
+          <div class="strip__pill" title="Luminosité · capteur Séjour">
+            <svg class="strip__pill-icon" style="--c:var(--info-500)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M2 12h2M20 12h2"/></svg>
+            <span class="strip__pill-val">334<span class="u">lx</span></span>
+            <svg class="strip__pill-spark" viewBox="0 0 100 18" preserveAspectRatio="none"><polyline fill="none" stroke="currentColor" style="color:var(--info-500)" stroke-width="1.3" points="0,4 14,3 28,5 42,7 56,9 70,11 84,13 100,15"/></svg>
+          </div>
+          <!-- ── Group break ── -->
+          <span class="strip__div strip__div--group"></span>
+          <!-- ── Counts / states ── -->
+          <div class="strip__pill strip__pill--calm" title="Mouvement · calme depuis 39 minutes">
+            <svg class="strip__pill-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="5" r="2"/><path d="M9 14l3-3 3 3"/></svg>
+            <span class="strip__pill-val">Calme</span>
+            <span class="strip__pill-meta">39 min</span>
+          </div>
+          <span class="strip__div"></span>
+          <div class="strip__pill strip__pill--active" title="1 lumière allumée sur 3">
+            <svg class="strip__pill-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6M10 22h4"/></svg>
+            <span class="strip__pill-val">1<span class="u">/ 3</span></span>
+          </div>
+          <span class="strip__div"></span>
+          <div class="strip__pill" title="3 volets · tous ouverts">
+            <svg class="strip__pill-icon" style="--c:var(--shutter-500)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/></svg>
+            <span class="strip__pill-val">3<span class="u">/ 3</span></span>
+            <span class="strip__pill-meta">· Ouvert</span>
+          </div>
+          <!-- ── Alerts section (only if any present) ── -->
+          <span class="strip__div strip__div--group"></span>
+          <div class="strip__pill strip__pill--alert" title="Porte-fenêtre du séjour ouverte">
+            <svg class="strip__pill-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M13 4v16h6V4M9 4v16"/><path d="M14 12h.01"/></svg>
+            <span class="strip__pill-val">1 ouverte</span>
+          </div>
+        </div>
+
+        <!-- ── Global commands row: own line, left-aligned ── -->
+        <div class="zcmds" aria-label="Commandes globales">
+          <button class="zcmds__btn" data-cat="light" title="Tout allumer">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6M10 22h4"/></svg>
+          </button>
+          <button class="zcmds__btn" data-cat="light-off" title="Tout éteindre">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M8.91 14a4.61 4.61 0 0 0-1.41-2.5A6 6 0 0 1 9.74 3.18"/><path d="M13.4 3.6a6 6 0 0 1 3.1 4.9 5 5 0 0 1-1.5 3.5c-.8.8-1.3 1.5-1.5 2.5"/><path d="M9 18h6M10 22h4"/><line x1="3" y1="3" x2="21" y2="21"/></svg>
+          </button>
+          <span class="zcmds__sep"></span>
+          <button class="zcmds__btn" data-cat="shutter" title="Ouvrir volets">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>
+          </button>
+          <button class="zcmds__btn" data-cat="shutter" title="Stop">
+            <svg viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="8" width="8" height="8" rx="1.2"/></svg>
+          </button>
+          <button class="zcmds__btn" data-cat="shutter" title="Fermer volets">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </button>
+        </div>
+      </div>
+
+      <div class="grid">
+        <!-- Left: Equipments -->
+        <div class="panel">
+          <div class="panel__head">
+            <span class="panel__title">Équipements</span>
+            <span class="panel__sub">dans cette zone</span>
+            <button class="panel__add" title="Ajouter un équipement" aria-label="Ajouter un équipement">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            </button>
+          </div>
+
+          <div class="cat-head">
+            <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6M10 22h4"/></svg>
+            Éclairages
+            <span class="cat-head__count">3</span>
+          </div>
+          <div class="eq">
+            <div class="eq__icon eq__icon--light"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6M10 22h4"/></svg></div>
+            <span class="eq__name">Applique x 1</span>
+            <div class="eq__slider"><div class="eq__slider-fill" style="width:0"></div><div class="eq__slider-knob" style="left:0"></div></div>
+            <div class="eq__value">0 %</div>
+            <button class="power-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+          </div>
+          <div class="eq eq--auto">
+            <div class="eq__icon eq__icon--light-on"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6M10 22h4"/></svg></div>
+            <span class="eq__name">Appliques x 2</span>
+            <div class="eq__slider"><div class="eq__slider-fill" style="width:4%"></div><div class="eq__slider-knob" style="left:4%"></div></div>
+            <div class="eq__value" style="color:var(--a-600)">4 %</div>
+            <button class="power-btn power-btn--on"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+          </div>
+          <div class="eq">
+            <div class="eq__icon eq__icon--light"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2"/></svg></div>
+            <span class="eq__name">Spots</span>
+            <div></div>
+            <div></div>
+            <button class="power-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+          </div>
+
+          <div class="cat-head">
+            <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg>
+            Volets
+            <span class="cat-head__count">3</span>
+          </div>
+          <div class="eq eq--auto-shutter">
+            <div class="eq__icon eq__icon--shutter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <span class="eq__name">Volet Ouest</span>
+            <div class="eq__slider" style="width:80px"><div class="eq__slider-fill eq__slider-fill--shutter" style="width:100%"></div><div class="eq__slider-knob eq__slider-knob--shutter" style="left:100%"></div></div>
+            <div class="shutter-ctrl">
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"/></svg></button>
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12"/></svg></button>
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg></button>
+            </div>
+            <span class="chip-state chip-state--closed">Fermé</span>
+          </div>
+          <div class="eq eq--auto-shutter">
+            <div class="eq__icon eq__icon--shutter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <span class="eq__name">Volet Sud</span>
+            <div class="eq__slider" style="width:80px"><div class="eq__slider-fill eq__slider-fill--shutter" style="width:100%"></div><div class="eq__slider-knob eq__slider-knob--shutter" style="left:100%"></div></div>
+            <div class="shutter-ctrl">
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"/></svg></button>
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12"/></svg></button>
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg></button>
+            </div>
+            <span class="chip-state chip-state--closed">Fermé</span>
+          </div>
+          <div class="eq eq--auto-shutter">
+            <div class="eq__icon eq__icon--shutter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <span class="eq__name">Volet Sud Ouest</span>
+            <div class="eq__slider" style="width:80px"><div class="eq__slider-fill eq__slider-fill--shutter" style="width:100%"></div><div class="eq__slider-knob eq__slider-knob--shutter" style="left:100%"></div></div>
+            <div class="shutter-ctrl">
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"/></svg></button>
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12"/></svg></button>
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg></button>
+            </div>
+            <span class="chip-state chip-state--closed">Fermé</span>
+          </div>
+
+          <div class="cat-head">
+            <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/></svg>
+            Capteurs
+            <span class="cat-head__count">3</span>
+          </div>
+          <div class="eq">
+            <div class="eq__icon eq__icon--sensor"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1.5"/><path d="m9 20 3-6 3 6"/><path d="m6 8 6 2 6-2"/><path d="M12 10v4"/></svg></div>
+            <span class="eq__name">PIRL</span>
+            <div class="sensor-val">334<span class="u">lx</span></div>
+            <span class="chip-state">RAS</span>
+          </div>
+          <div class="eq">
+            <div class="eq__icon eq__icon--sensor"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1.5"/><path d="m9 20 3-6 3 6"/><path d="m6 8 6 2 6-2"/><path d="M12 10v4"/></svg></div>
+            <span class="eq__name">PIR_00</span>
+            <div></div>
+            <span class="chip-state">RAS</span>
+          </div>
+          <div class="eq">
+            <div class="eq__icon eq__icon--sensor"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1.5"/><path d="m9 20 3-6 3 6"/><path d="m6 8 6 2 6-2"/><path d="M12 10v4"/></svg></div>
+            <span class="eq__name">PIR_01</span>
+            <div></div>
+            <span class="chip-state">RAS</span>
+          </div>
+
+          <div class="cat-head">
+            <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="4" width="20" height="14" rx="2"/><line x1="2" y1="20" x2="22" y2="20"/></svg>
+            Multimédia
+            <span class="cat-head__count">1</span>
+          </div>
+          <div class="eq">
+            <div class="eq__icon eq__icon--media"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="4" width="20" height="14" rx="2"/><line x1="2" y1="20" x2="22" y2="20"/></svg></div>
+            <span class="eq__name">TV</span>
+            <div></div>
+            <div></div>
+            <span class="chip-state chip-state--off">OFF</span>
+          </div>
+
+          <div class="cat-head">
+            <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="3"/></svg>
+            Autres
+            <span class="cat-head__count">2</span>
+          </div>
+          <div class="eq">
+            <div class="eq__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="3"/></svg></div>
+            <span class="eq__name">Switch Appliques</span>
+            <div></div>
+            <span class="last-action">single · 1h14</span>
+          </div>
+          <div class="eq">
+            <div class="eq__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="3"/></svg></div>
+            <span class="eq__name">Switch Sonos</span>
+            <div></div>
+            <span class="last-action">single · 169h33</span>
+          </div>
+        </div>
+
+        <!-- Right column -->
+        <div>
+          <!-- Comportements panel — same level as Équipements -->
+          <div class="panel" style="margin-bottom:.75rem">
+            <div class="panel__head">
+              <span class="panel__title">Comportements</span>
+              <span class="panel__sub">dans cette zone</span>
+              <span class="panel__count">3 + 1</span>
+            </div>
+
+            <!-- Sub-category: MODES -->
+            <div class="cat-head">
+              <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+              Modes
+              <button class="cat-head__add" title="Ajouter un mode" aria-label="Ajouter un mode">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              </button>
+            </div>
+            <div class="mode-row">
+              <div class="mode-row__icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+                <span class="mode-row__icon-dot"></span>
+              </div>
+              <div class="mode-row__main">
+                <div class="mode-row__name">Lumière jour</div>
+                <div class="mode-row__meta">1 action</div>
+              </div>
+              <button class="mode-row__apply">Apply</button>
+            </div>
+            <div class="mode-row">
+              <div class="mode-row__icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+                <span class="mode-row__icon-dot"></span>
+              </div>
+              <div class="mode-row__main">
+                <div class="mode-row__name">Lumière nuit</div>
+                <div class="mode-row__meta">1 action</div>
+              </div>
+              <button class="mode-row__apply">Apply</button>
+            </div>
+            <div class="mode-row mode-row--active">
+              <div class="mode-row__icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+                <span class="mode-row__icon-dot mode-row__icon-dot--active"></span>
+              </div>
+              <div class="mode-row__main">
+                <div class="mode-row__name">Lumière soir</div>
+                <div class="mode-row__meta">4 actions · appliqué 21:00</div>
+              </div>
+              <span class="mode-row__badge">Actif</span>
+            </div>
+
+            <!-- Sub-category: RECETTES -->
+            <div class="cat-head">
+              <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-5.35c0-.46.32-.84.73-1.04a4 4 0 0 0-2.13-7.59 5 5 0 0 0-9.2 0 4 4 0 0 0-2.13 7.59c.41.2.73.58.73 1.04V21M6 17h12"/></svg>
+              Recettes
+              <button class="cat-head__add" title="Ajouter une recette" aria-label="Ajouter une recette">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              </button>
+            </div>
+            <div class="recipe">
+              <div class="recipe__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-5.35c0-.46.32-.84.73-1.04a4 4 0 0 0-2.13-7.59 5 5 0 0 0-9.2 0 4 4 0 0 0-2.13 7.59c.41.2.73.58.73 1.04V21M6 17h12"/></svg></div>
+              <button class="recipe__open" title="Voir et éditer la recette">
+                <div class="recipe__name">Lumière dimmable sur mouvement</div>
+              </button>
+              <div class="recipe__toggle recipe__toggle--on" role="switch" aria-checked="true" tabindex="0"></div>
+              <div class="recipe__actions">
+                <button class="recipe__action" title="Voir les logs">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M8 21h12a2 2 0 0 0 2-2v-2H10v2a2 2 0 1 1-4 0V5a2 2 0 1 0-4 0v3h4"/><path d="M19 17V5a2 2 0 0 0-2-2H4"/><line x1="15" y1="8" x2="9" y2="8"/><line x1="15" y1="12" x2="9" y2="12"/></svg>
+                </button>
+                <button class="recipe__action recipe__action--primary" title="Dupliquer la recette">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                </button>
+                <button class="recipe__action recipe__action--danger" title="Supprimer la recette">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div class="panel">
+            <div class="panel__head">
+              <span class="panel__title">Activité</span>
+              <span class="panel__sub">dernière heure</span>
+              <span class="panel__count" style="background:var(--green-50);color:var(--green-700)">● live</span>
+            </div>
+            <div class="activity">
+              <div class="activity__group">22:00 → maintenant</div>
+              <div class="activity__item">
+                <div class="activity__item-icon activity__item-icon--recipe"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-5.35c0-.46.32-.84.73-1.04a4 4 0 0 0-2.13-7.59 5 5 0 0 0-9.2 0 4 4 0 0 0-2.13 7.59c.41.2.73.58.73 1.04V21M6 17h12"/></svg></div>
+                <div class="activity__item-text"><b>Appliques x2</b> → 4 % <span class="by">par Motion Light</span></div>
+                <span class="activity__item-time">22:41</span>
+              </div>
+              <div class="activity__item">
+                <div class="activity__item-icon activity__item-icon--motion"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="5" r="2"/><path d="M9 14l3-3 3 3"/></svg></div>
+                <div class="activity__item-text">Mouvement détecté sur <b>PIR_00</b></div>
+                <span class="activity__item-time">22:40</span>
+              </div>
+              <div class="activity__group">21:00</div>
+              <div class="activity__item">
+                <div class="activity__item-icon activity__item-icon--mode"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg></div>
+                <div class="activity__item-text">Mode <b>Lumière soir</b> activé <span class="by">par le calendrier</span></div>
+                <span class="activity__item-time">21:00</span>
+              </div>
+              <div class="activity__group">20:54</div>
+              <div class="activity__item">
+                <div class="activity__item-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/></svg></div>
+                <div class="activity__item-text"><b>Coucher du soleil</b> · phase Nuit</div>
+                <span class="activity__item-time">20:54</span>
+              </div>
+              <div class="activity__item">
+                <div class="activity__item-icon activity__item-icon--recipe"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/></svg></div>
+                <div class="activity__item-text">3 volets fermés <span class="by">par Sunset Shutters</span></div>
+                <span class="activity__item-time">20:30</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section__label" style="margin-top:3rem">Mobile · 390×844</div>
+  <div class="mob-wrap">
+    <div class="mob">
+      <!-- Status bar -->
+      <div class="mob__status">
+        <span>22:57</span>
+        <div class="mob__status-right">
+          <!-- Signal -->
+          <svg viewBox="0 0 24 24" fill="currentColor"><rect x="2" y="16" width="3" height="6" rx=".5"/><rect x="7" y="12" width="3" height="10" rx=".5"/><rect x="12" y="8" width="3" height="14" rx=".5"/><rect x="17" y="4" width="3" height="18" rx=".5"/></svg>
+          <!-- Wi-Fi -->
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M2 9a16 16 0 0 1 20 0"/><path d="M5 13a11 11 0 0 1 14 0"/><path d="M8.5 16.5a6 6 0 0 1 7 0"/><circle cx="12" cy="20" r="1.2" fill="currentColor"/></svg>
+          <!-- Battery -->
+          <svg viewBox="0 0 26 14" fill="none" stroke="currentColor" stroke-width="1.4"><rect x=".7" y=".7" width="22" height="12.6" rx="2.2"/><rect x="2.8" y="2.8" width="14" height="8.4" rx=".8" fill="currentColor" stroke="none"/><rect x="23.5" y="4.5" width="2" height="5" rx=".6" fill="currentColor" stroke="none"/></svg>
+        </div>
+      </div>
+
+      <!-- Top app bar -->
+      <div class="mob__topbar">
+        <button class="mob__burger" aria-label="Ouvrir le menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg></button>
+        <div class="mob__topbar-titles">
+          <div class="mob__topbar-title">Séjour</div>
+          <div class="mob__topbar-sub">RDC · Grange Neuve</div>
+        </div>
+        <!-- Connection status (dot only on mobile, like production) -->
+        <span class="mob__conn-dot" title="Connecté"></span>
+        <!-- Alarms (compact) -->
+        <button class="mob__alarm" aria-label="2 alertes système" title="2 alertes système">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="m21.73 18-8-14a2 2 0 0 0-3.46 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><line x1="12" y1="9" x2="12" y2="13"/><circle cx="12" cy="17" r=".5" fill="currentColor"/></svg>
+          <span>2</span>
+        </button>
+        <button class="mob__menu" aria-label="Menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="5" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="12" cy="19" r="1.5"/></svg></button>
+      </div>
+
+      <div class="mob__scroll">
+        <!-- Hero -->
+        <div class="mob__hero">
+          <div class="mob__strip">
+            <div class="mob__pill">
+              <svg class="mob__pill-icon" style="--c:var(--info-500)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M14 4v10.54a4 4 0 1 1-4 0V4a2 2 0 0 1 4 0z"/></svg>
+              <span class="mob__pill-val">21,4<span class="u">°C</span></span>
+            </div>
+            <span class="mob__strip-div"></span>
+            <div class="mob__pill">
+              <svg class="mob__pill-icon" style="--c:var(--info-500)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M12 2 7 9a6 6 0 1 0 10 0z"/></svg>
+              <span class="mob__pill-val">48<span class="u">%</span></span>
+            </div>
+            <span class="mob__strip-div"></span>
+            <div class="mob__pill">
+              <svg class="mob__pill-icon" style="--c:var(--info-500)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M2 12h2M20 12h2"/></svg>
+              <span class="mob__pill-val">334<span class="u">lx</span></span>
+            </div>
+            <span class="mob__strip-div mob__strip-div--group"></span>
+            <div class="mob__pill mob__pill--calm">
+              <svg class="mob__pill-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="5" r="2"/><path d="M9 14l3-3 3 3"/></svg>
+              <span class="mob__pill-val">Calme</span>
+              <span class="mob__pill-meta">39 min</span>
+            </div>
+            <span class="mob__strip-div"></span>
+            <div class="mob__pill mob__pill--active">
+              <svg class="mob__pill-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6M10 22h4"/></svg>
+              <span class="mob__pill-val">1<span class="u">/ 3</span></span>
+            </div>
+            <span class="mob__strip-div"></span>
+            <div class="mob__pill">
+              <svg class="mob__pill-icon" style="--c:var(--shutter-500)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/></svg>
+              <span class="mob__pill-val">3<span class="u">/ 3</span></span>
+              <span class="mob__pill-meta">· Ouvert</span>
+            </div>
+            <span class="mob__strip-div mob__strip-div--group"></span>
+            <div class="mob__pill mob__pill--alert">
+              <svg class="mob__pill-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M13 4v16h6V4M9 4v16"/></svg>
+              <span class="mob__pill-val">1 ouverte</span>
+            </div>
+          </div>
+
+          <!-- ── Global commands row: own line, left-aligned ── -->
+          <div class="mob__zcmds" aria-label="Commandes globales">
+            <button class="mob__zcmds-btn" data-cat="light" title="Tout allumer"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6M10 22h4"/></svg></button>
+            <button class="mob__zcmds-btn" data-cat="light-off" title="Tout éteindre"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M8.91 14a4.61 4.61 0 0 0-1.41-2.5A6 6 0 0 1 9.74 3.18"/><path d="M13.4 3.6a6 6 0 0 1 3.1 4.9 5 5 0 0 1-1.5 3.5c-.8.8-1.3 1.5-1.5 2.5"/><path d="M9 18h6M10 22h4"/><line x1="3" y1="3" x2="21" y2="21"/></svg></button>
+            <span class="mob__zcmds-sep"></span>
+            <button class="mob__zcmds-btn" data-cat="shutter" title="Ouvrir volets"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg></button>
+            <button class="mob__zcmds-btn" data-cat="shutter" title="Stop"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="8" width="8" height="8" rx="1.2"/></svg></button>
+            <button class="mob__zcmds-btn" data-cat="shutter" title="Fermer volets"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></button>
+          </div>
+        </div>
+
+        <!-- Équipements -->
+        <div class="mob__panel">
+          <div class="mob__panel-head">
+            <span class="mob__panel-title">Équipements</span>
+            <span class="mob__panel-sub">dans cette zone</span>
+            <span class="mob__panel-count">12</span>
+          </div>
+
+          <div class="mob__cat-head">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6M10 22h4"/></svg>
+            Éclairages
+            <span class="mob__cat-head-count">3</span>
+          </div>
+          <div class="mob__eq">
+            <div class="mob__eq-icon mob__eq-icon--light"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6M10 22h4"/></svg></div>
+            <span class="mob__eq-name">Applique x 1</span>
+            <span class="mob__eq-value">0 %</span>
+            <button class="mob__power"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+          </div>
+          <div class="mob__eq">
+            <div class="mob__eq-icon mob__eq-icon--light-on"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6M10 22h4"/></svg></div>
+            <span class="mob__eq-name">Appliques x 2</span>
+            <span class="mob__eq-value mob__eq-value--on">4 %</span>
+            <button class="mob__power mob__power--on"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+          </div>
+          <div class="mob__eq">
+            <div class="mob__eq-icon mob__eq-icon--light"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2"/></svg></div>
+            <span class="mob__eq-name">Plafonnier</span>
+            <span class="mob__eq-value">—</span>
+            <button class="mob__power"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+          </div>
+
+          <div class="mob__cat-head">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg>
+            Volets
+            <span class="mob__cat-head-count">3</span>
+          </div>
+          <div class="mob__eq">
+            <div class="mob__eq-icon mob__eq-icon--shutter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <span class="mob__eq-name">Volet gauche</span>
+            <div class="mob__shutter-grp">
+              <button class="is-active" aria-label="Ouvrir"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg></button>
+              <button aria-label="Stop"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="7" y="7" width="10" height="10" rx="1"/></svg></button>
+              <button aria-label="Fermer"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></button>
+            </div>
+          </div>
+          <div class="mob__eq">
+            <div class="mob__eq-icon mob__eq-icon--shutter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <span class="mob__eq-name">Volet centre</span>
+            <div class="mob__shutter-grp">
+              <button class="is-active" aria-label="Ouvrir"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg></button>
+              <button aria-label="Stop"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="7" y="7" width="10" height="10" rx="1"/></svg></button>
+              <button aria-label="Fermer"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></button>
+            </div>
+          </div>
+          <div class="mob__eq">
+            <div class="mob__eq-icon mob__eq-icon--shutter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <span class="mob__eq-name">Volet bureau</span>
+            <div class="mob__shutter-grp">
+              <button class="is-active" aria-label="Ouvrir"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg></button>
+              <button aria-label="Stop"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="7" y="7" width="10" height="10" rx="1"/></svg></button>
+              <button aria-label="Fermer"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></button>
+            </div>
+          </div>
+
+          <div class="mob__cat-head">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/></svg>
+            Capteurs
+            <span class="mob__cat-head-count">3</span>
+          </div>
+          <div class="mob__eq mob__eq--sensor">
+            <div class="mob__eq-icon mob__eq-icon--sensor"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1.5"/><path d="m9 20 3-6 3 6"/><path d="m6 8 6 2 6-2"/><path d="M12 10v4"/></svg></div>
+            <span class="mob__eq-name">PIRL</span>
+            <span class="mob__chip-state">RAS</span>
+          </div>
+          <div class="mob__eq mob__eq--sensor">
+            <div class="mob__eq-icon mob__eq-icon--sensor"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1.5"/><path d="m9 20 3-6 3 6"/><path d="m6 8 6 2 6-2"/><path d="M12 10v4"/></svg></div>
+            <span class="mob__eq-name">PIR_00</span>
+            <span class="mob__chip-state">RAS</span>
+          </div>
+          <div class="mob__eq mob__eq--sensor">
+            <div class="mob__eq-icon mob__eq-icon--sensor"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1.5"/><path d="m9 20 3-6 3 6"/><path d="m6 8 6 2 6-2"/><path d="M12 10v4"/></svg></div>
+            <span class="mob__eq-name">PIR_01</span>
+            <span class="mob__chip-state mob__chip-state--detected">Détecté 1m29</span>
+          </div>
+        </div>
+
+        <!-- Comportements -->
+        <div class="mob__panel">
+          <div class="mob__panel-head">
+            <span class="mob__panel-title">Comportements</span>
+            <span class="mob__panel-sub">dans cette zone</span>
+            <span class="mob__panel-count">5</span>
+          </div>
+
+          <div class="mob__cat-head">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+            Modes
+            <button class="mob__cat-head-add" title="Ajouter un mode" aria-label="Ajouter un mode">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            </button>
+          </div>
+          <div class="mob__mode">
+            <div class="mob__mode-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+              <span class="mob__mode-icon-dot mob__mode-icon-dot--on"></span>
+            </div>
+            <div class="mob__mode-main">
+              <div class="mob__mode-name">Lumière soir</div>
+              <div class="mob__mode-meta">actif depuis 1h32</div>
+            </div>
+            <span class="mob__mode-active-badge">Actif</span>
+          </div>
+          <div class="mob__mode">
+            <div class="mob__mode-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+              <span class="mob__mode-icon-dot"></span>
+            </div>
+            <div class="mob__mode-main">
+              <div class="mob__mode-name">Jour</div>
+              <div class="mob__mode-meta">06:14 → 21:00</div>
+            </div>
+            <button class="mob__mode-action">Appliquer</button>
+          </div>
+          <div class="mob__mode">
+            <div class="mob__mode-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+              <span class="mob__mode-icon-dot"></span>
+            </div>
+            <div class="mob__mode-main">
+              <div class="mob__mode-name">Nuit</div>
+              <div class="mob__mode-meta">à 00:12 (dans 1h15)</div>
+            </div>
+            <button class="mob__mode-action">Appliquer</button>
+          </div>
+
+          <div class="mob__cat-head">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-5.35c0-.46.32-.84.73-1.04a4 4 0 0 0-2.13-7.59 5 5 0 0 0-9.2 0 4 4 0 0 0-2.13 7.59c.41.2.73.58.73 1.04V21M6 17h12"/></svg>
+            Recettes
+            <button class="mob__cat-head-add" title="Ajouter une recette" aria-label="Ajouter une recette">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            </button>
+          </div>
+          <button class="mob__recipe mob__recipe--clickable" title="Voir et éditer">
+            <div class="mob__recipe-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-5.35c0-.46.32-.84.73-1.04a4 4 0 0 0-2.13-7.59 5 5 0 0 0-9.2 0 4 4 0 0 0-2.13 7.59c.41.2.73.58.73 1.04V21M6 17h12"/></svg></div>
+            <div class="mob__recipe-main">
+              <div class="mob__recipe-name">Lumière dimmable sur mouvement</div>
+            </div>
+            <div class="mob__toggle mob__toggle--on" role="switch" aria-checked="true" onclick="event.stopPropagation()"></div>
+          </button>
+          <button class="mob__recipe mob__recipe--clickable" title="Voir et éditer">
+            <div class="mob__recipe-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <div class="mob__recipe-main">
+              <div class="mob__recipe-name">Fermeture volets Nuit</div>
+            </div>
+            <div class="mob__toggle mob__toggle--on" role="switch" aria-checked="true" onclick="event.stopPropagation()"></div>
+          </button>
+        </div>
+
+        <!-- Activité -->
+        <div class="mob__panel">
+          <div class="mob__panel-head">
+            <span class="mob__panel-title">Activité</span>
+            <span class="mob__panel-sub">aujourd'hui</span>
+            <span class="mob__panel-count">6</span>
+          </div>
+          <div class="mob__act">
+            <span class="mob__act-time">22:54</span>
+            <span class="mob__act-dot mob__act-dot--shutter"></span>
+            <span class="mob__act-text">Volet bureau <b>ouvert</b> <span class="by">manuellement</span></span>
+          </div>
+          <div class="mob__act">
+            <span class="mob__act-time">21:25</span>
+            <span class="mob__act-dot mob__act-dot--light"></span>
+            <span class="mob__act-text"><b>Motion Light</b> a réglé Appliques à <b>4 %</b></span>
+          </div>
+          <div class="mob__act">
+            <span class="mob__act-time">21:18</span>
+            <span class="mob__act-dot mob__act-dot--motion"></span>
+            <span class="mob__act-text">Mouvement détecté <span class="by">capteur séjour</span></span>
+          </div>
+          <div class="mob__act">
+            <span class="mob__act-time">21:00</span>
+            <span class="mob__act-dot mob__act-dot--mode"></span>
+            <span class="mob__act-text">Mode <b>Lumière soir</b> activé <span class="by">par le calendrier</span></span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Bottom tab bar (production order: Dashboard / Maison / Énergie / Modes / Plus) -->
+      <div class="mob__tabs">
+        <div class="mob__tab">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+          <span class="mob__tab-label">Dashboard</span>
+        </div>
+        <div class="mob__tab mob__tab--active">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+          <span class="mob__tab-label">Maison</span>
+        </div>
+        <div class="mob__tab">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+          <span class="mob__tab-label">Énergie</span>
+        </div>
+        <div class="mob__tab">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+          <span class="mob__tab-label">Modes</span>
+        </div>
+        <div class="mob__tab">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+          <span class="mob__tab-label">Plus</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section__label" style="margin-top:3rem">Patterns d'équipements · couverture du design system</div>
+  <p style="max-width:1280px;margin:0 auto 1rem;padding:0 .25rem;font-size:.85rem;color:var(--n-500);line-height:1.55">Un exemple par type non encore mocké pour valider que le design system absorbe les 21 types d'équipement supportés par Sowel. Chaque ligne utilise les mêmes briques (eq__icon, eq__name, contrôles spécialisés).</p>
+
+  <div class="ptpanel">
+    <div class="panel">
+      <div class="panel__head">
+        <span class="panel__title">Équipements</span>
+        <span class="panel__sub">Maison entière · démonstration de patterns</span>
+        <button class="panel__add" aria-label="Ajouter">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        </button>
+      </div>
+
+      <!-- ─── THERMOSTAT ─── -->
+      <div class="cat-head">
+        <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4v10.54a4 4 0 1 1-4 0V4a2 2 0 0 1 4 0z"/></svg>
+        Thermostat
+      </div>
+      <div class="eq eq--therm">
+        <div class="eq__icon" style="background:var(--info-50);color:var(--info-500)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4v10.54a4 4 0 1 1-4 0V4a2 2 0 0 1 4 0z"/></svg></div>
+        <span class="eq__name">PAC</span>
+        <span class="therm-current">21,0<span class="u">°C</span> actuel</span>
+        <div class="therm-target">
+          <button class="therm-btn" aria-label="−"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg></button>
+          <span class="therm-target-val">20,0<span class="u">°</span></span>
+          <button class="therm-btn" aria-label="+"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"/></svg></button>
+        </div>
+        <button class="power-btn power-btn--on" title="Allumer"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+      </div>
+
+      <!-- ─── ÉNERGIE METERS ─── -->
+      <div class="cat-head">
+        <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+        Énergie
+      </div>
+      <div class="eq eq--energy">
+        <div class="eq__icon" style="background:var(--a-50);color:var(--a-500)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></div>
+        <span class="eq__name">Shelly Grid <span class="eq__tag">Compteur réseau</span></span>
+        <span class="energy-val">13.19<span class="u">kWh</span></span>
+        <span class="energy-meta">aujourd'hui</span>
+      </div>
+      <div class="eq eq--energy">
+        <div class="eq__icon" style="background:var(--green-50);color:var(--green-700)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"/></svg></div>
+        <span class="eq__name">Shelly Solar <span class="eq__tag eq__tag--prod">Production</span></span>
+        <span class="energy-val" style="color:var(--green-700)">5.81<span class="u">kWh</span></span>
+        <span class="energy-meta">aujourd'hui · pic 11h12</span>
+      </div>
+
+      <!-- ─── WEATHER FORECAST ─── -->
+      <div class="cat-head">
+        <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.5 19a4.5 4.5 0 1 0 0-9 6 6 0 0 0-11.6-2 5 5 0 0 0-1.4 9.8z"/></svg>
+        Météo
+      </div>
+      <div class="eq eq--forecast">
+        <div class="eq__icon" style="background:var(--info-50);color:var(--info-500)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.5 19a4.5 4.5 0 1 0 0-9 6 6 0 0 0-11.6-2 5 5 0 0 0-1.4 9.8z"/></svg></div>
+        <span class="eq__name">Prévisions Météo</span>
+        <div class="forecast-row">
+          <span class="forecast-day"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M2 12a10 10 0 1 0 14-9.1A8 8 0 1 1 2 12z"/></svg> <b>13°</b><small>min</small></span>
+          <span class="forecast-day"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.2 4.2l1.4 1.4"/></svg> <b>10°</b><small>auj</small></span>
+          <span class="forecast-day"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M16 14a4 4 0 0 1 0 7H7a5 5 0 0 1-1-9.9A7 7 0 0 1 18 8a5 5 0 0 1-2 9.8"/></svg> <b>12°</b><small>+1j</small></span>
+          <span class="forecast-day"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2"/></svg> <b>17°</b><small>+2j</small></span>
+          <span class="forecast-day"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="4"/></svg> <b>17°</b><small>+3j</small></span>
+        </div>
+      </div>
+
+      <!-- ─── REMOTES / BUTTONS ─── -->
+      <div class="cat-head">
+        <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="3"/></svg>
+        Télécommandes
+      </div>
+      <div class="eq eq--remote">
+        <div class="eq__icon" style="background:var(--n-50);color:var(--n-500)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="3"/></svg></div>
+        <span class="eq__name">Remote Marc</span>
+        <span class="chip-state chip-state--press">single 18h10</span>
+      </div>
+
+      <!-- ─── GATE (toggle command only, matches GateControl.tsx) ─── -->
+      <div class="cat-head">
+        <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 22V8a2 2 0 0 1 2-2h2v16M21 22V8a2 2 0 0 0-2-2h-2v16M9 22V4M15 22V4"/></svg>
+        Portail
+      </div>
+      <div class="eq eq--gate">
+        <div class="eq__icon" style="background:var(--green-50);color:var(--green-700)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 22V8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14M9 22V8M15 22V8"/></svg></div>
+        <span class="eq__name">Portail jardin</span>
+        <span class="chip-state" style="background:var(--green-50);color:var(--green-700)">Fermé</span>
+        <button class="gate-cmd" title="Commander le portail">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 21v-9l-4 -4l-4 4v9M14 14h6v-2a3 3 0 0 0 -3 -3l-3 0"/></svg>
+        </button>
+      </div>
+
+      <!-- ─── WATER VALVE ─── -->
+      <div class="cat-head">
+        <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2.5C8 7 5 11 5 14a7 7 0 0 0 14 0c0-3-3-7-7-11.5z"/></svg>
+        Eau
+      </div>
+      <div class="eq eq--water">
+        <div class="eq__icon" style="background:#E0F2FE;color:#0369A1"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2.5C8 7 5 11 5 14a7 7 0 0 0 14 0c0-3-3-7-7-11.5z"/></svg></div>
+        <span class="eq__name">Vanne potager</span>
+        <span class="water-val">1.2<span class="u">m³/h</span></span>
+        <span class="chip-state chip-state--on" style="background:#E0F2FE;color:#0369A1">Ouverte</span>
+        <button class="power-btn" title="Fermer"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+      </div>
+
+      <!-- ─── POOL (heat pump + cover) ─── -->
+      <div class="cat-head">
+        <svg class="cat-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12s4-2 10 0 10 0 10 0M2 18s4-2 10 0 10 0 10 0M2 6s4-2 10 0 10 0 10 0"/></svg>
+        Piscine
+      </div>
+      <div class="eq eq--therm">
+        <div class="eq__icon" style="background:#E0F2FE;color:#0369A1"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12s4-2 10 0 10 0 10 0M2 18s4-2 10 0 10 0 10 0"/></svg></div>
+        <span class="eq__name">Pompe à chaleur piscine</span>
+        <span class="therm-current">26,2<span class="u">°C</span> eau</span>
+        <div class="therm-target">
+          <button class="therm-btn" aria-label="−"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg></button>
+          <span class="therm-target-val">27,0<span class="u">°</span></span>
+          <button class="therm-btn" aria-label="+"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"/></svg></button>
+        </div>
+        <button class="power-btn power-btn--on" title="Mode chauffage"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+      </div>
+    </div>
+  </div>
+
+  <div class="notes" style="margin-top:1.25rem">
+    <h3>Couverture du design system</h3>
+    <ul>
+      <li><b>Lumières</b> <code>light_onoff</code> <code>light_dimmable</code> <code>light_color</code> — pattern icon + slider + power button (haut de page)</li>
+      <li><b>Volets</b> <code>shutter</code> + <code>gate</code> + <code>pool_cover</code> — pattern slider + state badge + segmented ↑■↓ (haut de page et Portail ci-dessus)</li>
+      <li><b>Capteurs</b> <code>sensor</code> — pattern icône + valeur + state badge (haut de page). Niveau batterie déplacé vers le monitoring batteries dédié.</li>
+      <li><b>Thermostat</b> <code>thermostat</code> <code>heater</code> <code>pool_heat_pump</code> — pattern courant + target +/- + power (ci-dessus)</li>
+      <li><b>Énergie</b> <code>energy_meter</code> <code>main_energy_meter</code> <code>energy_production_meter</code> — pattern read-only avec valeur en amber/vert (ci-dessus)</li>
+      <li><b>Météo</b> <code>weather</code> <code>weather_forecast</code> — pattern multi-valeur inline (ci-dessus)</li>
+      <li><b>Télécommandes</b> <code>button</code> + <code>switch</code> — pattern read-only avec dernier événement (ci-dessus)</li>
+      <li><b>Eau</b> <code>water_valve</code> — pattern read-only valeur + chip ouvert/fermé + power button (ci-dessus)</li>
+      <li><b>Pompes piscine</b> <code>pool_pump</code> — utilise le pattern shutter ou power-only selon le hardware</li>
+      <li><b>Médias</b> <code>media_player</code> + <code>appliance</code> — utilise le pattern icon + name + chevron (déjà mocké dans la section Multimédia)</li>
+    </ul>
+    <p style="margin-top:.65rem">Tous les patterns réutilisent les mêmes briques visuelles : <code>.eq__icon</code> tinté par catégorie, <code>.eq__name</code> truncable, plus des cellules spécifiques (slider, power-btn, shutter-grp, chip-state, battery, therm-target, energy-val, forecast-row). Aucun type d'équipement ne demande de nouveau pattern.</p>
+  </div>
+
+  <div class="section__label" style="margin-top:3rem">Modal · Édition d'une recette</div>
+  <p style="max-width:1280px;margin:0 auto 1rem;padding:0 .25rem;font-size:.85rem;color:var(--n-500);line-height:1.55">Champs alignés sur la recette <b>Lumière dimmable sur mouvement</b> en prod (équipements, délai, luminosité, seuil lux, extinction auto, interrupteurs, plages horaires). Notre ajout vs prod : la section <b>Surcharges par mode</b> permet de configurer les valeurs par mode dans le même écran — au lieu de naviguer entre la page Recette et la page Mode.</p>
+  <div class="modal-stage">
+    <div class="modal">
+      <div class="modal__head">
+        <div class="modal__head-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-5.35c0-.46.32-.84.73-1.04a4 4 0 0 0-2.13-7.59 5 5 0 0 0-9.2 0 4 4 0 0 0-2.13 7.59c.41.2.73.58.73 1.04V21M6 17h12"/></svg>
+        </div>
+        <div class="modal__head-titles">
+          <div class="modal__head-title">Lumière dimmable sur mouvement</div>
+          <div class="modal__head-sub">Recette · zone <b>Séjour</b> · pilotée par 1 mode</div>
+        </div>
+        <button class="modal__close" aria-label="Fermer"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+      </div>
+
+      <div class="modal__body">
+
+        <!-- Équipements (checklist, comme en prod) -->
+        <section class="msec">
+          <span class="msec__label">Lumières à contrôler<span class="msec__required">*</span></span>
+          <span class="msec__help">Lumières dimmables à contrôler (doivent appartenir à la zone)</span>
+          <div class="mcheck">
+            <label class="mcheck__item"><input type="checkbox" checked /> <span>Applique x 1</span></label>
+            <label class="mcheck__item"><input type="checkbox" checked /> <span>Appliques x 2</span></label>
+            <label class="mcheck__item"><input type="checkbox" /> <span>Spots</span></label>
+          </div>
+        </section>
+
+        <!-- Paramètres compact en grille 3 colonnes (aligné prod) -->
+        <section class="msec">
+          <span class="msec__label">Paramètres</span>
+          <div class="mfgrid">
+            <div class="mfield">
+              <label class="mfield__lab">Délai<span class="msec__required">*</span></label>
+              <div class="mfield__input"><input type="number" value="10" /><span class="mfield__suffix">min</span></div>
+              <span class="mfield__help">Sans mouvement avant extinction</span>
+            </div>
+            <div class="mfield">
+              <label class="mfield__lab">Luminosité</label>
+              <input type="number" value="254" min="1" max="254" />
+              <span class="mfield__help">Hors plages horaires (1-254)</span>
+            </div>
+            <div class="mfield">
+              <label class="mfield__lab">Seuil lux (max)</label>
+              <input type="number" value="2300" />
+              <span class="mfield__help">Au-dessus, les lumières ne s'allument pas</span>
+            </div>
+            <div class="mfield">
+              <label class="mfield__lab">Extinction auto<span class="mfield__lab-sub">sécurité</span></label>
+              <div class="mfield__input"><input type="number" placeholder="—" /><span class="mfield__suffix">min</span></div>
+              <span class="mfield__help">Anti-oubli — coupe même avec mouvement</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- Interrupteurs physiques -->
+        <section class="msec">
+          <span class="msec__label">Interrupteurs physiques</span>
+          <span class="msec__help">Pour allumer / éteindre manuellement</span>
+          <div class="mcheck">
+            <label class="mcheck__item"><input type="checkbox" /> <span>Switch Appliques</span></label>
+            <label class="mcheck__item"><input type="checkbox" /> <span>Switch Sonos</span></label>
+          </div>
+        </section>
+
+        <!-- Options -->
+        <section class="msec">
+          <span class="msec__label">Options</span>
+          <label class="mcheck__item"><input type="checkbox" /> <span>Inactif le jour</span></label>
+        </section>
+
+        <!-- Plages horaires (groupes avec border-left accent) -->
+        <section class="msec">
+          <span class="msec__label">Plages horaires</span>
+          <span class="msec__help">Définir des luminosités spécifiques sur certaines tranches</span>
+          <div class="mplage">
+            <div class="mplage__head">
+              <span class="mplage__title">Plage 1</span>
+              <button class="mplage__del" aria-label="Supprimer la plage"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
+            </div>
+            <div class="mplage__grid">
+              <div class="mfield">
+                <label class="mfield__lab">Début</label>
+                <input type="time" value="21:00" />
+              </div>
+              <div class="mfield">
+                <label class="mfield__lab">Fin</label>
+                <input type="time" value="08:00" />
+              </div>
+              <div class="mfield">
+                <label class="mfield__lab">Luminosité</label>
+                <input type="number" value="100" min="1" max="254" />
+              </div>
+            </div>
+          </div>
+          <div class="mplage__add-row">
+            <button class="mplage__add"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Plage 2</button>
+            <button class="mplage__add"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Plage 3</button>
+          </div>
+        </section>
+
+        <!-- Surcharges par mode (notre amélioration UX, n'existe pas en prod) -->
+        <section class="msec msec--enhance">
+          <span class="msec__label">Surcharges par mode <span class="msec__beta">amélioration UX</span></span>
+          <span class="msec__help">Quand un mode est actif, ses valeurs remplacent les paramètres globaux ci-dessus. Aujourd'hui, ces réglages sont éparpillés dans chaque page de mode.</span>
+          <div class="mover">
+            <div class="mover__row">
+              <span class="mover__dot mover__dot--on"></span>
+              <span class="mover__name">Lumière soir <span class="badge">Actif</span></span>
+              <span class="mover__val">Plage 21:00→08:00 · luminosité <b>4 %</b></span>
+              <button class="mover__edit">Modifier</button>
+            </div>
+            <div class="mover__row">
+              <span class="mover__dot"></span>
+              <span class="mover__name">Lumière jour</span>
+              <span class="mover__val">Désactivée le jour</span>
+              <button class="mover__edit">Modifier</button>
+            </div>
+            <div class="mover__row">
+              <span class="mover__dot"></span>
+              <span class="mover__name">Lumière nuit</span>
+              <span class="mover__val mover__val--off">Pas de surcharge</span>
+              <button class="mover__edit">Ajouter</button>
+            </div>
+          </div>
+        </section>
+
+      </div>
+
+      <div class="modal__foot">
+        <span class="modal__foot-status">Modifications non enregistrées</span>
+        <div class="modal__foot-actions">
+          <button class="mbtn">Annuler</button>
+          <button class="mbtn mbtn--primary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>Enregistrer</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section__label" style="margin-top:3rem">Dashboard · 1280×820</div>
+  <p style="max-width:1280px;margin:0 auto 1rem;padding:0 .25rem;font-size:.85rem;color:var(--n-500);line-height:1.55">Dashboard conforme au design system. Sidebar et topbar partagées avec la zone view. Grille 4 colonnes de widgets 273×240 px. Chaque widget réutilise les atoms (chip-state, power-btn, shutter-grp, therm-target). Le bouton « Éditer » à droite bascule en mode édition (drag, customize, delete).</p>
+
+  <div class="ui">
+    <aside class="sb">
+      <div class="sb__logo">
+        <svg viewBox="25 15 150 155" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" style="color:var(--p-500)"><path d="M100 30 L160 90 Q165 95 160 100 L160 150 Q160 158 152 158 L48 158 Q40 158 40 150 L40 100 Q35 95 40 90 Z"/></svg>
+        <b>SOWEL</b>
+      </div>
+      <div class="sb__item sb__item--active"><svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>Dashboard</div>
+      <div class="sb__item"><svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>Maison<span class="sb__chev">⌄</span></div>
+      <div class="sb__sep"></div>
+      <div class="sb__item"><svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>Modes</div>
+      <div class="sb__sep"></div>
+      <div class="sb__item"><svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>Analyse</div>
+      <div class="sb__sep"></div>
+      <div class="sb__item"><svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>Énergie</div>
+      <div class="sb__sep"></div>
+      <div class="sb__item" style="margin-top:auto"><svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2 4 7v6c0 5 3.5 9 8 10 4.5-1 8-5 8-10V7l-8-5z"/></svg>Administration</div>
+      <div class="sb__item"><svg class="sb__item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33"/></svg>Réglages</div>
+    </aside>
+
+    <div class="main">
+      <div class="topbar">
+        <div class="topbar__breadcrumb"><b>Dashboard</b></div>
+        <div class="topbar__spacer"></div>
+        <div class="topbar__chip"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>22:57:12</div>
+        <div class="topbar__chip topbar__chip--sun"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>06:14 — 20:54 <span class="topbar__chip-tag">Nuit</span></div>
+        <div class="topbar__conn topbar__conn--connected" title="Connecté"><span class="topbar__conn-dot"></span><span class="topbar__conn-lab">Connecté</span></div>
+        <div class="topbar__avatar"><div class="topbar__avatar-pic">MC</div>Marc</div>
+      </div>
+
+      <div class="dash-page">
+        <div class="dash-head">
+          <h1 class="dash-head__title">Dashboard</h1>
+          <button class="dash-head__edit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>Éditer</button>
+        </div>
+
+        <div class="dash-grid">
+
+          <!-- Portail (gate — production GateWidgetIcon, open) -->
+          <div class="widget">
+            <h3 class="widget__title">Portail</h3>
+            <div class="widget__art">
+              <svg viewBox="0 0 56 56" fill="none" style="color:var(--p-500);width:96px;height:96px">
+                <rect x="4" y="10" width="6" height="36" rx="3" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="currentColor" fill-opacity="0.06"/>
+                <circle cx="7" cy="10" r="3.5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+                <rect x="46" y="10" width="6" height="36" rx="3" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="currentColor" fill-opacity="0.06"/>
+                <circle cx="49" cy="10" r="3.5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+                <path d="M10 16 L16 20 L16 40 L10 44" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.06"/>
+                <line x1="13" y1="18" x2="13" y2="42" stroke="currentColor" stroke-width="1" stroke-opacity="0.18" stroke-linecap="round"/>
+                <path d="M46 16 L40 20 L40 40 L46 44" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.06"/>
+                <line x1="43" y1="18" x2="43" y2="42" stroke="currentColor" stroke-width="1" stroke-opacity="0.18" stroke-linecap="round"/>
+                <line x1="2" y1="48" x2="54" y2="48" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-opacity="0.1"/>
+              </svg>
+            </div>
+            <div class="widget__footer">
+              <span class="chip-state" style="background:var(--green-50);color:var(--green-700)">Ouvert</span>
+            </div>
+          </div>
+
+          <!-- Porte Garage (production GarageDoorIcon, closed) -->
+          <div class="widget">
+            <h3 class="widget__title">Porte Garage</h3>
+            <div class="widget__art">
+              <svg viewBox="0 0 56 56" fill="none" style="color:var(--p-500);width:96px;height:96px">
+                <path d="M6 16 L28 6 L50 16" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                <path d="M8 16 L8 48 L48 48 L48 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.03"/>
+                <rect x="13" y="20" width="30" height="26" rx="2" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                <line x1="13" y1="26.5" x2="43" y2="26.5" stroke="currentColor" stroke-width="1" stroke-opacity="0.18" stroke-linecap="round"/>
+                <line x1="13" y1="33" x2="43" y2="33" stroke="currentColor" stroke-width="1" stroke-opacity="0.18" stroke-linecap="round"/>
+                <line x1="13" y1="39.5" x2="43" y2="39.5" stroke="currentColor" stroke-width="1" stroke-opacity="0.18" stroke-linecap="round"/>
+                <line x1="26" y1="42" x2="30" y2="42" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-opacity="0.3"/>
+                <line x1="4" y1="48" x2="52" y2="48" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-opacity="0.12"/>
+              </svg>
+            </div>
+            <div class="widget__footer">
+              <span class="chip-state chip-state--closed">Fermé</span>
+            </div>
+          </div>
+
+          <!-- Shutter RDC (production ShutterWidgetIcon, mostly open — 2 slats) -->
+          <div class="widget">
+            <h3 class="widget__title">RDC</h3>
+            <div class="widget__art">
+              <svg viewBox="0 0 56 56" fill="none" style="color:var(--p-500);width:96px;height:96px">
+                <defs>
+                  <linearGradient id="shutter-slat-rdc" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.65"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.45"/>
+                  </linearGradient>
+                  <linearGradient id="shutter-glass-rdc" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.04"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.08"/>
+                  </linearGradient>
+                </defs>
+                <rect x="4" y="5" width="48" height="6" rx="3" fill="currentColor" opacity="0.2"/>
+                <rect x="4" y="10" width="48" height="42" rx="2" stroke="currentColor" stroke-width="1.2" fill="url(#shutter-glass-rdc)"/>
+                <line x1="28" y1="11" x2="28" y2="51" stroke="currentColor" stroke-width="0.6" opacity="0.1"/>
+                <line x1="5" y1="31" x2="51" y2="31" stroke="currentColor" stroke-width="0.6" opacity="0.1"/>
+                <rect x="6" y="12" width="44" height="4.5" rx="1" fill="url(#shutter-slat-rdc)"/>
+                <rect x="6" y="17.5" width="44" height="4.5" rx="1" fill="url(#shutter-slat-rdc)"/>
+                <rect x="6" y="17.5" width="44" height="5.5" rx="1.5" fill="currentColor" opacity="0.55"/>
+              </svg>
+            </div>
+            <div class="widget__footer">
+              <span class="chip-state" style="background:var(--green-50);color:var(--green-700)">Ouvert</span>
+              <div class="shutter-grp">
+                <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg></button>
+                <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="8" width="8" height="8" rx="1.2"/></svg></button>
+                <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Shutter Etage 1 (production ShutterWidgetIcon, fully closed — 7 slats) -->
+          <div class="widget">
+            <h3 class="widget__title">Etage 1</h3>
+            <div class="widget__art">
+              <svg viewBox="0 0 56 56" fill="none" style="color:var(--p-500);width:96px;height:96px">
+                <defs>
+                  <linearGradient id="shutter-slat-et1" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.65"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.45"/>
+                  </linearGradient>
+                  <linearGradient id="shutter-glass-et1" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.04"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.08"/>
+                  </linearGradient>
+                </defs>
+                <rect x="4" y="5" width="48" height="6" rx="3" fill="currentColor" opacity="0.2"/>
+                <rect x="4" y="10" width="48" height="42" rx="2" stroke="currentColor" stroke-width="1.2" fill="url(#shutter-glass-et1)"/>
+                <line x1="28" y1="11" x2="28" y2="51" stroke="currentColor" stroke-width="0.6" opacity="0.1"/>
+                <line x1="5" y1="31" x2="51" y2="31" stroke="currentColor" stroke-width="0.6" opacity="0.1"/>
+                <rect x="6" y="12" width="44" height="4.5" rx="1" fill="url(#shutter-slat-et1)"/>
+                <rect x="6" y="17.5" width="44" height="4.5" rx="1" fill="url(#shutter-slat-et1)"/>
+                <rect x="6" y="23" width="44" height="4.5" rx="1" fill="url(#shutter-slat-et1)"/>
+                <rect x="6" y="28.5" width="44" height="4.5" rx="1" fill="url(#shutter-slat-et1)"/>
+                <rect x="6" y="34" width="44" height="4.5" rx="1" fill="url(#shutter-slat-et1)"/>
+                <rect x="6" y="39.5" width="44" height="4.5" rx="1" fill="url(#shutter-slat-et1)"/>
+                <rect x="6" y="45" width="44" height="4.5" rx="1" fill="url(#shutter-slat-et1)"/>
+                <rect x="6" y="45" width="44" height="5.5" rx="1.5" fill="currentColor" opacity="0.55"/>
+              </svg>
+            </div>
+            <div class="widget__footer">
+              <span class="chip-state chip-state--closed">Fermé</span>
+              <div class="shutter-grp">
+                <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg></button>
+                <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="8" width="8" height="8" rx="1.2"/></svg></button>
+                <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></button>
+              </div>
+            </div>
+          </div>
+
+          <!-- PAC (production ThermometerIcon, cool — warm=false, level=0.4) -->
+          <div class="widget">
+            <h3 class="widget__title">PAC</h3>
+            <div class="widget__art">
+              <svg viewBox="0 0 56 56" fill="none" style="color:var(--p-500);width:96px;height:96px">
+                <defs>
+                  <linearGradient id="thermo-tube-pac" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.06"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.12"/>
+                  </linearGradient>
+                  <linearGradient id="thermo-fill-pac" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.2"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.4"/>
+                  </linearGradient>
+                  <clipPath id="thermo-clip-pac">
+                    <path d="M26 11 A1.5 1.5 0 0 1 30 11 L30 35.3 A7.5 7.5 0 1 1 26 35.3 Z"/>
+                  </clipPath>
+                </defs>
+                <path d="M24.5 9.5 A3.5 3.5 0 0 1 31.5 9.5 L31.5 33.7 A9 9 0 1 1 24.5 33.7 Z" fill="url(#thermo-tube-pac)" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.3"/>
+                <rect x="0" y="25" width="56" height="31" fill="url(#thermo-fill-pac)" clip-path="url(#thermo-clip-pac)"/>
+                <g stroke="currentColor" stroke-width="0.8" stroke-opacity="0.15"><line x1="33.5" y1="14" x2="36.5" y2="14"/><line x1="33.5" y1="20" x2="36.5" y2="20"/><line x1="33.5" y1="26" x2="36.5" y2="26"/><line x1="33.5" y1="32" x2="36.5" y2="32"/></g>
+              </svg>
+              <div class="widget__art-side">
+                <div class="widget__big">21,0<span class="u">°C</span></div>
+                <button class="power-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+              </div>
+            </div>
+            <div class="widget__footer">
+              <div class="therm-target">
+                <button class="therm-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg></button>
+                <span class="therm-target-val">18,0<span class="u">°C</span></span>
+                <button class="therm-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"/></svg></button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Poele (production HeaterWidgetIcon, comfort=true) -->
+          <div class="widget">
+            <h3 class="widget__title">Poêle</h3>
+            <div class="widget__art">
+              <svg viewBox="0 0 56 56" fill="none" style="color:var(--red-500);width:96px;height:96px">
+                <defs>
+                  <linearGradient id="heater-fin-poele" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.4"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.25"/>
+                  </linearGradient>
+                </defs>
+                <rect x="6" y="12" width="44" height="3" rx="1.5" fill="currentColor" opacity="0.25"/>
+                <rect x="9" y="16" width="4" height="24" rx="1" fill="url(#heater-fin-poele)"/>
+                <rect x="15" y="16" width="4" height="24" rx="1" fill="url(#heater-fin-poele)"/>
+                <rect x="21" y="16" width="4" height="24" rx="1" fill="url(#heater-fin-poele)"/>
+                <rect x="27" y="16" width="4" height="24" rx="1" fill="url(#heater-fin-poele)"/>
+                <rect x="33" y="16" width="4" height="24" rx="1" fill="url(#heater-fin-poele)"/>
+                <rect x="39" y="16" width="4" height="24" rx="1" fill="url(#heater-fin-poele)"/>
+                <rect x="45" y="16" width="4" height="24" rx="1" fill="url(#heater-fin-poele)"/>
+                <rect x="6" y="41" width="44" height="3" rx="1.5" fill="currentColor" opacity="0.25"/>
+                <rect x="10" y="44" width="3" height="4" rx="0.5" fill="currentColor" opacity="0.2"/>
+                <rect x="43" y="44" width="3" height="4" rx="0.5" fill="currentColor" opacity="0.2"/>
+                <g stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-opacity="0.25">
+                  <path d="M16 8 Q18 5 16 2" fill="none"/>
+                  <path d="M28 8 Q30 5 28 2" fill="none"/>
+                  <path d="M40 8 Q42 5 40 2" fill="none"/>
+                </g>
+              </svg>
+              <div class="widget__art-side">
+                <div class="widget__big">19,5<span class="u">°C</span></div>
+                <button class="power-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+              </div>
+            </div>
+            <div class="widget__footer">
+              <div class="therm-target">
+                <button class="therm-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg></button>
+                <span class="therm-target-val">20,0<span class="u">°C</span></span>
+                <button class="therm-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"/></svg></button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Station Météo (production MultiSensorIcon) -->
+          <div class="widget">
+            <h3 class="widget__title">Station Météo</h3>
+            <div class="widget__art">
+              <svg viewBox="0 0 56 56" fill="none" style="color:var(--p-500);width:96px;height:96px">
+                <defs>
+                  <linearGradient id="msensor-body-station" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.12"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.06"/>
+                  </linearGradient>
+                </defs>
+                <rect x="14" y="14" width="28" height="28" rx="6" fill="url(#msensor-body-station)" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.25"/>
+                <circle cx="28" cy="28" r="6" fill="currentColor" opacity="0.08" stroke="currentColor" stroke-width="1" stroke-opacity="0.2"/>
+                <circle cx="28" cy="28" r="2.5" fill="currentColor" opacity="0.25"/>
+                <path d="M38 8 Q42 14 38 20" stroke="currentColor" stroke-width="1" stroke-opacity="0.25" fill="none" stroke-linecap="round"/>
+                <path d="M42 6 Q46 13 42 19" stroke="currentColor" stroke-width="1" stroke-opacity="0.19" fill="none" stroke-linecap="round"/>
+                <path d="M46 4 Q50 12 46 18" stroke="currentColor" stroke-width="1" stroke-opacity="0.13" fill="none" stroke-linecap="round"/>
+                <circle cx="20" cy="20" r="1.5" fill="currentColor" opacity="0.3"/>
+              </svg>
+              <div class="widget__art-side" style="font-size:.78rem;color:var(--n-700);line-height:1.7">
+                <div>21,8 <span style="color:var(--n-400)">°C</span></div>
+                <div>41 <span style="color:var(--n-400)">%</span></div>
+                <div>2 <span style="color:var(--n-400)">km/h</span></div>
+                <div>65 <span style="color:var(--n-400)">%</span></div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Prévisions Météo (production Lucide Cloud, stormy variant) -->
+          <div class="widget">
+            <h3 class="widget__title">Prévisions Météo</h3>
+            <div class="widget__art">
+              <svg width="72" height="72" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" style="color:#7C3AED">
+                <path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z"/>
+                <path d="m13 14-3 5h4l-3 5"/>
+              </svg>
+              <div class="widget__art-side" style="font-size:.78rem;color:var(--n-700);line-height:1.6">
+                <div style="display:flex;align-items:baseline;gap:.25rem">
+                  <span class="widget__big" style="font-size:1.55rem">13</span>
+                  <span style="color:var(--n-400);font-size:.7rem">°C</span>
+                  <span style="color:var(--n-400);font-size:.78rem">7°</span>
+                </div>
+                <div>Stormy</div>
+                <div style="font-size:.7rem;color:var(--n-500)">💧 95 % · 💨 63 km/h</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Lave-linge (production Lucide WashingMachine, off) -->
+          <div class="widget">
+            <h3 class="widget__title">Lave-linge</h3>
+            <div class="widget__art">
+              <svg width="120" height="120" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="0.8" stroke-linecap="round" stroke-linejoin="round" style="color:var(--n-300)">
+                <path d="M3 6h3"/>
+                <path d="M17 6h.01"/>
+                <rect width="18" height="20" x="3" y="2" rx="2"/>
+                <circle cx="12" cy="13" r="5"/>
+                <path d="M12 18a2.5 2.5 0 0 0 0-5 2.5 2.5 0 0 1 0-5"/>
+              </svg>
+            </div>
+            <div class="widget__footer">
+              <span class="chip-state chip-state--off">OFF</span>
+            </div>
+          </div>
+
+          <!-- Pompe Piscine (production PoolPumpIcon, on=true) -->
+          <div class="widget">
+            <h3 class="widget__title">Pompe Piscine</h3>
+            <div class="widget__art">
+              <svg viewBox="0 0 56 56" fill="none" style="color:var(--p-500);width:96px;height:96px">
+                <path d="M14 16 L14 11 L42 11 L42 20 M42 36 L42 49 L3 49 M14 45 L14 49" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                <path d="M14 16 L14 11 L42 11 L42 20 M42 36 L42 49 L3 49 M14 45 L14 49" stroke="currentColor" stroke-opacity="0.35" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                <circle cx="28" cy="10" r="5" stroke="currentColor" stroke-width="1.6" fill="currentColor" fill-opacity="0.04"/>
+                <line x1="28" y1="10" x2="30.5" y2="7.5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+                <circle cx="28" cy="10" r="0.9" fill="currentColor"/>
+                <path d="M8 16 Q8 14 10 14 L18 14 Q20 14 20 16 L20 18 L8 18 Z" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.04" stroke-linejoin="round"/>
+                <path d="M8 18 Q5 21 5 25 L5 28 L23 28 L23 25 Q23 21 20 18 Z" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.04" stroke-linejoin="round"/>
+                <rect x="4" y="28" width="20" height="3" rx="0.5" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.06"/>
+                <path d="M5 31 L5 41 Q5 45 10 45 L18 45 Q23 45 23 41 L23 31 Z" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.12" stroke-linejoin="round"/>
+                <path d="M9 21 L9 25" stroke="currentColor" stroke-width="0.6" stroke-linecap="round" opacity="0.5"/>
+                <rect x="34" y="20" width="16" height="16" rx="1" stroke="currentColor" stroke-width="1.6" fill="currentColor" fill-opacity="0.04"/>
+                <circle cx="37" cy="23" r="0.9" fill="currentColor"/>
+                <circle cx="47" cy="23" r="0.9" fill="currentColor"/>
+                <circle cx="37" cy="33" r="0.9" fill="currentColor"/>
+                <circle cx="47" cy="33" r="0.9" fill="currentColor"/>
+              </svg>
+              <div class="widget__art-side">
+                <span class="chip-state" style="background:var(--a-50);color:var(--a-600)">ON</span>
+                <span class="widget__meta">6h 03m</span>
+              </div>
+            </div>
+            <div class="widget__footer">
+              <button class="power-btn power-btn--on"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+            </div>
+          </div>
+
+          <!-- Spot Piscine (production LightBulbIcon, on=false) -->
+          <div class="widget">
+            <h3 class="widget__title">Spot Piscine</h3>
+            <div class="widget__art">
+              <svg viewBox="0 0 56 56" fill="none" style="color:var(--p-500);width:96px;height:96px">
+                <defs>
+                  <linearGradient id="bulb-glass-spot" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.08"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.04"/>
+                  </linearGradient>
+                  <linearGradient id="bulb-base-spot" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.35"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.2"/>
+                  </linearGradient>
+                </defs>
+                <path d="M28 4C21.4 4 16 9.4 16 16c0 4.2 2.1 7.9 5.3 10.1L22 28.5v4a2 2 0 002 2h8a2 2 0 002-2v-4l.7-2.4C37.9 23.9 40 20.2 40 16c0-6.6-5.4-12-12-12z" fill="url(#bulb-glass-spot)" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.3"/>
+                <path d="M22 11c1.5-2.5 3.8-4.5 6-4.5.8 0 .6.4-.2.8-2 1.2-4 3.5-5 6.5-.3.8-.8.5-.8-2.8z" fill="currentColor" opacity="0.08"/>
+                <rect x="22" y="34.5" width="12" height="2.5" rx="1" fill="url(#bulb-base-spot)"/>
+                <rect x="23" y="38" width="10" height="2" rx="0.8" fill="url(#bulb-base-spot)" opacity="0.8"/>
+                <rect x="24" y="41" width="8" height="2" rx="1" fill="url(#bulb-base-spot)" opacity="0.6"/>
+              </svg>
+            </div>
+            <div class="widget__footer">
+              <span class="chip-state chip-state--off">OFF</span>
+              <button class="power-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+            </div>
+          </div>
+
+          <!-- Volet Piscine (production PoolCoverIcon, position=0 → fully closed, all slats) -->
+          <div class="widget">
+            <h3 class="widget__title">Volet Piscine</h3>
+            <div class="widget__art">
+              <svg viewBox="0 0 56 56" fill="none" style="color:var(--p-500);width:104px;height:104px">
+                <defs>
+                  <linearGradient id="pool-water-vp" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.04"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.08"/>
+                  </linearGradient>
+                  <linearGradient id="pool-slat-vp" x1="0" y1="0" x2="1" y2="0">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.45"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.65"/>
+                  </linearGradient>
+                </defs>
+                <rect x="3" y="12" width="50" height="32" rx="2" stroke="currentColor" stroke-width="1.2" fill="url(#pool-water-vp)"/>
+                <line x1="3" y1="28" x2="53" y2="28" stroke="currentColor" stroke-width="0.6" opacity="0.1"/>
+                <rect x="3.5"  y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="7"    y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="10.5" y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="14"   y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="17.5" y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="21"   y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="24.5" y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="28"   y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="31.5" y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="35"   y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="38.5" y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="42"   y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="45.5" y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+                <rect x="49"   y="14" width="3" height="28" rx="0.8" fill="url(#pool-slat-vp)"/>
+              </svg>
+            </div>
+            <div class="widget__footer">
+              <span class="chip-state chip-state--closed">Fermé</span>
+              <div class="shutter-grp shutter-grp--horizontal">
+                <button class="shutter-btn" title="Ouvrir"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg></button>
+                <button class="shutter-btn" title="Stop"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="8" width="8" height="8" rx="1.2"/></svg></button>
+                <button class="shutter-btn" title="Fermer"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></button>
+              </div>
+            </div>
+          </div>
+
+          <!-- PAC Piscine (production ThermometerIcon, warm=true, level=0.7 → heating/amber) -->
+          <div class="widget">
+            <h3 class="widget__title">PAC Piscine</h3>
+            <div class="widget__art">
+              <svg viewBox="0 0 56 56" fill="none" style="color:var(--a-500);width:96px;height:96px">
+                <defs>
+                  <linearGradient id="thermo-tube-pacp" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.06"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.12"/>
+                  </linearGradient>
+                  <linearGradient id="thermo-fill-pacp" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="currentColor" stop-opacity="0.45"/>
+                    <stop offset="100%" stop-color="currentColor" stop-opacity="0.7"/>
+                  </linearGradient>
+                  <clipPath id="thermo-clip-pacp">
+                    <path d="M26 11 A1.5 1.5 0 0 1 30 11 L30 35.3 A7.5 7.5 0 1 1 26 35.3 Z"/>
+                  </clipPath>
+                </defs>
+                <path d="M24.5 9.5 A3.5 3.5 0 0 1 31.5 9.5 L31.5 33.7 A9 9 0 1 1 24.5 33.7 Z" fill="url(#thermo-tube-pacp)" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.3"/>
+                <rect x="0" y="14" width="56" height="42" fill="url(#thermo-fill-pacp)" clip-path="url(#thermo-clip-pacp)"/>
+                <g stroke="currentColor" stroke-width="0.8" stroke-opacity="0.15"><line x1="33.5" y1="14" x2="36.5" y2="14"/><line x1="33.5" y1="20" x2="36.5" y2="20"/><line x1="33.5" y1="26" x2="36.5" y2="26"/><line x1="33.5" y1="32" x2="36.5" y2="32"/></g>
+              </svg>
+              <div class="widget__art-side">
+                <div class="widget__big">26,2<span class="u">°C</span></div>
+                <button class="power-btn power-btn--on"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+              </div>
+            </div>
+            <div class="widget__footer">
+              <div class="therm-target">
+                <button class="therm-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg></button>
+                <span class="therm-target-val">27,0<span class="u">°C</span></span>
+                <button class="therm-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"/></svg></button>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="notes">
+    <h3>2 palettes à comparer</h3>
+    <ul>
+      <li><b>Hybrid</b> — fond gris neutre (zinc), ocean blue, amber Sowel pour les lumières, ardoise pour les volets, sauge pour les capteurs. L'ambre reste un accent, plus une dominante.</li>
+      <li><b>Dark</b> — variante nuit : fond slate sombre, mêmes accents en versions claires. À envisager comme mode complémentaire, pas remplacement.</li>
+    </ul>
+    <h3 style="margin-top:.65rem">Ce qui reste identique entre les 2</h3>
+    <ul>
+      <li>Layout : sidebar identique, top bar, hero strip 4-cell, actions, grid 2-col avec colonne droite</li>
+      <li>3 ajouts UX : Mode actif highlight, Recipe detail card, Activity feed</li>
+      <li>Headers de catégorie tintés (couleur dérivée de chaque palette)</li>
+      <li>Indicateur ⚡ pour les équipements pilotés par recette/mode</li>
+      <li>Bouton power coloré quand allumé</li>
+    </ul>
+  </div>
+</section>
+
+<script>
+  const picker = document.getElementById('picker');
+  picker.addEventListener('click', (e) => {
+    const btn = e.target.closest('.picker__chip');
+    if (!btn) return;
+    document.documentElement.setAttribute('data-theme', btn.dataset.pick);
+    picker.querySelectorAll('.picker__chip').forEach(c => c.classList.remove('picker__chip--active'));
+    btn.classList.add('picker__chip--active');
+  });
+</script>
+
+</body>
+</html>

--- a/ui-redesign-roadmap.html
+++ b/ui-redesign-roadmap.html
@@ -1,0 +1,744 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sowel — Roadmap UI (progressive)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --p-50:#EEF5F8; --p-100:#D9E7EF; --p-500:#1A4F6E; --p-600:#144159;
+    --a-50:#FFF4D9; --a-500:#E5A23A; --a-600:#C68420;
+    --n-0:#FFFFFF; --n-25:#FAFAFA; --n-50:#F4F4F5; --n-100:#E9E9EB; --n-200:#D4D4D8;
+    --n-300:#A1A1AA; --n-400:#71717A; --n-500:#52525B; --n-600:#3F3F46; --n-700:#27272A; --n-800:#18181B;
+    --green-50:#E6F7EE; --green-500:#1FA260; --green-700:#0E6B3F;
+    --red-50:#FBE9E1; --red-500:#C7522E;
+    --shutter-500:#4F5763; --sensor-500:#4F7559; --light-500:#E5A23A;
+    --line:rgba(24,24,27,.08); --line-2:rgba(24,24,27,.14);
+  }
+  *,*::before,*::after{box-sizing:border-box}
+  html,body{margin:0;padding:0}
+  body{
+    font-family:'Inter',system-ui,sans-serif;
+    color:var(--n-700); background:var(--n-50);
+    line-height:1.55; -webkit-font-smoothing:antialiased;
+    font-feature-settings:"cv11" 1, "ss01" 1;
+  }
+
+  /* ── Layout ─── */
+  .wrap{max-width:1180px;margin:0 auto;padding:3rem 1.5rem 5rem}
+
+  /* ── Hero ─── */
+  .hero{margin-bottom:3.5rem;display:grid;grid-template-columns:1fr 1fr;gap:3rem;align-items:end}
+  .hero__eyebrow{
+    display:inline-flex;align-items:center;gap:.5rem;
+    font-size:.7rem;text-transform:uppercase;letter-spacing:.18em;
+    color:var(--a-500);font-weight:700;margin-bottom:1rem;
+  }
+  .hero__eyebrow::before{content:"";width:8px;height:8px;border-radius:50%;background:var(--a-500)}
+  .hero__title{
+    font-family:'Inter',serif;
+    font-size:3.4rem;font-weight:700;line-height:.98;letter-spacing:-.032em;
+    color:var(--n-800);margin:0 0 1.25rem;max-width:14ch;
+  }
+  .hero__title em{font-style:normal;color:var(--a-500)}
+  .hero__lead{font-size:1rem;color:var(--n-500);line-height:1.65;max-width:34rem}
+  .hero__lead b{color:var(--n-700);font-weight:600}
+
+  .hero__metrics{
+    display:grid;grid-template-columns:1fr 1fr;gap:1rem;
+    align-self:end;
+    padding:.25rem 0 .5rem;
+  }
+  .metric{
+    padding:1.1rem 1.25rem;background:var(--n-0);
+    border:1px solid var(--line);border-radius:12px;
+    display:flex;flex-direction:column;gap:.1rem;
+  }
+  .metric__val{
+    font-family:'JetBrains Mono';font-size:2.1rem;font-weight:600;
+    color:var(--n-800);letter-spacing:-.025em;line-height:1;
+    font-feature-settings:"tnum" 1;
+  }
+  .metric__val small{font-size:.55em;color:var(--n-400);font-weight:500;margin-left:.15rem}
+  .metric__lab{
+    font-size:.62rem;text-transform:uppercase;letter-spacing:.14em;
+    color:var(--n-400);font-weight:700;margin-top:.45rem;
+  }
+  .metric--accent .metric__val{color:var(--a-500)}
+
+  /* ── Philosophy callout ─── */
+  .philo{
+    margin:0 0 3.5rem;padding:1.75rem 2rem;
+    background:linear-gradient(120deg, var(--p-500), var(--p-600));
+    color:#fff;border-radius:14px;
+    display:grid;grid-template-columns:auto 1fr;gap:2rem;align-items:center;
+    overflow:hidden;position:relative;
+  }
+  .philo::after{
+    content:"";position:absolute;top:-40px;right:-40px;width:200px;height:200px;
+    background:radial-gradient(circle,var(--a-500) 0%,transparent 60%);
+    opacity:.18;
+  }
+  .philo__num{
+    font-family:'JetBrains Mono';font-size:4.5rem;font-weight:700;
+    line-height:1;letter-spacing:-.04em;
+    color:color-mix(in srgb, #fff 30%, transparent);
+    position:relative;z-index:1;
+  }
+  .philo__num em{font-style:normal;color:#fff}
+  .philo__txt{position:relative;z-index:1}
+  .philo__txt h2{font-size:1.4rem;margin:0 0 .5rem;font-weight:700;letter-spacing:-.015em}
+  .philo__txt p{font-size:.92rem;color:color-mix(in srgb, #fff 88%, transparent);margin:0;line-height:1.55}
+  .philo__txt b{color:#fff;font-weight:600}
+
+  /* ── Timeline rail (vertical line on left of phases) ─── */
+  .rail{position:relative;padding-left:3rem}
+  .rail::before{
+    content:"";position:absolute;left:1rem;top:0;bottom:0;width:2px;
+    background:linear-gradient(180deg,var(--n-200) 0%,var(--p-500) 12%,var(--a-500) 88%,var(--n-200) 100%);
+    border-radius:2px;
+  }
+
+  /* ── Phase card ─── */
+  .phase{
+    position:relative;
+    margin-bottom:2rem;
+    background:var(--n-0);border:1px solid var(--line);
+    border-radius:14px;overflow:hidden;
+    box-shadow:0 1px 2px rgba(15,42,60,.03), 0 4px 12px -6px rgba(15,42,60,.08);
+  }
+  /* Bullet on rail */
+  .phase::before{
+    content:"";position:absolute;left:-2.45rem;top:1.85rem;
+    width:18px;height:18px;border-radius:50%;
+    background:var(--n-0);border:3px solid var(--n-300);
+    z-index:1;
+  }
+  .phase--current::before{background:var(--a-500);border-color:var(--a-500);box-shadow:0 0 0 5px var(--a-50)}
+  .phase--done::before{background:var(--p-500);border-color:var(--p-500)}
+
+  .phase__head{
+    display:grid;grid-template-columns:auto 1fr auto;gap:1rem;align-items:center;
+    padding:1.1rem 1.4rem;border-bottom:1px solid var(--line);
+  }
+  .phase__num{
+    font-family:'JetBrains Mono';font-size:.78rem;font-weight:700;
+    color:var(--p-500);background:var(--p-50);
+    padding:.25rem .55rem;border-radius:var(--n-50);border-radius:6px;
+    letter-spacing:.04em;
+  }
+  .phase__title{
+    font-size:1.2rem;font-weight:700;color:var(--n-800);
+    letter-spacing:-.018em;line-height:1.2;margin:0;
+  }
+  .phase__title small{
+    display:block;font-size:.78rem;font-weight:500;color:var(--n-500);
+    letter-spacing:0;margin-top:.15rem;
+  }
+  .phase__pills{display:flex;gap:.4rem;flex-wrap:wrap}
+  .pill{
+    display:inline-flex;align-items:center;gap:.3rem;
+    padding:.25rem .55rem;border-radius:999px;
+    font-size:.68rem;font-weight:600;letter-spacing:.02em;
+  }
+  .pill__dot{width:6px;height:6px;border-radius:50%}
+  .pill--risk-low{background:var(--green-50);color:var(--green-700)}
+  .pill--risk-low .pill__dot{background:var(--green-500)}
+  .pill--risk-med{background:var(--a-50);color:var(--a-600)}
+  .pill--risk-med .pill__dot{background:var(--a-500)}
+  .pill--risk-high{background:var(--red-50);color:var(--red-500)}
+  .pill--risk-high .pill__dot{background:var(--red-500)}
+  .pill--effort{background:var(--n-100);color:var(--n-600)}
+  .pill--effort .pill__dot{background:var(--n-400)}
+
+  /* Body — 2 columns: changes list + visual diff */
+  .phase__body{display:grid;grid-template-columns:1fr 1.1fr;gap:0;align-items:stretch}
+  .phase__changes{padding:1.2rem 1.4rem;border-right:1px solid var(--line);min-width:0}
+  .phase__changes h4{
+    font-size:.65rem;text-transform:uppercase;letter-spacing:.14em;
+    color:var(--n-400);margin:0 0 .65rem;font-weight:700;
+  }
+  .phase__changes ul{margin:0 0 1.1rem;padding:0;list-style:none;display:flex;flex-direction:column;gap:.4rem}
+  .phase__changes li{
+    font-size:.85rem;color:var(--n-700);line-height:1.5;
+    padding-left:1.25rem;position:relative;
+  }
+  .phase__changes li::before{
+    content:"";position:absolute;left:0;top:.5rem;width:6px;height:6px;
+    border-radius:50%;background:var(--p-500);
+  }
+  .phase__changes li b{color:var(--n-800);font-weight:600}
+  .phase__value{
+    background:var(--n-25);border:1px solid var(--line);border-radius:8px;
+    padding:.75rem .9rem;
+    font-size:.78rem;color:var(--n-600);line-height:1.5;
+    display:flex;gap:.55rem;align-items:flex-start;
+  }
+  .phase__value svg{width:14px;height:14px;color:var(--a-500);flex:none;margin-top:.15rem}
+  .phase__value b{color:var(--n-800);font-weight:600}
+
+  .phase__visual{
+    padding:1.2rem 1.4rem;background:var(--n-25);
+    display:flex;flex-direction:column;gap:.6rem;
+  }
+  .phase__visual h4{
+    font-size:.65rem;text-transform:uppercase;letter-spacing:.14em;
+    color:var(--n-400);margin:0 0 .25rem;font-weight:700;
+  }
+  /* schematic mockup */
+  .mock{
+    background:var(--n-0);border:1px solid var(--line-2);border-radius:8px;
+    padding:.6rem;display:flex;gap:.55rem;
+    min-height:170px;font-size:9px;
+  }
+  .mock__sb{
+    width:38px;background:var(--n-0);border:1px solid var(--line);border-radius:5px;
+    display:flex;flex-direction:column;gap:3px;padding:5px 4px;
+  }
+  .mock__sb-item{height:6px;background:var(--n-100);border-radius:2px}
+  .mock__sb-item--active{background:var(--p-500)}
+  .mock__sb-sep{height:1px;background:var(--n-200);margin:2px 0}
+  .mock__main{flex:1;display:flex;flex-direction:column;gap:5px;min-width:0}
+  .mock__topbar{height:9px;background:var(--n-50);border-radius:3px;border:1px solid var(--line)}
+  .mock__hero{height:14px;background:var(--n-100);border-radius:3px}
+  .mock__strip{display:grid;grid-template-columns:repeat(4,1fr);gap:4px;height:24px}
+  .mock__strip--asym{grid-template-columns:1.5fr 1fr 1fr 1fr}
+  .mock__strip-cell{background:var(--n-50);border:1px solid var(--line);border-radius:3px}
+  .mock__strip-cell--anchor{background:linear-gradient(90deg, color-mix(in srgb, var(--p-500) 10%, transparent), transparent)}
+  .mock__strip-cell--accent{background:var(--a-50);border-color:var(--a-100)}
+  /* New: pill-row mockup (replaces grid strip for P2) */
+  .mock__pills{display:flex;align-items:center;gap:0;height:24px;padding:0 4px;background:var(--n-0);border:1px solid var(--line);border-radius:4px}
+  .mock__pill{height:12px;background:var(--n-100);border-radius:6px;margin:0 3px;flex:0 0 auto}
+  .mock__pill:nth-child(1){width:30px}
+  .mock__pill:nth-child(2){width:24px}
+  .mock__pill:nth-child(3){width:28px}
+  .mock__pill:nth-child(5){width:42px;background:color-mix(in srgb,var(--green-500) 25%,var(--n-50))}
+  .mock__pill:nth-child(6){width:24px;background:color-mix(in srgb,var(--a-500) 30%,var(--n-50))}
+  .mock__pill:nth-child(7){width:34px}
+  .mock__pill-gap{width:1px;height:18px;background:var(--n-200);margin:0 4px;flex:none}
+  .mock__pill--alert{width:34px !important;background:var(--red-500) !important}
+  .mock__grid{display:grid;grid-template-columns:1.4fr 1fr;gap:5px;flex:1;min-height:0}
+  .mock__panel{background:var(--n-25);border:1px solid var(--line);border-radius:3px;display:flex;flex-direction:column;overflow:hidden}
+  .mock__panel-head{height:7px;background:var(--p-50);border-bottom:1px solid var(--line)}
+  .mock__panel-row{height:7px;background:var(--n-0);border-top:1px solid var(--line)}
+  .mock__panel-row:first-of-type{border-top:none}
+  .mock__panel-row--on{background:color-mix(in srgb,var(--a-500) 15%,var(--n-0))}
+  .mock__panel-row--active{background:var(--green-50)}
+  .mock__panel-cat{height:5px;background:var(--n-25);border-top:1px solid var(--n-200);border-bottom:1px solid var(--n-200)}
+
+  /* Highlighter — where the phase changes things */
+  .mock__hl{
+    position:relative;
+  }
+  .mock__hl::after{
+    content:"";position:absolute;inset:-3px;
+    border:1.5px dashed var(--a-500);border-radius:5px;
+    pointer-events:none;
+    animation:phasePulse 2.6s ease-in-out infinite;
+  }
+  @keyframes phasePulse{
+    0%,100%{opacity:.55}
+    50%{opacity:.95}
+  }
+  .mock__caption{font-size:.7rem;color:var(--n-500);line-height:1.4}
+  .mock__caption b{color:var(--n-700);font-weight:600}
+
+  /* Activity feed mock (used in P3) */
+  .mock__feed{display:flex;flex-direction:column}
+  .mock__feed-row{height:8px;background:var(--n-0);border-top:1px solid var(--line);display:flex;align-items:center;gap:3px;padding:2px 4px}
+  .mock__feed-row:first-child{border-top:none}
+  .mock__feed-dot{width:4px;height:4px;border-radius:50%}
+
+  /* Modal mock (P6) */
+  .mock--modal{position:relative;padding:.85rem .6rem;justify-content:center;align-items:center}
+  .mock--modal::before{
+    content:"";position:absolute;inset:.6rem;
+    background:repeating-linear-gradient(45deg,var(--n-50),var(--n-50) 4px,var(--n-25) 4px,var(--n-25) 8px);
+    border-radius:5px;opacity:.5;
+  }
+  .mock__modal-box{
+    position:relative;width:80%;background:var(--n-0);
+    border:1px solid var(--line-2);border-radius:6px;
+    box-shadow:0 4px 12px rgba(0,0,0,.08);
+    padding:6px 8px;display:flex;flex-direction:column;gap:4px;
+  }
+  .mock__modal-head{display:flex;align-items:center;gap:4px}
+  .mock__modal-head-i{width:10px;height:10px;border-radius:2px;background:var(--p-50);border:1px solid var(--p-100)}
+  .mock__modal-head-t{flex:1;height:5px;background:var(--n-200);border-radius:2px}
+  .mock__modal-head-x{width:8px;height:8px;background:var(--n-100);border-radius:50%}
+  .mock__modal-sec{padding:3px 0;border-top:1px solid var(--line)}
+  .mock__modal-sec:first-of-type{border-top:none}
+  .mock__modal-lab{height:3px;width:35%;background:var(--n-200);border-radius:1px;margin-bottom:3px}
+  .mock__modal-row{height:5px;background:var(--n-50);border-radius:2px;margin-bottom:2px}
+  .mock__modal-foot{display:flex;justify-content:flex-end;gap:3px;padding-top:3px;border-top:1px solid var(--line)}
+  .mock__modal-btn{height:6px;width:18px;background:var(--n-100);border-radius:2px}
+  .mock__modal-btn--p{background:var(--p-500);width:24px}
+
+  /* Mobile mock (P3-4) */
+  .mock--mobile{justify-content:center;background:var(--n-50)}
+  .mock__phone{
+    width:80px;height:150px;background:var(--n-0);
+    border:1px solid var(--line-2);border-radius:10px;
+    display:flex;flex-direction:column;gap:3px;padding:6px 4px;
+    box-shadow:0 4px 10px rgba(0,0,0,.06);
+  }
+  .mock__phone-bar{height:5px;background:var(--n-100);border-radius:2px}
+  .mock__phone-hero{height:24px;background:linear-gradient(90deg, color-mix(in srgb, var(--p-500) 10%, transparent), transparent);border-radius:3px}
+  .mock__phone-actions{display:grid;grid-template-columns:1fr 1fr;gap:3px;height:14px}
+  .mock__phone-action{background:var(--n-50);border:1px solid var(--line);border-radius:2px}
+  .mock__phone-list{flex:1;background:var(--n-25);border:1px solid var(--line);border-radius:3px}
+  .mock__phone-tabs{display:flex;gap:3px;height:10px;border-top:1px solid var(--line);padding-top:3px}
+  .mock__phone-tab{flex:1;background:var(--n-100);border-radius:2px}
+  .mock__phone-tab--on{background:var(--p-500)}
+
+  /* Footer summary */
+  .end{
+    margin-top:3rem;padding:2rem 2.25rem;
+    background:var(--n-800);color:#fff;border-radius:14px;
+    display:grid;grid-template-columns:1.5fr 1fr;gap:2.5rem;align-items:center;
+  }
+  .end__title{font-size:1.55rem;font-weight:700;line-height:1.2;margin:0 0 .6rem;letter-spacing:-.02em}
+  .end__title em{font-style:normal;color:var(--a-500)}
+  .end__lead{font-size:.92rem;color:color-mix(in srgb, #fff 75%, transparent);line-height:1.6;margin:0}
+  .end__lead b{color:#fff;font-weight:600}
+  .end__cta{
+    display:inline-flex;flex-direction:column;gap:.5rem;
+  }
+  .end__btn{
+    display:inline-flex;align-items:center;justify-content:center;gap:.5rem;
+    padding:.85rem 1.25rem;
+    background:var(--a-500);color:#18170F;
+    border:none;border-radius:8px;
+    font-family:'Inter';font-size:.85rem;font-weight:600;letter-spacing:.02em;
+    cursor:pointer;text-decoration:none;
+  }
+  .end__btn:hover{background:var(--a-600);color:#fff}
+  .end__btn--ghost{
+    background:transparent;color:#fff;
+    border:1px solid color-mix(in srgb, #fff 25%, transparent);
+  }
+  .end__btn--ghost:hover{background:color-mix(in srgb, #fff 8%, transparent);color:#fff}
+
+  /* Responsive */
+  @media (max-width: 920px) {
+    .hero{grid-template-columns:1fr;gap:2rem}
+    .hero__title{font-size:2.4rem}
+    .phase__body{grid-template-columns:1fr}
+    .phase__changes{border-right:none;border-bottom:1px solid var(--line)}
+    .end{grid-template-columns:1fr}
+    .philo{grid-template-columns:1fr;text-align:left}
+    .philo__num{font-size:3rem}
+  }
+</style>
+</head>
+<body>
+
+<div class="wrap">
+
+  <!-- HERO -->
+  <header class="hero">
+    <div>
+      <div class="hero__eyebrow">Plan d'itération · Sowel UI</div>
+      <h1 class="hero__title">Pas de big bang.<br><em>Six paliers.</em></h1>
+      <p class="hero__lead">Migrer l'UI actuelle de Sowel vers la cible définie dans <b>ui-redesign-B-polished.html</b> en six itérations indépendantes. Chacune apporte une valeur livrable. Chacune est réversible si elle déplaît à l'usage.</p>
+    </div>
+    <div class="hero__metrics">
+      <div class="metric metric--accent">
+        <div class="metric__val">6</div>
+        <div class="metric__lab">Phases</div>
+      </div>
+      <div class="metric">
+        <div class="metric__val">3<small>+3</small></div>
+        <div class="metric__lab">Faible risque · puis risqué</div>
+      </div>
+      <div class="metric">
+        <div class="metric__val">∞</div>
+        <div class="metric__lab">Stop possible après chaque palier</div>
+      </div>
+      <div class="metric">
+        <div class="metric__val">1</div>
+        <div class="metric__lab">Cible finale</div>
+      </div>
+    </div>
+  </header>
+
+  <!-- PHILOSOPHY -->
+  <div class="philo">
+    <div class="philo__num"><em>0</em><span style="opacity:.4">.</span><em>1</em></div>
+    <div class="philo__txt">
+      <h2>Pourquoi par paliers, pas en une fois ?</h2>
+      <p>Une refonte d'un coup, c'est un <b>big bang qui force une décision sur tout en même temps</b> — palette, IA, motion, mobile. Or chaque choix doit pouvoir être <b>testé en isolation</b> : si la palette zinc déçoit en usage réel, on garde le hero asymétrique et l'activity feed. Six PR séparées, six rollbacks possibles.</p>
+    </div>
+  </div>
+
+  <!-- PHASES -->
+  <div class="rail">
+
+    <!-- PHASE 1 -->
+    <article class="phase">
+      <div class="phase__head">
+        <span class="phase__num">P1</span>
+        <h3 class="phase__title">Fondations typographiques<small>Aucune surface ne change. Tout devient plus lisible.</small></h3>
+        <div class="phase__pills">
+          <span class="pill pill--risk-low"><span class="pill__dot"></span>Risque nul</span>
+          <span class="pill pill--effort"><span class="pill__dot"></span>~3 j</span>
+        </div>
+      </div>
+      <div class="phase__body">
+        <div class="phase__changes">
+          <h4>Ce qui change</h4>
+          <ul>
+            <li><b>Tabular numbers</b> partout (chiffres alignés colonne, plus de saut visuel quand "1/3" devient "10/12")</li>
+            <li><b>Hiérarchie typo</b> : <code>titre</code> en plus gros et tracking négatif, <code>label</code> en uppercase tiny, <code>valeur</code> en mono</li>
+            <li><b>Sidebar : séparateurs horizontaux</b> autour de Modes / Analyse / Énergie</li>
+            <li><b>Icônes nav harmonisées</b> (bar-chart pour Analyse, zap pour Énergie)</li>
+          </ul>
+          <div class="phase__value">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+            <div><b>Valeur immédiate</b> : l'UI prend l'air d'un produit calibré sans changer aucun comportement. Aucune formation utilisateur.</div>
+          </div>
+        </div>
+        <div class="phase__visual">
+          <h4>Mockup schématique</h4>
+          <div class="mock">
+            <div class="mock__sb">
+              <div class="mock__sb-item"></div>
+              <div class="mock__sb-item mock__sb-item--active"></div>
+              <div class="mock__sb-item"></div>
+              <div class="mock__sb-sep mock__hl"></div>
+              <div class="mock__sb-item"></div>
+              <div class="mock__sb-sep mock__hl"></div>
+              <div class="mock__sb-item"></div>
+              <div class="mock__sb-sep mock__hl"></div>
+              <div class="mock__sb-item"></div>
+            </div>
+            <div class="mock__main">
+              <div class="mock__topbar"></div>
+              <div class="mock__hero mock__hl"></div>
+              <div class="mock__strip">
+                <div class="mock__strip-cell"></div>
+                <div class="mock__strip-cell"></div>
+                <div class="mock__strip-cell"></div>
+                <div class="mock__strip-cell"></div>
+              </div>
+              <div class="mock__grid">
+                <div class="mock__panel"><div class="mock__panel-head"></div><div class="mock__panel-row"></div><div class="mock__panel-row"></div><div class="mock__panel-row"></div></div>
+                <div class="mock__panel"><div class="mock__panel-head"></div><div class="mock__panel-row"></div><div class="mock__panel-row"></div></div>
+              </div>
+            </div>
+          </div>
+          <div class="mock__caption">Pointillés ambre = zones modifiées. <b>Le titre</b> respire, <b>la sidebar</b> respire.</div>
+        </div>
+      </div>
+    </article>
+
+    <!-- PHASE 2 -->
+    <article class="phase">
+      <div class="phase__head">
+        <span class="phase__num">P2</span>
+        <h3 class="phase__title">Strip pills honnête + alertes<small>Pattern aligné prod, conditionnel, avec section alertes confidente.</small></h3>
+        <div class="phase__pills">
+          <span class="pill pill--risk-low"><span class="pill__dot"></span>Risque faible</span>
+          <span class="pill pill--effort"><span class="pill__dot"></span>~3 j</span>
+        </div>
+      </div>
+      <div class="phase__body">
+        <div class="phase__changes">
+          <h4>Ce qui change</h4>
+          <ul>
+            <li>La strip devient une <b>rangée de pills à largeur contenu</b> séparées par 1px (vs grille 4 cellules égales)</li>
+            <li><b>Conditionnel</b> : chaque pill ne se rend que si la donnée existe (pas de lux ? pas de pill lux)</li>
+            <li><b>3 groupes</b> faiblement séparés : capteurs ambiants (°C, %, lx) → compteurs (motion, lumières, volets, eau) → <b>alertes (porte ouverte, fumée, fuite)</b></li>
+            <li>Pills d'alerte avec fond rouge + dot pulsant — <b>impossibles à manquer</b></li>
+            <li>Sparklines inline sur les capteurs ambiants (history InfluxDB)</li>
+            <li><b>Suppression du badge mode</b> à côté du titre Séjour</li>
+          </ul>
+          <div class="phase__value">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+            <div><b>Valeur immédiate</b> : la strip dit la vérité sur la zone. Une porte oubliée ouverte saute aux yeux dès qu'on entre dans la zone — pas besoin de scroller la liste des équipements.</div>
+          </div>
+        </div>
+        <div class="phase__visual">
+          <h4>Pattern aligné prod</h4>
+          <div class="mock">
+            <div class="mock__sb">
+              <div class="mock__sb-item"></div>
+              <div class="mock__sb-item mock__sb-item--active"></div>
+              <div class="mock__sb-item"></div>
+            </div>
+            <div class="mock__main">
+              <div class="mock__topbar"></div>
+              <div class="mock__hero"></div>
+              <div class="mock__pills mock__hl">
+                <span class="mock__pill"></span>
+                <span class="mock__pill"></span>
+                <span class="mock__pill"></span>
+                <span class="mock__pill-gap"></span>
+                <span class="mock__pill"></span>
+                <span class="mock__pill"></span>
+                <span class="mock__pill"></span>
+                <span class="mock__pill-gap"></span>
+                <span class="mock__pill mock__pill--alert"></span>
+              </div>
+              <div class="mock__grid">
+                <div class="mock__panel"><div class="mock__panel-head"></div><div class="mock__panel-row"></div><div class="mock__panel-row"></div><div class="mock__panel-row"></div></div>
+                <div class="mock__panel"><div class="mock__panel-head"></div><div class="mock__panel-row"></div><div class="mock__panel-row"></div></div>
+              </div>
+            </div>
+          </div>
+          <div class="mock__caption">Pills variable-width, 3 groupes, alerte en rouge à droite.</div>
+        </div>
+      </div>
+    </article>
+
+    <!-- PHASE 3 -->
+    <article class="phase">
+      <div class="phase__head">
+        <span class="phase__num">P3</span>
+        <h3 class="phase__title">Activity feed<small>La colonne droite vit. On comprend ce qui se passe dans la zone.</small></h3>
+        <div class="phase__pills">
+          <span class="pill pill--risk-low"><span class="pill__dot"></span>Risque faible</span>
+          <span class="pill pill--effort"><span class="pill__dot"></span>~5 j</span>
+        </div>
+      </div>
+      <div class="phase__body">
+        <div class="phase__changes">
+          <h4>Ce qui change</h4>
+          <ul>
+            <li>Nouvelle <b>colonne droite</b> avec un panel "Activité" (4-6 events récents de la zone)</li>
+            <li>Pastilles colorées par type d'event (mode, lumière, mouvement, volet)</li>
+            <li>Source d'event lisible : "par le calendrier", "par Motion Light", "par Marc"</li>
+            <li>Sur mobile, l'activity vit en bas du scroll</li>
+          </ul>
+          <div class="phase__value">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+            <div><b>Valeur immédiate</b> : on n'a plus besoin de chercher dans les logs pour comprendre "pourquoi cette lumière s'est allumée". <b>Premier pas vers la prédictibilité.</b></div>
+          </div>
+        </div>
+        <div class="phase__visual">
+          <h4>La nouvelle colonne</h4>
+          <div class="mock">
+            <div class="mock__sb">
+              <div class="mock__sb-item"></div>
+              <div class="mock__sb-item mock__sb-item--active"></div>
+              <div class="mock__sb-item"></div>
+            </div>
+            <div class="mock__main">
+              <div class="mock__topbar"></div>
+              <div class="mock__hero"></div>
+              <div class="mock__strip mock__strip--asym">
+                <div class="mock__strip-cell mock__strip-cell--anchor"></div>
+                <div class="mock__strip-cell"></div>
+                <div class="mock__strip-cell"></div>
+                <div class="mock__strip-cell"></div>
+              </div>
+              <div class="mock__grid">
+                <div class="mock__panel"><div class="mock__panel-head"></div><div class="mock__panel-row"></div><div class="mock__panel-row"></div><div class="mock__panel-row"></div></div>
+                <div class="mock__panel mock__hl">
+                  <div class="mock__panel-head"></div>
+                  <div class="mock__feed">
+                    <div class="mock__feed-row"><span class="mock__feed-dot" style="background:var(--p-500)"></span><span style="flex:1;height:3px;background:var(--n-100);border-radius:1px"></span></div>
+                    <div class="mock__feed-row"><span class="mock__feed-dot" style="background:var(--a-500)"></span><span style="flex:1;height:3px;background:var(--n-100);border-radius:1px"></span></div>
+                    <div class="mock__feed-row"><span class="mock__feed-dot" style="background:var(--sensor-500)"></span><span style="flex:1;height:3px;background:var(--n-100);border-radius:1px"></span></div>
+                    <div class="mock__feed-row"><span class="mock__feed-dot" style="background:var(--shutter-500)"></span><span style="flex:1;height:3px;background:var(--n-100);border-radius:1px"></span></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="mock__caption">Le feed Activité pose les fondations de tous les futurs gains "temporels".</div>
+        </div>
+      </div>
+    </article>
+
+    <!-- PHASE 4 -->
+    <article class="phase phase--current">
+      <div class="phase__head">
+        <span class="phase__num">P4</span>
+        <h3 class="phase__title">Palette Hybrid<small>Le warm cream cède la place au zinc neutre. L'ambre devient un accent réservé.</small></h3>
+        <div class="phase__pills">
+          <span class="pill pill--risk-med"><span class="pill__dot"></span>Risque moyen</span>
+          <span class="pill pill--effort"><span class="pill__dot"></span>~4 j + flag</span>
+        </div>
+      </div>
+      <div class="phase__body">
+        <div class="phase__changes">
+          <h4>Ce qui change</h4>
+          <ul>
+            <li>Fond passe de cream <code>#F7F5F0</code> à zinc <code>#F4F4F5</code> (neutre)</li>
+            <li>L'<b>ambre Sowel devient un accent</b>, plus une dominante — il ne s'utilise que pour : icône de lumière allumée, slider lumière, bouton power-on</li>
+            <li>Capteurs en sauge (vert grisé), volets en ardoise — non-bleu pour éviter la confusion avec le primary</li>
+            <li>Mode <b>Dark</b> disponible en option (palette nuit complète)</li>
+          </ul>
+          <div class="phase__value">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+            <div><b>Valeur immédiate</b> : l'UI a l'air de 2026, plus de 2018. Toggle <code>palette</code> dans les réglages permet de rollback per-user.</div>
+          </div>
+        </div>
+        <div class="phase__visual">
+          <h4>Mobile en parallèle possible</h4>
+          <div class="mock mock--mobile">
+            <div class="mock__phone">
+              <div class="mock__phone-bar"></div>
+              <div class="mock__phone-bar" style="background:var(--p-50)"></div>
+              <div class="mock__phone-hero mock__hl"></div>
+              <div class="mock__phone-actions">
+                <div class="mock__phone-action"></div>
+                <div class="mock__phone-action"></div>
+                <div class="mock__phone-action"></div>
+                <div class="mock__phone-action"></div>
+              </div>
+              <div class="mock__phone-list"></div>
+              <div class="mock__phone-tabs">
+                <div class="mock__phone-tab mock__phone-tab--on"></div>
+                <div class="mock__phone-tab"></div>
+                <div class="mock__phone-tab"></div>
+                <div class="mock__phone-tab"></div>
+                <div class="mock__phone-tab"></div>
+              </div>
+            </div>
+          </div>
+          <div class="mock__caption">Palette + version mobile peuvent shipper ensemble (même design system).</div>
+        </div>
+      </div>
+    </article>
+
+    <!-- PHASE 5 -->
+    <article class="phase">
+      <div class="phase__head">
+        <span class="phase__num">P5</span>
+        <h3 class="phase__title">Panel Comportements<small>Modes + Recettes fusionnés. Le lien mode↔recette devient visible.</small></h3>
+        <div class="phase__pills">
+          <span class="pill pill--risk-med"><span class="pill__dot"></span>Risque moyen</span>
+          <span class="pill pill--effort"><span class="pill__dot"></span>~7 j</span>
+        </div>
+      </div>
+      <div class="phase__body">
+        <div class="phase__changes">
+          <h4>Ce qui change</h4>
+          <ul>
+            <li>Un seul panel <b>Comportements</b> avec deux sous-catégories : <b>Modes</b> et <b>Recettes</b></li>
+            <li>Mode actif marqué d'un badge "Actif" + dot pulsant vert</li>
+            <li>Recette compacte sur 1 ligne : nom · params (avec petits dots verts indiquant les valeurs réglées par un mode)</li>
+            <li>Hiérarchie visuelle : panel head bleu pâle (catégorie mère), sous-cats neutres claires</li>
+          </ul>
+          <div class="phase__value">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+            <div><b>Valeur immédiate</b> : on comprend enfin <b>"qui pilote quoi"</b>. La confusion mode↔recette de la prod disparaît.</div>
+          </div>
+        </div>
+        <div class="phase__visual">
+          <h4>Le panel restructuré</h4>
+          <div class="mock">
+            <div class="mock__sb">
+              <div class="mock__sb-item"></div>
+              <div class="mock__sb-item mock__sb-item--active"></div>
+              <div class="mock__sb-item"></div>
+            </div>
+            <div class="mock__main">
+              <div class="mock__topbar"></div>
+              <div class="mock__hero"></div>
+              <div class="mock__strip mock__strip--asym">
+                <div class="mock__strip-cell mock__strip-cell--anchor"></div>
+                <div class="mock__strip-cell"></div>
+                <div class="mock__strip-cell"></div>
+                <div class="mock__strip-cell"></div>
+              </div>
+              <div class="mock__grid">
+                <div class="mock__panel"><div class="mock__panel-head"></div><div class="mock__panel-row"></div><div class="mock__panel-row mock__panel-row--on"></div><div class="mock__panel-row"></div></div>
+                <div class="mock__panel mock__hl">
+                  <div class="mock__panel-head"></div>
+                  <div class="mock__panel-cat"></div>
+                  <div class="mock__panel-row"></div>
+                  <div class="mock__panel-row mock__panel-row--active"></div>
+                  <div class="mock__panel-cat"></div>
+                  <div class="mock__panel-row"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="mock__caption">2 sous-cats dans un seul panel. La rangée verte = mode actif.</div>
+        </div>
+      </div>
+    </article>
+
+    <!-- PHASE 6 -->
+    <article class="phase">
+      <div class="phase__head">
+        <span class="phase__num">P6</span>
+        <h3 class="phase__title">Modal config recette<small>Édition d'une recette + ses surcharges par mode en un seul écran.</small></h3>
+        <div class="phase__pills">
+          <span class="pill pill--risk-high"><span class="pill__dot"></span>Risque élevé</span>
+          <span class="pill pill--effort"><span class="pill__dot"></span>~10 j</span>
+        </div>
+      </div>
+      <div class="phase__body">
+        <div class="phase__changes">
+          <h4>Ce qui change</h4>
+          <ul>
+            <li>Click sur une recette dans le panel Comportements ouvre un <b>overlay modal</b> dédié</li>
+            <li>4 sections : Équipements pilotés (chips), Paramètres globaux (form), <b>Surcharges par mode</b> (table avec valeur per-mode), Déclencheurs (cards)</li>
+            <li>Le footer indique "Modifications non enregistrées" + boutons Annuler / Enregistrer</li>
+            <li>Permet de supprimer le double aller-retour <code>Admin > Modes</code> ↔ <code>Admin > Recettes</code></li>
+          </ul>
+          <div class="phase__value">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+            <div><b>Valeur livrée</b> : config sans changer d'écran. Risque élevé car on touche au modèle existant — à valider en interne avant ship.</div>
+          </div>
+        </div>
+        <div class="phase__visual">
+          <h4>L'overlay au centre</h4>
+          <div class="mock mock--modal">
+            <div class="mock__modal-box mock__hl">
+              <div class="mock__modal-head">
+                <span class="mock__modal-head-i"></span>
+                <span class="mock__modal-head-t"></span>
+                <span class="mock__modal-head-x"></span>
+              </div>
+              <div class="mock__modal-sec">
+                <div class="mock__modal-lab"></div>
+                <div class="mock__modal-row" style="height:8px;background:var(--p-50)"></div>
+              </div>
+              <div class="mock__modal-sec">
+                <div class="mock__modal-lab"></div>
+                <div class="mock__modal-row"></div>
+                <div class="mock__modal-row"></div>
+                <div class="mock__modal-row"></div>
+              </div>
+              <div class="mock__modal-sec">
+                <div class="mock__modal-lab" style="background:var(--green-500)"></div>
+                <div class="mock__modal-row"></div>
+                <div class="mock__modal-row"></div>
+              </div>
+              <div class="mock__modal-foot">
+                <span class="mock__modal-btn"></span>
+                <span class="mock__modal-btn mock__modal-btn--p"></span>
+              </div>
+            </div>
+          </div>
+          <div class="mock__caption">Modal centrée avec backdrop hatchée. Une seule porte d'entrée pour <b>tout configurer</b>.</div>
+        </div>
+      </div>
+    </article>
+
+  </div>
+
+  <!-- END -->
+  <div class="end">
+    <div>
+      <h2 class="end__title">À l'arrivée du dernier palier :<br>l'UI cible <em>polished.html</em>.</h2>
+      <p class="end__lead">Chaque phase ci-dessus correspond à <b>une PR isolée</b>, livrée derrière un feature flag si nécessaire. La cible n'est pas figée : si une étape révèle un meilleur chemin, on l'intègre. La cible est un point de convergence, pas un cahier des charges.</p>
+    </div>
+    <div class="end__cta">
+      <a class="end__btn" href="ui-redesign-B-polished.html">Voir la cible polished →</a>
+      <a class="end__btn end__btn--ghost" href="https://app.sowel.org">Voir la prod actuelle →</a>
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/ui-redesign-zone-view.html
+++ b/ui-redesign-zone-view.html
@@ -1,0 +1,2175 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sowel — UI redesign proposals (Zone view)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --primary: #1A4F6E;
+    --primary-2: #246588;
+    --primary-hover: #13405A;
+    --primary-light: #E6F0F6;
+    --primary-tint: #F2F7FB;
+    --accent: #D4963F;
+    --accent-hover: #BB8232;
+    --accent-light: #FCF1E0;
+    --cream: #FAF6EE;
+    --bg: #F5F2EC;
+    --surface: #FFFFFF;
+    --ink: #0F2A3C;
+    --ink-2: #4A6478;
+    --ink-3: #8AA1B2;
+    --line: rgba(15,42,60,.10);
+    --line-2: rgba(15,42,60,.18);
+    --green: #2BAA68;
+    --green-light: #E6F5EC;
+    --red: #C7522E;
+    --amber: #D4963F;
+    --amber-light: #FCF1E0;
+    --shutter: #5C7A9A;
+    --shutter-light: #E6EDF4;
+    --sensor: #6B7E8E;
+    --shadow-sm: 0 1px 3px rgba(15,42,60,.06);
+    --shadow-md: 0 6px 24px -8px rgba(26,79,110,.18);
+    --shadow-lg: 0 30px 80px -20px rgba(26,79,110,.35), 0 8px 30px -6px rgba(26,79,110,.18);
+    --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+    --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: var(--font-body);
+    color: var(--ink);
+    background: var(--bg);
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Sticky variant nav */
+  .nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: flex;
+    gap: 0;
+    padding: .55rem 1.25rem;
+    background: rgba(255,255,255,0.94);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--line);
+    font-size: .82rem;
+  }
+  .nav__brand {
+    font-weight: 700;
+    color: var(--primary);
+    margin-right: auto;
+    letter-spacing: .04em;
+  }
+  .nav a {
+    padding: .35rem .8rem;
+    color: var(--ink-2);
+    text-decoration: none;
+    border-radius: 4px;
+  }
+  .nav a:hover { background: var(--primary-light); color: var(--primary); }
+
+  /* Section wrapper */
+  .variant {
+    padding: 3.5rem 1.5rem 4rem;
+    border-bottom: 1px solid var(--line);
+  }
+  .variant__head {
+    max-width: 1280px;
+    margin: 0 auto 1.5rem;
+  }
+  .variant__tag {
+    display: inline-flex;
+    align-items: center;
+    gap: .5rem;
+    padding: .3rem .8rem;
+    background: var(--ink);
+    color: white;
+    border-radius: 4px;
+    font-size: .7rem;
+    font-weight: 600;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    margin-bottom: .75rem;
+  }
+  .variant__tag span:last-child { opacity: .55; font-weight: 500; }
+  .variant__title { font-size: 1.5rem; font-weight: 700; margin: 0 0 .35rem; color: var(--ink); }
+  .variant__sub { color: var(--ink-2); margin: 0; font-size: .95rem; max-width: 720px; }
+
+  /* Shared product chrome wrapper */
+  .ui {
+    max-width: 1280px;
+    margin: 0 auto;
+    background: var(--surface);
+    border-radius: 14px;
+    box-shadow: var(--shadow-lg);
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    min-height: 720px;
+  }
+
+  /* Sidebar (shared, slightly different states per variant) */
+  .sb {
+    background: var(--surface);
+    border-right: 1px solid var(--line);
+    padding: 1.25rem 0;
+    font-size: .82rem;
+  }
+  .sb__logo {
+    display: flex; align-items: center; gap: .5rem;
+    padding: 0 1.25rem 1.25rem;
+    border-bottom: 1px solid var(--line);
+    margin-bottom: 1rem;
+  }
+  .sb__logo svg { width: 28px; height: 28px; }
+  .sb__logo b { font-weight: 700; letter-spacing: .1em; font-size: .9rem; color: var(--primary); }
+  .sb__group {
+    padding: .25rem .75rem;
+    margin-bottom: .25rem;
+  }
+  .sb__item {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .5rem .75rem;
+    border-radius: 6px;
+    color: var(--ink-2);
+    cursor: pointer;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    font-size: .72rem;
+  }
+  .sb__item--active { background: var(--primary-light); color: var(--primary); font-weight: 600; }
+  .sb__sub {
+    display: flex; flex-direction: column;
+    margin-left: 1rem;
+  }
+  .sb__sub-item {
+    padding: .35rem .75rem;
+    border-radius: 6px;
+    color: var(--ink-2);
+    font-size: .8rem;
+    cursor: pointer;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+  .sb__sub-item:hover { background: var(--primary-light); }
+  .sb__sub-item--active {
+    background: var(--primary);
+    color: white;
+    font-weight: 600;
+  }
+  .sb__chev { margin-left: auto; opacity: .55; font-size: .65rem; }
+
+  /* Main area common */
+  .main {
+    padding: 1.5rem 2rem 2rem;
+    background: var(--bg);
+    overflow-y: auto;
+  }
+
+  /* ============================================================ */
+  /* VARIANT A — Glanceable                                       */
+  /* ============================================================ */
+  .vA__topbar {
+    display: flex; align-items: center; gap: 1rem;
+    padding-bottom: 1.25rem;
+    margin-bottom: 1.5rem;
+    border-bottom: 1px solid var(--line);
+  }
+  .vA__breadcrumb {
+    font-size: .8rem;
+    color: var(--ink-3);
+    margin-right: auto;
+  }
+  .vA__breadcrumb b { color: var(--ink); font-weight: 600; }
+  .vA__clock {
+    display: inline-flex; align-items: center; gap: .4rem;
+    padding: .35rem .7rem;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    font-family: var(--font-mono);
+    font-size: .78rem;
+  }
+  .vA__sun {
+    display: inline-flex; align-items: center; gap: .4rem;
+    padding: .35rem .7rem;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    font-size: .78rem;
+    color: var(--ink-2);
+  }
+  .vA__sun b { color: var(--ink); font-weight: 600; }
+
+  /* Big zone hero card */
+  .vA__hero {
+    background: linear-gradient(135deg, var(--primary) 0%, var(--primary-2) 100%);
+    color: white;
+    border-radius: 16px;
+    padding: 1.75rem 1.75rem 1.5rem;
+    margin-bottom: 1.25rem;
+    position: relative;
+    overflow: hidden;
+  }
+  .vA__hero::after {
+    content: "";
+    position: absolute; top: -50%; right: -10%;
+    width: 60%; height: 200%;
+    background: radial-gradient(circle, rgba(212,150,63,.18) 0%, transparent 60%);
+    pointer-events: none;
+  }
+  .vA__zone-title {
+    display: flex; align-items: baseline; gap: .8rem;
+    margin-bottom: .25rem;
+  }
+  .vA__zone-name { font-size: 1.85rem; font-weight: 800; letter-spacing: -.02em; }
+  .vA__zone-status {
+    font-size: .75rem;
+    background: rgba(255,255,255,.18);
+    padding: .25rem .65rem;
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: .04em;
+  }
+  .vA__zone-status::before {
+    content: "●";
+    color: var(--green);
+    margin-right: .35rem;
+  }
+  .vA__zone-sub { font-size: .85rem; color: rgba(255,255,255,.75); margin-bottom: 1.2rem; }
+  .vA__metrics {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    position: relative; z-index: 1;
+  }
+  .vA__metric {
+    background: rgba(255,255,255,.10);
+    padding: .85rem 1rem;
+    border-radius: 10px;
+    backdrop-filter: blur(4px);
+  }
+  .vA__metric-label {
+    font-size: .62rem;
+    text-transform: uppercase;
+    letter-spacing: .12em;
+    color: rgba(255,255,255,.65);
+    margin-bottom: .35rem;
+    display: flex; align-items: center; gap: .35rem;
+  }
+  .vA__metric-value {
+    font-family: var(--font-mono);
+    font-size: 1.45rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+  .vA__metric-value .u { font-size: .8rem; opacity: .75; margin-left: 2px; }
+  .vA__metric-spark {
+    width: 100%; height: 18px;
+    margin-top: .35rem;
+  }
+  .vA__metric-foot {
+    font-size: .68rem;
+    color: rgba(255,255,255,.65);
+    margin-top: .35rem;
+  }
+  .vA__metric-foot b { color: white; font-weight: 600; }
+
+  .vA__actions {
+    display: flex; flex-wrap: wrap; gap: .5rem;
+    margin-bottom: 1.5rem;
+  }
+  .vA__action {
+    display: inline-flex; align-items: center; gap: .4rem;
+    padding: .55rem .9rem;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    font-size: .82rem;
+    font-weight: 500;
+    color: var(--ink);
+    cursor: pointer;
+    transition: all 120ms;
+  }
+  .vA__action:hover { border-color: var(--primary); color: var(--primary); }
+  .vA__action svg { width: 14px; height: 14px; opacity: .65; }
+
+  /* Equipment tiles */
+  .vA__section-title {
+    display: flex; align-items: center; gap: .6rem;
+    font-size: .68rem;
+    text-transform: uppercase;
+    letter-spacing: .14em;
+    color: var(--ink-3);
+    font-weight: 700;
+    margin: 1.75rem 0 .85rem;
+  }
+  .vA__section-title-count {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 1px 8px;
+    font-size: .68rem;
+    color: var(--ink-2);
+    font-family: var(--font-mono);
+  }
+
+  .vA__tiles {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: .85rem;
+  }
+  .vA__tile {
+    background: var(--surface);
+    border-radius: 12px;
+    padding: 1rem 1.1rem;
+    border: 1px solid var(--line);
+    transition: all 120ms;
+    cursor: pointer;
+  }
+  .vA__tile:hover { box-shadow: var(--shadow-md); border-color: var(--line-2); }
+  .vA__tile--on { background: linear-gradient(135deg, #FFF8EB 0%, var(--amber-light) 100%); border-color: rgba(212,150,63,.3); }
+  .vA__tile--shutter { background: linear-gradient(135deg, #F7F9FC 0%, var(--shutter-light) 100%); border-color: rgba(92,122,154,.2); }
+  .vA__tile-head {
+    display: flex; align-items: flex-start; justify-content: space-between;
+    gap: .5rem;
+    margin-bottom: .9rem;
+  }
+  .vA__tile-icon {
+    width: 32px; height: 32px;
+    border-radius: 8px;
+    background: var(--primary-light);
+    color: var(--primary);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .vA__tile--on .vA__tile-icon { background: var(--amber); color: white; }
+  .vA__tile--shutter .vA__tile-icon { background: var(--shutter); color: white; }
+  .vA__tile-icon svg { width: 18px; height: 18px; }
+  .vA__tile-state {
+    font-size: .68rem;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--primary-light);
+    color: var(--primary);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+  }
+  .vA__tile-state--off { background: rgba(0,0,0,.05); color: var(--ink-3); }
+  .vA__tile-state--on { background: var(--amber); color: white; }
+  .vA__tile-state--closed { background: var(--shutter); color: white; }
+  .vA__tile-name {
+    font-weight: 600;
+    font-size: .92rem;
+    margin-bottom: .2rem;
+    color: var(--ink);
+  }
+  .vA__tile-value {
+    font-family: var(--font-mono);
+    font-size: .85rem;
+    color: var(--ink-2);
+  }
+  .vA__tile-slider {
+    width: 100%; height: 4px;
+    background: rgba(0,0,0,.06);
+    border-radius: 999px;
+    margin-top: .75rem;
+    overflow: hidden;
+  }
+  .vA__tile-slider-fill {
+    height: 100%;
+    background: var(--amber);
+    border-radius: 999px;
+  }
+
+  /* Modes / Recipes row */
+  .vA__behaviors {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-top: 1.5rem;
+  }
+  .vA__panel {
+    background: var(--surface);
+    border-radius: 12px;
+    padding: 1rem 1.15rem 1.15rem;
+    border: 1px solid var(--line);
+  }
+  .vA__panel-head {
+    display: flex; align-items: center; gap: .55rem;
+    margin-bottom: .85rem;
+  }
+  .vA__panel-title {
+    font-size: .72rem;
+    text-transform: uppercase;
+    letter-spacing: .12em;
+    color: var(--ink-3);
+    font-weight: 700;
+    margin-right: auto;
+  }
+  .vA__panel-count {
+    background: var(--primary-light);
+    color: var(--primary);
+    border-radius: 999px;
+    padding: 1px 8px;
+    font-size: .68rem;
+    font-family: var(--font-mono);
+    font-weight: 600;
+  }
+  .vA__mode {
+    display: flex; align-items: center; gap: .65rem;
+    padding: .55rem 0;
+    border-top: 1px solid var(--line);
+  }
+  .vA__mode:first-of-type { border-top: 0; padding-top: 0; }
+  .vA__mode-dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--line-2);
+  }
+  .vA__mode--active .vA__mode-dot { background: var(--green); box-shadow: 0 0 0 4px rgba(43,170,104,.15); }
+  .vA__mode-name { font-weight: 600; font-size: .9rem; flex: 1; }
+  .vA__mode--active .vA__mode-name { color: var(--green); }
+  .vA__mode-meta { font-size: .72rem; color: var(--ink-3); margin-right: .5rem; }
+  .vA__mode-apply {
+    font-size: .72rem;
+    color: var(--primary);
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .vA__recipe {
+    padding: .7rem 0;
+    border-top: 1px solid var(--line);
+  }
+  .vA__recipe:first-of-type { border-top: 0; padding-top: 0; }
+  .vA__recipe-head {
+    display: flex; align-items: center; gap: .5rem;
+    margin-bottom: .35rem;
+  }
+  .vA__recipe-name { font-weight: 600; font-size: .9rem; flex: 1; }
+  .vA__recipe-toggle {
+    width: 32px; height: 18px;
+    background: var(--green);
+    border-radius: 999px;
+    position: relative;
+  }
+  .vA__recipe-toggle::after {
+    content: "";
+    position: absolute;
+    top: 2px; right: 2px;
+    width: 14px; height: 14px;
+    background: white;
+    border-radius: 50%;
+  }
+  .vA__recipe-meta {
+    font-size: .72rem;
+    color: var(--ink-3);
+    font-family: var(--font-mono);
+    line-height: 1.6;
+  }
+  .vA__recipe-meta b { color: var(--ink-2); }
+
+  /* ============================================================ */
+  /* VARIANT B — Dashboard                                        */
+  /* ============================================================ */
+  .vB__top {
+    display: flex; align-items: flex-end; justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--line);
+  }
+  .vB__title { font-size: 1.6rem; font-weight: 700; margin: 0; color: var(--ink); }
+  .vB__breadcrumb { font-size: .78rem; color: var(--ink-3); margin-bottom: .2rem; }
+  .vB__filters {
+    display: flex; gap: .5rem;
+  }
+  .vB__filter-chip {
+    display: inline-flex; align-items: center; gap: .35rem;
+    padding: .35rem .75rem;
+    border-radius: 6px;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    font-size: .8rem;
+    color: var(--ink-2);
+    cursor: pointer;
+  }
+  .vB__filter-chip--active {
+    background: var(--ink);
+    color: white;
+    border-color: var(--ink);
+  }
+
+  /* Compact metric ribbon */
+  .vB__ribbon {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr 1fr 1fr;
+    gap: 1px;
+    background: var(--line);
+    border-radius: 12px;
+    overflow: hidden;
+    margin-bottom: 1.5rem;
+    border: 1px solid var(--line);
+  }
+  .vB__ribbon-cell {
+    background: var(--surface);
+    padding: .85rem 1.1rem;
+  }
+  .vB__ribbon-label {
+    font-size: .65rem;
+    text-transform: uppercase;
+    letter-spacing: .12em;
+    color: var(--ink-3);
+    margin-bottom: .3rem;
+    font-weight: 700;
+  }
+  .vB__ribbon-value {
+    font-family: var(--font-mono);
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--ink);
+    line-height: 1;
+  }
+  .vB__ribbon-value .u { font-size: .7rem; opacity: .55; margin-left: 2px; }
+  .vB__ribbon-trend {
+    font-size: .68rem;
+    color: var(--ink-3);
+    margin-top: .25rem;
+  }
+  .vB__ribbon-trend .up { color: var(--green); }
+  .vB__ribbon-trend .down { color: var(--red); }
+  .vB__ribbon-spark { width: 100%; height: 18px; margin-top: .35rem; }
+
+  /* Two-column main */
+  .vB__cols {
+    display: grid;
+    grid-template-columns: 1.6fr 1fr;
+    gap: 1rem;
+  }
+  .vB__panel {
+    background: var(--surface);
+    border-radius: 12px;
+    border: 1px solid var(--line);
+    overflow: hidden;
+  }
+  .vB__panel-head {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .85rem 1rem;
+    border-bottom: 1px solid var(--line);
+    background: var(--primary-tint);
+  }
+  .vB__panel-title {
+    font-size: .72rem;
+    text-transform: uppercase;
+    letter-spacing: .12em;
+    color: var(--primary);
+    font-weight: 700;
+    margin-right: auto;
+  }
+  .vB__panel-count {
+    background: white;
+    color: var(--ink-2);
+    border-radius: 999px;
+    padding: 1px 8px;
+    font-size: .68rem;
+    font-family: var(--font-mono);
+    font-weight: 600;
+  }
+  .vB__row {
+    display: grid;
+    grid-template-columns: 28px 1fr auto auto;
+    gap: .85rem;
+    align-items: center;
+    padding: .6rem 1rem;
+    border-top: 1px solid var(--line);
+    font-size: .85rem;
+    transition: background 120ms;
+  }
+  .vB__row:hover { background: var(--primary-tint); }
+  .vB__row-icon {
+    width: 28px; height: 28px; border-radius: 6px;
+    background: var(--primary-light);
+    color: var(--primary);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .vB__row-icon svg { width: 15px; height: 15px; }
+  .vB__row-icon--amber { background: var(--amber-light); color: var(--amber); }
+  .vB__row-icon--shutter { background: var(--shutter-light); color: var(--shutter); }
+  .vB__row-name { font-weight: 500; color: var(--ink); }
+  .vB__row-sub { color: var(--ink-3); font-size: .72rem; font-family: var(--font-mono); }
+  .vB__row-value {
+    font-family: var(--font-mono);
+    font-size: .8rem;
+    color: var(--ink-2);
+    padding-right: .5rem;
+  }
+  .vB__row-toggle {
+    width: 32px; height: 18px;
+    border-radius: 999px;
+    background: rgba(0,0,0,.08);
+    position: relative;
+    cursor: pointer;
+  }
+  .vB__row-toggle::after {
+    content: "";
+    position: absolute; top: 2px; left: 2px;
+    width: 14px; height: 14px;
+    background: white;
+    border-radius: 50%;
+    transition: all 160ms;
+    box-shadow: 0 1px 2px rgba(0,0,0,.18);
+  }
+  .vB__row-toggle--on { background: var(--amber); }
+  .vB__row-toggle--on::after { left: 16px; }
+  .vB__row-slider {
+    width: 70px;
+    height: 4px;
+    background: rgba(0,0,0,.06);
+    border-radius: 999px;
+    position: relative;
+  }
+  .vB__row-slider::after {
+    content: "";
+    position: absolute;
+    left: 0; top: 0;
+    height: 100%;
+    background: var(--amber);
+    border-radius: 999px;
+  }
+  .vB__sub-head {
+    padding: .5rem 1rem;
+    background: var(--bg);
+    font-size: .68rem;
+    text-transform: uppercase;
+    letter-spacing: .1em;
+    color: var(--ink-3);
+    font-weight: 600;
+    border-top: 1px solid var(--line);
+    display: flex; align-items: center; gap: .5rem;
+  }
+
+  .vB__events {
+    padding: .35rem 1rem .85rem;
+  }
+  .vB__event {
+    display: grid;
+    grid-template-columns: 56px 1fr;
+    gap: .5rem;
+    padding: .45rem 0;
+    border-top: 1px dashed var(--line);
+    font-size: .8rem;
+  }
+  .vB__event:first-child { border-top: 0; }
+  .vB__event-time {
+    font-family: var(--font-mono);
+    font-size: .7rem;
+    color: var(--ink-3);
+  }
+  .vB__event-text { color: var(--ink-2); }
+  .vB__event-text b { color: var(--ink); font-weight: 600; }
+  .vB__event-text .ok { color: var(--green); font-weight: 600; }
+
+  /* ============================================================ */
+  /* VARIANT B — MOBILE                                           */
+  /* ============================================================ */
+  .vBm__row { display: flex; justify-content: center; }
+  .vBm__phone {
+    width: 412px;
+    background: #1F2A36;
+    border-radius: 42px;
+    padding: 12px;
+    box-shadow: var(--shadow-lg);
+    position: relative;
+  }
+  .vBm__phone::before {
+    content: "";
+    position: absolute;
+    top: 22px; left: 50%; transform: translateX(-50%);
+    width: 110px; height: 28px;
+    background: #0A0F15;
+    border-radius: 0 0 14px 14px;
+    z-index: 10;
+  }
+  .vBm__screen {
+    background: #FBFAF5;
+    border-radius: 32px;
+    overflow: hidden;
+    min-height: 860px;
+    position: relative;
+  }
+  .vBm__status {
+    height: 50px;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 1.5rem;
+    font-family: var(--font-mono);
+    font-size: .72rem;
+    color: var(--ink);
+    font-weight: 600;
+  }
+  .vBm__status-right { display: flex; gap: .3rem; align-items: center; opacity: .65; font-size: .65rem; }
+  .vBm__topbar {
+    display: flex; align-items: center; gap: .65rem;
+    padding: .5rem 1rem 1rem;
+    border-bottom: 1px solid var(--line);
+  }
+  .vBm__back {
+    width: 32px; height: 32px;
+    display: flex; align-items: center; justify-content: center;
+    color: var(--primary);
+    border-radius: 6px;
+    background: var(--primary-tint);
+  }
+  .vBm__title-block { flex: 1; }
+  .vBm__title-block h1 { font-size: 1.15rem; font-weight: 700; margin: 0; line-height: 1.1; }
+  .vBm__title-block .sub { font-size: .65rem; color: var(--ink-3); }
+  .vBm__icon-btn {
+    width: 36px; height: 36px;
+    border-radius: 6px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    display: flex; align-items: center; justify-content: center;
+    color: var(--ink-2);
+  }
+  .vBm__icon-btn svg { width: 16px; height: 16px; }
+
+  .vBm__body { padding: .85rem .85rem 2rem; overflow-y: auto; }
+
+  .vBm__ribbon {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1px;
+    background: var(--line);
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    margin-bottom: 1rem;
+  }
+  .vBm__ribbon-cell { background: var(--surface); padding: .65rem .8rem; }
+  .vBm__ribbon-label {
+    font-size: .58rem;
+    text-transform: uppercase;
+    letter-spacing: .12em;
+    color: var(--ink-3);
+    margin-bottom: .25rem;
+    font-weight: 700;
+  }
+  .vBm__ribbon-value {
+    font-family: var(--font-mono);
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--ink);
+    line-height: 1;
+  }
+  .vBm__ribbon-value .u { font-size: .65rem; opacity: .55; margin-left: 2px; }
+  .vBm__ribbon-foot { font-size: .62rem; color: var(--ink-3); margin-top: .25rem; }
+
+  .vBm__chips {
+    display: flex; gap: .4rem;
+    overflow-x: auto;
+    padding: 0 0 .25rem;
+    margin: 0 -.85rem 1rem;
+    padding-left: .85rem; padding-right: .85rem;
+    scrollbar-width: none;
+  }
+  .vBm__chips::-webkit-scrollbar { display: none; }
+  .vBm__chip {
+    flex-shrink: 0;
+    display: inline-flex; align-items: center; gap: .3rem;
+    padding: .35rem .75rem;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    font-size: .72rem;
+    color: var(--ink-2);
+  }
+  .vBm__chip--active {
+    background: var(--ink);
+    color: white;
+    border-color: var(--ink);
+  }
+
+  .vBm__panel {
+    background: var(--surface);
+    border-radius: 12px;
+    border: 1px solid var(--line);
+    overflow: hidden;
+    margin-bottom: .85rem;
+  }
+  .vBm__panel-head {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .7rem .85rem;
+    border-bottom: 1px solid var(--line);
+    background: var(--primary-tint);
+  }
+  .vBm__panel-title {
+    font-size: .68rem;
+    text-transform: uppercase;
+    letter-spacing: .12em;
+    color: var(--primary);
+    font-weight: 700;
+    margin-right: auto;
+  }
+  .vBm__panel-count {
+    background: white;
+    color: var(--ink-2);
+    border-radius: 999px;
+    padding: 1px 7px;
+    font-size: .65rem;
+    font-family: var(--font-mono);
+    font-weight: 600;
+  }
+  .vBm__sub-head {
+    padding: .35rem .85rem;
+    background: var(--bg);
+    font-size: .6rem;
+    text-transform: uppercase;
+    letter-spacing: .1em;
+    color: var(--ink-3);
+    font-weight: 600;
+    border-top: 1px solid var(--line);
+  }
+  .vBm__row-eq {
+    display: grid;
+    grid-template-columns: 28px 1fr auto auto;
+    gap: .65rem;
+    align-items: center;
+    padding: .55rem .85rem;
+    border-top: 1px solid var(--line);
+    font-size: .82rem;
+  }
+  .vBm__row-eq:hover { background: var(--primary-tint); }
+  .vBm__row-icon {
+    width: 28px; height: 28px;
+    border-radius: 6px;
+    background: var(--primary-light);
+    color: var(--primary);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .vBm__row-icon svg { width: 14px; height: 14px; }
+  .vBm__row-icon--amber { background: var(--amber-light); color: var(--amber); }
+  .vBm__row-icon--shutter { background: var(--shutter-light); color: var(--shutter); }
+  .vBm__row-name { font-weight: 500; color: var(--ink); font-size: .85rem; }
+  .vBm__row-sub { color: var(--ink-3); font-size: .68rem; font-family: var(--font-mono); }
+  .vBm__row-value { font-family: var(--font-mono); font-size: .72rem; color: var(--ink-2); }
+  .vBm__row-toggle {
+    width: 32px; height: 18px; border-radius: 999px;
+    background: rgba(0,0,0,.08);
+    position: relative; flex-shrink: 0;
+  }
+  .vBm__row-toggle::after {
+    content: ""; position: absolute; top: 2px; left: 2px;
+    width: 14px; height: 14px; background: white; border-radius: 50%;
+    box-shadow: 0 1px 2px rgba(0,0,0,.18);
+  }
+  .vBm__row-toggle--on { background: var(--amber); }
+  .vBm__row-toggle--on::after { left: 16px; }
+
+  .vBm__event {
+    display: grid;
+    grid-template-columns: 50px 1fr;
+    gap: .5rem;
+    padding: .45rem .85rem;
+    border-top: 1px dashed var(--line);
+    font-size: .76rem;
+  }
+  .vBm__event:first-of-type { border-top: 0; }
+  .vBm__event-time { font-family: var(--font-mono); font-size: .65rem; color: var(--ink-3); }
+  .vBm__event-text { color: var(--ink-2); }
+  .vBm__event-text b { color: var(--ink); font-weight: 600; }
+  .vBm__event-text .ok { color: var(--green); font-weight: 600; }
+
+  .vBm__tabs {
+    position: sticky;
+    bottom: 0;
+    background: rgba(255,255,255,.96);
+    backdrop-filter: blur(10px);
+    border-top: 1px solid var(--line);
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    padding: .5rem .25rem .65rem;
+  }
+  .vBm__tab {
+    display: flex; flex-direction: column; align-items: center; gap: 2px;
+    padding: .4rem 0;
+    color: var(--ink-3);
+    font-size: .58rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    border-radius: 6px;
+  }
+  .vBm__tab svg { width: 18px; height: 18px; }
+  .vBm__tab--active { color: var(--primary); }
+  .vBm__tab--active svg { color: var(--primary); }
+
+  /* Side-by-side desktop+mobile layout for B */
+  .vBm__compare {
+    display: flex; gap: 2rem; align-items: flex-start; justify-content: center;
+    flex-wrap: wrap;
+    max-width: 1320px;
+    margin: 0 auto;
+  }
+  .vBm__compare-label {
+    text-align: center;
+    font-size: .68rem;
+    text-transform: uppercase;
+    letter-spacing: .14em;
+    color: var(--ink-3);
+    font-weight: 700;
+    margin-bottom: .75rem;
+  }
+  .vBm__compare-label b { color: var(--ink); }
+  .vBm__compare-col { display: flex; flex-direction: column; align-items: center; }
+
+  /* ============================================================ */
+  /* VARIANT C — Tactile                                          */
+  /* ============================================================ */
+  .vC__top {
+    background: var(--surface);
+    border-radius: 16px;
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1.5rem;
+    box-shadow: var(--shadow-sm);
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 1.5rem;
+    align-items: center;
+  }
+  .vC__zone-name { font-size: 1.6rem; font-weight: 800; color: var(--ink); margin: 0; }
+  .vC__zone-path { font-size: .72rem; color: var(--ink-3); margin-top: .15rem; }
+  .vC__mini-metrics {
+    display: flex; gap: 1.5rem;
+    align-items: center;
+  }
+  .vC__mini-metric {
+    display: flex; align-items: center; gap: .5rem;
+  }
+  .vC__mini-icon {
+    width: 32px; height: 32px;
+    border-radius: 8px;
+    background: var(--primary-light);
+    color: var(--primary);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .vC__mini-icon svg { width: 16px; height: 16px; }
+  .vC__mini-icon--motion { background: var(--green-light); color: var(--green); }
+  .vC__mini-icon--lights { background: var(--amber-light); color: var(--amber); }
+  .vC__mini-icon--shutters { background: var(--shutter-light); color: var(--shutter); }
+  .vC__mini-val {
+    font-family: var(--font-mono);
+    font-weight: 700;
+    font-size: 1rem;
+    line-height: 1;
+  }
+  .vC__mini-lab { font-size: .65rem; text-transform: uppercase; letter-spacing: .08em; color: var(--ink-3); margin-top: .15rem; }
+  .vC__mode-pill {
+    display: inline-flex; align-items: center; gap: .55rem;
+    padding: .5rem .9rem;
+    background: var(--green-light);
+    color: var(--green);
+    font-weight: 600;
+    font-size: .82rem;
+    border-radius: 999px;
+  }
+  .vC__mode-pill::before { content: "●"; }
+
+  /* Light tiles (big, tactile) */
+  .vC__group-title {
+    display: flex; align-items: baseline; gap: .75rem;
+    margin: 2rem 0 .85rem;
+  }
+  .vC__group-title h2 {
+    font-size: 1rem; font-weight: 700; margin: 0; color: var(--ink);
+  }
+  .vC__group-title-meta {
+    font-size: .78rem; color: var(--ink-3);
+  }
+  .vC__group-title-action {
+    margin-left: auto;
+    font-size: .78rem; color: var(--primary);
+    font-weight: 600; cursor: pointer;
+  }
+
+  .vC__lights {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+  }
+  .vC__light {
+    background: var(--surface);
+    border-radius: 14px;
+    padding: 1.25rem 1.25rem 1rem;
+    box-shadow: var(--shadow-sm);
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: transform 140ms, box-shadow 140ms;
+  }
+  .vC__light:hover { transform: translateY(-1px); box-shadow: var(--shadow-md); }
+  .vC__light--on {
+    background: linear-gradient(160deg, #FFFDF6 0%, #FFF1D4 100%);
+    border-color: rgba(212,150,63,.35);
+  }
+  .vC__light-head {
+    display: flex; align-items: center; gap: .65rem; margin-bottom: 1rem;
+  }
+  .vC__light-bulb {
+    width: 38px; height: 38px;
+    border-radius: 50%;
+    background: #F0F0F0;
+    color: var(--ink-3);
+    display: flex; align-items: center; justify-content: center;
+    transition: all 200ms;
+  }
+  .vC__light--on .vC__light-bulb {
+    background: radial-gradient(circle, #FFD27A 0%, #D4963F 100%);
+    color: white;
+    box-shadow: 0 0 20px rgba(212,150,63,.45);
+  }
+  .vC__light-bulb svg { width: 18px; height: 18px; }
+  .vC__light-name { font-weight: 600; font-size: .95rem; flex: 1; }
+  .vC__light-state {
+    font-size: .68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: var(--ink-3);
+  }
+  .vC__light--on .vC__light-state { color: var(--amber); }
+  .vC__light-slider-wrap {
+    position: relative;
+    height: 8px;
+    background: rgba(0,0,0,.06);
+    border-radius: 999px;
+    margin-bottom: .55rem;
+  }
+  .vC__light-slider {
+    position: absolute; left: 0; top: 0; height: 100%;
+    background: linear-gradient(90deg, var(--amber) 0%, #FFD27A 100%);
+    border-radius: 999px;
+  }
+  .vC__light-slider-knob {
+    position: absolute; top: 50%; transform: translate(-50%, -50%);
+    width: 16px; height: 16px;
+    background: white;
+    border-radius: 50%;
+    box-shadow: 0 2px 6px rgba(0,0,0,.18);
+    border: 2px solid var(--amber);
+  }
+  .vC__light-meta {
+    display: flex; justify-content: space-between;
+    font-size: .75rem;
+    color: var(--ink-3);
+    font-family: var(--font-mono);
+  }
+  .vC__light-meta .pct { font-weight: 600; color: var(--ink-2); }
+  .vC__light--on .vC__light-meta .pct { color: var(--amber-hover); }
+
+  /* Shutters strip */
+  .vC__shutters {
+    background: var(--surface);
+    border-radius: 14px;
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+  }
+  .vC__shutter {
+    display: grid;
+    grid-template-columns: 38px 1fr 1fr auto;
+    gap: 1rem;
+    align-items: center;
+    padding: .85rem 1.25rem;
+    border-top: 1px solid var(--line);
+  }
+  .vC__shutter:first-child { border-top: 0; }
+  .vC__shutter-icon {
+    width: 38px; height: 38px;
+    border-radius: 8px;
+    background: var(--shutter-light);
+    color: var(--shutter);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .vC__shutter-name { font-weight: 600; font-size: .92rem; }
+  .vC__shutter-state {
+    font-size: .72rem;
+    color: var(--ink-3);
+    font-family: var(--font-mono);
+  }
+  .vC__shutter-bar {
+    height: 6px;
+    background: rgba(0,0,0,.06);
+    border-radius: 999px;
+    position: relative;
+    width: 100%;
+  }
+  .vC__shutter-bar::before {
+    content: "";
+    position: absolute;
+    left: 0; top: 0; height: 100%;
+    width: var(--w, 0%);
+    background: var(--shutter);
+    border-radius: 999px;
+  }
+  .vC__shutter-ctrl {
+    display: flex; gap: .25rem;
+  }
+  .vC__shutter-btn {
+    width: 30px; height: 30px;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    border-radius: 6px;
+    cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    color: var(--ink-2);
+  }
+  .vC__shutter-btn:hover { background: var(--shutter-light); color: var(--shutter); border-color: var(--shutter); }
+
+  /* Modes carousel (cards) */
+  .vC__modes {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+  }
+  .vC__mode-card {
+    background: var(--surface);
+    border-radius: 14px;
+    padding: 1.1rem 1.25rem;
+    box-shadow: var(--shadow-sm);
+    border: 1px solid transparent;
+    cursor: pointer;
+  }
+  .vC__mode-card--active {
+    border-color: var(--green);
+    background: linear-gradient(160deg, white 0%, var(--green-light) 100%);
+  }
+  .vC__mode-card-icon {
+    width: 36px; height: 36px;
+    border-radius: 50%;
+    background: var(--primary-light);
+    color: var(--primary);
+    display: flex; align-items: center; justify-content: center;
+    margin-bottom: .65rem;
+  }
+  .vC__mode-card--active .vC__mode-card-icon { background: var(--green); color: white; }
+  .vC__mode-card-name { font-weight: 700; font-size: 1rem; margin-bottom: .15rem; }
+  .vC__mode-card-meta { font-size: .75rem; color: var(--ink-3); }
+  .vC__mode-card--active .vC__mode-card-meta { color: var(--green); font-weight: 600; }
+
+  /* Recipes — large highlighted card */
+  .vC__recipe-card {
+    background: var(--surface);
+    border-radius: 14px;
+    box-shadow: var(--shadow-sm);
+    padding: 1.1rem 1.3rem 1.25rem;
+    margin-top: 1rem;
+    position: relative;
+    overflow: hidden;
+  }
+  .vC__recipe-card::before {
+    content: "";
+    position: absolute; left: 0; top: 0; bottom: 0;
+    width: 3px;
+    background: var(--accent);
+  }
+  .vC__recipe-head {
+    display: flex; align-items: center; gap: .65rem; margin-bottom: .6rem;
+  }
+  .vC__recipe-badge {
+    font-size: .62rem;
+    text-transform: uppercase;
+    letter-spacing: .14em;
+    color: var(--accent);
+    background: var(--amber-light);
+    padding: 3px 8px;
+    border-radius: 999px;
+    font-weight: 700;
+  }
+  .vC__recipe-name { font-weight: 700; font-size: 1.05rem; flex: 1; }
+  .vC__recipe-toggle {
+    width: 38px; height: 22px;
+    border-radius: 999px;
+    background: var(--green);
+    position: relative;
+  }
+  .vC__recipe-toggle::after {
+    content: "";
+    position: absolute; top: 3px; right: 3px;
+    width: 16px; height: 16px;
+    background: white;
+    border-radius: 50%;
+  }
+  .vC__recipe-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: .75rem;
+    margin-top: .85rem;
+  }
+  .vC__recipe-prop {
+    background: var(--bg);
+    border-radius: 8px;
+    padding: .5rem .65rem;
+  }
+  .vC__recipe-prop-label {
+    font-size: .58rem;
+    text-transform: uppercase;
+    letter-spacing: .12em;
+    color: var(--ink-3);
+    margin-bottom: .15rem;
+  }
+  .vC__recipe-prop-value {
+    font-family: var(--font-mono);
+    font-size: .85rem;
+    font-weight: 600;
+    color: var(--ink);
+  }
+
+  /* Notes */
+  .notes {
+    max-width: 1280px;
+    margin: 1.25rem auto 0;
+    padding: 1rem 1.25rem;
+    background: rgba(0,0,0,.03);
+    border: 1px dashed var(--line-2);
+    border-radius: 8px;
+    font-size: .82rem;
+    color: var(--ink-2);
+  }
+  .notes b { color: var(--ink); }
+  .notes ul { margin: .35rem 0 0; padding-left: 1.2rem; }
+  .notes li { margin: .15rem 0; }
+
+  /* Current vs proposed inline label */
+  .vs-current {
+    max-width: 1280px;
+    margin: 0 auto 2rem;
+    display: flex; align-items: center; gap: 1rem;
+    padding: .9rem 1.1rem;
+    background: var(--primary-light);
+    border: 1px solid rgba(26,79,110,.18);
+    border-radius: 8px;
+    font-size: .85rem;
+    color: var(--primary);
+  }
+  .vs-current svg { width: 18px; height: 18px; flex-shrink: 0; }
+</style>
+</head>
+<body>
+
+<nav class="nav">
+  <span class="nav__brand">Sowel · zone-view redesign proposals</span>
+  <a href="#vA">A · Glanceable</a>
+  <a href="#vB">B · Dashboard</a>
+  <a href="#vBm">B · Mobile</a>
+  <a href="#vC">C · Tactile</a>
+</nav>
+
+<div class="vs-current">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v4"/><circle cx="12" cy="16" r=".5"/></svg>
+  <div>
+    Each variant below is a redesign of the <b>Séjour</b> zone view (Grange Neuve). Real data preserved: 334 lx, Calm 16 min, 1/3 lights on, 3 shutters closed, Lumière soir mode active, Motion Light (Dimmable) recipe enabled. Use the nav to jump between proposals.
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- VARIANT A — Glanceable                                       -->
+<!-- ============================================================ -->
+<section id="vA" class="variant">
+  <div class="variant__head">
+    <div class="variant__tag"><span>A</span><span>Glanceable — hero card + tile grid</span></div>
+    <h2 class="variant__title">A zone you read in one second</h2>
+    <p class="variant__sub">Promote zone status as the hero of the page. Equipment becomes a tile grid (glanceable). Modes &amp; recipes get their own focused panels with one-tap interactions.</p>
+  </div>
+
+  <div class="ui">
+    <!-- Sidebar -->
+    <aside class="sb">
+      <div class="sb__logo">
+        <svg viewBox="25 15 150 155" fill="none" stroke="#1A4F6E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M100 30 L160 90 Q165 95 160 100 L160 150 Q160 158 152 158 L48 158 Q40 158 40 150 L40 100 Q35 95 40 90 Z"/>
+          <path d="M75 115 Q100 140 125 115" stroke="#3B95C2"/>
+          <path d="M78 95 Q83 87 88 95" stroke="#3B95C2"/>
+          <path d="M112 95 Q117 87 122 95" stroke="#3B95C2"/>
+        </svg>
+        <b>SOWEL</b>
+      </div>
+      <div class="sb__group">
+        <div class="sb__item"><span>⊟</span><span>Dashboard</span></div>
+        <div class="sb__item sb__item--active"><span>⌂</span><span>Maison</span><span class="sb__chev">⌄</span></div>
+        <div class="sb__sub">
+          <div class="sb__sub-item">Extérieur</div>
+          <div class="sb__sub-item">Sous-sol</div>
+          <div class="sb__sub-item">RDC</div>
+          <div class="sb__sub" style="margin-left:.65rem">
+            <div class="sb__sub-item">Entrée</div>
+            <div class="sb__sub-item">Bureau</div>
+            <div class="sb__sub-item">Cuisine</div>
+            <div class="sb__sub-item sb__sub-item--active">Séjour</div>
+          </div>
+          <div class="sb__sub-item">Etage 1</div>
+          <div class="sb__sub-item">Etage 2</div>
+        </div>
+        <div class="sb__item"><span>≡</span><span>Modes</span></div>
+        <div class="sb__item"><span>↗</span><span>Analyse</span></div>
+        <div class="sb__item"><span>⚡</span><span>Energy</span></div>
+      </div>
+    </aside>
+
+    <!-- Main -->
+    <div class="main">
+      <div class="vA__topbar">
+        <div class="vA__breadcrumb">Grange Neuve · <b>Séjour</b></div>
+        <div class="vA__clock"><span>🕐</span> 22:57:12</div>
+        <div class="vA__sun"><span>🌙</span> <b>Night</b> · sunset 20:54</div>
+      </div>
+
+      <!-- Hero zone card -->
+      <div class="vA__hero">
+        <div class="vA__zone-title">
+          <div class="vA__zone-name">Séjour</div>
+          <div class="vA__zone-status">Calm · Lumière soir</div>
+        </div>
+        <div class="vA__zone-sub">2 lights on, 3 shutters closed · last motion 16 min ago</div>
+        <div class="vA__metrics">
+          <div class="vA__metric">
+            <div class="vA__metric-label">☀ Luminosity</div>
+            <div class="vA__metric-value">334<span class="u">lx</span></div>
+            <svg class="vA__metric-spark" viewBox="0 0 120 18">
+              <polyline fill="none" stroke="rgba(255,255,255,.5)" stroke-width="1.5" points="0,12 10,8 20,10 30,5 40,6 50,3 60,2 70,4 80,7 90,9 100,11 110,12 120,13"/>
+            </svg>
+          </div>
+          <div class="vA__metric">
+            <div class="vA__metric-label">⚭ Motion</div>
+            <div class="vA__metric-value">Calm</div>
+            <div class="vA__metric-foot">last <b>16 min ago</b></div>
+          </div>
+          <div class="vA__metric">
+            <div class="vA__metric-label">💡 Lights</div>
+            <div class="vA__metric-value">1<span class="u">/ 3</span></div>
+            <div class="vA__metric-foot"><b>4%</b> avg brightness</div>
+          </div>
+          <div class="vA__metric">
+            <div class="vA__metric-label">▭ Shutters</div>
+            <div class="vA__metric-value">0<span class="u">/ 3</span></div>
+            <div class="vA__metric-foot"><b>Closed</b></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Zone-wide actions -->
+      <div class="vA__actions">
+        <button class="vA__action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg> All lights on</button>
+        <button class="vA__action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><line x1="2" y1="22" x2="22" y2="2"/></svg> All lights off</button>
+        <button class="vA__action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 21V3h18v18"/><path d="M7 21V9h10v12"/></svg> Open shutters</button>
+        <button class="vA__action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 21V3h18v18"/><path d="M3 9h18M3 15h18"/></svg> Close shutters</button>
+      </div>
+
+      <!-- Lights tiles -->
+      <div class="vA__section-title">💡 Lights <span class="vA__section-title-count">3</span></div>
+      <div class="vA__tiles">
+        <div class="vA__tile">
+          <div class="vA__tile-head">
+            <div class="vA__tile-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6M10 22h4"/></svg></div>
+            <span class="vA__tile-state vA__tile-state--off">Off</span>
+          </div>
+          <div class="vA__tile-name">Applique x1</div>
+          <div class="vA__tile-value">0%</div>
+          <div class="vA__tile-slider"><div class="vA__tile-slider-fill" style="width:0%"></div></div>
+        </div>
+        <div class="vA__tile vA__tile--on">
+          <div class="vA__tile-head">
+            <div class="vA__tile-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6M10 22h4"/></svg></div>
+            <span class="vA__tile-state vA__tile-state--on">On</span>
+          </div>
+          <div class="vA__tile-name">Appliques x2</div>
+          <div class="vA__tile-value">4%</div>
+          <div class="vA__tile-slider"><div class="vA__tile-slider-fill" style="width:4%"></div></div>
+        </div>
+        <div class="vA__tile">
+          <div class="vA__tile-head">
+            <div class="vA__tile-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2"/></svg></div>
+            <span class="vA__tile-state vA__tile-state--off">Off</span>
+          </div>
+          <div class="vA__tile-name">Spots</div>
+          <div class="vA__tile-value">—</div>
+          <div class="vA__tile-slider"><div class="vA__tile-slider-fill" style="width:0%"></div></div>
+        </div>
+      </div>
+
+      <!-- Shutters tiles -->
+      <div class="vA__section-title">▭ Shutters <span class="vA__section-title-count">3</span></div>
+      <div class="vA__tiles">
+        <div class="vA__tile vA__tile--shutter">
+          <div class="vA__tile-head">
+            <div class="vA__tile-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <span class="vA__tile-state vA__tile-state--closed">Closed</span>
+          </div>
+          <div class="vA__tile-name">Volet Ouest</div>
+          <div class="vA__tile-value">0%</div>
+        </div>
+        <div class="vA__tile vA__tile--shutter">
+          <div class="vA__tile-head">
+            <div class="vA__tile-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <span class="vA__tile-state vA__tile-state--closed">Closed</span>
+          </div>
+          <div class="vA__tile-name">Volet Sud</div>
+          <div class="vA__tile-value">0%</div>
+        </div>
+        <div class="vA__tile vA__tile--shutter">
+          <div class="vA__tile-head">
+            <div class="vA__tile-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <span class="vA__tile-state vA__tile-state--closed">Closed</span>
+          </div>
+          <div class="vA__tile-name">Volet Sud Ouest</div>
+          <div class="vA__tile-value">0%</div>
+        </div>
+      </div>
+
+      <!-- Behaviors: modes + recipes side by side -->
+      <div class="vA__behaviors">
+        <div class="vA__panel">
+          <div class="vA__panel-head">
+            <div class="vA__panel-title">Modes</div>
+            <span class="vA__panel-count">1 active</span>
+          </div>
+          <div class="vA__mode">
+            <div class="vA__mode-dot"></div>
+            <div class="vA__mode-name">Lumière jour</div>
+            <div class="vA__mode-meta">1 action</div>
+            <div class="vA__mode-apply">Apply</div>
+          </div>
+          <div class="vA__mode">
+            <div class="vA__mode-dot"></div>
+            <div class="vA__mode-name">Lumière nuit</div>
+            <div class="vA__mode-meta">1 action</div>
+            <div class="vA__mode-apply">Apply</div>
+          </div>
+          <div class="vA__mode vA__mode--active">
+            <div class="vA__mode-dot"></div>
+            <div class="vA__mode-name">Lumière soir</div>
+            <div class="vA__mode-meta">4 actions · globally active</div>
+            <div class="vA__mode-apply">Active</div>
+          </div>
+        </div>
+
+        <div class="vA__panel">
+          <div class="vA__panel-head">
+            <div class="vA__panel-title">Recipes</div>
+            <span class="vA__panel-count">1</span>
+          </div>
+          <div class="vA__recipe">
+            <div class="vA__recipe-head">
+              <div class="vA__recipe-name">Motion Light (Dimmable)</div>
+              <div class="vA__recipe-toggle"></div>
+            </div>
+            <div class="vA__recipe-meta">
+              Lights: <b>Applique x1, Appliques x2</b><br/>
+              Timeout <b>10m</b> · Brightness <b>254</b> · Lux ≤ <b>2300</b><br/>
+              Slot 1: <b>21:00 → 100%</b>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="notes">
+    <b>Intent.</b> Le but est de répondre en 1 seconde : « ça va dans cette pièce ? »
+    <ul>
+      <li>La hero card bleue centralise toutes les métriques de zone agrégées avec leurs sparklines — c'est ça que tu lis en arrivant</li>
+      <li>Équipements en tuiles 3-col, avec couleurs sémantiques (ambre = lumière, bleu acier = volet)</li>
+      <li>Toggle on/off et slider sont directement sur la tuile — pas besoin de cliquer pour entrer</li>
+      <li>Modes et Recipes en bas, en panneaux égaux — la recette active est un toggle vert direct</li>
+      <li>Inconvénient : moins d'infos d'un coup que ton design actuel. Bon pour mobile / tablette, peut frustrer les power-users sur écran 27"</li>
+    </ul>
+  </div>
+</section>
+
+<!-- ============================================================ -->
+<!-- VARIANT B — Dashboard                                        -->
+<!-- ============================================================ -->
+<section id="vB" class="variant" style="background:#FBFAF5;">
+  <div class="variant__head">
+    <div class="variant__tag"><span>B</span><span>Dashboard — info-dense, power user</span></div>
+    <h2 class="variant__title">Tout sur un écran, comme un cockpit</h2>
+    <p class="variant__sub">Pour les power users qui veulent voir équipements, modes, recettes et activité récente en un seul scroll. Ribbon de métriques en haut, colonne événements/modes à droite.</p>
+  </div>
+
+  <div class="ui">
+    <!-- Sidebar (same) -->
+    <aside class="sb">
+      <div class="sb__logo">
+        <svg viewBox="25 15 150 155" fill="none" stroke="#1A4F6E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M100 30 L160 90 Q165 95 160 100 L160 150 Q160 158 152 158 L48 158 Q40 158 40 150 L40 100 Q35 95 40 90 Z"/>
+          <path d="M75 115 Q100 140 125 115" stroke="#3B95C2"/>
+          <path d="M78 95 Q83 87 88 95" stroke="#3B95C2"/>
+          <path d="M112 95 Q117 87 122 95" stroke="#3B95C2"/>
+        </svg>
+        <b>SOWEL</b>
+      </div>
+      <div class="sb__group">
+        <div class="sb__item"><span>⊟</span><span>Dashboard</span></div>
+        <div class="sb__item sb__item--active"><span>⌂</span><span>Maison</span><span class="sb__chev">⌄</span></div>
+        <div class="sb__sub">
+          <div class="sb__sub-item">Extérieur</div>
+          <div class="sb__sub-item">Sous-sol</div>
+          <div class="sb__sub-item">RDC</div>
+          <div class="sb__sub" style="margin-left:.65rem">
+            <div class="sb__sub-item">Cuisine</div>
+            <div class="sb__sub-item sb__sub-item--active">Séjour</div>
+          </div>
+          <div class="sb__sub-item">Etage 1</div>
+        </div>
+        <div class="sb__item"><span>≡</span><span>Modes</span></div>
+        <div class="sb__item"><span>↗</span><span>Analyse</span></div>
+        <div class="sb__item"><span>⚡</span><span>Energy</span></div>
+      </div>
+    </aside>
+
+    <div class="main" style="background:#FBFAF5">
+      <div class="vB__top">
+        <div>
+          <div class="vB__breadcrumb">Grange Neuve · RDC</div>
+          <h1 class="vB__title">Séjour</h1>
+        </div>
+        <div class="vB__filters">
+          <button class="vB__filter-chip vB__filter-chip--active">All</button>
+          <button class="vB__filter-chip">Lights</button>
+          <button class="vB__filter-chip">Shutters</button>
+          <button class="vB__filter-chip">Sensors</button>
+          <button class="vB__filter-chip">Switches</button>
+        </div>
+      </div>
+
+      <!-- Metric ribbon -->
+      <div class="vB__ribbon">
+        <div class="vB__ribbon-cell">
+          <div class="vB__ribbon-label">☀ Luminosity</div>
+          <div class="vB__ribbon-value">334<span class="u">lx</span></div>
+          <svg class="vB__ribbon-spark" viewBox="0 0 200 18">
+            <polyline fill="none" stroke="#246588" stroke-width="1.5" points="0,12 15,9 30,11 45,5 60,6 75,3 90,2 105,4 120,7 135,9 150,11 165,12 180,13 200,12"/>
+          </svg>
+        </div>
+        <div class="vB__ribbon-cell">
+          <div class="vB__ribbon-label">⚭ Motion</div>
+          <div class="vB__ribbon-value">Calm</div>
+          <div class="vB__ribbon-trend">last <b style="color:var(--ink-2)">16 min</b> ago</div>
+        </div>
+        <div class="vB__ribbon-cell">
+          <div class="vB__ribbon-label">💡 Lights on</div>
+          <div class="vB__ribbon-value">1<span class="u">/3</span></div>
+          <div class="vB__ribbon-trend">avg <span class="up">4%</span> brightness</div>
+        </div>
+        <div class="vB__ribbon-cell">
+          <div class="vB__ribbon-label">▭ Shutters open</div>
+          <div class="vB__ribbon-value">0<span class="u">/3</span></div>
+          <div class="vB__ribbon-trend">all <b>Closed</b></div>
+        </div>
+      </div>
+
+      <!-- Two columns -->
+      <div class="vB__cols">
+
+        <!-- Left col: equipment list -->
+        <div class="vB__panel">
+          <div class="vB__panel-head">
+            <div class="vB__panel-title">Equipments</div>
+            <span class="vB__panel-count">12</span>
+          </div>
+
+          <div class="vB__sub-head">💡 Lights · 1 / 3 on</div>
+          <div class="vB__row">
+            <div class="vB__row-icon vB__row-icon--amber"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18h6M10 22h4M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/></svg></div>
+            <div><div class="vB__row-name">Applique x1</div></div>
+            <div class="vB__row-slider"><span style="--w:0"></span></div>
+            <div class="vB__row-toggle"></div>
+          </div>
+          <div class="vB__row">
+            <div class="vB__row-icon vB__row-icon--amber"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18h6M10 22h4M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/></svg></div>
+            <div><div class="vB__row-name">Appliques x2</div><div class="vB__row-sub">4% · on since 1h14</div></div>
+            <div class="vB__row-slider" style="position:relative"><span style="position:absolute;left:0;top:0;height:100%;width:4%;background:var(--amber);border-radius:999px;display:block"></span></div>
+            <div class="vB__row-toggle vB__row-toggle--on"></div>
+          </div>
+          <div class="vB__row">
+            <div class="vB__row-icon vB__row-icon--amber"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41"/></svg></div>
+            <div><div class="vB__row-name">Spots</div></div>
+            <div></div>
+            <div class="vB__row-toggle"></div>
+          </div>
+
+          <div class="vB__sub-head">▭ Shutters · 0 / 3 open</div>
+          <div class="vB__row">
+            <div class="vB__row-icon vB__row-icon--shutter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <div><div class="vB__row-name">Volet Ouest</div></div>
+            <div class="vB__row-value">Closed</div>
+            <div></div>
+          </div>
+          <div class="vB__row">
+            <div class="vB__row-icon vB__row-icon--shutter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <div><div class="vB__row-name">Volet Sud</div></div>
+            <div class="vB__row-value">Closed</div>
+            <div></div>
+          </div>
+          <div class="vB__row">
+            <div class="vB__row-icon vB__row-icon--shutter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <div><div class="vB__row-name">Volet Sud Ouest</div></div>
+            <div class="vB__row-value">Closed</div>
+            <div></div>
+          </div>
+
+          <div class="vB__sub-head">📡 Sensors · 3</div>
+          <div class="vB__row">
+            <div class="vB__row-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M3 12a9 9 0 0 1 18 0"/></svg></div>
+            <div><div class="vB__row-name">PIRL</div></div>
+            <div class="vB__row-value">334 lx · 100%</div>
+            <div></div>
+          </div>
+          <div class="vB__row">
+            <div class="vB__row-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M3 12a9 9 0 0 1 18 0"/></svg></div>
+            <div><div class="vB__row-name">PIR_00</div></div>
+            <div class="vB__row-value">Clear · 100%</div>
+            <div></div>
+          </div>
+          <div class="vB__row">
+            <div class="vB__row-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M3 12a9 9 0 0 1 18 0"/></svg></div>
+            <div><div class="vB__row-name">PIR_01</div></div>
+            <div class="vB__row-value">Clear · 85%</div>
+            <div></div>
+          </div>
+        </div>
+
+        <!-- Right col: modes + recipes + activity -->
+        <div>
+          <div class="vB__panel" style="margin-bottom:1rem">
+            <div class="vB__panel-head">
+              <div class="vB__panel-title">Modes</div>
+              <span class="vB__panel-count">1 / 3</span>
+            </div>
+            <div class="vB__row">
+              <div class="vB__row-icon"><span style="font-size:11px">○</span></div>
+              <div><div class="vB__row-name">Lumière jour</div><div class="vB__row-sub">1 action</div></div>
+              <div></div>
+              <div style="font-size:.75rem;color:var(--primary);font-weight:600;cursor:pointer">Apply</div>
+            </div>
+            <div class="vB__row">
+              <div class="vB__row-icon"><span style="font-size:11px">○</span></div>
+              <div><div class="vB__row-name">Lumière nuit</div><div class="vB__row-sub">1 action</div></div>
+              <div></div>
+              <div style="font-size:.75rem;color:var(--primary);font-weight:600;cursor:pointer">Apply</div>
+            </div>
+            <div class="vB__row" style="background:rgba(43,170,104,.05)">
+              <div class="vB__row-icon" style="background:var(--green-light);color:var(--green)"><span style="font-size:11px">●</span></div>
+              <div><div class="vB__row-name" style="color:var(--green)">Lumière soir</div><div class="vB__row-sub">4 actions · globally active</div></div>
+              <div></div>
+              <div style="font-size:.75rem;color:var(--green);font-weight:700">Active</div>
+            </div>
+          </div>
+
+          <div class="vB__panel" style="margin-bottom:1rem">
+            <div class="vB__panel-head">
+              <div class="vB__panel-title">Recipes</div>
+              <span class="vB__panel-count">1</span>
+            </div>
+            <div class="vB__row">
+              <div class="vB__row-icon vB__row-icon--amber"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-5.35c0-.46.32-.84.73-1.04a4 4 0 0 0-2.13-7.59 5 5 0 0 0-9.2 0 4 4 0 0 0-2.13 7.59c.41.2.73.58.73 1.04V21M6 17h12"/></svg></div>
+              <div><div class="vB__row-name">Motion Light (Dimmable)</div><div class="vB__row-sub">Timeout 10m · Lux ≤ 2300</div></div>
+              <div></div>
+              <div class="vB__row-toggle vB__row-toggle--on"></div>
+            </div>
+          </div>
+
+          <div class="vB__panel">
+            <div class="vB__panel-head">
+              <div class="vB__panel-title">Activity</div>
+              <span class="vB__panel-count">live</span>
+            </div>
+            <div class="vB__events">
+              <div class="vB__event">
+                <span class="vB__event-time">22:41</span>
+                <span class="vB__event-text"><b>Appliques x2</b> turned on by <b>Motion Light</b> <span class="ok">→ 4%</span></span>
+              </div>
+              <div class="vB__event">
+                <span class="vB__event-time">22:40</span>
+                <span class="vB__event-text">Motion detected on <b>PIR_00</b></span>
+              </div>
+              <div class="vB__event">
+                <span class="vB__event-time">21:00</span>
+                <span class="vB__event-text">Mode <b>Lumière soir</b> activated by calendar</span>
+              </div>
+              <div class="vB__event">
+                <span class="vB__event-time">20:54</span>
+                <span class="vB__event-text"><b>Sunset</b> — Night phase begins</span>
+              </div>
+              <div class="vB__event">
+                <span class="vB__event-time">20:30</span>
+                <span class="vB__event-text"><b>Volet Sud</b> closed by <b>Sunset Shutters</b></span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="notes">
+    <b>Intent.</b> Garde la densité d'info de l'actuel, mais lui donne un vrai squelette « cockpit ».
+    <ul>
+      <li>Ribbon métriques 4 colonnes — toujours visible, avec sparkline pour Luminosity (data InfluxDB déjà là)</li>
+      <li>Filtres en chips en haut (All / Lights / Shutters / Sensors / Switches) — recherche/filtre instant</li>
+      <li>Colonne droite ajoute un panneau <b>Activity</b> (log d'événements de la zone) — c'est ce qui manque le plus dans l'actuel pour comprendre <i>pourquoi</i> tel équipement a changé d'état</li>
+      <li>Toggles inline (lights, recipe) — pas besoin de clic supplémentaire</li>
+      <li>Bon pour ton usage personnel quotidien, gros écran. Moins beau sur mobile</li>
+    </ul>
+  </div>
+</section>
+
+<!-- ============================================================ -->
+<!-- VARIANT B — MOBILE                                           -->
+<!-- ============================================================ -->
+<section id="vBm" class="variant" style="background:#FBFAF5">
+  <div class="variant__head">
+    <div class="variant__tag"><span>B · Mobile</span><span>Same dashboard, condensed to a 412px screen</span></div>
+    <h2 class="variant__title">B sur ton téléphone</h2>
+    <p class="variant__sub">La même variante Dashboard, restructurée pour un viewport 412px (iPhone Pro). Sidebar absente (remplacée par une bottom bar), ribbon en 2×2, panneaux en accordéon vertical, tabs en bas pour switcher Equipments / Modes / Recipes / Activity sans scroller.</p>
+  </div>
+
+  <div class="vBm__row">
+    <div class="vBm__phone">
+      <div class="vBm__screen">
+
+        <!-- Status bar -->
+        <div class="vBm__status">
+          <span>22:57</span>
+          <span class="vBm__status-right">⚡ · 5G · 87%</span>
+        </div>
+
+        <!-- Top bar -->
+        <div class="vBm__topbar">
+          <div class="vBm__back">←</div>
+          <div class="vBm__title-block">
+            <h1>Séjour</h1>
+            <div class="sub">Grange Neuve · RDC</div>
+          </div>
+          <div class="vBm__icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="4" y1="6" x2="20" y2="6"/><line x1="6" y1="12" x2="18" y2="12"/><line x1="8" y1="18" x2="16" y2="18"/></svg></div>
+        </div>
+
+        <!-- Body -->
+        <div class="vBm__body">
+
+          <!-- Ribbon 2x2 -->
+          <div class="vBm__ribbon">
+            <div class="vBm__ribbon-cell">
+              <div class="vBm__ribbon-label">☀ Luminosity</div>
+              <div class="vBm__ribbon-value">334<span class="u">lx</span></div>
+              <div class="vBm__ribbon-foot">trending down</div>
+            </div>
+            <div class="vBm__ribbon-cell">
+              <div class="vBm__ribbon-label">⚭ Motion</div>
+              <div class="vBm__ribbon-value">Calm</div>
+              <div class="vBm__ribbon-foot">16 min ago</div>
+            </div>
+            <div class="vBm__ribbon-cell">
+              <div class="vBm__ribbon-label">💡 Lights</div>
+              <div class="vBm__ribbon-value">1<span class="u">/ 3</span></div>
+              <div class="vBm__ribbon-foot">avg 4%</div>
+            </div>
+            <div class="vBm__ribbon-cell">
+              <div class="vBm__ribbon-label">▭ Shutters</div>
+              <div class="vBm__ribbon-value">0<span class="u">/ 3</span></div>
+              <div class="vBm__ribbon-foot">all closed</div>
+            </div>
+          </div>
+
+          <!-- Filter chips (horizontal scroll) -->
+          <div class="vBm__chips">
+            <button class="vBm__chip vBm__chip--active">All</button>
+            <button class="vBm__chip">Lights</button>
+            <button class="vBm__chip">Shutters</button>
+            <button class="vBm__chip">Sensors</button>
+            <button class="vBm__chip">Switches</button>
+            <button class="vBm__chip">Media</button>
+          </div>
+
+          <!-- Active mode pill (sticky-ish indicator) -->
+          <div style="display:flex;align-items:center;justify-content:space-between;background:rgba(43,170,104,.08);padding:.55rem .85rem;border-radius:8px;margin-bottom:.85rem;border:1px solid rgba(43,170,104,.18)">
+            <div style="display:flex;align-items:center;gap:.4rem">
+              <span style="color:var(--green)">●</span>
+              <span style="font-weight:600;font-size:.82rem;color:var(--green)">Lumière soir</span>
+              <span style="font-size:.7rem;color:var(--ink-3)">· 4 actions</span>
+            </div>
+            <button style="background:transparent;border:1px solid rgba(43,170,104,.3);color:var(--green);font-size:.7rem;padding:3px 10px;border-radius:4px;font-weight:600">Change</button>
+          </div>
+
+          <!-- Equipments -->
+          <div class="vBm__panel">
+            <div class="vBm__panel-head">
+              <span class="vBm__panel-title">Equipments</span>
+              <span class="vBm__panel-count">12</span>
+            </div>
+            <div class="vBm__sub-head">💡 Lights · 1 / 3</div>
+            <div class="vBm__row-eq">
+              <div class="vBm__row-icon vBm__row-icon--amber"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18h6M10 22h4M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/></svg></div>
+              <div><div class="vBm__row-name">Applique x1</div></div>
+              <div></div>
+              <div class="vBm__row-toggle"></div>
+            </div>
+            <div class="vBm__row-eq">
+              <div class="vBm__row-icon vBm__row-icon--amber"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18h6M10 22h4M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/></svg></div>
+              <div><div class="vBm__row-name">Appliques x2</div><div class="vBm__row-sub">4% · 1h14</div></div>
+              <div></div>
+              <div class="vBm__row-toggle vBm__row-toggle--on"></div>
+            </div>
+            <div class="vBm__row-eq">
+              <div class="vBm__row-icon vBm__row-icon--amber"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2"/></svg></div>
+              <div><div class="vBm__row-name">Spots</div></div>
+              <div></div>
+              <div class="vBm__row-toggle"></div>
+            </div>
+
+            <div class="vBm__sub-head">▭ Shutters · 0 / 3</div>
+            <div class="vBm__row-eq">
+              <div class="vBm__row-icon vBm__row-icon--shutter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+              <div><div class="vBm__row-name">Volet Ouest</div></div>
+              <div class="vBm__row-value">Closed</div>
+              <div></div>
+            </div>
+            <div class="vBm__row-eq">
+              <div class="vBm__row-icon vBm__row-icon--shutter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+              <div><div class="vBm__row-name">Volet Sud</div></div>
+              <div class="vBm__row-value">Closed</div>
+              <div></div>
+            </div>
+            <div class="vBm__row-eq">
+              <div class="vBm__row-icon vBm__row-icon--shutter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+              <div><div class="vBm__row-name">Volet Sud Ouest</div></div>
+              <div class="vBm__row-value">Closed</div>
+              <div></div>
+            </div>
+
+            <div class="vBm__sub-head">📡 Sensors · 3 clear</div>
+            <div class="vBm__row-eq">
+              <div class="vBm__row-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M3 12a9 9 0 0 1 18 0"/></svg></div>
+              <div><div class="vBm__row-name">PIRL</div></div>
+              <div class="vBm__row-value">334lx · 100%</div>
+              <div></div>
+            </div>
+            <div class="vBm__row-eq">
+              <div class="vBm__row-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M3 12a9 9 0 0 1 18 0"/></svg></div>
+              <div><div class="vBm__row-name">PIR_00</div><div class="vBm__row-sub">Clear</div></div>
+              <div class="vBm__row-value">100%</div>
+              <div></div>
+            </div>
+            <div class="vBm__row-eq">
+              <div class="vBm__row-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M3 12a9 9 0 0 1 18 0"/></svg></div>
+              <div><div class="vBm__row-name">PIR_01</div><div class="vBm__row-sub">Clear</div></div>
+              <div class="vBm__row-value">85%</div>
+              <div></div>
+            </div>
+          </div>
+
+          <!-- Recipes -->
+          <div class="vBm__panel">
+            <div class="vBm__panel-head">
+              <span class="vBm__panel-title">Recipes</span>
+              <span class="vBm__panel-count">1 active</span>
+            </div>
+            <div class="vBm__row-eq">
+              <div class="vBm__row-icon vBm__row-icon--amber"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-5.35c0-.46.32-.84.73-1.04a4 4 0 0 0-2.13-7.59 5 5 0 0 0-9.2 0 4 4 0 0 0-2.13 7.59c.41.2.73.58.73 1.04V21M6 17h12"/></svg></div>
+              <div><div class="vBm__row-name">Motion Light (Dim)</div><div class="vBm__row-sub">10m · Lux ≤ 2300</div></div>
+              <div></div>
+              <div class="vBm__row-toggle vBm__row-toggle--on"></div>
+            </div>
+          </div>
+
+          <!-- Activity -->
+          <div class="vBm__panel">
+            <div class="vBm__panel-head">
+              <span class="vBm__panel-title">Activity</span>
+              <span class="vBm__panel-count">live</span>
+            </div>
+            <div class="vBm__event">
+              <span class="vBm__event-time">22:41</span>
+              <span class="vBm__event-text"><b>Appliques x2</b> on by Motion Light <span class="ok">→ 4%</span></span>
+            </div>
+            <div class="vBm__event">
+              <span class="vBm__event-time">22:40</span>
+              <span class="vBm__event-text">Motion on <b>PIR_00</b></span>
+            </div>
+            <div class="vBm__event">
+              <span class="vBm__event-time">21:00</span>
+              <span class="vBm__event-text">Mode <b>Lumière soir</b> applied</span>
+            </div>
+            <div class="vBm__event">
+              <span class="vBm__event-time">20:54</span>
+              <span class="vBm__event-text"><b>Sunset</b> · Night phase</span>
+            </div>
+          </div>
+
+        </div>
+
+        <!-- Bottom tab bar -->
+        <div class="vBm__tabs">
+          <div class="vBm__tab vBm__tab--active">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+            Zone
+          </div>
+          <div class="vBm__tab">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M21 12.8A9 9 0 1 1 11.2 3"/></svg>
+            Modes
+          </div>
+          <div class="vBm__tab">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18M3 12h18M21 3v18"/></svg>
+            Analyse
+          </div>
+          <div class="vBm__tab">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33"/></svg>
+            Settings
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <div class="notes">
+    <b>Intent (mobile).</b> Mêmes données, même architecture que B desktop, mais adaptée au pouce :
+    <ul>
+      <li>Ribbon 2×2 (au lieu de 4 colonnes) — la luminosité et le motion restent en haut</li>
+      <li>Bandeau du mode actif en évidence sous le ribbon (cliquable pour changer) — c'est l'info la plus utile en mobile (« quel mode est appliqué là ? »)</li>
+      <li>Chips de filtre scrollables horizontalement — natif sur mobile</li>
+      <li>Equipments, Recipes et Activity en panneaux empilés (1 col) — déjà 1 col en desktop, juste resserré</li>
+      <li>Bottom tab bar fixe : Zone / Modes / Analyse / Settings — navigation principale au pouce, sidebar non nécessaire en mobile</li>
+      <li>Targets touch &gt; 44px (les toggles font 32×18 mais leur zone tactile est élargie à 44×44 dans la pratique)</li>
+    </ul>
+  </div>
+</section>
+
+<!-- ============================================================ -->
+<!-- VARIANT C — Tactile                                          -->
+<!-- ============================================================ -->
+<section id="vC" class="variant" style="background:#F5F2EC">
+  <div class="variant__head">
+    <div class="variant__tag"><span>C</span><span>Tactile — consumer / smart home app feel</span></div>
+    <h2 class="variant__title">Une maison qu'on touche, pas qu'on configure</h2>
+    <p class="variant__sub">Inspiration Apple Home / Hue : gros boutons tangibles, ampoules qui s'allument visuellement, modes en cartes. Pour quand un visiteur ou un membre de la famille arrive sur l'UI.</p>
+  </div>
+
+  <div class="ui">
+    <aside class="sb">
+      <div class="sb__logo">
+        <svg viewBox="25 15 150 155" fill="none" stroke="#1A4F6E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M100 30 L160 90 Q165 95 160 100 L160 150 Q160 158 152 158 L48 158 Q40 158 40 150 L40 100 Q35 95 40 90 Z"/>
+          <path d="M75 115 Q100 140 125 115" stroke="#3B95C2"/>
+          <path d="M78 95 Q83 87 88 95" stroke="#3B95C2"/>
+          <path d="M112 95 Q117 87 122 95" stroke="#3B95C2"/>
+        </svg>
+        <b>SOWEL</b>
+      </div>
+      <div class="sb__group">
+        <div class="sb__item"><span>⊟</span><span>Dashboard</span></div>
+        <div class="sb__item sb__item--active"><span>⌂</span><span>Maison</span><span class="sb__chev">⌄</span></div>
+        <div class="sb__sub">
+          <div class="sb__sub-item">RDC</div>
+          <div class="sb__sub" style="margin-left:.65rem">
+            <div class="sb__sub-item">Cuisine</div>
+            <div class="sb__sub-item sb__sub-item--active">Séjour</div>
+          </div>
+          <div class="sb__sub-item">Etage 1</div>
+        </div>
+        <div class="sb__item"><span>≡</span><span>Modes</span></div>
+        <div class="sb__item"><span>↗</span><span>Analyse</span></div>
+        <div class="sb__item"><span>⚡</span><span>Energy</span></div>
+      </div>
+    </aside>
+
+    <div class="main" style="background:#F5F2EC">
+      <!-- Top zone bar -->
+      <div class="vC__top">
+        <div>
+          <h1 class="vC__zone-name">Séjour</h1>
+          <div class="vC__zone-path">Grange Neuve · RDC</div>
+        </div>
+        <div class="vC__mini-metrics">
+          <div class="vC__mini-metric">
+            <div class="vC__mini-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M2 12h2M20 12h2"/></svg></div>
+            <div><div class="vC__mini-val">334 lx</div><div class="vC__mini-lab">Luminosity</div></div>
+          </div>
+          <div class="vC__mini-metric">
+            <div class="vC__mini-icon vC__mini-icon--motion"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="5" r="2"/><path d="M9 14l3-3 3 3M9 21l3-3 3 3"/></svg></div>
+            <div><div class="vC__mini-val">Calm</div><div class="vC__mini-lab">16 min ago</div></div>
+          </div>
+          <div class="vC__mini-metric">
+            <div class="vC__mini-icon vC__mini-icon--lights"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18h6M10 22h4M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/></svg></div>
+            <div><div class="vC__mini-val">1 / 3</div><div class="vC__mini-lab">Lights on</div></div>
+          </div>
+          <div class="vC__mini-metric">
+            <div class="vC__mini-icon vC__mini-icon--shutters"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+            <div><div class="vC__mini-val">0 / 3</div><div class="vC__mini-lab">Shutters open</div></div>
+          </div>
+        </div>
+        <div class="vC__mode-pill">Lumière soir</div>
+      </div>
+
+      <!-- Lights (big tactile cards) -->
+      <div class="vC__group-title">
+        <h2>Lights</h2>
+        <span class="vC__group-title-meta">3 lights · 1 on · avg 4%</span>
+        <span class="vC__group-title-action">All on · All off</span>
+      </div>
+      <div class="vC__lights">
+        <div class="vC__light">
+          <div class="vC__light-head">
+            <div class="vC__light-bulb"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18h6M10 22h4M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/></svg></div>
+            <div class="vC__light-name">Applique x1</div>
+            <div class="vC__light-state">Off</div>
+          </div>
+          <div class="vC__light-slider-wrap">
+            <div class="vC__light-slider" style="width:0%"></div>
+            <div class="vC__light-slider-knob" style="left:0%"></div>
+          </div>
+          <div class="vC__light-meta"><span>0%</span><span class="pct">Tap to turn on</span></div>
+        </div>
+        <div class="vC__light vC__light--on">
+          <div class="vC__light-head">
+            <div class="vC__light-bulb"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18h6M10 22h4M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/></svg></div>
+            <div class="vC__light-name">Appliques x2</div>
+            <div class="vC__light-state">On</div>
+          </div>
+          <div class="vC__light-slider-wrap">
+            <div class="vC__light-slider" style="width:4%"></div>
+            <div class="vC__light-slider-knob" style="left:4%"></div>
+          </div>
+          <div class="vC__light-meta"><span>4% · on 1h14</span><span class="pct">By Motion Light</span></div>
+        </div>
+        <div class="vC__light">
+          <div class="vC__light-head">
+            <div class="vC__light-bulb"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M2 12h2M20 12h2"/></svg></div>
+            <div class="vC__light-name">Spots</div>
+            <div class="vC__light-state">Off</div>
+          </div>
+          <div class="vC__light-slider-wrap">
+            <div class="vC__light-slider" style="width:0%"></div>
+            <div class="vC__light-slider-knob" style="left:0%"></div>
+          </div>
+          <div class="vC__light-meta"><span>—</span><span class="pct">Tap to turn on</span></div>
+        </div>
+      </div>
+
+      <!-- Shutters -->
+      <div class="vC__group-title">
+        <h2>Shutters</h2>
+        <span class="vC__group-title-meta">3 shutters · all closed</span>
+        <span class="vC__group-title-action">Open all · Close all</span>
+      </div>
+      <div class="vC__shutters">
+        <div class="vC__shutter">
+          <div class="vC__shutter-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+          <div><div class="vC__shutter-name">Volet Ouest</div><div class="vC__shutter-state">Closed</div></div>
+          <div class="vC__shutter-bar" style="--w:0%"></div>
+          <div class="vC__shutter-ctrl">
+            <button class="vC__shutter-btn">↑</button>
+            <button class="vC__shutter-btn">■</button>
+            <button class="vC__shutter-btn">↓</button>
+          </div>
+        </div>
+        <div class="vC__shutter">
+          <div class="vC__shutter-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+          <div><div class="vC__shutter-name">Volet Sud</div><div class="vC__shutter-state">Closed</div></div>
+          <div class="vC__shutter-bar" style="--w:0%"></div>
+          <div class="vC__shutter-ctrl">
+            <button class="vC__shutter-btn">↑</button>
+            <button class="vC__shutter-btn">■</button>
+            <button class="vC__shutter-btn">↓</button>
+          </div>
+        </div>
+        <div class="vC__shutter">
+          <div class="vC__shutter-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg></div>
+          <div><div class="vC__shutter-name">Volet Sud Ouest</div><div class="vC__shutter-state">Closed</div></div>
+          <div class="vC__shutter-bar" style="--w:0%"></div>
+          <div class="vC__shutter-ctrl">
+            <button class="vC__shutter-btn">↑</button>
+            <button class="vC__shutter-btn">■</button>
+            <button class="vC__shutter-btn">↓</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Modes carousel -->
+      <div class="vC__group-title">
+        <h2>Modes</h2>
+        <span class="vC__group-title-meta">1 active</span>
+      </div>
+      <div class="vC__modes">
+        <div class="vC__mode-card">
+          <div class="vC__mode-card-icon">☀</div>
+          <div class="vC__mode-card-name">Lumière jour</div>
+          <div class="vC__mode-card-meta">1 action · tap to apply</div>
+        </div>
+        <div class="vC__mode-card">
+          <div class="vC__mode-card-icon">🌙</div>
+          <div class="vC__mode-card-name">Lumière nuit</div>
+          <div class="vC__mode-card-meta">1 action · tap to apply</div>
+        </div>
+        <div class="vC__mode-card vC__mode-card--active">
+          <div class="vC__mode-card-icon">●</div>
+          <div class="vC__mode-card-name">Lumière soir</div>
+          <div class="vC__mode-card-meta">Active · 4 actions</div>
+        </div>
+      </div>
+
+      <!-- Recipe card -->
+      <div class="vC__recipe-card">
+        <div class="vC__recipe-head">
+          <span class="vC__recipe-badge">Recipe · Active</span>
+          <span class="vC__recipe-name">Motion Light (Dimmable)</span>
+          <div class="vC__recipe-toggle"></div>
+        </div>
+        <div style="font-size:.85rem;color:var(--ink-2)">Applies to <b>Applique x1, Appliques x2</b>. Adjusts brightness with time of day.</div>
+        <div class="vC__recipe-grid">
+          <div class="vC__recipe-prop">
+            <div class="vC__recipe-prop-label">Timeout</div>
+            <div class="vC__recipe-prop-value">10 min</div>
+          </div>
+          <div class="vC__recipe-prop">
+            <div class="vC__recipe-prop-label">Lux threshold</div>
+            <div class="vC__recipe-prop-value">≤ 2300</div>
+          </div>
+          <div class="vC__recipe-prop">
+            <div class="vC__recipe-prop-label">Slot 1</div>
+            <div class="vC__recipe-prop-value">21:00 · 100%</div>
+          </div>
+          <div class="vC__recipe-prop">
+            <div class="vC__recipe-prop-label">Today</div>
+            <div class="vC__recipe-prop-value">14 trigs</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="notes">
+    <b>Intent.</b> Direction "smart home consumer" — l'UI doit donner envie d'interagir.
+    <ul>
+      <li>Top bar avec mini-metrics + pastille du mode actif → toujours visible</li>
+      <li>Lights en grandes cartes : l'ampoule s'illumine vraiment quand on est ON (gradient radial doré + glow)</li>
+      <li>Shutters avec contrôles directs ↑■↓ + position-bar visuelle</li>
+      <li>Modes en cartes flippables (gros boutons type Apple Home shortcuts)</li>
+      <li>La recipe a sa propre carte distincte avec un bandeau accent → c'est l'auto-magie visible</li>
+      <li>Pas top pour 30+ équipements (verbeux). Inverse du Variant B</li>
+    </ul>
+  </div>
+</section>
+
+<footer style="max-width:1280px;margin:2rem auto 3rem;padding:1.5rem;text-align:center;color:var(--ink-3);font-size:.82rem">
+  <p><b style="color:var(--ink)">Comparaison rapide</b> · <b style="color:var(--primary)">A Glanceable</b> — visiteur/mobile · <b style="color:var(--primary)">B Dashboard</b> — power user/desktop · <b style="color:var(--primary)">C Tactile</b> — usage quotidien famille</p>
+  <p style="margin-top:.5rem">Les 3 partagent : sidebar de navigation existante (inchangée), même couleurs Sowel (primary <code>#1A4F6E</code>, accent <code>#D4963F</code>), même fonts (Inter + JetBrains Mono).</p>
+</footer>
+
+</body>
+</html>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -3,87 +3,63 @@
 @import "@fontsource/inter/500.css";
 @import "@fontsource/inter/600.css";
 @import "@fontsource/jetbrains-mono/400.css";
+@import "../../design-system/tokens.css";
 
 /* ============================================================
-   Winch Design System — Tailwind v4 Theme
+   Sowel Design System — Tailwind v4 Theme
+   Light/dark palettes live in design-system/tokens.css.
+   The `.dark` class toggle on <html> (ui/src/theme.ts) is honored via
+   the extended `[data-theme="dark"], .dark` selector in tokens.css.
    ============================================================ */
 
 @theme {
-  /* Colors — Light mode (Ocean palette) */
-  --color-primary: #1A4F6E;
-  --color-primary-mid: #7FB8D4;
-  --color-primary-light: #E6F0F6;
-  --color-primary-hover: #13405A;
-  --color-accent: #D4963F;
-  --color-accent-hover: #BB8232;
-  --color-accent-light: #FDF0E0;
-  --color-background: #F8FAFB;
-  --color-surface: #FFFFFF;
-  --color-surface-raised: #FFFFFF;
-  --color-text: #1A1A1A;
-  --color-text-secondary: #6B7280;
-  --color-text-tertiary: #9CA3AF;
-  --color-border: #E1E6EA;
-  --color-border-light: #EDF0F3;
-  --color-active: #FACC15;
-  --color-active-text: #A16207;
-  --color-success: #3D8B6E;
-  --color-warning: #C88B3A;
-  --color-error: #C0453A;
+  /* Colors — resolved from design-system/tokens.css */
+  --color-primary:        var(--p-500);
+  --color-primary-mid:    var(--p-100);
+  --color-primary-light:  var(--p-50);
+  --color-primary-hover:  var(--p-600);
+  --color-accent:         var(--a-500);
+  --color-accent-hover:   var(--a-600);
+  --color-accent-light:   var(--a-50);
+  --color-background:     var(--n-50);
+  --color-surface:        var(--n-0);
+  --color-surface-raised: var(--n-0);
+  --color-text:           var(--n-700);
+  --color-text-secondary: var(--n-600);
+  --color-text-tertiary:  var(--n-400);
+  --color-border:         var(--line-2);
+  --color-border-light:   var(--line);
+  --color-active:         var(--a-500);
+  --color-active-text:    var(--a-600);
+  --color-success:        var(--green-500);
+  --color-warning:        var(--a-500);
+  --color-error:          var(--red-500);
 
   /* Typography */
-  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, monospace;
+  --font-sans: var(--font-body);
+  --font-mono: var(--font-mono);
 
-  /* Font sizes — Winch specific */
+  /* Font sizes — Sowel specific (no design-system equivalent yet) */
   --font-size-data-lg: 28px;
   --font-size-data-md: 20px;
 
-  /* Border radius */
+  /* Border radius — kept at production values; spec 098 will align to design system */
   --radius-sm: 6px;
   --radius-md: 10px;
   --radius-lg: 14px;
 
-  /* Shadows */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.08);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.12);
+  /* Shadows — resolved from design-system tokens (auto-darken in dark mode) */
+  --shadow-sm: var(--sh-1);
+  --shadow-md: var(--sh-2);
+  --shadow-lg: var(--sh-3);
 }
 
 /* ============================================================
-   Dark mode overrides — deep navy slate palette
+   Dark mode widget SVG boost (production-specific, kept outside @theme)
    ============================================================ */
 
-.dark {
-  --color-primary: #4A9FCC;
-  --color-primary-mid: #5CB3E0;
-  --color-primary-light: #1A2E42;
-  --color-primary-hover: #5CB3E0;
-  --color-accent: #E0A84F;
-  --color-accent-hover: #EBB85F;
-  --color-accent-light: #3A2A14;
-  --color-background: #111827;
-  --color-surface: #1E293B;
-  --color-surface-raised: #253040;
-  --color-text: #E8EAED;
-  --color-text-secondary: #94A3B8;
-  --color-text-tertiary: #64748B;
-  --color-border: #2D3A4F;
-  --color-border-light: #253040;
-  --color-active: #EAB308;
-  --color-active-text: #FDE68A;
-  --color-success: #5BB98C;
-  --color-warning: #E0A84F;
-  --color-error: #E05A50;
-
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.20);
-  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.30);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.40);
-
-  /* Boost widget SVG icon visibility on dark backgrounds */
-  svg[viewBox="0 0 56 56"] {
-    filter: brightness(1.6);
-  }
+.dark svg[viewBox="0 0 56 56"] {
+  filter: brightness(1.6);
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary

Phase 0 of the [UI redesign breakdown](../tree/feat/design-system-palette/specs/094-ui-redesign) — swap the Tailwind v4 `@theme` block to alias `design-system/tokens.css`. Introduces the refined Sowel palette (Hybrid light + Dark themes) as the source of truth.

- **No JSX changes.** Existing `.dark` class toggle in [ui/src/theme.ts](../tree/feat/design-system-palette/ui/src/theme.ts) continues to work — `tokens.css` now matches both `[data-theme="dark"]` and `.dark`.
- **Visual diff expected**: amber accent is more saturated, neutrals recalibrated to zinc, shadows tuned for the design system. Functional diff: zero.

## Changes

- `ui/src/index.css` — `@theme` block rewritten to use `var(--p-*)`, `var(--n-*)`, `var(--a-*)` etc. Legacy `.dark { ... }` block removed (dark palette now lives in `tokens.css`). SVG-boost rule for dark mode widgets preserved outside `@theme`.
- `design-system/tokens.css` — dark selector extended to `[data-theme=\"dark\"], .dark` so the existing app's `.dark` class toggling keeps working.
- `design-system/` — full reference (tokens, 21 component specs, motion, a11y, migration plan).
- `specs/094-ui-redesign/` — umbrella spec + Phase 0 implementation details.
- `specs/095-102/` — light scoping specs for each follow-up phase (typography, sidebar, strip pills, dashboard, equipment row, comportements, activity feed, recipe modal).
- `ui-redesign-B-polished.html` (and 2 earlier mock variants) — reference HTML implementation against which the design system was validated.

## Hex audit

~30 hex literals remain in `ui/src/`, all explicitly out of scope per [design-system/migration.md §6](../tree/feat/design-system-palette/design-system/migration.md):

- Chart palettes (Energy HP/HC, Autoconso, Injection, Analyse)
- SVG art colors in `WidgetIcons.tsx` (water waves)
- Mode badge colors in `ZoneRecipesSection.tsx` (eco green, night purple)

Chart colors will be addressed in a future dedicated spec.

## Test plan

- [x] `cd ui && npm run build` — succeeds
- [x] `npx tsc --noEmit` — passes (backend)
- [x] `cd ui && npx tsc -b --noEmit` — passes
- [x] `npx vitest run` — 429 tests pass
- [x] `npx eslint src/ --ext .ts` — clean
- [ ] **Manual**: open dev app, switch through Light / Dark / System modes, verify no console errors
- [ ] **Manual**: side-by-side screenshots on Dashboard, Zone view, Énergie
- [ ] **Manual**: verify amber light-on state on equipment rows still uses the new `--a-500` (`#F2C035`)

## Rollback

Single `git revert` of this commit restores the previous palette in seconds. The change is fully self-contained in two CSS files.

## Subsequent phases

Once merged, pick up phases via `/sowel-feature`:

1. **096** sidebar (fast win)
2. **097** strip pills (clusters + alert variant)
3. **098** dashboard (radius alignment)
4. **095** typography (in parallel, invisible polish)
5. **099** equipment row (long pole — 1 PR per equipment type)
6. **100 → 101 → 102** comportements, activity feed, recipe modal