### PR TITLE
fix(zones): drop awning zone aggregates (out of scope for spec 115)

### DIFF
--- a/docs/technical/data-model.fr.md
+++ b/docs/technical/data-model.fr.md
@@ -116,11 +116,9 @@ L'agrégation est **récursive** : une Zone parent agrège ses propres Equipment
 | `lightsOn`               | number         | COUNT (on)         | `light_state`         | Nombre de lumières allumées                                   |
 | `lightsTotal`            | number         | COUNT (all)        | `light_state`         | Nombre total d'équipements lumière                            |
 | `averageBrightness`      | number \| null | AVG (on only)      | `light_brightness`    | Luminosité moyenne des lumières allumées                      |
-| `shuttersOpen`           | number         | COUNT (open)       | `shutter_position`    | Nombre de volets ouverts (type=shutter)                       |
-| `shuttersTotal`          | number         | COUNT (all)        | `shutter_position`    | Nombre total de volets (type=shutter)                         |
-| `averageShutterPosition` | number \| null | AVG                | `shutter_position`    | Position moyenne des volets (%)                               |
-| `awningsDeployed`        | number         | COUNT (position>0) | `shutter_position`    | Nombre de stores bannes déployés (type=awning)                |
-| `awningsTotal`           | number         | COUNT (all)        | `shutter_position`    | Nombre total de stores bannes (type=awning)                   |
+| `shuttersOpen`           | number         | COUNT (open)       | `shutter_position`    | Nombre de volets ouverts (type=shutter uniquement)            |
+| `shuttersTotal`          | number         | COUNT (all)        | `shutter_position`    | Nombre total de volets (type=shutter uniquement)              |
+| `averageShutterPosition` | number \| null | AVG                | `shutter_position`    | Position moyenne des volets (%) — volets seuls                |
 | `totalPower`             | number         | SUM                | `power`               | Puissance instantanée totale (W)                              |
 | `totalEnergy`            | number         | SUM                | `energy`              | Consommation d'énergie totale (kWh)                           |
 | `heatingActive`          | boolean        | OR                 | thermostat equipments | true si un thermostat chauffe activement                      |

--- a/docs/technical/data-model/zones.md
+++ b/docs/technical/data-model/zones.md
@@ -63,9 +63,10 @@ interface ZoneAggregatedData {
   lightsTotal: number; // COUNT(all light equipments)
   shuttersOpen: number; // COUNT(open), category=shutter_position, type=shutter
   shuttersTotal: number; // COUNT(all shutter equipments)
-  averageShutterPosition: number | null; // AVG of shutter_position (%) on shutters
-  awningsDeployed: number; // COUNT(position>0), category=shutter_position, type=awning
-  awningsTotal: number; // COUNT(all awning equipments)
+  averageShutterPosition: number | null; // AVG of shutter_position (%) on shutters only
+  // Awnings (type=awning) share the shutter_position category but are
+  // intentionally NOT aggregated at the zone level. The awning dashboard
+  // widgets compute their own deployed/total counts locally.
   waterValvesOpen: number;
   waterValvesTotal: number;
   waterFlowTotal: number | null; // SUM of current water flow (when supported)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -168,8 +168,6 @@ export interface ZoneAggregatedData {
   shuttersOpen: number;
   shuttersTotal: number;
   averageShutterPosition: number | null;
-  awningsDeployed: number;
-  awningsTotal: number;
   waterValvesOpen: number;
   waterValvesTotal: number;
   waterFlowTotal: number | null;

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -122,8 +122,6 @@ describe("ZoneAggregator", () => {
         shuttersOpen: 0,
         shuttersTotal: 0,
         averageShutterPosition: null,
-        awningsDeployed: 0,
-        awningsTotal: 0,
         waterValvesOpen: 0,
         waterValvesTotal: 0,
         waterFlowTotal: null,
@@ -356,10 +354,10 @@ describe("ZoneAggregator", () => {
       expect(data?.averageShutterPosition).toBe(43); // round((80+0+50)/3) = 43
     });
 
-    it("counts awnings deployed/total separately from shutters", () => {
+    it("ignores awnings in zone aggregates (no awningsTotal/Deployed, no shutter pollution)", () => {
       const zone = zoneManager.create({ name: "Terrasse" });
 
-      // Awning at 50 (deployed)
+      // Awning at 50 (deployed) — must not bump shutter counts
       const devA = seedDevice(db, {
         name: "AwningRtm",
         dataKeys: [{ key: "position", type: "number", category: "shutter_position", value: "50" }],
@@ -369,7 +367,7 @@ describe("ZoneAggregator", () => {
         name: "ShutterRtm",
         dataKeys: [{ key: "position", type: "number", category: "shutter_position", value: "50" }],
       });
-      // Awning at 0 (retracted)
+      // Awning at 0 (retracted) — also must not bump shutter counts
       const devA0 = seedDevice(db, {
         name: "AwningRet",
         dataKeys: [{ key: "position", type: "number", category: "shutter_position", value: "0" }],
@@ -395,12 +393,13 @@ describe("ZoneAggregator", () => {
       aggregator.computeAll();
 
       const data = aggregator.getByZoneId(zone.id);
-      expect(data?.awningsTotal).toBe(2);
-      expect(data?.awningsDeployed).toBe(1); // only the one at 50 counts
+      // Awnings are intentionally excluded from zone aggregates (spec 115
+      // scope decision) — only the shutter feeds the shutter counters.
       expect(data?.shuttersTotal).toBe(1);
       expect(data?.shuttersOpen).toBe(1);
-      // averageShutterPosition stays a shutter-only summary — awning is not in it
       expect(data?.averageShutterPosition).toBe(50);
+      // ZoneAggregatedData no longer exposes awningsTotal/awningsDeployed —
+      // the awning dashboard widgets compute their counts locally.
     });
 
     it("returns null averageShutterPosition when no shutters", () => {

--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -35,8 +35,6 @@ interface Accumulator {
   shutterPositionCount: number;
   shuttersOpen: number;
   shuttersTotal: number;
-  awningsDeployed: number;
-  awningsTotal: number;
   waterValvesOpen: number;
   waterValvesTotal: number;
   waterFlowSum: number;
@@ -63,8 +61,6 @@ function emptyAccumulator(): Accumulator {
     shutterPositionCount: 0,
     shuttersOpen: 0,
     shuttersTotal: 0,
-    awningsDeployed: 0,
-    awningsTotal: 0,
     waterValvesOpen: 0,
     waterValvesTotal: 0,
     waterFlowSum: 0,
@@ -92,8 +88,6 @@ function mergeAccumulators(a: Accumulator, b: Accumulator): Accumulator {
     shutterPositionCount: a.shutterPositionCount + b.shutterPositionCount,
     shuttersOpen: a.shuttersOpen + b.shuttersOpen,
     shuttersTotal: a.shuttersTotal + b.shuttersTotal,
-    awningsDeployed: a.awningsDeployed + b.awningsDeployed,
-    awningsTotal: a.awningsTotal + b.awningsTotal,
     waterValvesOpen: a.waterValvesOpen + b.waterValvesOpen,
     waterValvesTotal: a.waterValvesTotal + b.waterValvesTotal,
     waterFlowSum: a.waterFlowSum + b.waterFlowSum,
@@ -126,8 +120,6 @@ function accumulatorToPublic(acc: Accumulator): ZoneAggregatedData {
       acc.shutterPositionCount > 0
         ? Math.round(acc.shutterPositionSum / acc.shutterPositionCount)
         : null,
-    awningsDeployed: acc.awningsDeployed,
-    awningsTotal: acc.awningsTotal,
     waterValvesOpen: acc.waterValvesOpen,
     waterValvesTotal: acc.waterValvesTotal,
     waterFlowTotal: acc.waterFlowHasData ? Math.round(acc.waterFlowSum * 100) / 100 : null,
@@ -156,8 +148,6 @@ function aggregatedDataEqual(a: ZoneAggregatedData, b: ZoneAggregatedData): bool
     a.shuttersOpen === b.shuttersOpen &&
     a.shuttersTotal === b.shuttersTotal &&
     a.averageShutterPosition === b.averageShutterPosition &&
-    a.awningsDeployed === b.awningsDeployed &&
-    a.awningsTotal === b.awningsTotal &&
     a.waterValvesOpen === b.waterValvesOpen &&
     a.waterValvesTotal === b.waterValvesTotal &&
     a.waterFlowTotal === b.waterFlowTotal &&
@@ -570,15 +560,11 @@ export class ZoneAggregator {
           break;
 
         case "shutter_position":
-          // Shared category between shutter + awning equipments; the type
-          // decides which counter family increments. averageShutterPosition
-          // stays a shutter-only summary.
-          if (equipmentType === "awning") {
-            acc.awningsTotal += 1;
-            if (typeof value === "number" && value > 0) {
-              acc.awningsDeployed += 1;
-            }
-          } else {
+          // Awnings share this category but are intentionally not aggregated
+          // at the zone level — the dashboard awning widgets compute their
+          // own deployed counts locally. Only shutters feed shuttersOpen /
+          // shuttersTotal / averageShutterPosition.
+          if (equipmentType !== "awning") {
             acc.shuttersTotal += 1;
             if (typeof value === "number") {
               acc.shutterPositionSum += value;

--- a/ui/src/components/home/ZoneAggregationPills.tsx
+++ b/ui/src/components/home/ZoneAggregationPills.tsx
@@ -13,7 +13,6 @@ import {
 } from "lucide-react";
 import { ShutterIcon } from "../icons/ShutterIcons";
 import { WaterValveIcon } from "../icons/WaterValveIcon";
-import { AwningIcon } from "../icons/AwningIcon";
 import { ZoneSparkline } from "../history/ZoneSparkline";
 import type { ZoneAggregatedData } from "../../types";
 
@@ -130,18 +129,6 @@ export function ZoneAggregationPills({
       variant: "default",
       iconTint: "text-text-secondary",
       valueTint: someOpen ? "text-text" : "text-text-tertiary",
-    });
-  }
-
-  if (data.awningsTotal > 0) {
-    const someDeployed = data.awningsDeployed > 0;
-    counterPills.push({
-      key: "awnings",
-      icon: <AwningIcon size={14} state={someDeployed ? "open" : "closed"} />,
-      label: `${data.awningsDeployed}/${data.awningsTotal}`,
-      variant: someDeployed ? "active" : "default",
-      iconTint: "text-text-secondary",
-      valueTint: someDeployed ? "text-text" : "text-text-tertiary",
     });
   }
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -163,8 +163,6 @@ export interface ZoneAggregatedData {
   shuttersOpen: number;
   shuttersTotal: number;
   averageShutterPosition: number | null;
-  awningsDeployed: number;
-  awningsTotal: number;
   waterValvesOpen: number;
   waterValvesTotal: number;
   waterFlowTotal: number | null;


### PR DESCRIPTION
## Summary
Awnings reuse the `shutter_position` category but were unintentionally given their own zone-level aggregates (`awningsDeployed`, `awningsTotal`) in the initial spec 115 commit. The dashboard awning widgets already compute their counts locally, so the zone aggregate fields and the matching "Stores bannes X/Y" pill are dead weight. This PR removes them.

- `ZoneAggregatedData.awningsDeployed` + `awningsTotal` dropped (shared/types.ts, ui/types.ts)
- Accumulator fields, init, merge, equals, and the awning branch of the `shutter_position` counter removed (zone-aggregator.ts)
- "Stores bannes X/Y" pill removed (ZoneAggregationPills.tsx) + unused `AwningIcon` import
- Test updated to assert that awnings are excluded from the shutter aggregates (regression guard)
- Docs (`data-model.fr.md` + `data-model/zones.md`) updated

Zone auto-orders (`allAwningsExtend/Stop/Retract`) are untouched — those are bulk commands, not aggregates.

## Test plan
- [x] `npx tsc --noEmit` and `cd ui && npx tsc -b --noEmit` pass
- [x] `npx vitest run` — 665 pass / 2 skipped, the aggregator suite includes the new regression assertion
- [x] `npx eslint` — no errors on touched files