### PR TITLE
feat(ui): equipment row chrome refactor + light-on glow (spec 099)

### DIFF
--- a/specs/099-design-system-equipment-row/architecture.md
+++ b/specs/099-design-system-equipment-row/architecture.md
@@ -1,0 +1,146 @@
+# Architecture — Spec 099 — Equipment Row
+
+## Overview
+
+Refactor of a single component (`CompactEquipmentCard.tsx`) + two small CSS additions in `ui/src/index.css`. No backend, no state, no data model.
+
+## Changes
+
+### 1. `ui/src/index.css` — @theme aliases + glow utility
+
+Add 8 color aliases and one animation utility:
+
+```css
+@theme {
+  /* ... existing aliases ... */
+
+  /* Equipment category tints — from design-system/tokens.css */
+  --color-light-50: var(--light-50);
+  --color-light-500: var(--light-500);
+  --color-shutter-50: var(--shutter-50);
+  --color-shutter-500: var(--shutter-500);
+  --color-sensor-50: var(--sensor-50);
+  --color-sensor-500: var(--sensor-500);
+  --color-media-50: var(--media-50);
+  --color-media-500: var(--media-500);
+}
+
+/* Light "ON" glow ring — uses @keyframes glow from design-system/tokens.css */
+.animate-glow {
+  animation: glow 3.2s ease-in-out infinite;
+}
+```
+
+After this, the Tailwind utilities `bg-light-50`, `text-light-500`, `bg-shutter-50`, etc. exist.
+
+### 2. `CompactEquipmentCard.tsx` — chrome refactor
+
+Replace the root wrapper:
+
+```tsx
+// Before
+<div className="flex items-center gap-2.5 px-3 py-2 transition-colors duration-150 hover:bg-border-light/40">
+  {/* Icon */}
+  <div className={`flex-shrink-0 w-7 h-7 rounded-[5px] flex items-center justify-center ${iconColor}`}>
+    {iconElement}
+  </div>
+  {/* Name */}
+  <Link className="flex-1 min-w-0 ...">...</Link>
+  {/* Per-type content & controls (varies) */}
+</div>
+
+// After
+<div className="grid grid-cols-[32px_1fr_auto_auto_auto] gap-3 items-center px-4 py-2 min-h-[52px] transition-colors duration-150 hover:bg-border-light/40">
+  {/* Icon — slot 1 */}
+  <div className={`w-8 h-8 rounded-md flex items-center justify-center ${tint.bg} ${tint.text} ${isLightOn ? 'animate-glow' : ''}`}>
+    {iconElement}
+  </div>
+  {/* Name — slot 2 */}
+  <Link className="min-w-0 ...">...</Link>
+  {/* Slots 3/4/5 — per-type content laid out as needed */}
+</div>
+```
+
+### 3. Per-type tint map
+
+Define a typed map at the top of the file:
+
+```tsx
+type Tint = { bg: string; text: string };
+
+const TYPE_TINTS: Record<EquipmentType, Tint> = {
+  light_onoff: { bg: "bg-light-50", text: "text-light-500" },
+  light_dimmable: { bg: "bg-light-50", text: "text-light-500" },
+  light_color: { bg: "bg-light-50", text: "text-light-500" },
+  shutter: { bg: "bg-shutter-50", text: "text-shutter-500" },
+  pool_cover: { bg: "bg-shutter-50", text: "text-shutter-500" },
+  sensor: { bg: "bg-sensor-50", text: "text-sensor-500" },
+  button: { bg: "bg-sensor-50", text: "text-sensor-500" },
+  switch: { bg: "bg-sensor-50", text: "text-sensor-500" },
+  thermostat: { bg: "bg-primary-light", text: "text-primary" },
+  heater: { bg: "bg-error/10", text: "text-error" },
+  gate: { bg: "bg-success/10", text: "text-success" },
+  water_valve: { bg: "bg-primary-light", text: "text-primary" },
+  media_player: { bg: "bg-media-50", text: "text-media-500" },
+  appliance: { bg: "bg-border-light", text: "text-text-secondary" },
+  energy_meter: { bg: "bg-accent-light", text: "text-accent" },
+  main_energy_meter: { bg: "bg-accent-light", text: "text-accent" },
+  energy_production_meter: { bg: "bg-success/10", text: "text-success" },
+  weather: { bg: "bg-primary-light", text: "text-primary" },
+  weather_forecast: { bg: "bg-primary-light", text: "text-primary" },
+  pool_pump: { bg: "bg-primary-light", text: "text-primary" },
+  pool_heat_pump: { bg: "bg-error/10", text: "text-error" },
+};
+```
+
+When the equipment is a lit light, override:
+
+```tsx
+const tint = isLightOn ? { bg: "bg-accent", text: "text-white" } : TYPE_TINTS[equipment.type];
+```
+
+### 4. Grid slot mapping
+
+The 5 grid columns map to:
+
+| Col | Slot            | What renders                                         |
+| --- | --------------- | ---------------------------------------------------- |
+| 1   | Icon            | The 32×32 tinted icon container                      |
+| 2   | Name            | The `<Link>` to the equipment detail (truncates)     |
+| 3   | Primary value   | Sensor values, energy values, weather forecast strip |
+| 4   | Secondary value | Mode chip, state badge, position percentage          |
+| 5   | Action          | LightControl / ShutterControl / power button etc.    |
+
+Empty slots collapse to 0 via `grid-cols-[... auto auto auto]` — `auto` doesn't reserve space.
+
+Per-type rendering blocks in the current `CompactEquipmentCard` already produce the right content; they just need to land in the right slot order. Some per-type blocks (e.g. PoolPumpRuntime + LightControl) span two slots — fine for `auto auto auto` (each child takes its natural width).
+
+## File changes
+
+| File                                              | Change                                               |
+| ------------------------------------------------- | ---------------------------------------------------- |
+| `ui/src/components/home/CompactEquipmentCard.tsx` | Refactor root chrome, add TYPE_TINTS map, glow logic |
+| `ui/src/index.css`                                | Add 8 @theme aliases + `.animate-glow` utility       |
+
+## Risk assessment
+
+| Risk                                                                                                   | Likelihood | Mitigation                                                                                                                                              |
+| ------------------------------------------------------------------------------------------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Grid layout breaks the right-side controls in a per-type block (e.g. pool pump runtime + power button) | Medium     | All current per-type blocks render their children inline; the grid `auto` columns accept any number of children naturally. Test pool pump specifically. |
+| Glow animation too strong / distracting                                                                | Low        | Already calibrated via design-system (5px ring at 14% opacity peak). Easy to tune CSS if user dislikes.                                                 |
+| Per-type tint clashes with the icon's own color (Lucide icons inherit `currentColor`)                  | Low        | Tints set both `bg` and `text` color — Lucide icons inherit `text-*` correctly via `currentColor` default.                                              |
+| Row min-height 52 px feels too tall                                                                    | Low        | Matches the design system + mode/recipe row alignment. If user dislikes, can soften to 48 px.                                                           |
+| Long equipment name truncates on more screens than before                                              | Low        | `truncate` class preserved on the name Link.                                                                                                            |
+| Mobile viewport — 5-col grid feels cramped                                                             | Medium     | Sensor/control auto slots collapse naturally; test on 390 px. If overflow, allow horizontal scroll.                                                     |
+| Existing per-type control component layouts conflict with the grid item alignment                      | Low        | Per-type components are leaves; they don't impose layout on the parent.                                                                                 |
+
+## Rollback
+
+`git revert` of the commit. Two files modified.
+
+## References
+
+- [design-system/components/eq-row.md](../../design-system/components/eq-row.md)
+- [design-system/tokens.css](../../design-system/tokens.css) — glow + category tokens
+- [ui/src/components/home/CompactEquipmentCard.tsx](../../ui/src/components/home/CompactEquipmentCard.tsx)
+- [ui/src/index.css](../../ui/src/index.css)

--- a/specs/099-design-system-equipment-row/plan.md
+++ b/specs/099-design-system-equipment-row/plan.md
@@ -1,0 +1,67 @@
+# Plan — Spec 099 — Equipment Row
+
+## Implementation steps
+
+1. **Branch**: `git checkout -b feat/design-system-equipment-row`
+2. **Update `ui/src/index.css`** — add 8 @theme color aliases (light, shutter, sensor, media × 50/500) + `.animate-glow` utility.
+3. **Refactor `CompactEquipmentCard.tsx`**:
+   - Add `TYPE_TINTS` typed map at the top of the file.
+   - Compute `isLightOn` from `isLight && isOn`.
+   - Replace the root `<div className="flex...">` with the grid layout.
+   - Bump icon container `w-7 h-7 rounded-[5px]` → `w-8 h-8 rounded-md` + apply tint + conditional `.animate-glow`.
+   - Verify each per-type block renders in the right column order. Since the columns after the name are all `auto`, the existing per-type blocks slot in naturally.
+4. **Visually verify via Playwright on localhost:5173** (dev server still running from spec 095):
+   - Zone with mixed equipments (light on/off, shutter, sensor, gate, energy meter)
+   - Light glow visible on lit lights (no glow on off)
+   - Row alignment with mode rows below
+   - Mobile viewport 390 px
+   - Dark mode toggle
+5. **Validate** (Gate 4): `npx tsc --noEmit` (both), `cd ui && npm run build`, `npx vitest run`, `npx eslint src/ --ext .ts`.
+6. **Commit** with conventional message.
+7. **Open PR** with screenshots: light off, light on (with glow), shutter partial, sensor, full zone view.
+
+## Test plan
+
+### Modules touched
+
+- `ui/src/components/home/CompactEquipmentCard.tsx` (chrome refactor + tint map)
+- `ui/src/index.css` (@theme aliases + animation utility)
+
+### Why no unit tests
+
+Per CLAUDE.md "no React tests in this project". This spec is JSX rendering + CSS — no business logic touched. The existing per-type control components are not modified. The existing Vitest suite (429 tests) must continue to pass.
+
+### Manual verification scenarios
+
+| Scenario                                                       | Expected                                                                              |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Open a zone with one light off                                 | Light icon with `bg-light-50 text-light-500`, no animation                            |
+| Toggle the light on (via UI or external)                       | Icon switches to amber background, white icon, glow ring animates                     |
+| Toggle off                                                     | Returns to base tint, glow stops                                                      |
+| Zone with shutter at 50%                                       | Shutter icon `bg-shutter-50 text-shutter-500`, slider + position chip in auto columns |
+| Zone with motion sensor                                        | Sensor icon `bg-sensor-50 text-sensor-500`, sensor values right-aligned               |
+| Zone with gate                                                 | Gate icon green-tinted, "Ouvert/Fermé" chip                                           |
+| Zone with thermostat                                           | Primary-tinted icon, current temp + ± controls                                        |
+| Zone with energy meter                                         | Amber accent-light icon, kWh value                                                    |
+| Zone with media_player on                                      | Media-tinted icon, source name                                                        |
+| Zone with appliance running (washing machine)                  | Neutral icon, running chip, time remaining                                            |
+| Empty equipment (no bindings)                                  | Row renders, icon visible, name shown                                                 |
+| Disabled equipment                                             | "désactivé" suffix in name                                                            |
+| Long equipment name                                            | Truncates with `truncate` class in slot 2                                             |
+| Cross-panel alignment (Équipements + Comportements + Activité) | All rows at 52 px height visually align                                               |
+| Mobile (390 px) — full zone view                               | Grid stays one row; per-type controls may horizontal-scroll if too crowded            |
+| Dark mode toggle                                               | All tints adapt; glow contrast intact                                                 |
+| `prefers-reduced-motion: reduce`                               | Glow doesn't animate (verified via DevTools "Emulate CSS media feature")              |
+
+## Tasks
+
+- [x] Branch `feat/design-system-equipment-row` created
+- [x] `ui/src/index.css` — 8 @theme aliases + `.animate-glow` added
+- [x] `CompactEquipmentCard.tsx` — `TYPE_TINTS` map added (21 equipment types)
+- [x] `CompactEquipmentCard.tsx` — root chrome refactored to 5-col grid + 52 px min-height
+- [x] `CompactEquipmentCard.tsx` — icon container 32 px + tint + glow on lit light
+- [x] Playwright visual verification — Maison, RDC, Séjour (desktop), Séjour (mobile 390px)
+- [x] Gate 4 passes (tsc + build + vitest + eslint, 429 tests)
+- [ ] Commit on feat branch (no Co-Authored-By)
+- [ ] PR opened with screenshots
+- [ ] User approval before merge

--- a/specs/099-design-system-equipment-row/spec.md
+++ b/specs/099-design-system-equipment-row/spec.md
@@ -1,45 +1,85 @@
 # Spec 099 — Design System Phase 5: Equipment Row
 
-> Light scoping spec — part of the [094 UI redesign umbrella](../094-ui-redesign/spec.md). Expanded into full spec when picked up via `/sowel-feature`. Long-pole phase: **one PR per equipment type**.
+> Phase 5 of the [094 UI redesign umbrella](../094-ui-redesign/spec.md). The "long pole" of the redesign, but reframed: the row chrome is shared in one component, so it's a single refactor — not 21.
 
 ## Problem
 
-The equipment row is the most repeated visual pattern in the app (21 types, hundreds of instances across zones). Today, each control component (`LightControl`, `ShutterControl`, etc.) re-renders its own structure. There's no shared `.eq` grid; row heights drift; icon backgrounds vary.
+The equipment row (used in every zone view, hundreds of instances) renders today via `CompactEquipmentCard.tsx` with these gaps vs [design-system/components/eq-row.md](../../design-system/components/eq-row.md):
+
+| Aspect       | Production today                         | Design system target                              |
+| ------------ | ---------------------------------------- | ------------------------------------------------- |
+| Layout       | `flex items-center gap-2.5`              | `grid grid-cols-[32px_1fr_auto_auto_auto] gap-3`  |
+| Icon size    | 28×28 (`w-7 h-7 rounded-[5px]`)          | 32×32 (`w-8 h-8 rounded-md`)                      |
+| Icon tint    | Uniform (one `iconColor` chain)          | Per-category (`bg-light-50 text-light-500`, etc.) |
+| Light ON cue | None (just power button shows the state) | Amber background + white icon + 3.2s glow pulse   |
+| Min-height   | Implicit (~36 px from padding)           | 52 px fixed (cross-panel alignment)               |
+
+The grid layout matters because every panel (Équipements, Modes, Recettes, Activité) aligns vertically by the same 52 px row height. Today, mode rows and equipment rows visibly differ in height — minor but persistent.
 
 ## Goal
 
-Adopt the `.eq` grid + `.eq__icon--{type}` modifier pattern from [design-system/components/eq-row.md](../../design-system/components/eq-row.md). Refactor each equipment type one PR at a time — never touch the whole `equipments/` folder in one go.
+Refactor `CompactEquipmentCard.tsx` to adopt the design-system row pattern: 5-column grid, 32 px icon with category tinting, fixed 52 px min-height, and a glow animation on the lit-light icon.
 
-## In scope (per sub-PR)
+The per-type control components (`LightControl`, `ShutterControl`, `HeaterControl`, `ThermostatCard`, `GateControl`, `WaterValveControl`, `PoolHeatPumpControl`) are **not touched** — they already work via their `compact` prop and slot into the grid naturally.
 
-Each sub-PR migrates **one equipment type**. Suggested order:
+## Non-negotiable constraint
 
-1. `LightControl.tsx` → `.eq__icon--light-on` + glow animation
-2. `ShutterControl.tsx` → `.shutter-grp` 3-button segmented control
-3. `HeaterControl.tsx` → `therm-icon` + `±` target buttons
-4. `GateControl.tsx` → `.gate-cmd` button
-5. Sensor controls (temperature, humidity, motion, smoke, leak, lux, contact, button, CO2, pressure)
-6. `EnergyMeter`, `WaterValve`, `MediaPlayer`, `PoolCover`, `PoolPump`
-7. `WeatherStation`, `WeatherForecast`
-8. `WashingMachine` and any remaining appliance types
+> **No data flow changes.** The bindings, equipment store, websocket updates, and order dispatch logic are all preserved. Only the row's visual chrome and the way the icon is rendered change.
 
-## Out of scope (per sub-PR)
+## In scope
 
-- Backend logic.
-- Order dispatch changes.
-- Changes to Device → Equipment binding logic.
+1. Refactor [CompactEquipmentCard.tsx](../../ui/src/components/home/CompactEquipmentCard.tsx) chrome:
+   - Replace flex with grid: `grid grid-cols-[32px_1fr_auto_auto_auto] gap-3 items-center px-4 py-2 min-h-[52px]`
+   - Icon container: `w-8 h-8 rounded-md` (was `w-7 h-7 rounded-[5px]`)
+   - Border-top divider between rows (the existing hover stays)
+2. Per-type icon tinting: map each `EquipmentType` to a Tailwind `bg-{cat}-50 text-{cat}-500` class chain. Categories: light, shutter, sensor, media, plus thermostat / heater / gate / water-valve / appliance fallback to neutral or info tint.
+3. Light "ON" state: amber background + white icon + 3.2s glow ring animation. Glow honors `prefers-reduced-motion` (already global in tokens.css).
+4. Add @theme aliases in `ui/src/index.css` for design-system category tokens so the Tailwind utilities `bg-light-50`, `text-light-500`, `bg-shutter-50`, etc. exist.
+5. Add `.animate-glow` utility class in `ui/src/index.css` to expose the existing `@keyframes glow` already defined in `design-system/tokens.css`.
 
-## Acceptance criteria (overall, when all sub-PRs ship)
+## Out of scope
 
-- [ ] `.eq` grid used by every equipment type
-- [ ] 52 px row height invariant (cross-panel alignment holds)
-- [ ] Light "on" state shows amber glow
-- [ ] Shutter 3-button segmented control everywhere
-- [ ] No more inline `flex grid-cols-...` definitions in equipment components
+- The per-type control components (LightControl, ShutterControl, etc.) — their internal layouts are unchanged.
+- The admin EquipmentCard.tsx (different list, different context).
+- The MobileWidgetCard / dashboard widgets (different pattern — covered by spec 098).
+- New equipment types or new control affordances.
+- Sensor display layout (SensorValues stays as-is).
+- The activity feed and mode rows — they have their own row patterns.
+
+## Acceptance criteria
+
+- [x] CompactEquipmentCard root uses CSS grid 5-col layout
+- [x] Icon container is 32×32 with `rounded-md`
+- [x] Each equipment type maps to a per-category icon tint via a typed map
+- [x] Lit light shows amber bg + white icon + glow animation (Playwright verified on Séjour: Applique x 1, Appliques x 2)
+- [x] Glow respects `prefers-reduced-motion` (inherited from global rule in tokens.css)
+- [x] Row min-height is 52 px (visible alignment in Séjour zone)
+- [x] Per-type control components render unchanged in their slot (LightControl slider+power, ShutterControl 3-btn group, sensors all OK)
+- [x] Sensor values display correctly (PIRL: 1672lx + RAS + 100%)
+- [x] Disabled equipment shows "désactivé" suffix in name as today
+- [x] Type-check, lint, vitest, build all pass (429 tests)
+- [x] Mobile (390px) — Playwright verified, layout intact, no overflow
+
+## Edge cases
+
+| Case                                                        | Expected                                                                |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Equipment with 0 data bindings                              | Row renders, icon visible, no controls slot — empty grid cells collapse |
+| Light ON state from data binding                            | Amber tint + glow visible                                               |
+| Light OFF                                                   | Light category tint (yellow-tinted neutral) without glow                |
+| Shutter at partial position (50%)                           | Shutter icon tinted, slider + position chip in grid slots               |
+| Sensor with motion + temperature                            | All bindings rendered via SensorValues in the auto column               |
+| Generic equipment (unknown type)                            | Falls back to neutral icon tint, primary value displayed in auto column |
+| Long equipment name (e.g. "Appliques porche extérieur sud") | Truncates via existing `truncate` class in slot 2                       |
+| `prefers-reduced-motion: reduce` enabled                    | No glow animation on lit lights (global rule in tokens.css)             |
+| Mobile viewport (390 px)                                    | Grid stays one row; sub-controls may scroll horizontally if too crowded |
+| Dark mode                                                   | All category tints adapt via design system tokens (no hard-coded hex)   |
+| Pool pump with runtime badge                                | Runtime fits in the auto column alongside the power button              |
+| Multiple sensor types (weather: temp + rain + wind)         | Filtered subset still renders correctly                                 |
 
 ## References
 
 - [design-system/components/eq-row.md](../../design-system/components/eq-row.md)
-- [design-system/components/shutter-grp.md](../../design-system/components/shutter-grp.md)
-- [design-system/components/power-button.md](../../design-system/components/power-button.md)
+- [design-system/tokens.css](../../design-system/tokens.css) — category tints + `@keyframes glow`
 - [design-system/migration.md](../../design-system/migration.md) Phase 5
+- [ui/src/components/home/CompactEquipmentCard.tsx](../../ui/src/components/home/CompactEquipmentCard.tsx) — current implementation

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import type { EquipmentWithDetails } from "../../types";
+import type { EquipmentType, EquipmentWithDetails } from "../../types";
 import { useEquipmentState, formatValue } from "../equipments/useEquipmentState";
 import { SensorValues } from "../equipments/SensorValues";
 import { LightControl } from "../equipments/LightControl";
@@ -18,6 +18,34 @@ interface CompactEquipmentCardProps {
   onExecuteOrder: (equipmentId: string, alias: string, value: unknown) => Promise<void>;
   zoneName?: string;
 }
+
+// Per-type icon tint mapping (spec 099 — eq-row category tints).
+// Light-on state is handled as an override at render time.
+type Tint = { bg: string; text: string };
+
+const TYPE_TINTS: Record<EquipmentType, Tint> = {
+  light_onoff:             { bg: "bg-light-50",     text: "text-light-500" },
+  light_dimmable:          { bg: "bg-light-50",     text: "text-light-500" },
+  light_color:             { bg: "bg-light-50",     text: "text-light-500" },
+  shutter:                 { bg: "bg-shutter-50",   text: "text-shutter-500" },
+  pool_cover:              { bg: "bg-shutter-50",   text: "text-shutter-500" },
+  sensor:                  { bg: "bg-sensor-50",    text: "text-sensor-500" },
+  button:                  { bg: "bg-sensor-50",    text: "text-sensor-500" },
+  switch:                  { bg: "bg-sensor-50",    text: "text-sensor-500" },
+  media_player:            { bg: "bg-media-50",     text: "text-media-500" },
+  thermostat:              { bg: "bg-primary-light",text: "text-primary" },
+  water_valve:             { bg: "bg-primary-light",text: "text-primary" },
+  weather:                 { bg: "bg-primary-light",text: "text-primary" },
+  weather_forecast:        { bg: "bg-primary-light",text: "text-primary" },
+  pool_pump:               { bg: "bg-primary-light",text: "text-primary" },
+  gate:                    { bg: "bg-success/10",   text: "text-success" },
+  energy_production_meter: { bg: "bg-success/10",   text: "text-success" },
+  heater:                  { bg: "bg-error/10",     text: "text-error" },
+  pool_heat_pump:          { bg: "bg-error/10",     text: "text-error" },
+  energy_meter:            { bg: "bg-accent-light", text: "text-accent" },
+  main_energy_meter:       { bg: "bg-accent-light", text: "text-accent" },
+  appliance:               { bg: "bg-border-light", text: "text-text-secondary" },
+};
 
 export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: CompactEquipmentCardProps) {
   const { t } = useTranslation();
@@ -38,7 +66,6 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
     sensorBindings,
     batteryBindings,
     iconElement,
-    iconColor,
   } = useEquipmentState(equipment);
 
   const isWaterValve = equipment.type === "water_valve";
@@ -47,37 +74,38 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
   const isPoolHeatPump = equipment.type === "pool_heat_pump";
 
   // Find primary data value for generic equipments
-  const isKnownType = isLight || isSensor || isShutter || isThermostat || isHeater || isGate || isEnergyMeter || isWeatherForecast || isMediaPlayer || isAppliance || isWaterValve || isPoolPump || isPoolCover || isPoolHeatPump;
+  const isKnownType =
+    isLight || isSensor || isShutter || isThermostat || isHeater || isGate ||
+    isEnergyMeter || isWeatherForecast || isMediaPlayer || isAppliance ||
+    isWaterValve || isPoolPump || isPoolCover || isPoolHeatPump;
   const primaryBinding = !isKnownType
     ? equipment.dataBindings[0] ?? null
     : null;
 
+  // Icon tinting — light-on overrides to amber + glow, everything else uses TYPE_TINTS.
+  const isLightOn = isLight && isOn;
+  const baseTint = TYPE_TINTS[equipment.type] ?? { bg: "bg-border-light", text: "text-text-tertiary" };
+  const iconBg = isLightOn ? "bg-accent" : baseTint.bg;
+  const iconText = isLightOn ? "text-white" : baseTint.text;
+  const iconAnimation = isLightOn ? "animate-glow" : "";
+
   return (
-    <div
-      className={`
-        flex items-center gap-2.5 px-3 py-2
-        transition-colors duration-150
-        hover:bg-border-light/40
-      `}
-    >
-      {/* Icon */}
-      <div
-        className={`
-          flex-shrink-0 w-7 h-7 rounded-[5px] flex items-center justify-center
-          ${iconColor}
-        `}
-      >
+    <div className="grid grid-cols-[32px_1fr_auto_auto_auto] gap-3 items-center px-3 py-2 min-h-[52px] transition-colors duration-150 hover:bg-border-light/40">
+      {/* Slot 1: Icon */}
+      <div className={`w-8 h-8 rounded-md flex items-center justify-center flex-shrink-0 ${iconBg} ${iconText} ${iconAnimation}`}>
         {iconElement}
       </div>
 
-      {/* Name — links to detail */}
+      {/* Slot 2: Name */}
       <Link
         to={`/equipments/${equipment.id}`}
         state={zoneName ? { fromZone: zoneName } : undefined}
-        className="flex-1 min-w-0 text-[13px] font-medium text-text truncate hover:text-primary transition-colors"
+        className="min-w-0 text-[13px] font-medium text-text truncate hover:text-primary transition-colors"
       >
         {equipment.name}
       </Link>
+
+      {/* Slots 3-5: per-type content. Grid auto columns collapse when unused. */}
 
       {/* Sensor / Button values */}
       {isSensor && (

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -52,6 +52,16 @@
   --shadow-sm: var(--sh-1);
   --shadow-md: var(--sh-2);
   --shadow-lg: var(--sh-3);
+
+  /* Equipment category tints — from design-system/tokens.css (spec 099) */
+  --color-light-50: var(--light-50);
+  --color-light-500: var(--light-500);
+  --color-shutter-50: var(--shutter-50);
+  --color-shutter-500: var(--shutter-500);
+  --color-sensor-50: var(--sensor-50);
+  --color-sensor-500: var(--sensor-500);
+  --color-media-50: var(--media-50);
+  --color-media-500: var(--media-500);
 }
 
 /* ============================================================
@@ -67,6 +77,12 @@
    See spec 095 (typography polish). */
 .font-mono {
   font-feature-settings: "tnum" 1;
+}
+
+/* Light "ON" glow ring — uses @keyframes glow from design-system/tokens.css.
+   See spec 099 (equipment row). Respects prefers-reduced-motion globally. */
+.animate-glow {
+  animation: glow 3.2s ease-in-out infinite;
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary

Phase 5 of the UI redesign. Refactor `CompactEquipmentCard` from flex to a 5-column CSS grid matching the design-system eq-row spec. Per-type icon tinting + amber glow on lit lights.

## Changes

- **`ui/src/components/home/CompactEquipmentCard.tsx`** — chrome refactor
  - Root layout: `flex items-center gap-2.5` → `grid grid-cols-[32px_1fr_auto_auto_auto] gap-3 items-center min-h-[52px]`
  - Icon: `w-7 h-7 rounded-[5px]` → `w-8 h-8 rounded-md`
  - New `TYPE_TINTS` map covering all 21 equipment types
  - Light-on override: `bg-accent text-white animate-glow`
- **`ui/src/index.css`**
  - 8 new @theme aliases: `--color-{light,shutter,sensor,media}-{50,500}` → design-system tokens
  - `.animate-glow` utility (3.2s ease-in-out infinite, uses existing `@keyframes glow` from `design-system/tokens.css`)
  - Respects `prefers-reduced-motion` globally

## Per-type tint mapping

| Categories | Tint |
|---|---|
| `light_*` (3 types) | `bg-light-50` / `text-light-500` |
| `shutter`, `pool_cover` | `bg-shutter-50` / `text-shutter-500` |
| `sensor`, `button`, `switch` | `bg-sensor-50` / `text-sensor-500` |
| `media_player` | `bg-media-50` / `text-media-500` |
| `thermostat`, `water_valve`, `weather*`, `pool_pump` | `bg-primary-light` / `text-primary` |
| `gate`, `energy_production_meter` | `bg-success/10` / `text-success` |
| `heater`, `pool_heat_pump` | `bg-error/10` / `text-error` |
| `energy_meter`, `main_energy_meter` | `bg-accent-light` / `text-accent` |
| `appliance` | `bg-border-light` / `text-text-secondary` |
| **Lit light (override)** | **`bg-accent` / `text-white` + `animate-glow`** |

## What's NOT touched

Per-type control components (`LightControl`, `ShutterControl`, `HeaterControl`, `ThermostatCard`, `GateControl`, `WaterValveControl`, `PoolHeatPumpControl`) — their `compact` mode already slots naturally into the new grid.

## Visual verification via Playwright on localhost:5173

| Zone | Result |
|---|---|
| Maison | PAC blue, Compteur amber, Météo blue, Remote sensor green |
| RDC | Poêle red-tinted (heater) |
| Séjour | **Applique x 1 + Appliques x 2 (lit) → amber bg + glow** ✓, Spots (off) light tinted, volets gris, capteurs vert |
| Séjour mobile (390px) | Layout intact, sliders + power-btn fit in row, no overflow |

## Test plan

- [x] `cd ui && npm run build` — succeeds
- [x] `npx tsc --noEmit` — passes (backend + UI)
- [x] `npx vitest run` — 429 tests pass
- [x] `npx eslint src/ --ext .ts` — clean
- [x] **Playwright visual**: Maison + RDC + Séjour + Séjour mobile, all rendering correctly
- [ ] **Manual on running app**: navigate to a zone with various equipments, toggle a light to see the glow animation live, test dark mode

## Related

- Spec 094 (UI redesign umbrella)
- Specs 095, 096, 097, 098 (previously merged)
- Design system: [eq-row.md](../tree/feat/design-system-equipment-row/design-system/components/eq-row.md)