### PR TITLE
fix(devices): preserve bound device data/orders across partial re-discoveries (spec 109)

### DIFF
--- a/specs/109-device-discovery-preserve-bound/spec.md
+++ b/specs/109-device-discovery-preserve-bound/spec.md
@@ -1,0 +1,95 @@
+# Spec 109 — Preserve bound device data/orders across partial re-discoveries
+
+> Bug fix. A partial discovery announcement was silently destroying equipment bindings via FK CASCADE.
+
+## Problem
+
+On 2026-05-17, the `Volet Piscine` (pool_cover, id `353fd74e-...`) in production silently lost its `shutter_state` order binding (and `shutter_position` data binding) to the underlying SONOFF 4CH PRO over Tasmota. The user noticed the open/close/stop control had vanished from the UI. The bindings had to be re-created by hand.
+
+Root cause traced to [src/devices/device-manager.ts:206-256](src/devices/device-manager.ts#L206-L256) inside `upsertFromDiscovery`:
+
+```ts
+// Remove stale data entries no longer exposed by the device
+for (const row of existingDataRows) {
+  if (!discoveredDataKeys.has(row.key)) {
+    this.stmts.deleteDeviceDataById.run(row.id);
+  }
+}
+// (same loop for orders)
+```
+
+Combined with the schema in `migrations/001_initial.sql`:
+
+```sql
+CREATE TABLE order_bindings (
+  ...
+  device_order_id TEXT NOT NULL REFERENCES device_orders(id) ON DELETE CASCADE,
+  ...
+);
+```
+
+Whenever an integration plugin re-publishes its device discovery (e.g. on plugin reconnect after a Sowel restart, on MQTT reconnect, on bridge restart), the device-manager re-syncs the `data` and `orders` lists. If the announcement omits a key — even briefly, even by mistake, even mid-boot — that key's `device_data` / `device_orders` row is deleted, and the FK CASCADE wipes every equipment binding pointing at it.
+
+In the pool-cover case, the SONOFF's `shutter_state` / `shutter_position` keys were almost certainly missing from one announcement during the v1.10.0 deploy restart (the Tasmota shutter module is initialised separately from `power1`/`power2`, which never miss an announcement). The CASCADE fired, the binding was gone. A later complete announcement restored the `device_orders` row with the same stable id, but the binding had already been destroyed.
+
+`pool_pump`'s binding survived because its order `state` maps to `power1`/`power2` — base Tasmota status, always present in every discovery message.
+
+## Goal
+
+A transient or partial discovery announcement MUST NOT destroy equipment bindings.
+
+## Approach
+
+Inside the stale-cleanup loops in `upsertFromDiscovery`, skip any `device_data` / `device_orders` row that an equipment currently binds to. The cleanup still removes truly orphaned rows (no equipment touches them), so genuine device-side changes (firmware update removes a feature) are not retained forever — but only when the row is unused.
+
+The rationale: a row that is bound represents a user-meaningful link. Even if the integration temporarily fails to announce its key, the system should hold the line until the user explicitly unbinds. Recovery is preferable to silent destruction.
+
+Pseudocode:
+
+```ts
+for (const row of existingRows) {
+  if (discoveredKeys.has(row.key)) continue;
+  const bound = countBindingsForRow(row.id);
+  if (bound > 0) {
+    logger.info({ deviceId, id: row.id, key: row.key }, "Stale row kept (bound to equipment)");
+    continue;
+  }
+  delete row.id;
+}
+```
+
+## Out of scope
+
+- Periodic explicit cleanup for "old, bound but unused" rows. Could be a future admin action.
+- Removing the FK CASCADE entirely. The cascade still does the right thing when a device is deliberately removed (full row deletion in `devices` cascades through). The fix is to stop _triggering_ the cascade on transient incompleteness, not to disable cascade.
+- Re-binding logic. If a binding does get destroyed (e.g. by older code paths or manual SQL), the user must re-bind via the existing UI.
+
+## Acceptance criteria
+
+- [x] A re-discovery announcement that omits a key WHILE that key is bound to an equipment leaves both the `device_data`/`device_orders` row and the binding intact.
+- [x] A re-discovery announcement that omits a key WHILE that key is unbound still deletes the row (existing cleanup semantics preserved).
+- [x] Vitest tests cover both cases in `src/devices/device-manager.test.ts`.
+- [x] A pino info log fires when a stale row is kept, so the situation is observable in production.
+
+## Test plan
+
+| Module         | Scenario                                                  | Expected                                                             |
+| -------------- | --------------------------------------------------------- | -------------------------------------------------------------------- |
+| device-manager | Re-discovery omits an order key that has an order_binding | Order row preserved, binding preserved (`device_order_id` unchanged) |
+| device-manager | Re-discovery omits a data key that has a data_binding     | Data row preserved, binding preserved (`device_data_id` unchanged)   |
+| device-manager | Re-discovery omits an unbound order key                   | Order row deleted (existing behavior)                                |
+| device-manager | Re-discovery omits an unbound data key                    | Data row deleted (existing behavior)                                 |
+
+All three scenarios live in `src/devices/device-manager.test.ts` (new tests appended to the `upsertFromDiscovery` describe block).
+
+## Files touched
+
+```
+src/devices/device-manager.ts            (skip-when-bound in two cleanup loops + 2 prepared statements)
+src/devices/device-manager.test.ts       (3 regression tests)
+specs/109-device-discovery-preserve-bound/spec.md
+```
+
+## Effort
+
+~30 min. Backend-only, two surgical edits + tests.

--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -148,6 +148,90 @@ describe("DeviceManager", () => {
       manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", sampleDevice);
       expect(manager.getById(device.id)?.name).toBe("PIR Salon");
     });
+
+    // Regression for the pool_cover incident: a partial discovery announcement
+    // must not destroy device data/order rows that an equipment still binds to,
+    // because the FK CASCADE on data_bindings/order_bindings would wipe the
+    // equipment binding silently. See specs/109-device-discovery-preserve-bound.
+    it("keeps device_order rows that are bound to an equipment when the key is missing from a re-discovery", () => {
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", sampleLight);
+      const device = manager.getAll()[0];
+      const stateOrder = manager.getDeviceOrders(device.id).find((o) => o.key === "state");
+      expect(stateOrder).toBeDefined();
+
+      // Bind the `state` order to an equipment (directly via SQL — DeviceManager
+      // does not own the equipment tables).
+      db.prepare("INSERT INTO zones (id, name) VALUES ('zone-1', 'Salon')").run();
+      db.prepare(
+        "INSERT INTO equipments (id, name, zone_id, type) VALUES ('eq-1', 'Lampe', 'zone-1', 'light')",
+      ).run();
+      db.prepare(
+        "INSERT INTO order_bindings (id, equipment_id, device_order_id, alias) VALUES (?, 'eq-1', ?, 'state')",
+      ).run("ob-1", stateOrder!.id);
+
+      // Partial re-discovery: `state` is omitted, only `brightness` is reported.
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", {
+        ...sampleLight,
+        orders: sampleLight.orders.filter((o) => o.key === "brightness"),
+      });
+
+      // The order row must survive (binding kept it alive).
+      const orders = manager.getDeviceOrders(device.id);
+      expect(orders.map((o) => o.key).sort()).toContain("state");
+      // Binding still references the same device_order id.
+      const binding = db.prepare("SELECT * FROM order_bindings WHERE id = 'ob-1'").get() as
+        | { device_order_id: string }
+        | undefined;
+      expect(binding?.device_order_id).toBe(stateOrder!.id);
+    });
+
+    it("keeps device_data rows that are bound to an equipment when the key is missing from a re-discovery", () => {
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", sampleLight);
+      const device = manager.getAll()[0];
+      const stateData = manager.getDeviceData(device.id).find((d) => d.key === "state");
+      expect(stateData).toBeDefined();
+
+      db.prepare("INSERT INTO zones (id, name) VALUES ('zone-1', 'Salon')").run();
+      db.prepare(
+        "INSERT INTO equipments (id, name, zone_id, type) VALUES ('eq-1', 'Lampe', 'zone-1', 'light')",
+      ).run();
+      db.prepare(
+        "INSERT INTO data_bindings (id, equipment_id, device_data_id, alias) VALUES (?, 'eq-1', ?, 'state')",
+      ).run("db-1", stateData!.id);
+
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", {
+        ...sampleLight,
+        data: sampleLight.data.filter((d) => d.key === "brightness"),
+      });
+
+      const data = manager.getDeviceData(device.id);
+      expect(data.map((d) => d.key).sort()).toContain("state");
+      const binding = db.prepare("SELECT * FROM data_bindings WHERE id = 'db-1'").get() as
+        | { device_data_id: string }
+        | undefined;
+      expect(binding?.device_data_id).toBe(stateData!.id);
+    });
+
+    it("still removes unbound stale entries on re-discovery", () => {
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", sampleLight);
+      const device = manager.getAll()[0];
+      expect(
+        manager
+          .getDeviceOrders(device.id)
+          .map((o) => o.key)
+          .sort(),
+      ).toEqual(["brightness", "state"]);
+
+      // No binding on `brightness` — it must still be cleaned up when missing.
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", {
+        ...sampleLight,
+        orders: sampleLight.orders.filter((o) => o.key === "state"),
+        data: sampleLight.data.filter((d) => d.key === "state"),
+      });
+
+      expect(manager.getDeviceOrders(device.id).map((o) => o.key)).toEqual(["state"]);
+      expect(manager.getDeviceData(device.id).map((d) => d.key)).toEqual(["state"]);
+    });
   });
 
   describe("updateDeviceData", () => {

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -114,6 +114,9 @@ export class DeviceManager {
       ),
       deleteDeviceDataById: this.db.prepare("DELETE FROM device_data WHERE id = ?"),
       getDeviceDataIds: this.db.prepare("SELECT id, key FROM device_data WHERE device_id = ?"),
+      countDataBindingsForDeviceData: this.db.prepare<[string]>(
+        "SELECT COUNT(*) AS c FROM data_bindings WHERE device_data_id = ?",
+      ),
       findDeviceOrderByDeviceAndKey: this.db.prepare<[string, string]>(
         "SELECT * FROM device_orders WHERE device_id = ? AND key = ?",
       ),
@@ -126,6 +129,9 @@ export class DeviceManager {
       ),
       deleteDeviceOrderById: this.db.prepare("DELETE FROM device_orders WHERE id = ?"),
       getDeviceOrderIds: this.db.prepare("SELECT id, key FROM device_orders WHERE device_id = ?"),
+      countOrderBindingsForDeviceOrder: this.db.prepare<[string]>(
+        "SELECT COUNT(*) AS c FROM order_bindings WHERE device_order_id = ?",
+      ),
       countDevices: this.db.prepare("SELECT COUNT(*) as count FROM devices"),
       countByStatus: this.db.prepare(
         "SELECT status, COUNT(*) as count FROM devices GROUP BY status",
@@ -203,15 +209,27 @@ export class DeviceManager {
           });
         }
       }
-      // Remove stale data entries no longer exposed by the device
+      // Remove stale data entries no longer exposed by the device — but keep
+      // rows currently bound to an equipment, otherwise a transient or partial
+      // discovery announcement (e.g. plugin reconnect mid-boot) would cascade-
+      // delete equipment data bindings and leave equipments orphaned.
       const existingDataRows = this.stmts.getDeviceDataIds.all(deviceId) as {
         id: string;
         key: string;
       }[];
       for (const row of existingDataRows) {
-        if (!discoveredDataKeys.has(row.key)) {
-          this.stmts.deleteDeviceDataById.run(row.id);
+        if (discoveredDataKeys.has(row.key)) continue;
+        const bound = this.stmts.countDataBindingsForDeviceData.get(row.id) as
+          | { c: number }
+          | undefined;
+        if (bound && bound.c > 0) {
+          this.logger.info(
+            { deviceId, dataId: row.id, key: row.key },
+            "Stale device data kept (bound to equipment)",
+          );
+          continue;
         }
+        this.stmts.deleteDeviceDataById.run(row.id);
       }
 
       // Sync Orders definitions: upsert by (device_id, key) to preserve stable IDs
@@ -244,15 +262,26 @@ export class DeviceManager {
           });
         }
       }
-      // Remove stale order entries no longer exposed by the device
+      // Remove stale order entries no longer exposed by the device — but keep
+      // rows currently bound to an equipment (same rationale as for data
+      // bindings above; see spec 109 for the pool-cover incident).
       const existingOrderRows = this.stmts.getDeviceOrderIds.all(deviceId) as {
         id: string;
         key: string;
       }[];
       for (const row of existingOrderRows) {
-        if (!discoveredOrderKeys.has(row.key)) {
-          this.stmts.deleteDeviceOrderById.run(row.id);
+        if (discoveredOrderKeys.has(row.key)) continue;
+        const bound = this.stmts.countOrderBindingsForDeviceOrder.get(row.id) as
+          | { c: number }
+          | undefined;
+        if (bound && bound.c > 0) {
+          this.logger.info(
+            { deviceId, orderId: row.id, key: row.key },
+            "Stale device order kept (bound to equipment)",
+          );
+          continue;
         }
+        this.stmts.deleteDeviceOrderById.run(row.id);
       }
     });
 


### PR DESCRIPTION
## Summary

Bug found on production after the v1.10.0 deploy: the `Volet Piscine` (pool_cover) lost its `shutter_state` order binding to the SONOFF 4CH PRO over Tasmota. The open/close/stop control vanished from the UI. The user had to re-create the binding by hand.

## Root cause

[src/devices/device-manager.ts:206-256](src/devices/device-manager.ts#L206-L256) — `upsertFromDiscovery` deleted any `device_data` / `device_orders` row whose key was absent from the current discovery announcement. Combined with `ON DELETE CASCADE` on `data_bindings.device_data_id` and `order_bindings.device_order_id`, a transient or partial announce (plugin reconnect mid-boot, MQTT bridge restart) silently destroyed equipment bindings.

`pool_pump` survived because its order `state` maps to `power1`/`power2` (base Tasmota status, always present). The Tasmota shutter module reports separately and was probably missing for one announce after the v1.10.0 restart.

## Changes

- `src/devices/device-manager.ts` — stale-cleanup loops now skip any row that has an active binding (`data_bindings` / `order_bindings`). Two new prepared statements (`countDataBindingsForDeviceData`, `countOrderBindingsForDeviceOrder`). Pino info log fires when a row is kept.
- `src/devices/device-manager.test.ts` — 3 regression tests: bound order preserved, bound data preserved, unbound rows still cleaned.
- `specs/109-device-discovery-preserve-bound/spec.md` — full incident write-up.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/ --ext .ts` — clean
- [x] `npx vitest run` — 536 tests pass (3 new)
- [x] All scenarios in the spec test plan covered

## Why this is the right fix

Three options were considered:

1. **Keep cleanup, protect bound rows** (chosen) — minimal change, preserves cleanup of genuine orphans while making transient incompleteness harmless.
2. Soft-delete via an `active` flag — bigger migration, touches every read path.
3. Drop the FK CASCADE — bindings become orphaned on legitimate device removal, requiring orphan-cleanup UI.

Option 1 keeps the semantics intuitive: a row that no equipment uses can be GC'd; a row that is in use is preserved until the user explicitly unbinds.

Closes the pool_cover incident. Release as v1.10.1 (patch).