### PR TITLE
feat(equipments): equipment availability propagation (spec 116, backend)

### DIFF
--- a/docs/technical/api-reference.md
+++ b/docs/technical/api-reference.md
@@ -98,12 +98,24 @@ All user management routes require admin role.
 
 | Method   | Path                                   | Description                                                                                                                            |
 | -------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET`    | `/api/v1/equipments`                   | List all equipments with bindings and current data.                                                                                    |
-| `GET`    | `/api/v1/equipments/:id`               | Get equipment with bindings and current data.                                                                                          |
+| `GET`    | `/api/v1/equipments`                   | List all equipments with bindings, current data, and derived `status` (see [Equipment status](#equipment-status-spec-116)).            |
+| `GET`    | `/api/v1/equipments/:id`               | Get equipment with bindings, current data, and derived `status`.                                                                       |
 | `POST`   | `/api/v1/equipments`                   | Create equipment. Body: `{ name, type, zoneId, icon?, description?, deviceIds? }`. If `deviceIds` provided, auto-bindings are created. |
 | `PUT`    | `/api/v1/equipments/:id`               | Update equipment. Body: `{ name?, type?, zoneId?, icon?, description?, enabled? }`.                                                    |
 | `DELETE` | `/api/v1/equipments/:id`               | Delete equipment. Returns 204.                                                                                                         |
 | `POST`   | `/api/v1/equipments/:id/orders/:alias` | Execute an equipment order. Body: `{ value }`.                                                                                         |
+
+### Equipment status (spec 116)
+
+`GET /equipments` and `GET /equipments/:id` include two derived fields:
+
+- `status: "online" | "degraded" | "offline"` — computed in memory from the backing devices' `status` and the freshness of streaming bindings.
+  - `offline`: every bound device is `offline`, OR the equipment has no device bindings.
+  - `degraded`: at least one device is `offline`, OR at least one streaming binding (`power`, `temperature`, etc.) has not been refreshed within its category timeout.
+  - `online`: everything healthy.
+- `statusReason?: { offlineDevices: string[]; staleBindings: string[]; offlineSince: string | null }` — present only when status ≠ `online`. Used by the UI tooltip.
+
+Each entry of `dataBindings[]` also gains `stale: boolean`. Only streaming categories ever flip to `true`; event-based categories (motion, contact_door, action, light_state, shutter_position, etc.) are always `false`.
 
 ### Data Bindings
 
@@ -464,9 +476,18 @@ Events are batched every 200ms and sent as a JSON array. High-frequency data eve
 [
   { "type": "device.data.updated", "deviceId": "...", "key": "temperature", "value": 22.5 },
   { "type": "equipment.data.changed", "equipmentId": "...", "alias": "state", "value": "ON" },
+  {
+    "type": "equipment.status.changed",
+    "equipmentId": "...",
+    "equipmentName": "Compteur Shelly",
+    "oldStatus": "online",
+    "newStatus": "offline"
+  },
   { "type": "zone.data.changed", "zoneId": "...", "key": "temperature", "value": 21.8 }
 ]
 ```
+
+The `equipment.status.changed` event (spec 116) is emitted by the EquipmentStatusTracker on every transition between `online` / `degraded` / `offline`. Deduplicated per equipment ID per batch.
 
 ### Activity Stream
 

--- a/docs/technical/plugin-development.md
+++ b/docs/technical/plugin-development.md
@@ -181,14 +181,48 @@ deps.settingsManager.set("integration.weather-forecast.last_poll", Date.now().to
 
 ### `deviceManager`
 
-Manage devices discovered by your plugin. Two main methods are used:
+Manage devices discovered by your plugin. Three main methods are used:
 
-| Method                | Signature                                                                                   | Description                                   |
-| --------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| `upsertFromDiscovery` | `(integrationId: string, source: string, discovered: DiscoveredDevice) => void`             | Create or update a device from discovery data |
-| `updateDeviceData`    | `(integrationId: string, sourceDeviceId: string, payload: Record<string, unknown>) => void` | Push new data values for an existing device   |
+| Method                | Signature                                                                                   | Description                                                                                                         |
+| --------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `upsertFromDiscovery` | `(integrationId: string, source: string, discovered: DiscoveredDevice) => void`             | Create or update a device from discovery data                                                                       |
+| `updateDeviceData`    | `(integrationId: string, sourceDeviceId: string, payload: Record<string, unknown>) => void` | Push new data values for an existing device                                                                         |
+| `updateDeviceStatus`  | `(integrationId: string, sourceDeviceId: string, status: "online" \| "offline") => void`    | Reflect device availability (mandatory, see [Device availability contract](#device-availability-contract-spec-116)) |
 
 See [Device Discovery](#device-discovery) and [Device Data Updates](#device-data-updates) for detailed usage.
+
+---
+
+## Device availability contract (spec 116)
+
+**Mandatory.** Every plugin MUST keep `device.status` truthful — it is the single source of truth Sowel relies on to derive equipment availability (`online` / `degraded` / `offline`), to drive UI badges, and to exclude offline equipments from zone aggregations.
+
+### What to call
+
+- `deviceManager.updateDeviceStatus(integrationId, sourceDeviceId, "online")` when the device starts responding (LWT topic flips to `online`, polling succeeds again, bridge reconnects, etc.).
+- `deviceManager.updateDeviceStatus(integrationId, sourceDeviceId, "offline")` when the device stops responding (LWT topic flips to `offline`, polling times out N times, plugin disconnects from its broker/cloud, bridge availability changes, etc.).
+
+Both calls are idempotent: emitting the same status twice in a row is cheap and does not re-emit events. Set the status as soon as you observe the transition; Sowel debounces downstream propagation.
+
+### Examples by transport
+
+| Transport                        | Source of truth                                                                                                                |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| MQTT (Tasmota, Shelly, somfyrts) | LWT topic (`tele/<root>/LWT` payload `Online`/`Offline`)                                                                       |
+| Zigbee2MQTT                      | `<friendlyName>/availability` topic (retained, `online`/`offline`)                                                             |
+| Cloud polling                    | After N consecutive HTTP failures, call `updateDeviceStatus(..., "offline")`. Reset to `"online"` on the next successful poll. |
+| Socket.IO / WebSocket            | `disconnect` event → mark offline; `connect` event → mark online                                                               |
+| Custom heartbeat                 | Internal timer: no heartbeat received past timeout → mark offline                                                              |
+
+### Why this matters
+
+Plugins that do not maintain `device.status` leave their devices stuck at `online` indefinitely, which makes equipments appear functional in the UI when they are not. A real bug in v1.13 surfaced this: a Shelly Pro 3EM was hors-tension for 30+ minutes; the Live Energy page kept displaying the last known value as if it was live because the plugin had not yet been wired to the LWT topic.
+
+An audit on a 96-device production instance (2026-05-24) found 24 devices stuck at `online` with `lastSeen` between 1 hour and 49 days — every one of those is a missed `updateDeviceStatus("offline")` call in the upstream plugin.
+
+### Limitations Sowel core does NOT compensate for
+
+Sowel core does **not** add a generic `device.lastSeen > timeout` watchdog on top of plugin-reported status. Battery-powered Zigbee endpoints (PIR, contact, water-leak) can legitimately stay silent for days without being offline, and any generic timeout produces too many false positives. The contract above is the only mechanism. Plugins that cannot meet it (fire-and-forget LoRa receivers, etc.) should consider implementing their own staleness logic and calling `updateDeviceStatus("offline")` on their own terms.
 
 ### `pluginDir`
 

--- a/specs/116-equipment-availability/architecture.md
+++ b/specs/116-equipment-availability/architecture.md
@@ -1,0 +1,433 @@
+# Architecture — Equipment availability propagation
+
+## Overview
+
+`Equipment.status` is a **derived** value, computed at read time inside `EquipmentManager`. There is no DB column, no migration, no event-driven cache invalidation. The composition happens whenever the equipment is read via `getByIdWithDetails` / `getAllWithDetails` — the same hooks that already merge `dataBindings`, `orderBindings`, and `computedData`.
+
+A small helper module — `src/equipments/equipment-status.ts` — owns the derivation logic. A separate `src/equipments/equipment-status-tracker.ts` subscribes to `device.status_changed` + `device.data.updated` events and emits `equipment.status.changed` when an equipment crosses a status boundary, so the UI can update reactively without polling.
+
+```
+                                       reads device.status + binding.lastUpdated
+                                       ┌──────────────────────────────────────┐
+                                       ▼                                      │
+                       ┌─────────────────────────────┐                       │
+device.status_changed  │   equipment-status.ts        │                       │
+device.data.updated  ──┤   derive(equipment,          │      one source       │
+                       │           bindings, devices) │ ◄─── of truth         │
+                       └──────────────┬──────────────┘                       │
+                                      │                                      │
+                       ┌──────────────▼──────────────┐                       │
+                       │  EquipmentManager            │                       │
+                       │  .getByIdWithDetails()       │ ───► includes        │
+                       │  .getAllWithDetails()        │      status field    │
+                       └──────────────┬──────────────┘                       │
+                                      │                                      │
+                       ┌──────────────▼──────────────┐                       │
+                       │  EquipmentStatusTracker      │  emits equipment.    │
+                       │  - listens to device events  │  status.changed      │
+                       │  - debounce 200 ms           │  on transitions     │
+                       │  - maintains a Map<id,status>│                      │
+                       └──────────────┬──────────────┘                       │
+                                      │                                      │
+                       ┌──────────────▼──────────────┐                       │
+                       │  EventBus                    │ ────► WebSocket ─────┘
+                       │  equipment.status.changed    │       UI Zustand store
+                       └──────────────────────────────┘       refreshes
+```
+
+## Type changes (`src/shared/types.ts`)
+
+```ts
+// === New ===
+
+export type EquipmentStatus = "online" | "degraded" | "offline";
+
+export interface EquipmentStatusReason {
+  /** Names of bound devices whose status is "offline". */
+  offlineDevices: string[];
+  /** Aliases of streaming bindings whose lastUpdated exceeds the timeout. */
+  staleBindings: string[];
+  /** Earliest lastSeen (devices) / lastUpdated (bindings) among the issues. */
+  offlineSince: string | null;
+}
+
+// === Modified ===
+
+export interface DataBindingWithValue extends DataBinding {
+  // ... existing fields ...
+  /** True iff the category is streaming AND lastUpdated exceeds the timeout.
+   *  Always false for event-based categories. */
+  stale: boolean;
+}
+
+export interface EquipmentWithDetails extends Equipment {
+  // ... existing fields ...
+  status: EquipmentStatus;
+  /** Present when status !== "online". */
+  statusReason?: EquipmentStatusReason;
+}
+
+// === ZoneAggregatedData ===
+
+export interface ZoneAggregatedData {
+  // ... existing fields ...
+  /** Per-data-category count of equipments that were skipped because they were
+   *  offline. Keys are DataCategory strings; missing keys mean zero. */
+  unavailableEquipmentsByCategory: Partial<Record<DataCategory, number>>;
+}
+
+// === EngineEvent union — new variant ===
+
+export type EngineEvent =
+  | /* ...existing... */
+  | {
+      type: "equipment.status.changed";
+      equipmentId: string;
+      oldStatus: EquipmentStatus;
+      newStatus: EquipmentStatus;
+    };
+```
+
+## Constants (`src/shared/constants.ts`)
+
+```ts
+export const STREAMING_CATEGORIES: ReadonlySet<DataCategory> = new Set([
+  "power",
+  "energy",
+  "voltage",
+  "current",
+  "temperature",
+  "temperature_outdoor",
+  "humidity",
+  "humidity_outdoor",
+  "pressure",
+  "luminosity",
+  "co2",
+  "voc",
+  "noise",
+  "battery",
+  "setpoint",
+  "pool_water_temperature",
+  "pool_temperature_setpoint",
+]);
+
+export const STREAMING_TIMEOUT_MS: Partial<Record<DataCategory, number>> = {
+  power: 2 * 60 * 1000,
+  energy: 10 * 60 * 1000,
+  voltage: 5 * 60 * 1000,
+  current: 5 * 60 * 1000,
+  temperature: 15 * 60 * 1000,
+  temperature_outdoor: 15 * 60 * 1000,
+  humidity: 15 * 60 * 1000,
+  humidity_outdoor: 15 * 60 * 1000,
+  pressure: 30 * 60 * 1000,
+  luminosity: 15 * 60 * 1000,
+  co2: 15 * 60 * 1000,
+  voc: 15 * 60 * 1000,
+  noise: 15 * 60 * 1000,
+  battery: 2 * 60 * 60 * 1000,
+  setpoint: 60 * 60 * 1000,
+  pool_water_temperature: 15 * 60 * 1000,
+  pool_temperature_setpoint: 60 * 60 * 1000,
+};
+
+export const DEFAULT_STREAMING_TIMEOUT_MS = 15 * 60 * 1000;
+```
+
+## New module: `src/equipments/equipment-status.ts`
+
+Pure functions, no I/O, fully unit-testable.
+
+```ts
+import {
+  STREAMING_CATEGORIES,
+  STREAMING_TIMEOUT_MS,
+  DEFAULT_STREAMING_TIMEOUT_MS,
+} from "../shared/constants.js";
+import type {
+  DataBindingWithValue,
+  DataCategory,
+  Device,
+  EquipmentStatus,
+  EquipmentStatusReason,
+} from "../shared/types.js";
+
+/** Returns true iff the binding is on a streaming category AND its
+ *  lastUpdated is older than the per-category threshold. Bindings that
+ *  have never been updated (lastUpdated === null) are NOT stale. */
+export function isStaleBinding(
+  category: DataCategory,
+  lastUpdated: string | null,
+  now: number = Date.now(),
+): boolean {
+  if (!STREAMING_CATEGORIES.has(category)) return false;
+  if (!lastUpdated) return false;
+  const timeoutMs = STREAMING_TIMEOUT_MS[category] ?? DEFAULT_STREAMING_TIMEOUT_MS;
+  const updatedMs = new Date(lastUpdated.replace(" ", "T").replace("Z", "+00:00")).getTime();
+  return now - updatedMs > timeoutMs;
+}
+
+/** Derive the equipment status from its bindings and the devices behind them.
+ *  Returns the status + a reason object that the UI uses for tooltips. */
+export function deriveEquipmentStatus(
+  bindings: DataBindingWithValue[],
+  devicesByBindingId: Map<string, Device>,
+  now: number = Date.now(),
+): { status: EquipmentStatus; reason: EquipmentStatusReason | null } {
+  if (bindings.length === 0) {
+    return {
+      status: "offline",
+      reason: { offlineDevices: [], staleBindings: [], offlineSince: null },
+    };
+  }
+
+  const uniqueDevices = new Map<string, Device>();
+  for (const b of bindings) {
+    const dev = devicesByBindingId.get(b.id);
+    if (dev) uniqueDevices.set(dev.id, dev);
+  }
+
+  const offlineDevices = [...uniqueDevices.values()].filter((d) => d.status === "offline");
+  const staleBindings = bindings.filter((b) => isStaleBinding(b.category, b.lastUpdated, now));
+
+  const allOffline = uniqueDevices.size > 0 && offlineDevices.length === uniqueDevices.size;
+  if (allOffline) {
+    return {
+      status: "offline",
+      reason: {
+        offlineDevices: offlineDevices.map((d) => d.name),
+        staleBindings: staleBindings.map((b) => b.alias),
+        offlineSince: earliestTimestamp([
+          ...offlineDevices.map((d) => d.lastSeen),
+          ...staleBindings.map((b) => b.lastUpdated),
+        ]),
+      },
+    };
+  }
+
+  if (offlineDevices.length > 0 || staleBindings.length > 0) {
+    return {
+      status: "degraded",
+      reason: {
+        offlineDevices: offlineDevices.map((d) => d.name),
+        staleBindings: staleBindings.map((b) => b.alias),
+        offlineSince: earliestTimestamp([
+          ...offlineDevices.map((d) => d.lastSeen),
+          ...staleBindings.map((b) => b.lastUpdated),
+        ]),
+      },
+    };
+  }
+
+  return { status: "online", reason: null };
+}
+
+function earliestTimestamp(values: (string | null)[]): string | null {
+  const valid = values.filter((v): v is string => v !== null);
+  if (valid.length === 0) return null;
+  return valid.reduce((min, v) => (v < min ? v : min));
+}
+```
+
+## EquipmentManager changes (`src/equipments/equipment-manager.ts`)
+
+Two hooks to extend: `getByIdWithDetails` and `getAllWithDetails`.
+
+```ts
+import { deriveEquipmentStatus, isStaleBinding } from "./equipment-status.js";
+
+// In getDataBindingsWithValues — annotate each binding with .stale:
+private getDataBindingsWithValues(equipmentId: string): DataBindingWithValue[] {
+  const rows = this.stmts.getDataBindings.all(equipmentId) as DataBindingRow[];
+  return rows.map((row) => {
+    const binding = rowToBindingWithValue(row);
+    return {
+      ...binding,
+      stale: isStaleBinding(binding.category, binding.lastUpdated),
+    };
+  });
+}
+
+// In getByIdWithDetails — add status:
+getByIdWithDetails(id: string): EquipmentWithDetails | null {
+  const equipment = this.getById(id);
+  if (!equipment) return null;
+
+  const dataBindings = this.getDataBindingsWithValues(id);
+  const orderBindings = this.getOrderBindingsWithDetails(id);
+  const computedData = this.getComputedData(id);
+
+  const devicesByBindingId = this.resolveDevicesForBindings(dataBindings, orderBindings);
+  const { status, reason } = deriveEquipmentStatus(dataBindings, devicesByBindingId);
+
+  return {
+    ...equipment,
+    dataBindings,
+    orderBindings,
+    status,
+    ...(reason !== null ? { statusReason: reason } : {}),
+    ...(computedData.length > 0 ? { computedData } : {}),
+  };
+}
+
+// resolveDevicesForBindings: small helper that maps each binding to its Device
+// using deviceManager.getById, returning a Map<bindingId, Device>. Cache the
+// per-call device lookups to avoid N+1.
+```
+
+`getAllWithDetails` follows the same pattern, with a single batch device fetch up front to avoid repeated DB hits when the equipment list is long.
+
+## New module: `src/equipments/equipment-status-tracker.ts`
+
+```ts
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { EquipmentManager } from "./equipment-manager.js";
+import type { EquipmentStatus } from "../shared/types.js";
+
+const DEBOUNCE_MS = 200;
+
+export class EquipmentStatusTracker {
+  private currentStatus = new Map<string, EquipmentStatus>();
+  private pending: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private equipmentManager: EquipmentManager,
+    private eventBus: EventBus,
+    private logger: Logger,
+  ) {
+    this.logger = logger.child({ module: "equipment-status-tracker" });
+  }
+
+  start(): void {
+    // Initial snapshot
+    for (const eq of this.equipmentManager.getAllWithDetails()) {
+      this.currentStatus.set(eq.id, eq.status);
+    }
+
+    this.eventBus.on((event) => {
+      if (
+        event.type === "device.status_changed" ||
+        event.type === "device.data.updated" ||
+        event.type === "equipment.bindings.changed"
+      ) {
+        this.scheduleRecompute();
+      }
+    });
+
+    // Periodic recompute every 60 s for streaming staleness (no event-driven trigger
+    // when nothing arrives — we need a wallclock tick).
+    setInterval(() => this.recompute(), 60_000).unref();
+  }
+
+  private scheduleRecompute(): void {
+    if (this.pending) return;
+    this.pending = setTimeout(() => {
+      this.pending = null;
+      this.recompute();
+    }, DEBOUNCE_MS);
+  }
+
+  private recompute(): void {
+    for (const eq of this.equipmentManager.getAllWithDetails()) {
+      const previous = this.currentStatus.get(eq.id);
+      if (previous !== eq.status) {
+        this.currentStatus.set(eq.id, eq.status);
+        this.eventBus.emit({
+          type: "equipment.status.changed",
+          equipmentId: eq.id,
+          oldStatus: previous ?? "online",
+          newStatus: eq.status,
+        });
+        this.logger.info(
+          { equipmentId: eq.id, name: eq.name, oldStatus: previous, newStatus: eq.status },
+          "Equipment status changed",
+        );
+      }
+    }
+  }
+}
+```
+
+Wired in `src/index.ts` after `EquipmentManager` is created and started, alongside other trackers.
+
+## EnergyAggregator changes (`src/energy/energy-aggregator.ts`)
+
+The live-power read happens in `getComputedDataForEquipment` (today returns the computed cumuls). Live power is currently read directly from the binding by the LiveEnergyPage (`sumPower` on `equipment.dataBindings` filtered by alias). We make that helper stale-aware on the **frontend** side; on the backend, we only need to ensure `equipment.dataBindings[].stale` is correctly set (already done via the `EquipmentManager` change above).
+
+For the InfluxDB-driven cumuls (hour/day/month/year): no change. Those are historical aggregates of points actually written to InfluxDB; they're inherently "what happened in the past" and not affected by current liveness.
+
+If the live power chart in the UI uses an `/api/v1/energy/live` endpoint (TBD — verify during implementation), that endpoint should also return `{ stale: true, lastUpdated }` per equipment when the binding is stale, mirroring the binding-level flag. If the chart reads directly from `equipment.dataBindings`, no backend change is needed beyond the `stale` flag.
+
+## ZoneAggregator changes (`src/zones/zone-aggregator.ts`)
+
+```ts
+// In the per-equipment loop:
+for (const equipment of equipments) {
+  // Existing code reads bindings + accumulates.
+  if (equipment.status === "offline") {
+    for (const binding of equipment.dataBindings) {
+      const cat = binding.category;
+      result.unavailableEquipmentsByCategory[cat] =
+        (result.unavailableEquipmentsByCategory[cat] ?? 0) + 1;
+    }
+    continue; // do not contribute to averages/sums
+  }
+  // Degraded equipments contribute with last known values — no change.
+  // ... existing accumulator logic ...
+}
+```
+
+The aggregator already calls `getAllWithDetails` (or equivalent) so the `status` field is available without extra fetches.
+
+## API surface
+
+- `GET /api/v1/equipments` — payload gains `status` + optional `statusReason` on each equipment. No breaking change (additive fields).
+- `GET /api/v1/equipments/:id` — same.
+- `GET /api/v1/zones/:id/aggregated` — payload gains `unavailableEquipmentsByCategory`. No breaking change.
+- WebSocket — new event type `equipment.status.changed` broadcast to authenticated clients.
+
+## Frontend changes (`ui/src/`)
+
+### Stores
+
+`stores/equipments.ts` (Zustand): on receiving `equipment.status.changed`, update the equipment's `status` field in-place. Triggers a re-render of any subscribed component.
+
+### Components
+
+| Component                                | Change                                                                                                                 |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `EquipmentStatusBadge.tsx` (NEW)         | Renders ambre/red badge for `degraded`/`offline`; nothing for `online`. With Lucide icon + tooltip via `<Tooltip>`.    |
+| `CompactEquipmentCard.tsx`               | Render badge top-right.                                                                                                |
+| `EquipmentDetailCard.tsx`                | Render badge next to name in header.                                                                                   |
+| `LiveEnergyPage.tsx`                     | In `sumPower`, also collect each binding's `stale` flag; if any contributing binding is stale, render the warning HUD. |
+| `EnergyDataPanel.tsx`                    | If `equipment.status !== "online"`, show "Last update X ago" subtitle.                                                 |
+| `ZoneWidget.tsx` / `CompactZoneCard.tsx` | Append "(X unavailable)" hint when `unavailableEquipmentsByCategory[<cat>] > 0`.                                       |
+| Dashboard family widgets                 | Append warning badge to header when any equipment in family is offline.                                                |
+
+### i18n
+
+New keys in `ui/src/i18n/locales/{en,fr}.json` (full list in spec.md FR12).
+
+## Database
+
+No migration. `Equipment.status` is derived. No new tables, no new columns.
+
+## Observability
+
+- Pino structured log on every status transition (in `EquipmentStatusTracker.recompute`).
+- Log level `info` for `online → degraded`, `info` for `degraded → offline`, `info` for any → `online`. Not `warn` — going offline can be intentional (user shut something off at the breaker).
+- No metrics endpoint changes.
+
+## Performance considerations
+
+- `EquipmentStatusTracker` periodic recompute runs every 60 s. With ~100 equipments × ~3 bindings each, the derivation cost is sub-millisecond. Negligible.
+- Debouncing event-driven recomputes by 200 ms avoids storm-recomputing during integration startup (when many `device.status_changed` events fire in a burst).
+- `getAllWithDetails` already iterates equipments; the new status derivation adds a Map lookup per binding (O(1)). No new DB hits beyond a single device fetch per binding (already cached in-Map per call).
+
+## Migration / rollout
+
+- No DB migration.
+- No backwards-incompatible API change (additive fields only).
+- Plugins that don't call `updateDeviceStatus` correctly will see their equipments stay `online` indefinitely — this is the existing behavior; the spec just exposes it. The plugin contract section in `plugin-development.md` documents known offenders and the path to fix them in their respective repos.
+- No feature flag. Ship directly; the behavior is purely additive.

--- a/specs/116-equipment-availability/plan.md
+++ b/specs/116-equipment-availability/plan.md
@@ -1,0 +1,174 @@
+# Plan — Equipment availability propagation
+
+## Implementation order
+
+Follow the standard Sowel order (types → constants → core logic → backend integration → tests → API/WS → UI). Each step is independently committable; the whole feature ships in one PR.
+
+### Step 1 — Types & constants
+
+- [ ] Add `EquipmentStatus`, `EquipmentStatusReason` to `src/shared/types.ts`.
+- [ ] Extend `DataBindingWithValue` with `stale: boolean`.
+- [ ] Extend `EquipmentWithDetails` with `status` + optional `statusReason`.
+- [ ] Extend `ZoneAggregatedData` with `unavailableEquipmentsByCategory`.
+- [ ] Add `equipment.status.changed` variant to the `EngineEvent` union.
+- [ ] Add `STREAMING_CATEGORIES`, `STREAMING_TIMEOUT_MS`, `DEFAULT_STREAMING_TIMEOUT_MS` to `src/shared/constants.ts`.
+- [ ] `npx tsc --noEmit` clean after this step (compilation may fail in downstream files — fix in the next steps as they reference the new fields).
+
+### Step 2 — Core logic (`src/equipments/equipment-status.ts`)
+
+- [ ] Create `equipment-status.ts` with `isStaleBinding` + `deriveEquipmentStatus` pure functions.
+- [ ] Create `equipment-status.test.ts` alongside it. Cover the matrix below.
+
+### Step 3 — EquipmentManager wiring
+
+- [ ] In `equipment-manager.ts`:
+  - Annotate `DataBindingWithValue` rows with `.stale` in `getDataBindingsWithValues`.
+  - Add `resolveDevicesForBindings(dataBindings, orderBindings): Map<bindingId, Device>` helper.
+  - Extend `getByIdWithDetails` + `getAllWithDetails` to call `deriveEquipmentStatus` and include `status` + `statusReason` in the response.
+- [ ] Update `equipment-manager.test.ts` to assert the new fields on the returned shape.
+
+### Step 4 — Status tracker (`src/equipments/equipment-status-tracker.ts`)
+
+- [ ] Create `EquipmentStatusTracker` class (constructor + `start` + `recompute` + debounce).
+- [ ] Subscribe to `device.status_changed`, `device.data.updated`, `equipment.bindings.changed`.
+- [ ] Add a 60 s wallclock tick (`setInterval(...).unref()`) to catch staleness transitions when no event fires.
+- [ ] Emit `equipment.status.changed` on transition.
+- [ ] Wire in `src/index.ts` after `EquipmentManager` is started.
+- [ ] Create `equipment-status-tracker.test.ts`.
+
+### Step 5 — EnergyAggregator + ZoneAggregator
+
+- [ ] `EnergyAggregator`: no functional change in this file if live power is read frontend-side from `equipment.dataBindings[].stale`. Verify; if a backend `/energy/live` endpoint exists, mirror the `stale` flag there.
+- [ ] `ZoneAggregator`: skip offline equipments in aggregation; populate `unavailableEquipmentsByCategory`.
+- [ ] Update `zone-aggregator.test.ts` with new scenarios.
+
+### Step 6 — WebSocket plumbing
+
+- [ ] In `src/api/ws-server.ts` (or wherever events are forwarded), ensure `equipment.status.changed` is broadcast to authenticated clients.
+- [ ] Verify no event-type filter blocks the new variant.
+
+### Step 7 — Documentation
+
+- [ ] Add the "Device availability contract" mandatory section to `docs/technical/plugin-development.md`.
+- [ ] Update `docs/technical/api-reference.md`:
+  - `GET /equipments` response shape: `status`, `statusReason`.
+  - `GET /zones/:id/aggregated` response shape: `unavailableEquipmentsByCategory`.
+  - WebSocket events: new `equipment.status.changed` event.
+- [ ] Update `docs/specs-index.md` with the new spec entry under a new "V1.14 — availability propagation" section.
+
+### Step 8 — Frontend store + types
+
+- [ ] Sync `ui/src/types.ts` (if shared types are duplicated UI-side) with backend changes.
+- [ ] In `ui/src/stores/equipments.ts`: handle `equipment.status.changed` to update the equipment in-place.
+
+### Step 9 — Frontend components
+
+- [ ] Create `ui/src/components/equipments/EquipmentStatusBadge.tsx` (size variants for compact / detail).
+- [ ] Mount in `CompactEquipmentCard.tsx` (top-right corner).
+- [ ] Mount in `EquipmentDetailCard.tsx` (next to name).
+- [ ] `LiveEnergyPage.tsx`: extend `sumPower` to collect stale flags; render the "Live data unavailable" HUD when any contributing binding is stale.
+- [ ] `EnergyDataPanel.tsx`: subtitle "Last update X ago" when source binding is stale.
+- [ ] `ZoneWidget.tsx` / `CompactZoneCard.tsx`: append "(X unavailable)" hint when relevant.
+- [ ] Dashboard family widgets (`ShuttersWidget`, `AwningsWidget`, `LightsWidget`, etc.): append warning badge to header when any equipment in family is offline.
+
+### Step 10 — i18n
+
+- [ ] Add all FR12 keys to `ui/src/i18n/locales/en.json` + `fr.json`.
+
+### Step 11 — Validation
+
+- [ ] `npx tsc --noEmit` clean.
+- [ ] `cd ui && npx tsc --noEmit` clean.
+- [ ] `npx vitest run` — all tests pass.
+- [ ] `npx eslint src/ --ext .ts` clean.
+- [ ] Manual validation in dev:
+  - Stop a plugin → its devices should turn `offline` (assuming the plugin calls `updateDeviceStatus` on shutdown).
+  - Manually mark a device offline via `PUT /devices/:id/status` (admin only, if available — else via `sqlite3 UPDATE`).
+  - Verify the equipment card shows the badge, the LiveEnergyPage shows the warning HUD, the zone widget shows the count.
+  - Restart the plugin → equipment status returns to online within 1 s of the next data push.
+- [ ] Release notes entry in `docs/release-notes.{md,fr.md}` (per spec 108) when bundling into a versioned release.
+
+---
+
+## Test Plan
+
+### Modules to test
+
+| Module                        | New file?                               | What it covers                                               |
+| ----------------------------- | --------------------------------------- | ------------------------------------------------------------ |
+| `equipment-status.ts`         | New: `equipment-status.test.ts`         | Pure derivation logic + `isStaleBinding`                     |
+| `equipment-manager.ts`        | Extend: `equipment-manager.test.ts`     | `status` field on `getByIdWithDetails` / `getAllWithDetails` |
+| `equipment-status-tracker.ts` | New: `equipment-status-tracker.test.ts` | Event emission on transitions, debouncing                    |
+| `zone-aggregator.ts`          | Extend: `zone-aggregator.test.ts`       | Offline-equipment exclusion + counter population             |
+
+### Scenarios
+
+#### `equipment-status.test.ts`
+
+| Scenario                                                                            | Expected                                                                                       |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `isStaleBinding("motion", "2026-05-01")` (event-based, very old)                    | `false` — event-based categories are never stale                                               |
+| `isStaleBinding("power", "2026-05-24T10:00:00Z")` with now = 2026-05-24T10:01:00Z   | `false` — within 2 min window                                                                  |
+| `isStaleBinding("power", "2026-05-24T10:00:00Z")` with now = 2026-05-24T10:05:00Z   | `true` — exceeds 2 min                                                                         |
+| `isStaleBinding("temperature", null)`                                               | `false` — never updated ≠ stale                                                                |
+| `isStaleBinding("contact_door", "2025-01-01")`                                      | `false` — event-based, never stale                                                             |
+| `isStaleBinding("battery", 3h ago)` with timeout 2h                                 | `true`                                                                                         |
+| Unknown future category not in `STREAMING_TIMEOUT_MS` but in `STREAMING_CATEGORIES` | Uses `DEFAULT_STREAMING_TIMEOUT_MS`                                                            |
+| `deriveEquipmentStatus([], new Map())` (no bindings)                                | `{ status: "offline", reason: { offlineDevices: [], staleBindings: [], offlineSince: null } }` |
+| 1 binding, device online, fresh                                                     | `{ status: "online", reason: null }`                                                           |
+| 1 binding, device offline                                                           | `{ status: "offline", offlineDevices: ["device-name"] }`                                       |
+| 2 bindings on 2 devices, 1 device offline                                           | `{ status: "degraded", offlineDevices: ["one"] }`                                              |
+| 2 bindings on 2 devices, both offline                                               | `{ status: "offline", offlineDevices: ["one", "two"] }`                                        |
+| 2 bindings same device online, 1 binding streaming stale                            | `{ status: "degraded", staleBindings: ["binding-alias"] }`                                     |
+| 2 bindings same device online, both streaming fresh                                 | `{ status: "online" }`                                                                         |
+| Device with `status: "unknown"` (treated as online) + no stale bindings             | `{ status: "online" }`                                                                         |
+| Device with `status: "unknown"` + 1 stale streaming binding                         | `{ status: "degraded" }`                                                                       |
+| `offlineSince` is the **earliest** of all offending timestamps                      | Verified for mixed offline-device + stale-binding case                                         |
+
+#### `equipment-manager.test.ts` (extensions)
+
+| Scenario                                                                        | Expected                                                          |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `getByIdWithDetails(equipmentId)` for an equipment with one online device       | Returned object has `status: "online"`, no `statusReason`         |
+| `getByIdWithDetails(equipmentId)` for an equipment with offline device          | Returned object has `status: "offline"`, `statusReason` populated |
+| `getAllWithDetails()` mixes online + offline + degraded equipments              | Each has correct `status`                                         |
+| `DataBindingWithValue.stale` is `true` for a power binding older than 2 min     | Yes                                                               |
+| `DataBindingWithValue.stale` is `false` for a motion binding older than 30 days | Yes                                                               |
+
+#### `equipment-status-tracker.test.ts`
+
+| Scenario                                                                                                      | Expected                                                                                                                      |
+| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Start with all equipments online, fire `device.status_changed` (offline) for a bound device                   | `equipment.status.changed` emitted with `oldStatus: "online"`, `newStatus: "offline"` (or `"degraded"` depending on bindings) |
+| Same transition triggers only one event even if multiple device events arrive within debounce window (200 ms) | Single emission                                                                                                               |
+| No transition (status stays online) → no event emitted                                                        | No call to `eventBus.emit("equipment.status.changed", ...)`                                                                   |
+| Streaming binding crosses staleness threshold during wallclock tick (60 s recompute)                          | `equipment.status.changed` emitted with `newStatus: "degraded"` (or `offline`)                                                |
+| Equipment back online after device reconnects                                                                 | `equipment.status.changed` emitted with `newStatus: "online"`                                                                 |
+
+#### `zone-aggregator.test.ts` (extensions)
+
+| Scenario                                                                                      | Expected                                                                                     |
+| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Zone with 3 temperature sensors, 1 offline → average                                          | Average uses 2 sensors; `unavailableEquipmentsByCategory.temperature === 1`                  |
+| Zone with 2 lights, 1 offline → counts                                                        | `lightsOn` counts only the online light; `unavailableEquipmentsByCategory.light_state === 1` |
+| Zone with all equipments online                                                               | `unavailableEquipmentsByCategory === {}`                                                     |
+| Zone with degraded equipment (has stale binding but device online) → still counted in average | Degraded equipments contribute; no counter increment                                         |
+
+### What is NOT tested
+
+- UI components (no React tests in this project — existing convention).
+- Database CRUD (`Equipment.status` is derived, not stored — nothing to test at DB layer).
+- The `device.status_changed` event itself (already tested in `device-manager.test.ts`).
+- Plugin-side compliance with the "Device availability contract" — that's verified in each plugin's own repo (separate issue track per plugin).
+
+### Manual validation matrix (FR + UI)
+
+| Surface                | How to validate                                                                                               |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Equipment compact card | Stop the Shelly plugin → ambre badge appears on the Shelly equipment row within 1 s                           |
+| Equipment detail card  | Open the equipment → badge next to name, tooltip shows offline devices                                        |
+| LiveEnergyPage         | Stop a `main_energy_meter`'s plugin → warning HUD replaces live power within 2 min                            |
+| EnergyDataPanel        | Same as above → "Last update X ago" caption                                                                   |
+| Zone widget            | Mark one equipment offline → "(1 unavailable)" hint appears                                                   |
+| Dashboard family       | Offline equipment in family → warning badge on widget header                                                  |
+| WebSocket reactivity   | Watch the browser DevTools network panel → `equipment.status.changed` arrives, UI updates without page reload |

--- a/specs/116-equipment-availability/spec.md
+++ b/specs/116-equipment-availability/spec.md
@@ -1,0 +1,290 @@
+# Spec 116 — Equipment availability propagation
+
+## Context
+
+When a physical device goes offline (power cut, network loss, plugin disconnection), Sowel's reactive pipeline stops at the device layer:
+
+- The `Device` entity already has a `status: "online" | "offline" | "unknown"` field updated by the plugin (see [`DeviceManager.updateDeviceStatus`](../../src/devices/device-manager.ts)) and a `lastSeen` timestamp.
+- The Devices list UI shows a colored dot (green / red / grey) reflecting that status.
+
+But this signal **does not propagate** to the layers users actually look at:
+
+- `Equipment` has no status field. The equipment cards show the last known value regardless of whether the underlying device is online.
+- `EnergyAggregator` queries InfluxDB for the live `power` point with **no freshness check**: a Shelly meter that was cut at the breaker keeps showing its last value as live data with no indicator.
+- `ZoneAggregator` averages temperatures and counts shutters from equipments whose data may be hours old.
+- Dashboard widgets and zone widgets aggregate without distinguishing live equipments from stale ones.
+
+The specific bug that triggered this spec: a Shelly Pro 3EM was hors-tension for 30+ minutes; the live energy graph kept displaying the last known value as if it was live data, with zero indication of staleness. The same pattern applies to any equipment whose device goes offline.
+
+This is a dormant systemic gap. Two prior specs partially referenced it:
+
+- Spec 062 (water valve) mentioned _"equipment shows as 'déconnecté' in UI, toggle disabled"_ → never implemented.
+- Spec 115 (awning) referenced a _"stale badge (existing pattern for any equipment)"_ → the pattern does not exist.
+
+## Goals
+
+1. Derive an **`Equipment.status`** (`online | degraded | offline`) from the bound devices' availability, computed in memory at read time (no DB migration).
+2. Flag each `DataBindingWithValue` as **stale** when its category is _streaming_ and the value has not been updated within the category's freshness window.
+3. Make `EnergyAggregator` honor the freshness window for live power: a stale `power` binding must surface as a stale live value, not as the last cached number.
+4. Make `ZoneAggregator` exclude offline equipments from numeric aggregations (averages, sums) and expose an `unavailableEquipments` counter so widgets can show a "X unavailable" hint.
+5. Add a **stale / degraded / offline badge** in every user-facing surface that today shows equipment values: compact equipment row, equipment detail card, LiveEnergyPage, EnergyDataPanel, zone widgets, dashboard family widgets.
+6. Emit a new `equipment.status.changed` event so the UI updates reactively without polling.
+7. Document a **plugin contract** that requires each integration plugin to maintain `device.status` truthfully. This is the long-term fix for the 25% of prod devices currently mis-labeled `online` after weeks of silence.
+
+## Non-Goals
+
+- **No `device.lastSeen` generic timeout.** Investigated in design; rejected because battery-powered Zigbee endpoints (PIR, contact, water leak) can legitimately stay silent for days without being offline. A generic seuil produces too many false positives. Detection relies on `device.status` (plugin contract) + streaming-category timeouts (contextual). Plugins that mis-report `device.status` are bugs to fix at the plugin level, not to compensate in Sowel core.
+- **No persistence of `equipment.status`.** Derived at read time inside `EquipmentManager.getByIdWithDetails` / `getAllWithDetails`, following the same pattern as `ZoneAggregatedData`. Avoids a stale denormalized column.
+- **No staleness on event-based categories.** `motion`, `contact_door`, `contact_window`, `water_leak`, `smoke`, `action`, `light_state`, `light_brightness`, `light_color_temp`, `light_color`, `shutter_position`, `lock_state`, `gate_state`, `cover_state`, `runtime_daily`, `weather_condition`, `media_*`, `appliance_state` are pushed only on change; absence of update means nothing about device health. A motion sensor in an empty house is normal.
+- **No new equipment type, no new data category, no new order category.** Additive metadata only.
+- **No recipe-engine integration in v1.** Recipes keep reading whatever the bindings expose; they can be made stale-aware in a follow-up spec if needed. (Today a recipe firing on a stale value would be a real bug — but solving it is a separate exercise that depends on whether each recipe wants strict or lenient semantics.)
+- **No retroactive backfill of `device.status` for plugins that already mis-report.** A Z2M device stuck at `online` for 49 days stays `online` until the plugin is fixed. The spec's plugin contract section flags this as a known prod issue with named offenders.
+- **No new REST endpoint.** `GET /equipments` and `GET /equipments/:id` simply return the new `status` field in their existing payloads.
+- **No equipment-level "auto-disable" or order blocking when offline.** Sending an order to an offline equipment still goes through the existing executeOrder path — the plugin handles its own offline behavior (may fail silently, may queue, may throw). UI may visually disable buttons for offline equipments but does not enforce it server-side.
+
+## Functional Requirements
+
+### FR1 — `EquipmentStatus` type + computed field
+
+- Add `EquipmentStatus = "online" | "degraded" | "offline"` to `src/shared/types.ts`.
+- Extend `EquipmentWithDetails` with:
+  - `status: EquipmentStatus`
+  - `statusReason?: { offlineDevices: string[], staleBindings: string[], offlineSince: string | null }` — populated only when status ≠ `online`, used by the UI tooltip.
+- Compute the status in `EquipmentManager.getByIdWithDetails` and `getAllWithDetails`:
+  - For each data binding, look up the source `Device.status` and the binding's `lastUpdated`.
+  - Apply the derivation rules (FR3 below).
+
+### FR2 — `DataBindingWithValue.stale` flag
+
+- Extend `DataBindingWithValue` with `stale: boolean` (default `false`).
+- Compute per binding: `stale = isStreamingCategory(category) AND (now - lastUpdated > STREAMING_TIMEOUT_MS[category])`.
+- For non-streaming categories, `stale` is always `false` (event-based: absence of update is not anomaly).
+
+### FR3 — Equipment status derivation rules
+
+Let `N = total devices bound to the equipment` (counted by unique `deviceId` across its data + order bindings), `Noffline = devices with device.status === "offline"`, `Nstale = bindings where stale === true`, `Nstreaming = bindings with isStreamingCategory(category)`.
+
+| Condition                                                                        | Status     |
+| -------------------------------------------------------------------------------- | ---------- |
+| `N === 0` (equipment has no device bindings)                                     | `offline`  |
+| `Noffline === N` (all bound devices are offline)                                 | `offline`  |
+| `Noffline > 0 OR Nstale > 0` (any device offline OR any streaming binding stale) | `degraded` |
+| All other cases (all devices online AND no streaming binding stale)              | `online`   |
+
+- Devices with `status === "unknown"` count as **online** for the purpose of status derivation (conservative: we have no evidence of failure). This matches today's UI semantics (grey dot ≠ red dot).
+- `statusReason.offlineDevices` lists the **names** of offline devices.
+- `statusReason.staleBindings` lists the binding **aliases** that are stale.
+- `statusReason.offlineSince` = earliest `lastSeen` among offline devices, OR earliest `lastUpdated` among stale streaming bindings. Used by the UI for the "X ago" tooltip.
+
+### FR4 — Streaming categories table
+
+In `src/shared/constants.ts`:
+
+```ts
+/** Categories where the device pushes a value at regular intervals,
+ *  even when unchanged. Absence of update = anomaly. */
+export const STREAMING_CATEGORIES: ReadonlySet<DataCategory> = new Set([
+  "power",
+  "energy",
+  "voltage",
+  "current",
+  "temperature",
+  "temperature_outdoor",
+  "humidity",
+  "humidity_outdoor",
+  "pressure",
+  "luminosity",
+  "co2",
+  "voc",
+  "noise",
+  "battery",
+  "setpoint",
+  "pool_water_temperature",
+  "pool_temperature_setpoint",
+]);
+
+/** Maximum age (ms) before a streaming binding is flagged stale. */
+export const STREAMING_TIMEOUT_MS: Record<string, number> = {
+  power: 2 * 60 * 1000, // 2 min — live electrical reads
+  energy: 10 * 60 * 1000, // 10 min — cumulative counter
+  voltage: 5 * 60 * 1000,
+  current: 5 * 60 * 1000,
+  temperature: 15 * 60 * 1000,
+  temperature_outdoor: 15 * 60 * 1000,
+  humidity: 15 * 60 * 1000,
+  humidity_outdoor: 15 * 60 * 1000,
+  pressure: 30 * 60 * 1000,
+  luminosity: 15 * 60 * 1000,
+  co2: 15 * 60 * 1000,
+  voc: 15 * 60 * 1000,
+  noise: 15 * 60 * 1000,
+  battery: 2 * 60 * 60 * 1000, // 2 h — battery reports are sparse
+  setpoint: 60 * 60 * 1000, // 1 h
+  pool_water_temperature: 15 * 60 * 1000,
+  pool_temperature_setpoint: 60 * 60 * 1000,
+};
+
+/** Default fallback for any future streaming category not yet listed above. */
+export const DEFAULT_STREAMING_TIMEOUT_MS = 15 * 60 * 1000;
+```
+
+Categories NOT in `STREAMING_CATEGORIES` (motion, contact_door, contact_window, water_leak, smoke, action, light_state, light_brightness, light_color_temp, light_color, shutter_position, lock_state, gate_state, cover_state, runtime_daily, weather_condition, media_volume, media_mute, media_input, appliance_state, uv, solar_radiation, wind, rain, generic) → never stale, full stop.
+
+### FR5 — EventBus: `equipment.status.changed`
+
+- Add a new `EngineEvent` variant in `src/shared/types.ts`:
+
+```ts
+| { type: "equipment.status.changed"; equipmentId: string; oldStatus: EquipmentStatus; newStatus: EquipmentStatus }
+```
+
+- Emitted by `EquipmentManager` (or a dedicated `EquipmentStatusTracker` helper — see architecture.md) whenever an equipment's derived status changes.
+- Forwarded to WebSocket clients via the existing `ws-server` event broadcast.
+- Plumb the UI store (Zustand) to update `equipment.status` reactively.
+
+### FR6 — EnergyAggregator: live power freshness
+
+- When `EnergyAggregator` computes the live `power` value for the LiveEnergyPage (currently read directly from the binding), it must consult the binding's `stale` flag.
+- If `power` is stale, the equipment's contribution to the live total is reported as `{ value: null, stale: true, lastUpdated }` rather than the cached number.
+- The cumuls (hour / day / month / year) are NOT affected: they come from InfluxDB historical points and are inherently historical, not "live".
+
+### FR7 — ZoneAggregator: exclusion + counter
+
+In `src/zones/zone-aggregator.ts`:
+
+- When iterating equipments to aggregate:
+  - Equipments with `status === "offline"` → skip entirely (do not contribute to temperature averages, light counts, shutter counts, etc.).
+  - Equipments with `status === "degraded"` → include with their last known values (degraded ≠ trust-broken; we just flag at the UI level).
+- Add `unavailableEquipmentsByCategory: Record<string, number>` to `ZoneAggregatedData` — a per-category counter of equipments that were skipped because they were offline (e.g. `{ temperature: 1, light_state: 0 }`).
+- Existing aggregated fields (`temperature`, `lightsOn`, etc.) reflect the **online + degraded** subset only.
+
+### FR8 — UI: equipment cards (compact + detail)
+
+- Add a `<EquipmentStatusBadge>` component in `ui/src/components/equipments/`:
+  - `degraded` → ambre badge "Dégradé" / "Degraded" with `AlertTriangle` icon (Lucide, stroke 1.5).
+  - `offline` → red badge "Déconnecté" / "Offline" with `WifiOff` icon.
+  - `online` → no badge (default state, no visual noise).
+- Render the badge:
+  - In `CompactEquipmentCard` (zone view rows): top-right corner of the row.
+  - In `EquipmentDetailCard` (detail page header): next to the equipment name.
+- Add a tooltip on hover (desktop) / tap (mobile) showing:
+  - Status (Online / Degraded / Offline)
+  - For degraded/offline: list of offline devices + "Last seen X ago"
+  - List of stale bindings with their `lastUpdated`
+
+### FR9 — UI: LiveEnergyPage stale indicator
+
+In `ui/src/components/energy/LiveEnergyPage.tsx`:
+
+- If the `main_energy_meter` equipment's `power` binding is stale: replace the live power value with a greyed placeholder + a `AlertTriangle` icon, and show a small caption "Données non temps réel" / "Live data unavailable" with relative time.
+- Same for `energy_production_meter` and any submeter widget.
+- The historical chart (5-min, 1-day) is NOT affected: it reads from InfluxDB.
+
+### FR10 — UI: EnergyDataPanel last-updated
+
+- In `ui/src/components/equipments/EnergyDataPanel.tsx`: when any of the displayed cumuls is backed by a `power` binding that is stale, show a small "Last updated X ago" subtitle in greyed text. Existing layout untouched.
+
+### FR11 — UI: zone widgets + dashboard family widgets
+
+- `ZoneWidget` (zone aggregate widgets on dashboard) and `CompactZoneCard` (zone row in zone list):
+  - If `unavailableEquipmentsByCategory[<relevant category>] > 0`, show a small "(X unavailable)" hint next to the count or the value.
+  - Pattern: `<Thermometer /> 21.3 °C (1 unavailable)`, `<Lightbulb /> 3/5 on (1 unavailable)`.
+- Dashboard family widgets (`ShuttersWidget`, `AwningsWidget`, `LightsWidget`, etc.): when any equipment in the family is offline, append a small warning badge to the widget header.
+
+### FR12 — i18n strings (en + fr)
+
+In `ui/src/i18n/locales/{en,fr}.json`:
+
+- `equipment.status.online`: "Online" / "En ligne"
+- `equipment.status.degraded`: "Degraded" / "Dégradé"
+- `equipment.status.offline`: "Disconnected" / "Déconnecté"
+- `equipment.status.tooltip.offlineDevices`: "{{count}} device(s) offline" / "{{count}} appareil(s) hors ligne"
+- `equipment.status.tooltip.staleBindings`: "{{count}} stale value(s)" / "{{count}} valeur(s) périmée(s)"
+- `equipment.status.tooltip.lastSeen`: "Last seen {{when}}" / "Vu pour la dernière fois {{when}}"
+- `energy.live.unavailable`: "Live data unavailable" / "Données live indisponibles"
+- `energy.live.lastUpdate`: "Last update {{when}}" / "Dernière donnée {{when}}"
+- `zones.aggregate.unavailable`: "({{count}} unavailable)" / "({{count}} indisponible)"
+
+`{{when}}` uses the existing relative-time helper (already used by `ElapsedCounter`).
+
+### FR13 — Plugin contract documentation
+
+Update [`docs/technical/plugin-development.md`](../../docs/technical/plugin-development.md) with a new mandatory section:
+
+```markdown
+## Device availability contract (mandatory)
+
+Each plugin MUST keep `device.status` truthful — it is the single source of truth Sowel relies on to derive equipment availability (spec 116).
+
+Required calls:
+
+- `deviceManager.updateDeviceStatus(integrationId, sourceDeviceId, "online")` when the device starts responding (LWT topic switches to `online`, polling succeeds, etc.).
+- `deviceManager.updateDeviceStatus(integrationId, sourceDeviceId, "offline")` when the device stops responding (LWT topic switches to `offline`, polling times out N times, plugin disconnects from its broker/cloud, etc.).
+
+Plugins that fail this contract leave their devices stuck at `online` indefinitely, which makes equipments appear functional in the UI when they are not. This was the root cause of a real bug shipped in v1.13 (Shelly meter went offline at the breaker, graph kept showing last value as live).
+
+Known offenders (to be fixed in their own plugin repos):
+
+- `sowel-plugin-zigbee2mqtt`: must wire the Z2M `<friendlyName>/availability` topic to `updateDeviceStatus`. Currently 24 prod devices are stuck `online` after up to 49 days of silence.
+- `sowel-plugin-mcz-maestro`: must call `updateDeviceStatus("offline")` when the Socket.IO connection drops or stays silent past the keepalive.
+
+Audits of other plugins (panasonic-cc, smartthings, netatmo-\*) should follow.
+```
+
+Also update `docs/technical/api-reference.md` to document `equipment.status` in the `GET /equipments` response shape and the new WebSocket event.
+
+### FR14 — Tests
+
+Implementation tests are scoped in [plan.md](plan.md). At a high level:
+
+- Unit tests for the status-derivation function (input: bindings + devices, output: `EquipmentStatus` + reason).
+- Unit tests for the streaming-timeout helper (`isStaleBinding`).
+- Unit tests for `EquipmentManager.getByIdWithDetails` exposing the computed status.
+- Unit tests for `ZoneAggregator` skipping offline equipments and incrementing the counter.
+- Unit tests for `EnergyAggregator` returning `{ stale: true }` when the power binding is stale.
+- Unit test for the `equipment.status.changed` event being emitted on transitions.
+
+## Acceptance Criteria
+
+- [ ] FR1: `EquipmentWithDetails.status` is one of `online | degraded | offline` in every `GET /equipments` and `GET /equipments/:id` response.
+- [ ] FR1: `statusReason` is present and populated when status ≠ `online`; absent when `online`.
+- [ ] FR2: `DataBindingWithValue.stale` is `true` exactly when the category is streaming and `lastUpdated` exceeds the per-category timeout.
+- [ ] FR3: Derivation rules verified by unit tests for the 6 main combinations (no bindings, all offline, one offline, all online + one stale, all online + all stale, fully healthy).
+- [ ] FR4: `STREAMING_CATEGORIES` and `STREAMING_TIMEOUT_MS` are exported from `constants.ts`; event-based categories (motion, contact\_\*, action, etc.) are explicitly NOT in the set.
+- [ ] FR5: `equipment.status.changed` event emitted on every status transition and forwarded over WebSocket.
+- [ ] FR6: When the live `power` binding is stale, `EnergyAggregator` exposes `{ value: null, stale: true, lastUpdated }` for the live read.
+- [ ] FR7: `ZoneAggregator` skips offline equipments in numeric aggregations and populates `unavailableEquipmentsByCategory`.
+- [ ] FR8: `<EquipmentStatusBadge>` renders correctly for the 3 states; visible on compact + detail cards with tooltip.
+- [ ] FR9: LiveEnergyPage shows the stale indicator when power is stale; otherwise no visual change.
+- [ ] FR10: EnergyDataPanel shows "Last update X ago" caption when its source is stale.
+- [ ] FR11: Zone widgets show the "(X unavailable)" hint when applicable.
+- [ ] FR12: All new i18n keys present in `en.json` + `fr.json`.
+- [ ] FR13: `plugin-development.md` updated; `api-reference.md` documents the new status field + event.
+- [ ] FR14: All new unit tests pass; existing tests still pass.
+- [ ] `npx tsc --noEmit` clean (backend + UI).
+- [ ] `npx vitest run` clean.
+- [ ] `npx eslint src/ --ext .ts` clean.
+- [ ] Manual validation: temporarily mark a device offline (via API or by stopping a plugin), verify the equipment cards, energy widgets, and zone widgets reflect the state within 1 s (WS round-trip).
+- [ ] Documentation: `docs/release-notes.{md,fr.md}` entry added when bundled into a release (per spec 108).
+
+## Edge Cases
+
+- **Equipment with order bindings only, no data bindings**: status derived from order-binding source devices. Same rules apply.
+- **Equipment with bindings to multiple devices, half offline**: status = `degraded`. UI tooltip lists which devices.
+- **Plugin restart / Sowel restart**: `device.status` is loaded from SQLite at boot. If the plugin doesn't re-poll quickly, status may briefly be stale (e.g. last persisted value). Status will refresh as soon as the plugin emits `updateDeviceStatus` for the first time. Acceptable: equipment status will catch up within seconds.
+- **Streaming binding never received a value** (`lastUpdated === null`): treated as **not stale** (we never had any value to begin with; the binding is fresh-but-empty, not silent). Avoids marking newly-created equipments as degraded.
+- **Equipment with computed data only** (e.g. energy cumuls, no underlying device data binding for those values): the equipment's status is derived from its actual device-backed bindings only. Computed entries are not part of the staleness check.
+- **`device.status === "unknown"`**: treated as online (conservative — no evidence of failure). Matches the existing grey-dot semantics in the Devices list.
+- **`shutter_position` is intentionally event-based**: a shutter that hasn't moved in 3 weeks is fine. A shutter equipment's status follows the device's `status` (LWT-based). If the device goes offline, the equipment is `offline` — but no stale-on-shutter_position check.
+- **Battery binding stale (2h timeout)**: a battery-powered Zigbee endpoint that hasn't sent a battery report in 2h is genuinely worth flagging. Reasonable across Aqara/Tuya/Sonoff defaults.
+- **Order issued to an offline equipment**: passes through the existing `executeOrder` flow. The plugin may fail to deliver (offline LWT) — that's its concern. UI may grey-out the button using `equipment.status === "offline"`, but does not block the call server-side.
+- **i18n missing key fallback**: react-i18next falls back to the key string (existing convention).
+
+## Related
+
+- Direct trigger: bug Shelly Pro 3EM coupé au tableau, graph live figé sans indicateur.
+- Spec 062 (water_valve): referenced "déconnecté" UI semantics — never delivered, this spec covers it.
+- Spec 115 (awning): referenced "stale badge (existing pattern)" — this spec creates that pattern.
+- Spec 111 (plugin soft isolation): defines the `system.integration.{connected,disconnected}` event pair already in use. We layer the **equipment**-level signal on top of the existing device-level one.
+- Future spec (out of scope): recipe staleness awareness — make recipes optionally refuse to fire on stale triggers. Today's behavior: recipes still fire on whatever the binding exposes.
+- Future spec (out of scope): per-device "liveness watchdog" for plugins that can't or won't implement `updateDeviceStatus` (e.g. fire-and-forget LoRa receivers). Could be opt-in per device.

--- a/specs/116-equipment-availability/ux-mockups.html
+++ b/specs/116-equipment-availability/ux-mockups.html
@@ -1,0 +1,1326 @@
+<!doctype html>
+<html lang="fr" data-theme="hybrid">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Spec 116 — UX mockups (Equipment availability)</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+
+<style>
+/* ──────────────────────────────────────────────────────────────
+   Sowel design tokens — copy of design-system/tokens.css
+   ────────────────────────────────────────────────────────────── */
+:root, [data-theme="hybrid"] {
+  --p-50:#EEF5F8;  --p-100:#D9E7EF; --p-500:#1A4F6E; --p-600:#144159; --p-700:#0F3146;
+  --a-50:#FFF6D6;  --a-100:#FCE89A; --a-500:#F2C035; --a-600:#D4A41C;
+  --n-0:#FFFFFF;   --n-25:#FAFAFA;  --n-50:#F4F4F5;  --n-100:#E9E9EB; --n-200:#D4D4D8;
+  --n-300:#A1A1AA; --n-400:#71717A; --n-500:#52525B; --n-600:#3F3F46; --n-700:#27272A;
+  --green-50:#E6F7EE; --green-500:#1FA260; --green-700:#0E6B3F;
+  --info-50:#E0EFFA;  --info-500:#247EB5;
+  --red-50:#FBE9E1;   --red-500:#C7522E;
+  --light-50:#FFF6D6;    --light-500:#F2C035;
+  --shutter-50:#E8EBEE;  --shutter-500:#4F5763;
+  --sensor-50:#EBF2EC;   --sensor-500:#4F7559;
+  --media-50:#EAE9F2;    --media-500:#5759A5;
+  --line:rgba(24,24,27,.08);
+  --line-2:rgba(24,24,27,.14);
+}
+[data-theme="dark"] {
+  --p-50:#1A2A38;  --p-100:#243B4E; --p-500:#5BA5CC; --p-600:#82BCDD;
+  --a-50:#332715;  --a-100:#5C3F1A; --a-500:#F2BC6E; --a-600:#FFCF8C;
+  --n-0:#16181E;   --n-25:#1B1D24;  --n-50:#1F2128;  --n-100:#262931; --n-200:#363941;
+  --n-300:#52565F; --n-400:#7E828B; --n-500:#9CA0AA; --n-600:#C7C9CF; --n-700:#E2E3E7;
+  --green-50:#0F2A1E; --green-500:#3DDB89; --green-700:#9AF0C6;
+  --info-50:#0F1F33;  --info-500:#5DA8F0;
+  --red-50:#2E1614;   --red-500:#F37B5F;
+  --light-50:#2D2415;   --light-500:#F2BC6E;
+  --shutter-50:#1B2230; --shutter-500:#94A3B8;
+  --sensor-50:#152920;  --sensor-500:#6BCF8C;
+  --media-50:#1B1F36;   --media-500:#9D9FE6;
+  --line:rgba(255,255,255,.06);
+  --line-2:rgba(255,255,255,.14);
+}
+:root {
+  --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--font-body);
+  color: var(--n-700);
+  background: var(--n-50);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "cv11" 1, "ss01" 1;
+}
+.font-mono { font-family: var(--font-mono); font-feature-settings: "tnum" 1; }
+
+/* ────────────────────────────────────────────────────────────── */
+/* Page layout                                                    */
+/* ────────────────────────────────────────────────────────────── */
+.page { max-width: 1320px; margin: 0 auto; padding: 32px 24px 80px; }
+.page__header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 8px;
+}
+.page__title { font-size: 28px; font-weight: 700; letter-spacing: -.025em; margin: 0; color: var(--n-700); }
+.page__subtitle { color: var(--n-500); font-size: 14px; margin-top: 4px; margin-bottom: 32px; max-width: 720px; }
+
+.theme-toggle {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 14px; border-radius: 999px;
+  background: var(--n-0); border: 1px solid var(--line-2);
+  font-size: 13px; color: var(--n-600); cursor: pointer;
+}
+.theme-toggle:hover { background: var(--p-50); border-color: var(--p-100); color: var(--p-500); }
+
+.section { margin-top: 56px; }
+.section__title {
+  font-size: 18px; font-weight: 600; color: var(--n-700);
+  display: flex; align-items: center; gap: 10px;
+  margin: 0 0 4px;
+}
+.section__num {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 26px; height: 26px; border-radius: 999px;
+  background: var(--p-500); color: var(--n-0);
+  font-size: 12px; font-weight: 600;
+}
+.section__desc { color: var(--n-500); font-size: 13px; margin: 0 0 16px 36px; max-width: 800px; }
+.section__file { color: var(--n-400); font-size: 11px; font-family: var(--font-mono); margin: 4px 0 16px 36px; }
+
+.triplet { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.triplet__col { display: flex; flex-direction: column; gap: 8px; }
+.triplet__label {
+  font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em;
+  color: var(--n-500); padding-left: 4px;
+}
+.triplet__label.is-online { color: var(--green-700); }
+.triplet__label.is-degraded { color: var(--a-600); }
+.triplet__label.is-offline { color: var(--red-500); }
+@media (max-width: 1000px) { .triplet { grid-template-columns: 1fr; } }
+
+/* ────────────────────────────────────────────────────────────── */
+/* Atoms                                                          */
+/* ────────────────────────────────────────────────────────────── */
+
+.surface {
+  background: var(--n-0);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+}
+
+/* Badge — spec 116 central component */
+.badge {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px; font-weight: 500;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+.badge--md { padding: 3px 10px; font-size: 12px; gap: 5px; }
+.badge--degraded {
+  background: color-mix(in srgb, var(--a-500) 14%, transparent);
+  color: var(--a-600);
+}
+.badge--offline {
+  background: color-mix(in srgb, var(--red-500) 12%, transparent);
+  color: var(--red-500);
+}
+.badge svg { stroke-width: 1.75; }
+
+/* Generic chip-state (matches polished + production .chip-state) */
+.chip-state {
+  display: inline-flex; align-items: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 11px; font-weight: 500;
+  background: var(--n-100); color: var(--n-500);
+}
+.chip-state--on { background: var(--green-50); color: var(--green-700); }
+.chip-state--closed { background: var(--n-100); color: var(--n-500); }
+
+/* Stale inline indicator on a single value */
+.stale { color: var(--n-400); font-style: italic; }
+.stale__age { font-size: 11px; font-family: var(--font-mono); color: var(--n-400); }
+
+/* ────────────────────────────────────────────────────────────── */
+/* 1. CompactEquipmentCard (.eq row pattern from production)      */
+/* ────────────────────────────────────────────────────────────── */
+.eq-host {
+  /* Mimics the zone container — devices rows live inside a card */
+  background: var(--n-0);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.eq-host__sep { height: 1px; background: var(--line); margin: 0 18px; }
+
+.eq {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  gap: 0.85rem;
+  align-items: center;
+  padding: 0.55rem 1.1rem;
+  min-height: 52px;
+  transition: background 150ms ease;
+  position: relative;
+}
+.eq:hover { background: color-mix(in srgb, var(--line) 50%, transparent); }
+.eq__icon {
+  width: 32px; height: 32px; border-radius: 6px;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.eq__icon svg { width: 15px; height: 15px; }
+.eq__icon--light    { background: var(--light-50);    color: var(--light-500); }
+.eq__icon--shutter  { background: var(--shutter-50);  color: var(--shutter-500); }
+.eq__icon--sensor   { background: var(--sensor-50);   color: var(--sensor-500); }
+.eq__icon--accent   { background: var(--a-50);        color: var(--a-600); }
+.eq__icon--primary  { background: var(--p-50);        color: var(--p-500); }
+.eq__icon--success  { background: var(--green-50);    color: var(--green-700); }
+.eq__name {
+  min-width: 0;
+  font-size: 14px; font-weight: 500; color: var(--n-700);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.eq__values {
+  display: flex; align-items: center; gap: 12px;
+  flex-shrink: 0;
+}
+.eq__sensor-val {
+  display: inline-flex; align-items: baseline; gap: 2px;
+  font-size: 13px; color: var(--n-600); font-family: var(--font-mono);
+}
+.eq__sensor-val svg { width: 13px; height: 13px; opacity: .6; margin-right: 4px; align-self: center; }
+.eq__sensor-val .u { font-size: 11px; color: var(--n-400); margin-left: 1px; }
+.eq__chip { /* boolean state like ON/OFF */
+  font-size: 11px; font-weight: 500;
+  padding: 2px 10px; border-radius: 999px;
+  background: var(--green-50); color: var(--green-700);
+}
+.eq__chip--off { background: var(--n-100); color: var(--n-400); }
+
+/* Slider compact (light dimmable) */
+.eq__slider-mini { display: inline-flex; align-items: center; gap: 6px; }
+.eq__slider-mini input { width: 80px; }
+
+/* Stale value variant for the degraded case */
+.eq__sensor-val--stale { color: var(--n-400); font-style: italic; }
+.eq__sensor-val--stale .u { color: var(--n-400); }
+.eq__stale-age {
+  font-size: 10px; font-family: var(--font-mono); color: var(--n-400);
+  margin-left: 6px;
+}
+
+/* Shutter mini buttons (compact row) */
+.shutter-grp { display: inline-flex; gap: 4px; }
+.shutter-btn {
+  width: 28px; height: 28px; border-radius: 6px;
+  border: 1px solid var(--line-2); background: var(--n-0); color: var(--n-500);
+  display: inline-flex; align-items: center; justify-content: center;
+  cursor: pointer; transition: all 150ms ease;
+}
+.shutter-btn:hover { color: var(--p-500); border-color: var(--p-100); background: var(--p-50); }
+.shutter-btn svg { width: 14px; height: 14px; stroke-width: 2; }
+
+.eq--offline .eq__icon,
+.eq--offline .shutter-grp { opacity: .55; }
+
+/* ────────────────────────────────────────────────────────────── */
+/* 2. EquipmentDetailPage card                                    */
+/* ────────────────────────────────────────────────────────────── */
+.detail {
+  background: var(--n-0);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 18px;
+}
+.detail__head {
+  display: flex; align-items: flex-start; gap: 12px;
+  margin-bottom: 18px;
+}
+.detail__head-icon {
+  width: 40px; height: 40px; border-radius: 8px;
+  background: var(--p-50); color: var(--p-500);
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.detail__title-line {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.detail__name { font-size: 16px; font-weight: 600; color: var(--n-700); }
+.detail__zone { font-size: 12px; color: var(--n-400); margin-top: 2px; }
+
+.detail__section-title {
+  font-size: 14px; font-weight: 600; color: var(--n-700);
+  display: flex; align-items: center; gap: 8px;
+  margin: 14px 0 10px;
+}
+.detail__section-title svg { width: 14px; height: 14px; stroke-width: 1.5; color: var(--n-500); }
+
+.detail__value-row {
+  background: color-mix(in srgb, var(--line) 50%, transparent);
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex; align-items: baseline; justify-content: space-between; gap: 12px;
+}
+.detail__value {
+  font-family: var(--font-mono); font-size: 20px; font-weight: 500;
+  color: var(--n-700); line-height: 1;
+}
+.detail__value--stale { color: var(--n-400); font-style: italic; }
+.detail__caption {
+  font-size: 11px; font-family: var(--font-mono); color: var(--n-400);
+}
+
+.detail__controls { display: flex; gap: 8px; margin-top: 14px; }
+.btn {
+  flex: 1; padding: 8px 12px;
+  background: var(--n-0); border: 1px solid var(--line-2);
+  border-radius: 6px; cursor: pointer;
+  font-size: 13px; color: var(--n-600);
+  transition: all 150ms ease;
+}
+.btn:hover { background: var(--p-50); border-color: var(--p-100); color: var(--p-500); }
+.btn:disabled, .btn[disabled] { opacity: .5; cursor: not-allowed; }
+
+.detail--offline .detail__controls,
+.detail--offline .detail__value-row,
+.detail--offline .detail__head-icon { opacity: .55; }
+.detail--offline .detail__title-line { opacity: 1; }
+
+/* ────────────────────────────────────────────────────────────── */
+/* 3. LiveEnergyPage flow diagram                                 */
+/* ────────────────────────────────────────────────────────────── */
+.live-frame {
+  background: var(--n-0);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 20px;
+  position: relative;
+  aspect-ratio: 3 / 2;
+}
+.live-flow {
+  position: relative;
+  width: 100%; height: 100%;
+}
+/* The 3 nodes use absolute positioning like production */
+.live-node {
+  position: absolute;
+  border: 1px solid var(--line-2);
+  border-radius: 14px;
+  background: var(--n-0);
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 4px;
+  padding: 8px 6px;
+  transition: opacity 200ms ease;
+}
+.live-node--house  { top: 4%;  left: 32%; width: 36%; height: 36%; }
+.live-node--grid   { bottom: 12%; left: 6%;  width: 22%; height: 29%; }
+.live-node--solar  { bottom: 12%; right: 6%; width: 22%; height: 29%; }
+.live-node__lab {
+  font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: .15em;
+  color: var(--n-400);
+}
+.live-node__icon { display: block; }
+.live-node__icon svg { width: 28px; height: 28px; stroke-width: 1.5; }
+.live-node--house  .live-node__icon { color: var(--p-500); }
+.live-node--grid   .live-node__icon { color: var(--n-500); }
+.live-node--solar  .live-node__icon { color: var(--green-500); }
+.live-node__val {
+  font-family: var(--font-mono); font-weight: 700; font-size: 20px;
+  display: inline-flex; align-items: baseline; gap: 2px;
+  color: var(--n-700);
+}
+.live-node__val .u { font-size: 11px; font-weight: 600; opacity: .6; }
+.live-node--house  .live-node__val { color: var(--p-500); }
+.live-node--solar  .live-node__val { color: var(--green-700); }
+.live-node__sub {
+  font-size: 10px; color: var(--n-400);
+  margin-top: 2px;
+}
+
+.live-node--inactive { opacity: .4; }
+.live-node--stale .live-node__val { color: var(--n-400); font-style: italic; }
+.live-node--offline {
+  border-color: color-mix(in srgb, var(--red-500) 35%, var(--line-2));
+  background: color-mix(in srgb, var(--red-500) 4%, var(--n-0));
+}
+.live-node--offline .live-node__icon { color: var(--n-300); }
+
+.live-svg { position: absolute; inset: 0; pointer-events: none; }
+.live-svg path { fill: none; }
+.live-status {
+  position: absolute;
+  bottom: 4%; left: 50%; transform: translateX(-50%);
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-family: var(--font-mono); font-size: 12px; font-weight: 700;
+  background: color-mix(in srgb, var(--green-500) 14%, transparent);
+  color: var(--green-700);
+  white-space: nowrap;
+}
+.live-status--stale {
+  background: color-mix(in srgb, var(--a-500) 14%, transparent);
+  color: var(--a-600);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.live-status--offline {
+  background: color-mix(in srgb, var(--red-500) 14%, transparent);
+  color: var(--red-500);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+
+/* Percentage pills on the SVG path */
+.live-pct {
+  position: absolute;
+  font-family: var(--font-mono); font-weight: 700; font-size: 11px;
+  padding: 2px 8px; border-radius: 999px;
+  background: var(--n-0); border: 1px solid var(--green-500); color: var(--green-700);
+  transform: translate(-50%, -50%);
+}
+
+/* ────────────────────────────────────────────────────────────── */
+/* 4. EnergyDataPanel — 2x2 grid                                  */
+/* ────────────────────────────────────────────────────────────── */
+.energy-panel {
+  background: var(--n-0);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 16px;
+}
+.energy-panel__head {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 16px;
+}
+.energy-panel__title {
+  font-size: 14px; font-weight: 600; color: var(--n-700);
+  display: flex; align-items: center; gap: 8px;
+}
+.energy-panel__title svg { width: 16px; height: 16px; stroke-width: 1.5; color: var(--a-600); }
+.energy-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+}
+.cumul {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--line) 60%, transparent);
+}
+.cumul__icon {
+  width: 40px; height: 40px; border-radius: 6px;
+  background: color-mix(in srgb, var(--a-500) 12%, transparent);
+  color: var(--a-600);
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.cumul__icon svg { width: 16px; height: 16px; stroke-width: 1.5; }
+.cumul__body { flex: 1; min-width: 0; }
+.cumul__lab { font-size: 12px; font-weight: 500; color: var(--n-400); }
+.cumul__val {
+  font-family: var(--font-mono); font-weight: 600; font-size: 18px;
+  line-height: 1; color: var(--n-700);
+  display: inline-flex; align-items: baseline; gap: 4px;
+  margin-top: 4px;
+}
+.cumul__val .u { font-size: 12px; color: var(--n-400); font-weight: 500; }
+.energy-panel__caption {
+  font-size: 11px; font-family: var(--font-mono); color: var(--n-400);
+  margin-top: 14px;
+  text-align: center;
+}
+.energy-panel__caption--err { color: var(--red-500); }
+
+/* ────────────────────────────────────────────────────────────── */
+/* 5+6. Dashboard widget (WidgetCard pattern)                     */
+/* ────────────────────────────────────────────────────────────── */
+.widget {
+  background: var(--n-0);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  display: flex; flex-direction: column;
+  height: 240px;
+  position: relative;
+  overflow: hidden;
+}
+.widget__title {
+  text-align: center;
+  font-size: 17px; font-weight: 600; color: var(--n-700);
+  margin: 0 0 8px;
+  display: flex; align-items: center; justify-content: center; gap: 6px;
+}
+.widget__title-badge { /* Place for the spec 116 indicator */
+  display: inline-flex; align-items: center; line-height: 1;
+}
+.widget__art {
+  display: flex; align-items: center; justify-content: center;
+  height: 104px;
+  margin: auto 0;
+  color: var(--p-500);
+}
+.widget__art svg { width: 96px; height: 96px; }
+.widget__art-side {
+  display: flex; flex-direction: column; align-items: flex-end; justify-content: center;
+  gap: 8px;
+  padding-left: 10px;
+}
+.widget__big {
+  font-family: var(--font-mono); font-weight: 700; font-size: 22px;
+  color: var(--n-700);
+  display: inline-flex; align-items: baseline; gap: 2px;
+}
+.widget__big .u { font-size: 11px; color: var(--n-400); font-weight: 500; }
+.widget__footer {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  margin-top: auto;
+  padding-top: 10px;
+}
+.widget__footer-center { justify-content: center; gap: 12px; }
+.widget__footnote {
+  font-size: 11px; color: var(--n-400);
+  text-align: center;
+  margin-top: 6px;
+}
+.widget__footnote--err { color: var(--red-500); }
+.widget--offline .widget__art { opacity: .35; }
+.widget--offline .shutter-grp .shutter-btn { opacity: .4; cursor: not-allowed; }
+
+/* Mini sensor row inside a multi-metric widget */
+.zone-pills {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 8px 10px;
+}
+.zone-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 12px; color: var(--n-600);
+}
+.zone-pill svg { width: 13px; height: 13px; stroke-width: 1.5; }
+.zone-pill__val { font-family: var(--font-mono); font-weight: 600; color: var(--n-700); }
+.zone-pill__hint { font-size: 10px; color: var(--n-400); font-family: var(--font-mono); }
+
+/* ────────────────────────────────────────────────────────────── */
+/* Tooltip                                                        */
+/* ────────────────────────────────────────────────────────────── */
+.tooltip {
+  background: var(--n-700); color: #F4F4F5;
+  padding: 12px 14px; border-radius: 8px;
+  font-size: 12px; line-height: 1.5;
+  max-width: 280px;
+  box-shadow: 0 4px 14px -4px rgba(15,42,60,.18);
+}
+.tooltip__title { font-size: 13px; font-weight: 600; color: var(--n-0); margin-bottom: 6px; }
+.tooltip__group { margin-top: 8px; }
+.tooltip__group-title { font-size: 11px; color: var(--n-300); }
+.tooltip ul { margin: 4px 0 0; padding-left: 16px; }
+.tooltip li { font-family: var(--font-mono); font-size: 11px; color: var(--n-100); }
+.tooltip__since { margin-top: 8px; font-size: 11px; color: var(--n-300); font-family: var(--font-mono); }
+[data-theme="dark"] .tooltip { background: var(--n-200); color: var(--n-700); }
+[data-theme="dark"] .tooltip__title { color: var(--n-700); }
+[data-theme="dark"] .tooltip__group-title,
+[data-theme="dark"] .tooltip__since { color: var(--n-500); }
+[data-theme="dark"] .tooltip li { color: var(--n-600); }
+
+/* Legend */
+.legend {
+  margin-top: 64px; padding-top: 24px;
+  border-top: 1px solid var(--line);
+  display: flex; gap: 24px; flex-wrap: wrap;
+  font-size: 12px; color: var(--n-500);
+}
+.legend__item { display: inline-flex; align-items: center; gap: 8px; }
+.legend__swatch { width: 14px; height: 14px; border-radius: 999px; }
+.legend code { font-family: var(--font-mono); color: var(--p-500); background: var(--p-50); padding: 1px 5px; border-radius: 4px; }
+</style>
+</head>
+
+<body>
+<div class="page">
+
+  <div class="page__header">
+    <div>
+      <h1 class="page__title">Spec 116 — Equipment availability</h1>
+      <div class="page__subtitle">Maquettes UX par écran impacté, 3 états comparés côte à côte. Reproduit fidèlement les composants Sowel actuels (CompactEquipmentCard, WidgetCard, EnergyDataPanel, LiveEnergyPage flow).</div>
+    </div>
+    <button class="theme-toggle" onclick="toggleTheme()">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
+      <span id="theme-label">Thème clair</span>
+    </button>
+  </div>
+
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <!-- 1. CompactEquipmentCard                                       -->
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <section class="section">
+    <h2 class="section__title"><span class="section__num">1</span> CompactEquipmentCard (ligne d'équipement dans une zone)</h2>
+    <p class="section__desc">Le pattern .eq de production : grid 32px/1fr/auto, bg transparent avec hover, séparateurs horizontaux. Badge offline remplace la valeur (1 info au lieu de 3). Degraded garde la valeur grisée + age inline (la valeur reste vaguement pertinente).</p>
+    <p class="section__file">ui/src/components/home/CompactEquipmentCard.tsx</p>
+
+    <div class="triplet">
+
+      <!-- ONLINE -->
+      <div class="triplet__col">
+        <div class="triplet__label is-online">État online · référence actuelle</div>
+        <div class="eq-host">
+          <div class="eq">
+            <div class="eq__icon eq__icon--light">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7c1 .9 1 2.3 1 2.3h6s0-1.4 1-2.3A7 7 0 0 0 12 2Z"/></svg>
+            </div>
+            <span class="eq__name">Lampe salon</span>
+            <div class="eq__values">
+              <span class="eq__chip">ON</span>
+            </div>
+          </div>
+          <div class="eq-host__sep"></div>
+          <div class="eq">
+            <div class="eq__icon eq__icon--sensor">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z"/></svg>
+            </div>
+            <span class="eq__name">Capteur séjour</span>
+            <div class="eq__values">
+              <span class="eq__sensor-val">21.4<span class="u">°C</span></span>
+              <span class="eq__sensor-val">48<span class="u">%</span></span>
+            </div>
+          </div>
+          <div class="eq-host__sep"></div>
+          <div class="eq">
+            <div class="eq__icon eq__icon--accent">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+            </div>
+            <span class="eq__name">Compteur principal</span>
+            <div class="eq__values">
+              <span class="eq__sensor-val">385<span class="u">W</span></span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- DEGRADED -->
+      <div class="triplet__col">
+        <div class="triplet__label is-degraded">État degraded · valeur grisée + age inline</div>
+        <div class="eq-host">
+          <div class="eq">
+            <div class="eq__icon eq__icon--light">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7c1 .9 1 2.3 1 2.3h6s0-1.4 1-2.3A7 7 0 0 0 12 2Z"/></svg>
+            </div>
+            <span class="eq__name">Lampe salon</span>
+            <div class="eq__values">
+              <span class="eq__chip">ON</span>
+            </div>
+          </div>
+          <div class="eq-host__sep"></div>
+          <div class="eq">
+            <div class="eq__icon eq__icon--sensor">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z"/></svg>
+            </div>
+            <span class="eq__name">Capteur séjour</span>
+            <div class="eq__values">
+              <span class="eq__sensor-val eq__sensor-val--stale">21.4<span class="u">°C</span></span>
+              <span class="eq__sensor-val eq__sensor-val--stale">48<span class="u">%</span></span>
+              <span class="eq__stale-age">23m</span>
+            </div>
+          </div>
+          <div class="eq-host__sep"></div>
+          <div class="eq">
+            <div class="eq__icon eq__icon--accent">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+            </div>
+            <span class="eq__name">Compteur principal</span>
+            <div class="eq__values">
+              <span class="eq__sensor-val eq__sensor-val--stale">385<span class="u">W</span></span>
+              <span class="eq__stale-age">5m</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- OFFLINE — badge replaces value -->
+      <div class="triplet__col">
+        <div class="triplet__label is-offline">État offline · badge remplace la valeur</div>
+        <div class="eq-host">
+          <div class="eq eq--offline">
+            <div class="eq__icon eq__icon--light">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7c1 .9 1 2.3 1 2.3h6s0-1.4 1-2.3A7 7 0 0 0 12 2Z"/></svg>
+            </div>
+            <span class="eq__name">Lampe salon</span>
+            <div class="eq__values">
+              <span class="badge badge--offline">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="2" x2="22" y2="22"/><path d="M8.5 16.5a5 5 0 0 1 7 0"/><path d="M2 8.82a15 15 0 0 1 4.17-2.65"/><path d="M10.66 5c4.01-.36 8.14.9 11.34 3.76"/><path d="M16.85 11.25a10 10 0 0 1 2.22 1.68"/><path d="M5 13a10 10 0 0 1 5.24-2.76"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+                Déconnecté
+              </span>
+            </div>
+          </div>
+          <div class="eq-host__sep"></div>
+          <div class="eq eq--offline">
+            <div class="eq__icon eq__icon--shutter">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/></svg>
+            </div>
+            <span class="eq__name">Volet salon</span>
+            <div class="eq__values">
+              <span class="badge badge--offline">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="2" x2="22" y2="22"/><path d="M8.5 16.5a5 5 0 0 1 7 0"/><path d="M2 8.82a15 15 0 0 1 4.17-2.65"/><path d="M10.66 5c4.01-.36 8.14.9 11.34 3.76"/><path d="M16.85 11.25a10 10 0 0 1 2.22 1.68"/><path d="M5 13a10 10 0 0 1 5.24-2.76"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+                Déconnecté
+              </span>
+            </div>
+          </div>
+          <div class="eq-host__sep"></div>
+          <div class="eq eq--offline">
+            <div class="eq__icon eq__icon--accent">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+            </div>
+            <span class="eq__name">Compteur principal</span>
+            <div class="eq__values">
+              <span class="badge badge--offline">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="2" x2="22" y2="22"/><path d="M8.5 16.5a5 5 0 0 1 7 0"/><path d="M2 8.82a15 15 0 0 1 4.17-2.65"/><path d="M10.66 5c4.01-.36 8.14.9 11.34 3.76"/><path d="M16.85 11.25a10 10 0 0 1 2.22 1.68"/><path d="M5 13a10 10 0 0 1 5.24-2.76"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+                Déconnecté
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <!-- 2. EquipmentDetailPage card                                   -->
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <section class="section">
+    <h2 class="section__title"><span class="section__num">2</span> EquipmentDetailPage · carte d'équipement</h2>
+    <p class="section__desc">Card bg-surface + border + rounded-[10px], pas de shadow (flat). Badge md à côté du nom dans le header. Caption mono sous la valeur pour la fraicheur. Boutons gardés (`opacity-55` en offline) — la décision passe / ne passe pas reste côté plugin.</p>
+    <p class="section__file">ui/src/pages/EquipmentDetailPage.tsx</p>
+
+    <div class="triplet">
+
+      <!-- ONLINE -->
+      <div class="triplet__col">
+        <div class="triplet__label is-online">État online</div>
+        <div class="detail">
+          <div class="detail__head">
+            <div class="detail__head-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/></svg>
+            </div>
+            <div>
+              <div class="detail__title-line">
+                <span class="detail__name">Volet salon</span>
+              </div>
+              <div class="detail__zone">Salon · Maison</div>
+            </div>
+          </div>
+          <div class="detail__section-title">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 12h20M12 2v20"/></svg>
+            Position
+          </div>
+          <div class="detail__value-row">
+            <span class="detail__value">42 <span style="font-size:13px;color:var(--n-400);font-weight:500">%</span></span>
+          </div>
+          <div class="detail__controls">
+            <button class="btn">Ouvrir</button>
+            <button class="btn">Stop</button>
+            <button class="btn">Fermer</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- DEGRADED -->
+      <div class="triplet__col">
+        <div class="triplet__label is-degraded">État degraded · badge ambre + caption</div>
+        <div class="detail">
+          <div class="detail__head">
+            <div class="detail__head-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/></svg>
+            </div>
+            <div>
+              <div class="detail__title-line">
+                <span class="detail__name">Volet salon</span>
+                <span class="badge badge--md badge--degraded">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                  Dégradé
+                </span>
+              </div>
+              <div class="detail__zone">Salon · Maison</div>
+            </div>
+          </div>
+          <div class="detail__section-title">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 12h20M12 2v20"/></svg>
+            Position
+          </div>
+          <div class="detail__value-row">
+            <span class="detail__value detail__value--stale">42 <span style="font-size:13px;color:var(--n-400);font-weight:500">%</span></span>
+            <span class="detail__caption">il y a 35 min</span>
+          </div>
+          <div class="detail__controls">
+            <button class="btn">Ouvrir</button>
+            <button class="btn">Stop</button>
+            <button class="btn">Fermer</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- OFFLINE -->
+      <div class="triplet__col">
+        <div class="triplet__label is-offline">État offline · badge rouge + tout muted</div>
+        <div class="detail detail--offline">
+          <div class="detail__head">
+            <div class="detail__head-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/></svg>
+            </div>
+            <div>
+              <div class="detail__title-line">
+                <span class="detail__name">Volet salon</span>
+                <span class="badge badge--md badge--offline">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="2" x2="22" y2="22"/><path d="M8.5 16.5a5 5 0 0 1 7 0"/><path d="M2 8.82a15 15 0 0 1 4.17-2.65"/><path d="M10.66 5c4.01-.36 8.14.9 11.34 3.76"/><path d="M16.85 11.25a10 10 0 0 1 2.22 1.68"/><path d="M5 13a10 10 0 0 1 5.24-2.76"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+                  Déconnecté
+                </span>
+              </div>
+              <div class="detail__zone">Salon · Maison</div>
+            </div>
+          </div>
+          <div class="detail__section-title">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 12h20M12 2v20"/></svg>
+            Position
+          </div>
+          <div class="detail__value-row">
+            <span class="detail__value detail__value--stale">— <span style="font-size:13px;color:var(--n-400);font-weight:500">%</span></span>
+            <span class="detail__caption">Hors ligne depuis 2 h</span>
+          </div>
+          <div class="detail__controls">
+            <button class="btn">Ouvrir</button>
+            <button class="btn">Stop</button>
+            <button class="btn">Fermer</button>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <!-- 3. LiveEnergyPage flow diagram                                -->
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <section class="section">
+    <h2 class="section__title"><span class="section__num">3</span> LiveEnergyPage · diagramme de flux énergie</h2>
+    <p class="section__desc">Reproduit le vrai layout : 3 nodes (Consommation centré haut, Réseau gauche, Production droite) avec icons + valeur mono. Lignes courbes + pills de répartition. Sur stale : valeur grisée par node + status pill "Données figées". Sur offline : node bordure rouge, statut explicite.</p>
+    <p class="section__file">ui/src/components/energy/LiveEnergyPage.tsx</p>
+
+    <div class="triplet">
+
+      <!-- ONLINE -->
+      <div class="triplet__col">
+        <div class="triplet__label is-online">État online · live à 1s</div>
+        <div class="live-frame">
+          <div class="live-flow">
+            <!-- SVG flow lines -->
+            <svg class="live-svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+              <path d="M 50 36 C 50 50, 30 60, 17 70" stroke="#6BCB77" stroke-width=".5" opacity=".8"/>
+              <path d="M 50 36 C 50 50, 70 60, 83 70" stroke="#6BCB77" stroke-width=".5" opacity=".8"/>
+              <path d="M 17 78 C 35 88, 65 88, 83 78" stroke="#6BCB77" stroke-width=".5" opacity=".8"/>
+            </svg>
+            <div class="live-pct" style="top: 56%; left: 28%;">59%</div>
+            <div class="live-pct" style="top: 84%; left: 50%;">41%</div>
+
+            <div class="live-node live-node--house">
+              <span class="live-node__lab">Consommation</span>
+              <span class="live-node__icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M13 9l-3 4h4l-3 4" stroke-width="1.6"/></svg>
+              </span>
+              <span class="live-node__val">380<span class="u">W</span></span>
+            </div>
+
+            <div class="live-node live-node--grid">
+              <span class="live-node__lab">Réseau</span>
+              <span class="live-node__icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 22 L20 22"/><path d="M7 22 L10 4"/><path d="M17 22 L14 4"/><path d="M9 4 L15 4"/><path d="M10 10 L14 10"/><path d="M9.5 16 L14.5 16"/></svg>
+              </span>
+              <span class="live-node__val"><span style="font-size:14px">↓</span>265<span class="u">W</span></span>
+            </div>
+
+            <div class="live-node live-node--solar">
+              <span class="live-node__lab">Production</span>
+              <span class="live-node__icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="6" width="18" height="12" rx="1"/><line x1="9" y1="6" x2="9" y2="18"/><line x1="15" y1="6" x2="15" y2="18"/><line x1="3" y1="12" x2="21" y2="12"/></svg>
+              </span>
+              <span class="live-node__val">650<span class="u">W</span></span>
+            </div>
+
+            <div class="live-status">Excédent solaire</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- DEGRADED · live stale -->
+      <div class="triplet__col">
+        <div class="triplet__label is-degraded">État degraded · données figées</div>
+        <div class="live-frame">
+          <div class="live-flow">
+            <svg class="live-svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+              <path d="M 50 36 C 50 50, 30 60, 17 70" stroke="#71717A" stroke-width=".5" opacity=".4" stroke-dasharray="1.5,1"/>
+              <path d="M 50 36 C 50 50, 70 60, 83 70" stroke="#71717A" stroke-width=".5" opacity=".4" stroke-dasharray="1.5,1"/>
+              <path d="M 17 78 C 35 88, 65 88, 83 78" stroke="#71717A" stroke-width=".5" opacity=".4" stroke-dasharray="1.5,1"/>
+            </svg>
+
+            <div class="live-node live-node--house live-node--stale">
+              <span class="live-node__lab">Consommation</span>
+              <span class="live-node__icon" style="color:var(--n-400)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M13 9l-3 4h4l-3 4" stroke-width="1.6"/></svg>
+              </span>
+              <span class="live-node__val">380<span class="u">W</span></span>
+              <span class="live-node__sub">il y a 47 min</span>
+            </div>
+
+            <div class="live-node live-node--grid live-node--stale">
+              <span class="live-node__lab">Réseau</span>
+              <span class="live-node__icon" style="color:var(--n-400)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 22 L20 22"/><path d="M7 22 L10 4"/><path d="M17 22 L14 4"/><path d="M9 4 L15 4"/><path d="M10 10 L14 10"/><path d="M9.5 16 L14.5 16"/></svg>
+              </span>
+              <span class="live-node__val"><span style="font-size:14px">↓</span>265<span class="u">W</span></span>
+              <span class="live-node__sub">il y a 47 min</span>
+            </div>
+
+            <div class="live-node live-node--solar live-node--stale">
+              <span class="live-node__lab">Production</span>
+              <span class="live-node__icon" style="color:var(--n-400)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="6" width="18" height="12" rx="1"/><line x1="9" y1="6" x2="9" y2="18"/><line x1="15" y1="6" x2="15" y2="18"/><line x1="3" y1="12" x2="21" y2="12"/></svg>
+              </span>
+              <span class="live-node__val">650<span class="u">W</span></span>
+              <span class="live-node__sub">il y a 47 min</span>
+            </div>
+
+            <div class="live-status live-status--stale">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+              Données figées il y a 47 min
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- OFFLINE -->
+      <div class="triplet__col">
+        <div class="triplet__label is-offline">État offline · compteur déconnecté</div>
+        <div class="live-frame">
+          <div class="live-flow">
+            <div class="live-node live-node--house live-node--offline">
+              <span class="live-node__lab">Consommation</span>
+              <span class="live-node__icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 11l9-8 9 8v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M13 9l-3 4h4l-3 4" stroke-width="1.6"/></svg>
+              </span>
+              <span class="live-node__val" style="color:var(--n-300)">— <span class="u">W</span></span>
+            </div>
+
+            <div class="live-node live-node--grid live-node--offline">
+              <span class="live-node__lab">Réseau</span>
+              <span class="live-node__icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 22 L20 22"/><path d="M7 22 L10 4"/><path d="M17 22 L14 4"/><path d="M9 4 L15 4"/><path d="M10 10 L14 10"/><path d="M9.5 16 L14.5 16"/></svg>
+              </span>
+              <span class="live-node__val" style="color:var(--n-300)">— <span class="u">W</span></span>
+            </div>
+
+            <div class="live-node live-node--solar live-node--offline">
+              <span class="live-node__lab">Production</span>
+              <span class="live-node__icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="6" width="18" height="12" rx="1"/><line x1="9" y1="6" x2="9" y2="18"/><line x1="15" y1="6" x2="15" y2="18"/><line x1="3" y1="12" x2="21" y2="12"/></svg>
+              </span>
+              <span class="live-node__val" style="color:var(--n-300)">— <span class="u">W</span></span>
+            </div>
+
+            <div class="live-status live-status--offline">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="2" x2="22" y2="22"/><path d="M8.5 16.5a5 5 0 0 1 7 0"/><path d="M2 8.82a15 15 0 0 1 4.17-2.65"/><path d="M10.66 5c4.01-.36 8.14.9 11.34 3.76"/><path d="M5 13a10 10 0 0 1 5.24-2.76"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+              Compteur déconnecté depuis 2 h
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <!-- 4. EnergyDataPanel                                            -->
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <section class="section">
+    <h2 class="section__title"><span class="section__num">4</span> EnergyDataPanel · cumuls</h2>
+    <p class="section__desc">Vrai layout : grid 2x2, chaque cumul = icon box accent + label + valeur mono. Cumuls inchangés (issus d'InfluxDB, donc historiquement justes même si live est mort). Caption sous le grid uniquement.</p>
+    <p class="section__file">ui/src/components/equipments/EnergyDataPanel.tsx</p>
+
+    <div class="triplet">
+
+      <!-- ONLINE -->
+      <div class="triplet__col">
+        <div class="triplet__label is-online">État online</div>
+        <div class="energy-panel">
+          <div class="energy-panel__head">
+            <div class="energy-panel__title">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+              Compteur principal
+            </div>
+          </div>
+          <div class="energy-grid">
+            <div class="cumul">
+              <span class="cumul__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span>
+              <div class="cumul__body"><div class="cumul__lab">Heure</div><div class="cumul__val">1.20<span class="u">kWh</span></div></div>
+            </div>
+            <div class="cumul">
+              <span class="cumul__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span>
+              <div class="cumul__body"><div class="cumul__lab">Jour</div><div class="cumul__val">12.40<span class="u">kWh</span></div></div>
+            </div>
+            <div class="cumul">
+              <span class="cumul__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="8" y1="14" x2="8" y2="14"/><line x1="12" y1="14" x2="12" y2="14"/><line x1="16" y1="14" x2="16" y2="14"/></svg></span>
+              <div class="cumul__body"><div class="cumul__lab">Mois</div><div class="cumul__val">384<span class="u">kWh</span></div></div>
+            </div>
+            <div class="cumul">
+              <span class="cumul__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><polyline points="17 14 13 18 11 16 7 20"/></svg></span>
+              <div class="cumul__body"><div class="cumul__lab">Année</div><div class="cumul__val">4 320<span class="u">kWh</span></div></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- DEGRADED -->
+      <div class="triplet__col">
+        <div class="triplet__label is-degraded">État degraded</div>
+        <div class="energy-panel">
+          <div class="energy-panel__head">
+            <div class="energy-panel__title">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+              Compteur principal
+            </div>
+            <span class="badge badge--degraded">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+              Dégradé
+            </span>
+          </div>
+          <div class="energy-grid">
+            <div class="cumul">
+              <span class="cumul__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span>
+              <div class="cumul__body"><div class="cumul__lab">Heure</div><div class="cumul__val">1.20<span class="u">kWh</span></div></div>
+            </div>
+            <div class="cumul">
+              <span class="cumul__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span>
+              <div class="cumul__body"><div class="cumul__lab">Jour</div><div class="cumul__val">12.40<span class="u">kWh</span></div></div>
+            </div>
+            <div class="cumul">
+              <span class="cumul__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span>
+              <div class="cumul__body"><div class="cumul__lab">Mois</div><div class="cumul__val">384<span class="u">kWh</span></div></div>
+            </div>
+            <div class="cumul">
+              <span class="cumul__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><polyline points="17 14 13 18 11 16 7 20"/></svg></span>
+              <div class="cumul__body"><div class="cumul__lab">Année</div><div class="cumul__val">4 320<span class="u">kWh</span></div></div>
+            </div>
+          </div>
+          <div class="energy-panel__caption">Dernière donnée live il y a 47 min</div>
+        </div>
+      </div>
+
+      <!-- OFFLINE -->
+      <div class="triplet__col">
+        <div class="triplet__label is-offline">État offline</div>
+        <div class="energy-panel">
+          <div class="energy-panel__head">
+            <div class="energy-panel__title">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+              Compteur principal
+            </div>
+            <span class="badge badge--offline">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="2" x2="22" y2="22"/><path d="M8.5 16.5a5 5 0 0 1 7 0"/><path d="M2 8.82a15 15 0 0 1 4.17-2.65"/><path d="M10.66 5c4.01-.36 8.14.9 11.34 3.76"/><path d="M5 13a10 10 0 0 1 5.24-2.76"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+              Déconnecté
+            </span>
+          </div>
+          <div class="energy-grid">
+            <div class="cumul">
+              <span class="cumul__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span>
+              <div class="cumul__body"><div class="cumul__lab">Heure</div><div class="cumul__val">1.20<span class="u">kWh</span></div></div>
+            </div>
+            <div class="cumul">
+              <span class="cumul__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span>
+              <div class="cumul__body"><div class="cumul__lab">Jour</div><div class="cumul__val">12.40<span class="u">kWh</span></div></div>
+            </div>
+            <div class="cumul">
+              <span class="cumul__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span>
+              <div class="cumul__body"><div class="cumul__lab">Mois</div><div class="cumul__val">384<span class="u">kWh</span></div></div>
+            </div>
+            <div class="cumul">
+              <span class="cumul__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><polyline points="17 14 13 18 11 16 7 20"/></svg></span>
+              <div class="cumul__body"><div class="cumul__lab">Année</div><div class="cumul__val">4 320<span class="u">kWh</span></div></div>
+            </div>
+          </div>
+          <div class="energy-panel__caption energy-panel__caption--err">Hors ligne depuis 2 h</div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <!-- 5. Dashboard widget (Volet)                                   -->
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <section class="section">
+    <h2 class="section__title"><span class="section__num">5</span> Dashboard widget · exemple Volet</h2>
+    <p class="section__desc">Pattern WidgetCard fidèle : hauteur 240px, titre centré 17px, illustration SVG 96px coloriée par catégorie (ici p-500 pour volet ouvert), footer chip + groupe de 3 boutons. Indicateur degraded/offline : petit triangle ambre ou icône wifi-off à côté du titre + footnote sous le footer.</p>
+    <p class="section__file">ui/src/components/dashboard/ZoneWidget.tsx + WidgetCard.tsx</p>
+
+    <div class="triplet" style="grid-template-columns: repeat(3, minmax(0, 280px));">
+
+      <div class="triplet__col">
+        <div class="triplet__label is-online">État online · 3/3 volets joignables</div>
+        <div class="widget">
+          <h3 class="widget__title">Volets RDC</h3>
+          <div class="widget__art">
+            <svg viewBox="0 0 56 56" fill="none">
+              <rect x="4" y="5" width="48" height="6" rx="3" fill="currentColor" opacity="0.2"/>
+              <rect x="4" y="10" width="48" height="42" rx="2" stroke="currentColor" stroke-width="1.2" fill="currentColor" fill-opacity="0.04"/>
+              <line x1="28" y1="11" x2="28" y2="51" stroke="currentColor" stroke-width="0.6" opacity="0.1"/>
+              <rect x="6" y="12" width="44" height="4.5" rx="1" fill="currentColor" opacity=".5"/>
+              <rect x="6" y="17.5" width="44" height="4.5" rx="1" fill="currentColor" opacity=".5"/>
+              <rect x="6" y="17.5" width="44" height="5.5" rx="1.5" fill="currentColor" opacity="0.55"/>
+            </svg>
+          </div>
+          <div class="widget__footer">
+            <span class="chip-state chip-state--on">Ouvert</span>
+            <div class="shutter-grp">
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="18 15 12 9 6 15"/></svg></button>
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="8" width="8" height="8" rx="1"/></svg></button>
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="6 9 12 15 18 9"/></svg></button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="triplet__col">
+        <div class="triplet__label is-degraded">État degraded · 1 volet sur 3 offline</div>
+        <div class="widget">
+          <h3 class="widget__title">
+            Volets RDC
+            <span class="widget__title-badge" style="color:var(--a-600)" title="1 indisponible">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            </span>
+          </h3>
+          <div class="widget__art">
+            <svg viewBox="0 0 56 56" fill="none">
+              <rect x="4" y="5" width="48" height="6" rx="3" fill="currentColor" opacity="0.2"/>
+              <rect x="4" y="10" width="48" height="42" rx="2" stroke="currentColor" stroke-width="1.2" fill="currentColor" fill-opacity="0.04"/>
+              <line x1="28" y1="11" x2="28" y2="51" stroke="currentColor" stroke-width="0.6" opacity="0.1"/>
+              <rect x="6" y="12" width="44" height="4.5" rx="1" fill="currentColor" opacity=".5"/>
+              <rect x="6" y="17.5" width="44" height="4.5" rx="1" fill="currentColor" opacity=".5"/>
+              <rect x="6" y="23" width="44" height="4.5" rx="1" fill="currentColor" opacity=".5"/>
+              <rect x="6" y="23" width="44" height="5.5" rx="1.5" fill="currentColor" opacity="0.55"/>
+            </svg>
+          </div>
+          <div class="widget__footer">
+            <span class="chip-state chip-state--on">2/3 ouverts</span>
+            <div class="shutter-grp">
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="18 15 12 9 6 15"/></svg></button>
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="8" width="8" height="8" rx="1"/></svg></button>
+              <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="6 9 12 15 18 9"/></svg></button>
+            </div>
+          </div>
+          <div class="widget__footnote">1 volet hors ligne</div>
+        </div>
+      </div>
+
+      <div class="triplet__col">
+        <div class="triplet__label is-offline">État offline · tous les volets hors ligne</div>
+        <div class="widget widget--offline">
+          <h3 class="widget__title">
+            Volets RDC
+            <span class="widget__title-badge" style="color:var(--red-500)" title="Tous hors ligne">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="2" x2="22" y2="22"/><path d="M8.5 16.5a5 5 0 0 1 7 0"/><path d="M2 8.82a15 15 0 0 1 4.17-2.65"/><path d="M10.66 5c4.01-.36 8.14.9 11.34 3.76"/><path d="M5 13a10 10 0 0 1 5.24-2.76"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+            </span>
+          </h3>
+          <div class="widget__art">
+            <svg viewBox="0 0 56 56" fill="none">
+              <rect x="4" y="5" width="48" height="6" rx="3" fill="currentColor" opacity="0.2"/>
+              <rect x="4" y="10" width="48" height="42" rx="2" stroke="currentColor" stroke-width="1.2" fill="currentColor" fill-opacity="0.04"/>
+            </svg>
+          </div>
+          <div class="widget__footer">
+            <span class="badge badge--offline">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="2" x2="22" y2="22"/><path d="M8.5 16.5a5 5 0 0 1 7 0"/><path d="M2 8.82a15 15 0 0 1 4.17-2.65"/><path d="M5 13a10 10 0 0 1 5.24-2.76"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+              0/3 joignables
+            </span>
+            <div class="shutter-grp">
+              <button class="shutter-btn" disabled><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="18 15 12 9 6 15"/></svg></button>
+              <button class="shutter-btn" disabled><svg viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="8" width="8" height="8" rx="1"/></svg></button>
+              <button class="shutter-btn" disabled><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="6 9 12 15 18 9"/></svg></button>
+            </div>
+          </div>
+          <div class="widget__footnote widget__footnote--err">3 volets hors ligne</div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <!-- 6. Dashboard widget — PAC thermostat (with art + side value)  -->
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <section class="section">
+    <h2 class="section__title"><span class="section__num">6</span> Dashboard widget · exemple PAC (thermostat)</h2>
+    <p class="section__desc">Variante du widget avec art à gauche + valeur principale à droite. Le triangle ambre dans le header se positionne après le titre. Important : la valeur du widget reste affichée en degraded (l'utilisateur peut encore identifier l'équipement), juste flaggée par le triangle.</p>
+    <p class="section__file">ui/src/components/dashboard/ZoneWidget.tsx (variant heating)</p>
+
+    <div class="triplet" style="grid-template-columns: repeat(3, minmax(0, 280px));">
+
+      <div class="triplet__col">
+        <div class="triplet__label is-online">État online</div>
+        <div class="widget">
+          <h3 class="widget__title">PAC</h3>
+          <div class="widget__art">
+            <svg viewBox="0 0 56 56" fill="none" style="color:var(--p-500);width:80px;height:80px">
+              <path d="M24.5 9.5 A3.5 3.5 0 0 1 31.5 9.5 L31.5 33.7 A9 9 0 1 1 24.5 33.7 Z" stroke="currentColor" stroke-width="1.2" fill="currentColor" fill-opacity=".08"/>
+              <rect x="0" y="32" width="56" height="24" fill="currentColor" fill-opacity=".25" clip-path="url(#tc1)"/>
+              <defs><clipPath id="tc1"><path d="M26 11 A1.5 1.5 0 0 1 30 11 L30 35.3 A7.5 7.5 0 1 1 26 35.3 Z"/></clipPath></defs>
+            </svg>
+            <div class="widget__art-side">
+              <div class="widget__big">21.0<span class="u">°C</span></div>
+              <button class="shutter-btn" style="background:var(--p-50);border-color:var(--p-100);color:var(--p-500)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+            </div>
+          </div>
+          <div class="widget__footer widget__footer-center">
+            <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
+            <span style="font-family:var(--font-mono);font-weight:600;color:var(--n-700)">18.0<span style="font-size:11px;color:var(--n-400);margin-left:2px">°C</span></span>
+            <button class="shutter-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
+          </div>
+        </div>
+      </div>
+
+      <div class="triplet__col">
+        <div class="triplet__label is-degraded">État degraded · sonde stale</div>
+        <div class="widget">
+          <h3 class="widget__title">
+            PAC
+            <span class="widget__title-badge" style="color:var(--a-600)">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            </span>
+          </h3>
+          <div class="widget__art">
+            <svg viewBox="0 0 56 56" fill="none" style="color:var(--p-500);width:80px;height:80px;opacity:.7">
+              <path d="M24.5 9.5 A3.5 3.5 0 0 1 31.5 9.5 L31.5 33.7 A9 9 0 1 1 24.5 33.7 Z" stroke="currentColor" stroke-width="1.2" fill="currentColor" fill-opacity=".08"/>
+              <rect x="0" y="32" width="56" height="24" fill="currentColor" fill-opacity=".25" clip-path="url(#tc2)"/>
+              <defs><clipPath id="tc2"><path d="M26 11 A1.5 1.5 0 0 1 30 11 L30 35.3 A7.5 7.5 0 1 1 26 35.3 Z"/></clipPath></defs>
+            </svg>
+            <div class="widget__art-side">
+              <div class="widget__big stale">21.0<span class="u">°C</span></div>
+              <button class="shutter-btn" style="background:var(--p-50);border-color:var(--p-100);color:var(--p-500)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></button>
+            </div>
+          </div>
+          <div class="widget__footnote">Température figée il y a 23 min</div>
+        </div>
+      </div>
+
+      <div class="triplet__col">
+        <div class="triplet__label is-offline">État offline · sonde déconnectée</div>
+        <div class="widget widget--offline">
+          <h3 class="widget__title">
+            PAC
+            <span class="widget__title-badge" style="color:var(--red-500)">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="2" x2="22" y2="22"/><path d="M8.5 16.5a5 5 0 0 1 7 0"/><path d="M5 13a10 10 0 0 1 5.24-2.76"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+            </span>
+          </h3>
+          <div class="widget__art">
+            <svg viewBox="0 0 56 56" fill="none" style="color:var(--p-500);width:80px;height:80px">
+              <path d="M24.5 9.5 A3.5 3.5 0 0 1 31.5 9.5 L31.5 33.7 A9 9 0 1 1 24.5 33.7 Z" stroke="currentColor" stroke-width="1.2" fill="none"/>
+            </svg>
+            <div class="widget__art-side">
+              <div class="widget__big" style="color:var(--n-300);font-style:italic">—<span class="u">°C</span></div>
+            </div>
+          </div>
+          <div class="widget__footnote widget__footnote--err">Sonde déconnectée depuis 2 h</div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <!-- Tooltip preview                                                -->
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <section class="section">
+    <h2 class="section__title"><span class="section__num">+</span> Tooltip détaillé (au survol des badges)</h2>
+    <p class="section__desc">Liste exacte des appareils + bindings concernés. Permet de comprendre pourquoi l'équipement est en degraded sans aller dans la page Devices.</p>
+
+    <div class="triplet">
+
+      <div class="triplet__col">
+        <div class="triplet__label is-degraded">Tooltip dégradé · device + binding</div>
+        <div class="tooltip">
+          <div class="tooltip__title">Dégradé</div>
+          <div class="tooltip__group">
+            <div class="tooltip__group-title">1 appareil hors ligne</div>
+            <ul><li>Compteur Shelly</li></ul>
+          </div>
+          <div class="tooltip__group">
+            <div class="tooltip__group-title">1 valeur périmée</div>
+            <ul><li>temperature (il y a 23 min)</li></ul>
+          </div>
+          <div class="tooltip__since">Anomalie depuis 23 min</div>
+        </div>
+      </div>
+
+      <div class="triplet__col">
+        <div class="triplet__label is-offline">Tooltip offline</div>
+        <div class="tooltip">
+          <div class="tooltip__title">Déconnecté</div>
+          <div class="tooltip__group">
+            <div class="tooltip__group-title">Appareil hors ligne</div>
+            <ul><li>SONOFF SWV salle de bain</li></ul>
+          </div>
+          <div class="tooltip__since">Hors ligne depuis 2 h</div>
+        </div>
+      </div>
+
+      <div class="triplet__col">
+        <div class="triplet__label is-degraded">Tooltip stale only · device online</div>
+        <div class="tooltip">
+          <div class="tooltip__title">Dégradé</div>
+          <div class="tooltip__group">
+            <div class="tooltip__group-title">2 valeurs périmées</div>
+            <ul>
+              <li>power (il y a 12 min)</li>
+              <li>voltage (il y a 12 min)</li>
+            </ul>
+          </div>
+          <div class="tooltip__since">Données périmées depuis 12 min</div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Legend -->
+  <div class="legend">
+    <span class="legend__item">
+      <span class="legend__swatch" style="background:color-mix(in srgb,var(--a-500) 14%,transparent)"></span>
+      Dégradé · <code>bg-warning/10</code> · <code>text-warning</code>
+    </span>
+    <span class="legend__item">
+      <span class="legend__swatch" style="background:color-mix(in srgb,var(--red-500) 12%,transparent)"></span>
+      Déconnecté · <code>bg-error/10</code> · <code>text-error</code>
+    </span>
+    <span class="legend__item">
+      <span class="legend__swatch" style="background:var(--n-100)"></span>
+      Stale value · <code>text-text-tertiary</code> italic
+    </span>
+    <span class="legend__item" style="margin-left:auto">
+      Tokens: <code>design-system/tokens.css</code>
+    </span>
+  </div>
+
+</div>
+
+<script>
+function toggleTheme() {
+  const html = document.documentElement;
+  const isDark = html.dataset.theme === "dark";
+  html.dataset.theme = isDark ? "hybrid" : "dark";
+  document.getElementById("theme-label").textContent = isDark ? "Thème clair" : "Thème sombre";
+}
+</script>
+
+</body>
+</html>

--- a/specs/116-equipment-availability/ux-mockups.md
+++ b/specs/116-equipment-availability/ux-mockups.md
@@ -1,0 +1,377 @@
+# UX mockups — Equipment availability propagation
+
+> **For the visual reference, open [`ux-mockups.html`](ux-mockups.html) in a browser.** That file reproduces the actual production components (CompactEquipmentCard `.eq` grid pattern, EnergyDataPanel 2x2 grid, LiveEnergyPage flow diagram, WidgetCard 240px height) using the real `design-system/tokens.css` colors. This `.md` is the textual contract: shared components, copy, and accessibility.
+
+This file complements [spec.md](spec.md) FR8 to FR11 and [architecture.md](architecture.md). It defines the visual language, the shared components, and the per-screen layout for the stale / degraded / offline indicators.
+
+All mockups are aligned on the Sowel design system defined in [`CLAUDE.md`](../../CLAUDE.md) and `design-system/tokens.css`. Reuses existing Tailwind semantic colors (`bg-error/10 text-error`, `bg-warning/10 text-warning`) and the `HeaderPill` / `ConnectionStatus` / `IntegrationRow` patterns already in the codebase. No new color tokens.
+
+---
+
+## 1. Design tokens used
+
+| Purpose              | Token / class                                                    | Notes                                                  |
+| -------------------- | ---------------------------------------------------------------- | ------------------------------------------------------ |
+| Offline (red)        | `bg-error/10 text-error`, `border-error/20`                      | Hard failure: device unreachable                       |
+| Degraded (ambre)     | `bg-warning/10 text-warning`, `border-warning/20`                | Partial failure: ≥1 device offline OR ≥1 binding stale |
+| Online (default)     | No badge                                                         | Silence is success                                     |
+| Stale value (inline) | `text-text-tertiary`, value italic                               | Greys out the number itself                            |
+| Last-seen caption    | `text-[11px] text-text-tertiary`                                 | Subtle, never primary                                  |
+| Pill radius          | `rounded-full`                                                   | Matches `HeaderPill`, `ConnectionStatus`               |
+| Card radius          | `rounded-[10px]`                                                 | Matches existing cards (CLAUDE.md spacing rules)       |
+| Pill padding (sm)    | `px-1.5 py-0.5`                                                  | Compact card variant                                   |
+| Pill padding (md)    | `px-2.5 py-1`                                                    | Detail card variant                                    |
+| Icon                 | Lucide, `strokeWidth={1.5}`, `size={14}` (sm) / `size={16}` (md) | Project convention                                     |
+| Font                 | Inter for labels, JetBrains Mono for timestamps                  | Per design system                                      |
+| Font size (badge)    | `text-[10px]` (sm) / `text-[12px]` (md)                          | Aligns with sidebar badge / HeaderPill                 |
+| Font weight (badge)  | `font-medium`                                                    | Matches sidebar offline-count badge                    |
+
+Icons:
+
+- Degraded → `AlertTriangle` (Lucide)
+- Offline → `WifiOff` (Lucide)
+- Stale value indicator → `Clock` (Lucide) — only used inline, never as a badge by itself
+
+---
+
+## 2. Shared component: `<EquipmentStatusBadge>`
+
+Single component, two size variants, three states. Hides itself when `status === "online"`.
+
+### Anatomy
+
+```
+┌─────────────────────────────────┐
+│  ⚠ Dégradé                     │   degraded — sm variant
+└─────────────────────────────────┘
+   ↑     ↑
+   icon  i18n label (equipment.status.degraded)
+   14px  10px font-medium
+   stroke 1.5
+
+┌─────────────────────────────────────────┐
+│  ⚠ Dégradé                              │   degraded — md variant (detail header)
+└─────────────────────────────────────────┘
+   16px       12px font-medium
+
+┌─────────────────────────────────┐
+│  ⊘ Déconnecté                   │   offline — sm variant
+└─────────────────────────────────┘
+```
+
+### Tailwind reference
+
+```tsx
+// Pseudo-implementation hint — actual file: ui/src/components/equipments/EquipmentStatusBadge.tsx
+const VARIANT = {
+  degraded: {
+    sm: "bg-warning/10 text-warning text-[10px] font-medium px-1.5 py-0.5 rounded-full inline-flex items-center gap-1",
+    md: "bg-warning/10 text-warning text-[12px] font-medium px-2.5 py-1 rounded-full inline-flex items-center gap-1.5",
+    icon: AlertTriangle,
+    labelKey: "equipment.status.degraded",
+  },
+  offline: {
+    sm: "bg-error/10 text-error text-[10px] font-medium px-1.5 py-0.5 rounded-full inline-flex items-center gap-1",
+    md: "bg-error/10 text-error text-[12px] font-medium px-2.5 py-1 rounded-full inline-flex items-center gap-1.5",
+    icon: WifiOff,
+    labelKey: "equipment.status.offline",
+  },
+};
+```
+
+### Tooltip (hover desktop / tap mobile)
+
+Reuses the existing `<Tooltip>` component. Content:
+
+```
+┌──────────────────────────────────────┐
+│  Dégradé                            │   ← title (text-[13px] font-medium)
+│                                      │
+│  2 appareils hors ligne :           │   ← text-[12px]
+│   • Compteur Shelly                  │
+│   • Volet salon                      │
+│                                      │
+│  1 valeur périmée :                 │
+│   • temperature (15 min)             │
+│                                      │
+│  Hors ligne depuis 47 min            │   ← text-[11px] text-text-tertiary
+└──────────────────────────────────────┘
+```
+
+---
+
+## 3. Shared inline indicator: stale value
+
+When a single binding value is stale but the equipment isn't fully offline, the **value itself** is greyed + italic + a tiny clock icon, with the relative time in mono.
+
+```
+Before:           After (stale):
+
+┌──────────┐      ┌────────────────────┐
+│ 21.4 °C  │      │ ⏱ 21.4 °C  3h ago │
+└──────────┘      └────────────────────┘
+  primary           text-text-tertiary
+  font-mono         italic, font-mono
+                    clock 12px stroke 1.5
+                    "3h ago" mono 10px
+```
+
+```tsx
+// Tailwind hint
+<span className="inline-flex items-center gap-1 text-text-tertiary italic">
+  <Clock size={12} strokeWidth={1.5} />
+  <span className="font-mono">21.4 °C</span>
+  <span className="text-[10px] font-mono">3h ago</span>
+</span>
+```
+
+---
+
+## 4. Per-screen mockups
+
+### 4.1 CompactEquipmentCard (zone row)
+
+The badge sits in the **top-right of the card**, above any per-type tint chip. Existing layout untouched.
+
+```
+ONLINE (default, today's behavior):
+┌────────────────────────────────────────────────────────────────┐
+│ 💡 Lampe salon                                          ●─────── │
+│    Salon                                                  on    │
+└────────────────────────────────────────────────────────────────┘
+
+DEGRADED (1 device offline among many, OR 1 streaming binding stale):
+The badge sits in the top-right corner. The value stays visible because it's
+still vaguely useful (last known reading), greyed + italic + small clock to
+signal staleness.
+┌────────────────────────────────────────────────────────────────┐
+│ ⚡ Compteur principal                          ⚠ Dégradé      │
+│    Maison                                       ⏱ 0 W  47m ago │
+└────────────────────────────────────────────────────────────────┘
+
+OFFLINE (all bound devices offline OR no bindings at all):
+The badge REPLACES the value entirely — "— %" + "2h ago" + badge was visual
+noise for the same information. The badge alone carries the status; the age
+stays underneath as a discrete mono caption.
+┌────────────────────────────────────────────────────────────────┐
+│ 🪟 Volet salon                                 ⊘ Déconnecté   │
+│    Salon                                                 2h ago│
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Behavior :**
+
+- **Degraded**: badge `absolute top-2 right-2` (sm variant). Value column keeps its layout, greyed.
+- **Offline**: NO top-right badge. Instead, the badge takes the whole value slot (right-aligned column), with the relative age below it in mono `text-[10px] text-text-tertiary`. Cleaner — one signal, not three (badge + dashed value + age).
+- Existing controls (slider, buttons) remain interactive in degraded state; in offline state, the controls receive a subtle `opacity-60` but stay clickable (the order will still be attempted — see spec.md Edge Cases).
+- The per-type icon tint chip on the left stays unchanged in degraded; muted to `opacity-60` in offline to match the rest of the row.
+
+### 4.2 EquipmentDetailCard (detail page)
+
+Badge in the **header row**, immediately after the equipment name, before the zone name.
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ 🪟  Volet salon  ⊘ Déconnecté                                       │
+│     Salon · Maison                                                    │
+│                                                                       │
+│     Position                                                          │
+│     ┌─────────────────────────────────────────────────────────┐     │
+│     │  ⏱ — %         Last update 2h ago                         │     │
+│     └─────────────────────────────────────────────────────────┘     │
+│                                                                       │
+│     [ Ouvrir ]   [ Stop ]   [ Fermer ]                               │
+│        (opacity-50 controls — clickable but visually muted)           │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+**Behavior :**
+
+- Md variant of the badge.
+- Controls keep their layout, with `opacity-60` overlay applied at container level when status === offline.
+- A small caption line below the value: `Dernière mise à jour il y a 2h` in `text-[11px] text-text-tertiary`.
+- No modal, no scary error message; the badge + caption are the entire UX.
+
+### 4.3 LiveEnergyPage (main energy widget)
+
+The most visible surface for the original Shelly bug. The **live power number** is replaced by a stale HUD.
+
+```
+ONLINE (today's behavior):
+┌────────────────────────────────────────────────────────────────┐
+│                                                                │
+│                       2 340 W                                  │
+│                    Live · 1s ago                               │
+│                                                                │
+│  ⬇ Réseau 1 800 W       ☀ Solaire 540 W                       │
+└────────────────────────────────────────────────────────────────┘
+
+STALE (Shelly disjoncté since 47 min):
+┌────────────────────────────────────────────────────────────────┐
+│                                                                │
+│         ⚠         — — — W                                      │
+│                Données live indisponibles                      │
+│                Dernière donnée il y a 47 min                   │
+│                                                                │
+│  ⬇ Réseau  ⏱ 1 800 W 47m ago   ☀ Solaire  ⏱ 540 W 47m ago    │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Behavior :**
+
+- Main gauge: large value replaced by `— — — W` in `text-text-tertiary` (28px mono), with `AlertTriangle` icon (24px ambre) prefixed.
+- Two captions stacked:
+  - `Données live indisponibles` — `text-[14px] text-text-secondary`
+  - `Dernière donnée il y a 47 min` — `text-[12px] text-text-tertiary font-mono`
+- Sub-sources (Réseau / Solaire) use the inline stale indicator from §3.
+- The historical chart below (5-min / 1-day / 1-week) is untouched — it reads from InfluxDB and is by nature historical.
+
+### 4.4 EnergyDataPanel (equipment detail — cumuls block)
+
+Subtle: cumuls (Heure / Jour / Mois / Année) come from InfluxDB so they remain accurate. Only adds a small `Dernière mise à jour…` caption when the live power binding is stale.
+
+```
+ONLINE:
+┌──────────────────────────────────────────────────────────┐
+│ ⚡ Compteur principal                                    │
+│                                                          │
+│  Heure       Jour        Mois        Année              │
+│  1.20 kWh   12.40 kWh   384 kWh    4 320 kWh           │
+└──────────────────────────────────────────────────────────┘
+
+DEGRADED (cumuls still valid from InfluxDB, but live is stale):
+┌──────────────────────────────────────────────────────────┐
+│ ⚡ Compteur principal             ⚠ Dégradé             │
+│                                                          │
+│  Heure       Jour        Mois        Année              │
+│  1.20 kWh   12.40 kWh   384 kWh    4 320 kWh           │
+│                                                          │
+│  Dernière donnée live il y a 47 min                     │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Behavior :**
+
+- Cumul values are NOT greyed (they're historical, accurate up to InfluxDB's last write).
+- Caption `Dernière donnée live il y a 47 min` appears in `text-[11px] text-text-tertiary` at the bottom of the panel.
+- Sm badge in the header.
+
+### 4.5 ZoneWidget (zone tile on dashboard / home page)
+
+Aggregated metrics. When one or more contributing equipments are offline, the count is shown next to the value as a discrete hint.
+
+```
+ONLINE (today):
+┌────────────────────────────┐
+│  🛋 Salon                  │
+│                            │
+│  🌡 21.4 °C    💧 48 %    │
+│  💡 2/3 on    🪟 1/3 open │
+└────────────────────────────┘
+
+DEGRADED (1 temperature sensor offline, 1 shutter offline):
+┌────────────────────────────┐
+│  🛋 Salon  ⚠              │
+│                            │
+│  🌡 21.4 °C  (1 indispo.) │
+│  💧 48 %                   │
+│  💡 2/3 on                 │
+│  🪟 1/2 open (1 indispo.) │
+└────────────────────────────┘
+```
+
+**Behavior :**
+
+- A small `AlertTriangle` ambre icon next to the zone name in the header when any equipment in the zone is offline. No badge text needed at this level (compact).
+- The `(1 indispo.)` hint appears in `text-[11px] text-text-tertiary` after each affected metric.
+- For counts (lights, shutters): the displayed total adapts (2/3 → 2/2 with the hint), so the user understands the count is over the **available** set only.
+
+### 4.6 Dashboard family widgets (Shutters, Awnings, Lights, Sensors, Heating, Water, Pool)
+
+Single badge in the **widget header**, no per-equipment treatment (that's the family widget's whole point: aggregate view).
+
+```
+ONLINE:
+┌──────────────────────────────────────┐
+│  🪟  Volets — Salon          3/3 ▲  │
+│                                      │
+│         ▲                            │
+│      [ Ouvrir tous ]                 │
+│      [ Stop ]                        │
+│      [ Fermer tous ]                 │
+└──────────────────────────────────────┘
+
+DEGRADED (1 shutter offline among 3):
+┌──────────────────────────────────────┐
+│  🪟  Volets — Salon  ⚠      2/3 ▲   │
+│                                      │
+│         ▲                            │
+│      [ Ouvrir tous ]                 │
+│      [ Stop ]                        │
+│      [ Fermer tous ]                 │
+│                                      │
+│      1 volet hors ligne              │
+└──────────────────────────────────────┘
+```
+
+**Behavior :**
+
+- Sm `AlertTriangle` ambre icon in header, no text label (the caption at the bottom carries the info).
+- Caption `1 volet hors ligne` in `text-[11px] text-text-tertiary` at the bottom of the widget.
+- Count adapts: 3/3 becomes 2/3 (deployed out of available, hidden equipments not counted).
+- Buttons stay enabled — `Fermer tous` still fires for the 2 reachable shutters.
+
+---
+
+## 5. Copy — final EN / FR
+
+| Key                                             | EN                         | FR                                   |
+| ----------------------------------------------- | -------------------------- | ------------------------------------ |
+| `equipment.status.online`                       | Online                     | En ligne                             |
+| `equipment.status.degraded`                     | Degraded                   | Dégradé                              |
+| `equipment.status.offline`                      | Disconnected               | Déconnecté                           |
+| `equipment.status.tooltip.offlineDevices_one`   | 1 device offline:          | 1 appareil hors ligne :              |
+| `equipment.status.tooltip.offlineDevices_other` | {{count}} devices offline: | {{count}} appareils hors ligne :     |
+| `equipment.status.tooltip.staleBindings_one`    | 1 stale value:             | 1 valeur périmée :                   |
+| `equipment.status.tooltip.staleBindings_other`  | {{count}} stale values:    | {{count}} valeurs périmées :         |
+| `equipment.status.tooltip.offlineSince`         | Offline since {{when}}     | Hors ligne depuis {{when}}           |
+| `equipment.status.lastUpdate`                   | Last update {{when}}       | Dernière mise à jour il y a {{when}} |
+| `energy.live.unavailable`                       | Live data unavailable      | Données live indisponibles           |
+| `energy.live.lastDatapoint`                     | Last datapoint {{when}}    | Dernière donnée il y a {{when}}      |
+| `zones.aggregate.unavailable_one`               | (1 unavailable)            | (1 indispo.)                         |
+| `zones.aggregate.unavailable_other`             | ({{count}} unavailable)    | ({{count}} indispo.)                 |
+| `dashboard.family.offlineCount_one`             | 1 device offline           | 1 appareil hors ligne                |
+| `dashboard.family.offlineCount_other`           | {{count}} devices offline  | {{count}} appareils hors ligne       |
+
+`{{when}}` is rendered via the existing relative-time formatter (used by `ElapsedCounter`): "47 min", "2h", "3j", etc. No em-dashes anywhere (per project convention).
+
+---
+
+## 6. Responsive behavior
+
+| Breakpoint | Compact card badge         | Detail badge | LiveEnergy HUD                                           |
+| ---------- | -------------------------- | ------------ | -------------------------------------------------------- |
+| < 640px    | Sm, icon-only (no label)   | Md           | Stack captions, smaller gauge (still text-text-tertiary) |
+| ≥ 640px    | Sm, icon + label           | Md           | Inline captions, full-size gauge                         |
+| ≥ 1024px   | Sm, icon + label + tooltip | Md + tooltip | Full layout with side-by-side sub-source pills           |
+
+For mobile, the compact card badge collapses to an icon-only chip (no `Dégradé` / `Déconnecté` label) to preserve horizontal space. The tooltip remains accessible on tap.
+
+---
+
+## 7. Accessibility
+
+- Badge has `role="status"` and `aria-label="{{equipment.name}} {{equipment.status}}"`.
+- Color is never the only signal: each state also carries a distinct icon (`AlertTriangle`, `WifiOff`).
+- Tooltip is reachable via keyboard (`tabindex={0}` on the badge wrapper).
+- Stale value inline indicator has `aria-label="Stale value, last updated {{when}}"`.
+- Contrast: `text-warning` on `bg-warning/10` and `text-error` on `bg-error/10` already pass WCAG AA in both light and dark mode (verified by existing usages in `ConnectionStatus.tsx`, `HeaderPill.tsx`, sidebar offline badges).
+
+---
+
+## 8. Out of scope for v1
+
+- Per-equipment "disable orders when offline" toggle. Buttons stay clickable; the plugin handles failed dispatch.
+- Sound or push notification on equipment transition to offline. Telegram / FCM notification publishers can be wired in a follow-up (would consume `equipment.status.changed`).
+- A dedicated "Health" page listing all offline equipments. Today's Devices page already does this at the device level; equipment-level health would be a follow-up.
+- Time-series of equipment availability (e.g. "uptime 96.4% this week"). Would need a dedicated InfluxDB series.

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -135,6 +135,8 @@ function getDedupKey(event: EngineEvent): string | null {
       return `dh:${event.deviceId}`;
     case "equipment.data.changed":
       return `e:${event.equipmentId}:${event.alias}`;
+    case "equipment.status.changed":
+      return `es:${event.equipmentId}`;
     case "zone.data.changed":
       return `z:${event.zoneId}`;
     default:

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -20,6 +20,8 @@ import type {
   OrderSource,
 } from "../shared/types.js";
 import { inferBindingCategory } from "./binding-candidates.js";
+import { deriveEquipmentStatus, isStaleBinding } from "./equipment-status.js";
+import type { Device } from "../shared/types.js";
 
 /** A function that returns computed data entries for a given equipment. */
 export type ComputedDataProvider = (equipmentId: string) => ComputedDataEntry[];
@@ -363,11 +365,20 @@ export class EquipmentManager {
     const equipment = this.getById(id);
     if (!equipment) return null;
 
+    const dataBindings = this.getDataBindingsWithValues(id);
+    const orderBindings = this.getOrderBindingsWithDetails(id);
     const computedData = this.getComputedData(id);
+
+    // Spec 116: derive equipment status from bindings + backing devices.
+    const devicesByBindingId = this.resolveDevicesForBindings(dataBindings);
+    const { status, reason } = deriveEquipmentStatus(dataBindings, devicesByBindingId);
+
     return {
       ...equipment,
-      dataBindings: this.getDataBindingsWithValues(id),
-      orderBindings: this.getOrderBindingsWithDetails(id),
+      dataBindings,
+      orderBindings,
+      status,
+      ...(reason !== null ? { statusReason: reason } : {}),
       ...(computedData.length > 0 ? { computedData } : {}),
     };
   }
@@ -375,11 +386,17 @@ export class EquipmentManager {
   getAllWithDetails(): EquipmentWithDetails[] {
     const equipments = this.getAll();
     return equipments.map((eq) => {
+      const dataBindings = this.getDataBindingsWithValues(eq.id);
+      const orderBindings = this.getOrderBindingsWithDetails(eq.id);
       const computedData = this.getComputedData(eq.id);
+      const devicesByBindingId = this.resolveDevicesForBindings(dataBindings);
+      const { status, reason } = deriveEquipmentStatus(dataBindings, devicesByBindingId);
       return {
         ...eq,
-        dataBindings: this.getDataBindingsWithValues(eq.id),
-        orderBindings: this.getOrderBindingsWithDetails(eq.id),
+        dataBindings,
+        orderBindings,
+        status,
+        ...(reason !== null ? { statusReason: reason } : {}),
         ...(computedData.length > 0 ? { computedData } : {}),
       };
     });
@@ -533,7 +550,34 @@ export class EquipmentManager {
       bindings.unshift(this.buildCoverStateBinding(equipmentId, state));
     }
 
+    // Annotate staleness on streaming bindings (spec 116).
+    const now = Date.now();
+    for (const binding of bindings) {
+      binding.stale = isStaleBinding(binding.category, binding.lastUpdated, now);
+    }
+
     return bindings;
+  }
+
+  /**
+   * Resolve the Device behind each binding for status derivation (spec 116).
+   * Returns a Map<bindingId, Device>. Virtual bindings (deviceId === "") are
+   * skipped. A small in-memory cache deduplicates device fetches across
+   * bindings that share a deviceId.
+   */
+  private resolveDevicesForBindings(bindings: DataBindingWithValue[]): Map<string, Device> {
+    const result = new Map<string, Device>();
+    const deviceCache = new Map<string, Device | null>();
+    for (const binding of bindings) {
+      if (!binding.deviceId) continue;
+      let device = deviceCache.get(binding.deviceId);
+      if (device === undefined) {
+        device = this.deviceManager.getById(binding.deviceId);
+        deviceCache.set(binding.deviceId, device);
+      }
+      if (device) result.set(binding.id, device);
+    }
+    return result;
   }
 
   /** Set the historize flag on a data binding. NULL = category default, 1 = force ON, 0 = force OFF. */
@@ -1010,6 +1054,7 @@ export class EquipmentManager {
       unit: undefined,
       lastUpdated: new Date().toISOString(),
       lastChanged: new Date().toISOString(),
+      stale: false, // virtual binding, always fresh
     };
   }
 
@@ -1032,6 +1077,7 @@ export class EquipmentManager {
       unit: undefined,
       lastUpdated: new Date().toISOString(),
       lastChanged: new Date().toISOString(),
+      stale: false, // virtual binding, always fresh
     };
   }
 
@@ -1256,6 +1302,7 @@ function rowToDataBindingWithValue(row: DataBindingJoinRow): DataBindingWithValu
     enumValues,
     lastUpdated: toISOUtc(row.last_updated),
     lastChanged: toISOUtc(row.last_changed),
+    stale: false, // annotated downstream by getDataBindingsWithValues (spec 116)
   };
 }
 

--- a/src/equipments/equipment-status-tracker.test.ts
+++ b/src/equipments/equipment-status-tracker.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EquipmentStatusTracker } from "./equipment-status-tracker.js";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+import type { EquipmentManager } from "./equipment-manager.js";
+import type { EquipmentWithDetails, EngineEvent } from "../shared/types.js";
+
+const testLogger = createLogger("silent").logger;
+
+// Minimal stub of EquipmentManager — the tracker only ever calls getAllWithDetails().
+function makeEquipmentManager(snapshots: EquipmentWithDetails[][]): {
+  manager: EquipmentManager;
+  advance: () => void;
+} {
+  let cursor = 0;
+  const manager = {
+    getAllWithDetails: () => snapshots[Math.min(cursor, snapshots.length - 1)],
+  } as unknown as EquipmentManager;
+  return {
+    manager,
+    advance: () => {
+      cursor += 1;
+    },
+  };
+}
+
+function makeEquipment(
+  id: string,
+  status: EquipmentWithDetails["status"],
+  name = id,
+): EquipmentWithDetails {
+  return {
+    id,
+    name,
+    zoneId: "zone-1",
+    type: "sensor",
+    enabled: true,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    dataBindings: [],
+    orderBindings: [],
+    status,
+  };
+}
+
+describe("EquipmentStatusTracker", () => {
+  let bus: EventBus;
+  let emitted: EngineEvent[];
+  let unsub: (() => void) | null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    bus = new EventBus(testLogger);
+    emitted = [];
+    unsub = bus.on((event) => {
+      if (event.type === "equipment.status.changed") emitted.push(event);
+    });
+  });
+
+  afterEach(() => {
+    unsub?.();
+    vi.useRealTimers();
+  });
+
+  it("does not emit on first observation (seeds the cache)", () => {
+    const { manager } = makeEquipmentManager([[makeEquipment("eq-1", "online")]]);
+    const tracker = new EquipmentStatusTracker(manager, bus, testLogger);
+    tracker.start();
+    tracker.recompute(); // explicit second pass — still no change
+    expect(emitted).toHaveLength(0);
+    tracker.destroy();
+  });
+
+  it("emits equipment.status.changed on online → offline transition", () => {
+    const initial = [makeEquipment("eq-1", "online", "Compteur")];
+    const next = [makeEquipment("eq-1", "offline", "Compteur")];
+    const { manager, advance } = makeEquipmentManager([initial, next]);
+    const tracker = new EquipmentStatusTracker(manager, bus, testLogger);
+    tracker.start();
+
+    advance();
+    bus.emit({
+      type: "device.status_changed",
+      deviceId: "d-1",
+      deviceName: "d",
+      status: "offline",
+    });
+    vi.advanceTimersByTime(250); // past the 200ms debounce
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      type: "equipment.status.changed",
+      equipmentId: "eq-1",
+      equipmentName: "Compteur",
+      oldStatus: "online",
+      newStatus: "offline",
+    });
+    tracker.destroy();
+  });
+
+  it("coalesces bursts of events into a single recompute within the debounce window", () => {
+    const initial = [makeEquipment("eq-1", "online")];
+    const next = [makeEquipment("eq-1", "degraded")];
+    const { manager, advance } = makeEquipmentManager([initial, next]);
+    const tracker = new EquipmentStatusTracker(manager, bus, testLogger);
+    tracker.start();
+
+    advance();
+    // Fire 5 events in rapid succession — debounce should coalesce to 1 recompute.
+    for (let i = 0; i < 5; i++) {
+      bus.emit({
+        type: "device.data.updated",
+        deviceId: "d-1",
+        deviceName: "d",
+        dataId: "dd-1",
+        key: "k",
+        value: i,
+        previous: i - 1,
+        timestamp: new Date().toISOString(),
+      });
+    }
+    vi.advanceTimersByTime(250);
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({ oldStatus: "online", newStatus: "degraded" });
+    tracker.destroy();
+  });
+
+  it("does not emit when status stays the same across events", () => {
+    const { manager } = makeEquipmentManager([[makeEquipment("eq-1", "online")]]);
+    const tracker = new EquipmentStatusTracker(manager, bus, testLogger);
+    tracker.start();
+
+    bus.emit({
+      type: "device.data.updated",
+      deviceId: "d-1",
+      deviceName: "d",
+      dataId: "dd-1",
+      key: "k",
+      value: 1,
+      previous: 0,
+      timestamp: new Date().toISOString(),
+    });
+    vi.advanceTimersByTime(250);
+
+    expect(emitted).toHaveLength(0);
+    tracker.destroy();
+  });
+
+  it("wallclock tick catches staleness transitions without any event", () => {
+    const initial = [makeEquipment("eq-1", "online")];
+    const next = [makeEquipment("eq-1", "degraded")];
+    const { manager, advance } = makeEquipmentManager([initial, next]);
+    const tracker = new EquipmentStatusTracker(manager, bus, testLogger);
+    tracker.start();
+
+    // Simulate time passing: the underlying lastUpdated would now be older
+    // than the streaming timeout — getAllWithDetails returns the new snapshot.
+    advance();
+    vi.advanceTimersByTime(60_000);
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({ oldStatus: "online", newStatus: "degraded" });
+    tracker.destroy();
+  });
+
+  it("forgets equipment state when equipment.removed fires", () => {
+    const { manager } = makeEquipmentManager([[makeEquipment("eq-1", "online")]]);
+    const tracker = new EquipmentStatusTracker(manager, bus, testLogger);
+    tracker.start();
+
+    bus.emit({
+      type: "equipment.removed",
+      equipmentId: "eq-1",
+      equipmentName: "Eq",
+      zoneId: "z",
+    });
+
+    // Once forgotten, if the same id reappears, the next observation is fresh
+    // (seeded silently) and does NOT emit a transition.
+    vi.advanceTimersByTime(60_000);
+    expect(emitted).toHaveLength(0);
+    tracker.destroy();
+  });
+});

--- a/src/equipments/equipment-status-tracker.ts
+++ b/src/equipments/equipment-status-tracker.ts
@@ -1,0 +1,112 @@
+/**
+ * EquipmentStatusTracker (spec 116).
+ *
+ * Listens to device + equipment events, recomputes equipment.status on a
+ * debounced cadence + a periodic wallclock tick (for staleness transitions
+ * that fire without any event), and emits `equipment.status.changed` on
+ * transitions so the WebSocket layer can push updates to UI clients.
+ */
+
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { EquipmentManager } from "./equipment-manager.js";
+import type { EquipmentStatus } from "../shared/types.js";
+
+/** Coalesce bursts of device events (e.g. integration startup) into a single recompute. */
+const DEBOUNCE_MS = 200;
+
+/** Wallclock cadence for catching staleness transitions when no event fires. */
+const TICK_MS = 60_000;
+
+export class EquipmentStatusTracker {
+  private logger: Logger;
+  private equipmentManager: EquipmentManager;
+  private eventBus: EventBus;
+
+  private currentStatus = new Map<string, EquipmentStatus>();
+  private pendingTimer: ReturnType<typeof setTimeout> | null = null;
+  private tickTimer: ReturnType<typeof setInterval> | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(equipmentManager: EquipmentManager, eventBus: EventBus, logger: Logger) {
+    this.equipmentManager = equipmentManager;
+    this.eventBus = eventBus;
+    this.logger = logger.child({ module: "equipment-status-tracker" });
+  }
+
+  start(): void {
+    // Take an initial snapshot so we only emit on subsequent transitions.
+    for (const equipment of this.equipmentManager.getAllWithDetails()) {
+      this.currentStatus.set(equipment.id, equipment.status);
+    }
+
+    this.unsubscribe = this.eventBus.on((event) => {
+      switch (event.type) {
+        case "device.status_changed":
+        case "device.data.updated":
+        case "equipment.created":
+        case "equipment.updated":
+          this.scheduleRecompute();
+          break;
+        case "equipment.removed":
+          this.currentStatus.delete(event.equipmentId);
+          break;
+      }
+    });
+
+    // Catch staleness transitions even when no event fires.
+    this.tickTimer = setInterval(() => this.recompute(), TICK_MS);
+    if (typeof this.tickTimer.unref === "function") this.tickTimer.unref();
+
+    this.logger.info({ initialCount: this.currentStatus.size }, "Equipment status tracker started");
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    if (this.pendingTimer) {
+      clearTimeout(this.pendingTimer);
+      this.pendingTimer = null;
+    }
+    if (this.tickTimer) {
+      clearInterval(this.tickTimer);
+      this.tickTimer = null;
+    }
+  }
+
+  private scheduleRecompute(): void {
+    if (this.pendingTimer) return; // already scheduled within the debounce window
+    this.pendingTimer = setTimeout(() => {
+      this.pendingTimer = null;
+      this.recompute();
+    }, DEBOUNCE_MS);
+    if (typeof this.pendingTimer.unref === "function") this.pendingTimer.unref();
+  }
+
+  /** Iterate equipments, emit on every status transition. Visible for tests. */
+  recompute(): void {
+    for (const equipment of this.equipmentManager.getAllWithDetails()) {
+      const previous = this.currentStatus.get(equipment.id);
+      if (previous === equipment.status) continue;
+      this.currentStatus.set(equipment.id, equipment.status);
+      // First-time observation (no previous): skip the event but seed the cache.
+      if (previous === undefined) continue;
+      this.eventBus.emit({
+        type: "equipment.status.changed",
+        equipmentId: equipment.id,
+        equipmentName: equipment.name,
+        oldStatus: previous,
+        newStatus: equipment.status,
+      });
+      this.logger.info(
+        {
+          equipmentId: equipment.id,
+          equipmentName: equipment.name,
+          oldStatus: previous,
+          newStatus: equipment.status,
+        },
+        "Equipment status changed",
+      );
+    }
+  }
+}

--- a/src/equipments/equipment-status.test.ts
+++ b/src/equipments/equipment-status.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import { isStaleBinding, deriveEquipmentStatus } from "./equipment-status.js";
+import type { DataBindingWithValue, Device } from "../shared/types.js";
+
+// ─── helpers ────────────────────────────────────────────────────────────
+
+const NOW = Date.parse("2026-05-26T10:00:00Z"); // fixed reference time
+
+function makeDevice(overrides: Partial<Device>): Device {
+  return {
+    id: "dev-1",
+    integrationId: "test",
+    sourceDeviceId: "src-1",
+    name: "Device 1",
+    zoneId: null,
+    source: "zigbee2mqtt",
+    status: "online",
+    lastSeen: "2026-05-26 09:59:50Z",
+    createdAt: "2026-01-01 00:00:00Z",
+    updatedAt: "2026-05-26 09:59:50Z",
+    ...overrides,
+  };
+}
+
+function makeBinding(overrides: Partial<DataBindingWithValue>): DataBindingWithValue {
+  return {
+    id: "bind-1",
+    equipmentId: "eq-1",
+    deviceDataId: "dd-1",
+    alias: "value",
+    deviceId: "dev-1",
+    deviceName: "Device 1",
+    key: "value",
+    type: "number",
+    category: "power",
+    value: 42,
+    lastUpdated: "2026-05-26 09:59:50Z",
+    lastChanged: "2026-05-26 09:59:50Z",
+    stale: false,
+    ...overrides,
+  };
+}
+
+// ─── isStaleBinding ─────────────────────────────────────────────────────
+
+describe("isStaleBinding", () => {
+  it("event-based category 'motion' is never stale, even very old", () => {
+    expect(isStaleBinding("motion", "2025-01-01 00:00:00Z", NOW)).toBe(false);
+  });
+
+  it("event-based category 'contact_door' is never stale", () => {
+    expect(isStaleBinding("contact_door", "2025-01-01 00:00:00Z", NOW)).toBe(false);
+  });
+
+  it("streaming 'power' within window (1 min ago) is not stale", () => {
+    expect(isStaleBinding("power", "2026-05-26 09:59:00Z", NOW)).toBe(false);
+  });
+
+  it("streaming 'power' beyond 2 min window is stale", () => {
+    expect(isStaleBinding("power", "2026-05-26 09:57:00Z", NOW)).toBe(true);
+  });
+
+  it("streaming 'temperature' is stale at 16 min (timeout is 15 min)", () => {
+    expect(isStaleBinding("temperature", "2026-05-26 09:44:00Z", NOW)).toBe(true);
+  });
+
+  it("streaming 'temperature' is not stale at 10 min", () => {
+    expect(isStaleBinding("temperature", "2026-05-26 09:50:00Z", NOW)).toBe(false);
+  });
+
+  it("streaming binding with lastUpdated === null is NOT stale (never received)", () => {
+    expect(isStaleBinding("temperature", null, NOW)).toBe(false);
+  });
+
+  it("streaming 'battery' stale only after 2h (sparse reports)", () => {
+    expect(isStaleBinding("battery", "2026-05-26 08:01:00Z", NOW)).toBe(false);
+    expect(isStaleBinding("battery", "2026-05-26 07:59:00Z", NOW)).toBe(true);
+  });
+
+  it("unparseable timestamp is treated as no value — not stale", () => {
+    expect(isStaleBinding("power", "not-a-date", NOW)).toBe(false);
+  });
+});
+
+// ─── deriveEquipmentStatus ──────────────────────────────────────────────
+
+describe("deriveEquipmentStatus", () => {
+  it("returns 'offline' when there are no bindings at all", () => {
+    const result = deriveEquipmentStatus([], new Map(), NOW);
+    expect(result.status).toBe("offline");
+    expect(result.reason).toEqual({
+      offlineDevices: [],
+      staleBindings: [],
+      offlineSince: null,
+    });
+  });
+
+  it("returns 'online' for 1 binding on an online device with fresh value", () => {
+    const binding = makeBinding({ category: "power", lastUpdated: "2026-05-26 09:59:30Z" });
+    const device = makeDevice({ status: "online" });
+    const map = new Map([[binding.id, device]]);
+    const result = deriveEquipmentStatus([binding], map, NOW);
+    expect(result.status).toBe("online");
+    expect(result.reason).toBeNull();
+  });
+
+  it("returns 'offline' when the single backing device is offline", () => {
+    const binding = makeBinding({});
+    const device = makeDevice({ status: "offline", name: "Compteur Shelly" });
+    const map = new Map([[binding.id, device]]);
+    const result = deriveEquipmentStatus([binding], map, NOW);
+    expect(result.status).toBe("offline");
+    expect(result.reason?.offlineDevices).toEqual(["Compteur Shelly"]);
+  });
+
+  it("returns 'degraded' when 1 device of 2 is offline", () => {
+    const b1 = makeBinding({ id: "b1", deviceId: "d1" });
+    const b2 = makeBinding({ id: "b2", deviceId: "d2", alias: "other" });
+    const d1 = makeDevice({ id: "d1", name: "Device One", status: "online" });
+    const d2 = makeDevice({ id: "d2", name: "Device Two", status: "offline" });
+    const map = new Map([
+      [b1.id, d1],
+      [b2.id, d2],
+    ]);
+    const result = deriveEquipmentStatus([b1, b2], map, NOW);
+    expect(result.status).toBe("degraded");
+    expect(result.reason?.offlineDevices).toEqual(["Device Two"]);
+  });
+
+  it("returns 'offline' when ALL backing devices are offline", () => {
+    const b1 = makeBinding({ id: "b1", deviceId: "d1" });
+    const b2 = makeBinding({ id: "b2", deviceId: "d2", alias: "other" });
+    const d1 = makeDevice({ id: "d1", name: "One", status: "offline" });
+    const d2 = makeDevice({ id: "d2", name: "Two", status: "offline" });
+    const map = new Map([
+      [b1.id, d1],
+      [b2.id, d2],
+    ]);
+    const result = deriveEquipmentStatus([b1, b2], map, NOW);
+    expect(result.status).toBe("offline");
+    expect(result.reason?.offlineDevices).toEqual(["One", "Two"]);
+  });
+
+  it("returns 'degraded' when device is online but a streaming binding is stale", () => {
+    const binding = makeBinding({
+      category: "power",
+      lastUpdated: "2026-05-26 09:50:00Z",
+      alias: "power",
+    });
+    const device = makeDevice({ status: "online" });
+    const map = new Map([[binding.id, device]]);
+    const result = deriveEquipmentStatus([binding], map, NOW);
+    expect(result.status).toBe("degraded");
+    expect(result.reason?.staleBindings).toEqual(["power"]);
+    expect(result.reason?.offlineDevices).toEqual([]);
+  });
+
+  it("device 'unknown' is treated as online — no degradation alone", () => {
+    const binding = makeBinding({ category: "power", lastUpdated: "2026-05-26 09:59:30Z" });
+    const device = makeDevice({ status: "unknown" });
+    const map = new Map([[binding.id, device]]);
+    const result = deriveEquipmentStatus([binding], map, NOW);
+    expect(result.status).toBe("online");
+  });
+
+  it("device 'unknown' + stale streaming binding → still degraded due to staleness", () => {
+    const binding = makeBinding({ category: "power", lastUpdated: "2026-05-26 09:50:00Z" });
+    const device = makeDevice({ status: "unknown" });
+    const map = new Map([[binding.id, device]]);
+    const result = deriveEquipmentStatus([binding], map, NOW);
+    expect(result.status).toBe("degraded");
+  });
+
+  it("offlineSince is the earliest of all offending timestamps", () => {
+    const b1 = makeBinding({
+      id: "b1",
+      deviceId: "d1",
+      category: "power",
+      lastUpdated: "2026-05-26 09:30:00Z", // stale (30 min ago)
+      alias: "power",
+    });
+    const b2 = makeBinding({
+      id: "b2",
+      deviceId: "d2",
+      alias: "other",
+    });
+    const d1 = makeDevice({ id: "d1", name: "One", status: "online" });
+    const d2 = makeDevice({
+      id: "d2",
+      name: "Two",
+      status: "offline",
+      lastSeen: "2026-05-26 09:45:00Z", // more recent than stale b1
+    });
+    const map = new Map([
+      [b1.id, d1],
+      [b2.id, d2],
+    ]);
+    const result = deriveEquipmentStatus([b1, b2], map, NOW);
+    expect(result.status).toBe("degraded");
+    // Earliest of "09:30:00" and "09:45:00" → "09:30:00"
+    expect(result.reason?.offlineSince).toBe("2026-05-26 09:30:00Z");
+  });
+
+  it("motion binding stale (would-be 21 days) does NOT trigger degradation", () => {
+    const binding = makeBinding({
+      category: "motion",
+      lastUpdated: "2026-05-05 10:00:00Z",
+      alias: "occupancy",
+      value: false,
+    });
+    const device = makeDevice({ status: "online" });
+    const map = new Map([[binding.id, device]]);
+    const result = deriveEquipmentStatus([binding], map, NOW);
+    expect(result.status).toBe("online");
+  });
+});

--- a/src/equipments/equipment-status.ts
+++ b/src/equipments/equipment-status.ts
@@ -1,0 +1,133 @@
+/**
+ * Equipment availability derivation (spec 116).
+ *
+ * Pure functions, no I/O. Called from EquipmentManager.getByIdWithDetails /
+ * getAllWithDetails to annotate each EquipmentWithDetails with a derived
+ * `status` field, and from EquipmentStatusTracker to emit transition events.
+ */
+
+import {
+  STREAMING_CATEGORIES,
+  STREAMING_TIMEOUT_MS,
+  DEFAULT_STREAMING_TIMEOUT_MS,
+} from "../shared/constants.js";
+import type {
+  DataBindingWithValue,
+  DataCategory,
+  Device,
+  EquipmentStatus,
+  EquipmentStatusReason,
+} from "../shared/types.js";
+
+/**
+ * Parse a SQLite-style ISO timestamp ("YYYY-MM-DD HH:MM:SSZ" or strict ISO 8601)
+ * to epoch milliseconds. Returns null for null inputs or unparseable values.
+ */
+function parseTimestamp(iso: string | null): number | null {
+  if (!iso) return null;
+  // SQLite datetime('now') returns "YYYY-MM-DD HH:MM:SS" without timezone — treat as UTC.
+  const normalized = iso.includes("T")
+    ? iso.replace("Z", "+00:00")
+    : iso.replace(" ", "T").replace("Z", "") + "Z";
+  const ms = Date.parse(normalized);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Returns true iff the binding is on a streaming category AND its lastUpdated
+ * is older than the per-category threshold. Bindings that have never received
+ * a value (lastUpdated === null) are NOT stale — we never had any value to
+ * begin with, so silence is expected.
+ */
+export function isStaleBinding(
+  category: DataCategory,
+  lastUpdated: string | null,
+  now: number = Date.now(),
+): boolean {
+  if (!STREAMING_CATEGORIES.has(category)) return false;
+  const updatedMs = parseTimestamp(lastUpdated);
+  if (updatedMs === null) return false;
+  const timeoutMs = STREAMING_TIMEOUT_MS[category] ?? DEFAULT_STREAMING_TIMEOUT_MS;
+  return now - updatedMs > timeoutMs;
+}
+
+/**
+ * Derive the equipment status from its bindings + the devices backing them.
+ *
+ * Rules (spec 116 FR3):
+ *  - 0 bindings              → "offline"
+ *  - all unique devices offline → "offline"
+ *  - any device offline OR any streaming binding stale → "degraded"
+ *  - otherwise              → "online"
+ *
+ * `device.status === "unknown"` counts as online (conservative — grey dot, not
+ * red, in the existing Devices UI).
+ *
+ * @param bindings           The equipment's data bindings (already annotated).
+ * @param devicesByBindingId Map from binding id to the Device behind it.
+ * @param now                Injection point for tests; defaults to Date.now().
+ */
+export function deriveEquipmentStatus(
+  bindings: DataBindingWithValue[],
+  devicesByBindingId: Map<string, Device>,
+  now: number = Date.now(),
+): { status: EquipmentStatus; reason: EquipmentStatusReason | null } {
+  if (bindings.length === 0) {
+    return {
+      status: "offline",
+      reason: { offlineDevices: [], staleBindings: [], offlineSince: null },
+    };
+  }
+
+  // Collect unique devices behind the bindings (an equipment can bind to
+  // several devices, and each device can back several bindings).
+  const uniqueDevices = new Map<string, Device>();
+  for (const binding of bindings) {
+    const device = devicesByBindingId.get(binding.id);
+    if (device) uniqueDevices.set(device.id, device);
+  }
+
+  const offlineDevices = [...uniqueDevices.values()].filter(
+    (device) => device.status === "offline",
+  );
+  const staleBindings = bindings.filter((binding) =>
+    isStaleBinding(binding.category, binding.lastUpdated, now),
+  );
+
+  const allOffline = uniqueDevices.size > 0 && offlineDevices.length === uniqueDevices.size;
+  if (allOffline) {
+    return {
+      status: "offline",
+      reason: {
+        offlineDevices: offlineDevices.map((device) => device.name),
+        staleBindings: staleBindings.map((binding) => binding.alias),
+        offlineSince: earliestTimestamp([
+          ...offlineDevices.map((device) => device.lastSeen),
+          ...staleBindings.map((binding) => binding.lastUpdated),
+        ]),
+      },
+    };
+  }
+
+  if (offlineDevices.length > 0 || staleBindings.length > 0) {
+    return {
+      status: "degraded",
+      reason: {
+        offlineDevices: offlineDevices.map((device) => device.name),
+        staleBindings: staleBindings.map((binding) => binding.alias),
+        offlineSince: earliestTimestamp([
+          ...offlineDevices.map((device) => device.lastSeen),
+          ...staleBindings.map((binding) => binding.lastUpdated),
+        ]),
+      },
+    };
+  }
+
+  return { status: "online", reason: null };
+}
+
+function earliestTimestamp(values: (string | null)[]): string | null {
+  const valid = values.filter((v): v is string => v !== null);
+  if (valid.length === 0) return null;
+  return valid.reduce((min, v) => (v < min ? v : min));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { EventBus } from "./core/event-bus.js";
 import { DeviceManager } from "./devices/device-manager.js";
 import { ZoneManager } from "./zones/zone-manager.js";
 import { EquipmentManager } from "./equipments/equipment-manager.js";
+import { EquipmentStatusTracker } from "./equipments/equipment-status-tracker.js";
 import { PoolRuntimeTracker } from "./equipments/pool-runtime-tracker.js";
 import { PoolWaterTempTracker } from "./equipments/pool-water-temp-tracker.js";
 import { ZoneAggregator } from "./zones/zone-aggregator.js";
@@ -190,6 +191,12 @@ async function main() {
   const zoneAggregator = new ZoneAggregator(zoneManager, equipmentManager, eventBus, logger);
   const sunlightManager = new SunlightManager(settingsManager, eventBus, logger);
   zoneAggregator.setSunlightManager(sunlightManager);
+
+  // 10b. Equipment availability tracker (spec 116) — emits equipment.status.changed
+  // on transitions between online/degraded/offline so the WebSocket layer can push
+  // the new state to UI clients without polling.
+  const equipmentStatusTracker = new EquipmentStatusTracker(equipmentManager, eventBus, logger);
+  equipmentStatusTracker.start();
 
   // 11. Create InfluxDB client and connect
   const influxClient = new InfluxClient(logger);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -174,3 +174,60 @@ export const WIDGET_FAMILY_TYPES: Record<WidgetFamily, EquipmentType[]> = {
   water: ["water_valve"],
   pool: ["pool_pump", "pool_cover", "pool_heat_pump"],
 };
+
+// ============================================================
+// Equipment availability — streaming categories (spec 116)
+// ============================================================
+
+/**
+ * Categories where the device pushes a value at regular intervals, even when
+ * unchanged. Absence of update past the timeout = anomaly. Event-based
+ * categories (motion, contact_door, action, light_state, shutter_position…)
+ * are intentionally NOT here: a PIR not firing for 3 weeks is normal.
+ */
+export const STREAMING_CATEGORIES: ReadonlySet<DataCategory> = new Set<DataCategory>([
+  "power",
+  "energy",
+  "voltage",
+  "current",
+  "temperature",
+  "temperature_outdoor",
+  "humidity",
+  "humidity_outdoor",
+  "pressure",
+  "luminosity",
+  "co2",
+  "voc",
+  "noise",
+  "battery",
+  "setpoint",
+  "pool_water_temperature",
+  "pool_temperature_setpoint",
+]);
+
+/**
+ * Per-category freshness window. A streaming binding whose lastUpdated is
+ * older than this value is flagged stale (spec 116). Categories listed in
+ * STREAMING_CATEGORIES but missing here fall back to DEFAULT_STREAMING_TIMEOUT_MS.
+ */
+export const STREAMING_TIMEOUT_MS: Partial<Record<DataCategory, number>> = {
+  power: 2 * 60 * 1000, // 2 min — live electrical reads
+  energy: 10 * 60 * 1000, // 10 min — cumulative counter
+  voltage: 5 * 60 * 1000,
+  current: 5 * 60 * 1000,
+  temperature: 15 * 60 * 1000,
+  temperature_outdoor: 15 * 60 * 1000,
+  humidity: 15 * 60 * 1000,
+  humidity_outdoor: 15 * 60 * 1000,
+  pressure: 30 * 60 * 1000,
+  luminosity: 15 * 60 * 1000,
+  co2: 15 * 60 * 1000,
+  voc: 15 * 60 * 1000,
+  noise: 15 * 60 * 1000,
+  battery: 2 * 60 * 60 * 1000, // 2 h — battery reports are sparse
+  setpoint: 60 * 60 * 1000, // 1 h
+  pool_water_temperature: 15 * 60 * 1000,
+  pool_temperature_setpoint: 60 * 60 * 1000,
+};
+
+export const DEFAULT_STREAMING_TIMEOUT_MS = 15 * 60 * 1000;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -174,6 +174,13 @@ export interface ZoneAggregatedData {
   sunrise: string | null;
   sunset: string | null;
   isDaylight: boolean | null;
+  /**
+   * Per-DataCategory count of equipments in this zone (and descendants) that
+   * were skipped from aggregation because their status === "offline" (spec 116).
+   * Missing keys mean zero. Lets UI render "(N unavailable)" hints next to the
+   * affected metric.
+   */
+  unavailableEquipmentsByCategory: Partial<Record<DataCategory, number>>;
 }
 
 // ============================================================
@@ -214,6 +221,22 @@ export interface Equipment {
   enabled: boolean;
   createdAt: string;
   updatedAt: string;
+}
+
+/**
+ * Derived availability of an equipment (spec 116). Computed in memory from
+ * the underlying devices' `status` and the freshness of streaming bindings.
+ * Never persisted.
+ */
+export type EquipmentStatus = "online" | "degraded" | "offline";
+
+export interface EquipmentStatusReason {
+  /** Names of bound devices whose status is "offline". */
+  offlineDevices: string[];
+  /** Aliases of streaming bindings whose lastUpdated exceeds the timeout. */
+  staleBindings: string[];
+  /** Earliest lastSeen (devices) / lastUpdated (bindings) among the issues. */
+  offlineSince: string | null;
 }
 
 export interface DataBinding {
@@ -284,6 +307,12 @@ export interface DataBindingWithValue extends DataBinding {
   lastUpdated: string | null;
   lastChanged: string | null;
   historize?: number | null;
+  /**
+   * True iff the category is streaming AND lastUpdated exceeds the per-category
+   * timeout (spec 116). Always false for event-based categories such as motion
+   * or contact_door (absence of update is not anomaly).
+   */
+  stale: boolean;
 }
 
 export interface OrderBindingWithDetails extends OrderBinding {
@@ -313,6 +342,10 @@ export interface EquipmentWithDetails extends Equipment {
   orderBindings: OrderBindingWithDetails[];
   /** Computed data not backed by device bindings (e.g. energy aggregator cumuls). */
   computedData?: ComputedDataEntry[];
+  /** Derived availability (spec 116). Always present. */
+  status: EquipmentStatus;
+  /** Populated only when status !== "online". */
+  statusReason?: EquipmentStatusReason;
 }
 
 // ============================================================
@@ -646,6 +679,13 @@ export type EngineEvent =
       value: unknown;
       error: string;
       source?: OrderSource;
+    }
+  | {
+      type: "equipment.status.changed";
+      equipmentId: string;
+      equipmentName: string;
+      oldStatus: EquipmentStatus;
+      newStatus: EquipmentStatus;
     }
   // Recipe events
   | { type: "recipe.instance.created"; instanceId: string; recipeId: string }

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -128,6 +128,7 @@ describe("ZoneAggregator", () => {
         sunrise: null,
         sunset: null,
         isDaylight: null,
+        unavailableEquipmentsByCategory: {},
       });
     });
 
@@ -154,6 +155,51 @@ describe("ZoneAggregator", () => {
 
       const data = aggregator.getByZoneId(zone.id);
       expect(data?.temperature).toBe(21);
+    });
+
+    // ──────────────────────────────────────────────────────────────
+    // Spec 116 — offline equipments excluded from aggregation
+    // ──────────────────────────────────────────────────────────────
+
+    it("skips offline equipments from aggregation and counts them in unavailableEquipmentsByCategory", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+
+      const dev1 = seedDevice(db, {
+        name: "Temp1",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "20" }],
+      });
+      const dev2 = seedDevice(db, {
+        name: "Temp2",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "22" }],
+      });
+      // Flip dev2 offline directly in DB — simulates a plugin reporting offline.
+      db.prepare("UPDATE devices SET status = 'offline' WHERE id = ?").run(dev2.deviceId);
+
+      const eq1 = equipmentManager.create({ name: "Sensor 1", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq1.id, dev1.dataIds[0], "temperature");
+      const eq2 = equipmentManager.create({ name: "Sensor 2", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq2.id, dev2.dataIds[0], "temperature");
+
+      aggregator.computeAll();
+      const data = aggregator.getByZoneId(zone.id);
+
+      // Average uses only the online sensor (20°C), not the (20+22)/2 = 21.
+      expect(data?.temperature).toBe(20);
+      expect(data?.unavailableEquipmentsByCategory).toEqual({ temperature: 1 });
+    });
+
+    it("leaves unavailableEquipmentsByCategory empty when all equipments are online", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const dev = seedDevice(db, {
+        name: "Temp",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "21" }],
+      });
+      const eq = equipmentManager.create({ name: "Sensor", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "temperature");
+
+      aggregator.computeAll();
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.unavailableEquipmentsByCategory).toEqual({});
     });
 
     it("aggregates humidity as AVG", () => {

--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -39,6 +39,8 @@ interface Accumulator {
   waterValvesTotal: number;
   waterFlowSum: number;
   waterFlowHasData: boolean;
+  /** Per-DataCategory count of equipments skipped because status === "offline" (spec 116). */
+  unavailableByCategory: Partial<Record<DataCategory, number>>;
 }
 
 function emptyAccumulator(): Accumulator {
@@ -65,7 +67,19 @@ function emptyAccumulator(): Accumulator {
     waterValvesTotal: 0,
     waterFlowSum: 0,
     waterFlowHasData: false,
+    unavailableByCategory: {},
   };
+}
+
+function mergeUnavailable(
+  a: Partial<Record<DataCategory, number>>,
+  b: Partial<Record<DataCategory, number>>,
+): Partial<Record<DataCategory, number>> {
+  const result: Partial<Record<DataCategory, number>> = { ...a };
+  for (const [cat, count] of Object.entries(b) as [DataCategory, number][]) {
+    result[cat] = (result[cat] ?? 0) + count;
+  }
+  return result;
 }
 
 function mergeAccumulators(a: Accumulator, b: Accumulator): Accumulator {
@@ -92,6 +106,7 @@ function mergeAccumulators(a: Accumulator, b: Accumulator): Accumulator {
     waterValvesTotal: a.waterValvesTotal + b.waterValvesTotal,
     waterFlowSum: a.waterFlowSum + b.waterFlowSum,
     waterFlowHasData: a.waterFlowHasData || b.waterFlowHasData,
+    unavailableByCategory: mergeUnavailable(a.unavailableByCategory, b.unavailableByCategory),
   };
 }
 
@@ -126,6 +141,7 @@ function accumulatorToPublic(acc: Accumulator): ZoneAggregatedData {
     sunrise: null,
     sunset: null,
     isDaylight: null,
+    unavailableEquipmentsByCategory: acc.unavailableByCategory,
   };
 }
 
@@ -153,8 +169,22 @@ function aggregatedDataEqual(a: ZoneAggregatedData, b: ZoneAggregatedData): bool
     a.waterFlowTotal === b.waterFlowTotal &&
     a.sunrise === b.sunrise &&
     a.sunset === b.sunset &&
-    a.isDaylight === b.isDaylight
+    a.isDaylight === b.isDaylight &&
+    unavailableEqual(a.unavailableEquipmentsByCategory, b.unavailableEquipmentsByCategory)
   );
+}
+
+function unavailableEqual(
+  a: Partial<Record<DataCategory, number>>,
+  b: Partial<Record<DataCategory, number>>,
+): boolean {
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  for (const key of keysA) {
+    if (a[key as DataCategory] !== b[key as DataCategory]) return false;
+  }
+  return true;
 }
 
 /**
@@ -442,6 +472,11 @@ export class ZoneAggregator {
 
   /**
    * Compute the direct accumulator for a zone from its own equipments.
+   *
+   * Spec 116: equipments whose derived status === "offline" are excluded from
+   * numeric aggregation. Each of their data-binding categories increments
+   * `unavailableByCategory` so the UI can surface "(N unavailable)" hints.
+   * Degraded equipments still contribute their last known values.
    */
   private computeDirectAccumulator(zoneId: string): Accumulator {
     const equipments = this.equipmentManager.getByZone(zoneId);
@@ -449,7 +484,18 @@ export class ZoneAggregator {
 
     for (const equipment of equipments) {
       if (equipment.type === "weather") continue; // Exclude weather from zone aggregation
-      const bindings = this.equipmentManager.getDataBindingsWithValues(equipment.id);
+      const withDetails = this.equipmentManager.getByIdWithDetails(equipment.id);
+      if (!withDetails) continue;
+
+      if (withDetails.status === "offline") {
+        for (const binding of withDetails.dataBindings) {
+          acc.unavailableByCategory[binding.category] =
+            (acc.unavailableByCategory[binding.category] ?? 0) + 1;
+        }
+        continue;
+      }
+
+      const bindings = withDetails.dataBindings;
       if (equipment.type === "water_valve") {
         this.accumulateWaterValve(acc, bindings);
       } else {


### PR DESCRIPTION
## Summary

Backend implementation of spec 116 — equipment availability propagation. PR 1 of 2; UI badges + LiveEnergyPage stale HUD ship in PR 2.

Triggered by a Shelly Pro 3EM going hors-tension at the breaker: the Live Energy page kept showing the last known value as live because `device.status` (correctly flipped to offline by the plugin's LWT handler) never reached the equipment layer. This PR closes that gap with a generic mechanism that covers Shelly + every other equipment whose backing device may go offline.

## Approach

Two signals combined to derive `Equipment.status`:

1. **`device.status`** from each plugin (existing `online | offline | unknown`).
2. **`data.lastUpdated > category timeout`** — only for streaming categories (`power`, `temperature`, `humidity`, `energy`, `voltage`, `current`, `pressure`, `luminosity`, `co2`, `voc`, `noise`, `battery`, `setpoint`, outdoor + pool sensors). Event-based categories (motion, contact, action, light_state, shutter_position, etc.) never go stale: a PIR not firing for 3 weeks in an empty house is normal.

No `device.lastSeen` generic watchdog: empirical prod check (96 devices) showed battery-powered Zigbee endpoints can dormir > 24h legitimately. The 24 prod devices stuck at `online` with `lastSeen` > 1h (worst: 49 days) are missing `updateDeviceStatus("offline")` calls in their respective plugins — documented as the **mandatory plugin contract** in `docs/technical/plugin-development.md`.

## Changes

- **Types** (`src/shared/types.ts`): `EquipmentStatus`, `EquipmentStatusReason`, `EquipmentWithDetails.status/statusReason`, `DataBindingWithValue.stale`, `ZoneAggregatedData.unavailableEquipmentsByCategory`, new `equipment.status.changed` event.
- **Constants** (`src/shared/constants.ts`): `STREAMING_CATEGORIES`, `STREAMING_TIMEOUT_MS`, `DEFAULT_STREAMING_TIMEOUT_MS`.
- **Core logic** (`src/equipments/equipment-status.ts`, new): pure `isStaleBinding` + `deriveEquipmentStatus`.
- **EquipmentManager** (`src/equipments/equipment-manager.ts`): annotate `dataBindings[].stale`, derive `status` + `statusReason` in `getByIdWithDetails` / `getAllWithDetails`. Per-call device fetch cache to avoid N+1.
- **EquipmentStatusTracker** (`src/equipments/equipment-status-tracker.ts`, new): subscribes to device + equipment events, 200ms debounce, 60s wallclock tick for stale transitions, emits `equipment.status.changed` on transitions. Wired in `src/index.ts`.
- **ZoneAggregator** (`src/zones/zone-aggregator.ts`): skips offline equipments from numeric aggregations, populates `unavailableEquipmentsByCategory` for UI hints. Degraded equipments still contribute their last known values.
- **WebSocket** (`src/api/websocket.ts`): dedup key for `equipment.status.changed` (routing auto via prefix).
- **Docs** (`plugin-development.md`, `api-reference.md`): mandatory plugin contract + new API fields + new WS event.
- **Spec folder** (`specs/116-equipment-availability/`): spec + architecture + plan + ux-mockups (md + html).

No DB migration (status derived at read time). Additive API only, no breaking changes.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `cd ui && npx tsc --noEmit` — clean (no UI changes in this PR)
- [x] `npx vitest run` — 694 passing, 2 skipped, 0 failing (28 new scenarios for spec 116)
- [x] `npx eslint src/ --ext .ts` — clean
- [ ] Manual: flip a device to offline via direct DB update (`UPDATE devices SET status='offline' WHERE id=...`), call `GET /equipments/<id>`, verify `status === "offline"` + `statusReason.offlineDevices` populated
- [ ] Manual: watch `equipment.status.changed` events on the WebSocket when toggling status

## Out of scope

UI rendering (badges, stale HUD on LiveEnergyPage, zone widget hints) — ships in PR 2 from the same branch family. Until PR 2 lands, the new fields are present in the API response but not visualized.