### PR TITLE
fix(plugins): refuse only escaping symlinks, allow internal ones (spec 089 C1)

### DIFF
--- a/src/packages/package-manager.test.ts
+++ b/src/packages/package-manager.test.ts
@@ -233,9 +233,9 @@ describe("PackageManager — spec 089 C1 attack regression guards", () => {
     );
   });
 
-  // C1.3 — tarball with a symlink entry is refused by post-extraction scan
-  it("refuses install when tarball contains a symlink", async () => {
-    // Add a symlink to the source dir before tarring.
+  // C1.3 — tarball with a symlink that ESCAPES the extract dir is refused
+  it("refuses install when tarball contains a symlink escaping the extract dir", async () => {
+    // Absolute symlink → escapes any extract dir.
     const symlinkSrc = resolve(pkgSrcDir, "evil-link");
     symlinkSync("/etc/passwd", symlinkSrc);
     await buildTarball(pkgSrcDir, tarballPath);
@@ -259,6 +259,67 @@ describe("PackageManager — spec 089 C1 attack regression guards", () => {
     await expect(manager.installFromGitHub("mchacher/sowel-plugin-test")).rejects.toBeInstanceOf(
       SymlinkInTarballError,
     );
+  });
+
+  // C1.3b — tarball with a symlink ESCAPING via .. traversal is refused
+  it("refuses install when tarball contains a symlink escaping via .. traversal", async () => {
+    const symlinkSrc = resolve(pkgSrcDir, "evil-link");
+    // Build a relative symlink with many .. so it always escapes regardless
+    // of where the tarball is extracted (e.g. /tmp/extract/evil-link → /etc/passwd).
+    symlinkSync("../../../../../../../../etc/passwd", symlinkSrc);
+    await buildTarball(pkgSrcDir, tarballPath);
+    const newSha = sha256OfFile(tarballPath);
+
+    setRegistry([
+      {
+        id: "test-plugin",
+        name: "Test",
+        description: "x",
+        icon: "Puzzle",
+        author: "mchacher",
+        repo: "mchacher/sowel-plugin-test",
+        owner: "mchacher",
+        sha256: newSha,
+        tags: [],
+      },
+    ]);
+    mockGithubFetch(tarballPath);
+
+    await expect(manager.installFromGitHub("mchacher/sowel-plugin-test")).rejects.toBeInstanceOf(
+      SymlinkInTarballError,
+    );
+  });
+
+  // C1.3c — internal symlink (npm node_modules/.bin pattern) is ALLOWED
+  it("allows install when tarball contains an internal symlink (e.g. node_modules/.bin)", async () => {
+    // Mimic node_modules/.bin/foo → ../foo/bin.js (npm-installed package layout).
+    const binDir = resolve(pkgSrcDir, "node_modules", ".bin");
+    const targetDir = resolve(pkgSrcDir, "node_modules", "foo");
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(resolve(targetDir, "bin.js"), "console.log('hi');\n");
+    // Relative target pointing within the extract tree.
+    symlinkSync("../foo/bin.js", resolve(binDir, "foo"));
+    await buildTarball(pkgSrcDir, tarballPath);
+    const newSha = sha256OfFile(tarballPath);
+
+    setRegistry([
+      {
+        id: "test-plugin",
+        name: "Test",
+        description: "x",
+        icon: "Puzzle",
+        author: "mchacher",
+        repo: "mchacher/sowel-plugin-test",
+        owner: "mchacher",
+        sha256: newSha,
+        tags: [],
+      },
+    ]);
+    mockGithubFetch(tarballPath);
+
+    const manifest = await manager.installFromGitHub("mchacher/sowel-plugin-test");
+    expect(manifest.id).toBe("test-plugin");
   });
 
   // C1 — package absent from registry is refused (not silently downloaded)

--- a/src/packages/package-manager.ts
+++ b/src/packages/package-manager.ts
@@ -1,4 +1,4 @@
-import { resolve, relative } from "node:path";
+import { resolve, relative, sep } from "node:path";
 import {
   existsSync,
   readFileSync,
@@ -7,6 +7,7 @@ import {
   createWriteStream,
   lstatSync,
   readdirSync,
+  readlinkSync,
 } from "node:fs";
 import { rename } from "node:fs/promises";
 import { pipeline } from "node:stream/promises";
@@ -599,27 +600,45 @@ export class PackageManager {
     }
 
     // ── Symlink post-extraction scan (spec 089 C1) ────────────
-    this.assertNoSymlinks(extractDir, entry.id);
+    // Refuse only symlinks that escape the extract dir (the real attack
+    // vector — e.g. link → /etc/passwd or ../../sensitive). Internal
+    // symlinks that point within the extracted tree are legitimate and
+    // common (e.g. node_modules/.bin/* shipped by every npm package).
+    this.assertNoEscapingSymlinks(extractDir, extractDir, entry.id);
 
     return extractDir;
   }
 
-  /** Walk a directory recursively; throw SymlinkInTarballError if any entry is a symlink. */
-  private assertNoSymlinks(dir: string, pluginId: string): void {
+  /**
+   * Walk a directory recursively. Throw SymlinkInTarballError if any
+   * symlink's target resolves OUTSIDE the extract root (escape attempt).
+   * Symlinks pointing within the root are allowed — npm packages
+   * routinely ship node_modules/.bin/* symlinks like that.
+   */
+  private assertNoEscapingSymlinks(root: string, dir: string, pluginId: string): void {
+    const rootAbs = resolve(root);
     const entries = readdirSync(dir, { withFileTypes: true });
     for (const e of entries) {
       const full = resolve(dir, e.name);
       const stat = lstatSync(full);
       if (stat.isSymbolicLink()) {
-        try {
-          rmSync(dir, { recursive: true, force: true });
-        } catch {
-          /* ignore */
+        const target = readlinkSync(full);
+        // Resolve target relative to the symlink's parent dir (POSIX semantics).
+        const resolved = resolve(dir, target);
+        if (resolved !== rootAbs && !resolved.startsWith(rootAbs + sep)) {
+          // Best-effort cleanup before bailing.
+          try {
+            rmSync(root, { recursive: true, force: true });
+          } catch {
+            /* ignore */
+          }
+          throw new SymlinkInTarballError(pluginId, relative(root, full));
         }
-        throw new SymlinkInTarballError(pluginId, relative(dir, full));
+        // Internal symlink — safe, skip (don't recurse into it).
+        continue;
       }
       if (e.isDirectory()) {
-        this.assertNoSymlinks(full, pluginId);
+        this.assertNoEscapingSymlinks(root, full, pluginId);
       }
     }
   }

--- a/src/packages/registry-types.ts
+++ b/src/packages/registry-types.ts
@@ -77,13 +77,15 @@ export class CommunityPluginConfirmationRequiredError extends Error {
   }
 }
 
-/** Thrown when a tarball contains a symlink entry (post-extraction scan). */
+/** Thrown when a tarball contains a symlink whose target escapes the extract dir. */
 export class SymlinkInTarballError extends Error {
   constructor(
     public readonly pluginId: string,
     public readonly symlinkPath: string,
   ) {
-    super(`Plugin ${pluginId}: tarball contains symlink (${symlinkPath}); refused for security.`);
+    super(
+      `Plugin ${pluginId}: tarball contains an escaping symlink (${symlinkPath}); refused for security.`,
+    );
     this.name = "SymlinkInTarballError";
   }
 }


### PR DESCRIPTION
## Summary

The post-extraction symlink scan in spec 089 was too aggressive: it refused **every** symlink in plugin tarballs, which broke installs of any plugin shipping npm-installed dependencies (because every npm package layout includes \`node_modules/.bin/*\` as symlinks).

## Problem

Real failure observed on \`domopi.local\` when installing the \`zigbee2mqtt\` plugin:

\`\`\`
SymlinkInTarballError: Plugin zigbee2mqtt: tarball contains symlink (mqtt); refused for security.
\`\`\`

That \`mqtt\` is \`node_modules/.bin/mqtt → ../mqtt/bin/mqtt.js\` — a standard npm-installed package layout, perfectly safe (the target resolves within the same node_modules tree).

## Fix

Only refuse symlinks whose target resolves OUTSIDE the extract dir — that's the real attack vector (\`link → /etc/passwd\`, \`link → ../../../sensitive\`). Internal symlinks are allowed.

Implementation in \`src/packages/package-manager.ts\`:

- Renamed \`assertNoSymlinks\` → \`assertNoEscapingSymlinks\`
- Tracks the extract root separately from the current recursion dir
- For each symlink: \`readlinkSync\` + \`resolve(parentDir, target)\`; refuse only if the result is not under the root

## Tests

\`src/packages/package-manager.test.ts\`:

- Existing test (absolute target \`/etc/passwd\`) still refused — keeps the security guarantee
- **NEW**: refused when symlink target is relative but escapes via \`..\` traversal
- **NEW**: allowed when target resolves within the extract tree (mimics \`node_modules/.bin/foo → ../foo/bin.js\`)

Total: 454 backend tests pass (was 452).

## Test plan

- [x] \`npx tsc --noEmit\` zero errors
- [x] \`npx vitest run\` — 454 tests pass
- [x] \`npx eslint src/ --ext .ts\` zero errors
- [ ] Manual: install \`sowel-plugin-zigbee2mqtt\` on the Pi after 1.6.4 release ships, verify success

## Rollout

This is a regression fix for spec 089 — ship as v1.6.4 ASAP so plugin installs work again.