### PR TITLE
fix(ui): pool_pump inline + shutter controls resolve by category

### DIFF
--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -672,21 +672,40 @@ function ShutterDetailContent({
   const position = slider.displayValue(devicePosition);
   const level = position !== null ? shutterLevel(position) : null;
 
-  const hasState = equipment.orderBindings.some((ob) => ob.alias === "state");
-  const hasPosition = equipment.orderBindings.some((ob) => ob.alias === "position");
+  // Resolve the move + position-set bindings by category first, falling back
+  // to the conventional alias (`state`, `position`) and finally to any
+  // shutter-flavoured key. Matches EquipmentWidget's resolver so manually-
+  // rebound shutters (alias defaulting to the device key) keep working here.
+  const moveBinding =
+    equipment.orderBindings.find(
+      (ob) => ob.category === "pool_cover_move" || ob.category === "shutter_move",
+    ) ??
+    equipment.orderBindings.find(
+      (ob) => ob.alias === "state" || /shutter\d*_state/.test(ob.alias),
+    );
+  const positionOrderBinding =
+    equipment.orderBindings.find((ob) => ob.category === "set_shutter_position") ??
+    equipment.orderBindings.find(
+      (ob) => ob.alias === "position" || /shutter\d*_position/.test(ob.alias),
+    );
+  const hasState = !!moveBinding;
+  const hasPosition = !!positionOrderBinding;
 
   const handleCommand = async (command: "OPEN" | "STOP" | "CLOSE") => {
-    if (executing || !hasState) return;
+    if (executing || !moveBinding) return;
     setExecuting(true);
     try {
-      await onExecuteOrder("state", command);
+      const enumMatch = moveBinding.enumValues?.find((v) => v.toUpperCase() === command);
+      await onExecuteOrder(moveBinding.alias, enumMatch ?? command);
     } finally {
       setExecuting(false);
     }
   };
 
-  const handlePositionCommit = () =>
-    slider.onCommit((v) => onExecuteOrder("position", v));
+  const handlePositionCommit = () => {
+    if (!positionOrderBinding) return;
+    slider.onCommit((v) => onExecuteOrder(positionOrderBinding.alias, v));
+  };
 
   return (
     <div className="flex flex-col gap-6">

--- a/ui/src/components/equipments/ShutterControl.tsx
+++ b/ui/src/components/equipments/ShutterControl.tsx
@@ -24,8 +24,26 @@ export function ShutterControl({ equipment, onExecuteOrder, compact }: ShutterCo
 
   const position = slider.displayValue(devicePosition);
 
-  const hasState = equipment.orderBindings.some((ob) => ob.alias === "state");
-  const hasPositionOrder = equipment.orderBindings.some((ob) => ob.alias === "position");
+  // Resolve the move + position-set bindings by category first, falling back
+  // to the conventional alias (`state`, `position`) and finally to any
+  // shutter-flavoured key. This matches EquipmentWidget's resolver and lets
+  // manually-rebound shutters (where alias defaults to the device key like
+  // `shutter_state`) keep working in the compact zone view and detail page.
+  const moveBinding =
+    equipment.orderBindings.find(
+      (ob) => ob.category === "pool_cover_move" || ob.category === "shutter_move",
+    ) ??
+    equipment.orderBindings.find(
+      (ob) => ob.alias === "state" || /shutter\d*_state/.test(ob.alias),
+    );
+  const positionOrderBinding =
+    equipment.orderBindings.find((ob) => ob.category === "set_shutter_position") ??
+    equipment.orderBindings.find(
+      (ob) => ob.alias === "position" || /shutter\d*_position/.test(ob.alias),
+    );
+
+  const hasState = !!moveBinding;
+  const hasPositionOrder = !!positionOrderBinding;
 
   // Pool covers slide horizontally → ←/→ arrows. Window shutters keep ↑/↓.
   const isHorizontal = equipment.type === "pool_cover";
@@ -35,17 +53,20 @@ export function ShutterControl({ equipment, onExecuteOrder, compact }: ShutterCo
   const handleCommand = async (command: "OPEN" | "STOP" | "CLOSE", e?: React.MouseEvent) => {
     e?.preventDefault();
     e?.stopPropagation();
-    if (executing || !hasState) return;
+    if (executing || !moveBinding) return;
     setExecuting(true);
     try {
-      await onExecuteOrder("state", command);
+      const enumMatch = moveBinding.enumValues?.find((v) => v.toUpperCase() === command);
+      await onExecuteOrder(moveBinding.alias, enumMatch ?? command);
     } finally {
       setExecuting(false);
     }
   };
 
-  const handlePositionCommit = () =>
-    slider.onCommit((v) => onExecuteOrder("position", v));
+  const handlePositionCommit = () => {
+    if (!positionOrderBinding) return;
+    slider.onCommit((v) => onExecuteOrder(positionOrderBinding.alias, v));
+  };
 
   if (compact) {
     // Layout: slider (80px) → state pill → 3 bordered 24×24 buttons (.shutter-btn).

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -200,9 +200,11 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
         />
       )}
 
-      {/* Pool pump: runtime badge + ON/OFF toggle (reuse LightControl compact) */}
+      {/* Pool pump: runtime badge + ON/OFF toggle (reuse LightControl compact).
+       * Wrapped in a single flex cell so the two children share the row's
+       * auto-sized grid column (otherwise the toggle wraps to a second line). */}
       {isPoolPump && (
-        <>
+        <div className="flex items-center gap-2 flex-shrink-0">
           <PoolPumpRuntime equipment={equipment} />
           {equipment.enabled && (
             <LightControl
@@ -211,7 +213,7 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
               compact
             />
           )}
-        </>
+        </div>
       )}
 
       {/* Pool cover: OPEN/STOP/CLOSE buttons + position slider (reuse ShutterControl compact) */}


### PR DESCRIPTION
## Summary

Four UI bugs reported on the Piscine zone in production after v1.10.1 ship + pool_cover re-binding:

1. **Pompe Piscine** — ON/OFF toggle button rendered on a second line under the icon (zone compact view).
2. **Volet Piscine** — no OPEN/STOP/CLOSE buttons in the zone compact view.
3. **Volet Piscine** — no OPEN/STOP/CLOSE in the dashboard mobile sheet.
4. **Volet Piscine** — no OPEN/STOP/CLOSE on the equipment detail page.

Two root causes:

- **Bugs 1**: `CompactEquipmentCard` rendered `<PoolPumpRuntime>` and `<LightControl>` as two siblings in a 3-column grid row, so the toggle wrapped to a new row.
- **Bugs 2/3/4**: `ShutterControl` and `WidgetDetailSheet`'s shutter view resolved orders by hard-coded alias (`"state"`, `"position"`). The user had re-bound the pool_cover yesterday after the spec 109 incident, with the alias defaulting to the device key (`"shutter_state"`), so `hasState` was always false on those surfaces. `EquipmentWidget` already uses category resolution and worked.

## Changes

- `ui/src/components/home/CompactEquipmentCard.tsx` — wrap pool_pump children in a single flex cell.
- `ui/src/components/equipments/ShutterControl.tsx` — resolve `moveBinding` / `positionOrderBinding` by category first (`pool_cover_move`, `shutter_move`, `set_shutter_position`), fall back to alias / `shutter\d*_state` pattern. Commands route through the resolved binding's actual alias.
- `ui/src/components/dashboard/WidgetDetailSheet.tsx` — same resolver pattern.

No backend changes, no migration, no API change. UI only.

## Test plan

- [x] `npx tsc --noEmit` + `cd ui && npx tsc -b --noEmit` — clean
- [x] `npx eslint src/ --ext .ts` + `cd ui && npx eslint .` — 0 errors (2 unrelated warnings)
- [x] `npx vitest run` — 536 tests green
- [x] `cd ui && npm run build` — bundle OK
- [ ] Visual check on prod after deploy:
  - Zone Piscine → Pompe row: toggle inline
  - Zone Piscine → Volet row: OPEN/STOP/CLOSE inline
  - Dashboard mobile → tap Volet Piscine widget: action buttons in sheet
  - /equipments/353fd74e-...: action buttons in detail panel