### PR TITLE
fix(ui): use linear time scale on TimeSeriesChart X-axis

### DIFF
--- a/ui/src/components/history/TimeSeriesChart.tsx
+++ b/ui/src/components/history/TimeSeriesChart.tsx
@@ -11,7 +11,7 @@ import {
   CartesianGrid,
 } from "recharts";
 import type { HistoryPoint } from "../../types";
-import type { TimeRange } from "./history-utils";
+import { rangeToDurationMs, type TimeRange } from "./history-utils";
 
 interface TimeSeriesChartProps {
   points: HistoryPoint[];
@@ -90,33 +90,40 @@ export function TimeSeriesChart({ points, range, resolution, unit, height = 200,
   const isDiscrete = dataType === "boolean" || dataType === "enum";
   const isPower = category === "power";
 
-  const { data, lastRealTime } = useMemo(() => {
+  const { data, lastRealTime, domain } = useMemo(() => {
     const mapped = points.map((p) => ({
       time: p.time,
-      label: formatTime(p.time, range),
+      ts: new Date(p.time).getTime(),
       value: p.value,
       min: p.min,
       max: p.max,
     }));
 
-    if (mapped.length === 0 || !fetchTime) return { data: mapped, lastRealTime: null as string | null };
+    if (mapped.length === 0) {
+      return { data: mapped, lastRealTime: null as string | null, domain: undefined };
+    }
 
     const lastPoint = mapped[mapped.length - 1];
-    const lastTime = new Date(lastPoint.time).getTime();
+    const lastRealTimeIso = lastPoint.time;
 
-    // Extend chart line to current time with a synthetic point
-    if (fetchTime - lastTime > 60_000) {
-      const nowIso = new Date(fetchTime).toISOString();
+    // Extend chart line to current time with a synthetic point (only when fetchTime is known)
+    if (fetchTime && fetchTime - lastPoint.ts > 60_000) {
       mapped.push({
-        time: nowIso,
-        label: formatTime(nowIso, range),
+        time: new Date(fetchTime).toISOString(),
+        ts: fetchTime,
         value: lastPoint.value,
         min: undefined,
         max: undefined,
       });
     }
 
-    return { data: mapped, lastRealTime: lastPoint.time };
+    // Anchor the X-axis to the requested window [now - range, now] so spacing is linear in time,
+    // not in data-point index. Without an explicit numeric domain Recharts would otherwise treat
+    // the axis as categorical and squash long gaps between irregular samples.
+    const to = fetchTime ?? mapped[mapped.length - 1].ts;
+    const from = to - rangeToDurationMs(range);
+
+    return { data: mapped, lastRealTime: lastRealTimeIso, domain: [from, to] as [number, number] };
   }, [points, range, fetchTime]);
 
   if (data.length === 0) {
@@ -153,11 +160,14 @@ export function TimeSeriesChart({ points, range, resolution, unit, height = 200,
 
         <CartesianGrid strokeDasharray="3 3" stroke={borderColor} />
         <XAxis
-          dataKey="label"
+          dataKey="ts"
+          type="number"
+          scale="time"
+          domain={domain ?? ["dataMin", "dataMax"]}
+          tickFormatter={(ts: number) => formatTime(new Date(ts).toISOString(), range)}
           tick={{ fontSize: 10, fill: textTertiary }}
           tickLine={false}
           axisLine={{ stroke: borderColor }}
-          interval="preserveStartEnd"
           minTickGap={40}
         />
         <YAxis

--- a/ui/src/components/history/history-utils.ts
+++ b/ui/src/components/history/history-utils.ts
@@ -16,3 +16,17 @@ export function rangeToFrom(range: TimeRange): string {
       return "-720h"; // 30 * 24
   }
 }
+
+/** Convert a TimeRange to its duration in milliseconds. */
+export function rangeToDurationMs(range: TimeRange): number {
+  switch (range) {
+    case "6h":
+      return 6 * 60 * 60 * 1000;
+    case "24h":
+      return 24 * 60 * 60 * 1000;
+    case "7d":
+      return 7 * 24 * 60 * 60 * 1000;
+    case "30d":
+      return 30 * 24 * 60 * 60 * 1000;
+  }
+}


### PR DESCRIPTION
## Problème

Sur le graphique `occupancy (motion)` de PIR 01 en fenêtre 24h (et plus généralement sur tout `TimeSeriesChart`), les étiquettes de l'axe X étaient espacées également en pixels (Δ = 82.56 px constant) mais représentaient des écarts temporels très irréguliers (10 min, 12 min, 30 min, 1 h 27, 2 h 34, 4 h 01). Les bursts d'événements occupaient autant de largeur que les longues plages sans signal, et l'on lisait la chronologie comme étirée/écrasée selon la densité d'échantillons.

## Cause racine

`XAxis` configurait `dataKey="label"` sans `type="number"` ni `scale="time"`. Recharts traitait alors l'axe comme **catégoriel** : chaque point de données reçoit la même largeur, peu importe son timestamp. Pour des séries à échantillonnage irrégulier (motion, contact, capteurs sparse, données `raw`), c'est faux.

## Correctif

- Mapping des points: ajout de `ts: number` (timestamp ms) à la place du `label` pré-formaté.
- `XAxis`: `dataKey="ts"`, `type="number"`, `scale="time"`, `domain={[now - range, now]}`, `tickFormatter` qui ré-applique `formatTime`.
- Nouveau helper `rangeToDurationMs` dans `history-utils.ts` pour ancrer le domaine sur la fenêtre demandée (`6h` / `24h` / `7d` / `30d`).
- Le point synthétique d'extension vers `fetchTime` continue de fonctionner.

Impact: tous les graphes non cumulatifs (motion, contact, température, humidité, pression, luminosité, batterie, CO2…) bénéficient désormais d'une grille temporelle linéaire. `HistoryBarChart` (cumulatif: énergie, pluie) n'est pas touché — ses buckets sont déjà à largeur fixe.

## Test plan

- [ ] Vérifier visuellement sur PIR 01 (24h, 6h, 7j, 30j) que les détections sont placées au bon moment dans la journée
- [ ] Vérifier sur un capteur régulier (température/humidité) qu'il n'y a pas de régression visuelle
- [ ] Vérifier sur Énergie (HistoryBarChart) qu'il n'y a pas de régression — non touché
- [ ] Tooltip affiche toujours la bonne date/heure au survol