### PR TITLE
feat(ui): computedData rain fallback in zone row + WeatherPanel

### DIFF
--- a/ui/src/components/equipments/WeatherPanel.tsx
+++ b/ui/src/components/equipments/WeatherPanel.tsx
@@ -1,12 +1,21 @@
 import { useTranslation } from "react-i18next";
 import { Wind, CloudRain, Thermometer } from "lucide-react";
-import type { DataBindingWithValue } from "../../types";
+import type { ComputedDataEntry, DataBindingWithValue } from "../../types";
 import { getBatteryIcon, getBatteryColor, formatSensorValue } from "./sensorUtils";
-import { angleToCompass } from "./weather-utils";
+import { angleToCompass, syntheticBindingFromComputed } from "./weather-utils";
 
 interface WeatherPanelProps {
   bindings: DataBindingWithValue[];
+  equipmentId: string;
+  /** Sowel-computed values (e.g. rain_24h, rain_1h) — surfaced when the matching `sum_rain_*` binding is missing. */
+  computedData?: ComputedDataEntry[];
 }
+
+/** Map from a computed alias to the binding key we want it to mimic. */
+const COMPUTED_RAIN_TO_KEY: Record<string, string> = {
+  rain_24h: "sum_rain_24",
+  rain_1h: "sum_rain_1",
+};
 
 /** i18n key for each weather-specific property key. */
 const KEY_LABELS: Record<string, string> = {
@@ -97,7 +106,7 @@ function getKindColor(kind: DeviceKind): string {
 /** Sort order for device kinds so they always appear in a consistent order. */
 const KIND_SORT: Record<DeviceKind, number> = { outdoor: 0, wind: 1, rain: 2 };
 
-export function WeatherPanel({ bindings }: WeatherPanelProps) {
+export function WeatherPanel({ bindings, equipmentId, computedData }: WeatherPanelProps) {
   // Group bindings by device
   const byDevice = new Map<string, { deviceName: string; bindings: DataBindingWithValue[] }>();
   for (const b of bindings) {
@@ -107,6 +116,36 @@ export function WeatherPanel({ bindings }: WeatherPanelProps) {
       byDevice.set(b.deviceId, group);
     }
     group.bindings.push(b);
+  }
+
+  // Inject synthetic rain bindings (from computedData) into the rain device group
+  // if the matching sum_rain_* binding isn't already attached. Attaches to an
+  // existing rain-category device when present, otherwise creates a synthetic
+  // "Pluviomètre" group.
+  if (computedData && computedData.length > 0) {
+    const rainHostBinding = bindings.find((b) => b.category === "rain");
+    const rainDeviceId = rainHostBinding?.deviceId ?? "computed-rain";
+    const rainDeviceName = rainHostBinding?.deviceName ?? "Pluviomètre";
+    const existingKeys = new Set(
+      (byDevice.get(rainDeviceId)?.bindings ?? []).map((b) => b.key),
+    );
+
+    for (const c of computedData) {
+      const targetKey = COMPUTED_RAIN_TO_KEY[c.alias];
+      if (!targetKey || existingKeys.has(targetKey)) continue;
+      const synthetic = syntheticBindingFromComputed(equipmentId, c, {
+        key: targetKey,
+        deviceId: rainDeviceId,
+        deviceName: rainDeviceName,
+      });
+      let group = byDevice.get(rainDeviceId);
+      if (!group) {
+        group = { deviceName: rainDeviceName, bindings: [] };
+        byDevice.set(rainDeviceId, group);
+      }
+      group.bindings.push(synthetic);
+      existingKeys.add(targetKey);
+    }
   }
 
   const devices = [...byDevice.values()].map((g) => {

--- a/ui/src/components/equipments/weather-utils.ts
+++ b/ui/src/components/equipments/weather-utils.ts
@@ -1,3 +1,40 @@
+import type { ComputedDataEntry, DataBindingWithValue } from "../../types";
+
+/**
+ * Build a synthetic DataBindingWithValue from a ComputedDataEntry so the
+ * value can flow through binding-shaped UI helpers (SensorValues, WeatherPanel).
+ *
+ * Use only as a fallback when the real cumulative-rain binding (sum_rain_*)
+ * isn't attached to the equipment but Sowel still exposes the computed value
+ * — typical of the Netatmo plugin which auto-binds only the instantaneous
+ * `rain` device-side and emits rain_1h / rain_24h as computed data.
+ *
+ * The returned binding mimics the shape of a real binding closely enough
+ * (key, category, unit, value) for downstream filters and formatters; the
+ * id is prefixed `computed:` so consumers that care can tell them apart.
+ */
+export function syntheticBindingFromComputed(
+  equipmentId: string,
+  computed: ComputedDataEntry,
+  options: { key: string; deviceId?: string; deviceName?: string },
+): DataBindingWithValue {
+  return {
+    id: `computed:${computed.alias}`,
+    equipmentId,
+    deviceDataId: `computed:${computed.alias}`,
+    alias: computed.alias,
+    deviceId: options.deviceId ?? "computed",
+    deviceName: options.deviceName ?? "computed",
+    key: options.key,
+    type: "number",
+    category: computed.category ?? "rain",
+    value: computed.value,
+    unit: computed.unit,
+    lastUpdated: computed.lastUpdated,
+    lastChanged: computed.lastUpdated,
+  };
+}
+
 /** 16-point compass abbreviations (FR). 0° = N, clockwise. */
 const COMPASS_FR = [
   "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE",

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -12,6 +12,8 @@ import { WaterValveControl } from "../equipments/WaterValveControl";
 import { PoolHeatPumpControl } from "../equipments/PoolHeatPumpControl";
 import { Cloud, Timer } from "lucide-react";
 import { parseForecastDays, CONDITION_ICONS, CONDITION_COLORS } from "../equipments/weatherForecastUtils";
+import { syntheticBindingFromComputed } from "../equipments/weather-utils";
+import type { DataBindingWithValue } from "../../types";
 
 interface CompactEquipmentCardProps {
   equipment: EquipmentWithDetails;
@@ -113,16 +115,7 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
           <SensorValues
             sensorBindings={
               equipment.type === "weather"
-                ? sensorBindings
-                    .filter((b) =>
-                      b.key === "temperature" ||
-                      b.key === "humidity" ||
-                      b.key === "sum_rain_24" ||
-                      b.key === "wind_strength"
-                    )
-                    .map((b) =>
-                      b.key === "sum_rain_24" ? { ...b, unit: "mm" } : b
-                    )
+                ? buildWeatherCompactBindings(equipment, sensorBindings)
                 : sensorBindings
             }
             batteryBindings={equipment.type === "weather" ? [] : batteryBindings}
@@ -253,6 +246,36 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
       )}
     </div>
   );
+}
+
+/**
+ * Build the 4-value summary shown on a weather equipment row in the zone view:
+ * temperature, humidity, 24h rain, wind strength — in that exact order.
+ *
+ * Falls back to `computedData.rain_24h` when the cumulative `sum_rain_24`
+ * binding isn't attached (typical of the Netatmo plugin which auto-binds only
+ * the bare `rain` device-side).
+ */
+function buildWeatherCompactBindings(
+  equipment: EquipmentWithDetails,
+  sensorBindings: DataBindingWithValue[],
+): DataBindingWithValue[] {
+  const byKey = (key: string) => sensorBindings.find((b) => b.key === key);
+  const temp = byKey("temperature");
+  const hum = byKey("humidity");
+  const wind = byKey("wind_strength");
+
+  // Annotate the rain row with "mm/24h" so the zone-row reading is unambiguous
+  // (otherwise a bare "0 mm" looks like an instantaneous reading).
+  const rainBindingFromData = byKey("sum_rain_24");
+  const rainComputed = equipment.computedData?.find((c) => c.alias === "rain_24h");
+  const rainBase = rainBindingFromData
+    ?? (rainComputed
+      ? syntheticBindingFromComputed(equipment.id, rainComputed, { key: "sum_rain_24" })
+      : undefined);
+  const rain = rainBase ? { ...rainBase, unit: "mm/24h" } : null;
+
+  return [temp, hum, rain, wind].filter((b): b is DataBindingWithValue => !!b);
 }
 
 function CompactForecast({ equipment }: { equipment: EquipmentWithDetails }) {

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -348,7 +348,11 @@ export function EquipmentDetailPage() {
       {equipment.type === "weather_forecast" ? (
         <WeatherForecastPanel bindings={equipment.dataBindings} />
       ) : equipment.type === "weather" ? (
-        <WeatherPanel bindings={equipment.dataBindings} />
+        <WeatherPanel
+          bindings={equipment.dataBindings}
+          equipmentId={equipment.id}
+          computedData={equipment.computedData}
+        />
       ) : isSensor ? (
         <SensorDataPanel bindings={equipment.dataBindings} equipmentId={equipment.id} />
       ) : null}


### PR DESCRIPTION
## Summary
Follow-up to spec 114 — extends the computedData rain fallback (already in the mobile drawer) to the **zone row** and the **WeatherPanel** on the equipment detail page.

Without this, equipments where the Netatmo plugin auto-binds only the instantaneous `rain` (no `sum_rain_24` / `sum_rain_1`) display "0 mm" or nothing for rain on the Maison zone view and on the rain module card, even though Sowel exposes the cumulative values through `equipment.computedData`.

- **CompactEquipmentCard**: 4-value weather row now falls back to `computedData.rain_24h` when `sum_rain_24` isn't bound. Unit reverted from "mm" to **"mm/24h"** to disambiguate from instantaneous readings (per user request).
- **WeatherPanel**: rain module card now injects synthetic bindings derived from `computedData.rain_24h / rain_1h` into the rain device group (or creates a synthetic "Pluviomètre" group when no rain device is attached). Hero falls back to the computed 24h cumulative.
- **Shared helper** `syntheticBindingFromComputed()` in `weather-utils.ts` so both views build the binding-shaped fallback identically.

## Test plan
- [ ] Open the Maison zone view → Station Météo row shows `T°  · Hum% · X mm/24h · Wind km/h` (or "—" when no rain at all).
- [ ] Open the equipment detail page → Rain module card shows "Pluie 24h" as hero with the computed value.