### PR TITLE
fix(zones): exclude pool_cover from shutter aggregates

### DIFF
--- a/docs/technical/data-model.fr.md
+++ b/docs/technical/data-model.fr.md
@@ -99,30 +99,30 @@ Le moteur **calcule automatiquement** les données agrégées de chaque Zone à 
 
 L'agrégation est **récursive** : une Zone parent agrège ses propres Equipments plus toutes les Zones enfants.
 
-| Attribute                | Type           | Règle d'agrégation | Source (DataCategory) | Description                                                   |
-| ------------------------ | -------------- | ------------------ | --------------------- | ------------------------------------------------------------- |
-| `temperature`            | number \| null | AVG                | `temperature`         | Température moyenne de la zone                                |
-| `humidity`               | number \| null | AVG                | `humidity`            | Humidité moyenne                                              |
-| `pressure`               | number \| null | AVG                | `pressure`            | Pression atmosphérique moyenne                                |
-| `luminosity`             | number \| null | AVG                | `luminosity`          | Luminosité moyenne (lux)                                      |
-| `co2`                    | number \| null | AVG                | `co2`                 | Niveau de CO2 moyen (ppm)                                     |
-| `voc`                    | number \| null | AVG                | `voc`                 | Niveau de COV moyen (ppb)                                     |
-| `motion`                 | boolean        | OR                 | `motion`              | true si AU MOINS UN capteur de mouvement détecte du mouvement |
-| `presence`               | boolean        | OR + timeout       | `motion`              | true si du mouvement détecté dans un timeout configurable     |
-| `openDoors`              | number         | COUNT (open)       | `contact_door`        | Nombre de contacts de porte ouverts                           |
-| `openWindows`            | number         | COUNT (open)       | `contact_window`      | Nombre de contacts de fenêtre ouverts                         |
-| `waterLeak`              | boolean        | OR                 | `water_leak`          | true si AU MOINS UN capteur de fuite d'eau se déclenche       |
-| `smoke`                  | boolean        | OR                 | `smoke`               | true si AU MOINS UN détecteur de fumée se déclenche           |
-| `lightsOn`               | number         | COUNT (on)         | `light_state`         | Nombre de lumières allumées                                   |
-| `lightsTotal`            | number         | COUNT (all)        | `light_state`         | Nombre total d'équipements lumière                            |
-| `averageBrightness`      | number \| null | AVG (on only)      | `light_brightness`    | Luminosité moyenne des lumières allumées                      |
-| `shuttersOpen`           | number         | COUNT (open)       | `shutter_position`    | Nombre de volets ouverts (type=shutter uniquement)            |
-| `shuttersTotal`          | number         | COUNT (all)        | `shutter_position`    | Nombre total de volets (type=shutter uniquement)              |
-| `averageShutterPosition` | number \| null | AVG                | `shutter_position`    | Position moyenne des volets (%) — volets seuls                |
-| `totalPower`             | number         | SUM                | `power`               | Puissance instantanée totale (W)                              |
-| `totalEnergy`            | number         | SUM                | `energy`              | Consommation d'énergie totale (kWh)                           |
-| `heatingActive`          | boolean        | OR                 | thermostat equipments | true si un thermostat chauffe activement                      |
-| `targetTemperature`      | number \| null | AVG                | thermostat equipments | Consigne de température cible moyenne                         |
+| Attribute                | Type           | Règle d'agrégation | Source (DataCategory) | Description                                                          |
+| ------------------------ | -------------- | ------------------ | --------------------- | -------------------------------------------------------------------- |
+| `temperature`            | number \| null | AVG                | `temperature`         | Température moyenne de la zone                                       |
+| `humidity`               | number \| null | AVG                | `humidity`            | Humidité moyenne                                                     |
+| `pressure`               | number \| null | AVG                | `pressure`            | Pression atmosphérique moyenne                                       |
+| `luminosity`             | number \| null | AVG                | `luminosity`          | Luminosité moyenne (lux)                                             |
+| `co2`                    | number \| null | AVG                | `co2`                 | Niveau de CO2 moyen (ppm)                                            |
+| `voc`                    | number \| null | AVG                | `voc`                 | Niveau de COV moyen (ppb)                                            |
+| `motion`                 | boolean        | OR                 | `motion`              | true si AU MOINS UN capteur de mouvement détecte du mouvement        |
+| `presence`               | boolean        | OR + timeout       | `motion`              | true si du mouvement détecté dans un timeout configurable            |
+| `openDoors`              | number         | COUNT (open)       | `contact_door`        | Nombre de contacts de porte ouverts                                  |
+| `openWindows`            | number         | COUNT (open)       | `contact_window`      | Nombre de contacts de fenêtre ouverts                                |
+| `waterLeak`              | boolean        | OR                 | `water_leak`          | true si AU MOINS UN capteur de fuite d'eau se déclenche              |
+| `smoke`                  | boolean        | OR                 | `smoke`               | true si AU MOINS UN détecteur de fumée se déclenche                  |
+| `lightsOn`               | number         | COUNT (on)         | `light_state`         | Nombre de lumières allumées                                          |
+| `lightsTotal`            | number         | COUNT (all)        | `light_state`         | Nombre total d'équipements lumière                                   |
+| `averageBrightness`      | number \| null | AVG (on only)      | `light_brightness`    | Luminosité moyenne des lumières allumées                             |
+| `shuttersOpen`           | number         | COUNT (open)       | `shutter_position`    | Nombre de volets ouverts (type=shutter — exclut awning + pool_cover) |
+| `shuttersTotal`          | number         | COUNT (all)        | `shutter_position`    | Nombre total de volets (type=shutter — exclut awning + pool_cover)   |
+| `averageShutterPosition` | number \| null | AVG                | `shutter_position`    | Position moyenne des volets (%) — type=shutter uniquement            |
+| `totalPower`             | number         | SUM                | `power`               | Puissance instantanée totale (W)                                     |
+| `totalEnergy`            | number         | SUM                | `energy`              | Consommation d'énergie totale (kWh)                                  |
+| `heatingActive`          | boolean        | OR                 | thermostat equipments | true si un thermostat chauffe activement                             |
+| `targetTemperature`      | number \| null | AVG                | thermostat equipments | Consigne de température cible moyenne                                |
 
 > **Note** : cette liste évoluera. De nouveaux attributs agrégés peuvent être ajoutés à mesure que de nouveaux types d'Equipment et DataCategories sont introduits.
 

--- a/docs/technical/data-model/zones.md
+++ b/docs/technical/data-model/zones.md
@@ -61,12 +61,14 @@ interface ZoneAggregatedData {
   smoke: boolean; // OR, category=smoke
   lightsOn: number; // COUNT(on), category=light_state
   lightsTotal: number; // COUNT(all light equipments)
-  shuttersOpen: number; // COUNT(open), category=shutter_position, type=shutter
-  shuttersTotal: number; // COUNT(all shutter equipments)
+  shuttersOpen: number; // COUNT(open), category=shutter_position, type=shutter ONLY
+  shuttersTotal: number; // COUNT(all shutter equipments), type=shutter ONLY
   averageShutterPosition: number | null; // AVG of shutter_position (%) on shutters only
-  // Awnings (type=awning) share the shutter_position category but are
-  // intentionally NOT aggregated at the zone level. The awning dashboard
-  // widgets compute their own deployed/total counts locally.
+  // Awnings (type=awning) and pool covers (type=pool_cover) share the
+  // shutter_position category but are intentionally NOT aggregated at the
+  // zone level — their dashboard widgets compute their own counts locally.
+  // Aggregating them here would surface phantom zone-level "all shutters"
+  // commands on zones that contain only awnings or pool covers.
   waterValvesOpen: number;
   waterValvesTotal: number;
   waterFlowTotal: number | null; // SUM of current water flow (when supported)

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -354,10 +354,10 @@ describe("ZoneAggregator", () => {
       expect(data?.averageShutterPosition).toBe(43); // round((80+0+50)/3) = 43
     });
 
-    it("ignores awnings in zone aggregates (no awningsTotal/Deployed, no shutter pollution)", () => {
+    it("ignores awnings and pool covers in shutter zone aggregates (shutter type only)", () => {
       const zone = zoneManager.create({ name: "Terrasse" });
 
-      // Awning at 50 (deployed) — must not bump shutter counts
+      // Awning at 50 — must not bump shutter counts
       const devA = seedDevice(db, {
         name: "AwningRtm",
         dataKeys: [{ key: "position", type: "number", category: "shutter_position", value: "50" }],
@@ -367,10 +367,15 @@ describe("ZoneAggregator", () => {
         name: "ShutterRtm",
         dataKeys: [{ key: "position", type: "number", category: "shutter_position", value: "50" }],
       });
-      // Awning at 0 (retracted) — also must not bump shutter counts
+      // Awning at 0
       const devA0 = seedDevice(db, {
         name: "AwningRet",
         dataKeys: [{ key: "position", type: "number", category: "shutter_position", value: "0" }],
+      });
+      // Pool cover at 80 — must not bump shutter counts either
+      const devPc = seedDevice(db, {
+        name: "PoolCoverRtm",
+        dataKeys: [{ key: "position", type: "number", category: "shutter_position", value: "80" }],
       });
 
       const awning = equipmentManager.create({ name: "Store 1", type: "awning", zoneId: zone.id });
@@ -390,16 +395,23 @@ describe("ZoneAggregator", () => {
       });
       equipmentManager.addDataBinding(awning2.id, devA0.dataIds[0], "position");
 
+      const poolCover = equipmentManager.create({
+        name: "Volet Piscine",
+        type: "pool_cover",
+        zoneId: zone.id,
+      });
+      equipmentManager.addDataBinding(poolCover.id, devPc.dataIds[0], "position");
+
       aggregator.computeAll();
 
       const data = aggregator.getByZoneId(zone.id);
-      // Awnings are intentionally excluded from zone aggregates (spec 115
-      // scope decision) — only the shutter feeds the shutter counters.
+      // Awnings and pool covers are intentionally excluded from zone
+      // aggregates — only `type=shutter` feeds the shutter counters. This
+      // prevents zone-level phantom "all shutters" commands appearing on
+      // pool / outdoor zones that contain only pool covers or awnings.
       expect(data?.shuttersTotal).toBe(1);
       expect(data?.shuttersOpen).toBe(1);
       expect(data?.averageShutterPosition).toBe(50);
-      // ZoneAggregatedData no longer exposes awningsTotal/awningsDeployed —
-      // the awning dashboard widgets compute their counts locally.
     });
 
     it("returns null averageShutterPosition when no shutters", () => {

--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -560,11 +560,16 @@ export class ZoneAggregator {
           break;
 
         case "shutter_position":
-          // Awnings share this category but are intentionally not aggregated
-          // at the zone level — the dashboard awning widgets compute their
-          // own deployed counts locally. Only shutters feed shuttersOpen /
-          // shuttersTotal / averageShutterPosition.
-          if (equipmentType !== "awning") {
+          // Only `shutter` equipments feed the shutter zone aggregates.
+          // Awnings and pool covers share this data category but are
+          // intentionally NOT aggregated at the zone level — their dashboard
+          // widgets compute their own counts locally, and letting them in
+          // here would surface zone-level shutter pills and bulk commands
+          // on zones that contain only awnings or pool covers (e.g. an
+          // Outdoor → Pool subtree showing a phantom "all shutters" command).
+          // The `allShuttersOpen/Stop/Close` zone orders already target
+          // type=shutter only.
+          if (equipmentType === "shutter") {
             acc.shuttersTotal += 1;
             if (typeof value === "number") {
               acc.shutterPositionSum += value;


### PR DESCRIPTION
## Summary
Pool covers shared the `shutter_position` data category with shutters and were being counted in the zone-level shutter aggregates (`shuttersOpen` / `shuttersTotal` / `averageShutterPosition`). This surfaced phantom "all shutters" pills and bulk commands on zones that contain only pool covers — e.g. a Piscine zone with just a `Volet Piscine` exposed shutter commands, and its parent Extérieur zone inherited them through the recursive aggregation. The `allShuttersOpen/Stop/Close` zone orders already target `type=shutter` only, so executing the phantom command was a no-op — only the UI lied.

Fix: positive type check `equipmentType === "shutter"` in the `shutter_position` case of the aggregator. This excludes both pool covers and awnings symmetrically (awnings were already excluded with a negative check; the new code is now uniform).

## Changes
- `src/zones/zone-aggregator.ts`: positive type filter on the shutter aggregate counters
- `src/zones/zone-aggregator.test.ts`: regression test extended with a pool_cover entry alongside the existing awning case
- `docs/technical/data-model.fr.md` + `data-model/zones.md`: comments updated to call out both exclusions

## Test plan
- [x] `npx tsc --noEmit` + `cd ui && npx tsc -b --noEmit` pass
- [x] `npx vitest run` — 665 pass / 2 skipped, regression test asserts shuttersTotal=1 with 2 awnings + 1 shutter + 1 pool_cover all sharing the same data category
- [x] `npx eslint` — clean