### PR TITLE
ci(release): block releases without release-notes (spec 108)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,42 @@ jobs:
         run: |
           docker buildx imagetools create --tag ${REPO}:latest ${REPO}:${FROM}
 
+  # ── Verify release-notes entry exists (spec 108) ─────────
+  # Greps both EN and FR release-notes pages for the version anchor that
+  # the in-app UpdatesSheet (spec 107) links to. Skipped on workflow_dispatch
+  # because the test_tag / restore_latest_from paths do not publish a new
+  # public version. On tag push, downstream jobs (ci → docker → release)
+  # depend on this job, so a missing entry fails the workflow BEFORE any
+  # Docker layer is built or a GitHub release is created.
+  verify-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check release-notes entry
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Skipping release-notes check on workflow_dispatch event"
+            exit 0
+          fi
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          ANCHOR="v$(echo "$VERSION" | tr . -)"
+          missing=0
+          for f in docs/release-notes.md docs/release-notes.fr.md; do
+            if ! grep -qF "{ #${ANCHOR} }" "$f"; then
+              echo "::error file=$f::Missing release-notes entry for v$VERSION (expected anchor: { #${ANCHOR} })"
+              missing=1
+            fi
+          done
+          if [ "$missing" = "1" ]; then
+            echo "Add a '### v$VERSION — YYYY-MM-DD { #${ANCHOR} }' block under the matching minor section in both EN and FR files, then re-tag (git tag -f v$VERSION && git push --force origin v$VERSION)."
+            exit 1
+          fi
+          echo "Release notes present for v$VERSION ✓"
+
   # ── CI checks ─────────────────────────────────────────────
   ci:
     if: github.event_name != 'workflow_dispatch' || inputs.restore_latest_from == ''
+    needs: verify-release-notes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,20 @@ Every entry in `plugins/registry.json` MUST carry `sha256` (64 hex chars) and `o
 
 If the registry CI fails on SHA256 mismatch, the fix is always to re-run `backfill-registry-sha256.mjs`, never to remove the field or bypass the check.
 
+### Release notes are mandatory (spec 108 — MANDATORY for AI agents)
+
+Every Sowel release MUST have a matching entry in **both** `docs/release-notes.md` and `docs/release-notes.fr.md` before the version tag is pushed. The in-app `UpdatesSheet` (spec 107) links to `https://docs.sowel.org/release-notes/#v<x>-<y>-<z>` from the core update row — missing entries break that link.
+
+Workflow when cutting a release (`vX.Y.Z`):
+
+1. Add a `### vX.Y.Z — YYYY-MM-DD { #vX-Y-Z }` block under the matching minor section in **both** `docs/release-notes.md` and `docs/release-notes.fr.md`. The explicit `{ #vX-Y-Z }` anchor is required — without it, MkDocs slugifies the heading into `vXYZ-YYYY-MM-DD` and the in-app link 404s.
+2. Stage and commit the docs together with the version bump in `package.json` / `ui/package.json` (single `release: vX.Y.Z` commit).
+3. Tag and push as usual via `scripts/release.sh`.
+
+The `verify-release-notes` job in `.github/workflows/release.yml` greps the tagged commit for `{ #vX-Y-Z }` in both files and fails the workflow (before any Docker layer is built) if either is missing. Recovery: add the entries, amend the commit, `git tag -f vX.Y.Z && git push --force origin vX.Y.Z`.
+
+**Do NOT bypass this check** by editing the workflow or skipping the grep — it is the contract that keeps `docs.sowel.org/release-notes` aligned with what is actually shipped.
+
 ### Event Bus
 
 - Typed `EventEmitter` with TypeScript discriminated union (`EngineEvent`)

--- a/specs/108-release-notes-required/architecture.md
+++ b/specs/108-release-notes-required/architecture.md
@@ -1,0 +1,104 @@
+# Spec 108 — Architecture
+
+CI guardrail only. No backend, no UI, no database, no event bus, no API.
+
+## Files touched
+
+| File                            | Change                                                                                                          |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `.github/workflows/release.yml` | New `verify-release-notes` job; `ci`, `build` (and any other downstream job) gain `needs: verify-release-notes` |
+| `CLAUDE.md`                     | New "Release notes are mandatory" section after spec 089                                                        |
+
+The reusable `release.sh` script is **not** modified. Per the discussion summarised in `spec.md` § "Why CI-only", duplicating the grep there gains no safety while doubling the maintenance surface.
+
+## Workflow job placement
+
+```yaml
+jobs:
+  verify-release-notes:
+    if: github.event_name == 'push' # tag pushes only
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check release-notes entry for ${{ github.ref_name }}
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          ANCHOR="v$(echo "$VERSION" | tr . -)"
+          missing=0
+          for f in docs/release-notes.md docs/release-notes.fr.md; do
+            if ! grep -qF "{ #${ANCHOR} }" "$f"; then
+              echo "::error file=$f::Missing release-notes entry for v$VERSION (expected anchor: { #${ANCHOR} })"
+              missing=1
+            fi
+          done
+          if [ "$missing" = "1" ]; then
+            echo "Add a '### v$VERSION — YYYY-MM-DD { #${ANCHOR} }' block under the matching minor section in both EN and FR files, then re-tag (git tag -f vX.Y.Z && git push --force origin vX.Y.Z)."
+            exit 1
+          fi
+
+  ci:
+    if: github.event_name != 'workflow_dispatch' || inputs.restore_latest_from == ''
+    needs: verify-release-notes
+    # … existing steps unchanged …
+
+  build:
+    needs: [ci, verify-release-notes]
+    # … existing steps unchanged …
+```
+
+The `if:` on `verify-release-notes` skips it for the manual
+`restore_latest_from` workflow_dispatch path — that flow does not
+publish a new version, it only repoints `:latest`, so no docs entry is
+required.
+
+## Edge cases
+
+- **Manual `workflow_dispatch` with `restore_latest_from`** — skipped
+  by the `if:` clause, as above.
+- **Test tag pushed (e.g. `v9.99.0-test`)** — the regex matches `v*`,
+  so the workflow fires. The check will fail (no docs entry for a test
+  tag), which is the desired behaviour: test tags are not real
+  releases. To skip the check for a deliberate test tag, push the tag
+  without the `v` prefix, or use `workflow_dispatch` with `test_tag`
+  instead (that input already exists in the workflow).
+- **Pre-release tags like `v1.10.0-rc.1`** — `tr . -` produces
+  `v1-10-0-rc-1`, which the check looks for. If we want pre-releases to
+  be exempt, add `if [[ "$VERSION" == *-* ]]; then exit 0; fi` before
+  the loop. Not needed today (no pre-release tags in history) but
+  documented here as a known toggle.
+- **Two consecutive releases on the same day** — irrelevant, the anchor
+  format includes only the version, not the date.
+
+## Why both files
+
+Both `docs/release-notes.md` (EN, default locale) and
+`docs/release-notes.fr.md` are required. The MkDocs i18n plugin builds
+each locale independently — a French-speaking user clicking the
+changelog link from a French UI lands on `/fr/release-notes/#vX-Y-Z`,
+which only exists if `release-notes.fr.md` carries the anchor. Failing
+the CI on either file is intentional.
+
+## Recovery
+
+When CI fails on a freshly pushed tag:
+
+```bash
+# 1. Add the EN + FR entries to docs/release-notes.{md,fr.md}
+git add docs/release-notes.md docs/release-notes.fr.md
+git commit --amend --no-edit          # fold into the release commit
+git push --force-with-lease            # update main
+git tag -f vX.Y.Z                      # repoint local tag at the new commit
+git push --force origin vX.Y.Z         # repoint remote tag → CI re-runs
+```
+
+`--force-with-lease` is safer than `--force` for `git push` on `main`;
+on the tag itself, plain `--force` is fine because tags do not have
+the same "someone may have pushed in between" semantics as branches.
+
+## Why CLAUDE.md too
+
+CI catches the mistake. CLAUDE.md prevents it from being made in the
+first place by Claude or any future contributor reading the project
+guide. The two surfaces are complementary, not redundant: CI is the
+enforced contract, CLAUDE.md is the documented expectation that helps
+agents and humans align with the contract.

--- a/specs/108-release-notes-required/plan.md
+++ b/specs/108-release-notes-required/plan.md
@@ -1,0 +1,30 @@
+# Spec 108 — Implementation plan
+
+CI guardrail. One YAML job, one CLAUDE.md section, one memory tweak. Single branch `feat/verify-release-notes`.
+
+## Tasks
+
+1. [ ] Read `.github/workflows/release.yml` to confirm the existing `ci`, `build`, `release` job graph
+2. [ ] Add a `verify-release-notes` job at the top of the workflow with the grep check (see `architecture.md`)
+3. [ ] Add `needs: verify-release-notes` to every downstream job (`ci`, `build`, anything that gates the published release). The `restore-latest` job stays untouched (manual dispatch path, no version change)
+4. [ ] Add the "Release notes are mandatory (spec 108 — MANDATORY for AI agents)" section to `CLAUDE.md`, right after the existing spec 089 section
+5. [ ] Update `~/.claude/projects/.../memory/feedback_release_notes_required.md` so the wording reflects "spec 108 is the enforced contract" (already drafted; verify it does not still say "spec 108 will enforce" in future tense)
+6. [ ] Sanity-check the YAML locally with `yq` or `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+7. [ ] Verify the grep against an existing release (`v1.9.0`): manually run the same script with `VERSION=1.9.0` and confirm exit 0
+8. [ ] Verify the grep against a fake version (`v99.99.99`): same script, confirm exit 1 with the error message
+9. [ ] Commit on `feat/verify-release-notes`, push, open PR
+10. [ ] Real validation happens at the next release: the check must pass for `vX.Y.Z` when the docs entries exist
+
+## Test plan
+
+The check itself is a single grep against two files — no business logic to unit-test (CLAUDE.md: "What NOT to test: simple CRUD wrappers, direct DB queries"). The deterministic verification matrix from `spec.md` § Test plan is the manual checklist driving steps 7 and 8.
+
+| Local dry-run                                           | Expected                                                   |
+| ------------------------------------------------------- | ---------------------------------------------------------- |
+| `VERSION=1.9.0` (anchor `{ #v1-9-0 }` present)          | Exit 0, no error                                           |
+| `VERSION=99.99.99` (no anchor anywhere)                 | Exit 1, two `::error file=…` lines (EN + FR), helpful hint |
+| `VERSION=1.9.0` with FR file temporarily missing anchor | Exit 1, one `::error file=docs/release-notes.fr.md` line   |
+
+The real CI proof is observed in the next release: either it succeeds (because the docs are kept in sync, as required by CLAUDE.md and memory), or it fails fast and the recovery flow from `architecture.md` is exercised once.
+
+No backend tests touched. No UI tests touched.

--- a/specs/108-release-notes-required/spec.md
+++ b/specs/108-release-notes-required/spec.md
@@ -1,0 +1,132 @@
+# Spec 108 — Block releases without release notes
+
+> Light spec: a single CI guardrail. One job in one workflow. No
+> backend, no UI, no local hook.
+
+## Problem
+
+Spec 107 made every UpdatesSheet row link to a versioned anchor on
+`docs.sowel.org/release-notes/#v<x>-<y>-<z>`. If the docs page does
+not have an entry for the new version, that link silently lands on
+the top of the page — the user thinks "nothing changed".
+
+Today there is nothing stopping anyone — including future-me — from
+running `scripts/release.sh 1.10.0` (or pushing a tag by hand) without
+first adding the matching entry to `docs/release-notes.md` and
+`docs/release-notes.fr.md`. The release ships, the changelog is
+missing, the in-app link breaks.
+
+## Goal
+
+Make it impossible to publish a Sowel release whose tagged commit
+lacks a corresponding release-notes entry. Failure must be loud and
+happen _before_ any image is built or release artifact is created.
+
+## Approach
+
+A single grep-based gate, in CI.
+
+The `Release` workflow runs on `push: tags: ["v*"]`. Add a job
+`verify-release-notes` that the existing `ci`, `build`, and `release`
+jobs all depend on (`needs: verify-release-notes`). The job:
+
+1. Checks out the tag.
+2. Extracts the version from `${GITHUB_REF#refs/tags/v}`.
+3. Greps both `docs/release-notes.md` and `docs/release-notes.fr.md`
+   for `{ #v<x>-<y>-<z> }`.
+4. Exits non-zero with a clear message on miss.
+
+```bash
+ANCHOR="v$(echo "$VERSION" | tr . -)"
+for f in docs/release-notes.md docs/release-notes.fr.md; do
+  if ! grep -qF "{ #${ANCHOR} }" "$f"; then
+    echo "::error file=$f::Missing release-notes entry for v$VERSION (expected anchor: { #${ANCHOR} })"
+    echo "Add a '### v$VERSION — YYYY-MM-DD { #${ANCHOR} }' block under the matching minor section in both EN and FR files, then re-tag."
+    exit 1
+  fi
+done
+```
+
+Because the other jobs `needs:` this one, the failure fires before
+the Docker layers, before the GitHub release, before `:latest` is
+repointed. The tag itself stays on the remote but the release is not
+published.
+
+### Recovery when the check fails
+
+```bash
+# 1. Add the entries to docs/release-notes.{md,fr.md}
+# 2. Amend the release commit (or add a fixup commit)
+git commit --amend --no-edit  # or: git commit -m "docs: add release notes for vX.Y.Z"
+git push                        # update main
+git tag -f vX.Y.Z              # repoint local tag at the new commit
+git push --force origin vX.Y.Z # repoint remote tag → CI re-runs
+```
+
+Two commands beyond the docs edit. No dangling Docker images, no
+broken in-app links, no published release lacking notes.
+
+### Why CI-only
+
+A pre-commit hook or check in `scripts/release.sh` would catch the
+mistake earlier locally, but:
+
+- It does not cover manual `git tag` paths, `workflow_dispatch`, or
+  cases where someone edits `release.sh` to skip the check.
+- It would duplicate logic — the CI gate is still needed as the
+  authoritative contract, so the script check becomes redundant.
+- The recovery from a CI miss is two commands (`git tag -f` +
+  `git push --force origin <tag>`), not a five-step ordeal.
+
+One gate, one source of truth, every path covered.
+
+## Out of scope
+
+- Auto-generating release notes from commit messages. The page is a
+  curated user-facing summary (see spec 107 / docs.sowel.org/release-notes),
+  not a raw conventional-commits dump. We keep the human editorial layer.
+- A pre-commit hook on the version bump. Releases happen through
+  `scripts/release.sh`, not arbitrary commits, so the check belongs
+  there.
+- A backfill for the 61 existing versions. They already have entries
+  thanks to spec 107.
+
+## Acceptance criteria
+
+- [ ] `.github/workflows/release.yml` has a `verify-release-notes` job
+      that runs first and is in the `needs:` list of `ci`, `build` and
+      `release`.
+- [ ] Pushing a `v*` tag whose commit lacks the EN or FR docs entry
+      fails CI with the actionable error, _before_ any Docker layer is
+      built or the GitHub release is created. (Verified by an
+      intentional dry-run test tag on a feature branch.)
+- [ ] Pushing a `v*` tag whose commit has both entries succeeds as
+      today.
+- [ ] The memory entry `feedback_release_notes_required.md` is updated
+      to point at this spec as the enforced contract.
+- [ ] `CLAUDE.md` documents the requirement under a "Release notes are
+      mandatory (spec 108 — MANDATORY for AI agents)" section, mirroring
+      the structure of the existing "Plugin supply chain security
+      (spec 089 — MANDATORY for AI agents)" section.
+
+## Test plan
+
+| Scenario                                                     | Expected                                                                               |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| CI `verify-release-notes` against `v1.9.0` (already shipped) | Job succeeds — `{ #v1-9-0 }` present in both files                                     |
+| CI `verify-release-notes` against `v1.99.0` (no entry)       | Job fails with a `::error` line naming both missing files; downstream jobs are skipped |
+| CI `verify-release-notes` against tag with anchor only in EN | Job fails naming `docs/release-notes.fr.md`                                            |
+| Test tag pushed to a feature branch (no entries)             | Workflow fails fast in the verify job; `ci`/`build`/`release` never run                |
+
+Backend unit tests are untouched. No UI changes.
+
+## Files touched
+
+```
+.github/workflows/release.yml      (new verify-release-notes job + needs:)
+specs/108-release-notes-required/  (spec + plan + arch)
+```
+
+## Effort
+
+~15 min. One YAML job. No script changes, no backend, no UI, no DB.


### PR DESCRIPTION
## Summary

New `verify-release-notes` job in `.github/workflows/release.yml` greps `docs/release-notes.md` and `docs/release-notes.fr.md` for the version anchor (`{ #vX-Y-Z }`, added by spec 107). The job runs first, and the existing `ci` job (and through it everything downstream — `docker`, `docker-arm64`, `promote-manifest`, `release`, `prune-ghcr`) gains `needs: verify-release-notes`. A tag pushed without docs entries fails the workflow before any Docker layer is built or the GitHub Release is created.

Follow-up to spec 107 — without this guardrail, the in-app "View changes" link from the UpdatesSheet silently lands on the top of the release-notes page when the entry is missing.

## Changes

- `.github/workflows/release.yml` — new `verify-release-notes` job + `needs:` on `ci`
- `CLAUDE.md` — new "Release notes are mandatory (spec 108 — MANDATORY for AI agents)" section, mirroring the spec 089 contract style
- `specs/108-release-notes-required/` — spec.md, architecture.md, plan.md

The `restore-latest` and `test_tag` paths bypass the grep via an in-step check on `github.event_name` — only real tag pushes are gated.

## Test plan

- [x] YAML parses (`node -e "yamlLib.load(...)"`) — jobs in order, `ci.needs = verify-release-notes`
- [x] Local grep dry-run against `v1.9.0` (anchor present) → exit 0
- [x] Local grep dry-run against `v99.99.99` (no anchor) → exit 1, two `::error file=...` lines, hint message
- [ ] Real validation on the next release: either the job passes (because CLAUDE.md + memory keep the discipline) or it fails fast and the recovery from `architecture.md` is exercised once

## Recovery (when CI fails on a tag)

```bash
# Add the EN + FR entries
git add docs/release-notes.md docs/release-notes.fr.md
git commit --amend --no-edit          # fold into the release commit
git push --force-with-lease           # update main
git tag -f vX.Y.Z                     # repoint local tag
git push --force origin vX.Y.Z        # repoint remote tag → CI re-runs
```