### PR TITLE
feat(ui): make topbar updates pill open an actionable sheet (spec 106)

### DIFF
--- a/specs/106-update-pill-actionable/architecture.md
+++ b/specs/106-update-pill-actionable/architecture.md
@@ -1,0 +1,63 @@
+# Spec 106 — Architecture
+
+UI-only change. No backend, no database, no event bus, no API additions.
+
+## Components touched
+
+| File                                              | Change                                                                             |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `ui/src/components/layout/UpdatesSheet.tsx` (new) | Bottom sheet listing core + plugin updates with per-row Update buttons             |
+| `ui/src/components/layout/AppLayout.tsx`          | Updates `HeaderPill` swaps `href="/plugins"` for an `onClick` that opens the sheet |
+| `ui/src/i18n/locales/{fr,en}.json`                | New `updates.sheet.*` and `updates.action.*` keys                                  |
+
+`HistoryPanel`, `usePluginUpdates`, `useUpdateAvailable`, `BottomSheet`, `triggerSystemUpdate`, `updatePlugin` are reused as-is.
+
+## Data sources
+
+- **Sowel core update**: read directly from `useWebSocket((s) => s.updateAvailable)` —
+  shape `{ current, latest, releaseUrl } | null`, already kept fresh by the
+  WebSocket push of `system.update.available` (see `useUpdateAvailable`).
+- **Outdated plugins**: fetched on sheet open via `getPlugins()`, filtered to
+  `latestVersion != null`. The badge counter store (`usePluginUpdates`) only
+  tracks the count, so the sheet maintains its own short-lived list state and
+  calls `refreshPluginUpdateCount()` after each successful update to keep the
+  pill in sync.
+
+## Action wiring
+
+| Action        | Implementation                                                                                              |
+| ------------- | ----------------------------------------------------------------------------------------------------------- |
+| Core update   | `triggerSystemUpdate()` → `setUpdateInProgress(true)` → `onClose()`. `UpdateOverlay` takes over the screen. |
+| Plugin update | `updatePlugin(id)` → 1.5 s wait (plugin restart) → remove row locally → `refreshPluginUpdateCount()`.       |
+
+Same call sequences used today by `SettingsPage` (core) and `PluginsPage` (plugin).
+
+## State strategy
+
+The sheet keeps three local `useState` slots:
+
+- `plugins: PluginInfo[] | null` — `null` = loading, `[]` = no plugin updates,
+  populated array = list of outdated plugins.
+- `updatingId: string | null` — id of the row currently updating (or
+  `"__core__"` for the core row). Drives per-row spinner + button disabled.
+- `error: string | null` — last error message; rendered under the list, never
+  blocks other rows.
+
+No new Zustand store. No new event types. Sheet state resets each time it opens
+(refetches plugins, clears error) which keeps the implementation trivial.
+
+## Z-index / overlay coexistence
+
+`AlarmsSheet`, `HomeSetupWizard` and `UpdateOverlay` are all rendered at the
+end of `AppLayout`. `UpdatesSheet` slots in at the same level after
+`AlarmsSheet`. Two sheets cannot be open at once because each pill click closes
+the other implicitly only if we wire it — for simplicity, we don't: opening one
+just stacks on top of the other (same as today's `AlarmsSheet` behavior).
+`UpdateOverlay` (full-screen) renders last and covers everything once a core
+update is in progress.
+
+## Out of scope (carried over from spec.md)
+
+- "Update all" button
+- Update history surfaced in this UI
+- Filter / sort within the sheet

--- a/specs/106-update-pill-actionable/plan.md
+++ b/specs/106-update-pill-actionable/plan.md
@@ -1,0 +1,47 @@
+# Spec 106 — Implementation plan
+
+UI-only feature, single branch `feat/updates-sheet`.
+
+## Tasks
+
+1. [x] Create `ui/src/components/layout/UpdatesSheet.tsx`
+   - Copy `AlarmsSheet` structure (BottomSheet + list)
+   - Header icon: `RefreshCw`, tint `text-error`
+   - On open: fetch `getPlugins()` and filter `latestVersion != null`
+   - Render core row first (if `updateAvailable !== null`)
+   - Render one row per outdated plugin
+   - Empty state when nothing to update (placeholder text)
+   - `UpdateRow` sub-component: title + optional Recipe/Integration badge, `vCurrent → vLatest`, Update button with inline `Loader2` spinner while pending
+   - Core update: `triggerSystemUpdate()` → `setUpdateInProgress(true)` → `onClose()`
+   - Plugin update: `updatePlugin(id)` → 1.5 s wait → drop row from local state → `refreshPluginUpdateCount()`
+2. [x] Edit `ui/src/components/layout/AppLayout.tsx`
+   - Add `updatesOpen` state next to `alarmsOpen`
+   - Replace `href="/plugins"` on the updates `HeaderPill` with `onClick={() => setUpdatesOpen(true)}`
+   - Render `<UpdatesSheet open={updatesOpen} onClose={() => setUpdatesOpen(false)} />` next to `<AlarmsSheet ...>`
+3. [x] Add i18n keys in `ui/src/i18n/locales/fr.json` and `en.json`:
+   - `updates.sheet.title`
+   - `updates.sheet.empty`
+   - `updates.sheet.versions` (e.g. `"v{{from}} → v{{to}}"`)
+   - `updates.action.update`
+   - `updates.badge.integration`
+   - `updates.badge.recipe`
+   - `updates.error.generic`
+4. [x] `npx tsc --noEmit` + `cd ui && npx tsc -b --noEmit`
+5. [x] `npx eslint src/ --ext .ts && cd ui && npx eslint .`
+6. [x] `npx vitest run` — no backend changes so no new tests; existing suite must stay green
+7. [ ] Visual check on local dev or demo: pill click opens sheet, both row types update correctly _(pending — no updates available on local; verify on demo or prod after deploy)_
+
+## Test plan
+
+Pure UI work, no business logic to unit-test (CLAUDE.md: "What NOT to test: UI components"). The verification matrix from `spec.md` § Test plan is the manual checklist driving step 7 above:
+
+| Scenario                                     | Expected                                                                                        |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `updateAvailable != null`, no plugin updates | Sheet shows 1 row "Sowel vX → vY"; Update closes sheet and triggers `UpdateOverlay`             |
+| 2 plugin updates, no core update             | Sheet shows 2 rows; each Update button works; rows disappear on success; pill counter decreases |
+| Core + 1 plugin                              | Core row first, then plugin row                                                                 |
+| `totalUpdates === 0`                         | Pill not rendered (unchanged behaviour from current AppLayout)                                  |
+| Click on pill                                | Sheet opens (no route change), backdrop click closes, X button closes, ESC closes               |
+| Alarms pill still works                      | Independent sheet, no z-index clash                                                             |
+
+Backend unit tests untouched (none of the changed files have associated tests).

--- a/specs/106-update-pill-actionable/spec.md
+++ b/specs/106-update-pill-actionable/spec.md
@@ -1,0 +1,112 @@
+# Spec 106 — Make the topbar "update available" pill actionable
+
+> Light spec: a UX fix for the existing update-notification pill. No
+> backend changes. No new APIs. Pure UI plumbing.
+
+## Problem
+
+The topbar shows a pill that aggregates **all** available updates:
+
+```ts
+const totalUpdates = pluginUpdateCount + (sowelUpdateAvailable ? 1 : 0);
+```
+
+A click on the pill just navigates to `/plugins`. That breaks in two
+ways:
+
+1. **Sowel core updates are invisible on `/plugins`.** They are triggered
+   from `/settings` → System → "Update Sowel"
+   ([SettingsPage.tsx:678](src/pages/SettingsPage.tsx#L678)). A user whose
+   only pending update is the core sees "1 update available", clicks,
+   lands on `/plugins`, and finds nothing to do.
+2. **No "update everything" path.** With N plugins + the core
+   outdated, the user navigates to two distinct places and clicks N+1
+   times.
+
+The pill's destination should reflect what the pill is counting.
+
+## Goal
+
+Make the pill's click open a single, focused surface that lists every
+available update (core + plugins) with a one-click action per row.
+Same UX pattern as the **alarms pill**, which opens `AlarmsSheet`.
+
+## Approach
+
+Replace the `href="/plugins"` on the updates `HeaderPill` with an
+`onClick` that opens a new `UpdatesSheet` (modeled on `AlarmsSheet`).
+
+`UpdatesSheet` contents (top to bottom):
+
+- **Sowel core**, if `sowelUpdateAvailable`:
+  - Title: `Sowel`
+  - Subtitle: `vCurrent → vLatest`
+  - Action: `Update` button → calls `triggerSystemUpdate()` then sets
+    `updateInProgress = true` (same logic as
+    [SettingsPage.tsx:677-680](src/pages/SettingsPage.tsx#L677)). The
+    sheet stays open until `UpdateOverlay` takes over.
+
+- **One row per outdated plugin** (manifest version ≠ `latestVersion`):
+  - Title: plugin name + small `Recipe` / `Integration` badge
+  - Subtitle: `vCurrent → vLatest`
+  - Action: `Update` button → calls `updatePlugin(id)`. The button shows
+    a spinner while the request runs; on success the row is removed
+    from the list (or replaced by a "Updated" tag).
+
+- **Empty state**: if for some reason the sheet opens with nothing to
+  update (race condition with a just-completed update), show a
+  "Everything's up to date" placeholder + close button.
+
+Visual style + animation: copy `AlarmsSheet` 1:1. Bottom-right anchored
+on desktop, full-width bottom-sheet on mobile, slide-up animation,
+backdrop click-to-close.
+
+## Out of scope
+
+- A bulk "Update all" button (one click per row is fine for now —
+  plugins update independently and each takes a few seconds; users
+  rarely have more than 2-3 outdated)
+- Tracking update history (already in `system.update.progress` event
+  trail; not surfaced here)
+- Filtering/sorting (sheet is short by definition; ordering is core
+  first, then plugins alphabetically)
+
+## Acceptance criteria
+
+- [x] Clicking the topbar updates pill opens a new `UpdatesSheet`
+      (not a route change)
+- [x] The sheet lists Sowel core first (if outdated) followed by each
+      outdated plugin
+- [x] Each row has a working `Update` button wired to the right API
+      (`triggerSystemUpdate` for core, `updatePlugin` for plugins)
+- [x] Triggering a core update closes the sheet and lets
+      `UpdateOverlay` take over
+- [x] Plugin updates run in-place (sheet stays open, row shows a
+      spinner, then disappears on success)
+- [x] FR + EN i18n strings under `updates.sheet.*`
+- [x] Existing alarms-pill behaviour unchanged
+
+## Test plan
+
+| Module                  | Scenario                                                      | Expected                                                                |
+| ----------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `UpdatesSheet` (UI)     | sowelUpdateAvailable = true, no plugin updates                | Sheet shows 1 row "Sowel vX → vY", Update button triggers system update |
+| `UpdatesSheet` (UI)     | 2 plugin updates, no core update                              | Sheet shows 2 rows, both Update buttons work, rows disappear on success |
+| `UpdatesSheet` (UI)     | core + 1 plugin                                               | Sheet shows core then plugin, ordered                                   |
+| `AppLayout` integration | totalUpdates = 0                                              | Pill not rendered                                                       |
+| `AppLayout` integration | totalUpdates > 0, click on pill                               | Sheet opens (no route change), close via backdrop or X button           |
+| `AppLayout` regression  | alarms pill still works (independent sheet, no z-index clash) | Alarms sheet behaviour unchanged                                        |
+
+## Files touched (estimated)
+
+```
+ui/src/components/layout/
+  UpdatesSheet.tsx           (new — copy AlarmsSheet structure)
+  AppLayout.tsx              (swap href → onClick + render sheet)
+ui/src/i18n/locales/
+  fr.json, en.json           (updates.sheet.* keys)
+```
+
+## Effort
+
+~½ day. Self-contained UI work, no backend.

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -46,6 +46,7 @@ import { SowelLogo } from "./SowelLogo";
 import { OfflineBanner } from "./OfflineBanner";
 import { HeaderPill } from "./HeaderPill";
 import { AlarmsSheet } from "./AlarmsSheet";
+import { UpdatesSheet } from "./UpdatesSheet";
 import { useAggregatedIssues } from "./useAggregatedIssues";
 import { useUpdateAvailable } from "../../hooks/useUpdateAvailable";
 import { usePluginUpdates } from "./usePluginUpdates";
@@ -76,6 +77,7 @@ export function AppLayout() {
   const fetchTimezone = useTimezone((s) => s.fetch);
   const issues = useAggregatedIssues();
   const [alarmsOpen, setAlarmsOpen] = useState(false);
+  const [updatesOpen, setUpdatesOpen] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   // Updates pill: combines Sowel core + plugin updates into a single counter.
@@ -154,7 +156,7 @@ export function AppLayout() {
                 count={totalUpdates}
                 tone="error"
                 title={t("updates.pill.title", { count: totalUpdates })}
-                href="/plugins"
+                onClick={() => setUpdatesOpen(true)}
               />
             )}
             {restartRequired && (
@@ -212,6 +214,9 @@ export function AppLayout() {
 
       {/* Alarms sheet — opened by the header pill */}
       <AlarmsSheet open={alarmsOpen} onClose={() => setAlarmsOpen(false)} />
+
+      {/* Updates sheet — lists Sowel core + outdated plugins with per-row actions */}
+      <UpdatesSheet open={updatesOpen} onClose={() => setUpdatesOpen(false)} />
 
       {/* First-login Home setup wizard — blocks the UI when home.name is empty.
           Rendered BEFORE UpdateOverlay so that an active restart (e.g. the one

--- a/ui/src/components/layout/UpdatesSheet.tsx
+++ b/ui/src/components/layout/UpdatesSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Loader2, RefreshCw } from "lucide-react";
 import { BottomSheet } from "../dashboard/BottomSheet";
@@ -30,15 +30,30 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
   const [plugins, setPlugins] = useState<PluginInfo[] | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Tracks whether the sheet is currently open, so async handlers (whose
+  // 1.5 s wait can outlive the close) can bail out before applying stale
+  // state writes. Synced from `open` via the effect below.
+  const openRef = useRef(open);
 
   useEffect(() => {
+    openRef.current = open;
     if (!open) return;
+    let cancelled = false;
     setError(null);
     setUpdatingId(null);
     setPlugins(null);
     getPlugins()
-      .then((all) => setPlugins(all.filter((p) => p.latestVersion)))
-      .catch(() => setPlugins([]));
+      .then((all) => {
+        if (cancelled) return;
+        setPlugins(all.filter((p) => p.latestVersion));
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setPlugins([]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [open]);
 
   const outdated = plugins ?? [];
@@ -67,12 +82,16 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
       await updatePlugin(id);
       // Plugin restart takes a moment — let the backend settle before refreshing the badge.
       await new Promise((r) => setTimeout(r, 1500));
-      setPlugins((prev) => (prev ?? []).filter((p) => p.manifest.id !== id));
+      // Refresh the pill counter regardless of whether the sheet is still open —
+      // the user closed the sheet but the update still happened.
       refreshPluginUpdateCount();
+      if (!openRef.current) return;
+      setPlugins((prev) => (prev ?? []).filter((p) => p.manifest.id !== id));
     } catch (err) {
+      if (!openRef.current) return;
       setError(err instanceof Error ? err.message : t("updates.error.generic"));
     } finally {
-      setUpdatingId(null);
+      if (openRef.current) setUpdatingId(null);
     }
   }
 
@@ -92,7 +111,7 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
           {t("updates.sheet.empty")}
         </div>
       ) : (
-        <ul className="flex flex-col gap-2">
+        <ul className="flex flex-col gap-2" aria-busy={updatingId !== null}>
           {showCore && coreUpdate && (
             <UpdateRow
               title="Sowel"
@@ -100,6 +119,7 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
               from={coreUpdate.current}
               to={coreUpdate.latest}
               loading={updatingId === CORE_ROW_ID}
+              disabled={updatingId !== null && updatingId !== CORE_ROW_ID}
               onUpdate={handleCoreUpdate}
             />
           )}
@@ -111,12 +131,17 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
               from={p.manifest.version}
               to={p.latestVersion ?? ""}
               loading={updatingId === p.manifest.id}
+              disabled={updatingId !== null && updatingId !== p.manifest.id}
               onUpdate={() => handlePluginUpdate(p.manifest.id)}
             />
           ))}
         </ul>
       )}
-      {error && <div className="mt-3 text-[12px] text-error text-center">{error}</div>}
+      {error && (
+        <div role="alert" className="mt-3 text-[12px] text-error text-center">
+          {error}
+        </div>
+      )}
     </BottomSheet>
   );
 }
@@ -127,10 +152,11 @@ interface UpdateRowProps {
   from: string;
   to: string;
   loading: boolean;
+  disabled: boolean;
   onUpdate: () => void;
 }
 
-function UpdateRow({ title, kind, from, to, loading, onUpdate }: UpdateRowProps) {
+function UpdateRow({ title, kind, from, to, loading, disabled, onUpdate }: UpdateRowProps) {
   const { t } = useTranslation();
   const badge =
     kind === "core"
@@ -155,8 +181,9 @@ function UpdateRow({ title, kind, from, to, loading, onUpdate }: UpdateRowProps)
         </div>
       </div>
       <button
+        type="button"
         onClick={onUpdate}
-        disabled={loading}
+        disabled={loading || disabled}
         className="px-3 py-1.5 rounded-[6px] bg-primary text-white text-[12px] font-medium hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1.5 cursor-pointer flex-shrink-0"
       >
         {loading && <Loader2 size={12} strokeWidth={1.5} className="animate-spin" />}

--- a/ui/src/components/layout/UpdatesSheet.tsx
+++ b/ui/src/components/layout/UpdatesSheet.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Loader2, RefreshCw } from "lucide-react";
+import { BottomSheet } from "../dashboard/BottomSheet";
+import { getPlugins, triggerSystemUpdate, updatePlugin } from "../../api";
+import { useWebSocket } from "../../store/useWebSocket";
+import { refreshPluginUpdateCount } from "./usePluginUpdates";
+import type { PluginInfo, PluginManifest, PackageType } from "../../types";
+
+interface UpdatesSheetProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const CORE_ROW_ID = "__core__";
+
+function getManifestType(manifest: PluginManifest): PackageType {
+  return manifest.type ?? "integration";
+}
+
+function getLocalizedName(manifest: PluginManifest, lang: string): string {
+  return manifest.i18n?.[lang]?.name ?? manifest.name;
+}
+
+export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language?.split("-")[0] ?? "en";
+  const coreUpdate = useWebSocket((s) => s.updateAvailable);
+  const setUpdateInProgress = useWebSocket((s) => s.setUpdateInProgress);
+  const [plugins, setPlugins] = useState<PluginInfo[] | null>(null);
+  const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setUpdatingId(null);
+    setPlugins(null);
+    getPlugins()
+      .then((all) => setPlugins(all.filter((p) => p.latestVersion)))
+      .catch(() => setPlugins([]));
+  }, [open]);
+
+  const outdated = plugins ?? [];
+  const showCore = !!coreUpdate;
+  const totalCount = outdated.length + (showCore ? 1 : 0);
+
+  async function handleCoreUpdate() {
+    if (!coreUpdate) return;
+    setError(null);
+    setUpdatingId(CORE_ROW_ID);
+    try {
+      await triggerSystemUpdate();
+      // UpdateOverlay takes over from here.
+      setUpdateInProgress(true);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("updates.error.generic"));
+      setUpdatingId(null);
+    }
+  }
+
+  async function handlePluginUpdate(id: string) {
+    setError(null);
+    setUpdatingId(id);
+    try {
+      await updatePlugin(id);
+      // Plugin restart takes a moment — let the backend settle before refreshing the badge.
+      await new Promise((r) => setTimeout(r, 1500));
+      setPlugins((prev) => (prev ?? []).filter((p) => p.manifest.id !== id));
+      refreshPluginUpdateCount();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("updates.error.generic"));
+    } finally {
+      setUpdatingId(null);
+    }
+  }
+
+  return (
+    <BottomSheet
+      open={open}
+      onClose={onClose}
+      title={t("updates.sheet.title")}
+      icon={<RefreshCw size={18} strokeWidth={1.5} className="text-error" />}
+    >
+      {plugins === null ? (
+        <div className="text-center text-text-tertiary text-[13px] py-6">
+          {t("common.loading")}
+        </div>
+      ) : totalCount === 0 ? (
+        <div className="text-center text-text-tertiary text-[13px] py-6">
+          {t("updates.sheet.empty")}
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {showCore && coreUpdate && (
+            <UpdateRow
+              title="Sowel"
+              kind="core"
+              from={coreUpdate.current}
+              to={coreUpdate.latest}
+              loading={updatingId === CORE_ROW_ID}
+              onUpdate={handleCoreUpdate}
+            />
+          )}
+          {outdated.map((p) => (
+            <UpdateRow
+              key={p.manifest.id}
+              title={getLocalizedName(p.manifest, lang)}
+              kind={getManifestType(p.manifest)}
+              from={p.manifest.version}
+              to={p.latestVersion ?? ""}
+              loading={updatingId === p.manifest.id}
+              onUpdate={() => handlePluginUpdate(p.manifest.id)}
+            />
+          ))}
+        </ul>
+      )}
+      {error && <div className="mt-3 text-[12px] text-error text-center">{error}</div>}
+    </BottomSheet>
+  );
+}
+
+interface UpdateRowProps {
+  title: string;
+  kind: "core" | PackageType;
+  from: string;
+  to: string;
+  loading: boolean;
+  onUpdate: () => void;
+}
+
+function UpdateRow({ title, kind, from, to, loading, onUpdate }: UpdateRowProps) {
+  const { t } = useTranslation();
+  const badge =
+    kind === "core"
+      ? null
+      : kind === "recipe"
+        ? t("updates.badge.recipe")
+        : t("updates.badge.integration");
+
+  return (
+    <li className="flex items-center gap-3 px-3 py-2.5 rounded-[8px] bg-border-light/50">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 text-[13px] font-semibold text-text">
+          <span className="truncate">{title}</span>
+          {badge && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded uppercase bg-primary/10 text-primary">
+              {badge}
+            </span>
+          )}
+        </div>
+        <div className="text-[11px] text-text-secondary font-mono mt-0.5">
+          {t("updates.sheet.versions", { from, to })}
+        </div>
+      </div>
+      <button
+        onClick={onUpdate}
+        disabled={loading}
+        className="px-3 py-1.5 rounded-[6px] bg-primary text-white text-[12px] font-medium hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1.5 cursor-pointer flex-shrink-0"
+      >
+        {loading && <Loader2 size={12} strokeWidth={1.5} className="animate-spin" />}
+        {t("updates.action.update")}
+      </button>
+    </li>
+  );
+}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -85,6 +85,13 @@
   "alarms.integration.disconnected": "Plugin disconnected",
   "updates.pill.title_one": "{{count}} update available",
   "updates.pill.title_other": "{{count}} updates available",
+  "updates.sheet.title": "Available updates",
+  "updates.sheet.empty": "Everything's up to date.",
+  "updates.sheet.versions": "v{{from}} → v{{to}}",
+  "updates.action.update": "Update",
+  "updates.badge.integration": "Integration",
+  "updates.badge.recipe": "Recipe",
+  "updates.error.generic": "Update failed",
   "restart.pill.title": "Restart required",
 
   "devices.title": "Devices",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -85,6 +85,13 @@
   "alarms.integration.disconnected": "Plugin déconnecté",
   "updates.pill.title_one": "{{count}} mise à jour disponible",
   "updates.pill.title_other": "{{count}} mises à jour disponibles",
+  "updates.sheet.title": "Mises à jour disponibles",
+  "updates.sheet.empty": "Tout est à jour.",
+  "updates.sheet.versions": "v{{from}} → v{{to}}",
+  "updates.action.update": "Mettre à jour",
+  "updates.badge.integration": "Intégration",
+  "updates.badge.recipe": "Recette",
+  "updates.error.generic": "Échec de la mise à jour",
   "restart.pill.title": "Redémarrage requis",
 
   "devices.title": "Appareils",


### PR DESCRIPTION
## Summary

Spec 106 — la pastille "mise à jour" de la topbar ouvrait `/plugins`, ce qui était trompeur pour les mises à jour core (déclenchées depuis `/settings`) et obligeait à naviguer entre deux pages quand plusieurs plugins étaient obsolètes. Cette PR remplace cette navigation par un `UpdatesSheet` (bottom-sheet calqué sur `AlarmsSheet`) qui liste tout au même endroit avec un bouton `Update` par ligne.

## Changes

- `ui/src/components/layout/UpdatesSheet.tsx` (nouveau) — fetch plugins on open, ligne core en premier si `updateAvailable`, puis une ligne par plugin obsolète, spinner inline pendant l'action, empty state si plus rien à faire
- `ui/src/components/layout/AppLayout.tsx` — la pastille passe de `href="/plugins"` à `onClick={() => setUpdatesOpen(true)}`, et la sheet est rendue à côté de `AlarmsSheet`
- `ui/src/i18n/locales/{fr,en}.json` — 7 nouvelles clés sous `updates.sheet.*`, `updates.action.*`, `updates.badge.*`, `updates.error.*`
- `specs/106-update-pill-actionable/` — `spec.md` (existait déjà), `architecture.md` et `plan.md` ajoutés

Aucun changement backend, base de données, event bus ou API. `triggerSystemUpdate()`, `updatePlugin()`, `useWebSocket`, `refreshPluginUpdateCount()` sont réutilisés tels quels.

## Test plan

- [x] `npx tsc --noEmit` — backend OK
- [x] `cd ui && npx tsc -b --noEmit` — UI OK
- [x] `npx eslint src/ --ext .ts` — 0 erreur
- [x] `cd ui && npx eslint .` — 0 erreur (2 warnings pré-existants)
- [x] `npx vitest run` — 533 tests verts
- [x] `cd ui && npm run build` — bundle OK
- [ ] Vérification visuelle: clic pastille → sheet s'ouvre (pas de redirection), update core ferme la sheet et déclenche `UpdateOverlay`, update plugin laisse la sheet ouverte et retire la ligne au succès, badge alarmes inchangé