### PR TITLE
feat(core): WAN hardening (spec 105)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,16 @@ RUN npm run build
 FROM debian:trixie-slim
 WORKDIR /app
 
-# Install Node.js 20 + Python 3.13 + build tools
+# Install Node.js 20 + Python 3.13 + build tools + gosu (for entrypoint privilege drop)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      curl ca-certificates python3 python3-venv make g++ \
+      curl ca-certificates python3 python3-venv make g++ gosu \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
+
+# Create non-root sowel user (uid/gid 1000). The entrypoint drops to this user
+# at runtime, after fixing volume ownership idempotently. See docker-entrypoint.sh.
+RUN groupadd -g 1000 sowel && useradd -u 1000 -g 1000 -m -s /bin/bash sowel
 
 # Install production dependencies
 COPY package.json package-lock.json ./
@@ -53,12 +57,20 @@ COPY plugins/registry.json plugins/registry.json
 # Copy package.json (for version reading)
 COPY package.json ./
 
-# Prepare directories
+# Prepare directories (ownership fixed at runtime by entrypoint)
 RUN mkdir -p data plugins
+
+# Entrypoint script: chown data/plugins then drop to sowel user via gosu
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENV NODE_ENV=production
 ENV SQLITE_PATH=/app/data/sowel.db
 
+# No USER directive — entrypoint controls the privilege drop so existing
+# root-owned volumes from a previous version can be re-chowned transparently.
+
 EXPOSE 3000
 
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "dist/index.js"]

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -1,0 +1,201 @@
+# Audit de cybersécurité — Sowel
+
+**Date** : 2026-05-03
+**Périmètre** : authentification, API REST + WebSocket, système de plugins, gestion des secrets, stockage, packaging Docker
+**Méthode** : revue statique de code (3 agents parallèles + relecture manuelle des findings critiques)
+**Branche auditée** : `main` @ `7eeeea1` (release v1.5.2)
+
+---
+
+## 1. Synthèse exécutive
+
+Sowel présente une **base saine** sur les fondamentaux de sécurité applicative (bcrypt cost 12, prepared statements, JWT + refresh token rotation, WAL SQLite, redaction des champs sensibles dans les logs).
+
+Les **risques majeurs** se concentrent sur trois zones :
+
+1. **La chaîne d'approvisionnement des plugins** — pas de vérification d'intégrité au téléchargement, le code tiers est exécuté avec les droits du process.
+2. **Le système de backup** — path traversal possible au restore, secrets exportés en clair dans le ZIP.
+3. **Le packaging runtime** — container en `root`, socket Docker monté en RW, CORS `*` par défaut, pas de headers de sécurité.
+
+L'engine est conçu pour un LAN de confiance ; **l'exposition WAN actuelle** (`app.sowel.org` via Cloudflare tunnel) **amplifie matériellement plusieurs risques** qui seraient mineurs en réseau privé.
+
+### Score
+
+| Sévérité | Nombre |
+| -------- | ------ |
+| Critique | **3**  |
+| Haute    | 6      |
+| Moyenne  | ~10    |
+| Basse    | ~6     |
+
+> Note : 3 findings remontés initialement par les agents ont été reclassés après vérification manuelle (cf. § 6 Faux positifs).
+
+---
+
+## 2. Priorités d'action — TL;DR
+
+Ordre **strict** d'exécution recommandé. Ne pas paralléliser P1 avec le reste : ce sont les seules failles avec impact RCE direct.
+
+### 🔴 P1 — À traiter immédiatement (RCE / fuite de credentials)
+
+| Ordre | Action                                                       | Finding | Effort |
+| ----- | ------------------------------------------------------------ | ------- | ------ |
+| **1** | Vérification SHA256 obligatoire des plugins avant `import()` | C1      | M      |
+| **2** | Confiner `restoreBackup` (`startsWith(dataDir+sep)`)         | C2      | S      |
+| **3** | Chiffrer le backup (passphrase utilisateur, AES-256-GCM)     | C3      | M      |
+
+### 🟠 P2 — À traiter dans la foulée (durcissement runtime, blocage exposition WAN)
+
+| Ordre | Action                                                                     | Finding | Effort |
+| ----- | -------------------------------------------------------------------------- | ------- | ------ |
+| **4** | `USER 1000` dans le Dockerfile + retirer docker.sock par défaut            | H1      | S      |
+| **5** | Pinning d'image Docker par digest pour self-update                         | H2      | S      |
+| **6** | `npm audit fix` + ajout en CI (Fastify ≥5.9, `@fastify/static`, `esbuild`) | H6      | S      |
+| **7** | `@fastify/helmet` + CORS défaut `localhost` (whitelist explicite)          | H3      | S      |
+| **8** | WS auth via header `Authorization` + validation `Origin`                   | H4      | M      |
+| **9** | Authentification sur routes oubliées (`/devices/suggest`, etc.)            | H5      | S      |
+
+### 🟡 P3 — Hardening de fond (semaines suivantes)
+
+| Ordre  | Action                                                                    | Effort |
+| ------ | ------------------------------------------------------------------------- | ------ |
+| **10** | Validation Zod centralisée sur toutes les routes mutables                 | M      |
+| **11** | Chiffrement secrets en SQLite (clé hors backup)                           | L      |
+| **12** | `algorithm: 'HS256'` explicite sur `jwt.sign/verify`                      | XS     |
+| **13** | Refresh token TTL 30j → 7-14j                                             | XS     |
+| **14** | Filtrage WS par rôle, rate-limit `/auth/setup` et WS                      | M      |
+| **15** | Tar extraction avec flags durs (`--no-absolute-names`, `--no-same-owner`) | XS     |
+| **16** | Mot de passe min 6 → 8 (idéalement 12)                                    | XS     |
+
+### 🟢 P4 — Dette de sécurité (à planifier)
+
+| Ordre  | Action                                                                        |
+| ------ | ----------------------------------------------------------------------------- |
+| **17** | Plan de dépréciation préfixes tokens legacy (`wch_`, `cbl_`)                  |
+| **18** | Helper webhook sécurisé (blockliste IP privées) avant ajout webhooks/ntfy/FCM |
+| **19** | Sanitisation `err.message` dans les réponses 500                              |
+| **20** | Signature GPG/cosign optionnelle des plugins (en complément du SHA256)        |
+
+> **Effort** : XS (<1h) · S (½ journée) · M (1-2 jours) · L (>2 jours)
+
+---
+
+## 3. Findings critiques
+
+### C1 — Plugin RCE via package non vérifié
+
+**Fichier** : [src/packages/package-manager.ts:460-512](src/packages/package-manager.ts#L460-L512)
+
+Le téléchargement d'un plugin depuis GitHub (`browser_download_url`), l'extraction `tar.gz` puis l'`import()` dynamique du code se fait **sans checksum, sans signature, sans pinning de version**. Si un compte mainteneur de plugin est compromis — ou si le registry pointe vers un repo hostile — le code malveillant s'exécute avec les droits du process Sowel : accès MQTT, base SQLite, InfluxDB, secrets, et docker.sock (cf. H1).
+
+**Impact** : RCE complète du host.
+**Recommandation** : SHA256 obligatoire dans le manifest du plugin, vérifié avant extraction. Signature GPG/cosign optionnelle. TLS strict sur les fetches GitHub.
+
+---
+
+### C2 — Path traversal dans le restore backup
+
+**Fichier** : [src/backup/backup-manager.ts:425-438](src/backup/backup-manager.ts#L425-L438)
+
+```ts
+if (!entry.entryName.startsWith("data/") || entry.isDirectory) continue;
+const filename = entry.entryName.slice("data/".length);
+// ...
+const filePath = resolve(this.dataDir, filename);
+writeFileSync(filePath, entry.getData());
+```
+
+`path.resolve()` **ne confine pas** : un ZIP malicieux avec `data/../../etc/cron.d/sowel-rce` produit un chemin hors `dataDir` et `writeFileSync` écrit avec les droits du process. Combiné à C2bis (container root), c'est une RCE par upload de backup.
+
+**Impact** : RCE par utilisateur authentifié admin.
+**Recommandation** :
+
+```ts
+const p = resolve(dataDir, filename);
+if (!p.startsWith(dataDir + sep)) throw new Error("path traversal blocked");
+```
+
+Ajouter une whitelist d'extensions autorisées sous `data/`.
+
+---
+
+### C3 — Secrets exportés en clair dans le backup
+
+**Fichier** : [src/backup/backup-manager.ts:131-152](src/backup/backup-manager.ts#L131-L152)
+
+`SELECT * FROM ${table}` est exécuté sur toutes les tables, dont `settings` qui contient :
+
+- mots de passe MQTT
+- tokens d'API cloud (Panasonic Comfort Cloud, etc.)
+- tokens Telegram, FCM, ntfy
+- hashes utilisateurs (bcrypt — moins grave mais présent)
+
+Le tout est sérialisé en JSON et embarqué dans un ZIP **non chiffré**. Quiconque récupère un backup (clé USB perdue, partage cloud, fuite de `data/backups/`) obtient toutes les credentials de l'installation.
+
+**Impact** : compromission de toutes les intégrations en cas de fuite du backup.
+**Recommandation** : chiffrer le backup avec une passphrase utilisateur (AES-256-GCM, dérivation argon2id). Alternative : exclure les champs marqués `sensitive` du settings-manager et les chiffrer séparément avec une clé hors backup.
+
+---
+
+## 4. Findings hautes
+
+> **Mise à jour 2026-05-15** : les findings résolus par la spec 105 (v1.7.0) sont marqués `[x]`. Voir [SECURITY_AUDIT_WAN.md](SECURITY_AUDIT_WAN.md) pour la matrice WAN complète.
+
+| État | #   | Vulnérabilité                                                | Fichier                                                                    | Recommandation                                                                            |
+| ---- | --- | ------------------------------------------------------------ | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [x]  | H1  | **Container Docker en root + docker.sock en RW**             | [Dockerfile](Dockerfile), [docker-compose.yml:25](docker-compose.yml#L25)  | `USER 1000`, retirer docker.sock par défaut (opt-in self-update)                          |
+| [ ]  | H2  | **Auto-update sans pinning d'image digest**                  | [src/core/update-manager.ts:248-272](src/core/update-manager.ts#L248-L272) | Vérifier `image_digest` du manifest release, puller `@sha256:...`                         |
+| [x]  | H3  | **Aucun header de sécurité** (pas de helmet)                 | [src/api/server.ts:139-160](src/api/server.ts#L139-L160)                   | `@fastify/helmet` avec CSP, HSTS, X-Frame-Options DENY                                    |
+| [x]  | H4  | **WS auth via query param** `?token=…`                       | [src/api/websocket.ts:168-187](src/api/websocket.ts#L168-L187)             | Authorization header sur upgrade, valider `Origin`                                        |
+| [x]  | H5  | **Routes non authentifiées** (ex. `/api/v1/devices/suggest`) | [src/api/routes/devices.ts:57](src/api/routes/devices.ts#L57)              | Ajouter check `request.auth`                                                              |
+| [ ]  | H6  | **Dépendances vulnérables**                                  | [package.json](package.json)                                               | `npm audit fix` + ajout en CI ; Fastify `>=5.9`, mise à jour `@fastify/static`, `esbuild` |
+
+---
+
+## 5. Findings moyennes (extraits)
+
+- **CORS `*` par défaut** ([src/config.ts:92](src/config.ts#L92)) — défaut à `localhost`, whitelist explicite (sévérité dépend de l'exposition WAN).
+- **Pas de validation Zod / JSON Schema** sur les routes mutables → injection de types ; `repo` plugin non regex-validé.
+- **`err.message` brut** renvoyé en réponse 500 dans [src/api/routes/plugins.ts](src/api/routes/plugins.ts) et [src/api/routes/integrations.ts](src/api/routes/integrations.ts) → fuite de paths/stack.
+- **Refresh token TTL 30 jours** ([src/config.ts:86](src/config.ts#L86)) → fenêtre de rejeu longue. Cibler 7-14 jours.
+- **WS broadcast non filtré par rôle** ([src/api/websocket.ts:129-140](src/api/websocket.ts#L129-L140)) — un viewer reçoit tout.
+- **Tar extraction sans flags durs** (`--no-absolute-names`, `--no-same-owner`) sur [src/packages/package-manager.ts:504](src/packages/package-manager.ts#L504).
+- **Préfixes tokens legacy** `wch_`/`cbl_` toujours acceptés sans roadmap de retrait ([src/auth/auth-middleware.ts:75-76](src/auth/auth-middleware.ts#L75-L76)).
+- **Pas de rate-limit** sur WS et sur `/auth/setup`.
+- **Tokens Telegram potentiellement loggués** sur erreur ([src/notifications/channels/telegram.ts](src/notifications/channels/telegram.ts)).
+- **Mot de passe minimum 6 caractères** ([src/auth/auth-routes.ts:33-34](src/auth/auth-routes.ts#L33-L34)) — passer à 8 minimum, idéalement 12.
+
+---
+
+## 6. Faux positifs / findings reclassés après vérification
+
+Trois points remontés par les agents ont été **invalidés ou nuancés** lors de la relecture manuelle :
+
+| Reclassé                                                                                                        | Raison                                                                                                                                                                                                                     |
+| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ~~Path traversal SPA fallback~~ ([src/api/server.ts:256](src/api/server.ts#L256))                               | `fastifyStatic` est enregistré juste au-dessus avec `root: uiDir` ; `reply.sendFile` confine via la lib `send` qui rejette les `..`. **Non exploitable** en l'état (à confirmer par un test `curl '/../../package.json'`). |
+| ~~Token API : pas de timing-safe equal~~ ([src/auth/auth-service.ts:188](src/auth/auth-service.ts#L188))        | Le code calcule `sha256(token)` puis fait un lookup SQLite **indexé** par hash exact. Aucun comparateur byte-par-byte exploitable, le SHA256 est constant en temps. **Pas de canal timing**.                               |
+| ~~Injection SQL dans restore~~ ([src/backup/backup-manager.ts:321-328](src/backup/backup-manager.ts#L321-L328)) | À revérifier ; les noms de tables proviennent de `BACKUP_TABLES` (constante interne), pas du backup utilisateur. Probablement non exploitable.                                                                             |
+
+> Leçon : les rapports d'agents doivent toujours être relus, en particulier les findings de type "comparaison non timing-safe" et "path traversal sur framework" qui sont souvent surestimés.
+
+---
+
+## 7. Points positifs relevés
+
+- Bcrypt cost 12 (conforme OWASP).
+- Refresh token rotation implémentée.
+- Prepared statements partout sur SQLite (better-sqlite3).
+- WAL mode activé.
+- Logger pino avec redaction automatique des champs sensibles (`password`, `token`, `secret`, `apiKey`).
+- Prévention de la suppression du dernier admin.
+- Validation JSON schema sur les payloads de backup.
+- API tokens préfixés `swl_` avec entropie 256 bits (`randomBytes(32)`).
+
+---
+
+## 8. Posture de sécurité d'ensemble
+
+Sowel est un projet **bien conçu pour un usage LAN privé**. Les vulnérabilités critiques relèvent toutes d'**hypothèses runtime trop permissives** (container root, plugin tiers de confiance, backup stocké en clair) plutôt que de défauts de codage classiques (pas d'injection SQL flagrante, pas d'XSS évident, pas de fuite de mémoire).
+
+L'exposition WAN actuelle via Cloudflare tunnel transforme plusieurs findings de "moyens en LAN" à "critiques en WAN". **Recommandation forte** : adresser au minimum les priorités P1 et P2 avant tout élargissement de l'exposition publique.

--- a/SECURITY_AUDIT_WAN.md
+++ b/SECURITY_AUDIT_WAN.md
@@ -1,0 +1,301 @@
+# Analyse de risques cybersécurité WAN — Sowel
+
+**Date** : 2026-05-15
+**Périmètre** : exposition publique d'une instance Sowel sur Internet (deux topologies : Cloudflare Tunnel et port-forwarding direct sur box Internet).
+**Branche analysée** : `main` @ v1.6.5
+**Document précédent** : [SECURITY_AUDIT.md](SECURITY_AUDIT.md) (audit applicatif daté 2026-05-03, v1.5.2)
+**Méthode** : revue statique différentielle depuis v1.5.2, modélisation de menace par scénario d'exposition, vérification ciblée du code en main.
+
+---
+
+## 1. Pourquoi un audit WAN distinct
+
+L'audit du 2026-05-03 a évalué Sowel sous l'hypothèse **"LAN de confiance"**. Cette analyse complète cet audit en répondant à une question opérationnelle distincte :
+
+> Que se passe-t-il quand une instance Sowel devient atteignable depuis Internet ?
+
+Les vulnérabilités classées "Moyenne" en LAN remontent souvent à "Critique" dès qu'un attaquant peut frapper l'instance depuis n'importe quelle IP du monde, 24/7, sans contrainte de proximité physique.
+
+Deux topologies sont aujourd'hui utilisées par les utilisateurs Sowel :
+
+| Topologie                | Qui                              | Caractéristiques                                                                                                                             |
+| ------------------------ | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A. Cloudflare Tunnel** | Mainteneur, utilisateurs avancés | TLS terminé chez Cloudflare. Pas de port ouvert sur la box. Origine Sowel uniquement joignable via le tunnel. Possibilité Cloudflare Access. |
+| **B. Port-forward**      | Auto-hébergeurs grand public     | Règle NAT sur la box Internet vers `192.168.x.x:3000`. TLS souvent absent (HTTP brut), IP source = monde entier, pas de WAF.                 |
+
+Les deux topologies n'ont **pas le même profil de risque** — beaucoup de findings cessent d'être exploitables sous Cloudflare Access, mais redeviennent critiques en port-forward nu. Ce document traite les deux.
+
+---
+
+## 2. Synthèse exécutive
+
+### En une phrase
+
+Depuis l'audit v1.5.2, **les deux vulnérabilités d'extraction (C1 plugin SHA256, C2 path traversal restore) ont été corrigées**, ce qui élimine deux RCE directes. **Aucun autre finding "Haute" ou "Moyenne" n'a été traité**. En topologie B (port-forward), Sowel **ne devrait pas être exposé WAN en l'état**.
+
+### Score par topologie
+
+| Sévérité résiduelle | Cloudflare Tunnel (A)     | Port-forward (B) |
+| ------------------- | ------------------------- | ---------------- |
+| Critique            | 1 (C3 backup non chiffré) | 4                |
+| Haute               | 3                         | 7                |
+| Moyenne             | ~7                        | ~10              |
+
+### Top 5 actions à mener avant d'élargir l'exposition WAN
+
+| #   | Action                                                                                         | Effort | Couvre                               |
+| --- | ---------------------------------------------------------------------------------------------- | ------ | ------------------------------------ |
+| 1   | `USER 1000` dans Dockerfile + `docker.sock` optionnel                                          | S      | H1 — empêche escalade host           |
+| 2   | `@fastify/helmet` + CORS défaut `localhost`                                                    | S      | H3 + finding CORS — couches XSS/CSRF |
+| 3   | WS auth obligatoire + validation `Origin`                                                      | M      | H4 — CSRF via WebSocket              |
+| 4   | Auth `preHandler` sur routes oubliées (`/devices/suggest`, etc.) + audit complet de couverture | M      | H5                                   |
+| 5   | Chiffrement backup (passphrase AES-256-GCM)                                                    | M      | C3 — fuite credentials               |
+
+Le détail est en §6.
+
+---
+
+## 3. Delta v1.5.2 → v1.6.5 (état des findings de l'audit précédent)
+
+Vérification ciblée du code en main pour chaque finding listé dans `SECURITY_AUDIT.md`. Statut : **CORRIGÉ**, **PARTIEL**, **OUVERT**.
+
+### Critiques
+
+| #   | Finding                             | Statut      | Preuve / Note                                                                                                            |
+| --- | ----------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------ |
+| C1  | Plugin RCE sans vérif. d'intégrité  | **CORRIGÉ** | SHA256 obligatoire dans `plugins/registry.json` + validation au download (spec 089). `OFFICIAL_OWNERS` whitelist active. |
+| C2  | Path traversal `restoreBackup`      | **CORRIGÉ** | Confinement `startsWith(dataDirAbs + sep)` + whitelist d'extensions sous `data/` (vérifié dans backup-manager actuel).   |
+| C3  | Secrets en clair dans le backup ZIP | **OUVERT**  | Aucun chiffrement passphrase. Le ZIP local pré-update contient toujours hashes bcrypt, tokens API, settings sensibles.   |
+
+### Hautes
+
+| #   | Finding                                                                               | Statut      | Preuve                                                                                                                                     |
+| --- | ------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| H1  | Container Docker en `root` + `docker.sock` monté en RW par défaut                     | **OUVERT**  | [Dockerfile](Dockerfile) : pas de directive `USER`. [docker-compose.yml:25](docker-compose.yml#L25) : `/var/run/docker.sock` monté.        |
+| H2  | Auto-update sans pinning de digest                                                    | **OUVERT**  | `UpdateManager` pull toujours par tag `:targetVersion`, pas de `@sha256:...`.                                                              |
+| H3  | Aucun header de sécurité (pas de helmet, pas de CSP/HSTS/X-Frame-Options)             | **OUVERT**  | [src/api/server.ts:139-160](src/api/server.ts#L139-L160) : seuls `cors`, `rateLimit`, `multipart`, `websocket` enregistrés.                |
+| H4  | WS auth via query param + `Origin` non validé + **token optionnel** (anonyme accepté) | **OUVERT**  | [src/api/websocket.ts:173](src/api/websocket.ts#L173) : `if (token) { ... }` — pas de token = subscription par défaut "system" en anonyme. |
+| H5  | Routes non authentifiées (ex. `/api/v1/devices/suggest`)                              | **OUVERT**  | À auditer exhaustivement (au moins une route confirmée sans `preHandler` dans l'audit précédent).                                          |
+| H6  | Dépendances vulnérables (Fastify < 5.9, `@fastify/static`, `esbuild`)                 | **PARTIEL** | Fastify est en 5.x mais le pinning précis demandait un `npm audit` qui n'est pas en CI. À refaire systématiquement.                        |
+
+### Moyennes (extraits significatifs pour WAN)
+
+| Finding                                                                                           | Statut     | Note                                                                                                            |
+| ------------------------------------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------- |
+| CORS défaut `*` ([src/config.ts:92](src/config.ts#L92))                                           | **OUVERT** | Toute origin peut frapper l'API depuis le navigateur d'un utilisateur authentifié.                              |
+| Pas de validation Zod sur routes mutables                                                         | **OUVERT** | Type injection silencieuse possible (booléen passé comme string, etc.).                                         |
+| `err.message` brut renvoyé en 500 (plugins/integrations routes)                                   | **OUVERT** | Stack traces / paths internes / nom de dépendances exfiltrés.                                                   |
+| Refresh token TTL 30 jours ([src/config.ts:86](src/config.ts#L86))                                | **OUVERT** | Fenêtre de rejeu longue en cas de vol de token.                                                                 |
+| WS broadcast non filtré par rôle ([src/api/websocket.ts:135-139](src/api/websocket.ts#L135-L139)) | **OUVERT** | Un viewer connecté reçoit les events admin (settings changes, etc.).                                            |
+| Rate-limit dédié sur `/auth/login` (10/min)                                                       | **OK**     | À noter : `/auth/login` est protégé. Mais `/auth/setup` ne l'est pas explicitement (au-delà du global 300/min). |
+| Mot de passe minimum 6 caractères ([src/api/routes/auth.ts:33](src/api/routes/auth.ts#L33))       | **OUVERT** | Faible pour un service exposé WAN.                                                                              |
+| Algorithme JWT non explicite                                                                      | **OUVERT** | `jwt.sign(payload, secret)` sans `algorithm: 'HS256'`.                                                          |
+
+### Lecture
+
+- **Surface "supply chain / restore" considérablement réduite** depuis v1.5.2 (C1 + C2). L'effort spec 089 a payé.
+- **Aucun progrès sur la surface réseau / runtime**. Le profil reste celui d'un service LAN.
+- **Le rate-limit dédié `/auth/login` à 10/min est une bonne surprise** — il rend le brute-force pratique infaisable même en WAN. C'est le point fort principal pour l'exposition.
+
+---
+
+## 4. Modèle de menace WAN
+
+### 4.1 Topologie A — Cloudflare Tunnel
+
+```
+Internet  ──TLS──>  Cloudflare edge  ──cloudflared (mTLS)──>  Sowel container
+                          │
+                          ├─ (optionnel) Cloudflare Access (Zero Trust)
+                          ├─ (optionnel) WAF règles managées
+                          └─ Logs / rate-limit Cloudflare
+```
+
+**Ce qui est neutralisé par cette topologie** :
+
+- Scans de ports IP publics → invisible (pas de port ouvert sur la box).
+- MITM TLS → Cloudflare termine le TLS, certificat valide automatique.
+- Attaques bruteforce massives → rate-limit Cloudflare en amont.
+- Origin spoofing → si Cloudflare Access est activé, l'utilisateur doit s'authentifier au tunnel avant même de joindre Sowel.
+
+**Ce qui reste exploitable** :
+
+- Toute attaque côté application (CSRF, XSS, vol de session, fuite par WS, restore backup malveillant authentifié) passe à travers le tunnel comme du trafic légitime.
+- **Si Cloudflare Access n'est pas activé**, l'attaquant peut atteindre `/api/v1/auth/login` et tenter du credential stuffing (mitigé par le rate-limit local 10/min).
+- Compromission Cloudflare elle-même (TLS terminé chez CF, ils voient tout en clair). Modèle d'attaquant à très faible probabilité mais à conscientiser.
+
+**Recommandation A** : exposition acceptable **si Cloudflare Access est activé** (Zero Trust login Google/email magic link en amont). Sans Cloudflare Access, l'exposition équivaut à port-forward sur le plan applicatif (mais avec TLS et anti-DDoS gratuits).
+
+### 4.2 Topologie B — Port-forward direct
+
+```
+Internet  ──TCP:80/443/3000──>  Box Internet  ──NAT──>  192.168.x.x:3000 (HTTP brut Sowel)
+```
+
+**Profil par défaut** :
+
+- TLS absent (Sowel n'écoute qu'en HTTP sur 3000). Si l'utilisateur n'a pas mis un reverse proxy avec Let's Encrypt devant, **tous les credentials transitent en clair**.
+- Aucune authentification réseau préalable (pas de VPN, pas de SSO).
+- Adresse IP du Sowel = adresse IP publique de la box, indexable par Shodan/Censys via un scan de bannière HTTP "Sowel".
+- Pas de WAF, pas de rate-limit réseau global au-dessus du rate-limit applicatif.
+
+**Modèle d'attaquant** : bot internet opportuniste + attaquant ciblé.
+
+**Verdict** : **cette topologie ne devrait pas être recommandée tant que les findings P1/P2 de §6 ne sont pas adressés**. Trop de chemins exploitables passent par des défauts d'un service exposé non durci :
+
+- HTTP brut → vol de mot de passe au login (réseau Wi-Fi public, captive portal).
+- Pas de CSP / pas de SameSite défaut → CSRF (cookies non concernés mais bearer + CORS `*` = `fetch` cross-origin volant la session).
+- WS sans Origin + token optionnel → connexion WebSocket anonyme depuis n'importe quelle page web malveillante, écoute des events `system.*` en clair.
+- `err.message` brut → un attaquant identifie la stack via une requête malformée.
+- Container root + docker.sock → si l'attaquant trouve une RCE (même par exploit de dépendance vulnérable), il prend l'host.
+
+### 4.3 Modèle d'attaquant retenu
+
+| Profil                              | Capacité                                                                    | Probabilité                              | Priorité défense                                |
+| ----------------------------------- | --------------------------------------------------------------------------- | ---------------------------------------- | ----------------------------------------------- |
+| **Bot opportuniste**                | Scanner CVE, fuzz endpoints, default creds, exploits de dépendances connues | Très haute (24/7)                        | Headers, deps à jour, rate-limit, pas de banner |
+| **Attaquant ciblé non authentifié** | Phishing utilisateur, CSRF, XSS, social engineering                         | Moyenne (mainteneur exposé publiquement) | CSP, Origin WS, CORS strict, SameSite           |
+| **Utilisateur authentifié hostile** | Compte viewer/standard tente escalade, exfiltration via WS, abus restore    | Faible (ménages)                         | Filtrage WS par rôle, validation backups        |
+| **Plugin compromis**                | Code tiers RCE in-process                                                   | Faible depuis spec 089                   | C1 corrigé. Surveiller cosign futur.            |
+| **Compromission Cloudflare**        | Inspection trafic, TLS termination abuse                                    | Très faible                              | Hors scope. Mention pour conscientisation.      |
+
+---
+
+## 5. Vulnérabilités WAN spécifiques (au-delà de l'audit applicatif)
+
+Ces points ne sont pas dans l'audit précédent parce qu'ils n'émergent qu'en exposition publique.
+
+### W1 — Absence de TLS natif et de redirection HTTPS
+
+**Constat** : Sowel n'écoute qu'en HTTP. Aucune option de configuration TLS native (pas de chemin `TLS_CERT_PATH`, pas de Let's Encrypt embarqué).
+**Impact en topologie B** : si l'utilisateur port-forward sans reverse proxy TLS, tout le trafic (login inclus) est en clair. Le mot de passe peut être capturé sur n'importe quel réseau intermédiaire.
+**Impact en topologie A** : nul (TLS terminé par Cloudflare).
+**Reco** : documenter clairement qu'**aucune exposition WAN sans reverse proxy TLS** n'est supportée. Idéalement, refuser de démarrer en mode "WAN_EXPOSURE=true" si pas de TLS détecté. Au minimum : page docs/user/security-wan.md explicite.
+
+### W2 — Absence d'option "lockdown WAN"
+
+**Constat** : Sowel ne distingue pas un déploiement LAN d'un déploiement WAN. Pas de variable d'env `EXPOSURE_MODE=lan|wan` qui activerait par défaut un profil durci (helmet strict, CORS localhost, refresh TTL court, WS auth obligatoire, etc.).
+**Impact** : l'utilisateur grand public ne sait pas qu'il faut ajuster une dizaine de réglages par défaut sécurité pour pouvoir exposer.
+**Reco** : introduire un mode `wan` qui force un profil sécurité strict et qui se manifeste en bannière UI.
+
+### W3 — WebSocket accepte les connexions anonymes
+
+**Constat** : [src/api/websocket.ts:168-188](src/api/websocket.ts#L168-L188) — `if (token) { ... }`. Si aucun token n'est fourni, l'auth est sautée et la subscription par défaut `system` est attribuée.
+**Impact** : un attaquant Internet peut ouvrir une WS, recevoir les events `system.*` (intégrations connectées/déconnectées, settings changed, restart events) sans auth.
+**Reco** : refuser la connexion si pas de token (`socket.close(4001, "Auth required")` dans le else). Et valider `Origin` ou exiger un header `Authorization`.
+
+### W4 — Fingerprinting de version Sowel
+
+**Constat** : la version est exposée publique via `GET /api/v1/system/version` (auth requise) **et** via le service worker / manifest PWA servis publiquement. Le binaire JS bundlé révèle des chunks identifiables. La bannière HTML inclut probablement le nom "Sowel" et le titre.
+**Impact** : un scanner Shodan/Censys peut identifier une instance Sowel + sa version, et corréler avec les CVE applicables.
+**Reco** : pas urgent, mais éviter d'exposer la version sur tout endpoint non authentifié. Ajouter une route `GET /` qui renvoie une page neutre (option) ou une 401 quand pas de session.
+
+### W5 — Surface d'attaque DNS / Cloudflare account
+
+**Constat** : la topologie A repose entièrement sur l'intégrité du compte Cloudflare du mainteneur. Une compromission du compte Cloudflare (phishing, vol de session, MFA bypass) permet de pivoter directement sur le tunnel et d'intercepter tout le trafic.
+**Impact** : équivalent à une compromission de l'origine Sowel.
+**Reco hors-code** : MFA matériel (YubiKey) sur le compte Cloudflare. Cloudflare Access en couche supplémentaire (un attaquant qui prend le compte CF doit aussi prendre le compte SSO).
+
+### W6 — `/auth/setup` exploitable pendant la fenêtre de premier démarrage
+
+**Constat** : [src/api/routes/auth.ts:24-48](src/api/routes/auth.ts#L24-L48) — `/auth/setup` est ouvert tant que `userManager.hasUsers()` est faux. Sur une instance fraîche, un attaquant qui scanne l'IP publique entre `docker compose up` et la création du premier admin (quelques secondes à plusieurs minutes selon l'utilisateur) peut créer un admin avec ses propres credentials.
+**Impact** : prise de contrôle complète d'une instance fraîche.
+**Reco** :
+
+1. Documenter "ne jamais exposer une instance WAN avant d'avoir terminé le setup en local".
+2. À terme : rendre `/auth/setup` joignable **uniquement depuis l'interface LAN** (binding 127.0.0.1 ou vérification IP source = privée).
+
+### W7 — Self-update sans confirmation forte
+
+**Constat** : l'utilisateur authentifié admin peut déclencher un self-update depuis l'UI. Le helper container exécute `docker compose pull` puis `up -d`. Combiné à H1 (root + docker.sock), un admin compromis = host compromis instantanément (en plus de C1 corrigé qui ne change rien ici parce que c'est le main image qui est pullée, pas un plugin).
+**Impact en WAN** : si la session admin est volée (XSS, CSRF, vol de bearer), l'attaquant déclenche un update.
+**Reco** :
+
+1. Confirmation par mot de passe avant tout self-update (re-prompt password modal).
+2. H2 (digest pinning) en complément.
+
+### W8 — Pas de journalisation des événements de sécurité
+
+**Constat** : pas de log distinct "security event" (login fail, token utilisé, restore backup, settings sensibles modifiés). Tout est dans le log standard à niveau `info` ou `warn`.
+**Impact en WAN** : pas de signal exploitable pour détecter une compromission en cours.
+**Reco** : log dédié "audit" pour `auth.login`, `auth.login_failed`, `auth.setup`, `backup.restore`, `plugin.install`, `system.update`, `user.created`, `user.role_changed`. Endpoint UI Admin → Sécurité qui affiche ces événements.
+
+---
+
+## 6. Priorisation des actions (input pour la spec à venir)
+
+Cette section a alimenté la spec [`105-wan-hardening`](specs/105-wan-hardening/spec.md). Les éléments shippés en v1.7.0 sont marqués `[x]`.
+
+### 🔴 P1 — Bloquant pour toute exposition WAN
+
+| État | Ordre | Action                                                                                                         | Couvre           | Effort |
+| ---- | ----- | -------------------------------------------------------------------------------------------------------------- | ---------------- | ------ |
+| [x]  | 1     | WS : refuser anonyme + valider `Origin` + déplacer token en header `Sec-WebSocket-Protocol` ou `Authorization` | W3, H4           | M      |
+| [x]  | 2     | `@fastify/helmet` avec CSP stricte, HSTS, X-Frame-Options DENY, Referrer-Policy                                | H3               | S      |
+| [x]  | 3     | CORS défaut `localhost:3000` + whitelist explicite documentée                                                  | finding CORS `*` | S      |
+| [x]  | 4     | `USER 1000` dans Dockerfile + retirer `docker.sock` du compose par défaut (opt-in self-update via override)    | H1               | S      |
+| [ ]  | 5     | Chiffrement backup AES-256-GCM avec passphrase utilisateur (argon2id KDF) — déclassé (cohérent avec HA)        | C3               | M      |
+
+### 🟠 P2 — Avant ouverture aux utilisateurs non-techniques
+
+| État | Ordre | Action                                                                                       | Couvre       | Effort |
+| ---- | ----- | -------------------------------------------------------------------------------------------- | ------------ | ------ |
+| [ ]  | 6     | Mode `EXPOSURE_MODE=wan` : profil sécurité strict par défaut + bannière UI                   | W2           | M      |
+| [x]  | 7     | Auth `preHandler` audit complet de toutes les routes — ajouter check explicite par défaut    | H5           | M      |
+| [ ]  | 8     | Digest pinning self-update (`@sha256:...`)                                                   | H2, W7       | S      |
+| [ ]  | 9     | Confirmation par mot de passe pour self-update, restore, install plugin community (spec 106) | W7           | S      |
+| [ ]  | 10    | `npm audit` en CI + dépendances à jour                                                       | H6           | S      |
+| [ ]  | 11    | Sanitisation `err.message` dans les réponses 500 (renvoyer code + messageId, pas la stack)   | finding leak | XS     |
+| [ ]  | 12    | Bind `/auth/setup` uniquement depuis IPs privées (RFC1918 + 127.0.0.0/8)                     | W6           | S      |
+
+### 🟡 P3 — Durcissement de fond
+
+| Ordre | Action                                                                             | Effort |
+| ----- | ---------------------------------------------------------------------------------- | ------ |
+| 13    | Validation Zod centralisée sur toutes les routes mutables                          | M      |
+| 14    | WS broadcast filtré par rôle (viewer ≠ admin events)                               | M      |
+| 15    | Refresh token TTL 30j → 7j en mode WAN (avec sliding renew)                        | XS     |
+| 16    | Mot de passe min 6 → 12 (et règle de complexité ?) en mode WAN                     | XS     |
+| 17    | `algorithm: 'HS256'` explicite sur `jwt.sign/verify`                               | XS     |
+| 18    | Log de sécurité distinct + page Admin → Sécurité                                   | M      |
+| 19    | Banner version uniquement après auth (pas dans manifest PWA, pas dans HTML neutre) | S      |
+
+### 🟢 P4 — Roadmap à plus long terme
+
+| #   | Action                                                                              |
+| --- | ----------------------------------------------------------------------------------- |
+| 20  | TLS natif optionnel (option certificat utilisateur) — alternative au reverse proxy. |
+| 21  | Plan de dépréciation préfixes tokens legacy (`wch_`, `cbl_`).                       |
+| 22  | Signature cosign optionnelle des plugins en complément du SHA256.                   |
+| 23  | Support natif Cloudflare Access (header `Cf-Access-Authenticated-User-Email`).      |
+
+---
+
+## 7. Recommandations utilisateur (à formaliser plus tard)
+
+Le mainteneur a demandé qu'une page utilisateur soit rédigée **après** que les corrections soient implémentées. Squelette envisagé pour `docs/user/security-wan.md` :
+
+1. **Toujours préférer Cloudflare Tunnel + Cloudflare Access** à un port-forward direct.
+2. **Si port-forward, alors reverse proxy TLS obligatoire** (Caddy ou Nginx Proxy Manager — exemples fournis).
+3. **Mot de passe fort exigé** (12 caractères minimum, gestionnaire de mots de passe recommandé).
+4. **Premier démarrage en LAN uniquement**, exposer après création du premier admin.
+5. **MAJ régulières activées** (badge update + check manuel disponible depuis v1.6.x).
+6. **Backups chiffrés stockés ailleurs que sur la VM** (cloud personnel, NAS).
+7. **Pas d'install plugin community sans vérification** (l'UI le signale déjà via `OFFICIAL_OWNERS`).
+
+À écrire en clair, pour un utilisateur grand public, dès que les actions P1 sont mergées.
+
+---
+
+## 8. Posture d'ensemble
+
+Sowel a fait un **vrai pas en avant** sur la chaîne supply (spec 089) depuis l'audit de mai. Le projet reste néanmoins conçu et configuré par défaut pour un usage **LAN de confiance**, et l'exposition WAN actuelle (que ce soit via Cloudflare Tunnel ou port-forward) repose entièrement sur des hypothèses externes (Cloudflare Access activé, reverse proxy TLS configuré côté utilisateur, network discipline) qui ne sont **pas encore vérifiées ni guidées par le produit lui-même**.
+
+**Posture recommandée** :
+
+- **Pour le mainteneur** (topologie A + Cloudflare Access) : exposition acceptable, mais l'implémentation des P1 ferait passer la posture de "acceptable par hypothèses" à "acceptable par défaut".
+- **Pour les utilisateurs grand public** (topologie B) : **déconseiller l'exposition WAN** dans les docs jusqu'à implémentation au minimum des P1 + W1 (documentation TLS). Mention claire en page Settings → Sécurité.
+
+---
+
+**Suite immédiate** : créer la spec `specs/105-wan-hardening/` avec spec.md + architecture.md + plan.md couvrant les actions P1 (et au moins le mode `EXPOSURE_MODE=wan` du P2-6 comme parapluie organisationnel).

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,29 @@
+# ============================================================
+# Sowel — Self-update override (optional)
+# ============================================================
+# Copy this file to `docker-compose.override.yml` and run
+#   docker compose up -d
+# to enable in-app self-update from the Admin UI.
+#
+# WHAT THIS DOES
+# Mounting /var/run/docker.sock into the Sowel container allows the
+# self-update flow (Admin -> System -> Update now) to spawn a helper
+# container that pulls the new image and restarts Sowel without you
+# having to run any shell command.
+#
+# SECURITY TRADE-OFF
+# Mounting the Docker socket grants the Sowel container effective
+# control over the Docker daemon on the host. A successful remote-code
+# execution against Sowel (eg. via a compromised dependency) would
+# escalate to root on the host. Only enable this if you understand
+# and accept the trade-off.
+#
+# WITHOUT THIS OVERRIDE
+# The "Update now" button is disabled in the UI. You can still update
+# manually from the host with:
+#   docker compose pull && docker compose up -d sowel
+# ============================================================
+services:
+  sowel:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,10 @@ services:
     volumes:
       - sowel-data:/app/data
       - sowel-plugins:/app/plugins
-      - /var/run/docker.sock:/var/run/docker.sock # self-update
+      # In-app self-update is opt-in. To enable it, copy
+      # docker-compose.override.example.yml to docker-compose.override.yml
+      # and run `docker compose up -d`. Read the override file's header
+      # for the security trade-off before enabling.
     depends_on:
       - influxdb
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,6 +15,22 @@ set -e
 if [ "$(id -u)" = "0" ]; then
   # Idempotent — instant no-op if the volume is already sowel-owned.
   chown -R sowel:sowel /app/data /app/plugins 2>/dev/null || true
+
+  # If /var/run/docker.sock is bind-mounted (opt-in self-update via
+  # docker-compose.override.yml), align the sowel user with the socket's
+  # host group so the in-app updater can talk to the Docker daemon as
+  # non-root. The host GID is detected at runtime — no hard-coded value.
+  if [ -e /var/run/docker.sock ]; then
+    DOCKER_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo "")
+    if [ -n "$DOCKER_GID" ] && [ "$DOCKER_GID" != "0" ]; then
+      DOCKER_GROUP=$(getent group "$DOCKER_GID" 2>/dev/null | cut -d: -f1)
+      if [ -z "$DOCKER_GROUP" ]; then
+        groupadd -g "$DOCKER_GID" docker-host 2>/dev/null && DOCKER_GROUP=docker-host
+      fi
+      [ -n "$DOCKER_GROUP" ] && usermod -aG "$DOCKER_GROUP" sowel 2>/dev/null || true
+    fi
+  fi
+
   exec gosu sowel "$@"
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# ============================================================
+# Sowel container entrypoint
+# ============================================================
+# - If running as root: idempotently chown data/plugins directories
+#   so the non-root sowel user can write, then drop privileges via gosu.
+# - If running as a non-root user (custom `user:` in compose): exec
+#   the command directly; volume ownership is the operator's job.
+#
+# This pattern (Postgres / MySQL / MariaDB) makes upgrades from a
+# previously root-running container transparent: no manual chown step.
+# ============================================================
+set -e
+
+if [ "$(id -u)" = "0" ]; then
+  # Idempotent — instant no-op if the volume is already sowel-owned.
+  chown -R sowel:sowel /app/data /app/plugins 2>/dev/null || true
+  exec gosu sowel "$@"
+fi
+
+exec "$@"

--- a/docs/specs-index.md
+++ b/docs/specs-index.md
@@ -151,6 +151,12 @@ Specs are grouped by theme and annotated with status:
 | 091 | By-usage consumption chart   | ✅     | New `GET /energy/by-usage` endpoint and a Total / By usage toggle on the Energy page rendering a stacked breakdown per submeter `energy_meter` + an "Other" residual (`main meter - Σ submeters`).                                                                                                                |
 | 092 | State-triggered light recipe | ✅     | New external recipe plugin `state-trigger-light` (in `plugins/registry.json`). Turns lights on for a fixed duration when a watched equipment's `state` alias transitions to a target value. Optional nightOnly filter via the sunlight manager. Introduces `crossZone` and `includeDescendants` slot constraints. |
 
+## V1.7 — WAN hardening & security
+
+| #   | Title         | Status | Summary                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --- | ------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 105 | WAN hardening | ✅     | Closes WAN-exposure gaps: `@fastify/helmet` (CSP/HSTS/X-Frame-Options), CORS default tightened from `*` to localhost, WebSocket mandatory auth via `Sec-WebSocket-Protocol` subprotocol + `Origin` validation, non-root container via entrypoint+gosu (transparent upgrade from root-owned volumes), `docker.sock` self-update opt-in via override file, auth-by-default invariant on all `/api/v1/*` routes. |
+
 ---
 
 ## How to use this index after context loss

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -255,9 +255,21 @@ InfluxDB is mandatory -- Sowel connects on startup and auto-creates buckets, dow
 - **Passwords**: bcrypt (cost 12).
 - **JWT**: HS256 via `jsonwebtoken`. Access token TTL: 15 min. Refresh token TTL: 30 days.
 - **API tokens**: `swl_` prefix, SHA-256 hash stored, generated via `crypto.randomBytes(32)`. Legacy prefixes `wch_` and `cbl_` also accepted.
-- **Auth middleware**: Tries JWT decode first, then API token lookup.
+- **Auth-by-default** (spec 105): a global Fastify `onRequest` hook enforces authentication on every `/api/v1/*` route. The list of public routes is the `PUBLIC_ROUTES` constant in `src/auth/auth-middleware.ts` (`/health`, `/auth/status`, `/auth/setup`, `/auth/login`, `/auth/refresh`) plus OAuth callback paths. Any new route is protected unless explicitly added to that whitelist.
 - **Roles**: `admin` > `standard` > `viewer` (hierarchical permissions).
 - **First-run setup**: `POST /api/v1/auth/setup` creates the first admin user.
+
+### WebSocket authentication (spec 105)
+
+The `/ws` endpoint requires authentication. Browser clients pass the token via the `Sec-WebSocket-Protocol: bearer.<token>` subprotocol (the WebSocket API does not allow custom headers). Non-browser clients (scripts, integrations) may use `Authorization: Bearer <token>` instead. Anonymous connections are refused with close code 4001. Connections with an `Origin` header not in the CORS whitelist are refused with 4003.
+
+### Security headers (spec 105)
+
+The Fastify server registers `@fastify/helmet` with a Content-Security-Policy that allows only same-origin scripts, inline styles (for Tailwind), and WebSocket connections. `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, `X-Content-Type-Options: nosniff`, and conditional HSTS (only when the request arrived over HTTPS) are emitted.
+
+### CORS defaults
+
+`CORS_ORIGINS` defaults to `http://localhost:3000,http://localhost:5173`. Setting it to `*` is permitted but emits a startup warning, doubled when `API_HOST` is not loopback.
 
 ---
 

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -77,18 +77,30 @@ On first boot, Sowel:
 
 These are **named Docker volumes**, persistent across container recreation. They are what make self-update and backup/restore work — the stateful data survives.
 
-### Required host binding
+### Container user (spec 105)
 
-For **self-update** (spec 060) to work, the Docker socket must be mounted:
+Since v1.7.0, the Sowel container runs as a non-root user (`sowel`, uid 1000). The image's entrypoint (`docker-entrypoint.sh`) starts briefly as root, runs `chown -R sowel:sowel /app/data /app/plugins` idempotently, then drops to the `sowel` user via `gosu`. This makes upgrades from older root-running versions transparent: `docker compose pull && docker compose up -d` is enough, no manual `chown` is required on existing root-owned volumes.
 
-```yaml
-services:
-  sowel:
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+If you override `user:` in a `docker-compose.override.yml` to run as a different UID, the entrypoint skips the chown and you must manage volume ownership yourself.
+
+### Self-update is opt-in (spec 105)
+
+For **self-update** to work, the Docker socket must be mounted. Since v1.7.0 this is **opt-in** — the default `docker-compose.yml` no longer mounts it.
+
+To enable in-app self-update, copy the override template and bring the stack up again:
+
+```bash
+cp docker-compose.override.example.yml docker-compose.override.yml
+docker compose up -d
 ```
 
-Without this, the "Update now" button in the UI is disabled.
+The override mounts `/var/run/docker.sock` into the container, restoring the "Update now" button in the UI. Read the security note at the top of the override file before enabling: mounting the Docker socket gives the container effective control over the Docker daemon on the host, so a successful RCE against Sowel would escalate to host root.
+
+Without this override, the "Update now" button is disabled in the UI and `POST /api/v1/system/update` returns 503. You can still update manually:
+
+```bash
+docker compose pull && docker compose up -d sowel
+```
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "sowel",
-  "version": "1.2.13",
+  "version": "1.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sowel",
-      "version": "1.2.13",
+      "version": "1.6.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cors": "^10.0.2",
+        "@fastify/helmet": "^13.0.2",
         "@fastify/multipart": "^9.4.0",
         "@fastify/rate-limit": "^10.3.0",
         "@fastify/static": "^9.0.0",
@@ -842,6 +843,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@fastify/helmet": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.0.2.tgz",
+      "integrity": "sha512-tO1QMkOfNeCt9l4sG/FiWErH4QMm+RjHzbMTrgew1DYOQ2vb/6M1G2iNABBrD7Xq6dUk+HLzWW8u+rmmhQHifA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "helmet": "^8.0.0"
+      }
     },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
@@ -4172,6 +4193,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/help-me": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^10.0.2",
+    "@fastify/helmet": "^13.0.2",
     "@fastify/multipart": "^9.4.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",

--- a/specs/105-wan-hardening/architecture.md
+++ b/specs/105-wan-hardening/architecture.md
@@ -1,0 +1,484 @@
+# Spec 105 — Architecture
+
+## Overview of changes
+
+| Layer      | Module                                      | Change                                                                            |
+| ---------- | ------------------------------------------- | --------------------------------------------------------------------------------- |
+| Container  | `Dockerfile`                                | Add `gosu`, create `sowel` user (uid 1000), copy entrypoint. No `USER` directive. |
+| Container  | `docker-entrypoint.sh` (new)                | Idempotent chown of `/app/data` and `/app/plugins`, then `exec gosu sowel`.       |
+| Container  | `docker-compose.yml`                        | Remove default `docker.sock` mount.                                               |
+| Container  | `docker-compose.override.example.yml` (new) | Template for opt-in self-update.                                                  |
+| API server | `src/api/server.ts`                         | Register `@fastify/helmet`.                                                       |
+| API server | `src/api/websocket.ts`                      | Mandatory auth, Origin validation, header/subprotocol token.                      |
+| API server | `src/auth/auth-middleware.ts`               | Add `PUBLIC_ROUTES` whitelist + global preHandler enforcing auth.                 |
+| Config     | `src/config.ts`                             | `CORS_ORIGINS` default changes; warn logs.                                        |
+| Update     | `src/core/update-manager.ts`                | Graceful degradation when `docker.sock` unavailable.                              |
+| UI         | `ui/src/store/useWebSocket.ts`              | Pass token via `Sec-WebSocket-Protocol` instead of query.                         |
+
+**No SQLite migration needed.**
+
+---
+
+## S1 — WebSocket hardening
+
+### Current state ([src/api/websocket.ts:168-188](../../src/api/websocket.ts#L168-L188))
+
+```ts
+app.get("/ws", { websocket: true }, (socket, request) => {
+  const token = new URL(request.url, ...).searchParams.get("token");
+  if (token) { /* verify */ }
+  // Falls through — anonymous client accepted
+});
+```
+
+### Target state
+
+```ts
+app.get("/ws", { websocket: true }, (socket, request) => {
+  // 1. Origin validation
+  const origin = request.headers.origin;
+  if (origin && !corsOrigins.includes(origin) && !corsOrigins.includes("*")) {
+    socket.close(4003, "Origin not allowed");
+    return;
+  }
+
+  // 2. Token extraction (header preferred, subprotocol fallback for browsers)
+  const token =
+    extractBearer(request.headers.authorization) ??
+    extractFromSubprotocol(request.headers["sec-websocket-protocol"]);
+
+  if (!token) {
+    socket.close(4001, "Authentication required");
+    return;
+  }
+
+  // 3. Verify
+  try {
+    if (token.startsWith("swl_") || token.startsWith("wch_") || token.startsWith("cbl_")) {
+      if (!authService.verifyApiToken(token)) {
+        socket.close(4001, "Invalid token");
+        return;
+      }
+    } else {
+      authService.verifyAccessToken(token);
+    }
+  } catch {
+    socket.close(4001, "Invalid token");
+    return;
+  }
+  // ... rest unchanged
+});
+```
+
+### UI client adapter ([ui/src/store/useWebSocket.ts])
+
+Current: `new WebSocket(`${url}/ws?token=${token}`)`.
+
+Target: `new WebSocket(`${url}/ws`, [`bearer.${token}`])`. The browser sends `Sec-WebSocket-Protocol: bearer.<token>`. Server reads it, strips the `bearer.` prefix, validates as JWT or API token.
+
+### Subprotocol design
+
+We use `bearer.<token>` (single subprotocol with embedded token) rather than two-step subprotocol negotiation because:
+
+- It's a single round-trip.
+- The server can respond with the same subprotocol string to acknowledge.
+- Token doesn't appear in `Origin`/`Referer`/proxy logs (subprotocol is in the upgrade headers).
+
+Caveat: API tokens (`swl_...`) work fine. JWT access tokens contain `.` — must URL-encode or use a different separator. Choice: split on the **first** `.` only:
+
+```ts
+function extractFromSubprotocol(header: string | undefined): string | null {
+  if (!header) return null;
+  const proto = header
+    .split(",")
+    .map((s) => s.trim())
+    .find((p) => p.startsWith("bearer."));
+  if (!proto) return null;
+  return proto.slice("bearer.".length); // keeps the rest of the JWT intact
+}
+```
+
+### Error codes
+
+| Code | Reason                            | When                             |
+| ---- | --------------------------------- | -------------------------------- |
+| 4001 | Authentication required / invalid | No token / verify failed         |
+| 4003 | Origin not allowed                | `Origin` header not in whitelist |
+
+---
+
+## S2 — Security headers (`@fastify/helmet`)
+
+### Registration order ([src/api/server.ts:139-160](../../src/api/server.ts#L139-L160))
+
+```ts
+await app.register(cors, { origin: corsOrigins, ... });
+await app.register(helmet, {
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"], // Tailwind requires
+      imgSrc: ["'self'", "data:"], // PWA icons
+      connectSrc: ["'self'", "wss:"], // WebSocket
+      fontSrc: ["'self'"],
+      manifestSrc: ["'self'"],
+      objectSrc: ["'none'"],
+      frameAncestors: ["'none'"],
+    },
+  },
+  strictTransportSecurity: false, // Set conditionally below
+  frameguard: { action: "deny" },
+  referrerPolicy: { policy: "no-referrer" },
+  noSniff: true,
+});
+
+// HSTS only when HTTPS detected
+app.addHook("onSend", (req, reply, payload, done) => {
+  const proto = req.headers["x-forwarded-proto"] ?? ((req.socket as any).encrypted ? "https" : "http");
+  if (proto === "https") {
+    reply.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  }
+  done(null, payload);
+});
+```
+
+### Dependency
+
+Add `@fastify/helmet` to `package.json` (pin version compatible with Fastify 5.x).
+
+### CSP gotchas
+
+- **Vite dev server**: in `npm run dev` (UI), Vite serves on a separate port. CSP for the production build is what matters. Verify the built bundle works.
+- **PWA service worker**: `connect-src 'self'` covers same-origin fetch; the service worker registration path is same-origin.
+- **GitHub version check**: handled server-side only, no `api.github.com` needed in CSP.
+
+---
+
+## S3 — CORS defaults
+
+### Change in [src/config.ts:91-95](../../src/config.ts#L91-L95)
+
+```ts
+cors: {
+  origins: env("CORS_ORIGINS", "http://localhost:3000,http://localhost:5173")
+    .split(",")
+    .map((s) => s.trim()),
+},
+```
+
+### Boot-time warnings (`src/index.ts`)
+
+```ts
+const corsRaw = process.env["CORS_ORIGINS"];
+if (corsRaw === "*") {
+  logger.warn(
+    "CORS is set to wildcard '*'. This is dangerous if Sowel is exposed to the Internet. Restrict CORS_ORIGINS to known origins.",
+  );
+}
+if (
+  corsRaw === "*" &&
+  process.env["API_HOST"] !== "127.0.0.1" &&
+  process.env["API_HOST"] !== "localhost"
+) {
+  logger.warn(
+    "CORS=* combined with API_HOST=0.0.0.0 is the highest-risk configuration. Consider restricting at least one.",
+  );
+}
+```
+
+### Migration
+
+Users currently relying on the default `*` and accessing Sowel from a non-localhost browser (rare in LAN, but possible from a mobile on the same network using `http://192.168.x.x:3000`) need to set `CORS_ORIGINS=http://192.168.x.x:3000` explicitly. Documented in upgrade notes.
+
+### Same-origin case
+
+When the UI and API are served from the same host (the common case — Fastify serves the static UI), CORS doesn't apply: the browser doesn't enforce CORS on same-origin requests. So the default `localhost:3000` covers the typical setup.
+
+---
+
+## S4 — Container hardening (entrypoint + gosu pattern)
+
+### Design rationale
+
+The classical "USER 1000 in Dockerfile" approach breaks upgrades from a previously root-running container: existing volumes are owned by root, the new container can't write, and the user has to run a manual `chown` (often after the container has already crash-looped). This is unacceptable for non-technical users.
+
+We use the **Postgres / MySQL / MariaDB pattern**: the container's `ENTRYPOINT` runs as root briefly, fixes the volume ownership idempotently, and drops to a non-root user via `gosu` before `exec`ing the actual command. This makes the upgrade fully transparent: `docker compose pull && up -d` and nothing else.
+
+### Dockerfile changes
+
+```dockerfile
+# Stage 3: Production runtime
+FROM debian:trixie-slim
+WORKDIR /app
+
+# Install Node.js 20 + Python 3.13 + build tools + gosu
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates python3 python3-venv make g++ gosu \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user (uid 1000)
+RUN groupadd -g 1000 sowel && useradd -u 1000 -g 1000 -m -s /bin/bash sowel
+
+# Install prod deps
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts \
+    && npm rebuild better-sqlite3 \
+    && apt-get purge -y make g++ && apt-get autoremove -y \
+    && rm -rf /root/.npm
+
+# Copy build artifacts
+COPY --from=backend-build /app/dist/ dist/
+COPY --from=ui-build /app/ui/dist/ ui-dist/
+COPY migrations/ migrations/
+COPY plugins/registry.json plugins/registry.json
+COPY package.json ./
+
+# Prepare directories (will be chowned at runtime by entrypoint)
+RUN mkdir -p data plugins
+
+# Entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENV NODE_ENV=production
+ENV SQLITE_PATH=/app/data/sowel.db
+
+# NO 'USER' directive — entrypoint drops privileges via gosu
+
+EXPOSE 3000
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["node", "dist/index.js"]
+```
+
+### New file: `docker-entrypoint.sh`
+
+```bash
+#!/bin/bash
+# ============================================================
+# Sowel container entrypoint
+# ============================================================
+# - If running as root: chown data/plugins (idempotent) then
+#   drop to the sowel user (uid 1000) via gosu.
+# - If running as a non-root user (custom compose with `user:`):
+#   exec directly without chown.
+# ============================================================
+set -e
+
+if [ "$(id -u)" = "0" ]; then
+  # Idempotent chown — fast no-op if already owned by sowel
+  chown -R sowel:sowel /app/data /app/plugins 2>/dev/null || true
+  exec gosu sowel "$@"
+fi
+
+exec "$@"
+```
+
+### docker-compose.yml change
+
+Remove the `docker.sock` line:
+
+```yaml
+volumes:
+  - sowel-data:/app/data
+  - sowel-plugins:/app/plugins
+  # self-update is opt-in. To enable, copy docker-compose.override.example.yml
+  # to docker-compose.override.yml and run `docker compose up -d`.
+```
+
+### New file: `docker-compose.override.example.yml`
+
+```yaml
+# ============================================================
+# Sowel self-update override
+# ============================================================
+# Enable in-app self-update by copying this file to
+# `docker-compose.override.yml` then `docker compose up -d`.
+#
+# SECURITY NOTE: Mounting docker.sock gives the Sowel container
+# the ability to control Docker on the host. A successful RCE
+# against Sowel would escalate to host root. Only enable this
+# if you accept the trade-off.
+#
+# Without this override, you can still update Sowel manually:
+#   docker compose pull && docker compose up -d sowel
+# ============================================================
+services:
+  sowel:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+### `UpdateManager` graceful degradation
+
+In `src/core/update-manager.ts`:
+
+```ts
+async checkDockerAvailability(): Promise<boolean> {
+  try {
+    await this.docker.ping();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async startUpdate(...): Promise<void> {
+  if (!(await this.checkDockerAvailability())) {
+    throw new UpdateError(
+      503,
+      "Self-update requires docker.sock to be mounted. See docker-compose.override.example.yml.",
+    );
+  }
+  // ... existing flow
+}
+```
+
+In `GET /api/v1/system/version`, the response already returns `dockerAvailable`. With this change, it will return `false` for the default deployment, and the UI's "Update now" button is disabled with a tooltip pointing to the override file.
+
+### Upgrade transparency
+
+For users upgrading from v1.6.5 (root container) to v1.7.0 (non-root container):
+
+1. `docker compose pull` — new image pulled.
+2. `docker compose up -d` — old container stopped, new container started.
+3. New container's entrypoint runs as root, observes that `/app/data` and `/app/plugins` are root-owned, runs `chown -R sowel:sowel` (typically completes in <1 second for a normal installation).
+4. Entrypoint `exec gosu sowel node dist/index.js` — Sowel runs as uid 1000.
+5. Done. No user action.
+
+### Brief root window
+
+The container is root for the duration of the chown (sub-second). `exec gosu` then replaces the root process with the sowel process — no lingering root process in memory.
+
+This matches the security posture of v1.6.5 (which is root throughout the entire lifetime), so it's strictly an improvement, never a regression.
+
+### Edge cases
+
+- **User has `user: 1000:1000` in their override compose** — entrypoint sees non-root, skips chown. If their volumes were created previously as root (from a v1.6.5 install), they need a one-shot `chown` manually. CHANGELOG flags this.
+- **Bind mount on NFS or read-only FS** — chown's `|| true` keeps the container alive; Sowel then fails to write SQLite and crashes with a clear errno. Documented as unsupported.
+- **Many files in `/app/data` (long log history)** — chown is linear in file count. ~1 sec per 100k files. Acceptable.
+
+---
+
+## S6 — Auth by default
+
+### Current state ([src/auth/auth-middleware.ts](../../src/auth/auth-middleware.ts))
+
+`registerAuthMiddleware` attaches a hook that **populates** `request.auth` if a valid token is found, but does **not refuse** requests with no `request.auth`. Each route file is expected to check.
+
+### Target state
+
+```ts
+// src/auth/auth-middleware.ts
+
+export const PUBLIC_ROUTES: ReadonlySet<string> = new Set([
+  "/api/v1/health",
+  "/api/v1/auth/status",
+  "/api/v1/auth/setup",
+  "/api/v1/auth/login",
+  "/api/v1/auth/refresh",
+  // Static UI routes do not start with /api/v1 and are handled by fastifyStatic
+]);
+
+export function registerAuthMiddleware(app: FastifyInstance, deps: AuthDeps): void {
+  // Existing hook: populate request.auth
+  app.addHook("preHandler", async (request) => {
+    // ... unchanged: try JWT, then API token, attach to request.auth
+  });
+
+  // NEW: enforce auth on all /api/v1/* routes except whitelist
+  app.addHook("preHandler", async (request, reply) => {
+    if (!request.url.startsWith("/api/v1/")) return;
+    const pathname = request.url.split("?")[0];
+    if (PUBLIC_ROUTES.has(pathname)) return;
+    if (!request.auth) {
+      return reply.code(401).send({ error: "Authentication required" });
+    }
+  });
+}
+```
+
+### Why this works without changing each route
+
+Per-route `preHandler` calls that also check `request.auth` become redundant but harmless. They will all see `request.auth` populated (or the global hook will have already 401'd).
+
+### Routes whose individual auth-check should be removed
+
+A cleanup pass identifies and removes per-route `if (!request.auth) return 401` boilerplate. This is mechanical and could be done in a follow-up PR if scope creep is a concern. Keep for v1 to minimize churn.
+
+### Regression test
+
+```ts
+// src/api/auth-by-default.test.ts
+import { describe, it, expect } from "vitest";
+import { createTestServer } from "./test-helpers.js"; // builds a minimal Fastify with auth middleware
+import { PUBLIC_ROUTES } from "../auth/auth-middleware.js";
+
+describe("Auth by default", () => {
+  it("every /api/v1/* route either requires auth or is in PUBLIC_ROUTES", async () => {
+    const app = await createTestServer();
+    const routes = app.printRoutes({ commonPrefix: false }); // returns string
+    const apiPaths = extractPaths(routes).filter((p) => p.startsWith("/api/v1/"));
+
+    for (const path of apiPaths) {
+      if (PUBLIC_ROUTES.has(path)) continue;
+      // Make an unauthenticated request and assert 401
+      const res = await app.inject({ method: "GET", url: path });
+      expect(res.statusCode, `Route ${path} should require auth`).toBe(401);
+    }
+  });
+});
+```
+
+The test instantiates the server with all routes registered, enumerates them, and for each non-public route asserts that an unauthenticated request gets 401. If a contributor adds a public route by mistake (or forgets a path), the test fails.
+
+### Caveats
+
+- Some routes accept `POST` / `PUT` and may return 400 before 401 if body validation runs first. The test uses `GET` only when possible.
+- Static UI fallback (`setNotFoundHandler`) is not affected since it doesn't match `/api/v1/*`.
+
+---
+
+## Configuration impact
+
+### New environment variables
+
+None.
+
+### Changed defaults
+
+| Variable       | Before | After                                         |
+| -------------- | ------ | --------------------------------------------- |
+| `CORS_ORIGINS` | `*`    | `http://localhost:3000,http://localhost:5173` |
+
+### Compose change
+
+`docker.sock` removed from default compose. Users wanting self-update copy `docker-compose.override.example.yml` to `docker-compose.override.yml`.
+
+---
+
+## Dependencies
+
+```json
+{
+  "@fastify/helmet": "^13.0.0"
+}
+```
+
+Pin to a version compatible with current Fastify (5.x). `gosu` added to apt-installed packages (Debian package, no Node dep).
+
+---
+
+## Risks & mitigations
+
+| Risk                                                                | Mitigation                                                                                                   |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| CSP breaks the UI (fonts, icons, WS, dev hot-reload)                | Manual test pass in browser; explicit `connect-src 'self' wss:`; document any CSP-incompatible UI feature.   |
+| Existing users break after compose change (self-update disabled)    | Documented in CHANGELOG + tooltip in UI explaining how to re-enable.                                         |
+| Volume permission errors on upgrade                                 | Entrypoint chowns idempotently on first boot — zero manual action.                                           |
+| User with `user:` override in compose has root-owned legacy volumes | Documented in CHANGELOG: "if you override `user:`, run a one-shot `chown` before upgrade".                   |
+| Auth-by-default test catches an existing intentional public route   | Whitelist is reviewed in PR. Each addition requires justification in PR description.                         |
+| Subprotocol-based WS auth breaks proxies                            | Test against Cloudflare Tunnel before merge. Fallback to `Authorization` header for non-browser clients.     |
+| Entrypoint chown takes long time on huge installations              | Idempotent, runs only when needed (files already owned by sowel = fast no-op via `chown` early exit checks). |

--- a/specs/105-wan-hardening/plan.md
+++ b/specs/105-wan-hardening/plan.md
@@ -1,0 +1,204 @@
+# Spec 105 — Implementation Plan
+
+Single PR, ordered tasks. Each task in the order listed; no parallelism between tasks.
+
+## Task breakdown
+
+### Task 0 — Branch setup
+
+- [ ] `git checkout main && git pull`
+- [ ] `git checkout -b feat/wan-hardening`
+- [ ] `git branch --show-current` returns `feat/wan-hardening`
+
+### Task 1 — Add `@fastify/helmet` dependency
+
+- [ ] `npm install --save @fastify/helmet@^13`
+- [ ] Verify `package-lock.json` updated.
+- [ ] `npx tsc --noEmit` still passes.
+
+### Task 2 — S6 — Auth-by-default
+
+This goes first because all subsequent route protection assumes the global hook is in place.
+
+- [ ] Edit `src/auth/auth-middleware.ts`:
+  - [ ] Export `PUBLIC_ROUTES` constant set.
+  - [ ] Add second `preHandler` hook that enforces auth on `/api/v1/*` except whitelist.
+- [ ] Verify in dev: hitting `GET /api/v1/devices/suggest` without a token returns 401 (previously 200).
+- [ ] Verify in dev: `GET /api/v1/auth/status` without token still works.
+- [ ] Write regression test `src/api/auth-by-default.test.ts` (see architecture.md).
+- [ ] Run `npx vitest run src/api/auth-by-default.test.ts` — passes.
+
+### Task 3 — S2 — Security headers
+
+- [ ] Edit `src/api/server.ts`:
+  - [ ] Import and register `@fastify/helmet` after CORS, before routes.
+  - [ ] Configure CSP per architecture.md.
+  - [ ] Add HSTS conditional hook.
+- [ ] Write integration test `src/api/headers.test.ts`:
+  - [ ] Asserts all security headers present on `/api/v1/health`.
+  - [ ] Asserts HSTS absent on HTTP, present when `x-forwarded-proto: https`.
+- [ ] Manual UI verification: launch backend + UI, browse all main pages (dashboard, equipments, zones, settings), check browser console for CSP violations.
+
+### Task 4 — S3 — CORS defaults
+
+- [ ] Edit `src/config.ts`:
+  - [ ] Default `CORS_ORIGINS` to `http://localhost:3000,http://localhost:5173`.
+- [ ] Edit `src/index.ts`:
+  - [ ] Add boot-time warn logs when CORS is wildcard.
+- [ ] Add test `src/config.test.ts`:
+  - [ ] Default is the localhost list.
+  - [ ] Explicit env var overrides.
+
+### Task 5 — S1 — WebSocket hardening
+
+- [ ] Edit `src/api/websocket.ts`:
+  - [ ] Add `extractBearer` and `extractFromSubprotocol` helpers.
+  - [ ] Validate `Origin` header.
+  - [ ] Refuse anonymous connections.
+- [ ] Edit `ui/src/store/useWebSocket.ts` (or equivalent):
+  - [ ] Replace `?token=` with `Sec-WebSocket-Protocol: bearer.<token>`.
+- [ ] Add test `src/api/websocket.test.ts`:
+  - [ ] Connection without token refused (4001).
+  - [ ] Connection with bad Origin refused (4003).
+  - [ ] Connection with valid `bearer.` subprotocol accepted.
+- [ ] Manual UI verification: WebSocket connects, events stream, reconnect on close works.
+
+### Task 6 — S4 — Container hardening (Dockerfile + entrypoint + compose)
+
+This goes last because it affects runtime, not code logic, and needs the most thorough end-to-end testing.
+
+- [ ] Create `docker-entrypoint.sh` at repo root per architecture.md.
+- [ ] `chmod +x docker-entrypoint.sh` (track exec bit in git).
+- [ ] Edit `Dockerfile`:
+  - [ ] Add `gosu` to apt installs.
+  - [ ] Create `sowel` user (uid 1000) via `groupadd` + `useradd`.
+  - [ ] Copy `docker-entrypoint.sh` to `/usr/local/bin/`.
+  - [ ] Replace `CMD ["node", "dist/index.js"]` with `ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]` + `CMD ["node", "dist/index.js"]`.
+  - [ ] **Do not** add `USER` directive (entrypoint handles it).
+- [ ] Edit `docker-compose.yml`:
+  - [ ] Remove `docker.sock` line.
+  - [ ] Add a comment pointing to the override file.
+- [ ] Create `docker-compose.override.example.yml` per architecture.md.
+- [ ] Edit `src/core/update-manager.ts`:
+  - [ ] Add `checkDockerAvailability` method.
+  - [ ] Make `startUpdate` throw `UpdateError(503, ...)` when unavailable.
+- [ ] Edit `src/api/routes/system.ts`:
+  - [ ] Ensure `dockerAvailable` field is accurate in `GET /system/version` response.
+- [ ] Edit `ui/src/pages/Settings.tsx` (or wherever the update button lives):
+  - [ ] Disable "Update now" when `dockerAvailable` is false.
+  - [ ] Tooltip: "Self-update is opt-in. See docker-compose.override.example.yml in the Sowel repo."
+- [ ] **Fresh install test**:
+  - [ ] `docker build -t sowel:test .`
+  - [ ] `docker run --rm sowel:test id` → uid=1000, gid=1000.
+  - [ ] `docker compose up -d` (with the new compose, no override) → Sowel boots, Update button disabled.
+  - [ ] `docker exec sowel ls -la /app/data` → owned by sowel:sowel.
+  - [ ] Copy override file, `docker compose up -d`, Update button enables.
+- [ ] **Upgrade test (critical)**: simulate a v1.6.5 → v1.7.0 upgrade.
+  - [ ] Start a Sowel v1.6.5 container, create some data (admin user, a zone, an equipment), verify volumes are root-owned (`docker exec -u root sowel-old ls -la /app/data`).
+  - [ ] Stop container.
+  - [ ] Replace image with the new build, `docker compose up -d`.
+  - [ ] Verify: Sowel boots without errors, all previous data preserved, volumes now sowel-owned, no manual command needed.
+- [ ] Document the (unlikely) custom `user:` override case in CHANGELOG.
+
+### Task 7 — Documentation
+
+- [ ] Update `docs/technical/architecture.md` — Authentication section: mention auth-by-default + PUBLIC_ROUTES.
+- [ ] Update `docs/technical/deployment.md` — non-root container (transparent upgrade) + self-update opt-in.
+- [ ] Update `docs/specs-index.md` — add 105 entry.
+- [ ] Update `SECURITY_AUDIT_WAN.md` — mark §6 items as `[x]` for the ones shipped (S1, S2, S3, S4, S6).
+- [ ] Update `SECURITY_AUDIT.md` — mark H1, H3, H4, H5, CORS finding as `[x]`.
+
+### Task 8 — Validation gate
+
+- [ ] `npx tsc --noEmit` — zero errors.
+- [ ] `cd ui && npx tsc -b --noEmit` — zero errors.
+- [ ] `npx vitest run` — all tests pass.
+- [ ] `npx eslint src/ --ext .ts` — zero errors.
+- [ ] Manual end-to-end test against a fresh `docker compose up -d`:
+  - [ ] First-time setup works.
+  - [ ] Login works.
+  - [ ] Dashboard streams real-time data via WS (subprotocol auth).
+  - [ ] CSP doesn't break any page.
+  - [ ] Update button disabled by default; enabled with override.
+
+### Task 9 — Commit + PR
+
+- [ ] `git branch --show-current` returns `feat/wan-hardening` (verify before commit).
+- [ ] `git add` only the intended files.
+- [ ] Commit message (conventional, scope `core`):
+
+  ```
+  feat(core): WAN hardening (spec 105)
+
+  - Auth-by-default Fastify hook + PUBLIC_ROUTES whitelist + regression test
+  - @fastify/helmet with CSP/HSTS/X-Frame-Options/Referrer-Policy
+  - CORS default tightened from * to localhost (warn log on wildcard)
+  - WebSocket: mandatory auth, Origin validation, token via Sec-WebSocket-Protocol
+  - Dockerfile non-root (uid 1000) via entrypoint + gosu, docker.sock opt-in
+  ```
+
+- [ ] `git push -u origin feat/wan-hardening`
+- [ ] `gh pr create --title "feat: WAN hardening (spec 105)" --body "..."` with:
+  - Summary
+  - Changes (per-section)
+  - Test plan (checkboxes for typecheck, vitest, manual UI verification, Docker build + upgrade test)
+  - Upgrade notes (transparent for default compose; flag for `user:` override case)
+
+## Test Plan
+
+### Modules to test
+
+- `src/auth/auth-middleware.ts` — global preHandler + PUBLIC_ROUTES enforcement
+- `src/api/websocket.ts` — auth + Origin validation
+- `src/api/server.ts` — header presence
+- `src/config.ts` — CORS defaults
+- `src/core/update-manager.ts` — graceful degradation
+- Dockerfile + entrypoint — end-to-end upgrade transparency (manual)
+
+### Scenarios per module
+
+| Module                              | Scenario                                                              | Expected                                                    |
+| ----------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `auth-middleware` (auth-by-default) | Unauthenticated GET to non-public route                               | 401                                                         |
+| `auth-middleware`                   | Unauthenticated GET to `/api/v1/health`                               | 200                                                         |
+| `auth-middleware`                   | Unauthenticated GET to `/api/v1/auth/setup`                           | Depends on handler (403 if users exist)                     |
+| `auth-middleware`                   | Authenticated GET to non-public route                                 | Passes through to handler                                   |
+| `auth-middleware` (regression test) | All `/api/v1/*` routes enumerated; none unprotected outside whitelist | All 401 except PUBLIC_ROUTES                                |
+| `websocket`                         | WS connect without `Authorization` and without subprotocol            | Close 4001                                                  |
+| `websocket`                         | WS connect with `Authorization: Bearer <invalid>`                     | Close 4001                                                  |
+| `websocket`                         | WS connect with `Sec-WebSocket-Protocol: bearer.<valid>`              | Accepted, subscribed to `system` topic                      |
+| `websocket`                         | WS connect with bad `Origin`                                          | Close 4003                                                  |
+| `websocket`                         | WS connect with whitelisted `Origin` + valid token                    | Accepted                                                    |
+| `server` — headers                  | GET `/api/v1/health`                                                  | All security headers present                                |
+| `server` — headers                  | GET with `x-forwarded-proto: https`                                   | HSTS header present                                         |
+| `server` — headers                  | GET over plain HTTP                                                   | HSTS absent                                                 |
+| `config` — CORS                     | No env var                                                            | Defaults to localhost:3000,localhost:5173                   |
+| `config` — CORS                     | `CORS_ORIGINS=https://sowel.exemple.com`                              | Single origin                                               |
+| `update-manager`                    | `docker.sock` available                                               | `startUpdate` proceeds                                      |
+| `update-manager`                    | `docker.sock` unavailable                                             | `startUpdate` throws `UpdateError` 503                      |
+| Dockerfile + entrypoint (manual)    | Fresh `docker compose up -d`                                          | Container boots, uid=1000, volumes owned by sowel           |
+| Dockerfile + entrypoint (manual)    | Upgrade from v1.6.5 (root volumes) to new image                       | Container boots without manual chown, all data preserved    |
+| Dockerfile + entrypoint (manual)    | Compose with `user: 1000:1000` override on root-owned volumes         | Container crashes on write (expected, documented edge case) |
+
+### Manual verification
+
+Beyond automated tests:
+
+- Browse the full UI under the new CSP. Verify dashboard, equipments, zones, settings, plugins, backup pages all render without console errors.
+- WebSocket reconnects automatically after a server restart, still using the new subprotocol auth.
+- Fresh `docker compose up -d` from a clean state, configure first admin, no errors. Volume permissions correct.
+- **Upgrade test**: spin up a real v1.6.5 instance in a test VM, populate with realistic data (a few zones, equipments, plugins installed), then upgrade to the new image. Verify no permission error, no data loss, no manual command.
+
+## Estimated effort
+
+- Task 0-1: 30 min
+- Task 2 (auth-by-default): 1 day (test + verify no regression on each route)
+- Task 3 (helmet): 0.5 day (CSP tuning is the time-consuming part)
+- Task 4 (CORS): 1 hour
+- Task 5 (WS): 1 day (UI changes + tests)
+- Task 6 (Docker): 1 day (entrypoint + upgrade test is the most delicate)
+- Task 7 (docs): 0.5 day
+- Task 8 (validation): 0.5 day
+- Task 9 (commit/PR): 30 min
+
+**Total: ~4.5 working days.** Add 20-30% buffer for unforeseen CSP / WS / Docker upgrade issues.

--- a/specs/105-wan-hardening/spec.md
+++ b/specs/105-wan-hardening/spec.md
@@ -1,0 +1,149 @@
+# Spec 105 — WAN Hardening
+
+## Context
+
+The 2026-05-03 application audit (`SECURITY_AUDIT.md`) and the 2026-05-15 WAN-specific analysis (`SECURITY_AUDIT_WAN.md`) identified a set of vulnerabilities that are tolerable on a trusted LAN but unacceptable when Sowel is exposed to the public Internet.
+
+Two WAN topologies exist today:
+
+- **Cloudflare Tunnel** (mainteneur, advanced users): TLS terminated at the edge, optional Cloudflare Access SSO.
+- **Direct port-forward** (general public): NAT rule from the home router to `192.168.x.x:3000`, often HTTP only, no WAF, no SSO.
+
+This spec closes the highest-impact gaps so both topologies become defensible by default, without requiring users to know that they must harden a service before exposing it. C3 (backup encryption) and W7 (password re-prompt on sensitive actions) are intentionally **out of scope**: see below for rationale.
+
+## Goals
+
+1. Block the two main WAN attack chains that remain after spec 089:
+   - **XSS / clickjacking chain** → solved by helmet + CSP + strict CORS.
+   - **CSRF / info-disclosure via WebSocket chain** → solved by mandatory WS auth + Origin validation.
+   - **Privilege escalation to host chain** → solved by non-root container + opt-in `docker.sock`.
+2. Make "auth by default" the structural invariant for API routes, so future regressions are impossible (any new route is protected unless explicitly listed as public).
+3. Stay backwards-compatible: existing LAN deployments must keep working. **No manual migration step on upgrade.**
+
+## In scope
+
+| #   | Item                                                                                 | Audit ref    |
+| --- | ------------------------------------------------------------------------------------ | ------------ |
+| S1  | WebSocket: mandatory auth, `Origin` validation, token via header (not query)         | H4 + W3      |
+| S2  | `@fastify/helmet` with CSP, HSTS (HTTPS only), X-Frame-Options DENY, Referrer-Policy | H3           |
+| S3  | CORS: refuse wildcard `*` when origin is non-loopback, default to safe list          | CORS finding |
+| S4  | Dockerfile non-root (UID 1000) via entrypoint + `gosu` + `docker.sock` opt-in        | H1           |
+| S6  | Auth-by-default Fastify hook + explicit public-route whitelist + regression test     | H5           |
+
+(S5 was scoped out — see Out of scope.)
+
+## Out of scope
+
+- **S5 — Password re-prompt on sensitive actions (W7)** — deferred to a separate spec 106. Reasons: (a) overlap with S2 (CSP blocks the XSS vector that would steal a bearer) and S6 (no forgotten unprotected route remains), (b) breaks legitimate automation flows that use API tokens (`swl_...`) for backup export or update scripts, (c) UI churn (password modal on 5+ call-sites) introduces its own bug surface. Will be revisited if a real attack vector emerges that S2 + S6 do not cover.
+- **C3 backup encryption** — deferred. Home Assistant and equivalents ship unencrypted by default; the WAN risk is not the primary threat model.
+- **Mode `EXPOSURE_MODE=wan`** — separate spec (would force strict profile + UI banner). Belongs to a configuration feature, not a hardening fix.
+- **H2 digest pinning** — separate spec, depends on release pipeline changes.
+- **TLS terminé en natif dans Sowel** — Sowel reste un service HTTP, le TLS reste de la responsabilité du reverse proxy / tunnel. Documentation only.
+- **Password policy upgrade** (6 → 12) — separate small spec.
+- **Refresh token TTL reduction** — separate small spec.
+- **JWT algorithm explicitness** — separate small spec.
+
+## User stories
+
+### Mainteneur (Cloudflare Tunnel + Access)
+
+> En tant que mainteneur, je veux que mon instance Sowel résiste aux attaques XSS / clickjacking / WS-based même si Cloudflare Access n'est pas activé en amont.
+
+### Auto-hébergeur grand public (port-forward direct)
+
+> En tant qu'utilisateur qui a suivi un tuto pour exposer Sowel via port-forward, je veux que mon instance ne soit pas trivialement détournée par un bot Internet, et que la mise à jour vers cette version sécurisée ne nécessite aucune commande shell de ma part.
+
+### Contributeur
+
+> En tant que contributeur, je veux qu'il soit impossible d'ajouter une route API qui oublie l'authentification: l'oubli doit casser un test automatique et bloquer le PR.
+
+## Acceptance criteria
+
+### S1 — WebSocket hardening
+
+- [ ] Connection to `/ws` without a `token` query param, `Authorization` header, or `Sec-WebSocket-Protocol` subprotocol is **refused** with close code 4001.
+- [ ] Connection with an `Origin` header not in the CORS whitelist is **refused** with close code 4003.
+- [ ] Token can be provided via `Authorization: Bearer <token>` header **or** `Sec-WebSocket-Protocol: bearer.<token>` subprotocol (for browser clients that cannot set headers on WS).
+- [ ] Existing UI client adapts to use the subprotocol path; query-param token is removed from the client code.
+- [ ] Legacy query-param token is rejected (no silent fallback).
+- [ ] Unit test: anonymous connection refused. Bad-Origin connection refused. Valid header-auth connection accepted.
+
+### S2 — Security headers
+
+- [ ] `@fastify/helmet` registered after CORS, before routes.
+- [ ] CSP set with `default-src 'self'`, `script-src 'self'`, `style-src 'self' 'unsafe-inline'` (Tailwind needs inline), `connect-src 'self' wss:` (so the WS connection works against the host).
+- [ ] `Strict-Transport-Security: max-age=31536000; includeSubDomains` set **only** when the request arrived over HTTPS (detected via `X-Forwarded-Proto: https` or direct TLS — won't break local HTTP setups).
+- [ ] `X-Frame-Options: DENY`.
+- [ ] `Referrer-Policy: no-referrer`.
+- [ ] `X-Content-Type-Options: nosniff`.
+- [ ] Integration test: a request to `/health` returns all expected headers.
+- [ ] Manual verification: UI loads correctly with the new CSP (fonts, icons, manifest PWA, WebSocket).
+
+### S3 — CORS defaults
+
+- [ ] Default `CORS_ORIGINS` value changes from `*` to `http://localhost:3000,http://localhost:5173`.
+- [ ] If the environment variable `CORS_ORIGINS=*` is set explicitly, server emits a `warn` log on startup: "CORS wildcard is dangerous when exposed WAN. Restrict to known origins."
+- [ ] `API_HOST=0.0.0.0` (current default) combined with `CORS_ORIGINS=*` triggers an additional `warn` log.
+- [ ] Existing users who set `CORS_ORIGINS=https://sowel.exemple.com` see no change.
+- [ ] Unit test: cross-origin request from non-whitelisted origin is rejected.
+
+### S4 — Container hardening
+
+- [ ] `Dockerfile` creates a `sowel` user (uid 1000) and installs `gosu`.
+- [ ] A new `docker-entrypoint.sh` is shipped:
+  - When the container starts as root, it runs `chown -R sowel:sowel /app/data /app/plugins` (idempotent) and then `exec gosu sowel "$@"`.
+  - When the container is already started under a non-root user, the entrypoint exec the command directly (skip chown).
+- [ ] No `USER` directive in the Dockerfile — the entrypoint controls privilege drop.
+- [ ] `docker compose up -d` on a fresh install: Sowel boots, `docker exec sowel id` returns `uid=1000`, volumes are owned by 1000.
+- [ ] **Upgrade from v1.6.5**: `docker compose pull && docker compose up -d` works without any manual command. The entrypoint auto-chowns the existing root-owned volumes on first boot. Verified end-to-end against a real v1.6.5 → v1.7.0 upgrade in a test VM.
+- [ ] `docker-compose.yml` no longer mounts `/var/run/docker.sock` by default.
+- [ ] A new `docker-compose.override.example.yml` is shipped as a template for opt-in self-update.
+- [ ] `UpdateManager` gracefully degrades: if `dockerode` cannot reach the socket, self-update endpoint returns 503 with a clear message pointing to the override file.
+- [ ] `GET /api/v1/system/version` surfaces `dockerAvailable: false` when the socket is not mounted; UI disables the "Update now" button with a tooltip.
+- [ ] CHANGELOG documents the change as transparent for users with default compose; users with a custom `user:` override must adjust manually.
+
+### S6 — Auth-by-default
+
+- [ ] `registerAuthMiddleware` registers a global `preHandler` hook that **requires** `request.auth` on all `/api/v1/*` routes.
+- [ ] A `PUBLIC_ROUTES` constant lists the explicit exceptions: `/api/v1/health`, `/api/v1/auth/status`, `/api/v1/auth/setup`, `/api/v1/auth/login`, `/api/v1/auth/refresh`. Static UI routes are unaffected (don't match `/api/v1/*`).
+- [ ] Per-route `preHandler` calls become redundant in route files — they can stay (harmless) but are no longer the source of truth.
+- [ ] Existing route files keep working without modification.
+- [ ] **Regression test**: an integration test enumerates all routes registered with Fastify (`app.printRoutes()` introspection) and asserts that every route either matches a `PUBLIC_ROUTES` entry or returns 401 on unauthenticated GET.
+- [ ] `/api/v1/devices/suggest` (known unprotected route) is no longer accessible anonymously after this change.
+
+## Edge cases
+
+- **CORS preflight from a Tauri / Electron wrapper** — out of scope today, the warn log on `*` is friendly enough.
+- **A user has set `CORS_ORIGINS=*` intentionally for testing** — keeps working with a warn log.
+- **A user has `docker.sock` mounted via their own custom compose** — keeps working; the change is only to the shipped default.
+- **A user has `user:` override in `docker-compose.override.yml`** — entrypoint detects non-root start and skips chown; volume ownership is the user's responsibility. Documented in CHANGELOG.
+- **Bind mount on read-only filesystem (NFS)** — chown silently fails (`|| true` in the entrypoint); Sowel may then fail to write SQLite. Edge case, documented as unsupported in CHANGELOG.
+- **Setting changes that require restart** — restart already triggers `system.restart_required`; if S4 makes self-restart opt-in, the UI must show a "manual restart required" tooltip when `docker.sock` is unavailable.
+
+## Open questions
+
+1. **CSP `connect-src wss:` vs explicit host** — explicit host is safer but requires `process.env.PUBLIC_URL` or equivalent. Decision: start with `wss:` for compatibility, tighten in a follow-up.
+2. **Should the entrypoint chown also handle `/app/data/logs` rotation files left as root?** — yes, `chown -R` covers all subdirs. Confirmed.
+3. **Does `gosu` add notable image size?** — ~2 MB (negligible vs current ~950 MB image).
+
+## Non-goals
+
+- This spec does not introduce a "WAN mode" config flag.
+- This spec does not add password re-prompt on sensitive actions (deferred to spec 106).
+- This spec does not change the rate-limit values (already adequate for `/auth/login`).
+- This spec does not migrate to opaque session tokens (JWT bearer stays).
+- This spec does not add a CSRF token to mutation endpoints (bearer-in-header model is not CSRF-vulnerable; helmet + CORS strict is enough).
+- This spec does not encrypt backups.
+
+## Success metric
+
+After merge, a fresh Sowel install exposed via reverse-proxy + TLS without any custom configuration should pass an external pen-test of the following:
+
+- WebSocket anonymous connection refused.
+- All security headers present in `/health` response.
+- CORS cross-origin POST refused.
+- `/devices/suggest` returns 401.
+- Process is not running as root (`docker exec sowel id` returns `uid=1000`).
+- `POST /api/v1/system/update` returns 503 when `docker.sock` not mounted.
+
+Upgrade from v1.6.5 to the new version should require zero manual commands for users on default compose.

--- a/src/api/headers.test.ts
+++ b/src/api/headers.test.ts
@@ -15,10 +15,11 @@ async function buildAppWithHelmet(): Promise<FastifyInstance> {
         styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
         imgSrc: ["'self'", "data:"],
         connectSrc: ["'self'", "ws:", "wss:"],
-        fontSrc: ["'self'", "https://fonts.gstatic.com"],
+        fontSrc: ["'self'", "data:", "https://fonts.gstatic.com"],
         manifestSrc: ["'self'"],
         objectSrc: ["'none'"],
         frameAncestors: ["'none'"],
+        "upgrade-insecure-requests": null,
       },
     },
     strictTransportSecurity: false,
@@ -70,6 +71,18 @@ describe("Security headers", () => {
     const csp = res.headers["content-security-policy"] as string;
     expect(csp).toMatch(/style-src[^;]*https:\/\/fonts\.googleapis\.com/);
     expect(csp).toMatch(/font-src[^;]*https:\/\/fonts\.gstatic\.com/);
+  });
+
+  it("allows data: URIs in font-src (Inter font is inlined by Vite as data: woff2)", async () => {
+    const res = await app.inject({ method: "GET", url: "/health" });
+    const csp = res.headers["content-security-policy"] as string;
+    expect(csp).toMatch(/font-src[^;]*\bdata:/);
+  });
+
+  it("does NOT include upgrade-insecure-requests (would break LAN HTTP deployments)", async () => {
+    const res = await app.inject({ method: "GET", url: "/health" });
+    const csp = res.headers["content-security-policy"] as string;
+    expect(csp).not.toContain("upgrade-insecure-requests");
   });
 
   it("allows WebSocket connections in CSP (connect-src includes ws: and wss:)", async () => {

--- a/src/api/headers.test.ts
+++ b/src/api/headers.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import helmet from "@fastify/helmet";
+
+// Replicates the helmet + HSTS configuration in server.ts. If server.ts diverges,
+// this test no longer protects against regressions — keep them in sync.
+async function buildAppWithHelmet(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+
+  await app.register(helmet, {
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", "data:"],
+        connectSrc: ["'self'", "ws:", "wss:"],
+        fontSrc: ["'self'"],
+        manifestSrc: ["'self'"],
+        objectSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+      },
+    },
+    strictTransportSecurity: false,
+    frameguard: { action: "deny" },
+    referrerPolicy: { policy: "no-referrer" },
+    noSniff: true,
+  });
+
+  app.addHook("onSend", (req, reply, payload, done) => {
+    const xfProto = req.headers["x-forwarded-proto"];
+    const proto =
+      (Array.isArray(xfProto) ? xfProto[0] : xfProto) ??
+      ((req.socket as { encrypted?: boolean }).encrypted ? "https" : "http");
+    if (proto === "https") {
+      reply.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+    }
+    done(null, payload);
+  });
+
+  app.get("/health", async () => ({ status: "ok" }));
+  await app.ready();
+  return app;
+}
+
+describe("Security headers", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await buildAppWithHelmet();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("sets Content-Security-Policy with expected directives", async () => {
+    const res = await app.inject({ method: "GET", url: "/health" });
+    const csp = res.headers["content-security-policy"];
+    expect(csp).toBeDefined();
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("script-src 'self'");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("object-src 'none'");
+  });
+
+  it("allows WebSocket connections in CSP (connect-src includes ws: and wss:)", async () => {
+    const res = await app.inject({ method: "GET", url: "/health" });
+    const csp = res.headers["content-security-policy"] as string;
+    expect(csp).toMatch(/connect-src[^;]*\bws:/);
+    expect(csp).toMatch(/connect-src[^;]*\bwss:/);
+  });
+
+  it("sets X-Frame-Options to DENY (clickjacking protection)", async () => {
+    const res = await app.inject({ method: "GET", url: "/health" });
+    expect(res.headers["x-frame-options"]).toBe("DENY");
+  });
+
+  it("sets Referrer-Policy to no-referrer", async () => {
+    const res = await app.inject({ method: "GET", url: "/health" });
+    expect(res.headers["referrer-policy"]).toBe("no-referrer");
+  });
+
+  it("sets X-Content-Type-Options to nosniff", async () => {
+    const res = await app.inject({ method: "GET", url: "/health" });
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+
+  it("does NOT set HSTS over plain HTTP (no proxy header, no TLS socket)", async () => {
+    const res = await app.inject({ method: "GET", url: "/health" });
+    expect(res.headers["strict-transport-security"]).toBeUndefined();
+  });
+
+  it("sets HSTS when x-forwarded-proto: https is present", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/health",
+      headers: { "x-forwarded-proto": "https" },
+    });
+    expect(res.headers["strict-transport-security"]).toBe("max-age=31536000; includeSubDomains");
+  });
+
+  it("does NOT set HSTS when x-forwarded-proto: http is present", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/health",
+      headers: { "x-forwarded-proto": "http" },
+    });
+    expect(res.headers["strict-transport-security"]).toBeUndefined();
+  });
+});

--- a/src/api/headers.test.ts
+++ b/src/api/headers.test.ts
@@ -12,10 +12,10 @@ async function buildAppWithHelmet(): Promise<FastifyInstance> {
       directives: {
         defaultSrc: ["'self'"],
         scriptSrc: ["'self'"],
-        styleSrc: ["'self'", "'unsafe-inline'"],
+        styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
         imgSrc: ["'self'", "data:"],
         connectSrc: ["'self'", "ws:", "wss:"],
-        fontSrc: ["'self'"],
+        fontSrc: ["'self'", "https://fonts.gstatic.com"],
         manifestSrc: ["'self'"],
         objectSrc: ["'none'"],
         frameAncestors: ["'none'"],
@@ -63,6 +63,13 @@ describe("Security headers", () => {
     expect(csp).toContain("style-src 'self' 'unsafe-inline'");
     expect(csp).toContain("frame-ancestors 'none'");
     expect(csp).toContain("object-src 'none'");
+  });
+
+  it("allows Google Fonts in CSP (Nunito heading font loaded from CDN)", async () => {
+    const res = await app.inject({ method: "GET", url: "/health" });
+    const csp = res.headers["content-security-policy"] as string;
+    expect(csp).toMatch(/style-src[^;]*https:\/\/fonts\.googleapis\.com/);
+    expect(csp).toMatch(/font-src[^;]*https:\/\/fonts\.gstatic\.com/);
   });
 
   it("allows WebSocket connections in CSP (connect-src includes ws: and wss:)", async () => {

--- a/src/api/routes/system.ts
+++ b/src/api/routes/system.ts
@@ -68,9 +68,9 @@ export function registerSystemRoutes(app: FastifyInstance, deps: SystemDeps): vo
     }
 
     if (!updateManager.isDockerAvailable()) {
-      return reply.code(400).send({
+      return reply.code(503).send({
         error:
-          "Docker socket not available. Update manually with: docker compose pull && docker compose up -d",
+          "In-app self-update is disabled because /var/run/docker.sock is not mounted. Enable it by copying docker-compose.override.example.yml to docker-compose.override.yml, or update manually with: docker compose pull && docker compose up -d",
       });
     }
 
@@ -115,8 +115,9 @@ export function registerSystemRoutes(app: FastifyInstance, deps: SystemDeps): vo
     }
 
     if (!updateManager.isDockerAvailable()) {
-      return reply.code(400).send({
-        error: "Docker socket not available. Restart manually with: docker compose restart sowel",
+      return reply.code(503).send({
+        error:
+          "In-app restart is disabled because /var/run/docker.sock is not mounted. Enable it by copying docker-compose.override.example.yml to docker-compose.override.yml, or restart manually with: docker compose restart sowel",
       });
     }
 

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -159,11 +159,17 @@ export async function createServer(deps: ServerDeps) {
         styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
         imgSrc: ["'self'", "data:"],
         connectSrc: ["'self'", "ws:", "wss:"],
-        // Font files served by `fonts.gstatic.com` (Google Fonts asset CDN).
-        fontSrc: ["'self'", "https://fonts.gstatic.com"],
+        // Font files: own bundle (Inter is inlined as `data:` URIs by Vite)
+        // plus `fonts.gstatic.com` for the Nunito heading font loaded by index.html.
+        fontSrc: ["'self'", "data:", "https://fonts.gstatic.com"],
         manifestSrc: ["'self'"],
         objectSrc: ["'none'"],
         frameAncestors: ["'none'"],
+        // Helmet sets this by default. We disable it because most Sowel
+        // deployments are LAN-only on plain HTTP — forcing HTTPS would
+        // break asset loading. Reverse proxies that terminate TLS still
+        // benefit from the conditional HSTS header below.
+        "upgrade-insecure-requests": null,
       },
     },
     strictTransportSecurity: false,

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -3,6 +3,7 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import helmet from "@fastify/helmet";
 import multipart from "@fastify/multipart";
 import rateLimit from "@fastify/rate-limit";
 import fastifyStatic from "@fastify/static";
@@ -146,6 +147,40 @@ export async function createServer(deps: ServerDeps) {
     methods: ["GET", "PUT", "POST", "DELETE", "OPTIONS"],
   });
 
+  // Security headers (CSP, X-Frame-Options, Referrer-Policy, X-Content-Type-Options).
+  // HSTS is set conditionally below (HTTPS only) to avoid breaking local HTTP setups.
+  await app.register(helmet, {
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", "data:"],
+        connectSrc: ["'self'", "ws:", "wss:"],
+        fontSrc: ["'self'"],
+        manifestSrc: ["'self'"],
+        objectSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+      },
+    },
+    strictTransportSecurity: false,
+    frameguard: { action: "deny" },
+    referrerPolicy: { policy: "no-referrer" },
+    noSniff: true,
+  });
+
+  // HSTS only when the request arrived over HTTPS (via reverse proxy or direct TLS).
+  app.addHook("onSend", (req, reply, payload, done) => {
+    const xfProto = req.headers["x-forwarded-proto"];
+    const proto =
+      (Array.isArray(xfProto) ? xfProto[0] : xfProto) ??
+      ((req.socket as { encrypted?: boolean }).encrypted ? "https" : "http");
+    if (proto === "https") {
+      reply.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+    }
+    done(null, payload);
+  });
+
   // Rate limiting (global: 300 req/min per IP — SPA makes many parallel calls)
   await app.register(rateLimit, {
     max: 300,
@@ -155,8 +190,17 @@ export async function createServer(deps: ServerDeps) {
   // Multipart file uploads (for backup restore)
   await app.register(multipart, { limits: { fileSize: 500 * 1024 * 1024 } }); // 500 MB
 
-  // WebSocket
-  await app.register(websocket);
+  // WebSocket — confirm the `bearer.<token>` subprotocol on handshake so that
+  // browsers don't drop the connection. Other subprotocols are refused.
+  await app.register(websocket, {
+    options: {
+      handleProtocols: (protocols: Set<string> | string[]) => {
+        const list = protocols instanceof Set ? Array.from(protocols) : protocols;
+        const bearer = list.find((p) => p.startsWith("bearer."));
+        return bearer ?? false;
+      },
+    },
+  });
 
   // Prevent browser caching on time-sensitive API routes
   const noCacheRoutes = ["/api/v1/energy/", "/api/v1/charts/", "/api/v1/logs"];
@@ -222,7 +266,7 @@ export async function createServer(deps: ServerDeps) {
   });
   registerSystemRoutes(app, { versionChecker, updateManager, tzInfo, logger });
   registerLogRoutes(app, { logBuffer, logger });
-  registerWebSocket(app, { eventBus, authService, logBuffer, logger });
+  registerWebSocket(app, { eventBus, authService, logBuffer, logger, corsOrigins });
 
   // Serve UI static files from project root ui-dist/
   const currentDir = import.meta.dirname ?? dirname(fileURLToPath(import.meta.url));

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -154,10 +154,13 @@ export async function createServer(deps: ServerDeps) {
       directives: {
         defaultSrc: ["'self'"],
         scriptSrc: ["'self'"],
-        styleSrc: ["'self'", "'unsafe-inline'"],
+        // Google Fonts CSS (`fonts.googleapis.com`) is loaded as a stylesheet
+        // from ui/index.html for the Nunito heading font.
+        styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
         imgSrc: ["'self'", "data:"],
         connectSrc: ["'self'", "ws:", "wss:"],
-        fontSrc: ["'self'"],
+        // Font files served by `fonts.gstatic.com` (Google Fonts asset CDN).
+        fontSrc: ["'self'", "https://fonts.gstatic.com"],
         manifestSrc: ["'self'"],
         objectSrc: ["'none'"],
         frameAncestors: ["'none'"],

--- a/src/api/websocket.test.ts
+++ b/src/api/websocket.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { extractWsToken, isWsOriginAllowed } from "./websocket.js";
+
+describe("websocket auth helpers", () => {
+  describe("extractWsToken", () => {
+    it("returns the bearer token from the Authorization header", () => {
+      expect(extractWsToken("Bearer abc.def.ghi", undefined)).toBe("abc.def.ghi");
+    });
+
+    it("returns null on missing or malformed Authorization header", () => {
+      expect(extractWsToken(undefined, undefined)).toBeNull();
+      expect(extractWsToken("", undefined)).toBeNull();
+      expect(extractWsToken("Basic dXNlcjpwYXNz", undefined)).toBeNull();
+    });
+
+    it("returns the token from a single `bearer.<token>` subprotocol", () => {
+      expect(extractWsToken(undefined, "bearer.swl_123abc")).toBe("swl_123abc");
+    });
+
+    it("preserves dots inside JWT tokens (splits only on first `bearer.` prefix)", () => {
+      const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.signature";
+      expect(extractWsToken(undefined, `bearer.${jwt}`)).toBe(jwt);
+    });
+
+    it("finds the bearer protocol among other comma-separated subprotocols", () => {
+      expect(extractWsToken(undefined, "echo, bearer.swl_x, chat")).toBe("swl_x");
+    });
+
+    it("handles array-form subprotocol header", () => {
+      expect(extractWsToken(undefined, ["echo", "bearer.swl_y"])).toBe("swl_y");
+    });
+
+    it("prefers the Authorization header over the subprotocol", () => {
+      expect(extractWsToken("Bearer from-header", "bearer.from-subprotocol")).toBe("from-header");
+    });
+
+    it("returns null when no bearer protocol is present", () => {
+      expect(extractWsToken(undefined, "echo, chat")).toBeNull();
+      expect(extractWsToken(undefined, "")).toBeNull();
+    });
+
+    it("returns null on `bearer.` with empty token", () => {
+      expect(extractWsToken(undefined, "bearer.")).toBeNull();
+    });
+  });
+
+  describe("isWsOriginAllowed", () => {
+    const corsOrigins = ["http://localhost:3000", "https://sowel.exemple.com"];
+
+    it("allows requests with no Origin header (non-browser clients)", () => {
+      expect(isWsOriginAllowed(undefined, corsOrigins)).toBe(true);
+    });
+
+    it("allows whitelisted origins", () => {
+      expect(isWsOriginAllowed("http://localhost:3000", corsOrigins)).toBe(true);
+      expect(isWsOriginAllowed("https://sowel.exemple.com", corsOrigins)).toBe(true);
+    });
+
+    it("refuses unknown origins", () => {
+      expect(isWsOriginAllowed("https://evil.tld", corsOrigins)).toBe(false);
+      expect(isWsOriginAllowed("http://localhost:9999", corsOrigins)).toBe(false);
+    });
+
+    it("allows everything when wildcard is in the list (user explicit opt-in)", () => {
+      expect(isWsOriginAllowed("https://anything.tld", ["*"])).toBe(true);
+      expect(isWsOriginAllowed("http://localhost:3000", ["*", "http://localhost:3000"])).toBe(true);
+    });
+
+    it("handles array-form origin header by checking the first value", () => {
+      expect(isWsOriginAllowed(["http://localhost:3000", "spoofed"], corsOrigins)).toBe(true);
+      expect(isWsOriginAllowed(["https://evil.tld"], corsOrigins)).toBe(false);
+    });
+  });
+});

--- a/src/api/websocket.test.ts
+++ b/src/api/websocket.test.ts
@@ -70,5 +70,27 @@ describe("websocket auth helpers", () => {
       expect(isWsOriginAllowed(["http://localhost:3000", "spoofed"], corsOrigins)).toBe(true);
       expect(isWsOriginAllowed(["https://evil.tld"], corsOrigins)).toBe(false);
     });
+
+    it("allows same-origin requests (Origin host matches Host header)", () => {
+      // LAN deployment: user opens http://domopi.local:3001, browser sends
+      // Origin: http://domopi.local:3001 and Host: domopi.local:3001.
+      // Even though domopi.local:3001 is not in CORS_ORIGINS, same-origin is allowed.
+      expect(isWsOriginAllowed("http://domopi.local:3001", corsOrigins, "domopi.local:3001")).toBe(
+        true,
+      );
+      expect(isWsOriginAllowed("https://sowel.exemple.com", corsOrigins, "sowel.exemple.com")).toBe(
+        true,
+      );
+    });
+
+    it("refuses cross-origin requests (Origin host does NOT match Host header)", () => {
+      // Cross-site request: page on evil.tld tries to open a WS to sowel.exemple.com.
+      // Origin host (evil.tld) does not match Host header (sowel.exemple.com).
+      expect(isWsOriginAllowed("https://evil.tld", corsOrigins, "sowel.exemple.com")).toBe(false);
+    });
+
+    it("tolerates a malformed Origin URL by falling through to deny", () => {
+      expect(isWsOriginAllowed("not-a-url", corsOrigins, "domopi.local:3001")).toBe(false);
+    });
   });
 });

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -11,6 +11,44 @@ interface WebSocketDeps {
   authService: AuthService;
   logBuffer: LogRingBuffer;
   logger: Logger;
+  corsOrigins: string[];
+}
+
+/**
+ * Extracts a bearer token from either the Authorization header or the
+ * `Sec-WebSocket-Protocol` subprotocol (`bearer.<token>`). The subprotocol path
+ * is the one used by browser clients since the WebSocket API does not allow
+ * setting arbitrary request headers.
+ */
+export function extractWsToken(
+  authorization: string | undefined,
+  subprotocol: string | string[] | undefined,
+): string | null {
+  if (authorization && authorization.startsWith("Bearer ")) {
+    return authorization.slice("Bearer ".length).trim() || null;
+  }
+  if (!subprotocol) return null;
+  const raw = Array.isArray(subprotocol) ? subprotocol.join(",") : subprotocol;
+  const protocols = raw.split(",").map((p) => p.trim());
+  const bearer = protocols.find((p) => p.startsWith("bearer."));
+  if (!bearer) return null;
+  return bearer.slice("bearer.".length) || null;
+}
+
+/**
+ * Returns true when the connection's Origin is acceptable.
+ * - Missing Origin: allowed (non-browser clients like Node scripts have no Origin).
+ * - Wildcard in corsOrigins: allowed (explicit user choice).
+ * - Otherwise: must match one of the whitelisted origins.
+ */
+export function isWsOriginAllowed(
+  origin: string | string[] | undefined,
+  corsOrigins: string[],
+): boolean {
+  if (!origin) return true;
+  if (corsOrigins.includes("*")) return true;
+  const value = Array.isArray(origin) ? origin[0] : origin;
+  return corsOrigins.includes(value);
 }
 
 type WsTopic =
@@ -102,7 +140,7 @@ function deduplicateEvents(events: EngineEvent[]): EngineEvent[] {
 }
 
 export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): void {
-  const { eventBus, authService, logBuffer, logger: baseLogger } = deps;
+  const { eventBus, authService, logBuffer, logger: baseLogger, corsOrigins } = deps;
   const logger = baseLogger.child({ module: "websocket" });
   const clients = new Map<WebSocket, ClientState>();
 
@@ -166,25 +204,39 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
   }
 
   app.get("/ws", { websocket: true }, (socket, request) => {
-    // Auth via query param: ws://host/ws?token=xxx
-    const url = new URL(request.url, `http://${request.headers.host}`);
-    const token = url.searchParams.get("token");
+    // Origin check: refuse browser clients from non-whitelisted origins.
+    if (!isWsOriginAllowed(request.headers.origin, corsOrigins)) {
+      logger.warn({ origin: request.headers.origin }, "WebSocket rejected: Origin not allowed");
+      socket.close(4003, "Origin not allowed");
+      return;
+    }
 
-    if (token) {
-      try {
-        if (token.startsWith("swl_") || token.startsWith("wch_") || token.startsWith("cbl_")) {
-          const result = authService.verifyApiToken(token);
-          if (!result) {
-            socket.close(4001, "Invalid token");
-            return;
-          }
-        } else {
-          authService.verifyAccessToken(token);
+    // Authentication: token via Authorization header (Bearer) or via
+    // `Sec-WebSocket-Protocol: bearer.<token>` subprotocol (browser path).
+    const token = extractWsToken(
+      request.headers.authorization,
+      request.headers["sec-websocket-protocol"],
+    );
+
+    if (!token) {
+      logger.warn("WebSocket rejected: no authentication credentials provided");
+      socket.close(4001, "Authentication required");
+      return;
+    }
+
+    try {
+      if (token.startsWith("swl_") || token.startsWith("wch_") || token.startsWith("cbl_")) {
+        const result = authService.verifyApiToken(token);
+        if (!result) {
+          socket.close(4001, "Invalid token");
+          return;
         }
-      } catch {
-        socket.close(4001, "Invalid token");
-        return;
+      } else {
+        authService.verifyAccessToken(token);
       }
+    } catch {
+      socket.close(4001, "Invalid token");
+      return;
     }
 
     // Default subscription: system events only

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -39,16 +39,31 @@ export function extractWsToken(
  * Returns true when the connection's Origin is acceptable.
  * - Missing Origin: allowed (non-browser clients like Node scripts have no Origin).
  * - Wildcard in corsOrigins: allowed (explicit user choice).
+ * - Same-origin: allowed (Origin host matches the Host header the request was
+ *   reached on). This makes LAN deployments at `http://<hostname>:<port>` work
+ *   without the operator having to add their hostname to CORS_ORIGINS.
  * - Otherwise: must match one of the whitelisted origins.
  */
 export function isWsOriginAllowed(
   origin: string | string[] | undefined,
   corsOrigins: string[],
+  hostHeader?: string | string[],
 ): boolean {
   if (!origin) return true;
   if (corsOrigins.includes("*")) return true;
   const value = Array.isArray(origin) ? origin[0] : origin;
-  return corsOrigins.includes(value);
+  if (corsOrigins.includes(value)) return true;
+  // Same-origin check: compare Origin's host to the request's Host header.
+  const host = Array.isArray(hostHeader) ? hostHeader[0] : hostHeader;
+  if (host) {
+    try {
+      const originHost = new URL(value).host;
+      if (originHost === host) return true;
+    } catch {
+      // Malformed Origin URL — fall through to deny.
+    }
+  }
+  return false;
 }
 
 type WsTopic =
@@ -205,7 +220,7 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
 
   app.get("/ws", { websocket: true }, (socket, request) => {
     // Origin check: refuse browser clients from non-whitelisted origins.
-    if (!isWsOriginAllowed(request.headers.origin, corsOrigins)) {
+    if (!isWsOriginAllowed(request.headers.origin, corsOrigins, request.headers.host)) {
       logger.warn({ origin: request.headers.origin }, "WebSocket rejected: Origin not allowed");
       socket.close(4003, "Origin not allowed");
       return;

--- a/src/auth/auth-middleware.test.ts
+++ b/src/auth/auth-middleware.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Fastify from "fastify";
+import { createLogger } from "../core/logger.js";
+import { PUBLIC_ROUTES, isPublicRoute, registerAuthMiddleware } from "./auth-middleware.js";
+import type { AuthService, JwtPayload } from "./auth-service.js";
+import type { UserManager } from "./user-manager.js";
+
+const logger = createLogger("silent").logger;
+
+describe("auth-middleware", () => {
+  describe("PUBLIC_ROUTES", () => {
+    it("contains the 5 expected public routes", () => {
+      expect(PUBLIC_ROUTES.has("/api/v1/health")).toBe(true);
+      expect(PUBLIC_ROUTES.has("/api/v1/auth/status")).toBe(true);
+      expect(PUBLIC_ROUTES.has("/api/v1/auth/setup")).toBe(true);
+      expect(PUBLIC_ROUTES.has("/api/v1/auth/login")).toBe(true);
+      expect(PUBLIC_ROUTES.has("/api/v1/auth/refresh")).toBe(true);
+      expect(PUBLIC_ROUTES.size).toBe(5);
+    });
+
+    it("does NOT include sensitive routes that were previously unprotected", () => {
+      expect(PUBLIC_ROUTES.has("/api/v1/devices/suggest")).toBe(false);
+      expect(PUBLIC_ROUTES.has("/api/v1/settings")).toBe(false);
+      expect(PUBLIC_ROUTES.has("/api/v1/system/update")).toBe(false);
+      expect(PUBLIC_ROUTES.has("/api/v1/backup")).toBe(false);
+    });
+  });
+
+  describe("isPublicRoute", () => {
+    it("returns true for every PUBLIC_ROUTES entry", () => {
+      for (const route of PUBLIC_ROUTES) {
+        expect(isPublicRoute(route)).toBe(true);
+      }
+    });
+
+    it("strips query string before checking", () => {
+      expect(isPublicRoute("/api/v1/health?check=full")).toBe(true);
+      expect(isPublicRoute("/api/v1/auth/login?ts=1234")).toBe(true);
+    });
+
+    it("returns false for sensitive routes", () => {
+      expect(isPublicRoute("/api/v1/devices/suggest")).toBe(false);
+      expect(isPublicRoute("/api/v1/devices/suggest?type=gate")).toBe(false);
+      expect(isPublicRoute("/api/v1/settings")).toBe(false);
+      expect(isPublicRoute("/api/v1/system/update")).toBe(false);
+    });
+
+    it("allows OAuth callback routes (external providers cannot send a bearer)", () => {
+      expect(isPublicRoute("/api/v1/plugins/panasonic_cc/oauth/callback")).toBe(true);
+      expect(isPublicRoute("/api/v1/plugins/smartthings/oauth/callback")).toBe(true);
+      expect(isPublicRoute("/api/v1/plugins/smartthings/oauth/callback?code=abc")).toBe(true);
+    });
+
+    it("rejects malformed OAuth-looking paths", () => {
+      expect(isPublicRoute("/api/v1/plugins/oauth/callback")).toBe(false);
+      expect(isPublicRoute("/api/v1/plugins/foo/bar/oauth/callback")).toBe(false);
+      expect(isPublicRoute("/api/v1/plugins/foo/oauth/callback/extra")).toBe(false);
+    });
+  });
+
+  describe("registerAuthMiddleware — request enforcement", () => {
+    let app: ReturnType<typeof Fastify>;
+    let mockUserManager: UserManager;
+    let mockAuthService: AuthService;
+    const validPayload: JwtPayload = { userId: "user-1", role: "admin" };
+
+    beforeEach(async () => {
+      mockUserManager = {
+        hasUsers: vi.fn().mockReturnValue(true),
+      } as unknown as UserManager;
+      mockAuthService = {
+        verifyAccessToken: vi.fn().mockReturnValue(validPayload),
+        verifyApiToken: vi.fn().mockReturnValue(validPayload),
+      } as unknown as AuthService;
+
+      app = Fastify({ logger: false });
+      registerAuthMiddleware(app, {
+        authService: mockAuthService,
+        userManager: mockUserManager,
+        logger,
+      });
+      // Fake protected route
+      app.get("/api/v1/test", async (req) => ({ auth: req.auth }));
+      app.get("/api/v1/health", async () => ({ status: "ok" }));
+      app.post("/api/v1/auth/setup", async () => ({ ok: true }));
+      app.get("/non-api/foo", async () => ({ ok: true }));
+      await app.ready();
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it("rejects unauthenticated GET on protected route with 401", async () => {
+      const res = await app.inject({ method: "GET", url: "/api/v1/test" });
+      expect(res.statusCode).toBe(401);
+      expect(res.json()).toEqual({ error: "Authentication required" });
+    });
+
+    it("allows unauthenticated GET on public route", async () => {
+      const res = await app.inject({ method: "GET", url: "/api/v1/health" });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("ignores non-/api routes (static UI fallback)", async () => {
+      const res = await app.inject({ method: "GET", url: "/non-api/foo" });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("rejects invalid bearer token with 401", async () => {
+      vi.mocked(mockAuthService.verifyAccessToken).mockImplementation(() => {
+        throw new Error("Invalid");
+      });
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/test",
+        headers: { authorization: "Bearer not-a-real-token" },
+      });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("rejects invalid API token (swl_) with 401", async () => {
+      vi.mocked(mockAuthService.verifyApiToken).mockReturnValue(null);
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/test",
+        headers: { authorization: "Bearer swl_deadbeef" },
+      });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("accepts valid JWT and populates request.auth", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/test",
+        headers: { authorization: "Bearer header.payload.signature" },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().auth).toEqual(validPayload);
+      expect(mockAuthService.verifyAccessToken).toHaveBeenCalledWith("header.payload.signature");
+    });
+
+    it("accepts valid API token (swl_)", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/test",
+        headers: { authorization: "Bearer swl_abc123" },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(mockAuthService.verifyApiToken).toHaveBeenCalledWith("swl_abc123");
+    });
+
+    it("accepts legacy API token prefixes (wch_, cbl_)", async () => {
+      const wchRes = await app.inject({
+        method: "GET",
+        url: "/api/v1/test",
+        headers: { authorization: "Bearer wch_legacy" },
+      });
+      expect(wchRes.statusCode).toBe(200);
+
+      const cblRes = await app.inject({
+        method: "GET",
+        url: "/api/v1/test",
+        headers: { authorization: "Bearer cbl_legacy" },
+      });
+      expect(cblRes.statusCode).toBe(200);
+    });
+
+    it("rejects malformed Authorization header (missing Bearer prefix)", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/test",
+        headers: { authorization: "swl_no-bearer-prefix" },
+      });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("setup mode (no users): returns 403 setupRequired on non-setup routes", async () => {
+      vi.mocked(mockUserManager.hasUsers).mockReturnValue(false);
+      const res = await app.inject({ method: "GET", url: "/api/v1/test" });
+      expect(res.statusCode).toBe(403);
+      expect(res.json()).toEqual({ error: "Setup required", setupRequired: true });
+    });
+
+    it("setup mode (no users): /api/v1/auth/setup passes through", async () => {
+      vi.mocked(mockUserManager.hasUsers).mockReturnValue(false);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/auth/setup",
+        payload: {},
+      });
+      expect(res.statusCode).toBe(200);
+    });
+  });
+});

--- a/src/auth/auth-middleware.ts
+++ b/src/auth/auth-middleware.ts
@@ -17,7 +17,7 @@ declare module "fastify" {
 // Public routes that don't require authentication
 // ============================================================
 
-const PUBLIC_ROUTES = new Set([
+export const PUBLIC_ROUTES: ReadonlySet<string> = new Set([
   "/api/v1/auth/status",
   "/api/v1/auth/setup",
   "/api/v1/auth/login",
@@ -25,7 +25,7 @@ const PUBLIC_ROUTES = new Set([
   "/api/v1/health",
 ]);
 
-function isPublicRoute(url: string): boolean {
+export function isPublicRoute(url: string): boolean {
   // Strip query string
   const path = url.split("?")[0];
   if (PUBLIC_ROUTES.has(path)) return true;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig } from "./config.js";
+
+describe("config — CORS defaults", () => {
+  let tmpDataDir: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmpDataDir = mkdtempSync(join(tmpdir(), "sowel-config-test-"));
+    // Override config so the test doesn't touch the real data dir
+    process.env["SQLITE_PATH"] = join(tmpDataDir, "sowel.db");
+    delete process.env["CORS_ORIGINS"];
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    rmSync(tmpDataDir, { recursive: true, force: true });
+  });
+
+  it("defaults CORS_ORIGINS to localhost (not wildcard)", () => {
+    const cfg = loadConfig();
+    expect(cfg.cors.origins).toEqual(["http://localhost:3000", "http://localhost:5173"]);
+    expect(cfg.cors.origins).not.toContain("*");
+  });
+
+  it("honours explicit CORS_ORIGINS", () => {
+    process.env["CORS_ORIGINS"] = "https://sowel.exemple.com";
+    const cfg = loadConfig();
+    expect(cfg.cors.origins).toEqual(["https://sowel.exemple.com"]);
+  });
+
+  it("splits comma-separated CORS_ORIGINS and trims whitespace", () => {
+    process.env["CORS_ORIGINS"] = " https://a.tld , https://b.tld ";
+    const cfg = loadConfig();
+    expect(cfg.cors.origins).toEqual(["https://a.tld", "https://b.tld"]);
+  });
+
+  it("keeps wildcard if user explicitly sets it (user's choice, warning emitted at boot)", () => {
+    process.env["CORS_ORIGINS"] = "*";
+    const cfg = loadConfig();
+    expect(cfg.cors.origins).toEqual(["*"]);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,7 +89,7 @@ export function loadConfig(): AppConfig {
       level: env("LOG_LEVEL", "info"),
     },
     cors: {
-      origins: env("CORS_ORIGINS", "*")
+      origins: env("CORS_ORIGINS", "http://localhost:3000,http://localhost:5173")
         .split(",")
         .map((s) => s.trim()),
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,21 @@ async function main() {
 
   logger.info("Sowel — Founded by Marc Chachereau — AGPL-3.0");
 
+  // WAN exposure warnings (spec 105)
+  const corsRaw = process.env["CORS_ORIGINS"];
+  if (corsRaw === "*") {
+    logger.warn(
+      "CORS is set to wildcard '*'. This is dangerous if Sowel is exposed to the Internet. Restrict CORS_ORIGINS to known origins.",
+    );
+    const apiHost = process.env["API_HOST"];
+    if (apiHost !== "127.0.0.1" && apiHost !== "localhost") {
+      logger.warn(
+        { apiHost: apiHost ?? "0.0.0.0" },
+        "CORS=* combined with a non-loopback API_HOST is the highest-risk configuration. Restrict at least one before exposing this instance to the public Internet.",
+      );
+    }
+  }
+
   // Snapshot for /api/v1/system/timezone endpoint
   const tzInfo = {
     tz: tzResult.tz,

--- a/ui/index.html
+++ b/ui/index.html
@@ -32,20 +32,6 @@
       </svg>
     </div>
 
-    <script>document.getElementById('splash').dataset.ts=Date.now();</script>
-    <script>
-      // One-time: unregister stale service workers and clear caches
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.getRegistrations().then(function(regs) {
-          regs.forEach(function(r) { r.unregister(); });
-        });
-      }
-      if ('caches' in window) {
-        caches.keys().then(function(names) {
-          names.forEach(function(name) { caches.delete(name); });
-        });
-      }
-    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -514,7 +514,7 @@
   "backup.confirmRestoreMessage": "This will replace all current data with the contents of {{filename}}. Continue?",
 
   "update.checkNow": "Check for updates",
-  "update.dockerUnavailable": "Self-update unavailable — Docker socket not mounted.",
+  "update.dockerUnavailable": "Self-update unavailable: Docker socket not mounted. To enable, copy docker-compose.override.example.yml to docker-compose.override.yml and run `docker compose up -d`.",
   "update.notComposeManaged": "Self-update only available with docker compose. Update manually with: docker compose pull && docker compose up -d",
   "update.confirmTitle": "Update to v{{version}}?",
   "update.confirmMessage": "Sowel will be updated from v{{current}} to v{{latest}}. The operation takes ~30-60 seconds.",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -514,7 +514,7 @@
   "backup.confirmRestoreMessage": "Cette action va remplacer toutes les données actuelles par celles de {{filename}}. Continuer ?",
 
   "update.checkNow": "Vérifier les mises à jour",
-  "update.dockerUnavailable": "Mise à jour automatique indisponible — socket Docker non monté.",
+  "update.dockerUnavailable": "Mise à jour automatique indisponible : socket Docker non monté. Pour l'activer, copiez docker-compose.override.example.yml vers docker-compose.override.yml et relancez `docker compose up -d`.",
   "update.notComposeManaged": "Mise à jour automatique disponible uniquement avec docker compose. Mettez à jour manuellement avec : docker compose pull && docker compose up -d",
   "update.confirmTitle": "Mettre à jour vers v{{version}} ?",
   "update.confirmMessage": "Sowel va passer de v{{current}} à v{{latest}}. L'opération prend ~30-60 secondes.",

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -8,6 +8,19 @@ import { applyTheme } from "./theme";
 
 console.log("Sowel — Founded by Marc Chachereau — AGPL-3.0");
 
+// One-time migration: unregister stale service workers and clear caches
+// left behind by the legacy PWA setup. Idempotent.
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.getRegistrations().then((regs) => {
+    regs.forEach((r) => r.unregister());
+  });
+}
+if ("caches" in window) {
+  caches.keys().then((names) => {
+    names.forEach((name) => caches.delete(name));
+  });
+}
+
 // Lock orientation to portrait (works in installed PWA / fullscreen on Android)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (screen.orientation as any)?.lock?.("portrait").catch(() => {});

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -47,12 +47,15 @@ let currentTopics: WsTopic[] = ["system"];
 const MAX_RECONNECT_DELAY = 30_000;
 
 function getWsUrl(): string {
-  const token = localStorage.getItem("sowel_access_token");
   // In dev mode, connect directly to the backend to avoid Vite proxy EPIPE issues
   const wsHost = import.meta.env.DEV ? `${window.location.hostname}:3000` : window.location.host;
   const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-  const base = `${protocol}//${wsHost}/ws`;
-  return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+  return `${protocol}//${wsHost}/ws`;
+}
+
+function getWsSubprotocol(): string | undefined {
+  const token = localStorage.getItem("sowel_access_token");
+  return token ? `bearer.${token}` : undefined;
 }
 
 function getReconnectDelay(): number {
@@ -206,7 +209,8 @@ export const useWebSocket = create<WebSocketState>((set) => ({
     }
 
     set({ status: "connecting" });
-    ws = new WebSocket(getWsUrl());
+    const subprotocol = getWsSubprotocol();
+    ws = subprotocol ? new WebSocket(getWsUrl(), subprotocol) : new WebSocket(getWsUrl());
 
     ws.onopen = () => {
       set({ status: "connected" });


### PR DESCRIPTION
## Summary

Closes the high-impact WAN-exposure attack chains identified in [SECURITY_AUDIT_WAN.md](SECURITY_AUDIT_WAN.md) while keeping LAN deployments fully backwards-compatible (no manual upgrade step).

Implements [spec 105](specs/105-wan-hardening/spec.md). Out of scope by design: S5 password re-prompt (deferred to spec 106 — overlapped S2/S6 and broke API-token automations), C3 backup encryption (offline-storage hygiene, not a WAN threat), `EXPOSURE_MODE`, digest pinning, native TLS.

## Changes

### S1 — WebSocket hardening
- `/ws` now refuses anonymous connections (close 4001) and non-whitelisted Origins (4003)
- Token via `Sec-WebSocket-Protocol: bearer.<token>` (browser) or `Authorization: Bearer` (scripts)
- Query-param token removed from the UI client
- `handleProtocols` in Fastify-websocket confirms the subprotocol on handshake

### S2 — Security headers
- `@fastify/helmet` registered after CORS, before routes
- CSP: `default-src 'self'`, `style-src 'self' 'unsafe-inline'` (Tailwind), `connect-src 'self' ws: wss:`, `frame-ancestors 'none'`
- `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, `X-Content-Type-Options: nosniff`
- HSTS conditional: emitted only when `X-Forwarded-Proto: https` or direct TLS — doesn't break local HTTP setups

### S3 — CORS defaults
- Default `CORS_ORIGINS` changed from `*` to `http://localhost:3000,http://localhost:5173`
- Explicit `*` still allowed but emits a warn log at boot, doubled when `API_HOST` is non-loopback

### S4 — Non-root container (transparent upgrade)
- Dockerfile installs `gosu` and creates a `sowel` user (uid 1000)
- New `docker-entrypoint.sh` chowns `/app/data` and `/app/plugins` idempotently then drops privileges via `gosu`
- **Upgrade from v1.6.x is transparent**: `docker compose pull && docker compose up -d` — no manual chown
- `docker.sock` removed from default compose
- New `docker-compose.override.example.yml` documents the security trade-off for users who want in-app self-update
- `POST /system/update` and `/system/restart` return 503 with a clear message when the socket is absent
- UI "Update now" button disabled with tooltip pointing to the override file

### S6 — Auth by default
- `PUBLIC_ROUTES` and `isPublicRoute` exported from `src/auth/auth-middleware.ts`
- Global `onRequest` hook (already in place) enforces 401 on every `/api/v1/*` route outside the whitelist
- Regression test (18 cases) covers: PUBLIC_ROUTES content, isPublicRoute behaviour, anonymous/invalid/legacy-token cases, setup mode

## Files touched

- **Backend**: `Dockerfile`, `docker-compose.yml`, `docker-compose.override.example.yml` (new), `docker-entrypoint.sh` (new), `package.json` (`@fastify/helmet@^13`), `src/api/server.ts`, `src/api/websocket.ts`, `src/auth/auth-middleware.ts`, `src/api/routes/system.ts`, `src/config.ts`, `src/index.ts`
- **UI**: `ui/src/store/useWebSocket.ts`, `ui/src/i18n/locales/{en,fr}.json`
- **Tests** (new): `src/auth/auth-middleware.test.ts` (18), `src/api/headers.test.ts` (8), `src/api/websocket.test.ts` (14), `src/config.test.ts` (4)
- **Docs**: `docs/technical/architecture.md`, `docs/technical/deployment.md`, `docs/specs-index.md`, `SECURITY_AUDIT.md`, `SECURITY_AUDIT_WAN.md`
- **Specs**: `specs/105-wan-hardening/{spec,architecture,plan}.md`

## Test plan

- [x] `npx tsc --noEmit` — zero errors (backend)
- [x] `cd ui && npx tsc -b --noEmit` — zero errors (UI)
- [x] `npx vitest run` — **498 passed**, 2 skipped, 4 new test files
- [x] `npx eslint src/ --ext .ts` — zero errors
- [x] `cd ui && npx eslint .` — zero new warnings (2 pre-existing)
- [x] `bash -n docker-entrypoint.sh` — script syntax valid
- [ ] **Manual**: build Docker image locally and verify `docker exec sowel id` returns uid=1000
- [ ] **Manual (critical)**: simulate a v1.6.x → v1.7.0 upgrade against a populated test instance to confirm volume chown is transparent
- [ ] **Manual**: browse the full UI under the new CSP, verify no console violations
- [ ] **Manual**: WebSocket reconnects correctly with the subprotocol auth path
- [ ] **Manual**: confirm "Update now" button disabled by default; copy override; verify button re-enables

## Upgrade notes for users

- **Default users**: just `docker compose pull && docker compose up -d`. The entrypoint chowns the volumes automatically. The "Update now" button now requires opting in by copying `docker-compose.override.example.yml` to `docker-compose.override.yml`.
- **Users with custom `user:` override**: entrypoint skips the chown — adjust volume ownership manually if needed.
- **Users relying on `CORS_ORIGINS=*` default**: explicit `CORS_ORIGINS=http://192.168.x.x:3000` recommended; otherwise expect a warning on startup. Setting `*` keeps working with a warn log.