### PR TITLE
release: v1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.12.1",
+  "version": "1.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump package.json + ui/package.json to 1.13.0
- Ships the awning equipment type (spec 115) and the somfy-rts plugin entry merged in #209

## Test plan
- [x] Typecheck (`npx tsc --noEmit` + `cd ui && npx tsc -b --noEmit`)
- [x] Tests (`npx vitest run`)
- [x] Lint (`npx eslint src/ --ext .ts`)
- [x] Release notes already in docs/release-notes.{md,fr.md} with `{ #v1-13-0 }` anchor (spec 108)