### PR TITLE
fix(ui): add mobile-web-app-capable meta alongside Apple variant

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#1A4F6E" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Sowel" />


### PR DESCRIPTION
## Summary
- Chrome's console flagged `<meta name=\"apple-mobile-web-app-capable\">` as deprecated and asked for the standard `<meta name=\"mobile-web-app-capable\">`.
- Adds the standard meta alongside the Apple one (both required: iOS Safari still does not honour the standard name).

## Context
Spotted while inspecting the dashboard with Chrome DevTools' Device Mode. The console warning was unrelated to the \"Vous êtes hors ligne\" banner observed at the same time (that one was Chrome DevTools \"Offline\" throttling auto-applied when entering Device Mode — `navigator.onLine` correctly returned `false`).

## Test plan
- [ ] Reload UI, open Chrome DevTools console, confirm the deprecation warning is gone.
- [ ] Confirm PWA install behaviour unchanged on iOS Safari (Apple meta still present).