### PR TITLE
fix(restart): add --force-recreate so the restart helper actually restarts

### DIFF
--- a/src/core/update-manager.test.ts
+++ b/src/core/update-manager.test.ts
@@ -212,9 +212,11 @@ describe("UpdateManager", () => {
       expect(runSpy).toHaveBeenCalledTimes(1);
       const callArg = runSpy.mock.calls[0][0] as { name: string; cmd: string[] };
       expect(callArg.name).toBe("sowel-restarter");
-      // Command should contain docker compose up -d (no pull)
       const fullCmd = callArg.cmd.join(" ");
-      expect(fullCmd).toContain("docker compose up -d sowel");
+      // Critical: --force-recreate must be present. Without it compose sees
+      // no diff (image + env unchanged) and never restarts the container,
+      // leaving the UI stuck on "Update in progress".
+      expect(fullCmd).toContain("docker compose up -d --force-recreate sowel");
       expect(fullCmd).not.toContain("docker compose pull");
 
       expect(progressEvents).toContain("restart");

--- a/src/core/update-manager.ts
+++ b/src/core/update-manager.ts
@@ -432,10 +432,13 @@ export class UpdateManager {
    * (e.g., after changing home location and re-deriving the timezone).
    *
    * The helper container runs:
-   *   sleep 3 && docker compose up -d <service>
+   *   sleep 3 && docker compose up -d --force-recreate <service>
    *
-   * which recreates the sowel container with the current image. The compose
-   * file is re-parsed so any env var changes are picked up.
+   * --force-recreate is critical: without it, compose sees no diff (image
+   * unchanged, env unchanged) and skips the restart entirely. Sowel would
+   * keep running with stale env, the UI would stay on "Update in progress"
+   * forever (the `updating` flag is intentionally never reset here since
+   * we expect to be killed by the helper).
    */
   async restartViaHelper(): Promise<void> {
     if (this.updating) {
@@ -455,7 +458,7 @@ export class UpdateManager {
       const cmd = [
         "sh",
         "-c",
-        `sleep 3 && echo "[sowel-restarter] recreating ${ctx.serviceName}..." && docker compose up -d ${ctx.serviceName} && echo "[sowel-restarter] done"`,
+        `sleep 3 && echo "[sowel-restarter] recreating ${ctx.serviceName}..." && docker compose up -d --force-recreate ${ctx.serviceName} && echo "[sowel-restarter] done"`,
       ];
       await this.runHelperContainer({
         name: RESTART_HELPER_NAME,


### PR DESCRIPTION
## Summary

Restart-via-helper (triggered after a Home location change in Settings) didn't actually restart the container. The UI was stuck on "Update in progress" forever, only browser refresh recovered.

## Repro

1. Fresh 1.6.4 install
2. Settings → General → fill Home name + lat/long → Save
3. "Restart required" toast appears → click "Restart now"
4. Page shows "Update in progress" loader, never dismisses
5. Manual page refresh is the only way out

## Root cause

\`restartViaHelper()\` spawned \`docker compose up -d <service>\` **without** \`--force-recreate\`. Compose saw no diff (image unchanged, env unchanged) and skipped the recreate:

\`\`\`
[sowel-restarter] recreating sowel...
 Container sowel-influxdb  Running
 Container sowel  Running            ← no recreate
[sowel-restarter] done
\`\`\`

Consequences:
- The sowel container kept running with stale env → new TZ never picked up
- Backend's \`updating\` flag stays set (intentional — restart helper is meant to kill us)
- UI's UpdateOverlay polls for engine-back-online → never happens → stuck

## Fix

Add \`--force-recreate\` to the restart helper command. Container is now actually replaced, old process dies, WS reconnects to new instance, overlay dismisses cleanly.

Same pattern as spec 104 (PR #179) which added \`--force-recreate\` to the update helper for an analogous bug.

## Test plan

- [x] Updated existing unit test in update-manager.test.ts to assert \`--force-recreate\` is in the spawned command
- [x] 454 backend tests pass
- [ ] Manual: after 1.6.5 release ships, change Home location on the Pi, verify the restart actually restarts and the UI overlay dismisses