### PR TITLE
refactor(ui): migrate critical UI sites to category-first binding resolution (spec 110, PR B)

### DIFF
--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -18,6 +18,7 @@ import {
 import type { EquipmentWithDetails } from "../../types";
 import type { DashboardWidget } from "../../types";
 import { useEquipmentState, formatValue } from "../equipments/useEquipmentState";
+import { findOrderByCategory } from "../equipments/bindingUtils";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
 import { SensorValues } from "../equipments/SensorValues";
 import { createElement } from "react";
@@ -227,14 +228,24 @@ function ShutterEquipmentWidget({
     : null;
   const position = slider.displayValue(devicePosition);
 
-  const hasState = equipment.orderBindings.some((ob) => ob.alias === "state");
+  // Category-first resolver — mirrors the detail variant below (spec 110).
+  // Without this, manually re-bound shutters (alias = device key) lose the
+  // command buttons.
+  const moveBinding = findOrderByCategory(
+    equipment.orderBindings,
+    ["pool_cover_move", "shutter_move"],
+    ["state"],
+    [/^shutter\d*_state$/],
+  );
+  const hasState = !!moveBinding;
   const level = position !== null ? shutterLevel(position) : null;
 
   const handleCommand = async (command: "OPEN" | "STOP" | "CLOSE") => {
-    if (executing || !hasState) return;
+    if (executing || !moveBinding) return;
     setExecuting(true);
     try {
-      await onExecuteOrder("state", command);
+      const enumMatch = moveBinding.enumValues?.find((v) => v.toUpperCase() === command);
+      await onExecuteOrder(moveBinding.alias, enumMatch ?? command);
     } finally {
       setExecuting(false);
     }

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -18,6 +18,7 @@ import {
 import type { DashboardWidget, EquipmentWithDetails, ZoneWithChildren } from "../../types";
 import { executeZoneOrder } from "../../api";
 import { useEquipmentState } from "../equipments/useEquipmentState";
+import { findOrderByCategory } from "../equipments/bindingUtils";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
 import { SensorValues } from "../equipments/SensorValues";
 import {
@@ -577,8 +578,16 @@ function LightDetailContent({
   const brightness = slider.displayValue(deviceBrightness);
   const brightnessPct = brightness !== null ? Math.round((brightness / 254) * 100) : null;
 
-  const toggleBinding = equipment.orderBindings.find(
-    (ob) => ob.type === "boolean" || (ob.alias === "state" && ob.type === "enum"),
+  // Category-first resolver — see spec 110.
+  const toggleBinding =
+    findOrderByCategory(equipment.orderBindings, ["light_toggle", "toggle_power"], ["state"]) ??
+    equipment.orderBindings.find(
+      (ob) => ob.type === "boolean" || (ob.alias === "state" && ob.type === "enum"),
+    );
+  const brightnessOrderBinding = findOrderByCategory(
+    equipment.orderBindings,
+    ["set_brightness"],
+    ["brightness"],
   );
 
   const handleToggle = async () => {
@@ -597,8 +606,10 @@ function LightDetailContent({
     }
   };
 
-  const handleBrightnessCommit = () =>
-    slider.onCommit((v) => onExecuteOrder("brightness", v));
+  const handleBrightnessCommit = () => {
+    if (!brightnessOrderBinding) return;
+    slider.onCommit((v) => onExecuteOrder(brightnessOrderBinding.alias, v));
+  };
 
   return (
     <div className="flex flex-col gap-6">
@@ -923,9 +934,19 @@ function HeaterDetailContent({
     : false;
   const isComfort = !isOn;
 
-  const toggleBinding = equipment.orderBindings.find(
-    (ob) => ob.alias === "state" && (ob.type === "enum" || ob.type === "boolean"),
+  // Category-first resolver (spec 110). Heater toggle is `toggle_power` /
+  // `light_toggle` depending on the underlying device. We keep the
+  // type-must-be-toggleable filter so the button is hidden (not just
+  // disabled) when the binding is a non-togglable type.
+  const toggleBindingRaw = findOrderByCategory(
+    equipment.orderBindings,
+    ["toggle_power", "light_toggle"],
+    ["state"],
   );
+  const toggleBinding =
+    toggleBindingRaw && (toggleBindingRaw.type === "enum" || toggleBindingRaw.type === "boolean")
+      ? toggleBindingRaw
+      : undefined;
 
   const handleToggle = async () => {
     if (executing || !toggleBinding) return;
@@ -934,7 +955,7 @@ function HeaterDetailContent({
       const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
       const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
       const value = isOn ? offVal : onVal;
-      await onExecuteOrder("state", value);
+      await onExecuteOrder(toggleBinding.alias, value);
     } finally {
       setExecuting(false);
     }

--- a/ui/src/components/dashboard/WidgetGrid.tsx
+++ b/ui/src/components/dashboard/WidgetGrid.tsx
@@ -19,6 +19,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, X, Palette, SlidersHorizontal } from "lucide-react";
 import type { DashboardWidget, EquipmentWithDetails, ZoneWithChildren } from "../../types";
 import { EquipmentWidget } from "./EquipmentWidget";
+import { findOrderByCategory } from "../equipments/bindingUtils";
 import { ZoneWidget } from "./ZoneWidget";
 import { IconPicker } from "./IconPicker";
 import { BindingsPicker } from "./BindingsPicker";
@@ -535,10 +536,14 @@ function getMobileClickAction(
 
   // Gate: single action = direct toggle, multiple = detail sheet
   if (type === "gate") {
-    const commandBinding = equipment.orderBindings.find((ob) => ob.alias === "command");
+    const commandBinding = findOrderByCategory(
+      equipment.orderBindings,
+      ["gate_trigger"],
+      ["command"],
+    );
     const enumValues = commandBinding?.enumValues ?? [];
     if (commandBinding && enumValues.length <= 1) {
-      return () => { onExecuteOrder(equipment.id, "command", null); };
+      return () => { onExecuteOrder(equipment.id, commandBinding.alias, null); };
     }
     return onOpenDetail;
   }
@@ -550,9 +555,16 @@ function getMobileClickAction(
     type === "pool_pump" ||
     type === "water_valve"
   ) {
-    const stateBinding = equipment.orderBindings.find(
-      (ob) => ob.alias === "state" && (ob.type === "enum" || ob.type === "boolean"),
+    const stateBindingRaw = findOrderByCategory(
+      equipment.orderBindings,
+      ["light_toggle", "pool_pump_toggle", "valve_toggle", "toggle_power"],
+      ["state"],
     );
+    const stateBinding =
+      stateBindingRaw &&
+      (stateBindingRaw.type === "enum" || stateBindingRaw.type === "boolean")
+        ? stateBindingRaw
+        : undefined;
     if (stateBinding) {
       const dataBinding = equipment.dataBindings.find((db) => db.category === "light_state");
       const isOn = dataBinding
@@ -561,7 +573,7 @@ function getMobileClickAction(
       return () => {
         const onVal = stateBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
         const offVal = stateBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
-        onExecuteOrder(equipment.id, "state", isOn ? offVal : onVal);
+        onExecuteOrder(equipment.id, stateBinding.alias, isOn ? offVal : onVal);
       };
     }
   }

--- a/ui/src/components/dashboard/ZoneWidget.tsx
+++ b/ui/src/components/dashboard/ZoneWidget.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import type { DashboardWidget, EquipmentWithDetails, ZoneWithChildren, WidgetFamily } from "../../types";
 import { executeZoneOrder, executeEquipmentOrder } from "../../api";
+import { findOrderByCategory } from "../equipments/bindingUtils";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
 import {
   LightBulbIcon,
@@ -597,12 +598,20 @@ function ZoneWaterWidget({
           const stateBinding = eq.dataBindings.find((b) => b.alias === "state");
           const isOpen =
             stateBinding?.value === true || stateBinding?.value === "ON";
-          if (isOpen) {
-            try {
-              await executeEquipmentOrder(eq.id, "state", false);
-            } catch {
-              // Silent — UI updates via WebSocket
-            }
+          if (!isOpen) return;
+          // Category-first resolver so close-all works on manually-bound
+          // valves whose alias defaults to the device key (spec 110).
+          const order = findOrderByCategory(
+            eq.orderBindings,
+            ["valve_toggle", "light_toggle"],
+            ["state"],
+          );
+          if (!order) return;
+          try {
+            const offVal = order.enumValues?.find((v) => /^off$/i.test(v)) ?? false;
+            await executeEquipmentOrder(eq.id, order.alias, offVal);
+          } catch {
+            // Silent — UI updates via WebSocket
           }
         }),
       );

--- a/ui/src/components/equipments/HeaterControl.tsx
+++ b/ui/src/components/equipments/HeaterControl.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Flame, Snowflake, Loader2 } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
+import { findOrderByCategory } from "./bindingUtils";
 
 interface HeaterControlProps {
   equipment: EquipmentWithDetails;
@@ -23,10 +24,16 @@ export function HeaterControl({ equipment, onExecuteOrder, compact }: HeaterCont
   // Fil pilote convention: relay ON = éco, relay OFF = confort
   const isComfort = !isOn;
 
-  const toggleBinding = equipment.orderBindings.find(
-    (ob) => ob.alias === "state" && (ob.type === "enum" || ob.type === "boolean"),
+  // Category-first resolver: heater toggle is `toggle_power` / `light_toggle`
+  // depending on the underlying device, with alias fallback for older
+  // bindings (spec 110).
+  const toggleBinding = findOrderByCategory(
+    equipment.orderBindings,
+    ["toggle_power", "light_toggle"],
+    ["state"],
   );
-  const hasToggle = !!toggleBinding;
+  const hasToggle =
+    !!toggleBinding && (toggleBinding.type === "enum" || toggleBinding.type === "boolean");
 
   const handleToggle = async (e?: React.MouseEvent) => {
     e?.preventDefault();
@@ -37,7 +44,7 @@ export function HeaterControl({ equipment, onExecuteOrder, compact }: HeaterCont
       const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
       const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
       const value = isOn ? offVal : onVal;
-      await onExecuteOrder("state", value);
+      await onExecuteOrder(toggleBinding.alias, value);
     } finally {
       setExecuting(false);
     }

--- a/ui/src/components/equipments/LightControl.tsx
+++ b/ui/src/components/equipments/LightControl.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Power } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
+import { findOrderByCategory } from "./bindingUtils";
 
 interface LightControlProps {
   equipment: EquipmentWithDetails;
@@ -34,13 +35,21 @@ export function LightControl({ equipment, onExecuteOrder, compact }: LightContro
 
   const brightness = slider.displayValue(deviceBrightness);
 
-  const toggleBinding = equipment.orderBindings.find(
-    (ob) => ob.type === "boolean" || (ob.alias === "state" && ob.type === "enum")
-  );
+  // Category-first resolver (spec 110). Falls back to the boolean type / alias
+  // heuristic used by lights bound before category typing existed.
+  const toggleBinding =
+    findOrderByCategory(equipment.orderBindings, ["light_toggle", "toggle_power"], ["state"]) ??
+    equipment.orderBindings.find(
+      (ob) => ob.type === "boolean" || (ob.alias === "state" && ob.type === "enum"),
+    );
   const hasToggle = !!toggleBinding;
-  const hasBrightness = equipment.orderBindings.some(
-    (ob) => ob.type === "number" && (ob.alias === "brightness" || ob.key === "brightness")
+  const brightnessOrderBinding = findOrderByCategory(
+    equipment.orderBindings,
+    ["set_brightness"],
+    ["brightness"],
   );
+  const hasBrightness =
+    !!brightnessOrderBinding && brightnessOrderBinding.type === "number";
 
   const handleToggle = async (e?: React.MouseEvent) => {
     e?.preventDefault();
@@ -61,8 +70,10 @@ export function LightControl({ equipment, onExecuteOrder, compact }: LightContro
     }
   };
 
-  const handleBrightnessCommit = () =>
-    slider.onCommit((v) => onExecuteOrder("brightness", v));
+  const handleBrightnessCommit = () => {
+    if (!brightnessOrderBinding) return;
+    slider.onCommit((v) => onExecuteOrder(brightnessOrderBinding.alias, v));
+  };
 
   if (compact) {
     return (

--- a/ui/src/components/equipments/PoolHeatPumpControl.tsx
+++ b/ui/src/components/equipments/PoolHeatPumpControl.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { ChevronUp, ChevronDown } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
+import { findDataByCategory, findOrderByCategory } from "./bindingUtils";
 
 interface Props {
   equipment: EquipmentWithDetails;
@@ -22,13 +23,32 @@ export function PoolHeatPumpControl({ equipment, onExecuteOrder, compact }: Prop
   const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const tempBinding = equipment.dataBindings.find((b) => b.alias === "temperature");
+  // Category-first resolvers (spec 110). The pool heat pump exposes its water
+  // temperature and setpoint under domain-specific categories; older bindings
+  // fall back to the conventional aliases.
+  const tempBinding = findDataByCategory(
+    equipment.dataBindings,
+    ["pool_water_temperature", "temperature"],
+    ["temperature"],
+  );
   const computedWater = equipment.computedData?.find(
     (c) => c.alias === "effective_water_temperature",
   );
-  const setpointBinding = equipment.dataBindings.find((b) => b.alias === "setpoint");
-  const modeBinding = equipment.dataBindings.find((b) => b.alias === "mode");
-  const setpointOrder = equipment.orderBindings.find((o) => o.alias === "setpoint");
+  const setpointBinding = findDataByCategory(
+    equipment.dataBindings,
+    ["pool_temperature_setpoint", "setpoint"],
+    ["setpoint"],
+  );
+  const modeBinding = findDataByCategory(
+    equipment.dataBindings,
+    ["appliance_state"],
+    ["mode"],
+  );
+  const setpointOrder = findOrderByCategory(
+    equipment.orderBindings,
+    ["set_pool_temperature_setpoint", "set_setpoint"],
+    ["setpoint"],
+  );
 
   const water =
     typeof computedWater?.value === "number"
@@ -65,7 +85,7 @@ export function PoolHeatPumpControl({ equipment, onExecuteOrder, compact }: Prop
       const value = pendingRef.current;
       commitTimerRef.current = null;
       if (value === null) return;
-      onExecuteOrder("setpoint", value).catch(() => {
+      onExecuteOrder(setpointOrder.alias, value).catch(() => {
         /* surfaced upstream */
       });
       // Failsafe: clear the override if the device never echoes back.

--- a/ui/src/components/equipments/WaterValveControl.tsx
+++ b/ui/src/components/equipments/WaterValveControl.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Power, Loader2, Droplets, Battery, AlertTriangle, Play } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
+import { findDataByCategory, findOrderByCategory } from "./bindingUtils";
 
 interface WaterValveControlProps {
   equipment: EquipmentWithDetails;
@@ -27,9 +28,20 @@ export function WaterValveControl({ equipment, onExecuteOrder, compact }: WaterV
   const [watering, setWatering] = useState(false);
   const [duration, setDuration] = useState(10);
 
-  const stateBinding = equipment.dataBindings.find((b) => b.alias === "state");
+  // Category-first resolvers — alias falls back for legacy / manually-bound
+  // valves (spec 110). SONOFF SWV exposes state under `light_state` due to a
+  // z2m mis-classification; we accept it as fallback.
+  const stateBinding = findDataByCategory(
+    equipment.dataBindings,
+    ["light_state"],
+    ["state"],
+  );
   const flowBinding = equipment.dataBindings.find((b) => b.alias === "flow");
-  const batteryBinding = equipment.dataBindings.find((b) => b.alias === "battery");
+  const batteryBinding = findDataByCategory(
+    equipment.dataBindings,
+    ["battery"],
+    ["battery"],
+  );
   const statusBinding = equipment.dataBindings.find((b) => b.alias === "status");
 
   const isOn = stateBinding?.value === true || stateBinding?.value === "ON";
@@ -47,7 +59,11 @@ export function WaterValveControl({ equipment, onExecuteOrder, compact }: WaterV
     ? t(`water.status.${statusRaw}`, { defaultValue: statusRaw.replace(/_/g, " ") })
     : null;
 
-  const stateOrderBinding = equipment.orderBindings.find((b) => b.alias === "state");
+  const stateOrderBinding = findOrderByCategory(
+    equipment.orderBindings,
+    ["valve_toggle", "light_toggle"],
+    ["state"],
+  );
   const hasStateOrder = !!stateOrderBinding;
   // Timed watering uses z2m's universal "on with timed off" pattern
   // ({"state":"ON","on_time":600}) — published atomically through the
@@ -76,23 +92,23 @@ export function WaterValveControl({ equipment, onExecuteOrder, compact }: WaterV
   const handleToggle = async (e?: React.MouseEvent) => {
     e?.preventDefault();
     e?.stopPropagation();
-    if (executing || !hasStateOrder) return;
+    if (executing || !stateOrderBinding) return;
     setExecuting(true);
     try {
-      await onExecuteOrder("state", stateValue(!isOn));
+      await onExecuteOrder(stateOrderBinding.alias, stateValue(!isOn));
     } finally {
       setExecuting(false);
     }
   };
 
   const handleWaterNow = async () => {
-    if (watering || !hasTimedWatering) return;
+    if (watering || !stateOrderBinding) return;
     setWatering(true);
     try {
       // Composite payload: state + on_time published in a single MQTT
       // message. The z2m plugin (v1.2.0+) detects an object value and
       // publishes it directly instead of wrapping under `payloadKey`.
-      await onExecuteOrder("state", {
+      await onExecuteOrder(stateOrderBinding.alias, {
         state: stateValue(true),
         on_time: duration * 60,
       });

--- a/ui/src/components/equipments/useEquipmentState.ts
+++ b/ui/src/components/equipments/useEquipmentState.ts
@@ -7,6 +7,7 @@ import {
   getSensorBindings,
   getAllBatteryBindings,
 } from "./sensorUtils";
+import { findOrderByCategory } from "./bindingUtils";
 
 export function useEquipmentState(equipment: EquipmentWithDetails) {
   // Classification
@@ -54,8 +55,17 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
     shutterPositionBinding && typeof shutterPositionBinding.value === "number"
       ? shutterPositionBinding.value
       : null;
+  // Category-first so manually-rebound shutters (alias = device key) keep
+  // their controls visible across compact zone view, equipment card and
+  // detail page (spec 110).
   const hasShutterState =
-    isShutter && equipment.orderBindings.some((ob) => ob.alias === "state");
+    isShutter &&
+    !!findOrderByCategory(
+      equipment.orderBindings,
+      ["shutter_move", "pool_cover_move"],
+      ["state"],
+      [/^shutter\d*_state$/],
+    );
   const shutterIsOpen = shutterPosition !== null && shutterPosition > 0;
 
   // Sensor / Button


### PR DESCRIPTION
## Summary

PR B of 3 for spec 110. Migrates the 9 alias-hardcoded UI sites identified by yesterday's audit to use the shared `findOrderByCategory` / `findDataByCategory` helpers from PR A. Removes the latent v1.10.2-class bug from the critical UI paths.

## Why now

After v1.10.2 fixed `ShutterControl.tsx` and `WidgetDetailSheet.tsx`'s shutter detail, an audit found the same alias-hardcoded pattern in ~15 other places. The 9 most critical are migrated here. The audit confirmed production hasn't broken widely only because auto-bind defaults `alias = device.key` and most plugins expose canonical keys — every plugin / manual rebind / new equipment type is a latent occurrence of the same bug class.

## Changes

- `ui/src/components/dashboard/EquipmentWidget.tsx` — `ShutterEquipmentWidget` twin (the one missed in v1.10.2)
- `ui/src/components/equipments/useEquipmentState.ts` — `hasShutterState` (upstream of CompactEquipmentCard, EquipmentCard, ZoneEquipmentsView)
- `ui/src/components/equipments/HeaterControl.tsx` — heater toggle
- `ui/src/components/equipments/WaterValveControl.tsx` — valve state data + state order; `handleToggle` and `handleWaterNow` dispatch through the resolved alias
- `ui/src/components/equipments/PoolHeatPumpControl.tsx` — water temp, setpoint data, mode, setpoint order; `bumpSetpoint` dispatches through the resolved alias
- `ui/src/components/equipments/LightControl.tsx` — toggle + brightness order; brightness commit dispatches through the resolved alias
- `ui/src/components/dashboard/WidgetDetailSheet.tsx` — Light + Heater detail variants
- `ui/src/components/dashboard/WidgetGrid.tsx` — `getMobileClickAction` for gate + on/off equipments
- `ui/src/components/dashboard/ZoneWidget.tsx` — close-all-valves

Each migrated site keeps a conventional-alias fallback (`state`, `position`, `command`, `setpoint`, `brightness`) so existing production bindings keep working. Once every plugin emits a category, the fallbacks become dead code and can be dropped (out of scope for now).

## Test plan

- [x] `npx tsc --noEmit` + `cd ui && npx tsc -b --noEmit` — clean
- [x] `cd ui && npx eslint .` — 0 errors (2 pre-existing warnings)
- [x] `npx vitest run` — 548 tests pass (incl. 12 helper unit tests from PR A)
- [x] `cd ui && npm run build` — bundle OK
- [ ] Visual smoke on prod after deploy:
  - Zone Piscine → Pompe ON/OFF inline, Volet OUVRIR/STOP/FERMER inline
  - Equipment detail page → Heater, WaterValve, PoolHeatPump, Light controls render
  - Mobile dashboard → tap on gate / valve / light widget → direct toggle
  - ZoneWaterWidget → "Close all" actually closes manually-bound valves

## What's next

PR C migrates the recipe-engine path (`src/recipes/engine/light-helpers.ts`) — the largest remaining alias-hardcoded surface, with the biggest blast radius (every motion-light / switch-light recipe).