### PR TITLE
fix(ui): production total matches stacked bars

### DIFF
--- a/ui/src/components/energy/ProductionPage.tsx
+++ b/ui/src/components/energy/ProductionPage.tsx
@@ -4,6 +4,7 @@ import { useEnergy } from "../../store/useEnergy";
 import { PeriodSelector } from "./PeriodSelector";
 import { ProductionBarChart } from "./ProductionBarChart";
 import { EnergyMobileNav } from "./EnergyMobileNav";
+import { displayedProductionTotalWh } from "./productionTotal";
 
 function formatKWh(wh: number, period: string): string {
   const kwh = wh / 1000;
@@ -64,7 +65,7 @@ export function ProductionPage() {
                 </span>
               </div>
               <div className="text-[15px] font-semibold text-text tabular-nums mt-1">
-                Total : {formatKWh(history.totals.total_production, period)} kWh
+                Total : {formatKWh(displayedProductionTotalWh(history.totals), period)} kWh
               </div>
             </div>
           )}

--- a/ui/src/components/energy/productionTotal.test.ts
+++ b/ui/src/components/energy/productionTotal.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { EnergyTotals } from "../../types";
+import { displayedProductionTotalWh } from "./productionTotal";
+
+function totals(partial: Partial<EnergyTotals>): EnergyTotals {
+  return {
+    total_consumption: 0,
+    total_hp: 0,
+    total_hc: 0,
+    total_production: 0,
+    total_autoconso: 0,
+    total_injection: 0,
+    ...partial,
+  };
+}
+
+describe("displayedProductionTotalWh", () => {
+  it("returns autoconso + injection", () => {
+    expect(
+      displayedProductionTotalWh(
+        totals({ total_autoconso: 13_600, total_injection: 2_480 }),
+      ),
+    ).toBe(16_080);
+  });
+
+  it("ignores total_production from the raw inverter series", () => {
+    // Real-world case from the bug report: solar meter measured 15.01 kWh
+    // but autoconso + injection on the grid meter side sums to 16.08 kWh
+    // because of per-minute clamping when injection > solar. The label
+    // must match the stacked bars, not the raw inverter total.
+    const t = totals({
+      total_production: 15_010,
+      total_autoconso: 13_600,
+      total_injection: 2_480,
+    });
+    expect(displayedProductionTotalWh(t)).toBe(16_080);
+  });
+
+  it("returns 0 when both components are 0", () => {
+    expect(displayedProductionTotalWh(totals({}))).toBe(0);
+  });
+});

--- a/ui/src/components/energy/productionTotal.ts
+++ b/ui/src/components/energy/productionTotal.ts
@@ -1,0 +1,15 @@
+import type { EnergyTotals } from "../../types";
+
+/**
+ * Production total shown under the chart legend.
+ *
+ * Equals the sum of the stacked bars (autoconso + injection) so the
+ * label always matches what the user sees on screen. We deliberately do
+ * NOT use `total_production` (raw inverter `energy` alias): grid and
+ * solar meters drift, so per-minute clamping in SelfConsumptionWriter
+ * (autoconso = max(0, solar - injection)) can leave the two series out
+ * of sync once injection > solar.
+ */
+export function displayedProductionTotalWh(totals: EnergyTotals): number {
+  return totals.total_autoconso + totals.total_injection;
+}


### PR DESCRIPTION
## Summary

The **Total** label under the Production chart legend showed a different value from the bars it sat under. Today: bars summed to **16,08 kWh** (autoconso 13,60 + injection 2,48) but the label read **15,01 kWh**.

### Root cause

Two independent InfluxDB series feed the chart:

| Element | Source |
|---|---|
| Stacked bars + per-hour tooltip + legend | `autoconso` + `injection` aliases (grid-side computation by `SelfConsumptionWriter`) |
| **Total label** | `energy` alias on the production meter (raw inverter series via `HistoryWriter`) |

The invariant `autoconso + injection = solar` only holds when `solar >= injection`. Per-minute, when the grid meter momentarily reports more export than the solar meter measured production (cross-meter time skew, calibration noise, or even just two 60s windows not perfectly aligned), the writer clamps `autoconso = max(0, solar - injection) = 0` but `injection` keeps the full grid value. Summed over a day, this leaves ~1 kWh of `injection` excess unmatched by the raw `energy` series. Hence the visible mismatch.

### Fix

Display `total_autoconso + total_injection` in the label so it always equals the stacked bars by construction. The raw `total_production` series is untouched and still available in the API for anyone wanting to compare the two physical meters.

Extracted as `displayedProductionTotalWh()` with a unit test that documents the rationale and pins the bug-report numbers as a regression case.

## Test plan

- [x] `npx vitest run ui/src/components/energy/productionTotal.test.ts` — 3 tests pass
- [x] `cd ui && npx tsc -b --noEmit` — clean
- [x] `cd ui && npx eslint src/components/energy/...` — clean
- [ ] Visual check in production: label under the Production chart equals `autoconso + injection` displayed in the legend