### PR TITLE
release: v1.13.2

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.13.x — Équipement store banne
 
+### v1.13.2 — 2026-05-24 { #v1-13-2 }
+
+- Correctif (zones) : exclusion des `pool_cover` des agrégats shutter de zone (`shuttersOpen` / `shuttersTotal` / `averageShutterPosition`). Les volets de piscine partagent la catégorie de donnée `shutter_position` avec les volets standards et étaient comptés, ce qui faisait apparaître des pastilles et commandes globales "Volets" fantômes sur les zones Piscine (et leurs zones parentes — par exemple un sous-arbre Extérieur → Piscine en héritait par récursivité). Les commandes de zone `allShuttersOpen/Stop/Close` ciblaient déjà `type=shutter` uniquement donc exécuter la commande fantôme était un no-op — seule l'UI mentait. Le correctif uniformise les exclusions awning et pool_cover (check positif `type === "shutter"`).
+
 ### v1.13.1 — 2026-05-24 { #v1-13-1 }
 
 - Correctif (zones) : suppression des agrégats `awningsDeployed` / `awningsTotal` livrés par erreur en v1.13.0. Les stores bannes réutilisent la catégorie `shutter_position` mais ne sont volontairement pas agrégés au niveau zone — les widgets dashboard awning calculent leurs comptes localement. La pastille "Stores bannes X/Y" disparaît de la vue zone, et un test de régression garantit que les stores ne polluent plus les agrégats des volets. Les commandes de zone (`allAwningsExtend/Stop/Retract`) ne sont pas touchées.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.13.x — Awning equipment
 
+### v1.13.2 — 2026-05-24 { #v1-13-2 }
+
+- Fix (zones): excluded `pool_cover` equipments from the shutter zone aggregates (`shuttersOpen` / `shuttersTotal` / `averageShutterPosition`). Pool covers share the `shutter_position` data category with shutters and were being counted, which surfaced phantom "all shutters" pills and bulk commands on Piscine zones (and their parent zones — e.g. an Outdoor → Pool subtree inherited them recursively). The `allShuttersOpen/Stop/Close` zone orders already targeted `type=shutter` only so executing the phantom command was a no-op — only the UI lied. The fix also makes awning and pool_cover exclusions uniform (positive `type === "shutter"` check).
+
 ### v1.13.1 — 2026-05-24 { #v1-13-1 }
 
 - Fix (zones): dropped the `awningsDeployed` / `awningsTotal` zone aggregates that shipped by mistake with v1.13.0. Awnings reuse the `shutter_position` data category but are intentionally not aggregated at the zone level — the dashboard awning widgets compute their counts locally. The "Stores bannes X/Y" pill is removed from the zone view, and a regression assertion now guarantees awnings don't pollute the shutter aggregates either. Bulk zone commands (`allAwningsExtend/Stop/Retract`) are untouched.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.13.1",
+  "version": "1.13.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump package.json + ui/package.json to 1.13.2
- Release notes entry (EN + FR) for the pool_cover aggregate fix merged in #214

## Test plan
- [x] Typecheck + tests + lint already green on #214
- [x] Release notes have the `{ #v1-13-2 }` anchor (spec 108)