### PR TITLE
docs: add Release Notes page (every version since v1.0.0)

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -1,0 +1,312 @@
+# Notes de version
+
+Sowel est versionné et déployé via CI/CD depuis `v1.0.0` (avril 2026, spec 055). Chaque version est publiée sous forme de :
+
+- Release GitHub avec un changelog généré — [github.com/mchacher/sowel/releases](https://github.com/mchacher/sowel/releases)
+- Image Docker multi-arch taggée `ghcr.io/mchacher/sowel:<version>` et `:latest`
+
+Cette page résume toutes les versions publiées, de la plus récente à la plus ancienne. Pour le diff complet entre deux versions : `https://github.com/mchacher/sowel/compare/v<a>...v<b>`.
+
+**Mettre à jour une instance en cours.** Sowel interroge GitHub toutes les heures et fait apparaître la mise à jour disponible dans la barre supérieure. Un clic sur la pastille ouvre la feuille des mises à jour et applique la nouvelle version en un clic (ajouté en v1.9.0). En ligne de commande : `cd /opt/sowel && docker compose pull && docker compose up -d`.
+
+---
+
+## 1.9.x — Pastille de mise à jour actionnable
+
+### v1.9.0 — 2026-05-17
+
+- La pastille de mise à jour de la barre supérieure ouvre désormais une feuille `UpdatesSheet` listant le cœur Sowel et les plugins obsolètes, avec un bouton `Mettre à jour` par ligne (spec 106). Remplace l'ancienne redirection aveugle vers `/plugins`, qui laissait les mises à jour du cœur invisibles.
+
+---
+
+## 1.8.x — Graphiques et flux d'activité
+
+### v1.8.1 — 2026-05-17
+
+- Les graphiques temporels utilisent désormais une échelle de temps linéaire sur l'axe X. Les données détection / contact / météo éparse ne sont plus comprimées visuellement quand les événements sont groupés dans le temps.
+
+### v1.8.0 — 2026-05-16
+
+- Nouveau flux d'activité dans la vue zone (spec 101). Affiche les événements des dernières 24 h avec un plafond adaptatif (10 sur mobile, 100 sur desktop), filtré par catégorie de liaison et limité à la zone courante.
+
+---
+
+## 1.7.x — Durcissement WAN
+
+### v1.7.0 — 2026-05-15
+
+- Durcissement WAN (spec 105) : CSP et vérification d'origine WebSocket renforcés pour une exposition publique sûre via tunnel Cloudflare. Google Fonts autorisé pour la police Nunito. Socket Docker accessible à l'utilisateur non-root `sowel`.
+- CI : runner GitHub ARM64 natif avec builds parallèles — le temps de release multi-arch passe d'environ 15 min à 3 min.
+
+---
+
+## 1.6.x — Design system et chaîne d'approvisionnement plugins
+
+### v1.6.6 — 2026-05-15
+
+- L'assistant de configuration déclenche automatiquement le redémarrage après validation ; séparateur décimal unifié pour les champs latitude/longitude.
+- CI : politique de rétention GHCR — les anciennes versions de conteneurs sont automatiquement purgées à chaque release.
+
+### v1.6.5 — 2026-05-15
+
+- Assistant de configuration Maison au premier login. Le helper de redémarrage passe désormais `--force-recreate` pour réellement redémarrer.
+
+### v1.6.4 — 2026-05-15
+
+- L'installation de plugin ne refuse plus que les liens symboliques _qui sortent du paquet_ ; les liens internes sont autorisés (spec 089 C1).
+
+### v1.6.3 — 2026-05-14
+
+- L'auto-mise à jour normalise le fichier compose vers `:latest`, force la recréation du conteneur et vérifie la nouvelle version (spec 104).
+- CI : création de la release GitHub conditionnée à la réussite du build ARM64.
+
+### v1.6.2 — 2026-05-14
+
+- Durcissement de la chaîne d'approvisionnement plugins (spec 089 C1+C2) : hashes SHA256 figés dans le registre, confirmation d'installation pour le namespace communautaire, confinement du chemin de restauration, liste blanche d'extensions, refus des liens symboliques, plafond de taille.
+
+### v1.6.1 — 2026-05-14
+
+- Correction du build Docker — le répertoire `design-system/` est désormais copié dans l'étape de build UI.
+
+### v1.6.0 — 2026-05-14
+
+- Refonte UI majeure pour parité avec le design system (specs 094–100) :
+  - Nouvelle palette et nouveaux tokens du design system
+  - Sidebar refactorisée en composants réutilisables
+  - Vue zone en 2 colonnes sur desktop avec bande d'agrégation et pills variantes
+  - Toolbar de commandes zone icon-only
+  - Chrome unifié pour les widgets du tableau de bord
+  - Typographie polie (letter-spacing, standardisation H1, tabular nums par défaut)
+  - Refactor du chrome des lignes d'équipement avec halo lumineux
+  - Alignement strict avec la maquette sur les panneaux de zone, parité mobile
+- Installateur en une commande (`install.sh`) ajouté.
+
+---
+
+## 1.5.x — Extension énergie et recettes
+
+### v1.5.10 — 2026-05-10
+
+- Revert interne sur la documentation.
+
+### v1.5.9 — 2026-05-09
+
+- Sélecteur de recettes réécrit en popover compacte (latéral sur desktop, bottom-sheet sur mobile). Palette pastel et coins arrondis sur le graphique énergie par usage.
+
+### v1.5.8 — 2026-05-08
+
+- Nouvelle recette `state-trigger-light` (spec 092). Les slots de recette gagnent les contraintes `crossZone` et `includeDescendants`, ainsi qu'un sélecteur "zone d'abord" pour les slots équipement unique.
+
+### v1.5.7 — 2026-05-08
+
+- Sous-compteurs en puissance uniquement et graphique de répartition énergie par usage (spec 091). Cumul Wh des sous-compteurs exposé comme donnée calculée sur l'équipement.
+
+### v1.5.6 — 2026-05-03
+
+- Toggle activer/désactiver par mapping sur les publications MQTT (spec 090).
+
+### v1.5.5 — 2026-05-03
+
+- Hot-load plugin : invalidation du cache pour les imports transitifs.
+
+### v1.5.4 — 2026-05-03
+
+- API plugin : getter `getDeviceDataLastUpdated` exposé ; bump du registre `shelly_mqtt`.
+
+### v1.5.3 — 2026-05-03
+
+- La requête de production énergie retombe sur le bucket horaire quand le bucket raw manque. Le tooltip de consommation sépare HP/HC entre réseau pur et autoconsommation.
+
+### v1.5.2 — 2026-05-03
+
+- Pastilles compactes en barre supérieure remplacent la bannière d'alarme et le warning d'intégration. Le statut énergie live se sépare selon la source dominante. Le dechargement plugin appelle toujours `stop()`.
+
+### v1.5.1 — 2026-05-03
+
+- Writer d'autoconsommation (spec 086 étapes E+F), plus corrections de bugs sur l'agrégateur et l'historique. Nouveau getter `getDeviceDataValue` pour l'hydratation des plugins.
+
+### v1.5.0 — 2026-05-02
+
+- Page de flux de puissance en direct (`/energy/live`) avec auto-détection des sources. Plugin Shelly MQTT ajouté au registre. Outil de migration de l'historique pour les équipements orphelins.
+
+---
+
+## 1.4.x — Pompe à chaleur piscine
+
+### v1.4.2 — 2026-05-01
+
+- Le tableau de bord mobile affiche la pompe à chaleur piscine comme un thermostat. Les intégrations désactivées restent visibles sur la page Intégrations. Toggle activer/désactiver directement sur la ligne.
+
+### v1.4.1 — 2026-05-01
+
+- Toggle persistant Activer/Désactiver sur le drawer d'intégration. Les anciennes images `ghcr.io/mchacher/sowel` sont purgées automatiquement après auto-mise à jour.
+
+### v1.4.0 — 2026-05-01
+
+- Nouveau type d'équipement `pool_heat_pump` et scaffolding du plugin Modbus associé.
+
+---
+
+## 1.3.x — Équipements piscine
+
+### v1.3.2 — 2026-04-19
+
+- La logique de rappel d'alarme passe dans le publisher de notification Telegram (spec 083). Remplissages adaptatifs au thème pour l'icône de pompe piscine (dark mode). Pill Ouvert/Fermé sur les cartes compactes de volets et de couverture piscine.
+
+### v1.3.1 — 2026-04-19
+
+- Mise en page des slots de recette : colonnes de largeur égale pour les paires homogènes.
+
+### v1.3.0 — 2026-04-19
+
+- Nouveaux types d'équipement `pool_pump` et `pool_cover` (spec 081), avec contrôles inline dans la vue zone compacte et un sélecteur de canal dédié côté device. Les appareils multi-canaux peuvent désormais alimenter plusieurs équipements. Le registre plugins peut être rechargé à la demande depuis l'UI.
+
+---
+
+## 1.2.x — Dispatch équipement v2 et catégories de domaine
+
+### v1.2.15 — 2026-04-19
+
+- Plugin Tasmota enregistré en v1.0.0 (spec 080). Le `install()` plugin redirige vers `update()` en cas de réinstallation.
+
+### v1.2.14 — 2026-04-18
+
+- Les devices stockent les valeurs enum ; l'UI surface les valeurs d'action dynamiquement (spec 079). Nouveau type d'effet bouton `zone_order` avec sélection équipement "zone d'abord" (spec 078).
+
+### v1.2.13 — 2026-04-18
+
+- Refactor : `dispatchConfig`, `apiVersion`, fallback brute-force supprimés (spec 074). Le dispatch v2 est désormais l'unique chemin.
+
+### v1.2.12 — 2026-04-18
+
+- Catégories de commande pour la résolution des ordres de zone (spec 077). Nouvelles catégories température/humidité extérieures et mise à jour du plugin `netatmo-weather` (spec 076).
+
+### v1.2.11 — 2026-04-18
+
+- Nouvelles catégories de domaine pour `media_player`, `appliance` et `thermostat` (spec 073).
+
+### v1.2.10 — 2026-04-18
+
+- L'ordre de zone sur thermostat passe par la catégorie de consigne (spec 070).
+
+### v1.2.9 — 2026-04-18
+
+- Les ordres de zone résolvent les alias par catégorie au lieu de noms en dur (spec 069).
+
+### v1.2.8 — 2026-04-18
+
+- Dispatch d'ordres v2 — les plugins reçoivent directement `orderKey` au lieu d'un blob `dispatchConfig` (spec 067).
+
+### v1.2.7 — 2026-04-15
+
+- Les ordres de zone volet utilisent l'état OPEN/CLOSE au lieu d'une position.
+
+### v1.2.6 — 2026-04-12
+
+- Nouvelle option `onChangeOnly` sur les publications MQTT.
+
+### v1.2.5 — 2026-04-12
+
+- Restauration du snapshot à chaque reconnexion — revert du changement de v1.2.4 après effets de bord.
+
+### v1.2.4 — 2026-04-12
+
+- Les publications MQTT ne bouclent plus sur snapshot à la reconnexion du broker ; republication au changement de mapping.
+
+### v1.2.3 — 2026-04-12
+
+- Suppression du verrou par fichier PID — il causait une boucle de crash Docker au redémarrage du conteneur.
+
+### v1.2.2 — 2026-04-12
+
+- Nettoyage interne.
+
+### v1.2.1 — 2026-04-12
+
+- Le helper d'auto-mise à jour préserve le `working_dir` compose de l'hôte.
+
+### v1.2.0 — 2026-04-12
+
+- Registre plugins découplé de la cadence de release de Sowel + champ de compatibilité `sowelVersion` (spec 066).
+
+---
+
+## 1.1.x — Eau et freecooling
+
+### v1.1.7 — 2026-04-12
+
+- Les badges et boutons de mise à jour utilisent désormais le rouge au lieu de l'ambre.
+
+### v1.1.6 — 2026-04-12
+
+- Nettoyage interne.
+
+### v1.1.5 — 2026-04-12
+
+- Le helper d'auto-mise à jour conserve `AutoRemove` désactivé temporairement pour le debug.
+
+### v1.1.4 — 2026-04-12
+
+- Nettoyage interne.
+
+### v1.1.3 — 2026-04-12
+
+- L'auto-mise à jour pull par tag de version au lieu de `:latest` (évite la course avec des releases concurrentes).
+
+### v1.1.2 — 2026-04-12
+
+- Nouvelle recette freecooling — ferme les volets avant le lever du soleil (spec 065).
+
+### v1.1.1 — 2026-04-12
+
+- Les paquets recette peuvent s'installer et se mettre à jour à chaud sans redémarrage du moteur.
+
+### v1.1.0 — 2026-04-12
+
+- Nouveau type d'équipement `water_valve` (spec 062) et recette d'arrosage automatique (spec 063).
+- Données météo calculées : pluie-1h / pluie-24h plus graphiques à barres cumulatifs (spec 064).
+- Le fuseau horaire est désormais auto-dérivé de la localisation du domicile (spec 061), avec un fallback sûr quand la table settings manque sur une installation fraîche.
+- Polish UX recettes, secondes sur l'horloge, auto-démarrage des plugins après install/update.
+
+---
+
+## 1.0.x — Premières versions
+
+### v1.0.8 — 2026-04-11
+
+- Nettoyage interne.
+
+### v1.0.7 — 2026-04-11
+
+- Pattern de conteneur helper pour l'auto-mise à jour + améliorations de détection (spec 060).
+
+### v1.0.6 — 2026-04-11
+
+- Nettoyage interne.
+
+### v1.0.5 — 2026-04-06
+
+- Registre plugins distant, récupéré au runtime avec fallback local (spec 059).
+- Image Docker passée à Debian Trixie pour Python 3.13+ (compatibilité bridge Panasonic Comfort Cloud).
+- CI : build `amd64` uniquement à ce stade (~5 min vs ~15 min) ; l'ARM64 reviendra plus tard.
+- Comparaison semver-aware pour les mises à jour de plugins.
+
+### v1.0.4 — 2026-04-06
+
+- Nettoyage interne.
+
+### v1.0.3 — 2026-04-06
+
+- L'export line-protocol du backup gère les valeurs non-string d'InfluxDB. La restauration vide `recipe_log` pour éviter les FK orphelines. L'image Docker runtime conserve `python3` pour le bridge Panasonic Comfort Cloud.
+
+### v1.0.2 — 2026-04-06
+
+- Le backup inclut désormais `refresh_tokens` pour qu'une instance restaurée garde les utilisateurs connectés.
+
+### v1.0.1 — 2026-04-06
+
+- Le `PRAGMA foreign_keys` du backup est déplacé hors de la transaction SQLite (il n'avait aucun effet à l'intérieur).
+
+### v1.0.0 — 2026-04-06
+
+- Première version versionnée. Ajoute le versioning `package.json`, le Dockerfile, le pipeline GitHub Actions de release et le `docker-compose.yml` de référence (spec 055). Tout ce qui précède ne vit que dans l'historique git pré-release.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,312 @@
+# Release notes
+
+Sowel has been versioned and shipped through CI/CD since `v1.0.0` (April 2026, spec 055). Every release is published as:
+
+- A signed GitHub release with a generated changelog — [github.com/mchacher/sowel/releases](https://github.com/mchacher/sowel/releases)
+- A multi-arch Docker image tagged `ghcr.io/mchacher/sowel:<version>` and `:latest`
+
+This page summarises every published version, newest first. For the full diff between two versions use `https://github.com/mchacher/sowel/compare/v<a>...v<b>`.
+
+**Updating a running instance.** Sowel polls GitHub every hour and surfaces the available update in the topbar. Click the pill to open the updates sheet and apply the new version in one click (added in v1.9.0). On the command line: `cd /opt/sowel && docker compose pull && docker compose up -d`.
+
+---
+
+## 1.9.x — Actionable updates pill
+
+### v1.9.0 — 2026-05-17
+
+- Topbar updates pill now opens an `UpdatesSheet` listing Sowel core + outdated plugins, with a one-click `Update` button per row (spec 106). Replaces the old blind redirect to `/plugins`, which left core updates invisible.
+
+---
+
+## 1.8.x — Charts & activity feed
+
+### v1.8.1 — 2026-05-17
+
+- Time-series charts now use a linear time scale on the X axis. Motion / contact / sparse weather data is no longer visually compressed when events are bunched in time.
+
+### v1.8.0 — 2026-05-16
+
+- New activity feed in zone view (spec 101). Shows the last 24 h of events with a responsive cap (10 on mobile, 100 on desktop), filtered by binding category and scoped to the current zone.
+
+---
+
+## 1.7.x — WAN hardening
+
+### v1.7.0 — 2026-05-15
+
+- WAN hardening (spec 105): CSP and WebSocket Origin check tightened for safe public exposure behind a Cloudflare tunnel. Google Fonts allow-listed for the Nunito heading font. Docker socket accessible to the non-root `sowel` user.
+- CI: native ARM64 GitHub runner with parallel builds — multi-arch release time dropped from ~15 min to ~3 min.
+
+---
+
+## 1.6.x — Design system + plugin supply chain
+
+### v1.6.6 — 2026-05-15
+
+- Setup wizard auto-triggers the restart after submit; unified decimal separator for latitude/longitude inputs.
+- CI: GHCR retention policy — old container versions auto-pruned on each release.
+
+### v1.6.5 — 2026-05-15
+
+- First-login Home setup wizard. Restart helper now passes `--force-recreate` so it actually restarts.
+
+### v1.6.4 — 2026-05-15
+
+- Plugin install only refuses _escaping_ symlinks now; internal symlinks are allowed (spec 089 C1).
+
+### v1.6.3 — 2026-05-14
+
+- Self-update normalises the compose file to `:latest`, force-recreates the container, and verifies the new version (spec 104).
+- CI: GitHub Release creation gated behind successful ARM64 build.
+
+### v1.6.2 — 2026-05-14
+
+- Plugin supply chain hardening (spec 089 C1+C2): SHA256 hashes pinned in the registry, community-namespace install confirmation, restore path confinement, extension whitelist, symlink refusal, size cap.
+
+### v1.6.1 — 2026-05-14
+
+- Docker build fix — `design-system/` is now copied into the UI build stage.
+
+### v1.6.0 — 2026-05-14
+
+- Major UI overhaul to design-system parity (specs 094–100):
+  - New design-system palette and tokens
+  - Sidebar refactored into reusable components
+  - Zone view 2-column layout on desktop with cluster aggregation strip and variant pills
+  - Icon-only zone command toolbar
+  - Dashboard widget chrome unified
+  - Typography polish (letter-spacing, H1 standardisation, tabular nums by default)
+  - Equipment row chrome refactor and light-on glow
+  - Strict mock alignment on zone panels, mobile parity with mockup
+- One-command installer (`install.sh`) added.
+
+---
+
+## 1.5.x — Energy & recipes expansion
+
+### v1.5.10 — 2026-05-10
+
+- Internal docs revert.
+
+### v1.5.9 — 2026-05-09
+
+- Recipe picker rewritten as a compact popover (side-positioned on desktop, bottom sheet on mobile). Pastel palette + rounded corners on the by-usage energy chart.
+
+### v1.5.8 — 2026-05-08
+
+- New `state-trigger-light` recipe (spec 092). Recipe slots gain `crossZone` and `includeDescendants` constraints, plus a zone-first picker for single-equipment slots.
+
+### v1.5.7 — 2026-05-08
+
+- Power-only submeters and a by-usage energy breakdown chart (spec 091). Submeter cumulative Wh exposed as computed equipment data.
+
+### v1.5.6 — 2026-05-03
+
+- Per-mapping enable/disable toggle on MQTT publishers (spec 090).
+
+### v1.5.5 — 2026-05-03
+
+- Plugin hot-load: transitive imports cache-busted.
+
+### v1.5.4 — 2026-05-03
+
+- Plugin API: `getDeviceDataLastUpdated` getter exposed; `shelly_mqtt` registry bump.
+
+### v1.5.3 — 2026-05-03
+
+- Energy production query falls back to the hourly bucket when raw is missing. Consumption tooltip splits HP/HC into grid-only + autoconsumption.
+
+### v1.5.2 — 2026-05-03
+
+- Compact header pills replace the alarm banner and integration warning. Live-energy status splits by which source dominates the supply. Plugin unload always calls `stop()`.
+
+### v1.5.1 — 2026-05-03
+
+- Self-consumption writer (spec 086 steps E+F), plus aggregator/history bug fixes. New `getDeviceDataValue` getter for plugin baseline hydration.
+
+### v1.5.0 — 2026-05-02
+
+- Live power-flow page (`/energy/live`) with auto-detection of sources. Shelly MQTT plugin added to the registry. History migration tool for orphaned equipments.
+
+---
+
+## 1.4.x — Pool heat pump
+
+### v1.4.2 — 2026-05-01
+
+- Mobile dashboard renders pool heat pump like a thermostat. Disabled integrations stay visible on the Integrations page. Enable/disable toggle surfaced directly on the row.
+
+### v1.4.1 — 2026-05-01
+
+- Persistent Disable/Enable toggle on the integration drawer. Old `ghcr.io/mchacher/sowel` images auto-pruned after self-update.
+
+### v1.4.0 — 2026-05-01
+
+- New `pool_heat_pump` equipment type plus the Modbus plugin scaffolding it relies on.
+
+---
+
+## 1.3.x — Pool equipments
+
+### v1.3.2 — 2026-04-19
+
+- Alarm reminder logic moved into the Telegram notification publisher (spec 083). Theme-aware fills for the pool pump icon (dark mode). Open/Closed pill in compact shutter and pool cover cards.
+
+### v1.3.1 — 2026-04-19
+
+- Recipe slot layout: equal-width columns for homogeneous pairs.
+
+### v1.3.0 — 2026-04-19
+
+- New `pool_pump` and `pool_cover` equipment types (spec 081), with inline controls in the compact zone view and a dedicated channel picker on the device side. Multi-channel devices can now back multiple equipments. Plugin registry can be reloaded on demand from the UI.
+
+---
+
+## 1.2.x — Equipment dispatch v2 + domain categories
+
+### v1.2.15 — 2026-04-19
+
+- Tasmota plugin registered v1.0.0 (spec 080). Plugin `install()` redirects to `update()` on reinstall.
+
+### v1.2.14 — 2026-04-18
+
+- Devices store enum values; UI surfaces dynamic action values (spec 079). New `zone_order` button effect type with zone-first equipment selection (spec 078).
+
+### v1.2.13 — 2026-04-18
+
+- Refactor: `dispatchConfig`, `apiVersion`, brute-force fallback removed (spec 074). v2 dispatch is now the only path.
+
+### v1.2.12 — 2026-04-18
+
+- Order categories for zone-order resolution (spec 077). New outdoor temperature/humidity categories and updated `netatmo-weather` plugin (spec 076).
+
+### v1.2.11 — 2026-04-18
+
+- New domain categories for `media_player`, `appliance`, and `thermostat` (spec 073).
+
+### v1.2.10 — 2026-04-18
+
+- Thermostat zone order resolves through the setpoint category (spec 070).
+
+### v1.2.9 — 2026-04-18
+
+- Zone orders resolve aliases by category instead of hardcoded names (spec 069).
+
+### v1.2.8 — 2026-04-18
+
+- Order dispatch v2 — plugins receive `orderKey` directly instead of a `dispatchConfig` blob (spec 067).
+
+### v1.2.7 — 2026-04-15
+
+- Shutter zone orders use the OPEN/CLOSE state instead of a position.
+
+### v1.2.6 — 2026-04-12
+
+- New `onChangeOnly` option on MQTT publishers.
+
+### v1.2.5 — 2026-04-12
+
+- Restore snapshot on every reconnect — reverts the v1.2.4 change after side effects.
+
+### v1.2.4 — 2026-04-12
+
+- MQTT publishers no longer loop on snapshot when the broker reconnects; re-publish on mapping change.
+
+### v1.2.3 — 2026-04-12
+
+- Removed the PID file lock — it caused a Docker crash loop on container restart.
+
+### v1.2.2 — 2026-04-12
+
+- Internal cleanup.
+
+### v1.2.1 — 2026-04-12
+
+- Self-update helper container preserves the host compose `working_dir`.
+
+### v1.2.0 — 2026-04-12
+
+- Plugin registry decoupled from the Sowel release cadence + `sowelVersion` compatibility field (spec 066).
+
+---
+
+## 1.1.x — Water + freecooling
+
+### v1.1.7 — 2026-04-12
+
+- Update badges and buttons now use red instead of amber.
+
+### v1.1.6 — 2026-04-12
+
+- Internal cleanup.
+
+### v1.1.5 — 2026-04-12
+
+- Self-update helper container keeps `AutoRemove` off temporarily for debugging.
+
+### v1.1.4 — 2026-04-12
+
+- Internal cleanup.
+
+### v1.1.3 — 2026-04-12
+
+- Self-update pulls by version tag instead of `:latest` (avoids racing with concurrent releases).
+
+### v1.1.2 — 2026-04-12
+
+- New freecooling recipe — closes shutters before sunrise (spec 065).
+
+### v1.1.1 — 2026-04-12
+
+- Recipe packages can hot-install and hot-update without engine restart.
+
+### v1.1.0 — 2026-04-12
+
+- New `water_valve` equipment type (spec 062) and auto-watering recipe (spec 063).
+- Computed weather data: rain-1h / rain-24h plus cumulative bar charts (spec 064).
+- Timezone is now auto-derived from the home location (spec 061), with a safe fallback when the settings table is missing on a fresh install.
+- Recipe UX polish, clock seconds, plugin auto-start after install/update.
+
+---
+
+## 1.0.x — First versioned releases
+
+### v1.0.8 — 2026-04-11
+
+- Internal cleanup.
+
+### v1.0.7 — 2026-04-11
+
+- Self-update helper container pattern + detection improvements (spec 060).
+
+### v1.0.6 — 2026-04-11
+
+- Internal cleanup.
+
+### v1.0.5 — 2026-04-06
+
+- Remote plugin registry, fetched at runtime with local fallback (spec 059).
+- Docker base image switched to Debian Trixie for Python 3.13+ (Panasonic Comfort Cloud bridge compatibility).
+- CI builds `amd64` only at this stage (~5 min vs ~15 min), with ARM64 added back later.
+- Semver-aware comparison for plugin updates.
+
+### v1.0.4 — 2026-04-06
+
+- Internal cleanup.
+
+### v1.0.3 — 2026-04-06
+
+- Backup line-protocol export handles non-string InfluxDB values. Restore clears `recipe_log` to avoid orphan FK refs. Docker runtime keeps `python3` for the Panasonic Comfort Cloud plugin bridge.
+
+### v1.0.2 — 2026-04-06
+
+- Backup now includes `refresh_tokens` so a restored instance keeps users logged in.
+
+### v1.0.1 — 2026-04-06
+
+- Backup `PRAGMA foreign_keys` moved outside the SQLite transaction (it had no effect inside).
+
+### v1.0.0 — 2026-04-06
+
+- First versioned release. Adds `package.json` versioning, the Dockerfile, the GitHub Actions release pipeline, and the reference `docker-compose.yml` (spec 055). Everything before this point lives in pre-release git history only.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ plugins:
             Recipes: Recettes
             Energy Monitoring: Suivi énergétique
             Remote Access: Accès distant
+            Release Notes: Notes de version
 
 nav:
   - Home: index.md
@@ -128,6 +129,7 @@ nav:
     - Recipes: user/recipes.md
     - Energy Monitoring: user/energy.md
     - Remote Access: user/remote-access.md
+  - Release Notes: release-notes.md
 
 extra:
   alternate:


### PR DESCRIPTION
## Summary

Adds a new top-level **Release Notes** page on docs.sowel.org reconstructing every published version since `v1.0.0` (April 2026, spec 055). 61 versions grouped by minor with per-patch notes, spec references, and a one-line "how to update" tip pointing at v1.9.0's new sheet.

## Changes

- `docs/release-notes.md` — EN, 312 lines
- `docs/release-notes.fr.md` — FR, 312 lines
- `mkdocs.yml` — entry added to both nav and FR nav_translations

## Test plan

- [x] `mkdocs build --strict` — exit 0, both `site/release-notes/` and `site/fr/release-notes/` generated
- [x] Spot-checked the admonition workaround: prettier strips the 4-space indent on `!!! tip`, so the intro line is a regular **bold** paragraph instead (matches `docs/user/devices.md` style, no rendering bug)
- [ ] Visual check on docs.sowel.org after deploy