### PR TITLE
feat(api): add ?type filter on GET /api/v1/equipments

### DIFF
--- a/docs/technical/api-reference.fr.md
+++ b/docs/technical/api-reference.fr.md
@@ -96,14 +96,14 @@ Toutes les routes de gestion des utilisateurs nécessitent le rôle admin.
 
 ## Equipments
 
-| Method   | Path                                   | Description                                                                                                                                             |
-| -------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET`    | `/api/v1/equipments`                   | Liste tous les équipements avec leurs liaisons et données courantes.                                                                                    |
-| `GET`    | `/api/v1/equipments/:id`               | Récupère un équipement avec liaisons et données courantes.                                                                                              |
-| `POST`   | `/api/v1/equipments`                   | Crée un équipement. Body : `{ name, type, zoneId, icon?, description?, deviceIds? }`. Si `deviceIds` est fourni, des liaisons automatiques sont créées. |
-| `PUT`    | `/api/v1/equipments/:id`               | Met à jour un équipement. Body : `{ name?, type?, zoneId?, icon?, description?, enabled? }`.                                                            |
-| `DELETE` | `/api/v1/equipments/:id`               | Supprime un équipement. Retourne 204.                                                                                                                   |
-| `POST`   | `/api/v1/equipments/:id/orders/:alias` | Exécute un ordre d'équipement. Body : `{ value }`.                                                                                                      |
+| Method   | Path                                   | Description                                                                                                                                                                                                      |
+| -------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/v1/equipments`                   | Liste tous les équipements avec leurs liaisons et données courantes. Paramètre optionnel `?type=<EquipmentType>` pour filtrer sur un seul type (ex. `energy_meter`). Une valeur inconnue renvoie une liste vide. |
+| `GET`    | `/api/v1/equipments/:id`               | Récupère un équipement avec liaisons et données courantes.                                                                                                                                                       |
+| `POST`   | `/api/v1/equipments`                   | Crée un équipement. Body : `{ name, type, zoneId, icon?, description?, deviceIds? }`. Si `deviceIds` est fourni, des liaisons automatiques sont créées.                                                          |
+| `PUT`    | `/api/v1/equipments/:id`               | Met à jour un équipement. Body : `{ name?, type?, zoneId?, icon?, description?, enabled? }`.                                                                                                                     |
+| `DELETE` | `/api/v1/equipments/:id`               | Supprime un équipement. Retourne 204.                                                                                                                                                                            |
+| `POST`   | `/api/v1/equipments/:id/orders/:alias` | Exécute un ordre d'équipement. Body : `{ value }`.                                                                                                                                                               |
 
 ### Data Bindings
 

--- a/docs/technical/api-reference.md
+++ b/docs/technical/api-reference.md
@@ -96,14 +96,14 @@ All user management routes require admin role.
 
 ## Equipments
 
-| Method   | Path                                   | Description                                                                                                                            |
-| -------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET`    | `/api/v1/equipments`                   | List all equipments with bindings, current data, and derived `status` (see [Equipment status](#equipment-status-spec-116)).            |
-| `GET`    | `/api/v1/equipments/:id`               | Get equipment with bindings, current data, and derived `status`.                                                                       |
-| `POST`   | `/api/v1/equipments`                   | Create equipment. Body: `{ name, type, zoneId, icon?, description?, deviceIds? }`. If `deviceIds` provided, auto-bindings are created. |
-| `PUT`    | `/api/v1/equipments/:id`               | Update equipment. Body: `{ name?, type?, zoneId?, icon?, description?, enabled? }`.                                                    |
-| `DELETE` | `/api/v1/equipments/:id`               | Delete equipment. Returns 204.                                                                                                         |
-| `POST`   | `/api/v1/equipments/:id/orders/:alias` | Execute an equipment order. Body: `{ value }`.                                                                                         |
+| Method   | Path                                   | Description                                                                                                                                                                                                                                       |
+| -------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/v1/equipments`                   | List all equipments with bindings, current data, and derived `status` (see [Equipment status](#equipment-status-spec-116)). Optional `?type=<EquipmentType>` narrows to a single type (e.g. `energy_meter`). Unknown values return an empty list. |
+| `GET`    | `/api/v1/equipments/:id`               | Get equipment with bindings, current data, and derived `status`.                                                                                                                                                                                  |
+| `POST`   | `/api/v1/equipments`                   | Create equipment. Body: `{ name, type, zoneId, icon?, description?, deviceIds? }`. If `deviceIds` provided, auto-bindings are created.                                                                                                            |
+| `PUT`    | `/api/v1/equipments/:id`               | Update equipment. Body: `{ name?, type?, zoneId?, icon?, description?, enabled? }`.                                                                                                                                                               |
+| `DELETE` | `/api/v1/equipments/:id`               | Delete equipment. Returns 204.                                                                                                                                                                                                                    |
+| `POST`   | `/api/v1/equipments/:id/orders/:alias` | Execute an equipment order. Body: `{ value }`.                                                                                                                                                                                                    |
 
 ### Equipment status (spec 116)
 

--- a/src/api/routes/equipments.test.ts
+++ b/src/api/routes/equipments.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+import { createLogger } from "../../core/logger.js";
+import { registerEquipmentRoutes } from "./equipments.js";
+
+// The ?type filter is the only logic worth exercising at the route
+// layer; the rest of the equipment surface is covered by manager-level
+// tests. A mocked EquipmentManager keeps this test fast and isolated.
+function makeManager(fixture: Array<{ id: string; type: string }>) {
+  return {
+    getAllWithDetails: () => fixture,
+    getByIdWithDetails: () => null,
+    // The rest of the EquipmentManager interface is unused by the
+    // routes we exercise here; we cast through `unknown` so the mock
+    // does not have to enumerate every signature.
+  } as unknown as Parameters<typeof registerEquipmentRoutes>[1]["equipmentManager"];
+}
+
+describe("GET /api/v1/equipments — ?type filter", () => {
+  let app: ReturnType<typeof Fastify>;
+
+  const fixture = [
+    { id: "1", type: "light_onoff" },
+    { id: "2", type: "energy_meter" },
+    { id: "3", type: "energy_meter" },
+    { id: "4", type: "main_energy_meter" },
+  ];
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    registerEquipmentRoutes(app, {
+      equipmentManager: makeManager(fixture),
+      logger: createLogger("silent").logger,
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("returns all equipments when ?type is omitted", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/equipments" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(4);
+  });
+
+  it("narrows the result set to a single type when ?type is set", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/equipments?type=energy_meter",
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Array<{ id: string; type: string }>;
+    expect(body).toHaveLength(2);
+    expect(body.every((eq) => eq.type === "energy_meter")).toBe(true);
+  });
+
+  it("returns an empty list for an unknown type (pass-through, no 400)", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/equipments?type=does_not_exist",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+});

--- a/src/api/routes/equipments.ts
+++ b/src/api/routes/equipments.ts
@@ -12,9 +12,15 @@ interface EquipmentsDeps {
 export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDeps): void {
   const { equipmentManager } = deps;
 
-  // GET /api/v1/equipments — List all equipments with bindings and current data
-  app.get("/api/v1/equipments", async () => {
-    return equipmentManager.getAllWithDetails();
+  // GET /api/v1/equipments — List all equipments with bindings and current data.
+  // Optional ?type=<EquipmentType> narrows the response to a single type
+  // (e.g. ?type=energy_meter for clients that only render submeter clamps).
+  // Unknown values yield an empty list rather than 400 so callers can
+  // safely pass-through user input without their own validation.
+  app.get<{ Querystring: { type?: string } }>("/api/v1/equipments", async (request) => {
+    const all = equipmentManager.getAllWithDetails();
+    const typeFilter = request.query.type;
+    return typeFilter ? all.filter((eq) => eq.type === typeFilter) : all;
   });
 
   // GET /api/v1/equipments/:id — Get equipment with bindings and current data


### PR DESCRIPTION
## Summary

- New optional `?type=<EquipmentType>` query param on `GET /api/v1/equipments`. Returns only equipments of the requested type.
- Unknown values return an empty list (pass-through, no 400) so callers can safely forward user input.
- Documented in `docs/technical/api-reference.{md,fr.md}`.

## Why

The sowel-energy-display firmware is gaining a live consumption breakdown screen (next iter 029). It only cares about `energy_meter` equipments. Without this filter the device would have to parse the full ~76-equipment payload (~100 KB) every poll on a 320 KB SRAM ESP32. With the filter, the payload drops to the 2-3 relevant entries (~5 KB).

## Test plan

- [x] New vitest cases: omitted / known type / unknown type → `46 files passed, 719/721 tests pass` (2 pre-existing skipped)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/api/routes/equipments.ts` clean
- [ ] Manual prod sanity: `curl -H "Authorization: Bearer ..." 'http://192.168.0.230:3000/api/v1/equipments?type=energy_meter'` (post-merge)