### PR TITLE
docs(user): add Preparing the Host page (Docker + Mosquitto)

### DIFF
--- a/docs/user/getting-started.fr.md
+++ b/docs/user/getting-started.fr.md
@@ -7,6 +7,9 @@ Cette page vous guide à travers l'installation de Sowel, la première connexion
 - **Docker** (recommandé) ou **Node.js 20+** pour une installation manuelle
 - Au moins une intégration installée depuis le catalogue intégré (**Administration > Plugins**). Sowel propose des plugins pour Zigbee2MQTT, Shelly, Panasonic, MCZ, Netatmo, Legrand, Tasmota, SmartThings, et bien d'autres. Un nouveau plugin s'installe en quelques secondes et le catalogue s'enrichit régulièrement.
 
+!!! tip "Hôte vierge ?"
+Si Docker n'est pas encore installé sur votre machine, ou si vous prévoyez d'utiliser des plugins MQTT (Zigbee2MQTT, Tasmota, Shelly...) sans broker existant, consultez d'abord [Préparer l'hôte](host-setup.md). Cette page couvre l'installation de Docker et de Mosquitto sur Raspberry Pi, Debian et Ubuntu.
+
 ## Installation
 
 ### Option 1 : Installation en une commande (recommandée)

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -7,6 +7,9 @@ This page walks you through installing Sowel, logging in for the first time, and
 - **Docker** (recommended) or **Node.js 20+** for manual installation
 - At least one integration installed from the in-app catalogue (**Administration > Plugins**). Sowel ships with plugins for Zigbee2MQTT, Shelly, Panasonic, MCZ, Netatmo, Legrand, Tasmota, SmartThings, and more. New plugins install in seconds and the list grows over time.
 
+!!! tip "Fresh host?"
+If Docker is not yet installed on your machine, or if you plan to use MQTT plugins (Zigbee2MQTT, Tasmota, Shelly...) without an existing broker, read [Preparing the Host](host-setup.md) first. That page covers Docker and Mosquitto setup on Raspberry Pi, Debian and Ubuntu.
+
 ## Installation
 
 ### Option 1: One-command install (recommended)

--- a/docs/user/host-setup.fr.md
+++ b/docs/user/host-setup.fr.md
@@ -1,0 +1,136 @@
+# Préparer l'hôte
+
+Si vous installez Sowel sur une machine fraîchement préparée (Raspberry Pi, mini-PC, VM Debian/Ubuntu), cette page couvre les deux dépendances que Sowel n'embarque pas : **Docker** et un **broker MQTT** (optionnel, selon les plugins que vous utilisez).
+
+!!! info "Vous avez déjà Docker et/ou un broker MQTT ?"
+Passez directement à [Premiers pas — Installation](getting-started.md#installation).
+
+## Spécificités Raspberry Pi
+
+Cette section ne concerne **que les Raspberry Pi** (3, 4, 5). Sur un PC/serveur Debian ou Ubuntu standard, sautez à [Installer Docker](#installer-docker).
+
+### Système 64-bit obligatoire
+
+Sowel ne fonctionne qu'en 64-bit. Vérifiez :
+
+```bash
+uname -m   # doit retourner "aarch64"
+```
+
+Si vous voyez `armv7l`, reflashez la carte SD avec **Raspberry Pi OS Lite 64-bit** via Raspberry Pi Imager.
+
+### Carte SD ou SSD
+
+Sowel et InfluxDB écrivent en continu. Une carte SD grand public meurt typiquement en 6 à 12 mois.
+
+- **Minimum** : carte SD haute endurance (SanDisk High Endurance, Samsung PRO Endurance), 64 Go ou plus.
+- **Recommandé** : SSD USB3 branché sur un port USB bleu. Beaucoup plus fiable et plus rapide.
+
+### Augmenter le swap
+
+Par défaut, Raspberry Pi OS alloue 100 Mo de swap, ce qui est trop juste lors des compactions InfluxDB.
+
+```bash
+sudo nano /etc/dphys-swapfile
+# changer CONF_SWAPSIZE=100 en CONF_SWAPSIZE=1024
+sudo systemctl restart dphys-swapfile
+```
+
+## Installer Docker
+
+Procédure officielle, valable sur Raspberry Pi OS, Debian et Ubuntu.
+
+```bash
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+```
+
+Puis **logout/login** (ou `newgrp docker`) pour que la nouvelle appartenance au groupe prenne effet :
+
+```bash
+newgrp docker
+groups        # doit maintenant inclure "docker"
+docker ps     # doit fonctionner sans sudo
+```
+
+!!! warning "Ne pas sauter le re-login"
+Si vous lancez le script d'installation Sowel sans re-login, il échoue avec `Error: cannot reach the Docker daemon`. Votre utilisateur est bien dans le groupe `docker`, mais votre **session shell courante** ne le sait pas encore.
+
+Activez Docker au boot (normalement fait automatiquement, à vérifier) :
+
+```bash
+sudo systemctl enable docker
+docker run --rm hello-world    # test
+```
+
+## Installer un broker MQTT (optionnel)
+
+!!! info "Sowel n'embarque pas de broker MQTT"
+Les plugins basés sur MQTT (Zigbee2MQTT, LoRa2MQTT, Tasmota, Shelly...) ont besoin d'un broker accessible sur le LAN. Si vous en avez déjà un, passez à la suite. Si vous n'utilisez aucun plugin MQTT, cette section ne vous concerne pas.
+
+Procédure pour Mosquitto, valable sur Raspberry Pi OS, Debian et Ubuntu.
+
+### Installation
+
+```bash
+sudo apt update
+sudo apt install -y mosquitto mosquitto-clients
+```
+
+Le service démarre automatiquement mais n'écoute que sur `localhost:1883` par défaut depuis Debian Bookworm.
+
+### Ouvrir au LAN
+
+Créez `/etc/mosquitto/conf.d/sowel.conf` :
+
+```
+listener 1883 0.0.0.0
+allow_anonymous true
+```
+
+Deux lignes suffisent. Toutes les autres options (`persistence`, `persistence_location`, etc.) sont déjà dans le `/etc/mosquitto/mosquitto.conf` par défaut. **Ne les redéfinissez pas**, Mosquitto refuse les valeurs dupliquées.
+
+Puis :
+
+```bash
+sudo systemctl restart mosquitto
+sudo systemctl status mosquitto   # doit afficher "active (running)"
+```
+
+!!! warning "Sécurité de `allow_anonymous true`"
+Sans authentification, n'importe quelle machine du LAN peut publier et s'abonner. **Acceptable** pour une installation domestique purement LAN derrière la box. **À éviter** si le port 1883 est exposé à Internet, ou sur un LAN partagé non fiable.
+
+    Pour ajouter un mot de passe, voir la [documentation Mosquitto](https://mosquitto.org/man/mosquitto-conf-5.html).
+
+### Tester
+
+Depuis une autre machine du LAN :
+
+```bash
+# terminal 1 (abonnement)
+mosquitto_sub -h <ip-de-l'hôte> -p 1883 -t test/#
+
+# terminal 2 (publication)
+mosquitto_pub -h <ip-de-l'hôte> -p 1883 -t test/hello -m "ok"
+```
+
+Si le message arrive, le broker est joignable. Vous pouvez maintenant pointer le plugin Zigbee2MQTT de Sowel (et Z2M lui-même) vers `mqtt://<ip-de-l'hôte>:1883`.
+
+## Dépannage
+
+### `Error: cannot reach the Docker daemon`
+
+Votre utilisateur n'est pas dans le groupe `docker`, ou votre session shell n'a pas rechargé ses groupes. Voir [Installer Docker](#installer-docker).
+
+### Mosquitto refuse de démarrer : `Duplicate persistence_location`
+
+Vous avez redéfini `persistence_location` (ou `persistence`) dans votre `conf.d/sowel.conf`. Ces options sont déjà dans le `mosquitto.conf` par défaut. Retirez-les de votre fichier : il ne doit contenir que `listener` et `allow_anonymous`.
+
+### `Start request repeated too quickly`
+
+Après plusieurs tentatives de démarrage ratées, systemd bloque les nouvelles requêtes `start`. Réinitialisez le compteur :
+
+```bash
+sudo systemctl reset-failed mosquitto
+sudo systemctl start mosquitto
+```

--- a/docs/user/host-setup.md
+++ b/docs/user/host-setup.md
@@ -1,0 +1,136 @@
+# Preparing the Host
+
+If you are installing Sowel on a freshly-prepared machine (Raspberry Pi, mini-PC, Debian/Ubuntu VM), this page covers the two dependencies that Sowel does not ship with: **Docker** and an **MQTT broker** (optional, depending on which plugins you use).
+
+!!! info "Already have Docker and/or an MQTT broker?"
+Skip directly to [Getting Started — Installation](getting-started.md#installation).
+
+## Raspberry Pi specifics
+
+This section only applies to **Raspberry Pi** (3, 4, 5). On a standard Debian or Ubuntu PC/server, jump to [Install Docker](#install-docker).
+
+### 64-bit OS required
+
+Sowel only runs in 64-bit. Check with:
+
+```bash
+uname -m   # must return "aarch64"
+```
+
+If you see `armv7l`, reflash the SD card with **Raspberry Pi OS Lite 64-bit** via Raspberry Pi Imager.
+
+### SD card or SSD
+
+Sowel and InfluxDB write continuously. A consumer-grade SD card typically dies in 6 to 12 months.
+
+- **Minimum**: high-endurance SD card (SanDisk High Endurance, Samsung PRO Endurance), 64 GB or more.
+- **Recommended**: USB3 SSD plugged into a blue USB port. Much more reliable and faster.
+
+### Increase swap
+
+By default Raspberry Pi OS allocates 100 MB of swap, which is too tight when InfluxDB compacts.
+
+```bash
+sudo nano /etc/dphys-swapfile
+# change CONF_SWAPSIZE=100 to CONF_SWAPSIZE=1024
+sudo systemctl restart dphys-swapfile
+```
+
+## Install Docker
+
+Official procedure, valid on Raspberry Pi OS, Debian and Ubuntu.
+
+```bash
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+```
+
+Then **logout/login** (or run `newgrp docker`) so the new group membership takes effect:
+
+```bash
+newgrp docker
+groups        # must now include "docker"
+docker ps     # must work without sudo
+```
+
+!!! warning "Don't skip the re-login"
+If you run the Sowel install script without re-logging in, it fails with `Error: cannot reach the Docker daemon`. Your user is in the `docker` group, but your **current shell session** does not know yet.
+
+Enable Docker at boot (usually done automatically, but verify):
+
+```bash
+sudo systemctl enable docker
+docker run --rm hello-world    # smoke test
+```
+
+## Install an MQTT broker (optional)
+
+!!! info "Sowel does not ship an MQTT broker"
+MQTT-based plugins (Zigbee2MQTT, LoRa2MQTT, Tasmota, Shelly...) need a broker reachable on your LAN. If you already have one, skip this section. If you do not use any MQTT plugin, this section is irrelevant.
+
+Procedure for Mosquitto, valid on Raspberry Pi OS, Debian and Ubuntu.
+
+### Install
+
+```bash
+sudo apt update
+sudo apt install -y mosquitto mosquitto-clients
+```
+
+The service starts automatically but only listens on `localhost:1883` by default since Debian Bookworm.
+
+### Open to the LAN
+
+Create `/etc/mosquitto/conf.d/sowel.conf`:
+
+```
+listener 1883 0.0.0.0
+allow_anonymous true
+```
+
+Two lines are enough. All other options (`persistence`, `persistence_location`, etc.) are already set in the default `/etc/mosquitto/mosquitto.conf`. **Do not redefine them**, Mosquitto refuses duplicate values.
+
+Then:
+
+```bash
+sudo systemctl restart mosquitto
+sudo systemctl status mosquitto   # must show "active (running)"
+```
+
+!!! warning "Security of `allow_anonymous true`"
+Without authentication, any machine on the LAN can publish and subscribe. **Acceptable** for a domestic setup that stays on the LAN behind the home router. **Avoid** if port 1883 is exposed to the Internet, or on a shared/untrusted LAN.
+
+    To add a password, see the [Mosquitto documentation](https://mosquitto.org/man/mosquitto-conf-5.html).
+
+### Test
+
+From another machine on the LAN:
+
+```bash
+# terminal 1 (subscribe)
+mosquitto_sub -h <host-ip> -p 1883 -t test/#
+
+# terminal 2 (publish)
+mosquitto_pub -h <host-ip> -p 1883 -t test/hello -m "ok"
+```
+
+If the message arrives, the broker is reachable. You can now point the Sowel Zigbee2MQTT plugin (and Z2M itself) to `mqtt://<host-ip>:1883`.
+
+## Troubleshooting
+
+### `Error: cannot reach the Docker daemon`
+
+Your user is not in the `docker` group, or your shell session did not reload its groups. See [Install Docker](#install-docker).
+
+### Mosquitto refuses to start: `Duplicate persistence_location`
+
+You redefined `persistence_location` (or `persistence`) in your `conf.d/sowel.conf`. These options are already in the default `mosquitto.conf`. Remove them from your file: only `listener` and `allow_anonymous` should remain.
+
+### `Start request repeated too quickly`
+
+After several failed start attempts, systemd blocks further `start` requests. Reset the counter:
+
+```bash
+sudo systemctl reset-failed mosquitto
+sudo systemctl start mosquitto
+```

--- a/docs/user/index.fr.md
+++ b/docs/user/index.fr.md
@@ -28,6 +28,10 @@ Cette séparation vous permet de penser en termes de _pièces et de fonctions_, 
 
 <div class="grid cards" markdown>
 
+- **[Préparer l'hôte](host-setup.md)**
+
+  Installation de Docker et Mosquitto sur Raspberry Pi, Debian ou Ubuntu. À sauter si vous avez déjà les deux.
+
 - **[Premiers pas](getting-started.md)**
 
   Installation, première connexion et configuration initiale.

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -28,6 +28,10 @@ This separation means you think about _rooms and functions_, not about Zigbee ad
 
 <div class="grid cards" markdown>
 
+- **[Preparing the Host](host-setup.md)**
+
+  Docker and Mosquitto setup on Raspberry Pi, Debian or Ubuntu. Skip if you already have both.
+
 - **[Getting Started](getting-started.md)**
 
   Installation, first login, and initial configuration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,7 @@ nav:
     - Specs Index: specs-index.md
   - User Guide:
     - user/index.md
+    - Preparing the Host: user/host-setup.md
     - Getting Started: user/getting-started.md
     - Devices: user/devices.md
     - Equipments: user/equipments.md


### PR DESCRIPTION
## Summary

- New user-facing page `docs/user/host-setup.md` (EN + FR) covering the two host-side dependencies Sowel does not ship with: Docker and an MQTT broker.
- Clearly separated **Raspberry Pi specifics** (64-bit OS, SD/SSD, swap via `dphys-swapfile`) from **universal Debian/Ubuntu/Pi** procedures.
- Documents the three common gotchas hit during a real install: `docker` group re-login, Mosquitto `Duplicate persistence_location`, and `Start request repeated too quickly`.
- Adds a `tip` callout in Getting Started (EN + FR) and a card in the User Guide index pointing to the new page.

## Test plan

- [ ] `mkdocs serve` locally and verify the new page appears in the User Guide nav, in both English (`/user/host-setup/`) and French (`/fr/user/host-setup/`).
- [ ] All internal links resolve (callouts in Getting Started, cards in User Guide index, "Skip to Installation" link inside Host Setup).
- [ ] After merge: confirm the page is live on https://docs.sowel.org/user/host-setup/ and https://docs.sowel.org/fr/user/host-setup/.