### PR TITLE
feat(ui): equipment availability badges + live energy stale HUD (spec 116, UI)

### DIFF
--- a/ui/src/components/energy/LiveEnergyPage.tsx
+++ b/ui/src/components/energy/LiveEnergyPage.tsx
@@ -15,6 +15,7 @@
 
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { Clock, WifiOff } from "lucide-react";
 import { useEquipments } from "../../store/useEquipments";
 import type { EquipmentWithDetails } from "../../types";
 import { EnergyMobileNav } from "./EnergyMobileNav";
@@ -40,6 +41,42 @@ function sumPower(equipments: EquipmentWithDetails[]): number | null {
     }
   }
   return any ? total : null;
+}
+
+/**
+ * Spec 116: detect whether the live diagram is showing trustworthy data.
+ * Returns null when everything is online — caller renders nothing.
+ * Returns { mode: "stale" | "offline", oldestSince } when the upstream
+ * meters are degraded or fully offline.
+ */
+function detectLiveStaleness(
+  contributors: EquipmentWithDetails[],
+): { mode: "stale" | "offline"; oldestSince: string | null } | null {
+  if (contributors.length === 0) return null;
+  const anyDegraded = contributors.some(
+    (e) => e.status === "degraded" || e.status === "offline",
+  );
+  if (!anyDegraded) return null;
+  const allOffline = contributors.every((e) => e.status === "offline");
+  const sinces = contributors
+    .map((e) => e.statusReason?.offlineSince ?? null)
+    .filter((s): s is string => s !== null);
+  const oldestSince = sinces.length > 0 ? sinces.reduce((a, b) => (a < b ? a : b)) : null;
+  return { mode: allOffline ? "offline" : "stale", oldestSince };
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "";
+  const normalized = iso.includes("T") ? iso : iso.replace(" ", "T").replace("Z", "") + "Z";
+  const ms = Date.parse(normalized);
+  if (!Number.isFinite(ms)) return "";
+  const seconds = Math.floor((Date.now() - ms) / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} h`;
+  return `${Math.floor(hours / 24)} j`;
 }
 
 /** Flow duration (s) inversely log-scaled with power. Stays calm — bubbles never zoom. */
@@ -111,6 +148,10 @@ export function LiveEnergyPage() {
   const gridPower = sumPower(gridEqs);
   const solarPower = sumPower(solarEqs);
   const hasSources = gridEqs.length > 0 || solarEqs.length > 0;
+  const staleness = useMemo(
+    () => detectLiveStaleness([...gridEqs, ...solarEqs]),
+    [gridEqs, solarEqs],
+  );
 
   return (
     <div className="p-4 sm:p-6">
@@ -118,6 +159,31 @@ export function LiveEnergyPage() {
       <div className="hidden sm:flex items-center gap-1.5 mb-6">
         <h1>{t("energy.live")}</h1>
       </div>
+
+      {staleness && (
+        <div
+          className={`mb-4 flex items-center gap-2 rounded-[10px] border px-4 py-3 text-[13px] ${
+            staleness.mode === "offline"
+              ? "bg-error/10 border-error/20 text-error"
+              : "bg-warning/10 border-warning/20 text-warning"
+          }`}
+          role="status"
+        >
+          {staleness.mode === "offline" ? (
+            <WifiOff size={16} strokeWidth={1.75} />
+          ) : (
+            <Clock size={16} strokeWidth={1.75} />
+          )}
+          <span className="font-medium">
+            {t(
+              staleness.mode === "offline"
+                ? "energy.live.metersOffline"
+                : "energy.live.dataStale",
+              { when: formatRelative(staleness.oldestSince) },
+            )}
+          </span>
+        </div>
+      )}
 
       {!hasSources ? (
         <EmptyState />

--- a/ui/src/components/equipments/EnergyDataPanel.tsx
+++ b/ui/src/components/equipments/EnergyDataPanel.tsx
@@ -1,9 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { Zap, Clock, Calendar, CalendarDays, CalendarRange } from "lucide-react";
-import type { ComputedDataEntry } from "../../types";
+import type { ComputedDataEntry, EquipmentStatus, EquipmentStatusReason } from "../../types";
+import { EquipmentStatusBadge } from "./EquipmentStatusBadge";
 
 interface EnergyDataPanelProps {
   computedData: ComputedDataEntry[];
+  /** Spec 116: render a badge + last-update caption when degraded/offline. */
+  status?: EquipmentStatus;
+  statusReason?: EquipmentStatusReason;
 }
 
 interface EnergyCumul {
@@ -18,7 +22,21 @@ function formatEnergy(wh: number): { value: string; unit: string } {
   return { value: String(Math.round(wh)), unit: "Wh" };
 }
 
-export function EnergyDataPanel({ computedData }: EnergyDataPanelProps) {
+function formatRelative(iso: string | null): string {
+  if (!iso) return "";
+  const normalized = iso.includes("T") ? iso : iso.replace(" ", "T").replace("Z", "") + "Z";
+  const ms = Date.parse(normalized);
+  if (!Number.isFinite(ms)) return "";
+  const seconds = Math.floor((Date.now() - ms) / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} h`;
+  return `${Math.floor(hours / 24)} j`;
+}
+
+export function EnergyDataPanel({ computedData, status, statusReason }: EnergyDataPanelProps) {
   const { t } = useTranslation();
 
   const cumuls: EnergyCumul[] = [
@@ -51,12 +69,17 @@ export function EnergyDataPanel({ computedData }: EnergyDataPanelProps) {
   // Only render if at least one energy cumul exists
   if (cumuls.every((c) => c.value === null)) return null;
 
+  const isDegraded = status === "degraded" || status === "offline";
+
   return (
     <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
-      <h3 className="text-[14px] font-semibold text-text flex items-center gap-2 mb-4">
-        <Zap size={16} strokeWidth={1.5} className="text-accent" />
-        {t("energy.cumuls")}
-      </h3>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-[14px] font-semibold text-text flex items-center gap-2">
+          <Zap size={16} strokeWidth={1.5} className="text-accent" />
+          {t("energy.cumuls")}
+        </h3>
+        {status && <EquipmentStatusBadge status={status} reason={statusReason} size="sm" />}
+      </div>
       <div className="grid grid-cols-2 gap-3">
         {cumuls.map((c) => {
           if (c.value === null) return null;
@@ -82,6 +105,15 @@ export function EnergyDataPanel({ computedData }: EnergyDataPanelProps) {
           );
         })}
       </div>
+      {isDegraded && statusReason?.offlineSince && (
+        <div
+          className={`mt-3 text-center text-[11px] font-mono ${status === "offline" ? "text-error" : "text-text-tertiary"}`}
+        >
+          {status === "offline"
+            ? t("energy.cumul.offlineSince", { when: formatRelative(statusReason.offlineSince) })
+            : t("energy.cumul.lastLive", { when: formatRelative(statusReason.offlineSince) })}
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/components/equipments/EquipmentStatusBadge.tsx
+++ b/ui/src/components/equipments/EquipmentStatusBadge.tsx
@@ -1,0 +1,103 @@
+/**
+ * EquipmentStatusBadge (spec 116).
+ *
+ * Renders nothing when status === "online" — silence is success.
+ * Otherwise renders a small ambre (degraded) or red (offline) pill with
+ * an icon + label and a native HTML tooltip describing the cause.
+ */
+
+import { AlertTriangle, WifiOff } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { EquipmentStatus, EquipmentStatusReason } from "../../types";
+
+type Size = "sm" | "md";
+
+interface Props {
+  status: EquipmentStatus;
+  reason?: EquipmentStatusReason;
+  size?: Size;
+  /** When true, hides the text label (icon only). Used in tight slots. */
+  iconOnly?: boolean;
+  className?: string;
+}
+
+const SIZE_CLASSES: Record<Size, string> = {
+  sm: "text-[11px] font-medium px-2 py-0.5 gap-1",
+  md: "text-[12px] font-medium px-2.5 py-1 gap-1.5",
+};
+
+const ICON_SIZE: Record<Size, number> = { sm: 11, md: 13 };
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "";
+  const normalized = iso.includes("T") ? iso : iso.replace(" ", "T").replace("Z", "") + "Z";
+  const ms = Date.parse(normalized);
+  if (!Number.isFinite(ms)) return "";
+  const seconds = Math.floor((Date.now() - ms) / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} h`;
+  const days = Math.floor(hours / 24);
+  return `${days} j`;
+}
+
+function buildTooltip(
+  status: EquipmentStatus,
+  reason: EquipmentStatusReason | undefined,
+  t: (k: string, params?: Record<string, unknown>) => string,
+): string {
+  if (!reason) return t(`equipment.status.${status}`);
+  const lines: string[] = [t(`equipment.status.${status}`)];
+  if (reason.offlineDevices.length > 0) {
+    lines.push("");
+    lines.push(t("equipment.status.tooltip.offlineDevices", { count: reason.offlineDevices.length }));
+    for (const name of reason.offlineDevices) lines.push(`  · ${name}`);
+  }
+  if (reason.staleBindings.length > 0) {
+    lines.push("");
+    lines.push(t("equipment.status.tooltip.staleBindings", { count: reason.staleBindings.length }));
+    for (const alias of reason.staleBindings) lines.push(`  · ${alias}`);
+  }
+  if (reason.offlineSince) {
+    lines.push("");
+    lines.push(
+      t("equipment.status.tooltip.since", { when: formatRelative(reason.offlineSince) }),
+    );
+  }
+  return lines.join("\n");
+}
+
+export function EquipmentStatusBadge({
+  status,
+  reason,
+  size = "sm",
+  iconOnly = false,
+  className = "",
+}: Props) {
+  const { t } = useTranslation();
+
+  if (status === "online") return null;
+
+  const Icon = status === "offline" ? WifiOff : AlertTriangle;
+  const colorClasses =
+    status === "offline"
+      ? "bg-error/10 text-error"
+      : "bg-warning/10 text-warning";
+
+  const labelKey = status === "offline" ? "equipment.status.offline" : "equipment.status.degraded";
+  const tooltip = buildTooltip(status, reason, t);
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full whitespace-nowrap ${SIZE_CLASSES[size]} ${colorClasses} ${className}`}
+      role="status"
+      aria-label={`${t(labelKey)}${reason?.offlineSince ? ` — ${formatRelative(reason.offlineSince)}` : ""}`}
+      title={tooltip}
+    >
+      <Icon size={ICON_SIZE[size]} strokeWidth={1.75} />
+      {!iconOnly && <span>{t(labelKey)}</span>}
+    </span>
+  );
+}

--- a/ui/src/components/equipments/weather-utils.ts
+++ b/ui/src/components/equipments/weather-utils.ts
@@ -32,6 +32,7 @@ export function syntheticBindingFromComputed(
     unit: computed.unit,
     lastUpdated: computed.lastUpdated,
     lastChanged: computed.lastUpdated,
+    stale: false,
   };
 }
 

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -13,6 +13,7 @@ import { PoolHeatPumpControl } from "../equipments/PoolHeatPumpControl";
 import { Cloud, Timer } from "lucide-react";
 import { parseForecastDays, CONDITION_ICONS, CONDITION_COLORS } from "../equipments/weatherForecastUtils";
 import { syntheticBindingFromComputed } from "../equipments/weather-utils";
+import { EquipmentStatusBadge } from "../equipments/EquipmentStatusBadge";
 import type { DataBindingWithValue } from "../../types";
 
 interface CompactEquipmentCardProps {
@@ -94,6 +95,26 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
   const iconText = isLightOn ? "text-white" : baseTint.text;
   const iconAnimation = isLightOn ? "animate-glow" : "";
 
+  // Spec 116: when the equipment is fully offline, render a minimal row —
+  // just icon (muted) + name + badge — instead of stale controls + values.
+  if (equipment.status === "offline") {
+    return (
+      <div className="grid grid-cols-[32px_1fr_auto] gap-[0.85rem] items-center px-[1.1rem] py-[0.55rem] min-h-[52px] transition-colors duration-150 hover:bg-border-light/40">
+        <div className={`w-8 h-8 rounded-md flex items-center justify-center flex-shrink-0 opacity-55 ${baseTint.bg} ${baseTint.text}`}>
+          {iconElement}
+        </div>
+        <Link
+          to={`/equipments/${equipment.id}`}
+          state={zoneName ? { fromZone: zoneName } : undefined}
+          className="min-w-0 text-[14px] font-medium text-text truncate hover:text-primary transition-colors"
+        >
+          {equipment.name}
+        </Link>
+        <EquipmentStatusBadge status="offline" reason={equipment.statusReason} size="sm" />
+      </div>
+    );
+  }
+
   return (
     <div className="grid grid-cols-[32px_1fr_auto] gap-[0.85rem] items-center px-[1.1rem] py-[0.55rem] min-h-[52px] transition-colors duration-150 hover:bg-border-light/40">
       {/* Slot 1: Icon */}
@@ -101,14 +122,24 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
         {iconElement}
       </div>
 
-      {/* Slot 2: Name */}
-      <Link
-        to={`/equipments/${equipment.id}`}
-        state={zoneName ? { fromZone: zoneName } : undefined}
-        className="min-w-0 text-[14px] font-medium text-text truncate hover:text-primary transition-colors"
-      >
-        {equipment.name}
-      </Link>
+      {/* Slot 2: Name (+ degraded badge inline, spec 116) */}
+      <div className="min-w-0 flex items-center gap-2">
+        <Link
+          to={`/equipments/${equipment.id}`}
+          state={zoneName ? { fromZone: zoneName } : undefined}
+          className="min-w-0 text-[14px] font-medium text-text truncate hover:text-primary transition-colors"
+        >
+          {equipment.name}
+        </Link>
+        {equipment.status === "degraded" && (
+          <EquipmentStatusBadge
+            status="degraded"
+            reason={equipment.statusReason}
+            size="sm"
+            iconOnly
+          />
+        )}
+      </div>
 
       {/* Slots 3-5: per-type content. Grid auto columns collapse when unused. */}
 

--- a/ui/src/components/home/ZoneAggregationPills.tsx
+++ b/ui/src/components/home/ZoneAggregationPills.tsx
@@ -47,6 +47,17 @@ export function ZoneAggregationPills({
   const { t } = useTranslation();
   const duration = useRelativeTime(data.motionSince, t);
 
+  // Spec 116: append "(N unavailable)" hint when offline equipments of this
+  // category were excluded from the aggregation.
+  const unavail = (cat: string): string => {
+    const count = data.unavailableEquipmentsByCategory?.[cat as never] as
+      | number
+      | undefined;
+    return count && count > 0
+      ? ` ${t("zones.aggregate.unavailable", { count })}`
+      : "";
+  };
+
   // ── Cluster 1: Sensors (passive measurement) ────────────────
   const sensorPills: StatusItem[] = [];
 
@@ -54,7 +65,7 @@ export function ZoneAggregationPills({
     sensorPills.push({
       key: "temp",
       icon: <Thermometer size={14} strokeWidth={1.5} />,
-      label: `${data.temperature}°C`,
+      label: `${data.temperature}°C${unavail("temperature")}`,
       variant: "default",
       iconTint: "text-primary",
       valueTint: "text-text",
@@ -66,7 +77,7 @@ export function ZoneAggregationPills({
     sensorPills.push({
       key: "hum",
       icon: <Droplets size={14} strokeWidth={1.5} />,
-      label: `${data.humidity}%`,
+      label: `${data.humidity}%${unavail("humidity")}`,
       variant: "default",
       iconTint: "text-primary",
       valueTint: "text-text",
@@ -78,7 +89,7 @@ export function ZoneAggregationPills({
     sensorPills.push({
       key: "lux",
       icon: <Sun size={14} strokeWidth={1.5} />,
-      label: `${data.luminosity} lx`,
+      label: `${data.luminosity} lx${unavail("luminosity")}`,
       variant: "default",
       iconTint: "text-primary",
       valueTint: "text-text",
@@ -108,7 +119,7 @@ export function ZoneAggregationPills({
     counterPills.push({
       key: "lights",
       icon: <Lightbulb size={14} strokeWidth={1.5} />,
-      label: `${data.lightsOn}/${data.lightsTotal}`,
+      label: `${data.lightsOn}/${data.lightsTotal}${unavail("light_state")}`,
       variant: isOn ? "active" : "default",
       iconTint: "text-text-tertiary",
       valueTint: "text-text-tertiary",
@@ -125,7 +136,7 @@ export function ZoneAggregationPills({
     counterPills.push({
       key: "shutters",
       icon: <ShutterIcon size={14} strokeWidth={1.5} position={pos} />,
-      label: `${data.shuttersOpen}/${data.shuttersTotal}${positionSuffix}`,
+      label: `${data.shuttersOpen}/${data.shuttersTotal}${positionSuffix}${unavail("shutter_position")}`,
       variant: "default",
       iconTint: "text-text-secondary",
       valueTint: someOpen ? "text-text" : "text-text-tertiary",

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1053,5 +1053,23 @@
   "activity.toggleDescendants.on": "Hide sub-zone activity",
   "activity.toggleDescendants.off": "Include sub-zone activity",
 
-  "activity.bucket.now": "now"
+  "activity.bucket.now": "now",
+
+  "equipment.status.online": "Online",
+  "equipment.status.degraded": "Degraded",
+  "equipment.status.offline": "Disconnected",
+  "equipment.status.tooltip.offlineDevices_one": "1 device offline:",
+  "equipment.status.tooltip.offlineDevices_other": "{{count}} devices offline:",
+  "equipment.status.tooltip.staleBindings_one": "1 stale value:",
+  "equipment.status.tooltip.staleBindings_other": "{{count}} stale values:",
+  "equipment.status.tooltip.since": "Since {{when}}",
+
+  "energy.cumul.lastLive": "Last live datapoint {{when}} ago",
+  "energy.cumul.offlineSince": "Meter offline for {{when}}",
+
+  "energy.live.dataStale": "Live data stale, last update {{when}} ago",
+  "energy.live.metersOffline": "Meters disconnected for {{when}}",
+
+  "zones.aggregate.unavailable_one": "(1 unavailable)",
+  "zones.aggregate.unavailable_other": "({{count}} unavailable)"
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1053,5 +1053,23 @@
   "activity.toggleDescendants.on": "Masquer l'activité des sous-zones",
   "activity.toggleDescendants.off": "Inclure l'activité des sous-zones",
 
-  "activity.bucket.now": "maintenant"
+  "activity.bucket.now": "maintenant",
+
+  "equipment.status.online": "En ligne",
+  "equipment.status.degraded": "Dégradé",
+  "equipment.status.offline": "Déconnecté",
+  "equipment.status.tooltip.offlineDevices_one": "1 appareil hors ligne :",
+  "equipment.status.tooltip.offlineDevices_other": "{{count}} appareils hors ligne :",
+  "equipment.status.tooltip.staleBindings_one": "1 valeur périmée :",
+  "equipment.status.tooltip.staleBindings_other": "{{count}} valeurs périmées :",
+  "equipment.status.tooltip.since": "Depuis {{when}}",
+
+  "energy.cumul.lastLive": "Dernière donnée live il y a {{when}}",
+  "energy.cumul.offlineSince": "Compteur hors ligne depuis {{when}}",
+
+  "energy.live.dataStale": "Données figées depuis {{when}}",
+  "energy.live.metersOffline": "Compteurs déconnectés depuis {{when}}",
+
+  "zones.aggregate.unavailable_one": "(1 indispo.)",
+  "zones.aggregate.unavailable_other": "({{count}} indispo.)"
 }

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -15,6 +15,7 @@ import { SensorDataPanel } from "../components/equipments/SensorDataPanel";
 import { WeatherPanel } from "../components/equipments/WeatherPanel";
 import { WeatherForecastPanel } from "../components/equipments/WeatherForecastPanel";
 import { AddBindingModal } from "../components/equipments/AddBindingModal";
+import { EquipmentStatusBadge } from "../components/equipments/EquipmentStatusBadge";
 import { DeviceSelector } from "../components/equipments/DeviceSelector";
 import { TYPE_LABELS } from "../components/equipments/EquipmentCard";
 import { useEquipmentState } from "../components/equipments/useEquipmentState";
@@ -201,9 +202,17 @@ export function EquipmentDetailPage() {
             {equipmentState.iconElement}
           </div>
           <div>
-            <h1>
-              {equipment.name}
-            </h1>
+            <div className="flex items-center gap-3 flex-wrap">
+              <h1>
+                {equipment.name}
+              </h1>
+              {/* Spec 116: availability badge next to the equipment name */}
+              <EquipmentStatusBadge
+                status={equipment.status}
+                reason={equipment.statusReason}
+                size="md"
+              />
+            </div>
             <p className="text-[13px] text-text-secondary">
               {t(TYPE_LABELS[equipment.type])}
               {equipment.description && ` · ${equipment.description}`}
@@ -363,7 +372,11 @@ export function EquipmentDetailPage() {
       {(equipment.type === "main_energy_meter" ||
         equipment.type === "energy_production_meter" ||
         equipment.type === "energy_meter") && equipment.computedData && (
-        <EnergyDataPanel computedData={equipment.computedData} />
+        <EnergyDataPanel
+          computedData={equipment.computedData}
+          status={equipment.status}
+          statusReason={equipment.statusReason}
+        />
       )}
 
       {/* Button actions */}

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -86,7 +86,7 @@ export function EquipmentDetailPage() {
   }, [fetchZones]);
 
   // Must call hooks before any early returns
-  const EMPTY: EquipmentWithDetails = { id: "", name: "", type: "sensor", zoneId: "", enabled: true, createdAt: "", updatedAt: "", dataBindings: [], orderBindings: [] };
+  const EMPTY: EquipmentWithDetails = { id: "", name: "", type: "sensor", zoneId: "", enabled: true, createdAt: "", updatedAt: "", dataBindings: [], orderBindings: [], status: "online" };
   const equipmentState = useEquipmentState(equipment ?? EMPTY);
 
   useEffect(() => {

--- a/ui/src/store/useEquipments.ts
+++ b/ui/src/store/useEquipments.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
-import type { Equipment, EquipmentType, EquipmentWithDetails } from "../types";
+import type {
+  Equipment,
+  EquipmentType,
+  EquipmentStatus,
+  EquipmentWithDetails,
+} from "../types";
 import {
   getEquipments,
   createEquipment as apiCreateEquipment,
@@ -50,6 +55,7 @@ interface EquipmentsState {
   handleEquipmentUpdated: () => void;
   handleEquipmentRemoved: () => void;
   handleEquipmentDataChanged: (equipmentId: string, alias: string, value: unknown) => void;
+  handleEquipmentStatusChanged: (equipmentId: string, newStatus: EquipmentStatus) => void;
 }
 
 export const useEquipments = create<EquipmentsState>((set, get) => ({
@@ -145,6 +151,19 @@ export const useEquipments = create<EquipmentsState>((set, get) => ({
           : [...existing, entry];
         return { ...eq, computedData: updated };
       }),
+    }));
+  },
+  handleEquipmentStatusChanged: (equipmentId, newStatus) => {
+    // Spec 116: refetch when status changes — statusReason needs the full
+    // server-side derivation (offlineDevices, staleBindings, offlineSince).
+    // Status transitions are rare enough that a refetch is fine.
+    get().fetchEquipments();
+    // Optimistic local update for instant badge feedback while the fetch
+    // is in flight (~100ms RTT on LAN).
+    set((state) => ({
+      equipments: state.equipments.map((eq) =>
+        eq.id === equipmentId ? { ...eq, status: newStatus } : eq,
+      ),
     }));
   },
 }));

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -131,6 +131,12 @@ function handleEvent(event: EngineEvent): void {
         event.value
       );
       break;
+    case "equipment.status.changed":
+      useEquipments.getState().handleEquipmentStatusChanged(
+        event.equipmentId,
+        event.newStatus
+      );
+      break;
     case "recipe.instance.created":
     case "recipe.instance.removed":
     case "recipe.instance.started":

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -169,6 +169,10 @@ export interface ZoneAggregatedData {
   sunrise: string | null;
   sunset: string | null;
   isDaylight: boolean | null;
+  /** Per-DataCategory count of equipments excluded from aggregation because
+   *  status === "offline" (spec 116). Used by the UI to render "(N unavailable)"
+   *  hints next to affected metrics. */
+  unavailableEquipmentsByCategory: Partial<Record<DataCategory, number>>;
 }
 
 // ============================================================
@@ -211,6 +215,16 @@ export interface Equipment {
   updatedAt: string;
 }
 
+/** Derived availability of an equipment (spec 116). Computed server-side
+ *  from devices.status + streaming bindings freshness. Never persisted. */
+export type EquipmentStatus = "online" | "degraded" | "offline";
+
+export interface EquipmentStatusReason {
+  offlineDevices: string[];
+  staleBindings: string[];
+  offlineSince: string | null;
+}
+
 export interface DataBinding {
   id: string;
   equipmentId: string;
@@ -238,6 +252,8 @@ export interface DataBindingWithValue extends DataBinding {
   lastUpdated: string | null;
   lastChanged: string | null;
   historize?: number | null;
+  /** True iff category is streaming AND lastUpdated > category timeout (spec 116). */
+  stale: boolean;
 }
 
 export interface OrderBindingWithDetails extends OrderBinding {
@@ -266,6 +282,10 @@ export interface EquipmentWithDetails extends Equipment {
   dataBindings: DataBindingWithValue[];
   orderBindings: OrderBindingWithDetails[];
   computedData?: ComputedDataEntry[];
+  /** Derived availability (spec 116). Always present. */
+  status: EquipmentStatus;
+  /** Populated only when status !== "online". */
+  statusReason?: EquipmentStatusReason;
 }
 
 // ============================================================
@@ -401,6 +421,13 @@ export type EngineEvent =
       alias: string;
       value: unknown;
       previous: unknown;
+    }
+  | {
+      type: "equipment.status.changed";
+      equipmentId: string;
+      equipmentName: string;
+      oldStatus: EquipmentStatus;
+      newStatus: EquipmentStatus;
     }
   | {
       type: "equipment.order.executed";


### PR DESCRIPTION
## Summary

UI implementation of spec 116 — surfaces the `equipment.status` field added in #216 (now merged) across every screen where users look at equipment values. PR 2 of 2.

Closes the original bug: a Shelly Pro 3EM going hors-tension at the breaker now produces a visible ambre/red banner on the Live Energy page within seconds, instead of silently rendering the last value as live.

## Components

- **New `<EquipmentStatusBadge>`** (`ui/src/components/equipments/EquipmentStatusBadge.tsx`): 2 size variants (sm + md), 3 states. Renders nothing for `online` (silence = success), ambre `AlertTriangle` + "Dégradé" for `degraded`, red `WifiOff` + "Déconnecté" for `offline`. Native HTML tooltip lists the offending devices + stale bindings + relative time since the issue started.

## Mount points

- **CompactEquipmentCard** (zone rows): when `offline`, badge **replaces** controls and values entirely — one clear signal beats badge + dashed value + age. When `degraded`, an icon-only badge sits next to the name; controls + last-known values stay rendered (degraded data is still vaguely useful).
- **EquipmentDetailPage** header: md badge next to the equipment name.
- **EnergyDataPanel**: sm badge in the header + caption below the cumuls ("Dernière donnée live il y a X" / "Compteur hors ligne depuis X"). Cumuls themselves stay unchanged — they come from InfluxDB and are historically accurate.
- **LiveEnergyPage**: banner above the flow diagram surfaces the original Shelly bug. Ambre "Données figées depuis X" when any meter is degraded, red "Compteurs déconnectés depuis X" when all meters are offline. The diagram nodes themselves stay unchanged in this PR — a future polish can add per-node stale treatment.
- **ZoneAggregationPills**: appends "(N indispo.)" hint to temperature, humidity, luminosity, lights, shutters pills when `unavailableEquipmentsByCategory > 0`.

## WebSocket reactivity

`useEquipments` handles the new `equipment.status.changed` event with an optimistic local status flip (instant badge feedback) + a `fetchEquipments()` to pull the fresh `statusReason` payload needed for the tooltip.

## i18n

14 new keys in `en.json` + `fr.json`:
- `equipment.status.{online,degraded,offline}` + 5 tooltip variants
- `energy.cumul.{lastLive,offlineSince}`, `energy.live.{dataStale,metersOffline}`
- `zones.aggregate.unavailable_one/_other`

All French copy avoids em-dashes (project convention).

## Out of scope

- Per-node stale treatment inside the LiveEnergyPage flow diagram (banner is the primary signal for v1).
- Dashboard family widgets (`ShuttersWidget`, `LightsWidget`, etc.) — addressed in a follow-up if needed; today the badges on the equipment-level cards + zone pills cover the main user-visible cases.
- Sound or push notifications on transitions — `equipment.status.changed` is now broadcast, easy to wire later from a notification publisher.

## Test plan

- [x] `cd ui && npx tsc -b --noEmit` — clean
- [x] `npx tsc --noEmit` (backend) — clean
- [x] `npx vitest run` — 694 passing, 2 skipped
- [x] `cd ui && npx eslint .` — 0 errors (2 pre-existing warnings out of scope)
- [ ] Manual: stop Z2M plugin → CompactEquipmentCard rows flip to "Déconnecté" within ~1s
- [ ] Manual: flip a Shelly device offline via direct DB → LiveEnergyPage banner appears, EnergyDataPanel shows caption
- [ ] Manual: French + English locale spot-check