### PR TITLE
feat(ci): GHCR retention policy — auto-prune old container versions on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,3 +214,25 @@ jobs:
           gh release create "$V" \
             --title "Sowel ${V#v}" \
             --generate-notes
+
+  # ── GHCR retention policy ─────────────────────────────────
+  # After a successful release, prune old container versions on GHCR so
+  # storage doesn't grow unbounded across patches. Keeps the N newest
+  # versions (by creation date) and never touches the :latest /
+  # :latest-arm64 floating tags. Each release adds ~6 manifests
+  # (multi-arch index + amd64 + arm64 + attestations + SBOM), so the
+  # default 30 covers roughly the last 5 releases — plenty for rollback.
+  prune-ghcr:
+    needs: [release]
+    if: always() && needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: sowel
+          package-type: container
+          owner: mchacher
+          min-versions-to-keep: 30
+          ignore-versions: '^(latest|latest-arm64)$'


### PR DESCRIPTION
## Summary

Add a \`prune-ghcr\` job to the release workflow that auto-prunes old container versions on GHCR after each release. Prevents the storage bloat we hit on \`mchacher/sowel\` (211 GHCR versions in ~4 weeks of patch releases).

## How

\`\`\`yaml
prune-ghcr:
  needs: [release]
  if: always() && needs.release.result == 'success'
  runs-on: ubuntu-latest
  permissions:
    packages: write
  steps:
    - uses: actions/delete-package-versions@v5
      with:
        package-name: sowel
        package-type: container
        owner: mchacher
        min-versions-to-keep: 30
        ignore-versions: '^(latest|latest-arm64)$'
\`\`\`

- \`min-versions-to-keep: 30\` — each release pushes ~6 manifests (multi-arch index + amd64 + arm64 + attestations + SBOM), so 30 covers ≈ 5 releases. Generous for rollback.
- \`ignore-versions\` — never deletes \`:latest\` or \`:latest-arm64\` (the floating tags users pull).
- \`needs: [release]\` — only runs after the release succeeded; doesn't garbage-collect history on a broken build.

## Rollback story

- Tagged versions like \`:1.6.4\` stay pullable for the last ~5 releases.
- Beyond that: git tag remains, source is reproducible from main + the historical Dockerfile, a fresh image can be \`docker build\`-ed locally.

## Test plan

- [ ] Cut the next release (v1.6.6 or whichever) and verify the \`prune-ghcr\` job runs at the end and deletes the right number of old versions
- [ ] \`:latest\` and \`:latest-arm64\` remain pullable after the prune

This is a low-risk YAML-only change; failure modes are bounded by \`min-versions-to-keep\` (worst case: nothing gets deleted, the bloat just doesn't get worse).