### PR TITLE
feat(backup): restore path confinement, extension whitelist, symlink refuse, size cap (spec 089 C2)

### DIFF
--- a/src/backup/backup-manager.test.ts
+++ b/src/backup/backup-manager.test.ts
@@ -3,7 +3,8 @@ import Database from "better-sqlite3";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { BackupManager } from "./backup-manager.js";
+import AdmZip from "adm-zip";
+import { BackupManager, BackupSizeCapExceededError } from "./backup-manager.js";
 import { createLogger } from "../core/logger.js";
 import type { InfluxClient } from "../core/influx-client.js";
 
@@ -166,7 +167,6 @@ describe("BackupManager", () => {
     it("can restore a backup that was just exported", async () => {
       // Seed some data
       db.prepare(`INSERT INTO settings (key, value) VALUES ('test', 'before-restore')`).run();
-
       // Export
       await manager.exportToFile("snapshot.zip");
 
@@ -186,6 +186,162 @@ describe("BackupManager", () => {
         value: string;
       };
       expect(restored.value).toBe("before-restore");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // SECURITY: regression guards for spec 089 C2 — restore confinement.
+  // Each test crafts a malicious ZIP that, on `main` before the fix,
+  // would write outside dataDir or extract banned files. Post-fix, the
+  // entry is skipped/rejected and no file lands outside dataDir.
+  // ────────────────────────────────────────────────────────────────
+  describe("restoreFromBuffer — spec 089 C2 attack regression guards", () => {
+    /** Build a minimal valid backup ZIP and add an arbitrary entry. */
+    function buildMaliciousZip(maliciousEntry: {
+      name: string;
+      data: Buffer;
+      attr?: number;
+    }): Buffer {
+      const zip = new AdmZip();
+      // Minimal payload — tables empty, restore won't write to SQLite but
+      // we still need a parseable sowel-backup.json.
+      const payload = {
+        version: 2,
+        exportedAt: new Date().toISOString(),
+        tables: Object.fromEntries(
+          // empty list for every BACKUP_TABLES key — keeps validate() happy
+          [
+            "settings",
+            "zones",
+            "devices",
+            "device_data",
+            "device_orders",
+            "equipments",
+            "data_bindings",
+            "order_bindings",
+            "users",
+            "api_tokens",
+            "refresh_tokens",
+            "recipe_instances",
+            "recipe_state",
+            "modes",
+            "zone_mode_impacts",
+            "calendar_profiles",
+            "calendar_slots",
+            "button_action_bindings",
+            "mqtt_brokers",
+            "mqtt_publishers",
+            "mqtt_publisher_mappings",
+            "chart_configs",
+            "notification_publishers",
+            "notification_publisher_mappings",
+            "dashboard_widgets",
+            "plugins",
+          ].map((k) => [k, []]),
+        ),
+      };
+      zip.addFile("sowel-backup.json", Buffer.from(JSON.stringify(payload)));
+      zip.addFile(maliciousEntry.name, maliciousEntry.data);
+      if (maliciousEntry.attr !== undefined) {
+        const e = zip.getEntry(maliciousEntry.name);
+        if (e) (e as unknown as { attr: number }).attr = maliciousEntry.attr;
+      }
+      return zip.toBuffer();
+    }
+
+    // C2.1 — path traversal via "data/../../" prefix
+    it("refuses ZIP entry that escapes dataDir via ..", async () => {
+      // Targeting an absolute path outside dataDir. Pre-fix this writes
+      // there; post-fix the entry is skipped and no file lands there.
+      const externalTarget = resolve(tmpDir, "..", "sowel-pwned-xyz");
+      // Build relative path that resolves to externalTarget from dataDir.
+      // dataDir = tmpDir → "../sowel-pwned-xyz" escapes it.
+      const buf = buildMaliciousZip({
+        name: "data/../sowel-pwned-xyz",
+        data: Buffer.from("pwned"),
+      });
+
+      await manager.restoreFromBuffer(buf);
+
+      // SECURITY: regression guard for spec 089 C2 (path traversal)
+      expect(existsSync(externalTarget)).toBe(false);
+    });
+
+    // C2.2 — symlink entry refused
+    it("refuses ZIP entry that is a symlink", async () => {
+      // Build entry with Unix mode S_IFLNK (0o120000) in upper 16 bits.
+      const symlinkAttr = (0o120000 << 16) >>> 0;
+      const buf = buildMaliciousZip({
+        name: "data/evil-link",
+        data: Buffer.from("/etc/passwd"),
+        attr: symlinkAttr,
+      });
+
+      await manager.restoreFromBuffer(buf);
+
+      // SECURITY: regression guard for spec 089 C2 (symlink injection)
+      expect(existsSync(resolve(tmpDir, "evil-link"))).toBe(false);
+    });
+
+    // C2.3 — banned extension (.so) refused
+    it("refuses ZIP entry with a banned extension (.so)", async () => {
+      const buf = buildMaliciousZip({
+        name: "data/payload.so",
+        data: Buffer.from("\x7fELF malicious"),
+      });
+
+      await manager.restoreFromBuffer(buf);
+
+      // SECURITY: regression guard for spec 089 C2 (extension whitelist)
+      expect(existsSync(resolve(tmpDir, "payload.so"))).toBe(false);
+    });
+
+    // C2.4 — banned extension (.node) refused
+    it("refuses ZIP entry with a banned extension (.node)", async () => {
+      const buf = buildMaliciousZip({
+        name: "data/payload.node",
+        data: Buffer.from("native module"),
+      });
+
+      await manager.restoreFromBuffer(buf);
+
+      // SECURITY: regression guard for spec 089 C2 (extension whitelist)
+      expect(existsSync(resolve(tmpDir, "payload.node"))).toBe(false);
+    });
+
+    // C2.5 — cumulative size cap exceeded throws
+    it("throws BackupSizeCapExceededError when cumulative size exceeds the cap", async () => {
+      // Instantiate a manager with a tiny cap so we can exercise the path
+      // without actually writing 1 GB.
+      const cappedManager = new BackupManager({
+        db,
+        influxClient: stubInflux,
+        logger,
+        dataDir: tmpDir,
+        maxRestoreBytes: 1024, // 1 KB cap
+      });
+      const buf = buildMaliciousZip({
+        name: "data/big.txt",
+        data: Buffer.alloc(2048, 0x41), // 2 KB > cap
+      });
+
+      // SECURITY: regression guard for spec 089 C2 (zip bomb cap)
+      await expect(cappedManager.restoreFromBuffer(buf)).rejects.toBeInstanceOf(
+        BackupSizeCapExceededError,
+      );
+    });
+
+    // C2.6 — legitimate entry with allowed extension restores normally
+    it("restores a legitimate .json entry under dataDir (regression)", async () => {
+      const buf = buildMaliciousZip({
+        name: "data/legit.json",
+        data: Buffer.from('{"ok": true}'),
+      });
+
+      await manager.restoreFromBuffer(buf);
+
+      expect(existsSync(resolve(tmpDir, "legit.json"))).toBe(true);
+      expect(readFileSync(resolve(tmpDir, "legit.json"), "utf-8")).toBe('{"ok": true}');
     });
   });
 });

--- a/src/backup/backup-manager.ts
+++ b/src/backup/backup-manager.ts
@@ -7,7 +7,7 @@ import {
   statSync,
   unlinkSync,
 } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { resolve, dirname, extname, sep } from "node:path";
 import archiver from "archiver";
 import AdmZip from "adm-zip";
 import type Database from "better-sqlite3";
@@ -19,6 +19,52 @@ export interface BackupManagerDeps {
   influxClient: InfluxClient;
   logger: Logger;
   dataDir: string; // path to data/ directory
+  /** Cap on cumulative uncompressed bytes during restore (spec 089 C2). Default 1 GB. */
+  maxRestoreBytes?: number;
+}
+
+// ── Spec 089 C2: backup restore hardening ─────────────────────────────
+// Extensions allowed in `data/` entries of a restore archive. Anything
+// else (executables, native modules, scripts) is rejected.
+const ALLOWED_RESTORE_EXTENSIONS = new Set([
+  ".json",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".svg",
+  ".webp",
+  ".db",
+  ".db-shm",
+  ".db-wal",
+  ".jwt-secret",
+  ".influx-token",
+  ".log",
+  ".txt",
+]);
+
+const DEFAULT_MAX_RESTORE_BYTES = 1024 * 1024 * 1024; // 1 GB
+
+/** Thrown when cumulative uncompressed entries exceed the configured cap. */
+export class BackupSizeCapExceededError extends Error {
+  readonly bytes: number;
+  readonly cap: number;
+  constructor(bytes: number, cap: number) {
+    super(`Backup payload exceeds size cap (${bytes} bytes > ${cap} bytes)`);
+    this.name = "BackupSizeCapExceededError";
+    this.bytes = bytes;
+    this.cap = cap;
+  }
+}
+
+/**
+ * ZIP entry detection: symlinks carry the Unix mode S_IFLNK (0o120000)
+ * in the upper 16 bits of the entry's external attributes. AdmZip exposes
+ * this on entry.attr.
+ */
+function isSymlinkEntry(entry: AdmZip.IZipEntry): boolean {
+  const attr = (entry as unknown as { attr?: number }).attr ?? 0;
+  const unixMode = (attr >>> 16) & 0xffff;
+  return (unixMode & 0o170000) === 0o120000;
 }
 
 // Tables to export, in dependency order (parents first)
@@ -108,12 +154,14 @@ export class BackupManager {
   private influxClient: InfluxClient;
   private logger: Logger;
   private dataDir: string;
+  private maxRestoreBytes: number;
 
   constructor(deps: BackupManagerDeps) {
     this.db = deps.db;
     this.influxClient = deps.influxClient;
     this.logger = deps.logger.child({ module: "backup-manager" });
     this.dataDir = deps.dataDir;
+    this.maxRestoreBytes = deps.maxRestoreBytes ?? DEFAULT_MAX_RESTORE_BYTES;
   }
 
   // ============================================================
@@ -421,16 +469,63 @@ export class BackupManager {
     }
 
     // 4. Restore data files (extract all data/* entries from ZIP)
+    //    Spec 089 C2: hardened against path traversal, symlink injection,
+    //    arbitrary extensions, and zip bombs.
     let filesRestored = 0;
+    let restoreBytes = 0;
+    const dataDirAbs = resolve(this.dataDir);
     for (const entry of zip.getEntries()) {
-      if (!entry.entryName.startsWith("data/") || entry.isDirectory) continue;
+      if (entry.isDirectory) continue;
+      if (!entry.entryName.startsWith("data/")) continue;
+
+      // Refuse symlink entries outright.
+      if (isSymlinkEntry(entry)) {
+        this.logger.warn(
+          { entry: entry.entryName },
+          "Backup restore: symlink entry refused (spec 089 C2)",
+        );
+        continue;
+      }
+
       const filename = entry.entryName.slice("data/".length);
       if (!filename || DATA_FILES_EXCLUDE.has(filename)) continue;
 
+      // Path confinement: resolve + verify the result stays under dataDir.
+      // Defeats `data/../../etc/passwd` and absolute-name games.
+      const filePath = resolve(this.dataDir, filename);
+      if (filePath !== dataDirAbs && !filePath.startsWith(dataDirAbs + sep)) {
+        this.logger.warn(
+          { entry: entry.entryName, resolved: filePath },
+          "Backup restore: path traversal refused (spec 089 C2)",
+        );
+        continue;
+      }
+
+      // Extension whitelist: reject .sh, .so, .node, etc.
+      const ext = extname(filename).toLowerCase();
+      if (ext && !ALLOWED_RESTORE_EXTENSIONS.has(ext)) {
+        this.logger.warn(
+          { entry: entry.entryName, ext },
+          "Backup restore: extension not allowed (spec 089 C2)",
+        );
+        continue;
+      }
+
+      // Read the uncompressed buffer and enforce cumulative cap.
+      // Cap exceeded is fatal — we cannot continue without risking disk fill.
+      const data = entry.getData();
+      restoreBytes += data.length;
+      if (restoreBytes > this.maxRestoreBytes) {
+        this.logger.error(
+          { bytes: restoreBytes, cap: this.maxRestoreBytes },
+          "Backup restore: cumulative size cap exceeded (spec 089 C2)",
+        );
+        throw new BackupSizeCapExceededError(restoreBytes, this.maxRestoreBytes);
+      }
+
       try {
-        const filePath = resolve(this.dataDir, filename);
         mkdirSync(dirname(filePath), { recursive: true });
-        writeFileSync(filePath, entry.getData());
+        writeFileSync(filePath, data);
         filesRestored++;
         this.logger.debug({ filename }, "Data file restored");
       } catch (err) {

--- a/src/packages/package-manager.test.ts
+++ b/src/packages/package-manager.test.ts
@@ -88,8 +88,10 @@ describe("PackageManager — spec 089 C1 attack regression guards", () => {
   let pkgSrcDir: string;
   let tarballPath: string;
   let realSha256: string;
+  let originalCwd: string;
 
   beforeEach(async () => {
+    originalCwd = process.cwd();
     tmpDir = mkdtempSync(resolve(tmpdir(), "sowel-pkg-test-"));
     pluginsDir = resolve(tmpDir, "plugins");
     mkdirSync(pluginsDir, { recursive: true });
@@ -121,6 +123,14 @@ describe("PackageManager — spec 089 C1 attack regression guards", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     db.close();
+    // Restore cwd BEFORE rmSync — otherwise the process is left with a
+    // deleted directory as cwd, and any later process.cwd() call (e.g.
+    // from the pino logger's worker thread) crashes with ENOENT/uv_cwd.
+    try {
+      process.chdir(originalCwd);
+    } catch {
+      /* best effort */
+    }
     rmSync(tmpDir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary

Closes the **C2** RCE vulnerability identified in the 2026-05-03 security audit (SECURITY_AUDIT.md):
`restoreBackup` was extracting ZIP entries with `path.resolve(dataDir, filename)` after a bypassable `startsWith("data/")` check. A crafted backup ZIP could write anywhere on disk (`/etc/cron.d/`, `/usr/bin/`, etc.) and yield RCE for an authenticated admin uploading a malicious backup.

Second of the two PRs for spec 089 (the C1 plugin supply chain shipped in #176). C3 (backup encryption) is explicitly deferred — see [spec.md](specs/089-security-hardening-supply-chain-backup/spec.md).

## Changes

`src/backup/backup-manager.ts` — hardened restore loop:

- **Symlink refusal**: entries whose ZIP external attributes' upper 16 bits decode as `S_IFLNK (0o120000)` are skipped with a structured warning.
- **Path confinement**: `resolve(dataDir, filename)` is checked against `dataDir + sep`. `data/../sowel-pwned` is refused.
- **Extension whitelist**: `{.json .png .jpg .jpeg .svg .webp .db .db-shm .db-wal .jwt-secret .influx-token .log .txt}`. `.so`, `.node`, `.sh`, executables are refused.
- **Cumulative size cap**: default 1 GB, configurable via `BackupManagerDeps.maxRestoreBytes` (used by tests). Past the cap, throws `BackupSizeCapExceededError` — fatal because we cannot continue without risking disk-fill.

Malicious entries are silently skipped (logger.warn), letting the legitimate part of a partial archive go through. Only size-cap is fatal.

## Tests

`src/backup/backup-manager.test.ts` — 6 new attack tests:

- C2.1 path traversal `data/../sowel-pwned-xyz` → no file outside dataDir
- C2.2 symlink entry (S_IFLNK external attr) → not created
- C2.3 `data/payload.so` → refused (extension)
- C2.4 `data/payload.node` → refused (extension)
- C2.5 cumulative size > cap → `BackupSizeCapExceededError`
- C2.6 (regression) `data/legit.json` still restores normally

Helper `buildMaliciousZip()` constructs ZIPs with arbitrary entry name / data / external attributes.

## Test plan

- [x] `npx tsc --noEmit` zero errors
- [x] `npx vitest run` — **444 tests pass** (6 new + 438 existing), 2 skipped
- [x] `npx eslint src/ --ext .ts` zero errors
- [ ] Manual: try restoring a hand-crafted ZIP with `data/../foo` → no file outside dataDir, warning in logs
- [ ] Manual: try restoring a ZIP with a `data/x.so` → entry skipped, warning in logs

## Spec

`specs/089-security-hardening-supply-chain-backup/` — same spec docs as #176.