### PR TITLE
release: v1.14.1

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.14.x — Disponibilité des équipements
 
+### v1.14.1 — 2026-05-26 { #v1-14-1 }
+
+- Fix (UI) : le libellé "Total" sous le graphique Production solaire correspond désormais à la somme des barres empilées (autoconsommation + injection réseau). Avant, ce libellé venait de la série brute `energy` de l'onduleur alors que les barres cumulaient les séries `autoconso` et `injection` calculées par minute, et les deux pouvaient diverger d'environ 1 kWh par jour à cause du décalage entre les compteurs solaire et réseau. Cosmétique uniquement, aucune donnée perdue.
+
 ### v1.14.0 — 2026-05-26 { #v1-14-0 }
 
 - Équipements : chaque équipement expose désormais un champ `status` dérivé (`online` / `degraded` / `offline`), calculé en mémoire à partir du `status` des devices sous-jacents et de la fraîcheur des bindings streaming (spec 116). L'UI affiche des pastilles ambre "Dégradé" et rouge "Déconnecté" sur toutes les surfaces où l'utilisateur voit des valeurs d'équipement : lignes compactes de zone (la pastille remplace les contrôles quand l'équipement est offline), header de la page détail, panneau de cumuls énergie (avec caption de fraîcheur), pastilles d'agrégation de zone (hint `(N indispo.)` quand un équipement offline a été exclu d'une métrique). La page Live Energy gagne une bannière en haut qui flag explicitement les compteurs périmés ou déconnectés. Déclenché par un vrai bug : un Shelly Pro 3EM coupé au tableau gardait le graphe d'énergie live affichant sa dernière valeur comme si c'était live, sans aucune indication.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.14.x — Equipment availability
 
+### v1.14.1 — 2026-05-26 { #v1-14-1 }
+
+- Fix (UI): the "Total" label under the Production solar chart now equals the sum of the stacked bars (autoconsumption + grid injection). Previously the label was sourced from the raw inverter `energy` series while the bars summed the per-minute `autoconso` and `injection` series, and the two could drift by ~1 kWh per day because of cross-meter timing skew. Visual only, no data lost.
+
 ### v1.14.0 — 2026-05-26 { #v1-14-0 }
 
 - Equipments: every equipment now exposes a derived `status` field (`online` / `degraded` / `offline`) computed in memory from the backing devices' `status` and the freshness of streaming bindings (spec 116). The UI ships ambre "Degraded" and red "Disconnected" badges on every surface where users see equipment values: compact zone rows (badge replaces controls when fully offline), equipment detail header, energy cumuls panel (with last-update caption), zone aggregation pills (`(N unavailable)` hint when an offline equipment was excluded from a metric). The Live Energy page gains a top banner that flags stale or disconnected meters explicitly. Triggered by a real bug: a Shelly Pro 3EM coupé au tableau kept the live energy graph displaying its last value as if it was live, with zero indication of staleness.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.14.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Patch release bundling [#220](https://github.com/mchacher/sowel/pull/220): production chart total now matches the stacked bars.
- Release notes added to `docs/release-notes.{md,fr.md}` under `## 1.14.x` with the required `{ #v1-14-1 }` anchor.

## Test plan

- [x] `npm run validate` (typecheck + lint + format + 698 tests + UI validate) green locally
- [ ] CI green
- [ ] Merge then tag `v1.14.1` to trigger the GitHub Actions release build