### PR TITLE
release: v1.15.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,12 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.15.x — Décomposition consommation live
+
+### v1.15.0 — 2026-05-27 { #v1-15-0 }
+
+- Feature (UI Énergie) : un donut "Décomposition consommation" apparaît désormais sous le diagramme Maison/Réseau/Solaire de la page Live (spec 117). Un segment par sous-compteur `energy_meter` et un segment "Autre" pour la part non instrumentée, dimensionnés par la puissance instantanée (W). Mise à jour réactive via le flux WebSocket des équipements, aucun nouvel endpoint ni changement de base. Les couleurs reprennent celles du graphique By-usage historique pour qu'un même clamp ait la même couleur dans les deux vues. Les sous-compteurs hors-ligne disparaissent du donut mais restent grisés dans la légende.
+
 ## 1.14.x — Disponibilité des équipements
 
 ### v1.14.1 — 2026-05-26 { #v1-14-1 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,12 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.15.x — Live submeter breakdown
+
+### v1.15.0 — 2026-05-27 { #v1-15-0 }
+
+- Feature (Energy UI): a "Consumption breakdown" donut now sits below the Maison/Réseau/Solaire diagram on the Live page (spec 117). One segment per `energy_meter` submeter and an "Other" residual for what no clamp measures, sized by instantaneous power (W). Updates reactively from the existing equipments WebSocket stream, no new endpoint or DB change. Colors match the historical By-usage chart so a given clamp keeps the same color in both views. Offline submeters drop out of the donut but stay listed greyed in the legend.
+
 ## 1.14.x — Equipment availability
 
 ### v1.14.1 — 2026-05-26 { #v1-14-1 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.14.1",
+  "version": "1.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release v1.15.0 — Live submeter breakdown donut on the Live energy page (spec 117).

See docs/release-notes.md and docs/release-notes.fr.md (entries with anchor #v1-15-0) for the full notes.