### PR TITLE
feat(api): add GET /api/v1/system/sunlight

### DIFF
--- a/src/api/routes/system.test.ts
+++ b/src/api/routes/system.test.ts
@@ -1,0 +1,87 @@
+import Fastify from "fastify";
+import { describe, it, expect, afterEach } from "vitest";
+import { createLogger } from "../../core/logger.js";
+import { registerSystemRoutes, type TzInfo } from "./system.js";
+import type { SunlightManager, SunlightData } from "../../zones/sunlight-manager.js";
+
+const logger = createLogger("silent").logger;
+
+interface BuildOpts {
+  authed?: boolean;
+  sunlight?: SunlightData;
+}
+
+async function buildApp(opts: BuildOpts = {}) {
+  const tzInfo: TzInfo = { tz: "Europe/Paris", source: "env", offsetHours: 2 };
+  const sunlight: SunlightData = opts.sunlight ?? {
+    sunrise: "06:12",
+    sunset: "21:31",
+    isDaylight: true,
+  };
+  const sunlightManager = {
+    getSunlightData: () => sunlight,
+  } as unknown as SunlightManager;
+
+  const app = Fastify({ logger: false });
+
+  if (opts.authed) {
+    app.addHook("preHandler", async (request) => {
+      request.auth = { userId: "u1", role: "admin" };
+    });
+  }
+
+  registerSystemRoutes(app, {
+    versionChecker: {} as never,
+    updateManager: {} as never,
+    tzInfo,
+    sunlightManager,
+    logger,
+  });
+  await app.ready();
+  return app;
+}
+
+describe("GET /api/v1/system/sunlight", () => {
+  let openApp: ReturnType<typeof Fastify> | null = null;
+
+  afterEach(async () => {
+    if (openApp) await openApp.close();
+    openApp = null;
+  });
+
+  it("rejects unauthenticated callers with 401", async () => {
+    openApp = await buildApp({ authed: false });
+    const res = await openApp.inject({ method: "GET", url: "/api/v1/system/sunlight" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns now + tz + sunlight snapshot to any authenticated user", async () => {
+    openApp = await buildApp({
+      authed: true,
+      sunlight: { sunrise: "06:12", sunset: "21:31", isDaylight: true },
+    });
+    const res = await openApp.inject({ method: "GET", url: "/api/v1/system/sunlight" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.tz).toBe("Europe/Paris");
+    expect(body.offsetHours).toBe(2);
+    expect(body.sunrise).toBe("06:12");
+    expect(body.sunset).toBe("21:31");
+    expect(body.isDaylight).toBe(true);
+    expect(typeof body.now).toBe("string");
+    expect(() => new Date(body.now).toISOString()).not.toThrow();
+  });
+
+  it("forwards null sunlight values before the first compute", async () => {
+    openApp = await buildApp({
+      authed: true,
+      sunlight: { sunrise: null, sunset: null, isDaylight: null },
+    });
+    const res = await openApp.inject({ method: "GET", url: "/api/v1/system/sunlight" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.sunrise).toBeNull();
+    expect(body.sunset).toBeNull();
+    expect(body.isDaylight).toBeNull();
+  });
+});

--- a/src/api/routes/system.ts
+++ b/src/api/routes/system.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { Logger } from "../../core/logger.js";
 import type { VersionChecker } from "../../core/version-checker.js";
 import type { UpdateManager } from "../../core/update-manager.js";
+import type { SunlightManager } from "../../zones/sunlight-manager.js";
 
 export interface TzInfo {
   tz: string;
@@ -13,6 +14,7 @@ interface SystemDeps {
   versionChecker: VersionChecker;
   updateManager: UpdateManager;
   tzInfo: TzInfo;
+  sunlightManager: SunlightManager;
   logger: Logger;
 }
 
@@ -20,7 +22,7 @@ interface SystemDeps {
 const CHECK_NOW_MIN_INTERVAL_MS = 10_000;
 
 export function registerSystemRoutes(app: FastifyInstance, deps: SystemDeps): void {
-  const { versionChecker, updateManager, tzInfo, logger: parentLogger } = deps;
+  const { versionChecker, updateManager, tzInfo, sunlightManager, logger: parentLogger } = deps;
   const logger = parentLogger.child({ module: "system-routes" });
 
   let lastCheckNow = 0;
@@ -105,6 +107,30 @@ export function registerSystemRoutes(app: FastifyInstance, deps: SystemDeps): vo
       return reply.code(401).send({ error: "Authentication required" });
     }
     return tzInfo;
+  });
+
+  // GET /api/v1/system/sunlight — current server time + daylight state
+  //
+  // Combines the SunlightManager's cached sunrise/sunset/isDaylight
+  // with a fresh `now` ISO timestamp and the timezone snapshot so that
+  // headless clients (the energy display firmware) can derive local
+  // time and switch to a dimmed brightness profile after sunset
+  // without running their own NTP client.
+  //
+  // Accessible to ANY authenticated user (read-only, no PII).
+  app.get("/api/v1/system/sunlight", async (request, reply) => {
+    if (!request.auth) {
+      return reply.code(401).send({ error: "Authentication required" });
+    }
+    const data = sunlightManager.getSunlightData();
+    return {
+      now: new Date().toISOString(),
+      tz: tzInfo.tz,
+      offsetHours: tzInfo.offsetHours,
+      sunrise: data.sunrise,
+      sunset: data.sunset,
+      isDaylight: data.isDaylight,
+    };
   });
 
   // POST /api/v1/system/restart — trigger a container restart via helper

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -36,6 +36,7 @@ import type { NotificationPublishService } from "../notifications/notification-p
 import type { PackageManager } from "../packages/package-manager.js";
 import type { PluginLoader } from "../plugins/plugin-loader.js";
 import type { BackupManager } from "../backup/backup-manager.js";
+import type { SunlightManager } from "../zones/sunlight-manager.js";
 import { registerAuthMiddleware } from "../auth/auth-middleware.js";
 import { registerDeviceRoutes } from "./routes/devices.js";
 import { registerHealthRoutes } from "./routes/health.js";
@@ -98,6 +99,7 @@ interface ServerDeps {
     source: "env" | "auto" | "fallback";
     offsetHours: number;
   };
+  sunlightManager: SunlightManager;
   eventBus: EventBus;
   integrationRegistry: IntegrationRegistry;
   logBuffer: LogRingBuffer;
@@ -136,6 +138,7 @@ export async function createServer(deps: ServerDeps) {
     versionChecker,
     updateManager,
     tzInfo,
+    sunlightManager,
     eventBus,
     integrationRegistry,
     logBuffer,
@@ -290,7 +293,13 @@ export async function createServer(deps: ServerDeps) {
     logger,
   });
   registerAuditRoutes(app, { auditLogger, logger });
-  registerSystemRoutes(app, { versionChecker, updateManager, tzInfo, logger });
+  registerSystemRoutes(app, {
+    versionChecker,
+    updateManager,
+    tzInfo,
+    sunlightManager,
+    logger,
+  });
   registerLogRoutes(app, { logBuffer, logger });
   registerActivityRoutes(app, { activityBuffer, logger });
   registerWebSocket(app, { eventBus, authService, logBuffer, logger, corsOrigins });

--- a/src/index.ts
+++ b/src/index.ts
@@ -357,6 +357,7 @@ async function main() {
     versionChecker,
     updateManager,
     tzInfo,
+    sunlightManager,
     eventBus,
     integrationRegistry,
     logBuffer,


### PR DESCRIPTION
## Summary

- New read-only endpoint that exposes the existing `SunlightManager` cache (sunrise / sunset / isDaylight) plus a fresh server-side ISO timestamp and the configured timezone.
- Lets headless clients (the energy display firmware) derive local time and switch to a dimmed brightness profile after sunset without bundling their own NTP client.
- Accessible to any authenticated user. Returns `null` for sunrise/sunset/isDaylight before the manager has computed its first sample.

## Test plan

- [x] vitest \`src/api/routes/system.test.ts\` — 3/3 pass (401 when unauthenticated, full payload when authed, null passthrough)
- [x] tsc --noEmit clean
- [ ] manual: \`curl -H 'Authorization: Bearer <token>' http://sowelox:3000/api/v1/system/sunlight\` returns sunrise / sunset / isDaylight