### PR TITLE
release: v1.15.2

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,12 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.15.x — Décomposition consommation live
 
+### v1.15.2 — 2026-05-28 { #v1-15-2 }
+
+- Correctif (core) : le `docker-compose.yml` officiel déclare désormais `extra_hosts: ["host.docker.internal:host-gateway"]` sur le service `sowel`. Les plugins MQTT (Zigbee2MQTT, LoRa2MQTT, Tasmota, Shelly, pont Somfy RTS...) peuvent enfin joindre un broker hébergé sur la même machine via `host.docker.internal:1883`, sans coder en dur l'IP LAN de l'hôte (fragile sous DHCP). Les installations existantes prennent le changement en rafraîchissant leur compose ou en ajoutant le bloc manuellement (voir `docs/user/host-setup.md`).
+- Correctif (UI/PWA) : suppression d'une boucle qui désinscrivait tous les service workers à chaque chargement de page et tuait la PWA aussitôt après son enregistrement par `vite-plugin-pwa`. Chrome Android refusait de proposer l'installation parce qu'aucun SW actif n'existait au moment de l'évaluation. La bannière d'installation réapparaît sur les déploiements HTTPS ; les utilisateurs existants doivent vider une fois les données du site pour que l'ancienne purge ne se rejoue pas.
+- Correctif (UI/Prévision météo) : la création d'un équipement `weather_forecast` depuis l'UI auto-bind à nouveau les 25 points de donnée émis par le plugin Open-Meteo. La table d'auto-binding du front n'avait pas d'entrée `weather_forecast`, donc chaque clé `j1_*`..`j5_*` était filtrée silencieusement et l'équipement résultant affichait un panneau de prévision vide. Les catégories Sowel concernées (`weather_condition`, `temperature_outdoor`, `rain`, `wind`) sont maintenant déclarées et verrouillées par un test unitaire.
+
 ### v1.15.1 — 2026-05-27 { #v1-15-1 }
 
 - Feature (API) : nouveau paramètre optionnel `?type=<EquipmentType>` sur `GET /api/v1/equipments`. Renvoie uniquement les équipements du type demandé (par ex. `?type=energy_meter`). Les valeurs inconnues retournent une liste vide plutôt qu'une 400, pour qu'un appelant puisse forwarder une saisie utilisateur sans validation préalable. Permet aux clients à mémoire contrainte (comme le firmware ESP32 sowel-energy-display) de passer d'un payload de 100 Ko à quelques Ko en ne demandant que les entrées utiles.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,12 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.15.x — Live submeter breakdown
 
+### v1.15.2 — 2026-05-28 { #v1-15-2 }
+
+- Fix (core): the official `docker-compose.yml` now declares `extra_hosts: ["host.docker.internal:host-gateway"]` on the `sowel` service. MQTT-based plugins (Zigbee2MQTT, LoRa2MQTT, Tasmota, Shelly, Somfy RTS bridge...) can now reach a broker hosted on the same machine via `host.docker.internal:1883` — no need to hard-code the host's LAN IP (fragile under DHCP). Existing installs pick up the change after refreshing their compose file or pulling the new image with the manual block added (see `docs/user/host-setup.md`).
+- Fix (UI/PWA): removed an unconditional service-worker unregister loop that ran on every page load and killed the PWA registration as soon as `vite-plugin-pwa` installed it. Chrome on Android refused to show the install prompt because no controlling SW existed at evaluation time. Install banners now appear again on HTTPS deployments; existing visitors should clear site data once so the previous wipe doesn't replay.
+- Fix (UI/weather forecast): creating a `weather_forecast` equipment from the UI now auto-binds the 25 data points emitted by the Open-Meteo plugin. The frontend auto-binding map had no entry for `weather_forecast`, so every `j1_*`..`j5_*` key was silently filtered out and the resulting equipment displayed an empty forecast panel. The relevant Sowel categories (`weather_condition`, `temperature_outdoor`, `rain`, `wind`) are now declared and locked by a unit test.
+
 ### v1.15.1 — 2026-05-27 { #v1-15-1 }
 
 - Feature (API): new optional `?type=<EquipmentType>` query parameter on `GET /api/v1/equipments`. Returns only equipments of the requested type (e.g. `?type=energy_meter`). Unknown values return an empty list rather than a 400 so callers can safely forward user input. Lets memory-constrained clients (like the sowel-energy-display ESP32 firmware) drop a 100 KB payload to a few KB by asking only for the entries they need.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.15.1",
+  "version": "1.15.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Patch release bundling three user-visible fixes since v1.15.1.

- **Fix (core, #227)**: `docker-compose.yml` now declares `extra_hosts: ["host.docker.internal:host-gateway"]` so MQTT plugins can reach a host-side broker without hard-coding the LAN IP.
- **Fix (UI/PWA, #228)**: stop unregistering the service worker on every page load — Chrome Android can show the install prompt again on HTTPS deployments.
- **Fix (UI/weather forecast, #229)**: declare `weather_forecast` in the frontend auto-binding map so creating a Weather Forecast equipment actually wires up the 25 data keys emitted by the Open-Meteo plugin.

Release notes added in both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-15-2 }` anchor required by spec 108's CI check.

## Test plan

- [x] `npm run validate` — 722 tests pass, typecheck + lint clean
- [ ] Squash-merge this PR, then push tag `v1.15.2` to trigger the GHCR multi-arch build