### PR TITLE
feat(ui): per-row changelog link in UpdatesSheet (spec 107)

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,7 +13,7 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.9.x — Pastille de mise à jour actionnable
 
-### v1.9.0 — 2026-05-17
+### v1.9.0 — 2026-05-17 { #v1-9-0 }
 
 - La pastille de mise à jour de la barre supérieure ouvre désormais une feuille `UpdatesSheet` listant le cœur Sowel et les plugins obsolètes, avec un bouton `Mettre à jour` par ligne (spec 106). Remplace l'ancienne redirection aveugle vers `/plugins`, qui laissait les mises à jour du cœur invisibles.
 
@@ -21,11 +21,11 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.8.x — Graphiques et flux d'activité
 
-### v1.8.1 — 2026-05-17
+### v1.8.1 — 2026-05-17 { #v1-8-1 }
 
 - Les graphiques temporels utilisent désormais une échelle de temps linéaire sur l'axe X. Les données détection / contact / météo éparse ne sont plus comprimées visuellement quand les événements sont groupés dans le temps.
 
-### v1.8.0 — 2026-05-16
+### v1.8.0 — 2026-05-16 { #v1-8-0 }
 
 - Nouveau flux d'activité dans la vue zone (spec 101). Affiche les événements des dernières 24 h avec un plafond adaptatif (10 sur mobile, 100 sur desktop), filtré par catégorie de liaison et limité à la zone courante.
 
@@ -33,7 +33,7 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.7.x — Durcissement WAN
 
-### v1.7.0 — 2026-05-15
+### v1.7.0 — 2026-05-15 { #v1-7-0 }
 
 - Durcissement WAN (spec 105) : CSP et vérification d'origine WebSocket renforcés pour une exposition publique sûre via tunnel Cloudflare. Google Fonts autorisé pour la police Nunito. Socket Docker accessible à l'utilisateur non-root `sowel`.
 - CI : runner GitHub ARM64 natif avec builds parallèles — le temps de release multi-arch passe d'environ 15 min à 3 min.
@@ -42,33 +42,33 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.6.x — Design system et chaîne d'approvisionnement plugins
 
-### v1.6.6 — 2026-05-15
+### v1.6.6 — 2026-05-15 { #v1-6-6 }
 
 - L'assistant de configuration déclenche automatiquement le redémarrage après validation ; séparateur décimal unifié pour les champs latitude/longitude.
 - CI : politique de rétention GHCR — les anciennes versions de conteneurs sont automatiquement purgées à chaque release.
 
-### v1.6.5 — 2026-05-15
+### v1.6.5 — 2026-05-15 { #v1-6-5 }
 
 - Assistant de configuration Maison au premier login. Le helper de redémarrage passe désormais `--force-recreate` pour réellement redémarrer.
 
-### v1.6.4 — 2026-05-15
+### v1.6.4 — 2026-05-15 { #v1-6-4 }
 
 - L'installation de plugin ne refuse plus que les liens symboliques _qui sortent du paquet_ ; les liens internes sont autorisés (spec 089 C1).
 
-### v1.6.3 — 2026-05-14
+### v1.6.3 — 2026-05-14 { #v1-6-3 }
 
 - L'auto-mise à jour normalise le fichier compose vers `:latest`, force la recréation du conteneur et vérifie la nouvelle version (spec 104).
 - CI : création de la release GitHub conditionnée à la réussite du build ARM64.
 
-### v1.6.2 — 2026-05-14
+### v1.6.2 — 2026-05-14 { #v1-6-2 }
 
 - Durcissement de la chaîne d'approvisionnement plugins (spec 089 C1+C2) : hashes SHA256 figés dans le registre, confirmation d'installation pour le namespace communautaire, confinement du chemin de restauration, liste blanche d'extensions, refus des liens symboliques, plafond de taille.
 
-### v1.6.1 — 2026-05-14
+### v1.6.1 — 2026-05-14 { #v1-6-1 }
 
 - Correction du build Docker — le répertoire `design-system/` est désormais copié dans l'étape de build UI.
 
-### v1.6.0 — 2026-05-14
+### v1.6.0 — 2026-05-14 { #v1-6-0 }
 
 - Refonte UI majeure pour parité avec le design system (specs 094–100) :
   - Nouvelle palette et nouveaux tokens du design system
@@ -85,47 +85,47 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.5.x — Extension énergie et recettes
 
-### v1.5.10 — 2026-05-10
+### v1.5.10 — 2026-05-10 { #v1-5-10 }
 
 - Revert interne sur la documentation.
 
-### v1.5.9 — 2026-05-09
+### v1.5.9 — 2026-05-09 { #v1-5-9 }
 
 - Sélecteur de recettes réécrit en popover compacte (latéral sur desktop, bottom-sheet sur mobile). Palette pastel et coins arrondis sur le graphique énergie par usage.
 
-### v1.5.8 — 2026-05-08
+### v1.5.8 — 2026-05-08 { #v1-5-8 }
 
 - Nouvelle recette `state-trigger-light` (spec 092). Les slots de recette gagnent les contraintes `crossZone` et `includeDescendants`, ainsi qu'un sélecteur "zone d'abord" pour les slots équipement unique.
 
-### v1.5.7 — 2026-05-08
+### v1.5.7 — 2026-05-08 { #v1-5-7 }
 
 - Sous-compteurs en puissance uniquement et graphique de répartition énergie par usage (spec 091). Cumul Wh des sous-compteurs exposé comme donnée calculée sur l'équipement.
 
-### v1.5.6 — 2026-05-03
+### v1.5.6 — 2026-05-03 { #v1-5-6 }
 
 - Toggle activer/désactiver par mapping sur les publications MQTT (spec 090).
 
-### v1.5.5 — 2026-05-03
+### v1.5.5 — 2026-05-03 { #v1-5-5 }
 
 - Hot-load plugin : invalidation du cache pour les imports transitifs.
 
-### v1.5.4 — 2026-05-03
+### v1.5.4 — 2026-05-03 { #v1-5-4 }
 
 - API plugin : getter `getDeviceDataLastUpdated` exposé ; bump du registre `shelly_mqtt`.
 
-### v1.5.3 — 2026-05-03
+### v1.5.3 — 2026-05-03 { #v1-5-3 }
 
 - La requête de production énergie retombe sur le bucket horaire quand le bucket raw manque. Le tooltip de consommation sépare HP/HC entre réseau pur et autoconsommation.
 
-### v1.5.2 — 2026-05-03
+### v1.5.2 — 2026-05-03 { #v1-5-2 }
 
 - Pastilles compactes en barre supérieure remplacent la bannière d'alarme et le warning d'intégration. Le statut énergie live se sépare selon la source dominante. Le dechargement plugin appelle toujours `stop()`.
 
-### v1.5.1 — 2026-05-03
+### v1.5.1 — 2026-05-03 { #v1-5-1 }
 
 - Writer d'autoconsommation (spec 086 étapes E+F), plus corrections de bugs sur l'agrégateur et l'historique. Nouveau getter `getDeviceDataValue` pour l'hydratation des plugins.
 
-### v1.5.0 — 2026-05-02
+### v1.5.0 — 2026-05-02 { #v1-5-0 }
 
 - Page de flux de puissance en direct (`/energy/live`) avec auto-détection des sources. Plugin Shelly MQTT ajouté au registre. Outil de migration de l'historique pour les équipements orphelins.
 
@@ -133,15 +133,15 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.4.x — Pompe à chaleur piscine
 
-### v1.4.2 — 2026-05-01
+### v1.4.2 — 2026-05-01 { #v1-4-2 }
 
 - Le tableau de bord mobile affiche la pompe à chaleur piscine comme un thermostat. Les intégrations désactivées restent visibles sur la page Intégrations. Toggle activer/désactiver directement sur la ligne.
 
-### v1.4.1 — 2026-05-01
+### v1.4.1 — 2026-05-01 { #v1-4-1 }
 
 - Toggle persistant Activer/Désactiver sur le drawer d'intégration. Les anciennes images `ghcr.io/mchacher/sowel` sont purgées automatiquement après auto-mise à jour.
 
-### v1.4.0 — 2026-05-01
+### v1.4.0 — 2026-05-01 { #v1-4-0 }
 
 - Nouveau type d'équipement `pool_heat_pump` et scaffolding du plugin Modbus associé.
 
@@ -149,15 +149,15 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.3.x — Équipements piscine
 
-### v1.3.2 — 2026-04-19
+### v1.3.2 — 2026-04-19 { #v1-3-2 }
 
 - La logique de rappel d'alarme passe dans le publisher de notification Telegram (spec 083). Remplissages adaptatifs au thème pour l'icône de pompe piscine (dark mode). Pill Ouvert/Fermé sur les cartes compactes de volets et de couverture piscine.
 
-### v1.3.1 — 2026-04-19
+### v1.3.1 — 2026-04-19 { #v1-3-1 }
 
 - Mise en page des slots de recette : colonnes de largeur égale pour les paires homogènes.
 
-### v1.3.0 — 2026-04-19
+### v1.3.0 — 2026-04-19 { #v1-3-0 }
 
 - Nouveaux types d'équipement `pool_pump` et `pool_cover` (spec 081), avec contrôles inline dans la vue zone compacte et un sélecteur de canal dédié côté device. Les appareils multi-canaux peuvent désormais alimenter plusieurs équipements. Le registre plugins peut être rechargé à la demande depuis l'UI.
 
@@ -165,67 +165,67 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.2.x — Dispatch équipement v2 et catégories de domaine
 
-### v1.2.15 — 2026-04-19
+### v1.2.15 — 2026-04-19 { #v1-2-15 }
 
 - Plugin Tasmota enregistré en v1.0.0 (spec 080). Le `install()` plugin redirige vers `update()` en cas de réinstallation.
 
-### v1.2.14 — 2026-04-18
+### v1.2.14 — 2026-04-18 { #v1-2-14 }
 
 - Les devices stockent les valeurs enum ; l'UI surface les valeurs d'action dynamiquement (spec 079). Nouveau type d'effet bouton `zone_order` avec sélection équipement "zone d'abord" (spec 078).
 
-### v1.2.13 — 2026-04-18
+### v1.2.13 — 2026-04-18 { #v1-2-13 }
 
 - Refactor : `dispatchConfig`, `apiVersion`, fallback brute-force supprimés (spec 074). Le dispatch v2 est désormais l'unique chemin.
 
-### v1.2.12 — 2026-04-18
+### v1.2.12 — 2026-04-18 { #v1-2-12 }
 
 - Catégories de commande pour la résolution des ordres de zone (spec 077). Nouvelles catégories température/humidité extérieures et mise à jour du plugin `netatmo-weather` (spec 076).
 
-### v1.2.11 — 2026-04-18
+### v1.2.11 — 2026-04-18 { #v1-2-11 }
 
 - Nouvelles catégories de domaine pour `media_player`, `appliance` et `thermostat` (spec 073).
 
-### v1.2.10 — 2026-04-18
+### v1.2.10 — 2026-04-18 { #v1-2-10 }
 
 - L'ordre de zone sur thermostat passe par la catégorie de consigne (spec 070).
 
-### v1.2.9 — 2026-04-18
+### v1.2.9 — 2026-04-18 { #v1-2-9 }
 
 - Les ordres de zone résolvent les alias par catégorie au lieu de noms en dur (spec 069).
 
-### v1.2.8 — 2026-04-18
+### v1.2.8 — 2026-04-18 { #v1-2-8 }
 
 - Dispatch d'ordres v2 — les plugins reçoivent directement `orderKey` au lieu d'un blob `dispatchConfig` (spec 067).
 
-### v1.2.7 — 2026-04-15
+### v1.2.7 — 2026-04-15 { #v1-2-7 }
 
 - Les ordres de zone volet utilisent l'état OPEN/CLOSE au lieu d'une position.
 
-### v1.2.6 — 2026-04-12
+### v1.2.6 — 2026-04-12 { #v1-2-6 }
 
 - Nouvelle option `onChangeOnly` sur les publications MQTT.
 
-### v1.2.5 — 2026-04-12
+### v1.2.5 — 2026-04-12 { #v1-2-5 }
 
 - Restauration du snapshot à chaque reconnexion — revert du changement de v1.2.4 après effets de bord.
 
-### v1.2.4 — 2026-04-12
+### v1.2.4 — 2026-04-12 { #v1-2-4 }
 
 - Les publications MQTT ne bouclent plus sur snapshot à la reconnexion du broker ; republication au changement de mapping.
 
-### v1.2.3 — 2026-04-12
+### v1.2.3 — 2026-04-12 { #v1-2-3 }
 
 - Suppression du verrou par fichier PID — il causait une boucle de crash Docker au redémarrage du conteneur.
 
-### v1.2.2 — 2026-04-12
+### v1.2.2 — 2026-04-12 { #v1-2-2 }
 
 - Nettoyage interne.
 
-### v1.2.1 — 2026-04-12
+### v1.2.1 — 2026-04-12 { #v1-2-1 }
 
 - Le helper d'auto-mise à jour préserve le `working_dir` compose de l'hôte.
 
-### v1.2.0 — 2026-04-12
+### v1.2.0 — 2026-04-12 { #v1-2-0 }
 
 - Registre plugins découplé de la cadence de release de Sowel + champ de compatibilité `sowelVersion` (spec 066).
 
@@ -233,35 +233,35 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.1.x — Eau et freecooling
 
-### v1.1.7 — 2026-04-12
+### v1.1.7 — 2026-04-12 { #v1-1-7 }
 
 - Les badges et boutons de mise à jour utilisent désormais le rouge au lieu de l'ambre.
 
-### v1.1.6 — 2026-04-12
+### v1.1.6 — 2026-04-12 { #v1-1-6 }
 
 - Nettoyage interne.
 
-### v1.1.5 — 2026-04-12
+### v1.1.5 — 2026-04-12 { #v1-1-5 }
 
 - Le helper d'auto-mise à jour conserve `AutoRemove` désactivé temporairement pour le debug.
 
-### v1.1.4 — 2026-04-12
+### v1.1.4 — 2026-04-12 { #v1-1-4 }
 
 - Nettoyage interne.
 
-### v1.1.3 — 2026-04-12
+### v1.1.3 — 2026-04-12 { #v1-1-3 }
 
 - L'auto-mise à jour pull par tag de version au lieu de `:latest` (évite la course avec des releases concurrentes).
 
-### v1.1.2 — 2026-04-12
+### v1.1.2 — 2026-04-12 { #v1-1-2 }
 
 - Nouvelle recette freecooling — ferme les volets avant le lever du soleil (spec 065).
 
-### v1.1.1 — 2026-04-12
+### v1.1.1 — 2026-04-12 { #v1-1-1 }
 
 - Les paquets recette peuvent s'installer et se mettre à jour à chaud sans redémarrage du moteur.
 
-### v1.1.0 — 2026-04-12
+### v1.1.0 — 2026-04-12 { #v1-1-0 }
 
 - Nouveau type d'équipement `water_valve` (spec 062) et recette d'arrosage automatique (spec 063).
 - Données météo calculées : pluie-1h / pluie-24h plus graphiques à barres cumulatifs (spec 064).
@@ -272,41 +272,41 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.0.x — Premières versions
 
-### v1.0.8 — 2026-04-11
+### v1.0.8 — 2026-04-11 { #v1-0-8 }
 
 - Nettoyage interne.
 
-### v1.0.7 — 2026-04-11
+### v1.0.7 — 2026-04-11 { #v1-0-7 }
 
 - Pattern de conteneur helper pour l'auto-mise à jour + améliorations de détection (spec 060).
 
-### v1.0.6 — 2026-04-11
+### v1.0.6 — 2026-04-11 { #v1-0-6 }
 
 - Nettoyage interne.
 
-### v1.0.5 — 2026-04-06
+### v1.0.5 — 2026-04-06 { #v1-0-5 }
 
 - Registre plugins distant, récupéré au runtime avec fallback local (spec 059).
 - Image Docker passée à Debian Trixie pour Python 3.13+ (compatibilité bridge Panasonic Comfort Cloud).
 - CI : build `amd64` uniquement à ce stade (~5 min vs ~15 min) ; l'ARM64 reviendra plus tard.
 - Comparaison semver-aware pour les mises à jour de plugins.
 
-### v1.0.4 — 2026-04-06
+### v1.0.4 — 2026-04-06 { #v1-0-4 }
 
 - Nettoyage interne.
 
-### v1.0.3 — 2026-04-06
+### v1.0.3 — 2026-04-06 { #v1-0-3 }
 
 - L'export line-protocol du backup gère les valeurs non-string d'InfluxDB. La restauration vide `recipe_log` pour éviter les FK orphelines. L'image Docker runtime conserve `python3` pour le bridge Panasonic Comfort Cloud.
 
-### v1.0.2 — 2026-04-06
+### v1.0.2 — 2026-04-06 { #v1-0-2 }
 
 - Le backup inclut désormais `refresh_tokens` pour qu'une instance restaurée garde les utilisateurs connectés.
 
-### v1.0.1 — 2026-04-06
+### v1.0.1 — 2026-04-06 { #v1-0-1 }
 
 - Le `PRAGMA foreign_keys` du backup est déplacé hors de la transaction SQLite (il n'avait aucun effet à l'intérieur).
 
-### v1.0.0 — 2026-04-06
+### v1.0.0 — 2026-04-06 { #v1-0-0 }
 
 - Première version versionnée. Ajoute le versioning `package.json`, le Dockerfile, le pipeline GitHub Actions de release et le `docker-compose.yml` de référence (spec 055). Tout ce qui précède ne vit que dans l'historique git pré-release.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,7 +13,7 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.9.x — Actionable updates pill
 
-### v1.9.0 — 2026-05-17
+### v1.9.0 — 2026-05-17 { #v1-9-0 }
 
 - Topbar updates pill now opens an `UpdatesSheet` listing Sowel core + outdated plugins, with a one-click `Update` button per row (spec 106). Replaces the old blind redirect to `/plugins`, which left core updates invisible.
 
@@ -21,11 +21,11 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.8.x — Charts & activity feed
 
-### v1.8.1 — 2026-05-17
+### v1.8.1 — 2026-05-17 { #v1-8-1 }
 
 - Time-series charts now use a linear time scale on the X axis. Motion / contact / sparse weather data is no longer visually compressed when events are bunched in time.
 
-### v1.8.0 — 2026-05-16
+### v1.8.0 — 2026-05-16 { #v1-8-0 }
 
 - New activity feed in zone view (spec 101). Shows the last 24 h of events with a responsive cap (10 on mobile, 100 on desktop), filtered by binding category and scoped to the current zone.
 
@@ -33,7 +33,7 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.7.x — WAN hardening
 
-### v1.7.0 — 2026-05-15
+### v1.7.0 — 2026-05-15 { #v1-7-0 }
 
 - WAN hardening (spec 105): CSP and WebSocket Origin check tightened for safe public exposure behind a Cloudflare tunnel. Google Fonts allow-listed for the Nunito heading font. Docker socket accessible to the non-root `sowel` user.
 - CI: native ARM64 GitHub runner with parallel builds — multi-arch release time dropped from ~15 min to ~3 min.
@@ -42,33 +42,33 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.6.x — Design system + plugin supply chain
 
-### v1.6.6 — 2026-05-15
+### v1.6.6 — 2026-05-15 { #v1-6-6 }
 
 - Setup wizard auto-triggers the restart after submit; unified decimal separator for latitude/longitude inputs.
 - CI: GHCR retention policy — old container versions auto-pruned on each release.
 
-### v1.6.5 — 2026-05-15
+### v1.6.5 — 2026-05-15 { #v1-6-5 }
 
 - First-login Home setup wizard. Restart helper now passes `--force-recreate` so it actually restarts.
 
-### v1.6.4 — 2026-05-15
+### v1.6.4 — 2026-05-15 { #v1-6-4 }
 
 - Plugin install only refuses _escaping_ symlinks now; internal symlinks are allowed (spec 089 C1).
 
-### v1.6.3 — 2026-05-14
+### v1.6.3 — 2026-05-14 { #v1-6-3 }
 
 - Self-update normalises the compose file to `:latest`, force-recreates the container, and verifies the new version (spec 104).
 - CI: GitHub Release creation gated behind successful ARM64 build.
 
-### v1.6.2 — 2026-05-14
+### v1.6.2 — 2026-05-14 { #v1-6-2 }
 
 - Plugin supply chain hardening (spec 089 C1+C2): SHA256 hashes pinned in the registry, community-namespace install confirmation, restore path confinement, extension whitelist, symlink refusal, size cap.
 
-### v1.6.1 — 2026-05-14
+### v1.6.1 — 2026-05-14 { #v1-6-1 }
 
 - Docker build fix — `design-system/` is now copied into the UI build stage.
 
-### v1.6.0 — 2026-05-14
+### v1.6.0 — 2026-05-14 { #v1-6-0 }
 
 - Major UI overhaul to design-system parity (specs 094–100):
   - New design-system palette and tokens
@@ -85,47 +85,47 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.5.x — Energy & recipes expansion
 
-### v1.5.10 — 2026-05-10
+### v1.5.10 — 2026-05-10 { #v1-5-10 }
 
 - Internal docs revert.
 
-### v1.5.9 — 2026-05-09
+### v1.5.9 — 2026-05-09 { #v1-5-9 }
 
 - Recipe picker rewritten as a compact popover (side-positioned on desktop, bottom sheet on mobile). Pastel palette + rounded corners on the by-usage energy chart.
 
-### v1.5.8 — 2026-05-08
+### v1.5.8 — 2026-05-08 { #v1-5-8 }
 
 - New `state-trigger-light` recipe (spec 092). Recipe slots gain `crossZone` and `includeDescendants` constraints, plus a zone-first picker for single-equipment slots.
 
-### v1.5.7 — 2026-05-08
+### v1.5.7 — 2026-05-08 { #v1-5-7 }
 
 - Power-only submeters and a by-usage energy breakdown chart (spec 091). Submeter cumulative Wh exposed as computed equipment data.
 
-### v1.5.6 — 2026-05-03
+### v1.5.6 — 2026-05-03 { #v1-5-6 }
 
 - Per-mapping enable/disable toggle on MQTT publishers (spec 090).
 
-### v1.5.5 — 2026-05-03
+### v1.5.5 — 2026-05-03 { #v1-5-5 }
 
 - Plugin hot-load: transitive imports cache-busted.
 
-### v1.5.4 — 2026-05-03
+### v1.5.4 — 2026-05-03 { #v1-5-4 }
 
 - Plugin API: `getDeviceDataLastUpdated` getter exposed; `shelly_mqtt` registry bump.
 
-### v1.5.3 — 2026-05-03
+### v1.5.3 — 2026-05-03 { #v1-5-3 }
 
 - Energy production query falls back to the hourly bucket when raw is missing. Consumption tooltip splits HP/HC into grid-only + autoconsumption.
 
-### v1.5.2 — 2026-05-03
+### v1.5.2 — 2026-05-03 { #v1-5-2 }
 
 - Compact header pills replace the alarm banner and integration warning. Live-energy status splits by which source dominates the supply. Plugin unload always calls `stop()`.
 
-### v1.5.1 — 2026-05-03
+### v1.5.1 — 2026-05-03 { #v1-5-1 }
 
 - Self-consumption writer (spec 086 steps E+F), plus aggregator/history bug fixes. New `getDeviceDataValue` getter for plugin baseline hydration.
 
-### v1.5.0 — 2026-05-02
+### v1.5.0 — 2026-05-02 { #v1-5-0 }
 
 - Live power-flow page (`/energy/live`) with auto-detection of sources. Shelly MQTT plugin added to the registry. History migration tool for orphaned equipments.
 
@@ -133,15 +133,15 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.4.x — Pool heat pump
 
-### v1.4.2 — 2026-05-01
+### v1.4.2 — 2026-05-01 { #v1-4-2 }
 
 - Mobile dashboard renders pool heat pump like a thermostat. Disabled integrations stay visible on the Integrations page. Enable/disable toggle surfaced directly on the row.
 
-### v1.4.1 — 2026-05-01
+### v1.4.1 — 2026-05-01 { #v1-4-1 }
 
 - Persistent Disable/Enable toggle on the integration drawer. Old `ghcr.io/mchacher/sowel` images auto-pruned after self-update.
 
-### v1.4.0 — 2026-05-01
+### v1.4.0 — 2026-05-01 { #v1-4-0 }
 
 - New `pool_heat_pump` equipment type plus the Modbus plugin scaffolding it relies on.
 
@@ -149,15 +149,15 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.3.x — Pool equipments
 
-### v1.3.2 — 2026-04-19
+### v1.3.2 — 2026-04-19 { #v1-3-2 }
 
 - Alarm reminder logic moved into the Telegram notification publisher (spec 083). Theme-aware fills for the pool pump icon (dark mode). Open/Closed pill in compact shutter and pool cover cards.
 
-### v1.3.1 — 2026-04-19
+### v1.3.1 — 2026-04-19 { #v1-3-1 }
 
 - Recipe slot layout: equal-width columns for homogeneous pairs.
 
-### v1.3.0 — 2026-04-19
+### v1.3.0 — 2026-04-19 { #v1-3-0 }
 
 - New `pool_pump` and `pool_cover` equipment types (spec 081), with inline controls in the compact zone view and a dedicated channel picker on the device side. Multi-channel devices can now back multiple equipments. Plugin registry can be reloaded on demand from the UI.
 
@@ -165,67 +165,67 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.2.x — Equipment dispatch v2 + domain categories
 
-### v1.2.15 — 2026-04-19
+### v1.2.15 — 2026-04-19 { #v1-2-15 }
 
 - Tasmota plugin registered v1.0.0 (spec 080). Plugin `install()` redirects to `update()` on reinstall.
 
-### v1.2.14 — 2026-04-18
+### v1.2.14 — 2026-04-18 { #v1-2-14 }
 
 - Devices store enum values; UI surfaces dynamic action values (spec 079). New `zone_order` button effect type with zone-first equipment selection (spec 078).
 
-### v1.2.13 — 2026-04-18
+### v1.2.13 — 2026-04-18 { #v1-2-13 }
 
 - Refactor: `dispatchConfig`, `apiVersion`, brute-force fallback removed (spec 074). v2 dispatch is now the only path.
 
-### v1.2.12 — 2026-04-18
+### v1.2.12 — 2026-04-18 { #v1-2-12 }
 
 - Order categories for zone-order resolution (spec 077). New outdoor temperature/humidity categories and updated `netatmo-weather` plugin (spec 076).
 
-### v1.2.11 — 2026-04-18
+### v1.2.11 — 2026-04-18 { #v1-2-11 }
 
 - New domain categories for `media_player`, `appliance`, and `thermostat` (spec 073).
 
-### v1.2.10 — 2026-04-18
+### v1.2.10 — 2026-04-18 { #v1-2-10 }
 
 - Thermostat zone order resolves through the setpoint category (spec 070).
 
-### v1.2.9 — 2026-04-18
+### v1.2.9 — 2026-04-18 { #v1-2-9 }
 
 - Zone orders resolve aliases by category instead of hardcoded names (spec 069).
 
-### v1.2.8 — 2026-04-18
+### v1.2.8 — 2026-04-18 { #v1-2-8 }
 
 - Order dispatch v2 — plugins receive `orderKey` directly instead of a `dispatchConfig` blob (spec 067).
 
-### v1.2.7 — 2026-04-15
+### v1.2.7 — 2026-04-15 { #v1-2-7 }
 
 - Shutter zone orders use the OPEN/CLOSE state instead of a position.
 
-### v1.2.6 — 2026-04-12
+### v1.2.6 — 2026-04-12 { #v1-2-6 }
 
 - New `onChangeOnly` option on MQTT publishers.
 
-### v1.2.5 — 2026-04-12
+### v1.2.5 — 2026-04-12 { #v1-2-5 }
 
 - Restore snapshot on every reconnect — reverts the v1.2.4 change after side effects.
 
-### v1.2.4 — 2026-04-12
+### v1.2.4 — 2026-04-12 { #v1-2-4 }
 
 - MQTT publishers no longer loop on snapshot when the broker reconnects; re-publish on mapping change.
 
-### v1.2.3 — 2026-04-12
+### v1.2.3 — 2026-04-12 { #v1-2-3 }
 
 - Removed the PID file lock — it caused a Docker crash loop on container restart.
 
-### v1.2.2 — 2026-04-12
+### v1.2.2 — 2026-04-12 { #v1-2-2 }
 
 - Internal cleanup.
 
-### v1.2.1 — 2026-04-12
+### v1.2.1 — 2026-04-12 { #v1-2-1 }
 
 - Self-update helper container preserves the host compose `working_dir`.
 
-### v1.2.0 — 2026-04-12
+### v1.2.0 — 2026-04-12 { #v1-2-0 }
 
 - Plugin registry decoupled from the Sowel release cadence + `sowelVersion` compatibility field (spec 066).
 
@@ -233,35 +233,35 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.1.x — Water + freecooling
 
-### v1.1.7 — 2026-04-12
+### v1.1.7 — 2026-04-12 { #v1-1-7 }
 
 - Update badges and buttons now use red instead of amber.
 
-### v1.1.6 — 2026-04-12
+### v1.1.6 — 2026-04-12 { #v1-1-6 }
 
 - Internal cleanup.
 
-### v1.1.5 — 2026-04-12
+### v1.1.5 — 2026-04-12 { #v1-1-5 }
 
 - Self-update helper container keeps `AutoRemove` off temporarily for debugging.
 
-### v1.1.4 — 2026-04-12
+### v1.1.4 — 2026-04-12 { #v1-1-4 }
 
 - Internal cleanup.
 
-### v1.1.3 — 2026-04-12
+### v1.1.3 — 2026-04-12 { #v1-1-3 }
 
 - Self-update pulls by version tag instead of `:latest` (avoids racing with concurrent releases).
 
-### v1.1.2 — 2026-04-12
+### v1.1.2 — 2026-04-12 { #v1-1-2 }
 
 - New freecooling recipe — closes shutters before sunrise (spec 065).
 
-### v1.1.1 — 2026-04-12
+### v1.1.1 — 2026-04-12 { #v1-1-1 }
 
 - Recipe packages can hot-install and hot-update without engine restart.
 
-### v1.1.0 — 2026-04-12
+### v1.1.0 — 2026-04-12 { #v1-1-0 }
 
 - New `water_valve` equipment type (spec 062) and auto-watering recipe (spec 063).
 - Computed weather data: rain-1h / rain-24h plus cumulative bar charts (spec 064).
@@ -272,41 +272,41 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.0.x — First versioned releases
 
-### v1.0.8 — 2026-04-11
+### v1.0.8 — 2026-04-11 { #v1-0-8 }
 
 - Internal cleanup.
 
-### v1.0.7 — 2026-04-11
+### v1.0.7 — 2026-04-11 { #v1-0-7 }
 
 - Self-update helper container pattern + detection improvements (spec 060).
 
-### v1.0.6 — 2026-04-11
+### v1.0.6 — 2026-04-11 { #v1-0-6 }
 
 - Internal cleanup.
 
-### v1.0.5 — 2026-04-06
+### v1.0.5 — 2026-04-06 { #v1-0-5 }
 
 - Remote plugin registry, fetched at runtime with local fallback (spec 059).
 - Docker base image switched to Debian Trixie for Python 3.13+ (Panasonic Comfort Cloud bridge compatibility).
 - CI builds `amd64` only at this stage (~5 min vs ~15 min), with ARM64 added back later.
 - Semver-aware comparison for plugin updates.
 
-### v1.0.4 — 2026-04-06
+### v1.0.4 — 2026-04-06 { #v1-0-4 }
 
 - Internal cleanup.
 
-### v1.0.3 — 2026-04-06
+### v1.0.3 — 2026-04-06 { #v1-0-3 }
 
 - Backup line-protocol export handles non-string InfluxDB values. Restore clears `recipe_log` to avoid orphan FK refs. Docker runtime keeps `python3` for the Panasonic Comfort Cloud plugin bridge.
 
-### v1.0.2 — 2026-04-06
+### v1.0.2 — 2026-04-06 { #v1-0-2 }
 
 - Backup now includes `refresh_tokens` so a restored instance keeps users logged in.
 
-### v1.0.1 — 2026-04-06
+### v1.0.1 — 2026-04-06 { #v1-0-1 }
 
 - Backup `PRAGMA foreign_keys` moved outside the SQLite transaction (it had no effect inside).
 
-### v1.0.0 — 2026-04-06
+### v1.0.0 — 2026-04-06 { #v1-0-0 }
 
 - First versioned release. Adds `package.json` versioning, the Dockerfile, the GitHub Actions release pipeline, and the reference `docker-compose.yml` (spec 055). Everything before this point lives in pre-release git history only.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,7 +129,7 @@ nav:
     - Recipes: user/recipes.md
     - Energy Monitoring: user/energy.md
     - Remote Access: user/remote-access.md
-  - Release Notes: release-notes.md
+    - Release Notes: release-notes.md
 
 extra:
   alternate:

--- a/specs/107-update-row-changelog-link/architecture.md
+++ b/specs/107-update-row-changelog-link/architecture.md
@@ -1,0 +1,66 @@
+# Spec 107 — Architecture
+
+UI-only change plus a small docs tweak to lock the anchor format. No backend, no database, no event bus, no API additions.
+
+## Files touched
+
+| File                                                | Change                                                                                     |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `ui/src/components/layout/UpdatesSheet.tsx`         | New `<a>` icon-button before each row's Update button + URL resolver                       |
+| `ui/src/i18n/locales/{fr,en}.json`                  | `updates.action.viewChangelog` with `{{from}}`/`{{to}}` interpolation                      |
+| `docs/release-notes.md`, `docs/release-notes.fr.md` | Add explicit `{ #v<x>-<y>-<z> }` attribute after every version heading (no content change) |
+
+The release notes content is unchanged, only the heading anchors gain
+deterministic IDs. `attr_list` is already enabled in `mkdocs.yml`.
+
+## URL resolution helper
+
+A pure function inside `UpdatesSheet.tsx` (no need for a utility module):
+
+```ts
+function changelogUrl(
+  kind: "core" | PackageType,
+  repo: string | undefined,
+  to: string,
+): string | null {
+  if (kind === "core") {
+    return `https://docs.sowel.org/release-notes/#v${to.replaceAll(".", "-")}`;
+  }
+  if (!repo) return null;
+  return `https://github.com/${repo}/releases/tag/v${to}`;
+}
+```
+
+`null` means "no link to show" — the icon button is simply not rendered
+for that row. Only happens for plugins whose registry entry omits the
+`repo` field.
+
+## Why a deterministic anchor
+
+Without `attr_list`, MkDocs Material slugifies `### v1.9.0 — 2026-05-17`
+into `v190-2026-05-17`: the dots are stripped, the date is appended.
+The UpdatesSheet does not know the release date, so it cannot compute
+that slug from the row data. Forcing the anchor to `{ #v1-9-0 }` makes
+the URL trivially derivable from the `to` version string alone.
+
+The same convention will apply to future releases — the docs page
+template gets a new entry on each release, with the anchor inlined.
+
+## Disabled state
+
+The link button is rendered inside a flex row that also contains the
+Update button. When the row is updating (i.e. `loading === true`), the
+link is replaced by the same `<button>` element with `disabled` /
+`aria-disabled` — that keeps the layout stable and prevents a
+context-switch click mid-update.
+
+A simpler alternative considered: keep the link clickable. Rejected
+because the user could open a new tab, switch back, and the update has
+already completed (row removed). Disabling makes intent clearer.
+
+## Plugins without `repo`
+
+The button is omitted, the row still functions. The Update button stays
+at its usual position. This avoids visual asymmetry (no empty slot) and
+is rare in practice — only old or community plugins might lack the
+field. No tooltip explaining the absence; we keep the UI quiet.

--- a/specs/107-update-row-changelog-link/plan.md
+++ b/specs/107-update-row-changelog-link/plan.md
@@ -1,0 +1,30 @@
+# Spec 107 — Implementation plan
+
+UI + docs anchors, single branch `feat/updates-changelog-link`.
+
+## Tasks
+
+1. [x] Add explicit `{ #v<x>-<y>-<z> }` anchors to every `### v<x>.<y>.<z> — <date>` heading in `docs/release-notes.md` and `docs/release-notes.fr.md`
+2. [x] Verify on a local `mkdocs build --strict` that anchors resolve (sample check: open `#v1-9-0` and `#v1-0-0` in the built HTML)
+3. [x] Edit `ui/src/components/layout/UpdatesSheet.tsx`:
+   - Add a `changelogUrl(kind, repo, to)` pure helper returning the URL or `null`
+   - In `UpdateRow`, render an `<a>` (when active) or `<button>` (when row is updating) before the Update button, with `FileText` icon, tint `text-text-tertiary`
+   - The `a`/`button` uses `target="_blank" rel="noopener noreferrer"` when it is an anchor
+   - Omit the element entirely when `changelogUrl()` returns `null`
+4. [x] Add i18n keys `updates.action.viewChangelog` to `ui/src/i18n/locales/fr.json` and `en.json` with `{{from}}`/`{{to}}` interpolation
+5. [x] `npx tsc --noEmit` + `cd ui && npx tsc -b --noEmit`
+6. [x] `npx eslint src/ --ext .ts && cd ui && npx eslint .`
+7. [x] `npx vitest run` — no backend changes, suite must stay green
+8. [x] `mkdocs build --strict` — anchors valid, no new warnings
+9. [ ] Visual check on local dev or demo: link opens the right docs anchor for core, the right GitHub release page for plugins _(pending — local pill only renders when an update is available; verify on prod/demo after deploy)_
+
+## Test plan
+
+Pure UI / docs work, no business logic to unit-test (CLAUDE.md: "What NOT to test: UI components"). The verification matrix from `spec.md` § Test plan is the manual checklist driving step 9.
+
+Two parts are deterministic enough to spot-check via grep + a fresh `mkdocs build` (step 2 + step 8 above):
+
+- Every `### v<x>.<y>.<z>` heading carries a matching `{ #v<x>-<y>-<z> }` attribute in both EN and FR files.
+- The built site (`site/release-notes/index.html`) has `id="v1-9-0"` (and friends) on the corresponding `<h3>`.
+
+Backend unit tests untouched.

--- a/specs/107-update-row-changelog-link/spec.md
+++ b/specs/107-update-row-changelog-link/spec.md
@@ -1,0 +1,102 @@
+# Spec 107 — Surface a changelog link per row in the UpdatesSheet
+
+> Light spec: a follow-up to spec 106. No backend changes. Pure UI plumbing
+>
+> - one URL convention.
+
+## Problem
+
+`UpdatesSheet` (spec 106, shipped in v1.9.0) lists Sowel core and outdated
+plugins with a one-click `Update` button per row. The button is fine, but
+the user clicks it blind — there is no way to see _what changed_ between
+the current and the proposed version. The only path today is:
+
+1. Remember the version numbers shown in the row (`v1.8.1 → v1.9.0`).
+2. Leave Sowel, open a browser tab.
+3. Navigate to `docs.sowel.org/release-notes` for the core, or hunt down
+   the plugin's GitHub repo for plugins.
+4. Scroll until the right version block is found.
+
+Three steps, one of which leaves the product. We just published a
+canonical release-notes page on docs.sowel.org and a registry that
+already knows where each plugin lives — we can make this one click.
+
+## Goal
+
+Add a discreet link next to each row's `Update` button that opens the
+relevant changelog in a new tab. Same row, same affordance, no layout
+change.
+
+## Approach
+
+For each `UpdateRow` in `UpdatesSheet`, render an icon-button immediately
+before the `Update` button:
+
+- **Icon**: `FileText` from Lucide (or `BookOpen` — keep one and document
+  it). 14 px, stroke 1.5, tint `text-text-tertiary` (matches the existing
+  pill secondary).
+- **Aria/title**: `t("updates.action.viewChangelog", { from, to })` →
+  `"View changes (v1.8.1 → v1.9.0)"` / `"Voir les changements (v1.8.1
+→ v1.9.0)"`.
+- **Behaviour**: `<a target="_blank" rel="noopener noreferrer">` with the
+  URL resolved as below.
+
+### URL resolution
+
+| Row kind                 | URL pattern                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `core`                   | `https://docs.sowel.org/release-notes/#v<to-with-dashes>` (e.g. `#v1-9-0`). Anchors are made stable by adding explicit `{ #v1-9-0 }` attributes after each version heading in `docs/release-notes.md` and `docs/release-notes.fr.md` (the `attr_list` extension is already enabled in `mkdocs.yml`). Without this, MkDocs auto-slugifies dotted version + date together into something like `v190-2026-05-17` which is hard to compute from the row data. |
+| `integration` / `recipe` | `https://github.com/<owner>/<repo>/releases/tag/v<to>`. `owner` and `repo` are derived from the `manifest.repo` field already exposed in the registry (e.g. `mchacher/sowel-plugin-zigbee2mqtt`).                                                                                                                                                                                                                                                         |
+
+Fallback for plugins without a `repo` field: hide the link button for
+that row only (keep the row otherwise functional).
+
+### Empty-state behaviour
+
+When the sheet is in the empty / loading / error state, no rows are
+rendered, so no link to worry about.
+
+## Out of scope
+
+- Inline changelog rendering inside the sheet — keep the click-out flow.
+  We'd otherwise have to fetch and parse the release notes per row, which
+  adds a network call and a markdown renderer for marginal benefit.
+- Linking from individual plugin cards on `/plugins` — separate UX touch,
+  could be a follow-up.
+- Linking from the Sowel `/settings` update card — also separate (a
+  permanent "What's new in v1.9.0?" link in the topbar could come next).
+
+## Acceptance criteria
+
+- [x] Every `UpdateRow` in `UpdatesSheet` shows a changelog link before
+      the Update button (except plugins with no `repo`).
+- [x] Clicking the link opens a new tab to the right URL (verified for
+      both core and plugin rows).
+- [x] The link is disabled while the row is updating (visually muted +
+      not focusable) to avoid context switch mid-action.
+- [x] FR + EN i18n string for the link tooltip.
+- [x] Existing v1.9.0 behaviour of the Update button is preserved.
+
+## Test plan
+
+| Scenario                            | Expected                                                        |
+| ----------------------------------- | --------------------------------------------------------------- |
+| Core row, click changelog           | New tab opens at `https://docs.sowel.org/release-notes/#v<to>`  |
+| Plugin with `repo`, click changelog | New tab opens at `https://github.com/<repo>/releases/tag/v<to>` |
+| Plugin without `repo`               | Changelog button not rendered; Update button still works        |
+| Row currently updating              | Changelog button disabled (no focus, muted)                     |
+| Anchor coverage on docs.sowel.org   | Manual check that `#v1-9-0` etc. resolve to the right section   |
+
+## Files touched (estimated)
+
+```
+ui/src/components/layout/UpdatesSheet.tsx   (add icon button + URL resolver)
+ui/src/i18n/locales/fr.json                 (updates.action.viewChangelog)
+ui/src/i18n/locales/en.json                 (updates.action.viewChangelog)
+```
+
+## Effort
+
+~½ day, UI-only. Existing `manifest.repo` field is already exposed in
+`PluginInfo`; the docs page anchors are already generated. No backend
+work.

--- a/ui/src/components/layout/UpdatesSheet.tsx
+++ b/ui/src/components/layout/UpdatesSheet.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2, RefreshCw } from "lucide-react";
+import { FileText, Loader2, RefreshCw } from "lucide-react";
 import { BottomSheet } from "../dashboard/BottomSheet";
 import { getPlugins, triggerSystemUpdate, updatePlugin } from "../../api";
 import { useWebSocket } from "../../store/useWebSocket";
@@ -20,6 +20,18 @@ function getManifestType(manifest: PluginManifest): PackageType {
 
 function getLocalizedName(manifest: PluginManifest, lang: string): string {
   return manifest.i18n?.[lang]?.name ?? manifest.name;
+}
+
+function changelogUrl(
+  kind: "core" | PackageType,
+  repo: string | undefined,
+  to: string,
+): string | null {
+  if (kind === "core") {
+    return `https://docs.sowel.org/release-notes/#v${to.replaceAll(".", "-")}`;
+  }
+  if (!repo) return null;
+  return `https://github.com/${repo}/releases/tag/v${to}`;
 }
 
 export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
@@ -118,23 +130,28 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
               kind="core"
               from={coreUpdate.current}
               to={coreUpdate.latest}
+              changelogHref={changelogUrl("core", undefined, coreUpdate.latest)}
               loading={updatingId === CORE_ROW_ID}
               disabled={updatingId !== null && updatingId !== CORE_ROW_ID}
               onUpdate={handleCoreUpdate}
             />
           )}
-          {outdated.map((p) => (
-            <UpdateRow
-              key={p.manifest.id}
-              title={getLocalizedName(p.manifest, lang)}
-              kind={getManifestType(p.manifest)}
-              from={p.manifest.version}
-              to={p.latestVersion ?? ""}
-              loading={updatingId === p.manifest.id}
-              disabled={updatingId !== null && updatingId !== p.manifest.id}
-              onUpdate={() => handlePluginUpdate(p.manifest.id)}
-            />
-          ))}
+          {outdated.map((p) => {
+            const to = p.latestVersion ?? "";
+            return (
+              <UpdateRow
+                key={p.manifest.id}
+                title={getLocalizedName(p.manifest, lang)}
+                kind={getManifestType(p.manifest)}
+                from={p.manifest.version}
+                to={to}
+                changelogHref={changelogUrl(getManifestType(p.manifest), p.manifest.repo, to)}
+                loading={updatingId === p.manifest.id}
+                disabled={updatingId !== null && updatingId !== p.manifest.id}
+                onUpdate={() => handlePluginUpdate(p.manifest.id)}
+              />
+            );
+          })}
         </ul>
       )}
       {error && (
@@ -151,12 +168,22 @@ interface UpdateRowProps {
   kind: "core" | PackageType;
   from: string;
   to: string;
+  changelogHref: string | null;
   loading: boolean;
   disabled: boolean;
   onUpdate: () => void;
 }
 
-function UpdateRow({ title, kind, from, to, loading, disabled, onUpdate }: UpdateRowProps) {
+function UpdateRow({
+  title,
+  kind,
+  from,
+  to,
+  changelogHref,
+  loading,
+  disabled,
+  onUpdate,
+}: UpdateRowProps) {
   const { t } = useTranslation();
   const badge =
     kind === "core"
@@ -164,6 +191,7 @@ function UpdateRow({ title, kind, from, to, loading, disabled, onUpdate }: Updat
       : kind === "recipe"
         ? t("updates.badge.recipe")
         : t("updates.badge.integration");
+  const changelogTitle = t("updates.action.viewChangelog", { from, to });
 
   return (
     <li className="flex items-center gap-3 px-3 py-2.5 rounded-[8px] bg-border-light/50">
@@ -180,6 +208,29 @@ function UpdateRow({ title, kind, from, to, loading, disabled, onUpdate }: Updat
           {t("updates.sheet.versions", { from, to })}
         </div>
       </div>
+      {changelogHref &&
+        (loading ? (
+          <button
+            type="button"
+            disabled
+            aria-label={changelogTitle}
+            title={changelogTitle}
+            className="p-1.5 rounded-[6px] text-text-tertiary opacity-50 cursor-not-allowed flex-shrink-0"
+          >
+            <FileText size={14} strokeWidth={1.5} />
+          </button>
+        ) : (
+          <a
+            href={changelogHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={changelogTitle}
+            title={changelogTitle}
+            className="p-1.5 rounded-[6px] text-text-tertiary hover:text-text-secondary hover:bg-border-light transition-colors cursor-pointer flex-shrink-0"
+          >
+            <FileText size={14} strokeWidth={1.5} />
+          </a>
+        ))}
       <button
         type="button"
         onClick={onUpdate}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -89,6 +89,7 @@
   "updates.sheet.empty": "Everything's up to date.",
   "updates.sheet.versions": "v{{from}} → v{{to}}",
   "updates.action.update": "Update",
+  "updates.action.viewChangelog": "View changes (v{{from}} → v{{to}})",
   "updates.badge.integration": "Integration",
   "updates.badge.recipe": "Recipe",
   "updates.error.generic": "Update failed",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -89,6 +89,7 @@
   "updates.sheet.empty": "Tout est à jour.",
   "updates.sheet.versions": "v{{from}} → v{{to}}",
   "updates.action.update": "Mettre à jour",
+  "updates.action.viewChangelog": "Voir les changements (v{{from}} → v{{to}})",
   "updates.badge.integration": "Intégration",
   "updates.badge.recipe": "Recette",
   "updates.error.generic": "Échec de la mise à jour",


### PR DESCRIPTION
## Summary

Follow-up to spec 106. Each row of `UpdatesSheet` now exposes a discreet `FileText` icon-link before the Update button, opening the relevant changelog in a new tab so the user can see *what changed* before applying.

- **Core row** → `https://docs.sowel.org/release-notes/#v<x-y-z>`
- **Plugin row** → `https://github.com/<owner>/<repo>/releases/tag/v<x.y.z>` (from `manifest.repo`)
- **Plugin without `repo`** → link omitted, row otherwise unchanged
- **Row updating** → link replaced by a disabled button so the user can't context-switch mid-update

## Changes

- `ui/src/components/layout/UpdatesSheet.tsx` — `changelogUrl()` helper + `<a>`/`<button>` element added to `UpdateRow`
- `ui/src/i18n/locales/{fr,en}.json` — `updates.action.viewChangelog` with `from`/`to` interpolation
- `docs/release-notes.{md,fr.md}` — explicit `{ #v<x>-<y>-<z> }` anchor on every version heading (no content change); without this, MkDocs slugifies version+date together into `v190-2026-05-17`, which would force us to also pass the release date to the UI
- `mkdocs.yml` — Release Notes moved from a top-level tab to inside the User Guide nav (per request)
- `specs/107-update-row-changelog-link/` — `spec.md`, `architecture.md`, `plan.md`

## Test plan

- [x] `npx tsc --noEmit` (backend) — OK
- [x] `cd ui && npx tsc -b --noEmit` — OK
- [x] `cd ui && npx eslint .` — 0 errors (2 unrelated warnings)
- [x] `npx vitest run` — 533 tests green
- [x] `cd ui && npm run build` — bundle OK
- [x] `mkdocs build --strict` — exit 0, both `site/release-notes/index.html` and `site/fr/release-notes/index.html` contain `id="v1-9-0"` (et al.)
- [ ] Visual check: pill click → sheet → core row link opens docs.sowel.org anchor; plugin row link opens GitHub release page; row mid-update has the link disabled. _(deferred: the topbar pill only renders when an update is actually available)_