### PR TITLE
release: v1.14.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,14 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.14.x — Disponibilité des équipements
+
+### v1.14.0 — 2026-05-26 { #v1-14-0 }
+
+- Équipements : chaque équipement expose désormais un champ `status` dérivé (`online` / `degraded` / `offline`), calculé en mémoire à partir du `status` des devices sous-jacents et de la fraîcheur des bindings streaming (spec 116). L'UI affiche des pastilles ambre "Dégradé" et rouge "Déconnecté" sur toutes les surfaces où l'utilisateur voit des valeurs d'équipement : lignes compactes de zone (la pastille remplace les contrôles quand l'équipement est offline), header de la page détail, panneau de cumuls énergie (avec caption de fraîcheur), pastilles d'agrégation de zone (hint `(N indispo.)` quand un équipement offline a été exclu d'une métrique). La page Live Energy gagne une bannière en haut qui flag explicitement les compteurs périmés ou déconnectés. Déclenché par un vrai bug : un Shelly Pro 3EM coupé au tableau gardait le graphe d'énergie live affichant sa dernière valeur comme si c'était live, sans aucune indication.
+- Contrat plugin : une nouvelle section obligatoire de `plugin-development.md` documente que chaque plugin DOIT maintenir `device.status` à jour via `updateDeviceStatus()`. Un audit prod a trouvé 24 devices coincés à "online" avec un `lastSeen` entre 1 heure et 49 jours ; ce sont des bugs plugin upstream à corriger (topic `availability` Z2M, déconnexion Socket.IO MCZ, etc.), pas des gaps du core Sowel. Sowel n'ajoute volontairement pas de watchdog générique `device.lastSeen > timeout` car les capteurs Zigbee sur pile peuvent rester silencieux pendant des jours sans être offline.
+- API : nouvel endpoint `GET /api/v1/system/sunlight` qui expose sunrise / sunset / isDaylight (#218). Aussi : les payloads `GET /equipments` et `GET /equipments/:id` gagnent `status` + `statusReason` optionnel ; le payload `GET /zones/:id/aggregated` gagne `unavailableEquipmentsByCategory` ; le WebSocket gagne un nouvel event `equipment.status.changed` diffusé à chaque transition.
+
 ## 1.13.x — Équipement store banne
 
 ### v1.13.2 — 2026-05-24 { #v1-13-2 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,14 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.14.x — Equipment availability
+
+### v1.14.0 — 2026-05-26 { #v1-14-0 }
+
+- Equipments: every equipment now exposes a derived `status` field (`online` / `degraded` / `offline`) computed in memory from the backing devices' `status` and the freshness of streaming bindings (spec 116). The UI ships ambre "Degraded" and red "Disconnected" badges on every surface where users see equipment values: compact zone rows (badge replaces controls when fully offline), equipment detail header, energy cumuls panel (with last-update caption), zone aggregation pills (`(N unavailable)` hint when an offline equipment was excluded from a metric). The Live Energy page gains a top banner that flags stale or disconnected meters explicitly. Triggered by a real bug: a Shelly Pro 3EM coupé au tableau kept the live energy graph displaying its last value as if it was live, with zero indication of staleness.
+- Plugin contract: a new mandatory section in `plugin-development.md` documents that every plugin MUST keep `device.status` truthful via `updateDeviceStatus()`. A prod audit found 24 devices stuck at "online" with `lastSeen` between 1 hour and 49 days; those are upstream plugin bugs to fix (Z2M `availability` topic, MCZ Socket.IO disconnect, etc.), not Sowel core gaps. Sowel intentionally does not add a generic `device.lastSeen > timeout` watchdog because battery-powered Zigbee endpoints can stay silent for days without being offline.
+- API: new `GET /api/v1/system/sunlight` endpoint exposing sunrise / sunset / isDaylight (#218). Also: `GET /equipments` and `GET /equipments/:id` payloads gain `status` + optional `statusReason`; `GET /zones/:id/aggregated` payload gains `unavailableEquipmentsByCategory`; WebSocket gains a new `equipment.status.changed` event broadcast on every transition.
+
 ## 1.13.x — Awning equipment
 
 ### v1.13.2 — 2026-05-24 { #v1-13-2 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.13.2",
+  "version": "1.14.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.13.2",
+  "version": "1.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Release v1.14.0 — ships **spec 116 (equipment availability propagation)** plus the small `GET /api/v1/system/sunlight` API addition merged in #218.

## Changes since v1.13.2

- #216 — feat(equipments): derive equipment availability from devices + streaming staleness (spec 116, backend)
- #217 — feat(ui): equipment availability badges + live energy stale HUD (spec 116, UI)
- #218 — feat(api): add GET /api/v1/system/sunlight

## Release notes

Added in both `docs/release-notes.md` (EN) and `docs/release-notes.fr.md` (FR) with the mandatory `{ #v1-14-0 }` anchor for the in-app UpdatesSheet deep link (spec 108).

## Test plan

- [x] `npm run validate` — passes (typecheck + lint + 695 tests + UI typecheck/lint)
- [x] Release notes entry present in both EN + FR with the anchor
- [ ] CI build picks up `v1.14.0` tag after merge and publishes to ghcr.io/mchacher/sowel:1.14.0 + :latest