### PR TITLE
fix(ui): stop unregistering the PWA service worker on every load

### DIFF
--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -8,19 +8,6 @@ import { applyTheme } from "./theme";
 
 console.log("Sowel — Founded by Marc Chachereau — AGPL-3.0");
 
-// One-time migration: unregister stale service workers and clear caches
-// left behind by the legacy PWA setup. Idempotent.
-if ("serviceWorker" in navigator) {
-  navigator.serviceWorker.getRegistrations().then((regs) => {
-    regs.forEach((r) => r.unregister());
-  });
-}
-if ("caches" in window) {
-  caches.keys().then((names) => {
-    names.forEach((name) => caches.delete(name));
-  });
-}
-
 // Lock orientation to portrait (works in installed PWA / fullscreen on Android)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (screen.orientation as any)?.lock?.("portrait").catch(() => {});


### PR DESCRIPTION
## Summary

- Remove the "one-time migration" block in [ui/src/main.tsx](ui/src/main.tsx) that unregistered every service worker and cleared every cache on every page load.
- Lets `vite-plugin-pwa` (`registerType: "autoUpdate"`) actually keep a controlling SW alive, which is required for Chrome on Android to show the install banner.

## Root cause

The block was labelled "one-time migration" but had no guard, so it ran on every visit. Sequence on each load:

1. The auto-injected SW registration script runs (from `vite-plugin-pwa`).
2. `main.tsx` immediately calls `getRegistrations().then(r => r.unregister())`.
3. By the time Chrome evaluates installability, there is no controlling SW with a fetch handler.

Result: the install prompt never fires, even on HTTPS with a valid manifest and the right icons. As a side effect, no offline cache survives either.

`autoUpdate` already replaces a legacy SW on the first load of a new build, so the migration block was redundant from day one of the vite-plugin-pwa setup.

## Test plan

- [x] `npm run validate` (backend) + `cd ui && npm run lint && npm run typecheck` — pass
- [ ] Build prod (`cd ui && npm run build`), serve via Sowel, open over HTTPS on Chrome Android, clear site data once, reload, wait for engagement → install prompt appears
- [ ] After install, the app opens in standalone mode and the splash screen shows