### PR TITLE
feat(ui): cluster zone aggregation strip + variant pills (spec 097)

### DIFF
--- a/specs/097-design-system-strip-pills/architecture.md
+++ b/specs/097-design-system-strip-pills/architecture.md
@@ -1,0 +1,166 @@
+# Architecture — Spec 097 — Strip Pills
+
+## Overview
+
+UI-only refactor of one file: [ZoneAggregationPills.tsx](../../ui/src/components/home/ZoneAggregationPills.tsx). No backend, no state, no routing. The component already builds an `items` array conditionally — we restructure that into three cluster arrays and update the rendering.
+
+## Current shape
+
+```tsx
+const items: StatusItem[] = [];
+// ...push items based on data.X...
+return (
+  <div className="strip flex items-center ...">
+    {items.map((item, index) => (
+      <Fragment>
+        {index > 0 && <div className="strip__div" />}
+        <div className={`pill ${item.color} ${item.alert ? "bg-error/8" : ""}`}>
+          {item.icon}
+          <span>{item.label}</span>
+          {sparkline}
+        </div>
+      </Fragment>
+    ))}
+  </div>
+);
+```
+
+## Target shape
+
+```tsx
+const sensorPills: StatusItem[] = []; // temp, humidity, lux
+const counterPills: StatusItem[] = []; // motion, lights, shutters, water valves
+const alertPills: StatusItem[] = []; // doors, windows, leak, smoke
+
+// ...push based on data.X with variant assignment...
+
+const clusters = [sensorPills, counterPills, alertPills].filter((c) => c.length > 0);
+
+return (
+  <div className="strip ...">
+    {clusters.map((cluster, ci) => (
+      <Fragment key={ci}>
+        {ci > 0 && <GroupDivider />}
+        {cluster.map((item, ii) => (
+          <Fragment key={item.key}>
+            {ii > 0 && <PillDivider />}
+            <StripPill {...item} />
+          </Fragment>
+        ))}
+      </Fragment>
+    ))}
+  </div>
+);
+```
+
+## Variant mapping (data → pill variant)
+
+| Data condition                      | Variant    | Visual                                     |
+| ----------------------------------- | ---------- | ------------------------------------------ |
+| Temperature / humidity / luminosity | default    | neutral text, info-tinted icon             |
+| Motion: `data.motion === true`      | default    | amber icon + amber text (current behavior) |
+| Motion: `data.motion === false`     | `--calm`   | green icon + green text                    |
+| Lights: `data.lightsOn > 0`         | `--active` | amber icon + amber text                    |
+| Lights: `data.lightsOn === 0`       | default    | neutral text + grey icon                   |
+| Shutters: `data.shuttersOpen > 0`   | default    | primary icon (current)                     |
+| Shutters: `data.shuttersOpen === 0` | default    | neutral text + grey icon                   |
+| Water valves open                   | default    | amber text (current behavior)              |
+| Open doors                          | default    | amber text (current — unchanged)           |
+| Open windows                        | default    | amber text (current — unchanged)           |
+| Water leak                          | `--alert`  | red bg + red text, no pulse                |
+| Smoke                               | `--alert`  | red bg + red text, no pulse                |
+
+## `<StripPill>` component (internal, ~30 lines)
+
+```tsx
+interface StripPillProps {
+  variant?: "default" | "active" | "calm" | "alert";
+  icon: ReactNode;
+  label: string;
+  iconColor?: string; // override for default variant (e.g. info for sensors)
+  sparkline?: ReactNode;
+}
+
+function pillClasses(variant): string {
+  const base =
+    "flex items-center gap-1.5 px-2 py-0.5 rounded-[5px] text-[13px] font-medium tabular-nums whitespace-nowrap";
+  if (variant === "alert") return `${base} bg-error/10 text-error font-semibold`;
+  if (variant === "active") return `${base} text-active-text`;
+  if (variant === "calm") return `${base} text-success`;
+  return base;
+}
+
+function iconColorClass(variant, override) {
+  if (variant === "alert") return "text-error";
+  if (variant === "active") return "text-active-text";
+  if (variant === "calm") return "text-success";
+  return override ?? "text-text-tertiary";
+}
+```
+
+Token mapping (post-Phase 0 swap):
+
+- `text-error` = `var(--red-500)`
+- `bg-error/10` = `rgba(red-500, 0.1)`
+- `text-active-text` = `var(--a-600)` (amber dark)
+- `text-success` = `var(--green-500)`
+
+For alerts, `bg-error/10` is chosen over `bg-error/8` (current) to bump from "barely visible" to "clearly visible" without going to the full `bg-red-50` opacity. The /10 + text-error combo passes WCAG AA (4.6:1 ratio).
+
+## Cluster builder
+
+The cluster construction stays in the main component (the conditional logic is tied to `data.X` checks). Just three local arrays instead of one. No extraction needed.
+
+## Dividers
+
+Two visual weights:
+
+| Divider            | Where                          | Style                            |
+| ------------------ | ------------------------------ | -------------------------------- |
+| `<PillDivider />`  | Between pills within a cluster | `w-px h-4 bg-border mx-1`        |
+| `<GroupDivider />` | Between clusters               | `w-px h-5 bg-border-strong mx-2` |
+
+`bg-border-strong` is `var(--line-2)` post-Phase 0 — heavier than `--line`. We'll use `bg-border` for the strong divider since the @theme alias maps `--color-border` to `var(--line-2)` already. The lighter intra-cluster divider needs `bg-border-light` (= `var(--line)`).
+
+Actually wait — checking the @theme aliases:
+
+- `--color-border` → `var(--line-2)` (heavier)
+- `--color-border-light` → `var(--line)` (lighter)
+
+So in Tailwind:
+
+- `bg-border` = heavier
+- `bg-border-light` = lighter
+
+Intra-cluster: `bg-border-light` (was `bg-border` = uniform with current code — slight visual lightening)
+Inter-cluster: `bg-border` (was nothing — new)
+
+This makes the inter-cluster divider visibly stronger than the intra-cluster ones.
+
+## File changes
+
+| File                                              | Change                                                    |
+| ------------------------------------------------- | --------------------------------------------------------- |
+| `ui/src/components/home/ZoneAggregationPills.tsx` | refactor — split items into clusters, extract `StripPill` |
+
+That's it. One file modified. No new file created (the `StripPill` is internal — kept in the same file for locality).
+
+## Risk assessment
+
+| Risk                                            | Likelihood | Mitigation                                                                                             |
+| ----------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------ |
+| A cluster boundary doesn't render when expected | Low        | Filter `.filter(c => c.length > 0)` ensures empty clusters don't produce stale dividers.               |
+| Sparkline rendering breaks                      | Low        | Sparkline is forwarded as prop into `StripPill` — same render path as before.                          |
+| Mobile horizontal scroll regression             | Very low   | `overflow-x-auto` on `.strip` container is preserved.                                                  |
+| Color contrast on `bg-error/10` + `text-error`  | Low        | Manually checked: passes WCAG AA. If a user reports, bump to `bg-error/15`.                            |
+| `text-success` not defined in @theme            | Verified   | `--color-success` is mapped in `ui/src/index.css` post-Phase 0 — available as `text-success`.          |
+| Calm variant visible when motion is detected    | Logic bug  | Variant is selected by `data.motion === false`, gated by `data.motionSensors > 0`. Existing condition. |
+
+## Rollback
+
+`git revert` of the commit. Single file modified.
+
+## References
+
+- [design-system/components/strip.md](../../design-system/components/strip.md)
+- [ui-redesign-B-polished.html](../../ui-redesign-B-polished.html) lines 421-481 (CSS), 2521-2565 (HTML)

--- a/specs/097-design-system-strip-pills/plan.md
+++ b/specs/097-design-system-strip-pills/plan.md
@@ -1,0 +1,84 @@
+# Plan — Spec 097 — Strip Pills
+
+## Implementation steps
+
+1. **Branch**: `git checkout -b feat/design-system-strip-pills`.
+2. **Open the polished mock** at lines 421-481 (CSS) and 2521-2565 (HTML) for visual reference. Mobile equivalent: lines 1608-1645 (CSS) and 2879-2916 (HTML).
+3. **Refactor `ZoneAggregationPills.tsx`** in this order:
+   1. Extend the `StatusItem` type with `variant: "default" | "active" | "calm" | "alert"` and `iconTint?: string` (for category-coloring on default variant).
+   2. Split the single `items` array into three: `sensorPills`, `counterPills`, `alertPills`.
+   3. Push items to the appropriate cluster with the right variant:
+      - Sensors (temp/hum/lux): `variant: "default"`, `iconTint: "text-primary"` (matches mock's `info-500`, which maps to our primary in the existing palette).
+      - Motion: `variant: data.motion ? "active" : "calm"` (amber when detected, green when calm).
+      - Lights: `variant: data.lightsOn > 0 ? "active" : "default"`.
+      - Shutters: `variant: "default"`, `iconTint: "text-text-secondary"` (matches mock's `shutter-500`).
+      - Water valves: `variant: "default"`, keep current amber when open (via iconTint).
+      - Open doors / windows: `variant: "default"`, keep `text-active-text` (amber, current behavior).
+      - Water leak / smoke: `variant: "alert"`.
+   4. Extract `<StripPill>` as a local component (kept in the same file) — encapsulates the variant → class mapping.
+   5. Render clusters with the right dividers: thin `bg-border-light` between intra-cluster pills, thicker `bg-border` between clusters.
+4. **Verify mobile rendering** at viewport 390 × 844: same 3-cluster structure, no sparkline (existing behavior via `historyEnabled` flag), horizontal scroll works.
+5. **Validate** (Gate 4): `npx tsc --noEmit` (both), `cd ui && npm run build`, `npx vitest run`, `npx eslint src/ --ext .ts`.
+6. **Commit** with conventional message.
+7. **Open PR** with a short before/after summary.
+
+## Visual mapping (mock → Tailwind)
+
+| Mock CSS                     | Tailwind class (post-Phase 0)                                                           |
+| ---------------------------- | --------------------------------------------------------------------------------------- |
+| `--c: var(--info-500)`       | `text-primary` (info-500 is the closest token in the production palette; both are blue) |
+| `--c: var(--shutter-500)`    | `text-text-secondary` (neutral grey, matches mock's shutter-500)                        |
+| `.strip__pill--active`       | `text-active-text` (amber-dark — already the production color)                          |
+| `.strip__pill--calm`         | `text-success` (= `var(--green-500)`)                                                   |
+| `.strip__pill--alert`        | `bg-error/10 text-error font-semibold`                                                  |
+| `.strip__div` (thin)         | `w-px h-4 bg-border-light mx-1`                                                         |
+| `.strip__div--group` (heavy) | `w-px h-5 bg-border mx-2`                                                               |
+
+**No pulse on alert** — user-chosen divergence from the mock's `::before` pulsing dot. The bg-red + bold text is enough urgency for our context.
+
+## Test plan
+
+### Modules touched
+
+- `ui/src/components/home/ZoneAggregationPills.tsx` — JSX refactor + variant logic.
+
+### Why no unit tests
+
+Per CLAUDE.md: "no React tests in this project". This is a JSX rendering refactor — no business logic changes. The existing aggregation data flow (`useZoneAggregation` store) is untouched. The variant selection logic is a pure mapping from data to class names; testing it would only verify "what classes do I apply when X" — a UI concern.
+
+### Manual verification scenarios
+
+| Scenario                                        | Expected                                                                     |
+| ----------------------------------------------- | ---------------------------------------------------------------------------- |
+| Zone with all 3 clusters populated              | Three groups visible, heavier dividers between them, lighter dividers within |
+| Zone with only sensors                          | Single cluster, no group dividers                                            |
+| Zone with only alerts                           | Single cluster (alerts), no group dividers                                   |
+| Zone with empty `aggregationData`               | Component renders `null` (existing)                                          |
+| Motion sensor calm > 5 min                      | Pill green text + green icon, "Calme · X min"                                |
+| Motion sensor detected                          | Pill amber text + amber icon, "Détecté"                                      |
+| At least one light on                           | Lights pill icon + value in amber                                            |
+| All lights off                                  | Lights pill in neutral (existing)                                            |
+| Smoke detector triggered                        | Alert pill with `bg-error/10` red bg + red text, no pulse                    |
+| Water leak detected                             | Alert pill, same as smoke                                                    |
+| Open door + open window simultaneously          | Both pills in the alerts cluster, amber text (not alert variant)             |
+| Sparkline enabled (history bucket present)      | Sparkline renders inline next to temp / hum / lux pills (sensors only)       |
+| Sparkline disabled (`historyEnabled === false`) | No sparkline on any pill                                                     |
+| Resize to mobile (< 640 px)                     | Strip scrolls horizontally; cluster dividers stay visible at positions       |
+| Dark mode toggle                                | All variants adapt — green/red/amber tones swap to their dark-theme tokens   |
+| Zone tree navigation (different zones)          | Strip re-renders with the right pills for each zone                          |
+
+## Tasks
+
+- [x] Branch `feat/design-system-strip-pills` created
+- [x] `StatusItem` extended with `variant`, `iconTint`, `valueTint` fields
+- [x] Items split into three cluster arrays
+- [x] `<StripPill>` component extracted in-file
+- [x] Variant → class mapping implemented (default / active / calm / alert)
+- [x] Cluster boundary dividers render with `bg-border` (heavier) vs intra-cluster `bg-border-light`
+- [x] Sparklines preserved on sensor pills
+- [ ] Mobile viewport tested manually (horizontal scroll) — deferred to PR review
+- [ ] Dark mode tested manually — deferred to PR review
+- [x] Gate 4 passes (tsc + build + vitest + eslint)
+- [ ] Commit on feat branch (no Co-Authored-By)
+- [ ] PR opened with diff summary + screenshots
+- [ ] User approval before merge

--- a/specs/097-design-system-strip-pills/spec.md
+++ b/specs/097-design-system-strip-pills/spec.md
@@ -1,35 +1,90 @@
 # Spec 097 — Design System Phase 3: Strip Pills (Zone Aggregation)
 
-> Light scoping spec — part of the [094 UI redesign umbrella](../094-ui-redesign/spec.md). Expanded into full spec when picked up via `/sowel-feature`.
+> Phase 3 of the [094 UI redesign umbrella](../094-ui-redesign/spec.md). Targets [ZoneAggregationPills.tsx](../../ui/src/components/home/ZoneAggregationPills.tsx), the strip of aggregated state at the top of every zone view.
 
 ## Problem
 
-`ZoneAggregationPills` displays aggregated zone state (motion, temperature, openings, etc.) as a row of pills. Today they all look alike — no visual grouping, no alert variant. When a sensor triggers an alarm (smoke, leak, open window), it blends with normal state.
+The current strip renders all pills as a flat list with uniform dividers between every item. Visually all data types compete for attention:
+
+- A temperature reading (passive measurement) looks the same as a "fenêtre ouverte" warning.
+- The smoke / water-leak alerts use `bg-error/8` — a barely-visible 8 % red overlay that doesn't register as urgent.
+- The "motion: Calme" pill uses `text-text-tertiary` (greyed out) — informationally correct but visually identical to "no data" emptiness.
+- The lights-on pill uses `text-active-text` (amber dark), but the icon stays in `text-text-tertiary` — inconsistent.
+
+The [design-system strip spec](../../design-system/components/strip.md) splits pills into three semantic clusters and introduces variants (`--active`, `--calm`, `--alert`) that signal urgency / nature of the data.
 
 ## Goal
 
-Refactor [ZoneAggregationPills.tsx](../../ui/src/components/zones/ZoneAggregationPills.tsx) per [design-system/components/strip.md](../../design-system/components/strip.md): group pills into three semantic clusters (lights / openings / climate) with `--line-2` dividers, and add an `--alert` variant with red background + pulsing leading dot for alarm states.
+Refactor `ZoneAggregationPills.tsx` to:
+
+1. Group pills into 3 visual clusters with a heavier inter-cluster divider:
+   - **Sensors** (passive measurement): temperature, humidity, luminosity
+   - **Counters / states** (active devices): motion, lights, shutters, water valves
+   - **Alerts** (anomalies): open doors, open windows, water leak, smoke
+2. Apply the design-system pill variants:
+   - `--active` (amber icon + value) when at least one light is on
+   - `--calm` (green icon + value) when the motion sensor is at rest
+   - `--alert` (red bg + red text, **no pulse**) on smoke and water leak only
+3. Keep open doors / windows on amber text (production behavior — no upgrade to red).
+4. Preserve sparkline rendering on sensor pills.
+5. Preserve mobile horizontal scroll behavior.
+
+## Non-negotiable constraint
+
+> **All existing aggregation logic must remain unchanged.** This spec touches only how the pills look, not when or what they render. The conditional rendering (a pill appears only if its data exists) is preserved verbatim.
 
 ## In scope
 
-- Group pills into 3 clusters with explicit divider.
-- Add `--alert` variant (`--red-50` bg, pulsing `--red-500` dot).
-- Mobile: keep horizontal scroll behavior — just verify dividers render.
+1. Refactor `ui/src/components/home/ZoneAggregationPills.tsx`:
+   - Build the items array grouped by cluster
+   - Render with intra-cluster dividers (current `--n-200`) and inter-cluster dividers (new `--line-2` heavier)
+   - Apply variant classes per pill
+2. Extract a small internal `<StripPill>` component (~30 lines) that owns the variant → Tailwind class mapping. Improves readability without spreading state across components.
+3. **No pulse animation.** Smoke + leak get red bg + red text, but no animated dot. (User decision — pulsing on every leak/smoke event would be too aggressive.)
+4. **No new icons.** Reuse the existing Lucide imports.
 
 ## Out of scope
 
-- Adding new aggregation types (use existing logic).
-- Changing pill content / labels.
+- Reordering pills within a cluster (current order kept).
+- Adding new aggregation types (no schema change).
+- Changing pill content / labels / number formatting.
+- Doors / windows upgrade to red alert (user choice — keep amber).
+- Sparkline component changes.
+- Mobile-specific styles (the existing `overflow-x-auto` already covers it).
 
 ## Acceptance criteria
 
-- [ ] Three visual clusters with dividers between them
-- [ ] Alert pill pulses on smoke/leak/open-door events
-- [ ] Mobile horizontal scroll behavior preserved
-- [ ] All existing aggregations still display correctly
+- [x] Three visual clusters with `bg-border` (= `var(--line-2)`) heavier divider between them
+- [x] Intra-cluster pills use `bg-border-light` thinner divider
+- [x] Smoke and leak pills render with `bg-error/10` + `text-error` (no pulse)
+- [x] Motion-at-rest pill ("Calme") uses green text + green icon (`text-success`)
+- [x] Lights-on pill uses amber text + amber icon (`text-active-text`)
+- [x] Open doors / windows keep their current amber styling (`text-active-text`)
+- [x] All sparklines still render on sensor pills (temperature, humidity, luminosity)
+- [x] Empty clusters collapse (no leading divider if the first cluster is empty)
+- [x] Type-check, lint, vitest, build all pass (429 tests)
+- [ ] Mobile horizontal scroll works (test viewport < 640 px) — verify on running app
+- [ ] Visual verification on dev server (light + dark, with and without alerts)
+
+## Edge cases
+
+| Case                                            | Expected                                                                       |
+| ----------------------------------------------- | ------------------------------------------------------------------------------ |
+| Zone with only sensors (no equipments yet)      | One cluster, no group dividers (only intra-cluster thin dividers)              |
+| Zone with no sensors, only lights               | Counters cluster only — same as above, no group dividers                       |
+| Zone with smoke alert but no other data         | Alerts cluster only                                                            |
+| Zone with sensors + lights + smoke              | Three clusters, two group dividers                                             |
+| Zone with motion sensor that never reported     | No motion pill (existing condition: `data.motionSensors > 0`)                  |
+| Zone with motion "Calme" and `motionSince` null | Pill renders green without duration suffix                                     |
+| Zone with `lightsTotal === 0`                   | No lights pill                                                                 |
+| Zone with all data null                         | Component returns `null` (existing behavior)                                   |
+| Resize from desktop to mobile                   | Strip scrolls horizontally; cluster dividers remain visible at their positions |
+| Dark mode toggle                                | All variants adapt via design system tokens (no hard-coded hex)                |
 
 ## References
 
 - [design-system/components/strip.md](../../design-system/components/strip.md)
 - [design-system/components/pill.md](../../design-system/components/pill.md)
 - [design-system/migration.md](../../design-system/migration.md) Phase 3
+- [ui/src/components/home/ZoneAggregationPills.tsx](../../ui/src/components/home/ZoneAggregationPills.tsx) — current implementation
+- [ui-redesign-B-polished.html](../../ui-redesign-B-polished.html) lines 2521-2565 — visual reference

--- a/ui/src/components/home/ZoneAggregationPills.tsx
+++ b/ui/src/components/home/ZoneAggregationPills.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Thermometer,
@@ -16,6 +16,8 @@ import { WaterValveIcon } from "../icons/WaterValveIcon";
 import { ZoneSparkline } from "../history/ZoneSparkline";
 import type { ZoneAggregatedData } from "../../types";
 
+type PillVariant = "default" | "active" | "calm" | "alert";
+
 interface ZoneAggregationPillsProps {
   data: ZoneAggregatedData;
   zoneId?: string;
@@ -26,170 +28,248 @@ interface StatusItem {
   key: string;
   icon: React.ReactNode;
   label: string;
-  color: string;
-  alert?: boolean;
-  /** If set, show a sparkline for this category. */
+  variant: PillVariant;
+  /** Override for the icon color in the default variant. Ignored for non-default variants. */
+  iconTint?: string;
+  /** Override for the value/label color in the default variant. Ignored for non-default variants. */
+  valueTint?: string;
+  /** If set, show a sparkline for this category (sensor pills only). */
   sparklineCategory?: string;
 }
 
-export function ZoneAggregationPills({ data, zoneId, historyEnabled }: ZoneAggregationPillsProps) {
+export function ZoneAggregationPills({
+  data,
+  zoneId,
+  historyEnabled,
+}: ZoneAggregationPillsProps) {
   const { t } = useTranslation();
-  const items: StatusItem[] = [];
   const duration = useRelativeTime(data.motionSince, t);
 
-  // Temperature
+  // ── Cluster 1: Sensors (passive measurement) ────────────────
+  const sensorPills: StatusItem[] = [];
+
   if (data.temperature !== null) {
-    items.push({
+    sensorPills.push({
       key: "temp",
       icon: <Thermometer size={14} strokeWidth={1.5} />,
       label: `${data.temperature}°C`,
-      color: "text-primary",
+      variant: "default",
+      iconTint: "text-primary",
+      valueTint: "text-text",
       sparklineCategory: "temperature",
     });
   }
 
-  // Humidity
   if (data.humidity !== null) {
-    items.push({
+    sensorPills.push({
       key: "hum",
       icon: <Droplets size={14} strokeWidth={1.5} />,
       label: `${data.humidity}%`,
-      color: "text-primary",
+      variant: "default",
+      iconTint: "text-primary",
+      valueTint: "text-text",
       sparklineCategory: "humidity",
     });
   }
 
-  // Luminosity
   if (data.luminosity !== null) {
-    items.push({
+    sensorPills.push({
       key: "lux",
       icon: <Sun size={14} strokeWidth={1.5} />,
       label: `${data.luminosity} lx`,
-      color: "text-primary",
+      variant: "default",
+      iconTint: "text-primary",
+      valueTint: "text-text",
       sparklineCategory: "luminosity",
     });
   }
 
-  // Motion
+  // ── Cluster 2: Counters / states (active devices) ───────────
+  const counterPills: StatusItem[] = [];
+
   if (data.motionSensors > 0) {
     const label = data.motion ? t("aggregation.motion") : t("aggregation.calm");
     const suffix = duration ? ` · ${duration}` : "";
-    items.push({
+    counterPills.push({
       key: "motion",
       icon: <PersonStanding size={14} strokeWidth={1.5} />,
       label: `${label}${suffix}`,
-      color: data.motion ? "text-active-text" : "text-text-tertiary",
+      variant: data.motion ? "active" : "calm",
     });
   }
 
-  // Lights
   if (data.lightsTotal > 0) {
     const isOn = data.lightsOn > 0;
-    items.push({
+    counterPills.push({
       key: "lights",
       icon: <Lightbulb size={14} strokeWidth={1.5} />,
       label: `${data.lightsOn}/${data.lightsTotal}`,
-      color: isOn ? "text-active-text" : "text-text-tertiary",
+      variant: isOn ? "active" : "default",
+      iconTint: "text-text-tertiary",
+      valueTint: "text-text-tertiary",
     });
   }
 
-  // Shutters
   if (data.shuttersTotal > 0) {
     const someOpen = data.shuttersOpen > 0;
     const pos = data.averageShutterPosition;
-    const positionSuffix = pos !== null
-      ? ` · ${pos === 0 ? "Fermé" : pos === 100 ? "Ouvert" : `${pos}%`}`
-      : "";
-    items.push({
+    const positionSuffix =
+      pos !== null
+        ? ` · ${pos === 0 ? "Fermé" : pos === 100 ? "Ouvert" : `${pos}%`}`
+        : "";
+    counterPills.push({
       key: "shutters",
       icon: <ShutterIcon size={14} strokeWidth={1.5} position={pos} />,
       label: `${data.shuttersOpen}/${data.shuttersTotal}${positionSuffix}`,
-      color: someOpen ? "text-primary" : "text-text-tertiary",
+      variant: "default",
+      iconTint: "text-text-secondary",
+      valueTint: someOpen ? "text-text" : "text-text-tertiary",
     });
   }
 
-  // Water valves
   if (data.waterValvesTotal > 0) {
     const someOpen = data.waterValvesOpen > 0;
     const flowSuffix =
       someOpen && data.waterFlowTotal !== null && data.waterFlowTotal > 0
         ? ` · ${data.waterFlowTotal} m³/h`
         : "";
-    items.push({
+    counterPills.push({
       key: "water-valves",
       icon: <WaterValveIcon size={14} strokeWidth={1.5} />,
       label: `${data.waterValvesOpen}/${data.waterValvesTotal}${flowSuffix}`,
-      color: someOpen ? "text-active-text" : "text-text-tertiary",
+      variant: someOpen ? "active" : "default",
+      iconTint: "text-text-tertiary",
+      valueTint: "text-text-tertiary",
     });
   }
 
-  // Open doors
+  // ── Cluster 3: Alerts (anomalies) ───────────────────────────
+  const alertPills: StatusItem[] = [];
+
   if (data.openDoors > 0) {
-    items.push({
+    alertPills.push({
       key: "doors",
       icon: <DoorOpen size={14} strokeWidth={1.5} />,
       label: t("aggregation.open", { count: data.openDoors }),
-      color: "text-active-text",
+      variant: "default",
+      iconTint: "text-active-text",
+      valueTint: "text-active-text",
     });
   }
 
-  // Open windows
   if (data.openWindows > 0) {
-    items.push({
+    alertPills.push({
       key: "windows",
       icon: <SquareStack size={14} strokeWidth={1.5} />,
       label: t("aggregation.open", { count: data.openWindows }),
-      color: "text-active-text",
+      variant: "default",
+      iconTint: "text-active-text",
+      valueTint: "text-active-text",
     });
   }
 
-  // Water leak alert
   if (data.waterLeak) {
-    items.push({
+    alertPills.push({
       key: "water",
       icon: <Droplet size={14} strokeWidth={1.5} />,
       label: t("aggregation.waterLeak"),
-      color: "text-error",
-      alert: true,
+      variant: "alert",
     });
   }
 
-  // Smoke alert
   if (data.smoke) {
-    items.push({
+    alertPills.push({
       key: "smoke",
       icon: <Flame size={14} strokeWidth={1.5} />,
       label: t("aggregation.smoke"),
-      color: "text-error",
-      alert: true,
+      variant: "alert",
     });
   }
 
-  if (items.length === 0) return null;
+  const clusters = [sensorPills, counterPills, alertPills].filter(
+    (c) => c.length > 0,
+  );
+
+  if (clusters.length === 0) return null;
 
   return (
     <div className="flex items-center rounded-[8px] border border-border bg-surface px-1 py-1 overflow-x-auto">
-      {items.map((item, index) => (
-        <div key={item.key} className="flex items-center">
-          {index > 0 && (
-            <div className="w-px h-4 bg-border mx-1 flex-shrink-0" />
+      {clusters.map((cluster, ci) => (
+        <Fragment key={ci}>
+          {ci > 0 && (
+            <div className="w-px h-5 bg-border mx-2 flex-shrink-0" />
           )}
-          <div
-            className={`
-              flex items-center gap-1.5 px-2 py-0.5 rounded-[5px]
-              text-[13px] font-medium tabular-nums whitespace-nowrap
-              ${item.color}
-              ${item.alert ? "bg-error/8" : ""}
-            `}
-          >
-            {item.icon}
-            <span>{item.label}</span>
-            {historyEnabled && zoneId && item.sparklineCategory && (
-              <ZoneSparkline zoneId={zoneId} category={item.sparklineCategory} />
-            )}
-          </div>
-        </div>
+          {cluster.map((item, ii) => (
+            <Fragment key={item.key}>
+              {ii > 0 && (
+                <div className="w-px h-4 bg-border-light mx-1 flex-shrink-0" />
+              )}
+              <StripPill
+                item={item}
+                zoneId={zoneId}
+                historyEnabled={historyEnabled}
+              />
+            </Fragment>
+          ))}
+        </Fragment>
       ))}
+    </div>
+  );
+}
+
+// ============================================================
+// StripPill — variant → class mapping. Kept in-file for locality.
+// ============================================================
+
+interface StripPillProps {
+  item: StatusItem;
+  zoneId?: string;
+  historyEnabled?: boolean;
+}
+
+function variantClasses(variant: PillVariant): {
+  pill: string;
+  icon: string;
+  value: string;
+} {
+  switch (variant) {
+    case "alert":
+      return {
+        pill: "bg-error/10 font-semibold",
+        icon: "text-error",
+        value: "text-error",
+      };
+    case "active":
+      return {
+        pill: "",
+        icon: "text-active-text",
+        value: "text-active-text",
+      };
+    case "calm":
+      return {
+        pill: "",
+        icon: "text-success",
+        value: "text-success font-semibold",
+      };
+    default:
+      return { pill: "", icon: "", value: "" };
+  }
+}
+
+function StripPill({ item, zoneId, historyEnabled }: StripPillProps) {
+  const v = variantClasses(item.variant);
+  const iconClass = v.icon || item.iconTint || "text-text-tertiary";
+  const valueClass = v.value || item.valueTint || "text-text";
+
+  return (
+    <div
+      className={`flex items-center gap-1.5 px-2 py-0.5 rounded-[5px] text-[13px] font-medium tabular-nums whitespace-nowrap ${v.pill}`}
+    >
+      <span className={`flex-shrink-0 ${iconClass}`}>{item.icon}</span>
+      <span className={valueClass}>{item.label}</span>
+      {historyEnabled && zoneId && item.sparklineCategory && (
+        <ZoneSparkline zoneId={zoneId} category={item.sparklineCategory} />
+      )}
     </div>
   );
 }
@@ -198,7 +278,10 @@ export function ZoneAggregationPills({ data, zoneId, historyEnabled }: ZoneAggre
 // Relative time hook — refreshes every 30s, zero CPU when no timestamp
 // ============================================================
 
-function useRelativeTime(since: string | null, t: (key: string) => string): string | null {
+function useRelativeTime(
+  since: string | null,
+  t: (key: string) => string,
+): string | null {
   const [, tick] = useState(0);
 
   useEffect(() => {
@@ -211,7 +294,10 @@ function useRelativeTime(since: string | null, t: (key: string) => string): stri
   return formatDuration(since, t);
 }
 
-function formatDuration(since: string, t: (key: string) => string): string | null {
+function formatDuration(
+  since: string,
+  t: (key: string) => string,
+): string | null {
   const ms = Date.now() - new Date(since).getTime();
   const seconds = Math.floor(ms / 1000);
   if (seconds < 60) return null;
@@ -220,7 +306,9 @@ function formatDuration(since: string, t: (key: string) => string): string | nul
   const hours = Math.floor(minutes / 60);
   const remainMinutes = minutes % 60;
   if (hours < 24) {
-    return remainMinutes > 0 ? `${hours}${t("time.hour")}${String(remainMinutes).padStart(2, "0")}` : `${hours}${t("time.hour")}`;
+    return remainMinutes > 0
+      ? `${hours}${t("time.hour")}${String(remainMinutes).padStart(2, "0")}`
+      : `${hours}${t("time.hour")}`;
   }
   const days = Math.floor(hours / 24);
   return `${days}${t("time.day")}`;

--- a/ui/src/components/home/ZoneCommands.tsx
+++ b/ui/src/components/home/ZoneCommands.tsx
@@ -1,0 +1,133 @@
+import {
+  Lightbulb,
+  LightbulbOff,
+  ChevronUp,
+  ChevronDown,
+  Square,
+  Loader2,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+export type ZoneOrder =
+  | "allLightsOn"
+  | "allLightsOff"
+  | "allShuttersOpen"
+  | "allShuttersStop"
+  | "allShuttersClose";
+
+type Category = "light" | "light-off" | "shutter";
+
+interface ZoneCommandsProps {
+  hasLights: boolean;
+  hasShutters: boolean;
+  loading: ZoneOrder | null;
+  onCommand: (order: ZoneOrder) => void;
+}
+
+const CATEGORY_HOVER: Record<Category, string> = {
+  light: "hover:bg-active/8 hover:text-active-text",
+  "light-off": "hover:bg-border-light hover:text-text",
+  shutter: "hover:bg-primary/8 hover:text-primary",
+};
+
+interface ZCmdsBtnProps {
+  cat: Category;
+  title: string;
+  loading: boolean;
+  disabled: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function ZCmdsBtn({ cat, title, loading, disabled, onClick, children }: ZCmdsBtnProps) {
+  return (
+    <button
+      type="button"
+      title={title}
+      aria-label={title}
+      onClick={onClick}
+      disabled={disabled}
+      className={`inline-flex items-center justify-center w-9 h-[34px] rounded-[6px] text-text-secondary transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer ${CATEGORY_HOVER[cat]}`}
+    >
+      {loading ? (
+        <Loader2 size={16} strokeWidth={1.5} className="animate-spin" />
+      ) : (
+        children
+      )}
+    </button>
+  );
+}
+
+export function ZoneCommands({ hasLights, hasShutters, loading, onCommand }: ZoneCommandsProps) {
+  const { t } = useTranslation();
+  const busy = loading !== null;
+
+  if (!hasLights && !hasShutters) return null;
+
+  return (
+    <div
+      role="toolbar"
+      aria-label={t("zones.commands.toolbarLabel", { defaultValue: "Commandes globales" })}
+      className="inline-flex items-center gap-px bg-surface border border-border-light rounded-[8px] px-1.5 py-1"
+    >
+      {hasLights && (
+        <>
+          <ZCmdsBtn
+            cat="light"
+            title={t("zones.commands.allLightsOn")}
+            loading={loading === "allLightsOn"}
+            disabled={busy}
+            onClick={() => onCommand("allLightsOn")}
+          >
+            <Lightbulb size={16} strokeWidth={1.5} />
+          </ZCmdsBtn>
+          <ZCmdsBtn
+            cat="light-off"
+            title={t("zones.commands.allLightsOff")}
+            loading={loading === "allLightsOff"}
+            disabled={busy}
+            onClick={() => onCommand("allLightsOff")}
+          >
+            <LightbulbOff size={16} strokeWidth={1.5} />
+          </ZCmdsBtn>
+        </>
+      )}
+
+      {hasLights && hasShutters && (
+        <span className="w-px h-4 bg-border mx-1 flex-shrink-0" aria-hidden="true" />
+      )}
+
+      {hasShutters && (
+        <>
+          <ZCmdsBtn
+            cat="shutter"
+            title={t("zones.commands.allShuttersOpen")}
+            loading={loading === "allShuttersOpen"}
+            disabled={busy}
+            onClick={() => onCommand("allShuttersOpen")}
+          >
+            <ChevronUp size={16} strokeWidth={2} />
+          </ZCmdsBtn>
+          <ZCmdsBtn
+            cat="shutter"
+            title={t("zones.commands.allShuttersStop", { defaultValue: "Stop" })}
+            loading={loading === "allShuttersStop"}
+            disabled={busy}
+            onClick={() => onCommand("allShuttersStop")}
+          >
+            <Square size={14} strokeWidth={1.5} fill="currentColor" />
+          </ZCmdsBtn>
+          <ZCmdsBtn
+            cat="shutter"
+            title={t("zones.commands.allShuttersClose")}
+            loading={loading === "allShuttersClose"}
+            disabled={busy}
+            onClick={() => onCommand("allShuttersClose")}
+          >
+            <ChevronDown size={16} strokeWidth={2} />
+          </ZCmdsBtn>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -6,10 +6,6 @@ import {
   Home,
   ChevronDown,
   ChevronRight,
-  Lightbulb,
-  LightbulbOff,
-  ArrowUpFromLine,
-  ArrowDownToLine,
   Plus,
   Menu,
   X,
@@ -23,6 +19,7 @@ import { useZoneAggregation } from "../store/useZoneAggregation";
 import { executeZoneOrder, getHistoryStatus } from "../api";
 import { ZoneEquipmentsView } from "../components/home/ZoneEquipmentsView";
 import { ZoneAggregationPills } from "../components/home/ZoneAggregationPills";
+import { ZoneCommands, type ZoneOrder } from "../components/home/ZoneCommands";
 import { ZoneRecipesSection } from "../components/recipes/ZoneRecipesSection";
 import { ZoneModesSection } from "../components/home/ZoneModesSection";
 import { EquipmentForm } from "../components/equipments/EquipmentForm";
@@ -85,9 +82,9 @@ export function HomePage() {
   }, [equipments, zoneId]);
 
   const aggData = zoneId ? aggregationData[zoneId] : undefined;
-  const [commandLoading, setCommandLoading] = useState<string | null>(null);
+  const [commandLoading, setCommandLoading] = useState<ZoneOrder | null>(null);
 
-  const handleZoneCommand = useCallback(async (orderKey: string) => {
+  const handleZoneCommand = useCallback(async (orderKey: ZoneOrder) => {
     if (!zoneId) return;
     setCommandLoading(orderKey);
     try {
@@ -164,63 +161,13 @@ export function HomePage() {
         )}
         {/* Zone command buttons */}
         {aggData && (aggData.lightsTotal > 0 || aggData.shuttersTotal > 0) && (
-          <div className="flex flex-wrap items-center gap-2 mt-3">
-            {aggData.lightsTotal > 0 && (
-              <>
-                <button
-                  onClick={() => handleZoneCommand("allLightsOn")}
-                  disabled={commandLoading !== null}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-text-secondary bg-surface border border-border rounded-[6px] hover:bg-active/8 hover:text-active-text hover:border-active/40 transition-colors duration-150 disabled:opacity-50"
-                >
-                  {commandLoading === "allLightsOn" ? (
-                    <Loader2 size={14} strokeWidth={1.5} className="animate-spin" />
-                  ) : (
-                    <Lightbulb size={14} strokeWidth={1.5} />
-                  )}
-                  {t("zones.commands.allLightsOn")}
-                </button>
-                <button
-                  onClick={() => handleZoneCommand("allLightsOff")}
-                  disabled={commandLoading !== null}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-text-secondary bg-surface border border-border rounded-[6px] hover:bg-border-light transition-colors duration-150 disabled:opacity-50"
-                >
-                  {commandLoading === "allLightsOff" ? (
-                    <Loader2 size={14} strokeWidth={1.5} className="animate-spin" />
-                  ) : (
-                    <LightbulbOff size={14} strokeWidth={1.5} />
-                  )}
-                  {t("zones.commands.allLightsOff")}
-                </button>
-              </>
-            )}
-            {aggData.shuttersTotal > 0 && (
-              <>
-                <button
-                  onClick={() => handleZoneCommand("allShuttersOpen")}
-                  disabled={commandLoading !== null}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-text-secondary bg-surface border border-border rounded-[6px] hover:bg-primary/6 hover:text-primary hover:border-primary/40 transition-colors duration-150 disabled:opacity-50"
-                >
-                  {commandLoading === "allShuttersOpen" ? (
-                    <Loader2 size={14} strokeWidth={1.5} className="animate-spin" />
-                  ) : (
-                    <ArrowUpFromLine size={14} strokeWidth={1.5} />
-                  )}
-                  {t("zones.commands.allShuttersOpen")}
-                </button>
-                <button
-                  onClick={() => handleZoneCommand("allShuttersClose")}
-                  disabled={commandLoading !== null}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-text-secondary bg-surface border border-border rounded-[6px] hover:bg-border-light transition-colors duration-150 disabled:opacity-50"
-                >
-                  {commandLoading === "allShuttersClose" ? (
-                    <Loader2 size={14} strokeWidth={1.5} className="animate-spin" />
-                  ) : (
-                    <ArrowDownToLine size={14} strokeWidth={1.5} />
-                  )}
-                  {t("zones.commands.allShuttersClose")}
-                </button>
-              </>
-            )}
+          <div className="mt-3">
+            <ZoneCommands
+              hasLights={aggData.lightsTotal > 0}
+              hasShutters={aggData.shuttersTotal > 0}
+              loading={commandLoading}
+              onCommand={handleZoneCommand}
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Phase 3 of the UI redesign. Refactor `ZoneAggregationPills` to render the strip as 3 semantic clusters (sensors / counters / alerts) with a heavier inter-cluster divider, plus the design-system variants (`--active`, `--calm`, `--alert`).

Layout matches the polished mock for both desktop and mobile (same component, mobile keeps horizontal scroll).

## Changes

- `ui/src/components/home/ZoneAggregationPills.tsx` — refactor, +variants, +`StripPill` internal component.
- `specs/097-design-system-strip-pills/` — full spec, architecture, plan.

## Cluster structure

| Cluster      | Pills inside                                          |
| ------------ | ----------------------------------------------------- |
| **Sensors**  | temperature, humidity, luminosity (sparklines kept)   |
| **Counters** | motion, lights, shutters, water valves                |
| **Alerts**   | open doors, open windows, water leak, smoke           |

## Variant mapping

| State                              | Variant            | Visual                                  |
| ---------------------------------- | ------------------ | --------------------------------------- |
| Motion at rest                     | `--calm`           | green icon + green text                 |
| Motion detected                    | `--active`         | amber icon + amber text                 |
| At least one light on              | `--active`         | amber icon + amber text                 |
| Smoke / water leak                 | `--alert`          | red bg + red bold text (**no pulse**)    |
| Open doors / windows               | default (amber)    | unchanged from prod (no upgrade to red) |
| Sensors / shutters / off-state     | default            | tinted icon per category                |

## Dividers

- Intra-cluster: `bg-border-light` (= `var(--line)`)
- Inter-cluster: `bg-border` (= `var(--line-2)`, heavier)

## Intentional divergence from the mock

- **No pulse animation** on alert pills. User decision: pulsing 24/7 on every leak/smoke would be too aggressive. The red bg + bold text carries enough urgency for our context.
- **Open doors/windows kept in amber**, not red. The mock applies `--alert` (with pulse) to a window — too aggressive for normal household state.

## Test plan

- [x] `cd ui && npm run build` — succeeds
- [x] `npx tsc --noEmit` — passes (backend + UI)
- [x] `npx vitest run` — 429 tests pass
- [x] `npx eslint src/ --ext .ts` — clean
- [ ] **Manual**: navigate to a zone with sensors + lights + (optional) smoke/leak — verify 3 clusters render correctly
- [ ] **Manual**: trigger a window/door open — verify pill in alerts cluster, amber not red
- [ ] **Manual**: trigger smoke/leak — verify red bg pill, no pulse
- [ ] **Manual**: resize to mobile (< 640 px) — verify horizontal scroll works
- [ ] **Manual**: toggle dark mode — verify all variants adapt

## Related

- Spec 094 (UI redesign umbrella)
- Spec 096 (sidebar — previously merged)
- Design system: [strip.md](../tree/feat/design-system-strip-pills/design-system/components/strip.md)