### PR TITLE
refactor(equipments): category-first binding resolvers + tests (spec 110, PR A)

### DIFF
--- a/specs/110-category-first-binding-resolution/spec.md
+++ b/specs/110-category-first-binding-resolution/spec.md
@@ -1,0 +1,171 @@
+# Spec 110 — Category-first binding resolution across the codebase
+
+> Architectural refactor split into 3 PRs. No new user-facing feature; the
+> goal is to make the existing `alias` / `category` contract live up to its
+> design promise.
+
+## Problem
+
+A binding (data or order) carries two identifiers:
+
+- `alias` — a per-equipment string label, often equal to the device key.
+- `category` — a typed concept from `DataCategory` / `OrderCategory` in
+  [src/shared/types.ts](src/shared/types.ts) (e.g. `shutter_move`,
+  `pool_cover_move`, `set_brightness`, `temperature`).
+
+The design intent (specs 069/070/073/074/077/079) is that **callers
+resolve bindings by category**, treating alias as cosmetic. The category
+catalog is the contract.
+
+A cross-file audit run on 2026-05-17 (right after fixes for spec 109 +
+v1.10.2) found that the canonical category-first resolver pattern exists
+in only **four places**, while ~15+ other UI and recipe sites resolve
+bindings by **hardcoded alias literals**. Production has not broken
+widely because:
+
+- Auto-binding defaults `alias = device.key`.
+- Most plugins (Z2M, basic Tasmota, lora2mqtt) expose canonical keys
+  (`state`, `brightness`, `power`, `setpoint`) that match the literals.
+
+The pool_cover case (v1.10.2) was the first reported breakage: the
+SONOFF 4CH PRO over Tasmota exposes `shutter_state`, not `state`, so the
+literal lookup found nothing.
+
+Every plugin that picks a non-canonical key, every user that renames a
+binding through the UI, every new equipment type is a latent occurrence
+of the same bug class. The recipe engine is especially exposed: a
+broken motion-light recipe fails silently — the user notices only when
+the room stays dark.
+
+## Goal
+
+Establish category-first / alias-fallback resolution as the single
+canonical pattern across the codebase, with a shared helper instead of
+copy-pasted resolvers. Remove the latent bug class.
+
+## Approach
+
+A migration in **three reviewable PRs**:
+
+### PR A — Helper + tests (this PR)
+
+- Add `findOrderByCategory` and `findDataByCategory` to
+  `ui/src/components/equipments/bindingUtils.ts`.
+- 12 vitest unit tests covering category match, multi-category, alias
+  fallback, regex pattern fallback, precedence ordering, edge cases.
+- Wire `vitest.config.ts` to also pick up `ui/src/**/*.test.ts` so UI
+  pure-logic helpers are testable from the root `npx vitest run` suite
+  (no React rendering, just pure functions).
+
+The helpers are not consumed yet; PR B and PR C make them load-bearing.
+
+### PR B — Migrate critical UI sites
+
+Migrate the alias-hardcoded resolvers identified by the audit, in
+priority order. Each is wired through `findOrderByCategory` /
+`findDataByCategory` with the appropriate category set.
+
+| File:line                                                         | Severity                                    | Reason                                                                                          |
+| ----------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `EquipmentWidget.tsx:222-237` (`ShutterEquipmentWidget` twin)     | critical                                    | Identical bug to v1.10.2 — was the second copy in the same file, missed in the v1.10.2 fix      |
+| `useEquipmentState.ts:57-58`                                      | critical                                    | Upstream of `CompactEquipmentCard`, `EquipmentCard`, `ZoneEquipmentsView` (≥5 downstream views) |
+| `HeaterControl.tsx:26-40`                                         | critical                                    | Heater toggle                                                                                   |
+| `LightControl.tsx:38-65` (brightness dispatch)                    | critical                                    | All dimmable light brightness sliders                                                           |
+| `WaterValveControl.tsx:30-82`                                     | critical                                    | Valve open/close                                                                                |
+| `PoolHeatPumpControl.tsx:25-68`                                   | critical                                    | Heat pump setpoint                                                                              |
+| `WidgetDetailSheet.tsx:580-601, 918-937` (Light + Heater detail)  | critical                                    | Dispatch hardcoded                                                                              |
+| `WidgetGrid.tsx:538-564` (`getMobileClickAction`)                 | critical                                    | Mobile direct toggle                                                                            |
+| `ZoneWidget.tsx:602` (close-all-valves)                           | critical                                    | Zone-level valve close                                                                          |
+| `EquipmentWidget.tsx:317-339, 733-736` (PoolHeatPump + Appliance) | critical for setpoint, moderate for display | Setpoint dispatch                                                                               |
+| `EquipmentWidget.tsx:798-819` (WaterValve widget)                 | moderate                                    | No category match yet                                                                           |
+| `MobileWidgetCard.tsx:91-285`                                     | cosmetic                                    | Display-only text                                                                               |
+| `ZoneWidget.tsx:385-602` (other read paths)                       | cosmetic                                    | Aggregation display                                                                             |
+
+### PR C — Migrate the recipe path
+
+The largest single risk: `src/recipes/engine/light-helpers.ts` is the
+chokepoint for `motion-light`, `switch-light`, `state-trigger-light`,
+`presence-heater`. It calls `dispatchOrder(lightId, "state", …)` and
+`dispatchOrder(lightId, "brightness", …)` with the alias hardcoded.
+
+This PR introduces a backend twin of the helpers in
+`src/equipments/binding-resolver.ts` (or extends `equipment-manager.ts`
+directly), migrates `light-helpers.ts` and any other recipe-engine
+caller, and adds dedicated vitest coverage. Hooks back into the same
+category catalog declared in `src/shared/types.ts`.
+
+## Out of scope
+
+- **Schema gap** (audit § 4.1): `OrderCategory` lacks `operation_mode`,
+  `fan_speed`, `eco_mode`, `appliance_state_set`, etc. Thermostat and
+  appliance domains stay alias-keyed until categories are minted. A
+  separate spec should define the missing category vocabulary.
+- **Duplicate `inferBindingCategory` between backend and frontend**
+  (audit § 4.3). Best addressed once the schema gap is closed.
+- **MQTT publisher mapping references** (`mqtt-publish-service.ts:396`)
+  use alias as a user-stored opaque identifier — by design, not
+  migrated.
+- **`AddBindingModal` / `BindingsPicker` UIs** expose alias as a user
+  input label — by design, not migrated.
+
+## Acceptance criteria
+
+PR A (this one):
+
+- [x] `findOrderByCategory` and `findDataByCategory` exported from
+      `ui/src/components/equipments/bindingUtils.ts`.
+- [x] 12 vitest unit tests covering the helper, all passing.
+- [x] `vitest.config.ts` picks up `ui/src/**/*.test.ts`.
+- [x] No call sites migrated yet — helpers exist but are unused.
+
+PR B:
+
+- [ ] All "critical" rows from the table above migrated to the helper.
+- [ ] TypeScript + ESLint + vitest pass.
+- [ ] Visual smoke on prod: shutter / heater / valve / pool_heat_pump
+      controls render and dispatch correctly across compact zone view,
+      equipment detail page, and mobile dashboard sheet.
+
+PR C:
+
+- [ ] `light-helpers.ts` resolves the move / brightness orders by
+      category, with alias fallback.
+- [ ] Vitest tests cover the migrated path (category match, alias
+      fallback, missing-binding fallthrough).
+- [ ] Any motion-light / switch-light recipe continues to dispatch
+      orders correctly after the migration.
+
+## Files touched
+
+```
+PR A:
+  ui/src/components/equipments/bindingUtils.ts        (+findOrderByCategory, findDataByCategory)
+  ui/src/components/equipments/bindingUtils.test.ts   (new, 12 tests)
+  vitest.config.ts                                    (+ui/src/**/*.test.ts)
+  specs/110-category-first-binding-resolution/spec.md (this file)
+
+PR B:
+  ui/src/components/dashboard/EquipmentWidget.tsx
+  ui/src/components/equipments/useEquipmentState.ts
+  ui/src/components/equipments/HeaterControl.tsx
+  ui/src/components/equipments/LightControl.tsx
+  ui/src/components/equipments/WaterValveControl.tsx
+  ui/src/components/equipments/PoolHeatPumpControl.tsx
+  ui/src/components/dashboard/WidgetDetailSheet.tsx
+  ui/src/components/dashboard/WidgetGrid.tsx
+  ui/src/components/dashboard/ZoneWidget.tsx
+  ui/src/components/dashboard/MobileWidgetCard.tsx
+
+PR C:
+  src/recipes/engine/light-helpers.ts
+  src/equipments/binding-resolver.ts (new, backend twin)
+  src/equipments/binding-resolver.test.ts (new)
+```
+
+## Effort
+
+- PR A: ~½ day, fully testable
+- PR B: ~1 day, manual visual verification at the end
+- PR C: ~½ day, testable
+
+Total ~2 days spread over the next sessions.

--- a/ui/src/components/equipments/bindingUtils.test.ts
+++ b/ui/src/components/equipments/bindingUtils.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { findDataByCategory, findOrderByCategory } from "./bindingUtils";
+
+describe("findOrderByCategory", () => {
+  it("matches the first binding by category", () => {
+    const bindings = [
+      { alias: "state", category: "light_toggle" as const },
+      { alias: "brightness", category: "set_brightness" as const },
+    ];
+    expect(findOrderByCategory(bindings, ["light_toggle"])).toEqual(bindings[0]);
+  });
+
+  it("matches any of several categories (covers pool_cover_move + shutter_move)", () => {
+    const bindings = [
+      { alias: "shutter_state", category: "pool_cover_move" as const },
+    ];
+    expect(
+      findOrderByCategory(bindings, ["pool_cover_move", "shutter_move"]),
+    ).toEqual(bindings[0]);
+  });
+
+  it("returns the binding regardless of its alias when category matches", () => {
+    // The exact scenario from the v1.10.2 production incident: user re-bound the
+    // shutter order manually so alias defaulted to the device key.
+    const bindings = [{ alias: "shutter_state", category: "pool_cover_move" as const }];
+    const match = findOrderByCategory(bindings, ["pool_cover_move", "shutter_move"]);
+    expect(match?.alias).toBe("shutter_state");
+  });
+
+  it("falls back to aliasFallbacks when no category matches", () => {
+    const bindings = [
+      { alias: "state", category: undefined },
+      { alias: "brightness", category: undefined },
+    ];
+    expect(
+      findOrderByCategory(bindings, ["pool_cover_move"], ["state"]),
+    ).toEqual(bindings[0]);
+  });
+
+  it("falls back to aliasPatterns when no category nor alias matches", () => {
+    const bindings = [
+      { alias: "shutter2_state", category: undefined },
+      { alias: "brightness", category: undefined },
+    ];
+    expect(
+      findOrderByCategory(
+        bindings,
+        ["pool_cover_move"],
+        ["state"],
+        [/^shutter\d*_state$/],
+      ),
+    ).toEqual(bindings[0]);
+  });
+
+  it("prefers category over alias when both match", () => {
+    const bindings = [
+      { alias: "state", category: undefined },
+      { alias: "shutter_state", category: "shutter_move" as const },
+    ];
+    expect(
+      findOrderByCategory(bindings, ["shutter_move"], ["state"]),
+    ).toEqual(bindings[1]);
+  });
+
+  it("returns undefined when nothing matches", () => {
+    const bindings = [
+      { alias: "brightness", category: "set_brightness" as const },
+    ];
+    expect(findOrderByCategory(bindings, ["pool_cover_move"], ["state"])).toBeUndefined();
+  });
+
+  it("returns undefined for an empty bindings array", () => {
+    expect(findOrderByCategory([], ["light_toggle"], ["state"])).toBeUndefined();
+  });
+
+  it("does not match a binding whose category is undefined when only category is provided", () => {
+    const bindings = [{ alias: "state", category: undefined }];
+    expect(findOrderByCategory(bindings, ["light_toggle"])).toBeUndefined();
+  });
+});
+
+describe("findDataByCategory", () => {
+  it("matches by data category", () => {
+    const bindings = [
+      { alias: "temperature", category: "temperature" as const },
+      { alias: "humidity", category: "humidity" as const },
+    ];
+    expect(findDataByCategory(bindings, ["humidity"])).toEqual(bindings[1]);
+  });
+
+  it("falls back to alias when category is missing", () => {
+    const bindings = [
+      { alias: "position", category: undefined },
+    ];
+    expect(
+      findDataByCategory(bindings, ["shutter_position"], ["position"]),
+    ).toEqual(bindings[0]);
+  });
+
+  it("returns the right binding when alias differs from convention but category matches", () => {
+    // E.g. a manually re-bound pool_cover position data.
+    const bindings = [
+      { alias: "shutter_position", category: "shutter_position" as const },
+    ];
+    const match = findDataByCategory(bindings, ["shutter_position"], ["position"]);
+    expect(match?.alias).toBe("shutter_position");
+  });
+});

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -7,10 +7,94 @@ import {
 } from "../../api";
 import type {
   DataBindingWithValue,
+  DataCategory,
   EquipmentType,
   OrderBindingWithDetails,
+  OrderCategory,
 } from "../../types";
 import { computeBindingCandidates } from "../../lib/binding-candidates";
+
+// ============================================================
+// Read-side resolvers (category-first, alias fallback)
+// ============================================================
+
+/** Minimal binding shape the resolvers need. */
+interface MinimalOrderBinding {
+  alias: string;
+  category?: OrderCategory;
+}
+interface MinimalDataBinding {
+  alias: string;
+  category?: DataCategory;
+}
+
+/**
+ * Find an order binding by category, with optional alias and regex fallbacks.
+ *
+ * Resolution order:
+ *   1. First binding whose `category` is in `categories`.
+ *   2. First binding whose `alias` is in `aliasFallbacks` (legacy
+ *      compatibility for bindings that pre-date category typing).
+ *   3. First binding whose `alias` matches any of `aliasPatterns` (e.g.
+ *      `^shutter\d*_state$` for indexed channels).
+ *
+ * Always pass at least one category. The fallbacks are for migration —
+ * once every plugin emits a category and every binding carries one,
+ * fallbacks can be dropped.
+ *
+ * @example
+ * const move = findOrderByCategory(
+ *   eq.orderBindings,
+ *   ["pool_cover_move", "shutter_move"],
+ *   ["state"],
+ *   [/^shutter\d*_state$/],
+ * );
+ * if (move) await onExecuteOrder(move.alias, "OPEN");
+ */
+export function findOrderByCategory<T extends MinimalOrderBinding>(
+  bindings: readonly T[],
+  categories: readonly OrderCategory[],
+  aliasFallbacks?: readonly string[],
+  aliasPatterns?: readonly RegExp[],
+): T | undefined {
+  const byCategory = bindings.find(
+    (b) => b.category !== undefined && categories.includes(b.category),
+  );
+  if (byCategory) return byCategory;
+  if (aliasFallbacks && aliasFallbacks.length > 0) {
+    const byAlias = bindings.find((b) => aliasFallbacks.includes(b.alias));
+    if (byAlias) return byAlias;
+  }
+  if (aliasPatterns && aliasPatterns.length > 0) {
+    return bindings.find((b) => aliasPatterns.some((re) => re.test(b.alias)));
+  }
+  return undefined;
+}
+
+/** Find a data binding by category, with the same fallback semantics. */
+export function findDataByCategory<T extends MinimalDataBinding>(
+  bindings: readonly T[],
+  categories: readonly DataCategory[],
+  aliasFallbacks?: readonly string[],
+  aliasPatterns?: readonly RegExp[],
+): T | undefined {
+  const byCategory = bindings.find(
+    (b) => b.category !== undefined && categories.includes(b.category),
+  );
+  if (byCategory) return byCategory;
+  if (aliasFallbacks && aliasFallbacks.length > 0) {
+    const byAlias = bindings.find((b) => aliasFallbacks.includes(b.alias));
+    if (byAlias) return byAlias;
+  }
+  if (aliasPatterns && aliasPatterns.length > 0) {
+    return bindings.find((b) => aliasPatterns.some((re) => re.test(b.alias)));
+  }
+  return undefined;
+}
+
+// ============================================================
+// Write-side auto-binding (existing)
+// ============================================================
 
 /** Maps equipment types to relevant data categories for auto-binding. */
 const RELEVANT_DATA: Record<string, string[]> = {

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "ui/src/**/*.test.ts"],
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## Summary

PR A of 3 for spec 110. Introduces the canonical category-first / alias-fallback binding resolvers as shared helpers, with full unit-test coverage. No call sites migrated yet — this PR is pure scaffolding.

PRs B and C (separate) will migrate the ~15 alias-hardcoded sites identified in yesterday's cross-file audit (run after spec 109 + v1.10.2 production bugs).

## Why now

The audit found the canonical resolver pattern lives in only four places, while ~15+ UI and recipe sites resolve bindings by hardcoded alias literals. Production has not broken widely because auto-bind defaults `alias = device.key` and most plugins emit canonical keys (`state`, `brightness`, `power`, `setpoint`). The pool_cover incident (v1.10.2) was the first user-visible occurrence of the latent bug class. Every new plugin / manual re-bind / new equipment type is a potential next occurrence.

## Changes

- `ui/src/components/equipments/bindingUtils.ts` — adds `findOrderByCategory` and `findDataByCategory`. Resolution order: category → exact alias → regex pattern.
- `ui/src/components/equipments/bindingUtils.test.ts` — 12 vitest unit tests (multi-category, alias fallback, pattern fallback, precedence, edge cases).
- `vitest.config.ts` — also picks up `ui/src/**/*.test.ts` so pure-logic UI helpers run from the root `npx vitest run` suite.
- `specs/110-category-first-binding-resolution/spec.md` — migration plan with the full call-site inventory.

## Test plan

- [x] `npx tsc --noEmit` + `cd ui && npx tsc -b --noEmit` — clean
- [x] `cd ui && npx eslint .` — 0 errors (2 pre-existing warnings)
- [x] `npx vitest run` — 548 tests pass (12 new), down from 0 failures
- [ ] No visual changes — helpers exist but are not yet consumed

## What's next

- **PR B**: migrate the critical UI sites (EquipmentWidget twin, useEquipmentState, Heater/WaterValve/PoolHeatPump/Light controls, WidgetGrid mobile, ZoneWidget close-all-valves).
- **PR C**: migrate the recipe-engine path (`light-helpers.ts` + callers) with a backend twin of the helper.