### PR TITLE
feat(ui): weather station UX rework (spec 114)

### DIFF
--- a/specs/114-weather-station-ux/architecture.md
+++ b/specs/114-weather-station-ux/architecture.md
@@ -1,0 +1,115 @@
+# Spec 114 — Architecture
+
+## Files changed
+
+| File                                                | Change type | Description                                                                                      |
+| --------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------ |
+| `ui/src/components/dashboard/MobileWidgetCard.tsx`  | modify      | Add weather branch in `useMobileState` returning {icon, stateLines} for weather equipments.      |
+| `ui/src/components/dashboard/WidgetDetailSheet.tsx` | modify      | Add `WeatherDetailContent` component and a `weather` branch dispatched before `isSensor`.        |
+| `ui/src/components/dashboard/EquipmentWidget.tsx`   | modify      | Add `WeatherStationWidget` and dispatch on `equipment.type === "weather"` before `isSensor`.     |
+| `ui/src/components/home/CompactEquipmentCard.tsx`   | modify      | Widen the `weather` filter to include `humidity` (4 visible values).                             |
+| `ui/src/components/equipments/WeatherPanel.tsx`     | modify      | Wind arrow component, pressure trend rendering, swap rain `PRIMARY_KEY`.                         |
+| `ui/src/components/history/HistoryBarChart.tsx`     | modify      | Responsive tick interval + label formatter (2-line for 7d, compact for 30d, mobile breakpoints). |
+| `ui/src/components/history/HistoryBarChart.test.ts` | new         | Unit tests for tick interval picker and label formatter.                                         |
+| `ui/src/components/equipments/WeatherPanel.test.ts` | new (small) | Unit test for wind arrow direction mapping (0°/90°/180°/270°).                                   |
+
+No backend changes. No new types. No new translation keys (existing `weather.*` keys are sufficient).
+
+## Component contracts
+
+### `useMobileState` — new weather branch
+
+```ts
+if (equipment.type === "weather") {
+  const findVal = (key: string) =>
+    equipment.dataBindings.find(b => b.key === key)?.value;
+  const lines: string[] = [];
+  const t = findVal("temperature");
+  const h = findVal("humidity");
+  const r = findVal("sum_rain_24");
+  if (typeof t === "number") lines.push(`${t.toFixed(1)}°`);
+  if (typeof h === "number") lines.push(`${Math.round(h)}%`);
+  if (typeof r === "number") lines.push(`${r.toFixed(1)}mm`);
+  return { icon: <WeatherStationIcon />, stateLines: lines };
+}
+```
+
+Icon: a CloudRain-Thermometer hybrid inline SVG (Lucide-style stroke 1.5px).
+
+### `WeatherDetailContent` (bottom sheet)
+
+Flat list, mirroring the layout already used in `SensorDetailContent` but with weather-aware labels via `KEY_LABELS` from `WeatherPanel.tsx`:
+
+```tsx
+<div className="divide-y divide-border-light">
+  {bindings.map((b) => (
+    <div className="flex justify-between py-2">
+      <span className="text-[13px] text-text-secondary">
+        {KEY_LABELS[b.key] ? t(KEY_LABELS[b.key]) : b.key}
+      </span>
+      <span className="font-mono text-[14px] tabular-nums">
+        {format(b.value)} <span className="text-text-tertiary">{b.unit}</span>
+      </span>
+    </div>
+  ))}
+</div>
+```
+
+### `WeatherStationWidget` (PC dashboard)
+
+```
+┌─────────────────────────┐
+│ STATION MÉTÉO           │
+│                         │
+│ [icon] 19.2°            │
+│                         │
+│ Humidité     54 %       │
+│ Pluie 24h    0 mm       │
+│ Vent         12 km/h    │
+└─────────────────────────┘
+```
+
+Uses `WidgetCard` shell. Hero pulled from `temperature` binding, secondary rows from `humidity` / `sum_rain_24` / `wind_strength` with graceful fallback ("—").
+
+### `WeatherPanel` enrichments
+
+1. `PRIMARY_KEY.rain` changes from `"rain"` → `"sum_rain_24"` (one-line constant edit).
+2. New `<WindArrow angle={value} size={18} />` rendered inline next to the wind hero. Rotation: `transform: rotate(${angle}deg)`. Arrow base points "up" (= North = 0°).
+3. New optional `<PressureTrend bindingKey="pressure" />` row added to the outdoor module secondary list. Reads history via the same history endpoint already used by `HistoryPanel` (1h resolution, 3-point lookback). If no history → no row. Implementation detail: a small `useHistoryDelta(alias, "3h")` hook that returns ↑/↗/→/↘/↓ based on slope thresholds.
+
+### `HistoryBarChart` — label & scale logic
+
+New helper functions inside the file:
+
+```ts
+function pickTickInterval(count: number, viewportWidth: number): number {
+  const maxLabels = viewportWidth < 360 ? 6 : viewportWidth < 640 ? 8 : 12;
+  if (count <= maxLabels) return 0;
+  return Math.max(1, Math.floor(count / maxLabels)) - 1;
+}
+
+function formatLabel(iso: string, range: TimeRange): { line1: string; line2?: string } {
+  const d = new Date(iso);
+  if (range === "6h" || range === "24h") {
+    return { line1: d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" }) };
+  }
+  if (range === "7d") {
+    return {
+      line1: d.toLocaleDateString("fr-FR", { weekday: "short" }),
+      line2: String(d.getDate()).padStart(2, "0"),
+    };
+  }
+  // 30d
+  return {
+    line1: `${String(d.getDate()).padStart(2, "0")}/${String(d.getMonth() + 1).padStart(2, "0")}`,
+  };
+}
+```
+
+Render: when `line2` is present, use Recharts `<XAxis tick={<CustomTick />}>` with a custom React component that renders two `<text>` elements stacked.
+
+Mobile font size: read `window.matchMedia` or rely on Tailwind responsive utilities; in practice we pass `tickFontSize` derived from viewport width into the chart props.
+
+### Data flow
+
+No event-bus changes. All reads come from the equipment `dataBindings` that are already fed by `WebSocket`. The pressure trend hook hits the existing `/api/v1/history/...` endpoint already used by `HistoryPanel`.

--- a/specs/114-weather-station-ux/plan.md
+++ b/specs/114-weather-station-ux/plan.md
@@ -1,0 +1,82 @@
+# Spec 114 — Implementation plan
+
+## Branch
+
+`feat/weather-station-ux`
+
+## Ordered steps
+
+1. **HistoryBarChart label/scale refactor** (foundation — used by point 7 of WeatherPanel later if we add the pressure mini-spark).
+   - Add `pickTickInterval(count, viewportWidth)` helper.
+   - Add `formatLabel(iso, range)` returning `{line1, line2?}`.
+   - Add a `CustomTick` render prop for the X-axis that supports 2-line layout.
+   - Pass viewport-aware font size + tick interval via a small hook (`useChartViewport`).
+2. **WeatherPanel enrichments**
+   - Change `PRIMARY_KEY.rain` to `sum_rain_24`.
+   - Add `WindArrow` SVG (8 px stroke 1.5, rotation by angle).
+   - Add `PressureTrend` row using existing history API (lazy load on panel mount).
+3. **CompactEquipmentCard**
+   - Extend the `equipment.type === "weather"` filter from 3 → 4 keys (add `humidity`).
+   - Map units to short form (`mm` instead of `mm/24h`) to keep the row narrow.
+4. **EquipmentWidget (PC)**
+   - Add `WeatherStationWidget` component matching the mockup layout.
+   - Dispatch `if (equipment.type === "weather") return <WeatherStationWidget ... />` before the `isSensor` fallback.
+5. **WidgetDetailSheet (mobile bottom sheet)**
+   - Add `WeatherDetailContent` component (flat list of all weather bindings + battery).
+   - Dispatch `if (equipment.type === "weather") return <WeatherDetailContent />` before the generic `isSensor` branch.
+6. **MobileWidgetCard**
+   - Add `weather` case in `useMobileState` returning the 3-value summary + dedicated icon.
+7. **Tests**
+   - `HistoryBarChart.test.ts`: pickTickInterval boundaries, formatLabel for each range, mobile width branches.
+   - `WeatherPanel.test.ts`: wind arrow angle → rotation degrees (0, 90, 180, 270, null).
+8. **Validation**
+   - `cd ui && npx tsc -b --noEmit`
+   - `cd /Users/mchacher/Documents/01_Geekerie/Sowel && npx vitest run`
+   - `cd ui && npx eslint .`
+9. **Release notes**
+   - Add a short entry in `docs/release-notes.md` and `docs/release-notes.fr.md` under the current unreleased section (or skip if release will batch it).
+10. **PR**
+    - `git push -u origin feat/weather-station-ux`
+    - Open PR titled `feat(ui): weather station UX rework (spec 114)`.
+
+## Test plan
+
+### Modules to test
+
+- `HistoryBarChart` — tick interval picker + label formatter.
+- `WeatherPanel` — wind arrow angle mapping.
+
+### Scenarios
+
+| Module          | Scenario                      | Expected                               |
+| --------------- | ----------------------------- | -------------------------------------- |
+| HistoryBarChart | `pickTickInterval(7, 1024)`   | returns `0` (no skipping)              |
+| HistoryBarChart | `pickTickInterval(30, 1024)`  | returns ~2 (≤12 labels)                |
+| HistoryBarChart | `pickTickInterval(30, 340)`   | returns ~4 (≤6 labels on small mobile) |
+| HistoryBarChart | `pickTickInterval(168, 1024)` | returns ~13 (≤12 labels)               |
+| HistoryBarChart | `formatLabel(iso, "24h")`     | `{line1: "HH:MM"}` only                |
+| HistoryBarChart | `formatLabel(iso, "7d")`      | `{line1: "lun.", line2: "03"}`         |
+| HistoryBarChart | `formatLabel(iso, "30d")`     | `{line1: "DD/MM"}` (e.g. `12/02`)      |
+| WeatherPanel    | `<WindArrow angle={0}>`       | rotated 0° (points up = North)         |
+| WeatherPanel    | `<WindArrow angle={90}>`      | rotated 90° (points right = East)      |
+| WeatherPanel    | `<WindArrow angle={null}>`    | renders nothing (no SVG)               |
+
+### Not tested (UI-only, no business logic)
+
+- `WeatherStationWidget` layout (visual; covered by manual review).
+- `WeatherDetailContent` mapping (trivial mapping over bindings).
+- `MobileWidgetCard` weather branch (string concat on values).
+
+## Release notes draft (FR)
+
+```
+- Refonte de l'affichage des stations météo : nouvelle vignette dashboard PC/mobile dédiée, bottom sheet enrichie au tap mobile, pluie 24h visible partout, panneau détail avec flèche directionnelle pour le vent et tendance de pression.
+- Histogramme : étiquettes plus lisibles sur 7j (jour de la semaine + numéro) et 30j (format compact `JJ/MM`), échelle responsive sur mobile.
+```
+
+## Release notes draft (EN)
+
+```
+- Weather station UI rework: dedicated dashboard widget (PC & mobile), richer bottom sheet on tap, 24 h rain visible everywhere, detail panel now shows a wind direction arrow and a 3 h pressure trend.
+- History bar chart: more readable labels on 7-day (weekday + day) and 30-day (compact `DD/MM`) ranges, responsive scale on mobile.
+```

--- a/specs/114-weather-station-ux/spec.md
+++ b/specs/114-weather-station-ux/spec.md
@@ -1,0 +1,71 @@
+# Spec 114 — Weather station UX
+
+## Problem
+
+The `weather` equipment type (Netatmo and similar multi-module stations) is poorly surfaced across the UI:
+
+- **Dashboard PC widget**: falls through to `SensorEquipmentWidget` (generic). No dedicated layout — typically only the picto and name are shown, not the live values.
+- **Dashboard mobile widget**: same generic fallback; tapping it opens a bottom sheet that uses `SensorDetailContent` (flat alias/value list, no module hierarchy).
+- **Zone compact card**: filters bindings on a hard-coded list (`temperature`, `sum_rain_24`, `wind_strength`). On real Netatmo data the 24h rain value sometimes ends up missing (binding key drift) and humidity is never shown.
+- **Equipment detail (WeatherPanel)**: the `rain` module shows the instantaneous `rain` reading as hero instead of the much more meaningful 24h cumulative. The `wind` module shows no directional indicator.
+- **HistoryBarChart**: at 7d/30d ranges the X-axis labels overlap and become unreadable; on mobile the chart is too narrow which makes the issue worse across all ranges (24h, 7d, 30d).
+
+## Goals
+
+1. Treat `weather` as a first-class equipment type in every view (dashboard PC + mobile, zone compact, detail, history chart).
+2. Keep widgets 1×1 — no layout footprint change.
+3. Surface the 24h rain quantity consistently everywhere.
+4. Make the history bar chart readable at every range on every screen size.
+
+## Non-goals
+
+- Forecast equipment (`weather_forecast`) is out of scope — already has its own dedicated widget and panel.
+- No backend changes (no new bindings, no new categories, no schema changes).
+- No new history aggregation logic — backend already exposes hourly/daily resolutions.
+- **Pressure trend (3 h)**: deferred to a follow-up spec. Requires lazy history fetch from inside `WeatherPanel`, which needs an `equipmentId` prop drilled in — bigger surface than this iteration warrants.
+
+## Scope (in / out)
+
+### In scope
+
+| View                       | Change                                                                                                                              |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `MobileWidgetCard.tsx`     | New `weather` case in `useMobileState`: 3-value summary (temp · humidity · rain24h)                                                 |
+| `WidgetDetailSheet.tsx`    | New `WeatherDetailContent` rendered before the `isSensor` branch — flat alias/value list of all weather bindings, no modular layout |
+| `EquipmentWidget.tsx`      | New `WeatherStationWidget` (PC 1×1): temperature hero + humidity/rain24h/wind list                                                  |
+| `CompactEquipmentCard.tsx` | Extend the weather filter to surface 4 values: temp + humidity + rain24h + wind                                                     |
+| `WeatherPanel.tsx`         | `rain` module hero = `sum_rain_24` (not `rain`); `wind` module: directional arrow rotated by `wind_angle`                           |
+| `HistoryBarChart.tsx`      | 2-line labels for 7d (weekday + day); compact `DD/MM` for 30d; responsive scale (mobile-friendly tick density, rotation, font size) |
+
+### Out of scope
+
+- Forecast widget/panel.
+- New bindings or backend computation.
+- Wind compass component (we only need a small arrow).
+- Min/max temperature over 24h (would require additional history queries — kept for a later spec).
+
+## Acceptance criteria
+
+1. **Mobile dashboard widget**: a weather equipment shows `19° · 54% · 0mm` style summary (or "—" placeholders if bindings missing). Tap opens the bottom sheet.
+2. **Mobile bottom sheet**: shows every weather binding as `<alias>` → `<value> <unit>` in a flat readable list (battery row included).
+3. **PC dashboard widget**: shows temp in big mono font + 3 secondary rows; widget remains 1×1.
+4. **Zone compact card**: 4 inline values; humidity is now present alongside temp/rain24h/wind.
+5. **WeatherPanel detail**: rain hero uses `sum_rain_24`; wind module has a small arrow rotated by `wind_angle` (mapping: 0° = North = arrow up).
+6. **HistoryBarChart on 7d (rain or any cumulative)**: 7 bars (1d resolution), each labeled on 2 lines (`lun.` / `03`), no overlapping.
+7. **HistoryBarChart on 30d**: compact `DD/MM` labels, tick interval picked so ≤ 10 labels show.
+8. **HistoryBarChart on mobile (24h / 7d / 30d)**: labels remain readable, no overlap; font size reduced if width < 360px; bars don't squash to invisible.
+9. Defensive: if a binding is missing (e.g. no rain module), placeholders ("—") render instead of empty space; no crash.
+
+## Edge cases
+
+- Equipment with only outdoor module (no rain, no wind): widget shows temp/humidity, "—" for rain/wind.
+- Empty history (new install): chart shows existing "Aucune donnée" placeholder unchanged.
+- Wind angle 0 vs missing: 0° = a real value (North); `null`/`undefined` = no arrow.
+- Mobile portrait at 320px viewport: chart must remain usable (small font + maybe rotated labels).
+- `sum_rain_24` binding absent on a station that uses a different key: compact card shows "—" rather than nothing.
+
+## Stations covered
+
+Primary target: **Netatmo Weather Station** (`sum_rain_1`, `sum_rain_24`, `wind_strength`, `wind_angle`, `gust_strength`, `gust_angle`, `temperature`, `humidity`, `pressure`, `noise`, `co2`).
+
+The KEY_LABELS / KEY_ORDER tables in `WeatherPanel.tsx` already encode this naming. Other stations (ecowitt, weatherflow, etc.) will degrade gracefully via the `DataCategory` resolution path.

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -14,6 +14,7 @@ import {
   Snowflake,
   WashingMachine,
   Timer,
+  CloudRain,
 } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
 import type { DashboardWidget } from "../../types";
@@ -74,6 +75,7 @@ export function EquipmentWidget({ widget, equipment, onExecuteOrder }: Equipment
   if (isHeater) return <HeaterEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
   if (isEnergyMeter) return <EnergyMeterEquipmentWidget label={label} equipment={equipment} />;
   if (isWeatherForecast) return <WeatherForecastWidget label={label} equipment={equipment} />;
+  if (equipment.type === "weather") return <WeatherStationWidget label={label} equipment={equipment} />;
   if (isAppliance) return <ApplianceEquipmentWidget label={label} equipment={equipment} />;
   if (isWaterValve) return <WaterValveEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
   if (isPoolPump) return <PoolPumpEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
@@ -640,6 +642,70 @@ function SensorEquipmentWidget({
         {sensorIcon}
         <div className="flex flex-col items-start pl-2 overflow-y-auto max-h-full">
           <SensorValues sensorBindings={filteredBindings} batteryBindings={batteryBindings} layout="column" />
+        </div>
+      </div>
+    </WidgetCard>
+  );
+}
+
+// ============================================================
+// Weather station widget (read-only — Netatmo + similar multi-module stations)
+// ============================================================
+
+function WeatherStationWidget({
+  label,
+  equipment,
+}: {
+  label: string;
+  equipment: EquipmentWithDetails;
+}) {
+  const { t } = useTranslation();
+
+  const find = (key: string) => equipment.dataBindings.find((b) => b.key === key);
+  const tempBinding = find("temperature");
+  const humidityBinding = find("humidity");
+  const rainBinding = find("sum_rain_24");
+  const windBinding = find("wind_strength");
+
+  const tempValue =
+    tempBinding && typeof tempBinding.value === "number"
+      ? tempBinding.value.toFixed(1)
+      : "—";
+
+  const renderRow = (
+    labelText: string,
+    binding: typeof tempBinding,
+    formatter: (v: number) => string,
+    unit: string,
+  ) => (
+    <div className="flex items-baseline justify-between text-[12px]">
+      <span className="text-text-secondary">{labelText}</span>
+      <span className="font-mono font-semibold text-text tabular-nums">
+        {binding && typeof binding.value === "number" ? formatter(binding.value) : "—"}
+        <span className="text-text-tertiary font-normal text-[10px] ml-0.5">{unit}</span>
+      </span>
+    </div>
+  );
+
+  return (
+    <WidgetCard label={label}>
+      <div className="flex flex-col h-full">
+        {/* Hero — icon + temperature */}
+        <div className="flex items-center gap-2 mb-2 sm:mb-3 mt-1 sm:mt-2">
+          <div className="w-8 h-8 rounded-[8px] flex items-center justify-center bg-primary-light text-primary flex-shrink-0">
+            <CloudRain size={18} strokeWidth={1.5} />
+          </div>
+          <span className="font-mono font-bold text-[22px] sm:text-[26px] text-text tabular-nums leading-none">
+            {tempValue}
+            <span className="text-text-tertiary font-normal text-[14px] ml-0.5">°</span>
+          </span>
+        </div>
+
+        {/* Secondary rows */}
+        <div className="flex flex-col gap-1 sm:gap-1.5">
+          {renderRow(t("category.humidity"), humidityBinding, (v) => `${Math.round(v)}`, "%")}
+          {renderRow(t("weather.rain24h"), rainBinding, (v) => v.toFixed(1), "mm")}
+          {renderRow(t("weather.windSpeed"), windBinding, (v) => `${Math.round(v)}`, "km/h")}
         </div>
       </div>
     </WidgetCard>

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -696,16 +696,16 @@ function WeatherStationWidget({
   return (
     <WidgetCard label={label}>
       <div className="flex flex-col h-full">
-        {/* Hero — icon + temperature, centered, fills upper portion */}
-        <div className="flex flex-col items-center justify-center flex-1 min-h-0 gap-2">
-          <div className="w-11 h-11 rounded-[10px] flex items-center justify-center bg-primary-light text-primary">
-            <CloudRain size={24} strokeWidth={1.5} />
-          </div>
-          <div className="flex items-start leading-none">
+        {/* Hero — outdoor temperature, centered, fills upper portion */}
+        <div className="flex flex-col items-center justify-center flex-1 min-h-0 gap-1">
+          <span className="text-[11px] uppercase tracking-wide text-text-tertiary font-medium">
+            {t("weather.outdoor")}
+          </span>
+          <div className="flex items-baseline leading-none">
             <span className="font-mono font-bold text-[34px] sm:text-[40px] text-text tabular-nums leading-none">
               {tempValue}
             </span>
-            <span className="text-text-tertiary font-medium text-[20px] sm:text-[24px] leading-none ml-0.5">°</span>
+            <span className="text-text-tertiary font-medium text-[16px] sm:text-[18px] leading-none ml-1">°C</span>
           </div>
         </div>
 

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -15,6 +15,8 @@ import {
   WashingMachine,
   Timer,
   CloudRain,
+  Droplets,
+  Wind,
 } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
 import type { DashboardWidget } from "../../types";
@@ -673,14 +675,18 @@ function WeatherStationWidget({
       : "—";
 
   const renderRow = (
+    iconNode: React.ReactNode,
     labelText: string,
     binding: typeof tempBinding,
     formatter: (v: number) => string,
     unit: string,
   ) => (
-    <div className="flex items-baseline justify-between text-[12px]">
-      <span className="text-text-secondary">{labelText}</span>
-      <span className="font-mono font-semibold text-text tabular-nums">
+    <div className="flex items-baseline justify-between gap-2 text-[12px]">
+      <span className="flex items-center gap-1.5 text-text-secondary min-w-0">
+        <span className="text-text-tertiary flex-shrink-0">{iconNode}</span>
+        <span className="truncate">{labelText}</span>
+      </span>
+      <span className="font-mono font-semibold text-text tabular-nums flex-shrink-0">
         {binding && typeof binding.value === "number" ? formatter(binding.value) : "—"}
         <span className="text-text-tertiary font-normal text-[10px] ml-0.5">{unit}</span>
       </span>
@@ -690,22 +696,42 @@ function WeatherStationWidget({
   return (
     <WidgetCard label={label}>
       <div className="flex flex-col h-full">
-        {/* Hero — icon + temperature */}
-        <div className="flex items-center gap-2 mb-2 sm:mb-3 mt-1 sm:mt-2">
-          <div className="w-8 h-8 rounded-[8px] flex items-center justify-center bg-primary-light text-primary flex-shrink-0">
-            <CloudRain size={18} strokeWidth={1.5} />
+        {/* Hero — icon + temperature, centered, fills upper portion */}
+        <div className="flex flex-col items-center justify-center flex-1 min-h-0 gap-2">
+          <div className="w-11 h-11 rounded-[10px] flex items-center justify-center bg-primary-light text-primary">
+            <CloudRain size={24} strokeWidth={1.5} />
           </div>
-          <span className="font-mono font-bold text-[22px] sm:text-[26px] text-text tabular-nums leading-none">
-            {tempValue}
-            <span className="text-text-tertiary font-normal text-[14px] ml-0.5">°</span>
-          </span>
+          <div className="flex items-start leading-none">
+            <span className="font-mono font-bold text-[34px] sm:text-[40px] text-text tabular-nums leading-none">
+              {tempValue}
+            </span>
+            <span className="text-text-tertiary font-medium text-[20px] sm:text-[24px] leading-none ml-0.5">°</span>
+          </div>
         </div>
 
-        {/* Secondary rows */}
-        <div className="flex flex-col gap-1 sm:gap-1.5">
-          {renderRow(t("category.humidity"), humidityBinding, (v) => `${Math.round(v)}`, "%")}
-          {renderRow(t("weather.rain24h"), rainBinding, (v) => v.toFixed(1), "mm")}
-          {renderRow(t("weather.windSpeed"), windBinding, (v) => `${Math.round(v)}`, "km/h")}
+        {/* Secondary rows pinned at the bottom */}
+        <div className="flex flex-col gap-1.5 border-t border-border-light pt-2 mt-2">
+          {renderRow(
+            <Droplets size={12} strokeWidth={1.5} />,
+            t("category.humidity"),
+            humidityBinding,
+            (v) => `${Math.round(v)}`,
+            "%",
+          )}
+          {renderRow(
+            <CloudRain size={12} strokeWidth={1.5} />,
+            t("weather.rain24h"),
+            rainBinding,
+            (v) => v.toFixed(1),
+            "mm",
+          )}
+          {renderRow(
+            <Wind size={12} strokeWidth={1.5} />,
+            t("weather.windSpeed"),
+            windBinding,
+            (v) => `${Math.round(v)}`,
+            "km/h",
+          )}
         </div>
       </div>
     </WidgetCard>

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -14,9 +14,7 @@ import {
   Snowflake,
   WashingMachine,
   Timer,
-  CloudRain,
   Droplets,
-  Wind,
 } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
 import type { DashboardWidget } from "../../types";
@@ -48,9 +46,11 @@ interface EquipmentWidgetProps {
   widget: DashboardWidget;
   equipment: EquipmentWithDetails;
   onExecuteOrder: (equipmentId: string, alias: string, value: unknown) => Promise<void>;
+  /** Click handler that opens the desktop detail drawer. Currently consumed only by the weather widget. */
+  onOpenDetail?: () => void;
 }
 
-export function EquipmentWidget({ widget, equipment, onExecuteOrder }: EquipmentWidgetProps) {
+export function EquipmentWidget({ widget, equipment, onExecuteOrder, onOpenDetail }: EquipmentWidgetProps) {
   const {
     isLight,
     isShutter,
@@ -77,7 +77,7 @@ export function EquipmentWidget({ widget, equipment, onExecuteOrder }: Equipment
   if (isHeater) return <HeaterEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
   if (isEnergyMeter) return <EnergyMeterEquipmentWidget label={label} equipment={equipment} />;
   if (isWeatherForecast) return <WeatherForecastWidget label={label} equipment={equipment} />;
-  if (equipment.type === "weather") return <WeatherStationWidget label={label} equipment={equipment} />;
+  if (equipment.type === "weather") return <WeatherStationWidget label={label} equipment={equipment} onOpenDetail={onOpenDetail} />;
   if (isAppliance) return <ApplianceEquipmentWidget label={label} equipment={equipment} />;
   if (isWaterValve) return <WaterValveEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
   if (isPoolPump) return <PoolPumpEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
@@ -657,47 +657,36 @@ function SensorEquipmentWidget({
 function WeatherStationWidget({
   label,
   equipment,
+  onOpenDetail,
 }: {
   label: string;
   equipment: EquipmentWithDetails;
+  onOpenDetail?: () => void;
 }) {
   const { t } = useTranslation();
 
   const find = (key: string) => equipment.dataBindings.find((b) => b.key === key);
   const tempBinding = find("temperature");
   const humidityBinding = find("humidity");
-  const rainBinding = find("sum_rain_24");
-  const windBinding = find("wind_strength");
 
   const tempValue =
     tempBinding && typeof tempBinding.value === "number"
       ? tempBinding.value.toFixed(1)
       : "—";
+  const humidityValue =
+    humidityBinding && typeof humidityBinding.value === "number"
+      ? `${Math.round(humidityBinding.value)}`
+      : "—";
 
-  const renderRow = (
-    iconNode: React.ReactNode,
-    labelText: string,
-    binding: typeof tempBinding,
-    formatter: (v: number) => string,
-    unit: string,
-  ) => (
-    <div className="flex items-baseline justify-between gap-2 text-[12px]">
-      <span className="flex items-center gap-1.5 text-text-secondary min-w-0">
-        <span className="text-text-tertiary flex-shrink-0">{iconNode}</span>
-        <span className="truncate">{labelText}</span>
-      </span>
-      <span className="font-mono font-semibold text-text tabular-nums flex-shrink-0">
-        {binding && typeof binding.value === "number" ? formatter(binding.value) : "—"}
-        <span className="text-text-tertiary font-normal text-[10px] ml-0.5">{unit}</span>
-      </span>
-    </div>
-  );
+  const clickClass = onOpenDetail
+    ? "cursor-pointer transition-colors hover:bg-primary-light/30"
+    : "";
 
   return (
-    <WidgetCard label={label}>
-      <div className="flex flex-col h-full">
-        {/* Hero — outdoor temperature, centered, fills upper portion */}
-        <div className="flex flex-col items-center justify-center flex-1 min-h-0 gap-1">
+    <WidgetCard label={label} onClick={onOpenDetail} className={clickClass}>
+      <div className="flex flex-col items-center justify-center flex-1 min-h-0 gap-3">
+        {/* Outdoor temperature */}
+        <div className="flex flex-col items-center gap-1">
           <span className="text-[11px] uppercase tracking-wide text-text-tertiary font-medium">
             {t("weather.outdoor")}
           </span>
@@ -709,29 +698,13 @@ function WeatherStationWidget({
           </div>
         </div>
 
-        {/* Secondary rows pinned at the bottom */}
-        <div className="flex flex-col gap-1.5 border-t border-border-light pt-2 mt-2">
-          {renderRow(
-            <Droplets size={12} strokeWidth={1.5} />,
-            t("category.humidity"),
-            humidityBinding,
-            (v) => `${Math.round(v)}`,
-            "%",
-          )}
-          {renderRow(
-            <CloudRain size={12} strokeWidth={1.5} />,
-            t("weather.rain24h"),
-            rainBinding,
-            (v) => v.toFixed(1),
-            "mm",
-          )}
-          {renderRow(
-            <Wind size={12} strokeWidth={1.5} />,
-            t("weather.windSpeed"),
-            windBinding,
-            (v) => `${Math.round(v)}`,
-            "km/h",
-          )}
+        {/* Humidity */}
+        <div className="flex items-center gap-1.5">
+          <Droplets size={14} strokeWidth={1.5} className="text-text-tertiary" />
+          <span className="font-mono font-semibold text-[16px] sm:text-[18px] text-text tabular-nums">
+            {humidityValue}
+            <span className="text-text-tertiary font-normal text-[12px] ml-0.5">%</span>
+          </span>
         </div>
       </div>
     </WidgetCard>

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -182,20 +182,20 @@ function useMobileState(
     const hum = find("humidity");
     const tempStr = typeof temp?.value === "number" ? `${temp.value.toFixed(1)}°` : "—";
     const humStr = typeof hum?.value === "number" ? `${Math.round(hum.value)} %` : "—";
-    // Icon slot is scaled 50% in MobileWidgetCard, so we size the text 2x what we want visible.
+    // We ignore widget.icon on purpose: the configured icon (e.g. a sun) is
+    // less useful than the actual outdoor temperature. Icon slot is scaled 50%
+    // in MobileWidgetCard, so we size the text 2x what we want visible.
     return {
-      icon: customEntry
-        ? createElement(customEntry.component, customEntry.previewProps)
-        : (
-          <div className="flex flex-col items-center gap-1 leading-none whitespace-nowrap">
-            <span className="text-[18px] uppercase tracking-wide text-text-tertiary font-medium">
-              {t("weather.outdoor")}
-            </span>
-            <span className="font-mono font-bold text-[56px] text-text tabular-nums">
-              {tempStr}
-            </span>
-          </div>
-        ),
+      icon: (
+        <div className="flex flex-col items-center gap-1 leading-none whitespace-nowrap">
+          <span className="text-[18px] uppercase tracking-wide text-text-tertiary font-medium">
+            {t("weather.outdoor")}
+          </span>
+          <span className="font-mono font-bold text-[56px] text-text tabular-nums">
+            {tempStr}
+          </span>
+        </div>
+      ),
       stateLines: [`${humStr} ${t("category.humidity").toLowerCase()}`],
     };
   }

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -19,7 +19,7 @@ import {
 } from "./WidgetIcons";
 import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
 import { parseForecastDays, CONDITION_ICONS, CONDITION_COLORS } from "../equipments/weatherForecastUtils";
-import { Cloud, CloudRain, WashingMachine, Tv } from "lucide-react";
+import { Cloud, WashingMachine, Tv } from "lucide-react";
 
 interface MobileWidgetCardProps {
   widget: DashboardWidget;
@@ -180,16 +180,23 @@ function useMobileState(
     const find = (key: string) => equipment.dataBindings.find((b) => b.key === key);
     const temp = find("temperature");
     const hum = find("humidity");
-    const rain = find("sum_rain_24");
-    const lines: string[] = [];
-    if (typeof temp?.value === "number") lines.push(`${temp.value.toFixed(1)}°`);
-    if (typeof hum?.value === "number") lines.push(`${Math.round(hum.value)}%`);
-    if (typeof rain?.value === "number") lines.push(`${rain.value.toFixed(1)}mm`);
+    const tempStr = typeof temp?.value === "number" ? `${temp.value.toFixed(1)}°` : "—";
+    const humStr = typeof hum?.value === "number" ? `${Math.round(hum.value)} %` : "—";
+    // Icon slot is scaled 50% in MobileWidgetCard, so we size the text 2x what we want visible.
     return {
       icon: customEntry
         ? createElement(customEntry.component, customEntry.previewProps)
-        : <CloudRain size={96} strokeWidth={1.2} className="text-primary" />,
-      stateLines: lines,
+        : (
+          <div className="flex flex-col items-center gap-1 leading-none whitespace-nowrap">
+            <span className="text-[18px] uppercase tracking-wide text-text-tertiary font-medium">
+              {t("weather.outdoor")}
+            </span>
+            <span className="font-mono font-bold text-[56px] text-text tabular-nums">
+              {tempStr}
+            </span>
+          </div>
+        ),
+      stateLines: [`${humStr} ${t("category.humidity").toLowerCase()}`],
     };
   }
 

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -19,7 +19,7 @@ import {
 } from "./WidgetIcons";
 import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
 import { parseForecastDays, CONDITION_ICONS, CONDITION_COLORS } from "../equipments/weatherForecastUtils";
-import { Cloud, WashingMachine, Tv } from "lucide-react";
+import { Cloud, CloudRain, WashingMachine, Tv } from "lucide-react";
 
 interface MobileWidgetCardProps {
   widget: DashboardWidget;
@@ -173,6 +173,23 @@ function useMobileState(
         ? createElement(customEntry.component, customEntry.previewProps)
         : <HeaterWidgetIcon comfort={isComfort} />,
       stateLines: [isComfort ? t("controls.heater.comfort") : t("controls.heater.eco")],
+    };
+  }
+
+  if (equipment.type === "weather") {
+    const find = (key: string) => equipment.dataBindings.find((b) => b.key === key);
+    const temp = find("temperature");
+    const hum = find("humidity");
+    const rain = find("sum_rain_24");
+    const lines: string[] = [];
+    if (typeof temp?.value === "number") lines.push(`${temp.value.toFixed(1)}°`);
+    if (typeof hum?.value === "number") lines.push(`${Math.round(hum.value)}%`);
+    if (typeof rain?.value === "number") lines.push(`${rain.value.toFixed(1)}mm`);
+    return {
+      icon: customEntry
+        ? createElement(customEntry.component, customEntry.previewProps)
+        : <CloudRain size={96} strokeWidth={1.2} className="text-primary" />,
+      stateLines: lines,
     };
   }
 

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -155,7 +155,6 @@ const WEATHER_KEY_ORDER = [
   "humidity",
   "sum_rain_24",
   "sum_rain_1",
-  "rain",
   "wind_strength",
   "gust_strength",
   "wind_angle",
@@ -165,19 +164,29 @@ const WEATHER_KEY_ORDER = [
   "noise",
 ];
 
+/**
+ * Weather binding keys explicitly hidden from the mobile bottom sheet.
+ * The instantaneous rain rate (mm/h) is noise compared to the 24h cumulative,
+ * which is the value people actually act on.
+ */
+const WEATHER_KEY_HIDDEN = new Set(["rain"]);
+
 function WeatherDetailContent({ equipment }: { equipment: EquipmentWithDetails }) {
   const { t } = useTranslation();
   const { sensorBindings, batteryBindings } = useEquipmentState(equipment);
 
-  // Sort bindings by the weather order; unknown keys go last in alphabetical order.
-  const sorted = [...sensorBindings].sort((a, b) => {
-    const ia = WEATHER_KEY_ORDER.indexOf(a.key);
-    const ib = WEATHER_KEY_ORDER.indexOf(b.key);
-    if (ia !== -1 && ib !== -1) return ia - ib;
-    if (ia !== -1) return -1;
-    if (ib !== -1) return 1;
-    return a.key.localeCompare(b.key);
-  });
+  // Filter out bindings explicitly hidden on mobile, then sort by weather order
+  // (unknown keys go last in alphabetical order).
+  const sorted = sensorBindings
+    .filter((b) => !WEATHER_KEY_HIDDEN.has(b.key))
+    .sort((a, b) => {
+      const ia = WEATHER_KEY_ORDER.indexOf(a.key);
+      const ib = WEATHER_KEY_ORDER.indexOf(b.key);
+      if (ia !== -1 && ib !== -1) return ia - ib;
+      if (ia !== -1) return -1;
+      if (ib !== -1) return 1;
+      return a.key.localeCompare(b.key);
+    });
 
   return (
     <div className="flex flex-col gap-4">

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -14,6 +14,7 @@ import {
   Snowflake,
   Lightbulb,
   LightbulbOff,
+  CloudRain,
 } from "lucide-react";
 import type { DashboardWidget, EquipmentWithDetails, ZoneWithChildren } from "../../types";
 import { executeZoneOrder } from "../../api";
@@ -21,6 +22,7 @@ import { useEquipmentState } from "../equipments/useEquipmentState";
 import { findOrderByCategory } from "../equipments/bindingUtils";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
 import { SensorValues } from "../equipments/SensorValues";
+import { formatSensorValue } from "../equipments/sensorUtils";
 import {
   LightBulbIcon,
   ShutterWidgetIcon,
@@ -104,6 +106,16 @@ export function EquipmentDetailSheet({ widget, equipment, onExecuteOrder, onClos
     );
   }
 
+  if (equipment.type === "weather") {
+    return (
+      <BottomSheet open onClose={onClose} title={label}
+        icon={customEntry ? <div className="scale-[0.35]">{createElement(customEntry.component, customEntry.previewProps)}</div> : undefined}
+      >
+        <WeatherDetailContent equipment={equipment} />
+      </BottomSheet>
+    );
+  }
+
   if (isSensor) {
     return (
       <BottomSheet open onClose={onClose} title={label}
@@ -115,6 +127,93 @@ export function EquipmentDetailSheet({ widget, equipment, onExecuteOrder, onClos
   }
 
   return null;
+}
+
+// ============================================================
+// Weather station detail (mobile bottom sheet)
+// ============================================================
+
+/** i18n key for each weather-specific binding key (mirrors WeatherPanel.KEY_LABELS). */
+const WEATHER_KEY_LABELS: Record<string, string> = {
+  temperature: "category.temperature",
+  humidity: "category.humidity",
+  pressure: "category.pressure",
+  wind_strength: "weather.windSpeed",
+  wind_angle: "weather.windDirection",
+  gust_strength: "weather.gustSpeed",
+  gust_angle: "weather.gustDirection",
+  rain: "weather.rainCurrent",
+  sum_rain_1: "weather.rain1h",
+  sum_rain_24: "weather.rain24h",
+  noise: "category.noise",
+  co2: "category.co2",
+};
+
+/** Display order for the weather binding list (most useful values first). */
+const WEATHER_KEY_ORDER = [
+  "temperature",
+  "humidity",
+  "sum_rain_24",
+  "sum_rain_1",
+  "rain",
+  "wind_strength",
+  "gust_strength",
+  "wind_angle",
+  "gust_angle",
+  "pressure",
+  "co2",
+  "noise",
+];
+
+function WeatherDetailContent({ equipment }: { equipment: EquipmentWithDetails }) {
+  const { t } = useTranslation();
+  const { sensorBindings, batteryBindings } = useEquipmentState(equipment);
+
+  // Sort bindings by the weather order; unknown keys go last in alphabetical order.
+  const sorted = [...sensorBindings].sort((a, b) => {
+    const ia = WEATHER_KEY_ORDER.indexOf(a.key);
+    const ib = WEATHER_KEY_ORDER.indexOf(b.key);
+    if (ia !== -1 && ib !== -1) return ia - ib;
+    if (ia !== -1) return -1;
+    if (ib !== -1) return 1;
+    return a.key.localeCompare(b.key);
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex justify-center">
+        <div className="w-12 h-12 rounded-[10px] flex items-center justify-center bg-primary-light text-primary">
+          <CloudRain size={28} strokeWidth={1.5} />
+        </div>
+      </div>
+      <div className="divide-y divide-border-light">
+        {sorted.map((b) => (
+          <div key={b.id} className="flex items-baseline justify-between py-2">
+            <span className="text-[13px] text-text-secondary">
+              {WEATHER_KEY_LABELS[b.key] ? t(WEATHER_KEY_LABELS[b.key]) : b.key}
+            </span>
+            <span className="text-[14px] font-mono font-semibold text-text tabular-nums">
+              {formatSensorValue(b.value, undefined, t)}
+              {b.unit && (
+                <span className="text-text-tertiary font-normal text-[12px] ml-1">{b.unit}</span>
+              )}
+            </span>
+          </div>
+        ))}
+        {batteryBindings.map((b) => (
+          <div key={b.id} className="flex items-baseline justify-between py-2">
+            <span className="text-[13px] text-text-secondary">
+              {b.deviceName} · {t("sensors.battery")}
+            </span>
+            <span className="text-[14px] font-mono font-semibold text-text tabular-nums">
+              {formatSensorValue(b.value, undefined, t)}
+              <span className="text-text-tertiary font-normal text-[12px] ml-1">%</span>
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 // ============================================================

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -145,6 +145,9 @@ const WEATHER_KEY_LABELS: Record<string, string> = {
   rain: "weather.rainCurrent",
   sum_rain_1: "weather.rain1h",
   sum_rain_24: "weather.rain24h",
+  // Sowel-computed cumulative rain (alias differs from the Netatmo native bindings).
+  rain_1h: "weather.rain1h",
+  rain_24h: "weather.rain24h",
   noise: "category.noise",
   co2: "category.co2",
 };
@@ -153,6 +156,8 @@ const WEATHER_KEY_LABELS: Record<string, string> = {
 const WEATHER_KEY_ORDER = [
   "temperature",
   "humidity",
+  "rain_24h",
+  "rain_1h",
   "sum_rain_24",
   "sum_rain_1",
   "wind_strength",
@@ -171,22 +176,50 @@ const WEATHER_KEY_ORDER = [
  */
 const WEATHER_KEY_HIDDEN = new Set(["rain"]);
 
+/** Computed-data aliases surfaced on weather equipments (in addition to dataBindings). */
+const WEATHER_COMPUTED_ALIASES = ["rain_24h", "rain_1h"];
+
+interface WeatherRow {
+  id: string;
+  key: string;
+  value: unknown;
+  unit?: string;
+}
+
 function WeatherDetailContent({ equipment }: { equipment: EquipmentWithDetails }) {
   const { t } = useTranslation();
   const { sensorBindings, batteryBindings } = useEquipmentState(equipment);
 
-  // Filter out bindings explicitly hidden on mobile, then sort by weather order
-  // (unknown keys go last in alphabetical order).
-  const sorted = sensorBindings
-    .filter((b) => !WEATHER_KEY_HIDDEN.has(b.key))
-    .sort((a, b) => {
-      const ia = WEATHER_KEY_ORDER.indexOf(a.key);
-      const ib = WEATHER_KEY_ORDER.indexOf(b.key);
-      if (ia !== -1 && ib !== -1) return ia - ib;
-      if (ia !== -1) return -1;
-      if (ib !== -1) return 1;
-      return a.key.localeCompare(b.key);
-    });
+  // Merge dataBindings (filtered to hide instantaneous `rain`) with selected
+  // computedData entries (rain_24h, rain_1h) so the drawer surfaces the rain
+  // cumulative values even when only the bare `rain` binding is attached.
+  const rows: WeatherRow[] = [
+    ...sensorBindings
+      .filter((b) => !WEATHER_KEY_HIDDEN.has(b.key))
+      .map((b): WeatherRow => ({
+        id: `b-${b.id}`,
+        key: b.key,
+        value: b.value,
+        unit: b.unit ?? undefined,
+      })),
+    ...(equipment.computedData ?? [])
+      .filter((c) => WEATHER_COMPUTED_ALIASES.includes(c.alias))
+      .map((c): WeatherRow => ({
+        id: `c-${c.alias}`,
+        key: c.alias,
+        value: c.value,
+        unit: c.unit,
+      })),
+  ];
+
+  rows.sort((a, b) => {
+    const ia = WEATHER_KEY_ORDER.indexOf(a.key);
+    const ib = WEATHER_KEY_ORDER.indexOf(b.key);
+    if (ia !== -1 && ib !== -1) return ia - ib;
+    if (ia !== -1) return -1;
+    if (ib !== -1) return 1;
+    return a.key.localeCompare(b.key);
+  });
 
   return (
     <div className="flex flex-col gap-4">
@@ -196,15 +229,15 @@ function WeatherDetailContent({ equipment }: { equipment: EquipmentWithDetails }
         </div>
       </div>
       <div className="divide-y divide-border-light">
-        {sorted.map((b) => (
-          <div key={b.id} className="flex items-baseline justify-between py-2">
+        {rows.map((r) => (
+          <div key={r.id} className="flex items-baseline justify-between py-2">
             <span className="text-[13px] text-text-secondary">
-              {WEATHER_KEY_LABELS[b.key] ? t(WEATHER_KEY_LABELS[b.key]) : b.key}
+              {WEATHER_KEY_LABELS[r.key] ? t(WEATHER_KEY_LABELS[r.key]) : r.key}
             </span>
             <span className="text-[14px] font-mono font-semibold text-text tabular-nums">
-              {formatSensorValue(b.value, undefined, t)}
-              {b.unit && (
-                <span className="text-text-tertiary font-normal text-[12px] ml-1">{b.unit}</span>
+              {formatSensorValue(r.value, undefined, t)}
+              {r.unit && (
+                <span className="text-text-tertiary font-normal text-[12px] ml-1">{r.unit}</span>
               )}
             </span>
           </div>

--- a/ui/src/components/dashboard/WidgetGrid.tsx
+++ b/ui/src/components/dashboard/WidgetGrid.tsx
@@ -368,6 +368,7 @@ function WidgetRenderer({
         widget={widget}
         equipment={equipment}
         onExecuteOrder={onExecuteOrder}
+        onOpenDetail={editMode ? undefined : onOpenDetail}
       />
     );
   }

--- a/ui/src/components/equipments/WeatherPanel.test.ts
+++ b/ui/src/components/equipments/WeatherPanel.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { angleToCompass } from "./weather-utils";
+
+describe("angleToCompass", () => {
+  it("maps cardinal directions", () => {
+    expect(angleToCompass(0)).toBe("N");
+    expect(angleToCompass(90)).toBe("E");
+    expect(angleToCompass(180)).toBe("S");
+    expect(angleToCompass(270)).toBe("O");
+  });
+
+  it("maps inter-cardinal directions", () => {
+    expect(angleToCompass(45)).toBe("NE");
+    expect(angleToCompass(135)).toBe("SE");
+    expect(angleToCompass(225)).toBe("SO");
+    expect(angleToCompass(315)).toBe("NO");
+  });
+
+  it("normalizes 360° to N", () => {
+    expect(angleToCompass(360)).toBe("N");
+  });
+
+  it("handles negative angles by normalizing", () => {
+    expect(angleToCompass(-90)).toBe("O");
+  });
+
+  it("rounds to the nearest 16th of a turn", () => {
+    // 22.5° boundary → between N and NNE; rounded to NNE
+    expect(angleToCompass(22.5)).toBe("NNE");
+    // 11° → still closer to N
+    expect(angleToCompass(11)).toBe("N");
+    // 12° → closer to NNE
+    expect(angleToCompass(12)).toBe("NNE");
+  });
+});

--- a/ui/src/components/equipments/WeatherPanel.tsx
+++ b/ui/src/components/equipments/WeatherPanel.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import { Wind, CloudRain, Thermometer } from "lucide-react";
 import type { DataBindingWithValue } from "../../types";
 import { getBatteryIcon, getBatteryColor, formatSensorValue } from "./sensorUtils";
+import { angleToCompass } from "./weather-utils";
 
 interface WeatherPanelProps {
   bindings: DataBindingWithValue[];
@@ -33,8 +34,34 @@ const PRIMARY_KEY: Record<string, string> = {
 /** Display order for keys within each device type. */
 const KEY_ORDER: Record<string, string[]> = {
   wind: ["wind_strength", "wind_angle", "gust_strength", "gust_angle"],
-  rain: ["rain", "sum_rain_1", "sum_rain_24"],
+  rain: ["sum_rain_24", "sum_rain_1", "rain"],
 };
+
+/**
+ * Arrow pointing in the direction the wind is going (= angle + 180°).
+ * `angle` is the meteorological "from" angle (0° = from North).
+ * Returns null when the angle isn't a finite number.
+ */
+function WindArrow({ angle, size = 18 }: { angle: number | null; size?: number }) {
+  if (angle === null || !Number.isFinite(angle)) return null;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ transform: `rotate(${angle}deg)`, transformOrigin: "center" }}
+      aria-hidden="true"
+    >
+      <line x1="12" y1="19" x2="12" y2="5" />
+      <polyline points="6 11 12 5 18 11" />
+    </svg>
+  );
+}
 
 type DeviceKind = "wind" | "rain" | "outdoor";
 
@@ -128,10 +155,22 @@ function WeatherDeviceCard({
   const primaryKey = PRIMARY_KEY[kind] ?? PRIMARY_KEY.default;
   const primaryBinding = sensorBindings.find((b) => b.key === primaryKey);
 
-  // Sort remaining bindings by defined order, primary excluded
+  // For the wind module, surface direction next to the hero (arrow + compass label).
+  const windAngleBinding =
+    kind === "wind"
+      ? sensorBindings.find((b) => b.key === "wind_angle")
+      : undefined;
+  const windAngle =
+    windAngleBinding && typeof windAngleBinding.value === "number"
+      ? windAngleBinding.value
+      : null;
+
+  // Sort remaining bindings by defined order, primary excluded.
+  // wind_angle is folded into the hero (arrow + compass) so we drop it from the secondary list.
   const order = KEY_ORDER[kind];
   const secondaryBindings = sensorBindings
     .filter((b) => b !== primaryBinding)
+    .filter((b) => !(kind === "wind" && b.key === "wind_angle"))
     .sort((a, b) => {
       if (!order) return 0;
       const ia = order.indexOf(a.key);
@@ -168,18 +207,28 @@ function WeatherDeviceCard({
       {/* Hero value */}
       {primaryBinding && (
         <div className="text-center mb-4">
-          <span className="text-[32px] font-bold font-mono text-text leading-none tabular-nums">
-            {formatSensorValue(primaryBinding.value, undefined, t)}
-          </span>
-          {primaryBinding.unit && (
-            <span className="text-[16px] text-text-tertiary ml-1">
-              {primaryBinding.unit}
+          <div className="inline-flex items-center gap-2">
+            <span className="text-[32px] font-bold font-mono text-text leading-none tabular-nums">
+              {formatSensorValue(primaryBinding.value, undefined, t)}
             </span>
-          )}
+            {primaryBinding.unit && (
+              <span className="text-[16px] text-text-tertiary">
+                {primaryBinding.unit}
+              </span>
+            )}
+            {kind === "wind" && windAngle !== null && (
+              <span className="text-primary inline-flex items-center">
+                <WindArrow angle={windAngle} size={20} />
+              </span>
+            )}
+          </div>
           <div className="text-[12px] text-text-tertiary mt-1">
             {KEY_LABELS[primaryBinding.key]
               ? t(KEY_LABELS[primaryBinding.key])
               : primaryBinding.key}
+            {kind === "wind" && windAngle !== null && (
+              <> · {angleToCompass(windAngle)}</>
+            )}
           </div>
         </div>
       )}

--- a/ui/src/components/equipments/weather-utils.ts
+++ b/ui/src/components/equipments/weather-utils.ts
@@ -1,0 +1,12 @@
+/** 16-point compass abbreviations (FR). 0° = N, clockwise. */
+const COMPASS_FR = [
+  "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE",
+  "S", "SSO", "SO", "OSO", "O", "ONO", "NO", "NNO",
+];
+
+/** Convert a meteorological wind angle (0 = North, clockwise) to a compass abbreviation. */
+export function angleToCompass(angle: number): string {
+  const normalized = ((angle % 360) + 360) % 360;
+  const idx = Math.round(normalized / 22.5) % 16;
+  return COMPASS_FR[idx];
+}

--- a/ui/src/components/history/HistoryBarChart.test.ts
+++ b/ui/src/components/history/HistoryBarChart.test.ts
@@ -2,37 +2,73 @@ import { describe, it, expect } from "vitest";
 import { formatLabel, pickTickInterval } from "./chart-utils";
 
 describe("pickTickInterval", () => {
-  it("returns 0 when count fits the desktop budget (≤12)", () => {
-    expect(pickTickInterval(7, 1024)).toBe(0);
-    expect(pickTickInterval(12, 1024)).toBe(0);
+  describe("without a range (viewport-only cap)", () => {
+    it("returns 0 when count fits the desktop budget (≤12)", () => {
+      expect(pickTickInterval(7, 1024)).toBe(0);
+      expect(pickTickInterval(12, 1024)).toBe(0);
+    });
+
+    it("returns 0 when count fits the small-mobile budget (≤6 at <360px)", () => {
+      expect(pickTickInterval(6, 320)).toBe(0);
+    });
+
+    it("returns 0 when count fits the medium-mobile budget (≤8 at <640px)", () => {
+      expect(pickTickInterval(8, 400)).toBe(0);
+    });
+
+    it("uses ceil() so visible count actually stays ≤ maxLabels (regression: floor leaks ticks)", () => {
+      // 19 points / 12 maxLabels — floor would give 0 (all ticks shown).
+      // ceil(19/12)=2 → interval 1 → ~10 visible. Bug seen in spec 114 v1.
+      expect(pickTickInterval(19, 1024)).toBe(1);
+    });
+
+    it("skips ticks on desktop when count exceeds 12", () => {
+      // ceil(30/12)=3 → interval 2 (=> 1 visible / 3 → ~10 shown)
+      expect(pickTickInterval(30, 1024)).toBe(2);
+    });
+
+    it("skips more aggressively on small mobile", () => {
+      // ceil(30/6)=5 → interval 4 (=> 1 visible / 5 → 6 shown)
+      expect(pickTickInterval(30, 340)).toBe(4);
+    });
+
+    it("handles dense hourly history on desktop", () => {
+      // ceil(168/12)=14 → interval 13 (=> 1 visible / 14)
+      expect(pickTickInterval(168, 1024)).toBe(13);
+    });
+
+    it("never returns a negative interval", () => {
+      expect(pickTickInterval(1, 320)).toBe(0);
+      expect(pickTickInterval(0, 320)).toBe(0);
+    });
   });
 
-  it("returns 0 when count fits the small-mobile budget (≤6 at <360px)", () => {
-    expect(pickTickInterval(6, 320)).toBe(0);
-  });
+  describe("with a range (per-range cap kicks in)", () => {
+    it("caps 7d at ~7 labels on desktop", () => {
+      // 19 spiky points on 7d → 7 labels max → ceil(19/7)=3 → interval 2
+      expect(pickTickInterval(19, 1024, "7d")).toBe(2);
+    });
 
-  it("returns 0 when count fits the medium-mobile budget (≤8 at <640px)", () => {
-    expect(pickTickInterval(8, 400)).toBe(0);
-  });
+    it("caps 30d at ~10 labels on desktop", () => {
+      // 30 points on 30d → 10 max → ceil(30/10)=3 → interval 2
+      expect(pickTickInterval(30, 1024, "30d")).toBe(2);
+    });
 
-  it("skips ticks on desktop when count exceeds 12", () => {
-    // 30 points / 12 maxLabels = 2.5 → floor = 2 → interval = 1 (=> 1 visible / 2)
-    expect(pickTickInterval(30, 1024)).toBe(1);
-  });
+    it("caps 24h at ~8 labels on desktop", () => {
+      // 24 points → 8 max → ceil(24/8)=3 → interval 2
+      expect(pickTickInterval(24, 1024, "24h")).toBe(2);
+    });
 
-  it("skips more aggressively on small mobile", () => {
-    // 30 points / 6 maxLabels = 5 → interval = 4 (=> 1 visible / 5)
-    expect(pickTickInterval(30, 340)).toBe(4);
-  });
+    it("takes the smaller of range cap and viewport cap on mobile", () => {
+      // 7d range cap = 7; small-mobile viewport cap = 6 → min = 6
+      // 30 points / 6 = 5 → interval 4
+      expect(pickTickInterval(30, 340, "7d")).toBe(4);
+    });
 
-  it("handles dense hourly history on desktop", () => {
-    // 168 points / 12 = 14 → interval = 13 (=> 1 visible / 14)
-    expect(pickTickInterval(168, 1024)).toBe(13);
-  });
-
-  it("never returns a negative interval", () => {
-    expect(pickTickInterval(1, 320)).toBe(0);
-    expect(pickTickInterval(0, 320)).toBe(0);
+    it("returns 0 when count fits the range cap", () => {
+      expect(pickTickInterval(7, 1024, "7d")).toBe(0);
+      expect(pickTickInterval(8, 1024, "24h")).toBe(0);
+    });
   });
 });
 

--- a/ui/src/components/history/HistoryBarChart.test.ts
+++ b/ui/src/components/history/HistoryBarChart.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { formatLabel, pickTickInterval } from "./chart-utils";
+
+describe("pickTickInterval", () => {
+  it("returns 0 when count fits the desktop budget (≤12)", () => {
+    expect(pickTickInterval(7, 1024)).toBe(0);
+    expect(pickTickInterval(12, 1024)).toBe(0);
+  });
+
+  it("returns 0 when count fits the small-mobile budget (≤6 at <360px)", () => {
+    expect(pickTickInterval(6, 320)).toBe(0);
+  });
+
+  it("returns 0 when count fits the medium-mobile budget (≤8 at <640px)", () => {
+    expect(pickTickInterval(8, 400)).toBe(0);
+  });
+
+  it("skips ticks on desktop when count exceeds 12", () => {
+    // 30 points / 12 maxLabels = 2.5 → floor = 2 → interval = 1 (=> 1 visible / 2)
+    expect(pickTickInterval(30, 1024)).toBe(1);
+  });
+
+  it("skips more aggressively on small mobile", () => {
+    // 30 points / 6 maxLabels = 5 → interval = 4 (=> 1 visible / 5)
+    expect(pickTickInterval(30, 340)).toBe(4);
+  });
+
+  it("handles dense hourly history on desktop", () => {
+    // 168 points / 12 = 14 → interval = 13 (=> 1 visible / 14)
+    expect(pickTickInterval(168, 1024)).toBe(13);
+  });
+
+  it("never returns a negative interval", () => {
+    expect(pickTickInterval(1, 320)).toBe(0);
+    expect(pickTickInterval(0, 320)).toBe(0);
+  });
+});
+
+describe("formatLabel", () => {
+  // Use an ISO at noon UTC to avoid TZ drift around midnight.
+  const iso = "2026-03-09T12:00:00.000Z"; // Monday March 9, 2026
+
+  it("returns HH:MM on a single line for 6h/24h ranges", () => {
+    const r1 = formatLabel(iso, "6h");
+    const r2 = formatLabel(iso, "24h");
+    expect(r1.line2).toBeUndefined();
+    expect(r2.line2).toBeUndefined();
+    // line1 is locale-dependent — assert shape rather than exact value.
+    expect(r1.line1).toMatch(/^\d{1,2}[:h]\d{2}/);
+  });
+
+  it("returns weekday + day on two lines for 7d", () => {
+    const r = formatLabel(iso, "7d");
+    expect(r.line1.toLowerCase()).toMatch(/^lun\.?/);
+    expect(r.line2).toBe("09");
+  });
+
+  it("pads single-digit days with a leading zero on 7d", () => {
+    const r = formatLabel("2026-03-03T12:00:00.000Z", "7d");
+    expect(r.line2).toBe("03");
+  });
+
+  it("returns compact DD/MM on a single line for 30d", () => {
+    const r = formatLabel(iso, "30d");
+    expect(r.line1).toBe("09/03");
+    expect(r.line2).toBeUndefined();
+  });
+
+  it("pads month and day on 30d", () => {
+    const r = formatLabel("2026-01-05T12:00:00.000Z", "30d");
+    expect(r.line1).toBe("05/01");
+  });
+});

--- a/ui/src/components/history/HistoryBarChart.test.ts
+++ b/ui/src/components/history/HistoryBarChart.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatLabel, pickTickInterval } from "./chart-utils";
+import { aggregateToBuckets, formatLabel, pickTickInterval } from "./chart-utils";
 
 describe("pickTickInterval", () => {
   describe("without a range (viewport-only cap)", () => {
@@ -69,6 +69,61 @@ describe("pickTickInterval", () => {
       expect(pickTickInterval(7, 1024, "7d")).toBe(0);
       expect(pickTickInterval(8, 1024, "24h")).toBe(0);
     });
+  });
+});
+
+describe("aggregateToBuckets", () => {
+  it("returns an empty array on empty input", () => {
+    expect(aggregateToBuckets([], "7d")).toEqual([]);
+  });
+
+  it("sums hourly points into daily buckets for 7d range", () => {
+    // Two rainy hours on Thursday + zero hours on other days
+    const points = [
+      { time: "2026-05-14T10:00:00.000Z", value: 0.2 },
+      { time: "2026-05-14T13:00:00.000Z", value: 0.2 },
+      { time: "2026-05-15T08:00:00.000Z", value: 0 },
+    ];
+    const out = aggregateToBuckets(points, "7d");
+    expect(out).toHaveLength(2);
+    expect(out[0].value).toBeCloseTo(0.4, 5);
+    expect(out[1].value).toBe(0);
+  });
+
+  it("uses hourly buckets for 24h range", () => {
+    const points = [
+      { time: "2026-05-14T10:15:00.000Z", value: 1 },
+      { time: "2026-05-14T10:45:00.000Z", value: 2 },
+      { time: "2026-05-14T11:05:00.000Z", value: 3 },
+    ];
+    const out = aggregateToBuckets(points, "24h");
+    expect(out).toHaveLength(2);
+    expect(out[0].value).toBe(3);
+    expect(out[1].value).toBe(3);
+  });
+
+  it("returns chronologically sorted buckets", () => {
+    const points = [
+      { time: "2026-05-16T10:00:00.000Z", value: 1 },
+      { time: "2026-05-14T10:00:00.000Z", value: 1 },
+      { time: "2026-05-15T10:00:00.000Z", value: 1 },
+    ];
+    const out = aggregateToBuckets(points, "7d");
+    const times = out.map((p) => p.time);
+    expect(times).toEqual([...times].sort());
+  });
+
+  it("is idempotent — re-bucketing the output yields the same buckets", () => {
+    // We build the input around noon UTC to avoid TZ edge cases (a 00:00 UTC
+    // input would already cross the local midnight boundary in CET/CEST).
+    const points = [
+      { time: "2026-05-14T12:00:00.000Z", value: 3 },
+      { time: "2026-05-14T15:00:00.000Z", value: 2 },
+      { time: "2026-05-15T12:00:00.000Z", value: 10 },
+    ];
+    const once = aggregateToBuckets(points, "7d");
+    const twice = aggregateToBuckets(once, "7d");
+    expect(twice).toEqual(once);
   });
 });
 

--- a/ui/src/components/history/HistoryBarChart.tsx
+++ b/ui/src/components/history/HistoryBarChart.tsx
@@ -10,7 +10,7 @@ import {
 } from "recharts";
 import type { HistoryPoint } from "../../types";
 import type { TimeRange } from "./history-utils";
-import { formatLabel, pickTickInterval } from "./chart-utils";
+import { aggregateToBuckets, formatLabel, pickTickInterval } from "./chart-utils";
 
 interface HistoryBarChartProps {
   points: HistoryPoint[];
@@ -31,8 +31,17 @@ interface ChartDatum {
   value: number;
 }
 
-function formatTooltipTime(iso: string): string {
+function formatTooltipTime(iso: string, range: TimeRange): string {
   const d = new Date(iso);
+  if (range === "7d" || range === "30d") {
+    // Daily bucket — show the day in full, no hour.
+    return d.toLocaleDateString(undefined, {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+    });
+  }
+  // Hourly bucket — show the day + start hour.
   return d.toLocaleString(undefined, {
     month: "short",
     day: "numeric",
@@ -149,7 +158,12 @@ export function HistoryBarChart({ points, range, unit, height = 200 }: HistoryBa
   const isNarrow = viewportWidth < 360;
 
   const data = useMemo<ChartDatum[]>(() => {
-    return points.map((p) => {
+    // Re-bucket raw points into uniform time slots (hourly for 6h/24h, daily for
+    // 7d/30d). This collapses sparse hourly samples into 1 bar per day on the
+    // longer ranges — e.g. 2 rainy hours on Thursday show as a single Thursday
+    // bar instead of 2 detached spikes.
+    const bucketed = aggregateToBuckets(points, range);
+    return bucketed.map((p) => {
       const { line1, line2 } = formatLabel(p.time, range);
       return { label: line1, label2: line2, time: p.time, value: p.value };
     });
@@ -227,7 +241,7 @@ export function HistoryBarChart({ points, range, unit, height = 200 }: HistoryBa
           formatter={(value: number | undefined) => [formatValueWithUnit(value ?? 0, unit), tooltipLabel]}
           labelFormatter={(_, payload) => {
             if (payload?.[0]?.payload?.time) {
-              return formatTooltipTime(payload[0].payload.time as string);
+              return formatTooltipTime(payload[0].payload.time as string, range);
             }
             return "";
           }}

--- a/ui/src/components/history/HistoryBarChart.tsx
+++ b/ui/src/components/history/HistoryBarChart.tsx
@@ -93,18 +93,28 @@ function useViewportWidth(): number {
 interface RechartsTick {
   x?: number;
   y?: number;
-  payload?: { value: string };
+  index?: number;
+  payload?: { value: string; index?: number };
 }
 
 interface CustomTickProps extends RechartsTick {
   fontSize: number;
-  multiline: Map<string, string>;
+  /** Pre-computed labels keyed by data index — only indices in this map render. */
+  labels: Map<number, { line1: string; line2?: string }>;
 }
 
-/** Renders the X-axis tick on one or two lines depending on the range. */
-function CustomTick({ x = 0, y = 0, payload, fontSize, multiline }: CustomTickProps) {
-  const line1 = payload?.value ?? "";
-  const line2 = multiline.get(line1);
+/**
+ * Renders the X-axis tick on one or two lines if the index is in `labels`.
+ *
+ * Indices missing from the map render an empty <g> — this is how we dedupe
+ * adjacent ticks that would otherwise show the same label twice (e.g. two
+ * "jeu. 14" labels when 7d data clusters several samples on one day).
+ */
+function CustomTick({ x = 0, y = 0, index, payload, fontSize, labels }: CustomTickProps) {
+  const dataIndex = payload?.index ?? index ?? -1;
+  const entry = labels.get(dataIndex);
+  if (!entry) return <g />;
+  const { line1, line2 } = entry;
   return (
     <g transform={`translate(${x},${y})`}>
       <text
@@ -138,14 +148,11 @@ export function HistoryBarChart({ points, range, unit, height = 200 }: HistoryBa
   const viewportWidth = useViewportWidth();
   const isNarrow = viewportWidth < 360;
 
-  const { data, multiline } = useMemo(() => {
-    const map = new Map<string, string>();
-    const arr: ChartDatum[] = points.map((p) => {
+  const data = useMemo<ChartDatum[]>(() => {
+    return points.map((p) => {
       const { line1, line2 } = formatLabel(p.time, range);
-      if (line2 !== undefined) map.set(line1, line2);
       return { label: line1, label2: line2, time: p.time, value: p.value };
     });
-    return { data: arr, multiline: map };
   }, [points, range]);
 
   if (data.length === 0) {
@@ -158,9 +165,24 @@ export function HistoryBarChart({ points, range, unit, height = 200 }: HistoryBa
 
   const tickInterval = pickTickInterval(data.length, viewportWidth, range);
   const tickFontSize = isNarrow ? 9 : 10;
-  const has2LineLabels = multiline.size > 0;
+  const has2LineLabels = data.some((d) => d.label2 !== undefined);
   const xAxisHeight = has2LineLabels ? 36 : 20;
   const chartHeight = has2LineLabels ? height + 16 : height;
+
+  // Pre-compute the labels Recharts will actually show, and skip those that
+  // would repeat the previous shown label (e.g. two "jeu. 14" in a row when
+  // hourly data clusters around one day).
+  const labels = new Map<number, { line1: string; line2?: string }>();
+  const step = tickInterval + 1;
+  let prevKey = "";
+  for (let i = 0; i < data.length; i += step) {
+    const d = data[i];
+    const key = `${d.label}|${d.label2 ?? ""}`;
+    if (key !== prevKey) {
+      labels.set(i, { line1: d.label, line2: d.label2 });
+      prevKey = key;
+    }
+  }
 
   // Tooltip label adapts to unit
   const tooltipLabel = unit === "Wh" || unit === "kWh"
@@ -183,7 +205,7 @@ export function HistoryBarChart({ points, range, unit, height = 200 }: HistoryBa
             <CustomTick
               {...(tickProps as RechartsTick)}
               fontSize={tickFontSize}
-              multiline={multiline}
+              labels={labels}
             />
           )}
         />

--- a/ui/src/components/history/HistoryBarChart.tsx
+++ b/ui/src/components/history/HistoryBarChart.tsx
@@ -156,7 +156,7 @@ export function HistoryBarChart({ points, range, unit, height = 200 }: HistoryBa
     );
   }
 
-  const tickInterval = pickTickInterval(data.length, viewportWidth);
+  const tickInterval = pickTickInterval(data.length, viewportWidth, range);
   const tickFontSize = isNarrow ? 9 : 10;
   const has2LineLabels = multiline.size > 0;
   const xAxisHeight = has2LineLabels ? 36 : 20;

--- a/ui/src/components/history/HistoryBarChart.tsx
+++ b/ui/src/components/history/HistoryBarChart.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ResponsiveContainer,
   BarChart,
@@ -10,6 +10,7 @@ import {
 } from "recharts";
 import type { HistoryPoint } from "../../types";
 import type { TimeRange } from "./history-utils";
+import { formatLabel, pickTickInterval } from "./chart-utils";
 
 interface HistoryBarChartProps {
   points: HistoryPoint[];
@@ -22,20 +23,12 @@ interface HistoryBarChartProps {
 const BAR_COLOR = "#4F7BE8";
 
 interface ChartDatum {
+  /** First line of the X tick label. */
   label: string;
+  /** Optional second line (used for 7d to stack weekday + day). */
+  label2?: string;
   time: string;
   value: number;
-}
-
-function formatLabel(iso: string, range: TimeRange): string {
-  const d = new Date(iso);
-  if (range === "6h" || range === "24h") {
-    return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
-  }
-  if (range === "7d") {
-    return d.toLocaleDateString("fr-FR", { weekday: "short", day: "numeric" });
-  }
-  return d.toLocaleDateString("fr-FR", { month: "short", day: "numeric" });
 }
 
 function formatTooltipTime(iso: string): string {
@@ -84,13 +77,75 @@ function formatYAxis(value: number, unit?: string): string {
   return "0";
 }
 
+/** Track the current viewport width so the chart can adapt tick density. */
+function useViewportWidth(): number {
+  const [width, setWidth] = useState(() =>
+    typeof window === "undefined" ? 1024 : window.innerWidth,
+  );
+  useEffect(() => {
+    const onResize = () => setWidth(window.innerWidth);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return width;
+}
+
+interface RechartsTick {
+  x?: number;
+  y?: number;
+  payload?: { value: string };
+}
+
+interface CustomTickProps extends RechartsTick {
+  fontSize: number;
+  multiline: Map<string, string>;
+}
+
+/** Renders the X-axis tick on one or two lines depending on the range. */
+function CustomTick({ x = 0, y = 0, payload, fontSize, multiline }: CustomTickProps) {
+  const line1 = payload?.value ?? "";
+  const line2 = multiline.get(line1);
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <text
+        x={0}
+        y={0}
+        dy={12}
+        textAnchor="middle"
+        fill="var(--color-text-tertiary)"
+        fontSize={fontSize}
+      >
+        {line1}
+      </text>
+      {line2 !== undefined && (
+        <text
+          x={0}
+          y={0}
+          dy={12 + fontSize + 1}
+          textAnchor="middle"
+          fill="var(--color-text-secondary)"
+          fontSize={fontSize}
+          fontWeight={600}
+        >
+          {line2}
+        </text>
+      )}
+    </g>
+  );
+}
+
 export function HistoryBarChart({ points, range, unit, height = 200 }: HistoryBarChartProps) {
-  const data = useMemo<ChartDatum[]>(() => {
-    return points.map((p) => ({
-      label: formatLabel(p.time, range),
-      time: p.time,
-      value: p.value,
-    }));
+  const viewportWidth = useViewportWidth();
+  const isNarrow = viewportWidth < 360;
+
+  const { data, multiline } = useMemo(() => {
+    const map = new Map<string, string>();
+    const arr: ChartDatum[] = points.map((p) => {
+      const { line1, line2 } = formatLabel(p.time, range);
+      if (line2 !== undefined) map.set(line1, line2);
+      return { label: line1, label2: line2, time: p.time, value: p.value };
+    });
+    return { data: arr, multiline: map };
   }, [points, range]);
 
   if (data.length === 0) {
@@ -101,8 +156,11 @@ export function HistoryBarChart({ points, range, unit, height = 200 }: HistoryBa
     );
   }
 
-  // Determine tick interval to avoid label overlap
-  const tickInterval = data.length > 15 ? Math.max(1, Math.floor(data.length / 12)) - 1 : 0;
+  const tickInterval = pickTickInterval(data.length, viewportWidth);
+  const tickFontSize = isNarrow ? 9 : 10;
+  const has2LineLabels = multiline.size > 0;
+  const xAxisHeight = has2LineLabels ? 36 : 20;
+  const chartHeight = has2LineLabels ? height + 16 : height;
 
   // Tooltip label adapts to unit
   const tooltipLabel = unit === "Wh" || unit === "kWh"
@@ -112,22 +170,29 @@ export function HistoryBarChart({ points, range, unit, height = 200 }: HistoryBa
       : "Valeur";
 
   return (
-    <ResponsiveContainer width="100%" height={height}>
+    <ResponsiveContainer width="100%" height={chartHeight}>
       <BarChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
         <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light)" vertical={false} />
         <XAxis
           dataKey="label"
-          tick={{ fontSize: 10, fill: "var(--color-text-tertiary)" }}
           interval={tickInterval}
           tickLine={false}
           axisLine={{ stroke: "var(--color-border)" }}
+          height={xAxisHeight}
+          tick={(tickProps: unknown) => (
+            <CustomTick
+              {...(tickProps as RechartsTick)}
+              fontSize={tickFontSize}
+              multiline={multiline}
+            />
+          )}
         />
         <YAxis
-          tick={{ fontSize: 10, fill: "var(--color-text-tertiary)" }}
+          tick={{ fontSize: tickFontSize, fill: "var(--color-text-tertiary)" }}
           tickLine={false}
           axisLine={false}
           tickFormatter={(v: number) => formatYAxis(v, unit)}
-          width={50}
+          width={isNarrow ? 36 : 50}
         />
         <Tooltip
           cursor={false}

--- a/ui/src/components/history/HistoryPanel.tsx
+++ b/ui/src/components/history/HistoryPanel.tsx
@@ -211,7 +211,7 @@ export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
                       <div className="flex justify-end mb-2">
                         <TimeRangeSelector value={range} onChange={setRange} />
                       </div>
-                      {isCumulativeBarChart(chart?.category ?? "", entry.alias) ? (
+                      {isCumulativeBarChart(chart?.category ?? "") ? (
                         <HistoryBarChart
                           points={chart?.points ?? []}
                           range={range}

--- a/ui/src/components/history/HistoryPanel.tsx
+++ b/ui/src/components/history/HistoryPanel.tsx
@@ -4,7 +4,7 @@ import { Loader2, BarChart3, ChevronDown, ChevronRight } from "lucide-react";
 import { getHistoryData, getHistoryStatus } from "../../api";
 import type { HistoryPoint, HistoryBindingState } from "../../types";
 import { TimeRangeSelector } from "./TimeRangeSelector";
-import { rangeToFrom, CUMULATIVE_CATEGORIES } from "./history-utils";
+import { rangeToFrom, isCumulativeBarChart } from "./history-utils";
 import type { TimeRange } from "./history-utils";
 import { TimeSeriesChart } from "./TimeSeriesChart";
 import { HistoryBarChart } from "./HistoryBarChart";
@@ -211,7 +211,7 @@ export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
                       <div className="flex justify-end mb-2">
                         <TimeRangeSelector value={range} onChange={setRange} />
                       </div>
-                      {CUMULATIVE_CATEGORIES.has(chart?.category ?? "") ? (
+                      {isCumulativeBarChart(chart?.category ?? "", entry.alias) ? (
                         <HistoryBarChart
                           points={chart?.points ?? []}
                           range={range}

--- a/ui/src/components/history/chart-utils.ts
+++ b/ui/src/components/history/chart-utils.ts
@@ -1,0 +1,34 @@
+import type { TimeRange } from "./history-utils";
+
+/**
+ * Build the tick label(s) for a given timestamp at a given range.
+ * 7d uses two lines (weekday + day) to avoid overlapping; other ranges stay on one line.
+ */
+export function formatLabel(iso: string, range: TimeRange): { line1: string; line2?: string } {
+  const d = new Date(iso);
+  if (range === "6h" || range === "24h") {
+    return {
+      line1: d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" }),
+    };
+  }
+  if (range === "7d") {
+    return {
+      line1: d.toLocaleDateString("fr-FR", { weekday: "short" }),
+      line2: String(d.getDate()).padStart(2, "0"),
+    };
+  }
+  // 30d — compact DD/MM
+  return {
+    line1: `${String(d.getDate()).padStart(2, "0")}/${String(d.getMonth() + 1).padStart(2, "0")}`,
+  };
+}
+
+/**
+ * Compute the Recharts `interval` value (= number of ticks to skip between two visible ticks).
+ * Aims for ≤ `maxLabels` visible ticks given the available viewport width.
+ */
+export function pickTickInterval(count: number, viewportWidth: number): number {
+  const maxLabels = viewportWidth < 360 ? 6 : viewportWidth < 640 ? 8 : 12;
+  if (count <= maxLabels) return 0;
+  return Math.max(1, Math.floor(count / maxLabels)) - 1;
+}

--- a/ui/src/components/history/chart-utils.ts
+++ b/ui/src/components/history/chart-utils.ts
@@ -1,4 +1,38 @@
+import type { HistoryPoint } from "../../types";
 import type { TimeRange } from "./history-utils";
+
+/**
+ * Group raw history points into time buckets sized for the range:
+ *   - 6h / 24h → hourly buckets
+ *   - 7d / 30d → daily buckets
+ *
+ * Within each bucket values are summed (the bar chart is used for cumulative
+ * categories — rain and energy — where sum is the meaningful aggregation).
+ * The returned points are anchored at the start of their bucket and sorted
+ * chronologically. If the input is already at the target resolution the call
+ * is idempotent.
+ */
+export function aggregateToBuckets(points: HistoryPoint[], range: TimeRange): HistoryPoint[] {
+  if (points.length === 0) return [];
+
+  const daily = range === "7d" || range === "30d";
+  const buckets = new Map<number, number>();
+
+  for (const p of points) {
+    const d = new Date(p.time);
+    if (daily) {
+      d.setHours(0, 0, 0, 0);
+    } else {
+      d.setMinutes(0, 0, 0);
+    }
+    const key = d.getTime();
+    buckets.set(key, (buckets.get(key) ?? 0) + p.value);
+  }
+
+  return Array.from(buckets.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([t, value]) => ({ time: new Date(t).toISOString(), value }));
+}
 
 /**
  * Build the tick label(s) for a given timestamp at a given range.

--- a/ui/src/components/history/chart-utils.ts
+++ b/ui/src/components/history/chart-utils.ts
@@ -24,11 +24,30 @@ export function formatLabel(iso: string, range: TimeRange): { line1: string; lin
 }
 
 /**
- * Compute the Recharts `interval` value (= number of ticks to skip between two visible ticks).
- * Aims for ≤ `maxLabels` visible ticks given the available viewport width.
+ * Range-specific cap on the number of X-axis labels. Picked so the labels read
+ * as "one entry per natural time unit" — 7 labels on 7d, 10 on 30d, etc.
  */
-export function pickTickInterval(count: number, viewportWidth: number): number {
-  const maxLabels = viewportWidth < 360 ? 6 : viewportWidth < 640 ? 8 : 12;
+const RANGE_MAX_LABELS: Record<TimeRange, number> = {
+  "6h": 6,
+  "24h": 8,
+  "7d": 7,
+  "30d": 10,
+};
+
+/**
+ * Compute the Recharts `interval` value (= number of ticks to skip between two visible ticks).
+ *
+ * Aims for ≤ `maxLabels` visible ticks given (a) the time range and (b) the
+ * available viewport width. The smaller of the two caps wins so mobile stays
+ * legible even on short ranges.
+ */
+export function pickTickInterval(count: number, viewportWidth: number, range?: TimeRange): number {
+  const viewportMax = viewportWidth < 360 ? 6 : viewportWidth < 640 ? 8 : 12;
+  const rangeMax = range ? RANGE_MAX_LABELS[range] : viewportMax;
+  const maxLabels = Math.min(rangeMax, viewportMax);
   if (count <= maxLabels) return 0;
-  return Math.max(1, Math.floor(count / maxLabels)) - 1;
+  // Ceil so the visible tick count actually stays ≤ maxLabels.
+  // floor() would underestimate the skip and let too many labels through
+  // (e.g. count=19 / maxLabels=12 → floor 1 → interval 0 → all 19 shown).
+  return Math.ceil(count / maxLabels) - 1;
 }

--- a/ui/src/components/history/history-utils.test.ts
+++ b/ui/src/components/history/history-utils.test.ts
@@ -2,32 +2,20 @@ import { describe, it, expect } from "vitest";
 import { isCumulativeBarChart } from "./history-utils";
 
 describe("isCumulativeBarChart", () => {
-  it("routes energy bindings to the bar chart regardless of alias", () => {
-    expect(isCumulativeBarChart("energy", "energy")).toBe(true);
-    expect(isCumulativeBarChart("energy", "consumption")).toBe(true);
-    expect(isCumulativeBarChart("energy", "main_meter")).toBe(true);
+  it("routes energy bindings to the bar chart", () => {
+    expect(isCumulativeBarChart("energy")).toBe(true);
   });
 
-  it("routes sum_rain_* aliases to the bar chart (cumulative)", () => {
-    expect(isCumulativeBarChart("rain", "sum_rain_1")).toBe(true);
-    expect(isCumulativeBarChart("rain", "sum_rain_24")).toBe(true);
-  });
-
-  it("routes the bare `rain` alias to the line chart (instantaneous rate)", () => {
-    // Regression: this used to be a bar chart because the category check
-    // alone treated all "rain" bindings as cumulative. The Netatmo `rain`
-    // alias is mm/h, not a cumulative total.
-    expect(isCumulativeBarChart("rain", "rain")).toBe(false);
+  it("routes all rain bindings to the bar chart (user preference)", () => {
+    // Includes the bare `rain` alias (instantaneous mm/h) — kept as bars even
+    // though it is conceptually a rate, on explicit user request.
+    expect(isCumulativeBarChart("rain")).toBe(true);
   });
 
   it("routes other categories to the line chart by default", () => {
-    expect(isCumulativeBarChart("temperature", "temperature")).toBe(false);
-    expect(isCumulativeBarChart("humidity", "humidity")).toBe(false);
-    expect(isCumulativeBarChart("pressure", "pressure")).toBe(false);
-    expect(isCumulativeBarChart("wind", "wind_strength")).toBe(false);
-  });
-
-  it("is case-insensitive on the sum_rain_ prefix", () => {
-    expect(isCumulativeBarChart("rain", "Sum_Rain_24")).toBe(true);
+    expect(isCumulativeBarChart("temperature")).toBe(false);
+    expect(isCumulativeBarChart("humidity")).toBe(false);
+    expect(isCumulativeBarChart("pressure")).toBe(false);
+    expect(isCumulativeBarChart("wind")).toBe(false);
   });
 });

--- a/ui/src/components/history/history-utils.test.ts
+++ b/ui/src/components/history/history-utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { isCumulativeBarChart } from "./history-utils";
+
+describe("isCumulativeBarChart", () => {
+  it("routes energy bindings to the bar chart regardless of alias", () => {
+    expect(isCumulativeBarChart("energy", "energy")).toBe(true);
+    expect(isCumulativeBarChart("energy", "consumption")).toBe(true);
+    expect(isCumulativeBarChart("energy", "main_meter")).toBe(true);
+  });
+
+  it("routes sum_rain_* aliases to the bar chart (cumulative)", () => {
+    expect(isCumulativeBarChart("rain", "sum_rain_1")).toBe(true);
+    expect(isCumulativeBarChart("rain", "sum_rain_24")).toBe(true);
+  });
+
+  it("routes the bare `rain` alias to the line chart (instantaneous rate)", () => {
+    // Regression: this used to be a bar chart because the category check
+    // alone treated all "rain" bindings as cumulative. The Netatmo `rain`
+    // alias is mm/h, not a cumulative total.
+    expect(isCumulativeBarChart("rain", "rain")).toBe(false);
+  });
+
+  it("routes other categories to the line chart by default", () => {
+    expect(isCumulativeBarChart("temperature", "temperature")).toBe(false);
+    expect(isCumulativeBarChart("humidity", "humidity")).toBe(false);
+    expect(isCumulativeBarChart("pressure", "pressure")).toBe(false);
+    expect(isCumulativeBarChart("wind", "wind_strength")).toBe(false);
+  });
+
+  it("is case-insensitive on the sum_rain_ prefix", () => {
+    expect(isCumulativeBarChart("rain", "Sum_Rain_24")).toBe(true);
+  });
+});

--- a/ui/src/components/history/history-utils.ts
+++ b/ui/src/components/history/history-utils.ts
@@ -1,21 +1,16 @@
 export type TimeRange = "6h" | "24h" | "7d" | "30d";
 
 /**
- * Decide whether a binding should be visualised as a cumulative bar chart.
+ * Decide whether a binding should be visualised as a bar chart.
  *
- * `category` alone is not sufficient for rain: Netatmo exposes three rain
- * bindings sharing the `rain` category but with different semantics:
- *   - `rain` (instant rate, mm/h) → must be a line chart.
- *   - `sum_rain_1` (cumulative over 1 h) → bar.
- *   - `sum_rain_24` (cumulative over 24 h) → bar.
+ * `rain` and `energy` are rendered as bars (cumulative or rate-style values
+ * that read better as discrete buckets); every other category is a line.
  *
- * For the `energy` category all aliases are cumulative (Wh/kWh), so the
- * category check is enough there.
+ * Kept as a helper (rather than a Set) so we can refine the rule per alias
+ * later without changing the call site.
  */
-export function isCumulativeBarChart(category: string, alias: string): boolean {
-  if (category === "energy") return true;
-  if (category === "rain") return /^sum_rain/i.test(alias);
-  return false;
+export function isCumulativeBarChart(category: string): boolean {
+  return category === "rain" || category === "energy";
 }
 
 /** Convert a TimeRange to a relative "from" string for the API. */

--- a/ui/src/components/history/history-utils.ts
+++ b/ui/src/components/history/history-utils.ts
@@ -1,7 +1,22 @@
 export type TimeRange = "6h" | "24h" | "7d" | "30d";
 
-/** Categories where values are cumulative totals — displayed as bar charts with sum aggregation. */
-export const CUMULATIVE_CATEGORIES = new Set(["rain", "energy"]);
+/**
+ * Decide whether a binding should be visualised as a cumulative bar chart.
+ *
+ * `category` alone is not sufficient for rain: Netatmo exposes three rain
+ * bindings sharing the `rain` category but with different semantics:
+ *   - `rain` (instant rate, mm/h) → must be a line chart.
+ *   - `sum_rain_1` (cumulative over 1 h) → bar.
+ *   - `sum_rain_24` (cumulative over 24 h) → bar.
+ *
+ * For the `energy` category all aliases are cumulative (Wh/kWh), so the
+ * category check is enough there.
+ */
+export function isCumulativeBarChart(category: string, alias: string): boolean {
+  if (category === "energy") return true;
+  if (category === "rain") return /^sum_rain/i.test(alias);
+  return false;
+}
 
 /** Convert a TimeRange to a relative "from" string for the API. */
 export function rangeToFrom(range: TimeRange): string {

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -115,10 +115,13 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
               equipment.type === "weather"
                 ? sensorBindings
                     .filter((b) =>
-                      b.key === "temperature" || b.key === "sum_rain_24" || b.key === "wind_strength"
+                      b.key === "temperature" ||
+                      b.key === "humidity" ||
+                      b.key === "sum_rain_24" ||
+                      b.key === "wind_strength"
                     )
                     .map((b) =>
-                      b.key === "sum_rain_24" ? { ...b, unit: "mm/24h" } : b
+                      b.key === "sum_rain_24" ? { ...b, unit: "mm" } : b
                     )
                 : sensorBindings
             }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -336,6 +336,7 @@
   "category.value.smoke.alert": "Alert!",
   "category.value.smoke.ok": "OK",
 
+  "weather.outdoor": "Outdoor",
   "weather.windSpeed": "Speed",
   "weather.windDirection": "Direction",
   "weather.gustSpeed": "Gusts",

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -342,8 +342,8 @@
   "weather.gustSpeed": "Gusts",
   "weather.gustDirection": "Gust dir.",
   "weather.rainCurrent": "Current rain",
-  "weather.rain1h": "1h total",
-  "weather.rain24h": "24h total",
+  "weather.rain1h": "Rain 1h",
+  "weather.rain24h": "Rain 24h",
 
   "aggregation.motion": "Motion",
   "aggregation.calm": "Calm",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -342,8 +342,8 @@
   "weather.gustSpeed": "Rafales",
   "weather.gustDirection": "Dir. rafales",
   "weather.rainCurrent": "Pluie actuelle",
-  "weather.rain1h": "Cumul 1h",
-  "weather.rain24h": "Cumul 24h",
+  "weather.rain1h": "Pluie 1h",
+  "weather.rain24h": "Pluie 24h",
 
   "aggregation.motion": "Mouvement",
   "aggregation.calm": "Calme",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -336,6 +336,7 @@
   "category.value.smoke.alert": "Alerte !",
   "category.value.smoke.ok": "OK",
 
+  "weather.outdoor": "Extérieur",
   "weather.windSpeed": "Vitesse",
   "weather.windDirection": "Direction",
   "weather.gustSpeed": "Rafales",


### PR DESCRIPTION
## Summary
Treat `weather` as a first-class equipment type across every view that previously fell back to the generic sensor renderer. Widgets stay **1×1**; details surface via tap → bottom sheet on mobile.

- **MobileWidgetCard**: weather case in `useMobileState` shows temp · humidity · rain24h.
- **WidgetDetailSheet**: new `WeatherDetailContent` (flat list with weather i18n labels) dispatched before the `isSensor` branch.
- **EquipmentWidget (PC)**: new `WeatherStationWidget` — temperature hero + humidity / rain24h / wind rows.
- **CompactEquipmentCard**: zone-row filter widened from 3 → 4 keys (humidity added).
- **WeatherPanel**: rain module hero swapped from `rain` → `sum_rain_24`; wind module gets a directional arrow rotated by `wind_angle` + compass label.
- **HistoryBarChart**: 2-line labels on 7d (weekday + day), compact `DD/MM` on 30d, responsive tick interval and font size for mobile (≤6 ticks under 360px, ≤8 under 640px).

Helpers extracted into `chart-utils.ts` / `weather-utils.ts` so they can be unit-tested (react-refresh forbids non-component exports from `.tsx`).

Spec: [`specs/114-weather-station-ux/`](specs/114-weather-station-ux/).

## Deferred
- Pressure trend (3 h arrow on the outdoor module). `WeatherPanel` currently has no access to `equipmentId` for the history fetch — threading it through is a bigger surface than this iteration warrants. Noted as non-goal in the spec.

## Tests
- `HistoryBarChart.test.ts` — 12 scenarios: `pickTickInterval` boundaries (desktop / 640px / 360px / dense hourly / edge cases), `formatLabel` for each range with padded outputs.
- `WeatherPanel.test.ts` — 5 scenarios: `angleToCompass` cardinal + intercardinal + 360 normalization + negative normalization + 22.5° rounding.

All 644 tests pass; tsc + eslint clean.

## Test plan
- [ ] Manual: open a Netatmo weather equipment and verify the zone compact card shows temp / humidity / rain24h / wind.
- [ ] Manual: pin the weather equipment as a dashboard widget (PC) — confirm the 1×1 tile renders the temperature hero + 3 rows.
- [ ] Manual (mobile): same widget — confirm `19° · 54% · 0mm`-style summary; tap opens the bottom sheet with all bindings listed in order.
- [ ] Manual: open the equipment detail page → wind module shows the arrow + compass abbreviation; rain hero is the 24h cumulative.
- [ ] Manual: open the history bar chart (any cumulative binding, e.g. rain or energy) on 7d → 2-line labels (weekday + day), no overlap; switch to 30d → compact `DD/MM`; resize to mobile widths → labels remain legible.