### PR TITLE
fix(ui): avoid double-highlight on sidebar section header + active sub-item

### DIFF
--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -116,6 +116,10 @@ export function Sidebar() {
 
   const adminActive = ADMIN_ROUTES.some((r) => location.pathname.startsWith(r));
   const energyActive = location.pathname.startsWith("/energy");
+  const modesSubActive = !collapsed && expandedSection === "modes" && location.pathname.startsWith("/modes/");
+  const analyseSubActive = !collapsed && expandedSection === "analyse" && location.pathname.startsWith("/analyse/");
+  const energySubActive = !collapsed && expandedSection === "energy" && energyActive;
+  const adminSubActive = !collapsed && expandedSection === "admin" && adminActive;
 
   return (
     <aside
@@ -182,6 +186,7 @@ export function Sidebar() {
           icon={<Layers size={ICON_SIZE} strokeWidth={1.5} />}
           collapsed={collapsed}
           end
+          subActive={modesSubActive}
           expanded={collapsed ? undefined : expandedSection === "modes"}
           title={collapsed ? t("nav.modes") : undefined}
           onClick={(e) => {
@@ -202,6 +207,7 @@ export function Sidebar() {
           icon={<BarChart3 size={ICON_SIZE} strokeWidth={1.5} />}
           collapsed={collapsed}
           end
+          subActive={analyseSubActive}
           expanded={collapsed ? undefined : expandedSection === "analyse"}
           title={collapsed ? t("nav.analyse") : undefined}
           onClick={(e) => {
@@ -223,6 +229,7 @@ export function Sidebar() {
               icon={<Zap size={ICON_SIZE} strokeWidth={1.5} />}
               collapsed={collapsed}
               active={energyActive}
+              subActive={energySubActive}
               expanded={collapsed ? undefined : expandedSection === "energy"}
               title={collapsed ? t("nav.energy") : undefined}
               onClick={(e) => {
@@ -275,6 +282,7 @@ export function Sidebar() {
                 label={t("nav.administration")}
                 icon={<Shield size={ICON_SIZE} strokeWidth={1.5} />}
                 active={adminActive}
+                subActive={adminSubActive}
                 expanded={expandedSection === "admin"}
                 onClick={() => toggleSection("admin")}
               />

--- a/ui/src/components/layout/SidebarSectionHeader.tsx
+++ b/ui/src/components/layout/SidebarSectionHeader.tsx
@@ -7,8 +7,15 @@ interface SidebarSectionHeaderProps {
   to?: string;
   label: string;
   icon: ReactNode;
-  /** When true, an active state is forced (e.g. ADMIN_ROUTES matcher). */
+  /** Override — am I the active leaf (full pill bg)? Default = NavLink's automatic isActive. */
   active?: boolean;
+  /**
+   * When true, a sub-item carries the leaf — render the header in "parent" style
+   * (primary text + icon, no bg fill). Use this whenever the section is expanded
+   * and a deeper route is the current view, so the header and the sub-item don't
+   * highlight at the same time.
+   */
+  subActive?: boolean;
   /** When defined, renders an expand chevron. */
   expanded?: boolean;
   collapsed?: boolean;
@@ -20,27 +27,34 @@ interface SidebarSectionHeaderProps {
   onClick?: (e: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => void;
 }
 
-function headerClasses(isActive: boolean, collapsed: boolean): string {
+function headerClasses(
+  isInSection: boolean,
+  isLeaf: boolean,
+  collapsed: boolean,
+): string {
   const base =
     "flex items-center gap-2 px-3 py-1.5 w-full rounded-[6px] transition-colors duration-150 ease-out";
   const layout = collapsed ? "justify-center" : "";
-  const state = isActive
+  const state = isLeaf
     ? "bg-primary-light"
-    : "hover:bg-background";
+    : isInSection
+      ? ""
+      : "hover:bg-background";
   return `${base} ${layout} ${state}`.trim();
 }
 
-function labelClasses(isActive: boolean): string {
-  const base = "text-[11px] font-semibold uppercase tracking-wider transition-colors";
-  return `${base} ${isActive ? "text-primary" : "text-text-secondary"}`;
+function labelClasses(isInSection: boolean): string {
+  const base =
+    "text-[11px] font-semibold uppercase tracking-wider transition-colors";
+  return `${base} ${isInSection ? "text-primary" : "text-text-secondary"}`;
 }
 
-function iconColorClass(isActive: boolean): string {
-  return isActive ? "text-primary" : "text-text-secondary";
+function iconColorClass(isInSection: boolean): string {
+  return isInSection ? "text-primary" : "text-text-secondary";
 }
 
 interface ContentProps {
-  isActive: boolean;
+  isInSection: boolean;
   collapsed: boolean;
   label: string;
   icon: ReactNode;
@@ -48,25 +62,37 @@ interface ContentProps {
   badge?: ReactNode;
 }
 
-function HeaderContent({ isActive, collapsed, label, icon, expanded, badge }: ContentProps) {
+function HeaderContent({
+  isInSection,
+  collapsed,
+  label,
+  icon,
+  expanded,
+  badge,
+}: ContentProps) {
   return (
     <>
-      <span className={`flex-shrink-0 relative ${iconColorClass(isActive)}`}>
+      <span className={`flex-shrink-0 relative ${iconColorClass(isInSection)}`}>
         {icon}
       </span>
-      {!collapsed && (
-        <span className={labelClasses(isActive)}>{label}</span>
-      )}
+      {!collapsed && <span className={labelClasses(isInSection)}>{label}</span>}
       {!collapsed && (badge !== undefined || expanded !== undefined) && (
         <span className="ml-auto flex items-center gap-1 flex-shrink-0">
           {badge}
-          {expanded !== undefined && (
-            expanded ? (
-              <ChevronDown size={12} strokeWidth={1.5} className="text-text-tertiary" />
+          {expanded !== undefined &&
+            (expanded ? (
+              <ChevronDown
+                size={12}
+                strokeWidth={1.5}
+                className="text-text-tertiary"
+              />
             ) : (
-              <ChevronRight size={12} strokeWidth={1.5} className="text-text-tertiary" />
-            )
-          )}
+              <ChevronRight
+                size={12}
+                strokeWidth={1.5}
+                className="text-text-tertiary"
+              />
+            ))}
         </span>
       )}
     </>
@@ -78,6 +104,7 @@ export function SidebarSectionHeader({
   label,
   icon,
   active,
+  subActive,
   expanded,
   collapsed = false,
   badge,
@@ -85,6 +112,16 @@ export function SidebarSectionHeader({
   title,
   onClick,
 }: SidebarSectionHeaderProps) {
+  function resolveState(navIsActive: boolean) {
+    // subActive forces parent style (in-section text/icon, no bg). It wins over
+    // the leaf detection because the visible sub-item carries the leaf.
+    if (subActive) {
+      return { isInSection: true, isLeaf: false };
+    }
+    const isLeaf = active ?? navIsActive;
+    return { isInSection: isLeaf, isLeaf };
+  }
+
   if (to) {
     return (
       <NavLink
@@ -92,33 +129,39 @@ export function SidebarSectionHeader({
         end={end}
         onClick={onClick}
         title={title}
-        className={({ isActive: navIsActive }) =>
-          headerClasses(active ?? navIsActive, collapsed)
-        }
+        className={({ isActive: navIsActive }) => {
+          const { isInSection, isLeaf } = resolveState(navIsActive);
+          return headerClasses(isInSection, isLeaf, collapsed);
+        }}
       >
-        {({ isActive: navIsActive }) => (
-          <HeaderContent
-            isActive={active ?? navIsActive}
-            collapsed={collapsed}
-            label={label}
-            icon={icon}
-            expanded={expanded}
-            badge={badge}
-          />
-        )}
+        {({ isActive: navIsActive }) => {
+          const { isInSection } = resolveState(navIsActive);
+          return (
+            <HeaderContent
+              isInSection={isInSection}
+              collapsed={collapsed}
+              label={label}
+              icon={icon}
+              expanded={expanded}
+              badge={badge}
+            />
+          );
+        }}
       </NavLink>
     );
   }
+
+  const { isInSection, isLeaf } = resolveState(false);
 
   return (
     <button
       type="button"
       onClick={onClick}
       title={title}
-      className={`${headerClasses(active ?? false, collapsed)} cursor-pointer`}
+      className={`${headerClasses(isInSection, isLeaf, collapsed)} cursor-pointer`}
     >
       <HeaderContent
-        isActive={active ?? false}
+        isInSection={isInSection}
         collapsed={collapsed}
         label={label}
         icon={icon}


### PR DESCRIPTION
## Summary

Follow-up to spec 096 (sidebar refactor). When a section is expanded and a sub-item is the current route, both the section header and the sub-item were rendering as active simultaneously (e.g. ÉNERGIE + Consommation both showing bg-primary-light).

Restores the production-original convention: in expanded mode, the section header only signals "you are in this section" via primary text/icon — no bg fill. The bg-pill belongs to the leaf sub-item alone.

## Changes

- `ui/src/components/layout/SidebarSectionHeader.tsx` — refactor to a 3-state model (idle / parent / leaf). New `subActive` prop selects the parent style.
- `ui/src/components/layout/Sidebar.tsx` — pass `subActive` on Modes / Analyse / Énergie / Admin headers when the section is expanded AND the current path matches a sub-item:
  - `modesSubActive = expanded && pathname.startsWith("/modes/")`
  - `analyseSubActive = expanded && pathname.startsWith("/analyse/")`
  - `energySubActive = expanded && pathname.startsWith("/energy")`
  - `adminSubActive = expanded && admin-route-matched`

## States cheat sheet

| When                                                | Header           | Sub-item       |
| --------------------------------------------------- | ---------------- | -------------- |
| /energy/consumption, sidebar expanded               | text-only parent | full pill leaf |
| /energy/consumption, sidebar collapsed              | full pill leaf   | (hidden)       |
| /modes (exact), section expanded                    | full pill leaf   | (no match)     |
| /modes/abc, section expanded                        | text-only parent | full pill leaf |
| /dashboard                                          | full pill leaf   | n/a            |

## Test plan

- [x] `cd ui && npm run build` — succeeds
- [x] `npx tsc --noEmit` — passes (backend)
- [x] `cd ui && npx tsc -b --noEmit` — passes
- [x] `npx vitest run` — 429 tests pass
- [x] `npx eslint src/ --ext .ts` — clean
- [ ] **Manual**: confirm ÉNERGIE + Consommation no longer both highlighted on /energy/consumption
- [ ] **Manual**: same check on /modes/<id>, /analyse/<id>, /devices (admin sub-routes)
- [ ] **Manual**: in collapsed sidebar mode, the icon still lights up on any /energy/* or admin route

## Related

- Incident report: spec 096 (sidebar refactor) shipped this regression. See feedback_verify_branch_before_commit in user memory for the meta-incident around the merge process.