### PR TITLE
fix(core): map host.docker.internal in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,13 @@ services:
       # docker-compose.override.example.yml to docker-compose.override.yml
       # and run `docker compose up -d`. Read the override file's header
       # for the security trade-off before enabling.
+    extra_hosts:
+      # Makes the host machine reachable as `host.docker.internal` from
+      # inside the Sowel container. Required for MQTT-based plugins
+      # (Zigbee2MQTT, LoRa2MQTT, Tasmota, Shelly, Somfy RTS bridge...)
+      # to reach a broker running on the host without relying on the
+      # host's LAN IP (which can change with DHCP).
+      - "host.docker.internal:host-gateway"
     depends_on:
       - influxdb
 


### PR DESCRIPTION
## Summary

- Add `extra_hosts: ["host.docker.internal:host-gateway"]` to the `sowel` service in the official `docker-compose.yml`.
- Lets MQTT-based plugins (Zigbee2MQTT, LoRa2MQTT, Tasmota, Shelly, Somfy RTS bridge...) reach a broker hosted on the same machine via a stable name, instead of the host's LAN IP (fragile under DHCP).

## Root cause

From inside the Sowel container, before this fix:
- `127.0.0.1:1883` → `ECONNREFUSED` (loopback = container, not host)
- `host.docker.internal:1883` → `ENOTFOUND` (no `extra_hosts` mapping)
- `<host-LAN-IP>:1883` → OK, but breaks the day the router hands out a new lease

Confirmed during a real install (Pi 4 + Mosquitto on host) where the Somfy RTS plugin failed to connect. After adding the line, `host.docker.internal:1883` resolves to the host gateway and the broker is reachable. The recently added `docs/user/host-setup.md` (which tells users to install Mosquitto on the host) makes this path the recommended one, so the trap will only get more frequent without the fix.

## Test plan

- [ ] `docker compose config` passes (validated locally)
- [ ] On a fresh install with Mosquitto on the host, an MQTT plugin configured with `host.docker.internal:1883` connects successfully
- [ ] Existing installs upgrading via `docker compose pull && up -d` see the new mapping after refreshing their compose file