### PR TITLE
feat(ui): outdoor module support + weather widget rework

### DIFF
--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -693,10 +693,10 @@ function WeatherStationWidget({
     ? "cursor-pointer transition-colors hover:bg-primary-light/30"
     : "";
 
-  // Both modules present → side-by-side. Only one → centered with no label
-  // (implicit). Neither → single em-dash.
+  // Both bound → side by side with explicit labels.
+  // Only one bound → keep the explicit label (outdoor or indoor) so the user
+  // still knows which one they're reading — no implicit single.
   const both = !!outdoor && !!indoor;
-  const single = outdoor ?? indoor;
 
   return (
     <WidgetCard label={label} onClick={onOpenDetail} className={clickClass}>
@@ -707,8 +707,12 @@ function WeatherStationWidget({
             <div className="w-px bg-border self-stretch" />
             <WeatherTempColumn label={t("weather.indoor")} value={fmt(indoor)} />
           </div>
+        ) : outdoor ? (
+          <WeatherTempColumn label={t("weather.outdoor")} value={fmt(outdoor)} />
+        ) : indoor ? (
+          <WeatherTempColumn label={t("weather.indoor")} value={fmt(indoor)} />
         ) : (
-          <WeatherTempColumn label={null} value={fmt(single)} />
+          <WeatherTempColumn label={null} value="—" />
         )}
       </div>
     </WidgetCard>

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -14,12 +14,12 @@ import {
   Snowflake,
   WashingMachine,
   Timer,
-  Droplets,
 } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
 import type { DashboardWidget } from "../../types";
 import { useEquipmentState, formatValue } from "../equipments/useEquipmentState";
 import { findOrderByCategory } from "../equipments/bindingUtils";
+import { findTempIndoor, findTempOutdoor } from "../equipments/weather-utils";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
 import { SensorValues } from "../equipments/SensorValues";
 import { createElement } from "react";
@@ -683,49 +683,53 @@ function WeatherStationWidget({
 }) {
   const { t } = useTranslation();
 
-  const find = (key: string) => equipment.dataBindings.find((b) => b.key === key);
-  const tempBinding = find("temperature");
-  const humidityBinding = find("humidity");
+  const outdoor = findTempOutdoor(equipment.dataBindings);
+  const indoor = findTempIndoor(equipment.dataBindings);
 
-  const tempValue =
-    tempBinding && typeof tempBinding.value === "number"
-      ? tempBinding.value.toFixed(1)
-      : "—";
-  const humidityValue =
-    humidityBinding && typeof humidityBinding.value === "number"
-      ? `${Math.round(humidityBinding.value)}`
-      : "—";
+  const fmt = (b: typeof outdoor) =>
+    b && typeof b.value === "number" ? b.value.toFixed(1) : "—";
 
   const clickClass = onOpenDetail
     ? "cursor-pointer transition-colors hover:bg-primary-light/30"
     : "";
 
+  // Both modules present → side-by-side. Only one → centered with no label
+  // (implicit). Neither → single em-dash.
+  const both = !!outdoor && !!indoor;
+  const single = outdoor ?? indoor;
+
   return (
     <WidgetCard label={label} onClick={onOpenDetail} className={clickClass}>
-      <div className="flex flex-col items-center justify-center flex-1 min-h-0 gap-3">
-        {/* Outdoor temperature */}
-        <div className="flex flex-col items-center gap-1">
-          <span className="text-[11px] uppercase tracking-wide text-text-tertiary font-medium">
-            {t("weather.outdoor")}
-          </span>
-          <div className="flex items-baseline leading-none">
-            <span className="font-mono font-bold text-[34px] sm:text-[40px] text-text tabular-nums leading-none">
-              {tempValue}
-            </span>
-            <span className="text-text-tertiary font-medium text-[16px] sm:text-[18px] leading-none ml-1">°C</span>
+      <div className="flex items-stretch justify-center flex-1 min-h-0">
+        {both ? (
+          <div className="flex items-stretch gap-4 sm:gap-6">
+            <WeatherTempColumn label={t("weather.outdoor")} value={fmt(outdoor)} />
+            <div className="w-px bg-border self-stretch" />
+            <WeatherTempColumn label={t("weather.indoor")} value={fmt(indoor)} />
           </div>
-        </div>
-
-        {/* Humidity */}
-        <div className="flex items-center gap-1.5">
-          <Droplets size={14} strokeWidth={1.5} className="text-text-tertiary" />
-          <span className="font-mono font-semibold text-[16px] sm:text-[18px] text-text tabular-nums">
-            {humidityValue}
-            <span className="text-text-tertiary font-normal text-[12px] ml-0.5">%</span>
-          </span>
-        </div>
+        ) : (
+          <WeatherTempColumn label={null} value={fmt(single)} />
+        )}
       </div>
     </WidgetCard>
+  );
+}
+
+function WeatherTempColumn({ label, value }: { label: string | null; value: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-1">
+      {label && (
+        <span className="text-[11px] uppercase tracking-wide text-text-tertiary font-medium">
+          {label}
+        </span>
+      )}
+      <div className="flex items-baseline leading-none">
+        <span className="font-mono font-bold text-[32px] sm:text-[36px] text-text tabular-nums leading-none">
+          {value}
+        </span>
+        <span className="text-text-tertiary font-medium text-[14px] sm:text-[16px] leading-none ml-1">°C</span>
+      </div>
+    </div>
   );
 }
 

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -203,11 +203,21 @@ function useMobileState(
     const fmt = (b: typeof outdoor) =>
       b && typeof b.value === "number" ? `${b.value.toFixed(1)}°` : "—";
     const both = !!outdoor && !!indoor;
-    const single = outdoor ?? indoor;
     // Icon slot is scaled 50% by MobileWidgetCard, so we size text 2x what
-    // we want visible. Both-modules layout puts the temps side by side with
-    // small "Ext./Int." captions above each. Single-module layout falls back
-    // to one centered temperature with no label (implicit).
+    // we want visible. Both: temps side by side with short "Ext./Int."
+    // captions. Single: one temperature with its explicit scope label —
+    // never implicit, since reading just "20.5°" leaves the user wondering
+    // which one this is.
+    const singleColumn = (b: typeof outdoor, captionKey: string) => (
+      <div className="flex flex-col items-center gap-1 leading-none whitespace-nowrap">
+        <span className="text-[18px] uppercase tracking-wide text-text-tertiary font-medium">
+          {t(captionKey)}
+        </span>
+        <span className="font-mono font-bold text-[56px] text-text tabular-nums leading-none">
+          {fmt(b)}
+        </span>
+      </div>
+    );
     return {
       icon: both ? (
         <div className="flex items-end gap-3 leading-none whitespace-nowrap">
@@ -229,11 +239,13 @@ function useMobileState(
             </span>
           </div>
         </div>
+      ) : outdoor ? (
+        singleColumn(outdoor, "weather.outdoorShort")
+      ) : indoor ? (
+        singleColumn(indoor, "weather.indoorShort")
       ) : (
         <div className="flex flex-col items-center gap-1 leading-none whitespace-nowrap">
-          <span className="font-mono font-bold text-[56px] text-text tabular-nums">
-            {fmt(single)}
-          </span>
+          <span className="font-mono font-bold text-[56px] text-text tabular-nums">—</span>
         </div>
       ),
       stateLines: [],

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -20,6 +20,7 @@ import {
 } from "./WidgetIcons";
 import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
 import { parseForecastDays, CONDITION_ICONS, CONDITION_COLORS } from "../equipments/weatherForecastUtils";
+import { findTempIndoor, findTempOutdoor } from "../equipments/weather-utils";
 import { Cloud, WashingMachine, Tv } from "lucide-react";
 
 interface MobileWidgetCardProps {
@@ -197,26 +198,45 @@ function useMobileState(
   }
 
   if (equipment.type === "weather") {
-    const find = (key: string) => equipment.dataBindings.find((b) => b.key === key);
-    const temp = find("temperature");
-    const hum = find("humidity");
-    const tempStr = typeof temp?.value === "number" ? `${temp.value.toFixed(1)}°` : "—";
-    const humStr = typeof hum?.value === "number" ? `${Math.round(hum.value)} %` : "—";
-    // We ignore widget.icon on purpose: the configured icon (e.g. a sun) is
-    // less useful than the actual outdoor temperature. Icon slot is scaled 50%
-    // in MobileWidgetCard, so we size the text 2x what we want visible.
+    const outdoor = findTempOutdoor(equipment.dataBindings);
+    const indoor = findTempIndoor(equipment.dataBindings);
+    const fmt = (b: typeof outdoor) =>
+      b && typeof b.value === "number" ? `${b.value.toFixed(1)}°` : "—";
+    const both = !!outdoor && !!indoor;
+    const single = outdoor ?? indoor;
+    // Icon slot is scaled 50% by MobileWidgetCard, so we size text 2x what
+    // we want visible. Both-modules layout puts the temps side by side with
+    // small "Ext./Int." captions above each. Single-module layout falls back
+    // to one centered temperature with no label (implicit).
     return {
-      icon: (
+      icon: both ? (
+        <div className="flex items-end gap-3 leading-none whitespace-nowrap">
+          <div className="flex flex-col items-center gap-1">
+            <span className="text-[18px] uppercase tracking-wide text-text-tertiary font-medium">
+              {t("weather.outdoorShort")}
+            </span>
+            <span className="font-mono font-bold text-[48px] text-text tabular-nums leading-none">
+              {fmt(outdoor)}
+            </span>
+          </div>
+          <div className="w-px self-stretch bg-border" />
+          <div className="flex flex-col items-center gap-1">
+            <span className="text-[18px] uppercase tracking-wide text-text-tertiary font-medium">
+              {t("weather.indoorShort")}
+            </span>
+            <span className="font-mono font-bold text-[48px] text-text tabular-nums leading-none">
+              {fmt(indoor)}
+            </span>
+          </div>
+        </div>
+      ) : (
         <div className="flex flex-col items-center gap-1 leading-none whitespace-nowrap">
-          <span className="text-[18px] uppercase tracking-wide text-text-tertiary font-medium">
-            {t("weather.outdoor")}
-          </span>
           <span className="font-mono font-bold text-[56px] text-text tabular-nums">
-            {tempStr}
+            {fmt(single)}
           </span>
         </div>
       ),
-      stateLines: [`${humStr} ${t("category.humidity").toLowerCase()}`],
+      stateLines: [],
     };
   }
 

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -15,14 +15,27 @@ import {
   Lightbulb,
   LightbulbOff,
   CloudRain,
+  Wind,
+  Thermometer,
 } from "lucide-react";
-import type { DashboardWidget, EquipmentWithDetails, ZoneWithChildren } from "../../types";
+import type {
+  DashboardWidget,
+  DataBindingWithValue,
+  EquipmentWithDetails,
+  ZoneWithChildren,
+} from "../../types";
 import { executeZoneOrder } from "../../api";
 import { useEquipmentState } from "../equipments/useEquipmentState";
 import { findOrderByCategory } from "../equipments/bindingUtils";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
 import { SensorValues } from "../equipments/SensorValues";
-import { formatSensorValue } from "../equipments/sensorUtils";
+import {
+  formatSensorValue,
+  getBatteryColor,
+  getBatteryIcon,
+  SENSOR_DATA_CATEGORIES,
+} from "../equipments/sensorUtils";
+import { syntheticBindingFromComputed } from "../equipments/weather-utils";
 import {
   LightBulbIcon,
   ShutterWidgetIcon,
@@ -180,71 +193,122 @@ const WEATHER_KEY_HIDDEN = new Set(["rain"]);
 /** Computed-data aliases surfaced on weather equipments (in addition to dataBindings). */
 const WEATHER_COMPUTED_ALIASES = ["rain_24h", "rain_1h"];
 
-interface WeatherRow {
-  id: string;
-  key: string;
-  category?: string;
-  value: unknown;
-  unit?: string;
+/** Maps a computed alias to the binding key it should pretend to be. */
+const COMPUTED_RAIN_TO_KEY: Record<string, string> = {
+  rain_24h: "sum_rain_24",
+  rain_1h: "sum_rain_1",
+};
+
+type WeatherKind = "outdoor" | "indoor" | "wind" | "rain";
+
+/** Classify a device by the categories its bindings expose. */
+function detectWeatherKind(bindings: readonly DataBindingWithValue[]): WeatherKind {
+  const cats = new Set(bindings.map((b) => b.category));
+  if (cats.has("wind")) return "wind";
+  if (cats.has("rain")) return "rain";
+  if (cats.has("temperature_outdoor") || cats.has("humidity_outdoor")) return "outdoor";
+  return "indoor";
+}
+
+const KIND_SORT: Record<WeatherKind, number> = { outdoor: 0, indoor: 1, wind: 2, rain: 3 };
+
+function getKindIcon(kind: WeatherKind) {
+  switch (kind) {
+    case "wind":
+      return <Wind size={16} strokeWidth={1.5} />;
+    case "rain":
+      return <CloudRain size={16} strokeWidth={1.5} />;
+    case "outdoor":
+    case "indoor":
+      return <Thermometer size={16} strokeWidth={1.5} />;
+  }
 }
 
 function WeatherDetailContent({ equipment }: { equipment: EquipmentWithDetails }) {
   const { t } = useTranslation();
-  const { sensorBindings, batteryBindings } = useEquipmentState(equipment);
 
-  // Merge dataBindings (filtered to hide instantaneous `rain`) with selected
-  // computedData entries (rain_24h, rain_1h) so the drawer surfaces the rain
-  // cumulative values even when only the bare `rain` binding is attached.
-  const rows: WeatherRow[] = [
-    ...sensorBindings
-      .filter((b) => !WEATHER_KEY_HIDDEN.has(b.key))
-      .map((b): WeatherRow => ({
-        id: `b-${b.id}`,
-        key: b.key,
-        category: b.category,
-        value: b.value,
-        unit: b.unit ?? undefined,
-      })),
-    ...(equipment.computedData ?? [])
-      .filter((c) => WEATHER_COMPUTED_ALIASES.includes(c.alias))
-      .map((c): WeatherRow => ({
-        id: `c-${c.alias}`,
-        key: c.alias,
-        value: c.value,
-        unit: c.unit,
-      })),
-  ];
+  // Group sensor bindings by physical device. Mirrors the layout used in
+  // the equipment detail page (WeatherPanel) so a user who knows that view
+  // gets the same mental model here, just rendered as compact sections
+  // instead of card grid.
+  const sensorBindings = equipment.dataBindings.filter(
+    (b) =>
+      SENSOR_DATA_CATEGORIES.includes(b.category) &&
+      b.category !== "battery" &&
+      !WEATHER_KEY_HIDDEN.has(b.key),
+  );
 
-  // Temperature and humidity both have a documented indoor/outdoor pair
-  // (`*` vs `*_outdoor`). Always qualify the row label by the actual
-  // category so the user knows which is which, even when only one variant
-  // is bound today (a Netatmo with only the base station, or only the
-  // outdoor module). Other categories (wind, rain, pressure, co2, noise)
-  // are unambiguous by their physical source — no suffix.
-  const labelFor = (r: WeatherRow): string => {
-    const base = WEATHER_KEY_LABELS[r.key] ? t(WEATHER_KEY_LABELS[r.key]) : r.key;
-    if (r.category === "temperature_outdoor") return `${base} (${t("weather.outdoor")})`;
-    if (r.category === "temperature") return `${base} (${t("weather.indoor")})`;
-    if (r.category === "humidity_outdoor") return `${base} (${t("weather.outdoor")})`;
-    if (r.category === "humidity") return `${base} (${t("weather.indoor")})`;
-    return base;
-  };
+  interface DeviceGroup {
+    deviceName: string;
+    bindings: DataBindingWithValue[];
+    battery: DataBindingWithValue | null;
+  }
+  const byDevice = new Map<string, DeviceGroup>();
+  for (const b of sensorBindings) {
+    let g = byDevice.get(b.deviceId);
+    if (!g) {
+      g = { deviceName: b.deviceName, bindings: [], battery: null };
+      byDevice.set(b.deviceId, g);
+    }
+    g.bindings.push(b);
+  }
+  // Attach one battery per device group
+  for (const bat of equipment.dataBindings.filter((b) => b.category === "battery")) {
+    const g = byDevice.get(bat.deviceId);
+    if (g) g.battery = bat;
+  }
 
-  // Outdoor variants sort before indoor for the same key (mirrors the compact
-  // widget layout where outdoor is on the left).
-  const outdoorRank = (r: WeatherRow): number =>
-    r.category === "temperature_outdoor" || r.category === "humidity_outdoor" ? 0 : 1;
+  // Inject synthetic rain rows from computedData (rain_24h / rain_1h) so the
+  // sheet still surfaces cumulative rain even when only the bare instantaneous
+  // `rain` binding is attached. Attach to the existing rain device if any,
+  // otherwise create a virtual "Pluviomètre" group.
+  const rainHost = sensorBindings.find((b) => b.category === "rain");
+  const rainDeviceId = rainHost?.deviceId ?? "computed-rain";
+  const rainDeviceName = rainHost?.deviceName ?? t("weather.rainCurrent");
+  const existingRainKeys = new Set(
+    (byDevice.get(rainDeviceId)?.bindings ?? []).map((b) => b.key),
+  );
+  for (const c of (equipment.computedData ?? []).filter((c) =>
+    WEATHER_COMPUTED_ALIASES.includes(c.alias),
+  )) {
+    const targetKey = COMPUTED_RAIN_TO_KEY[c.alias];
+    if (!targetKey || existingRainKeys.has(targetKey)) continue;
+    const synthetic = syntheticBindingFromComputed(equipment.id, c, {
+      key: targetKey,
+      deviceId: rainDeviceId,
+      deviceName: rainDeviceName,
+    });
+    let g = byDevice.get(rainDeviceId);
+    if (!g) {
+      g = { deviceName: rainDeviceName, bindings: [], battery: null };
+      byDevice.set(rainDeviceId, g);
+    }
+    g.bindings.push(synthetic);
+    existingRainKeys.add(targetKey);
+  }
 
-  rows.sort((a, b) => {
+  // Order rows within each device by WEATHER_KEY_ORDER.
+  const sortBindings = (a: DataBindingWithValue, b: DataBindingWithValue): number => {
     const ia = WEATHER_KEY_ORDER.indexOf(a.key);
     const ib = WEATHER_KEY_ORDER.indexOf(b.key);
-    if (ia !== -1 && ib !== -1 && ia !== ib) return ia - ib;
-    if (ia !== -1 && ib === -1) return -1;
-    if (ib !== -1 && ia === -1) return 1;
-    const ro = outdoorRank(a) - outdoorRank(b);
-    if (ro !== 0) return ro;
+    if (ia !== -1 && ib !== -1) return ia - ib;
+    if (ia !== -1) return -1;
+    if (ib !== -1) return 1;
     return a.key.localeCompare(b.key);
-  });
+  };
+
+  // Sort devices: outdoor first (matches compact widget), indoor next,
+  // then wind, then rain. Empty groups are dropped silently.
+  const devices = [...byDevice.entries()]
+    .filter(([, g]) => g.bindings.length > 0)
+    .map(([id, g]) => ({
+      id,
+      deviceName: g.deviceName,
+      bindings: [...g.bindings].sort(sortBindings),
+      battery: g.battery,
+      kind: detectWeatherKind(g.bindings),
+    }))
+    .sort((a, b) => KIND_SORT[a.kind] - KIND_SORT[b.kind]);
 
   return (
     <div className="flex flex-col gap-4">
@@ -253,29 +317,56 @@ function WeatherDetailContent({ equipment }: { equipment: EquipmentWithDetails }
           <CloudRain size={28} strokeWidth={1.5} />
         </div>
       </div>
-      <div className="divide-y divide-border-light">
-        {rows.map((r) => (
-          <div key={r.id} className="flex items-baseline justify-between py-2">
-            <span className="text-[13px] text-text-secondary">{labelFor(r)}</span>
-            <span className="text-[14px] font-mono font-semibold text-text tabular-nums">
-              {formatSensorValue(r.value, undefined, t)}
-              {r.unit && (
-                <span className="text-text-tertiary font-normal text-[12px] ml-1">{r.unit}</span>
-              )}
-            </span>
-          </div>
-        ))}
-        {batteryBindings.map((b) => (
-          <div key={b.id} className="flex items-baseline justify-between py-2">
-            <span className="text-[13px] text-text-secondary">
-              {b.deviceName} · {t("sensors.battery")}
-            </span>
-            <span className="text-[14px] font-mono font-semibold text-text tabular-nums">
-              {formatSensorValue(b.value, undefined, t)}
-              <span className="text-text-tertiary font-normal text-[12px] ml-1">%</span>
-            </span>
-          </div>
-        ))}
+      <div className="space-y-3">
+        {devices.map((dev) => {
+          const batteryLevel =
+            dev.battery && typeof dev.battery.value === "number"
+              ? dev.battery.value
+              : null;
+          return (
+            <div
+              key={dev.id}
+              className="rounded-[8px] border border-border-light overflow-hidden"
+            >
+              <div className="bg-border-light/40 px-3 py-2 flex items-center gap-2">
+                <span className="text-text-tertiary">{getKindIcon(dev.kind)}</span>
+                <span className="text-[12px] font-semibold uppercase tracking-wide text-text-secondary flex-1 min-w-0 truncate">
+                  {dev.deviceName}
+                </span>
+                {dev.battery && (
+                  <span
+                    className={`flex items-center gap-1 flex-shrink-0 ${getBatteryColor(batteryLevel)}`}
+                  >
+                    {getBatteryIcon(batteryLevel, 13, 1.5)}
+                    <span className="text-[11px] tabular-nums">
+                      {batteryLevel !== null ? `${batteryLevel}%` : "?"}
+                    </span>
+                  </span>
+                )}
+              </div>
+              <div className="divide-y divide-border-light">
+                {dev.bindings.map((b) => (
+                  <div
+                    key={b.id}
+                    className="flex items-baseline justify-between px-3 py-2"
+                  >
+                    <span className="text-[13px] text-text-secondary">
+                      {WEATHER_KEY_LABELS[b.key] ? t(WEATHER_KEY_LABELS[b.key]) : b.key}
+                    </span>
+                    <span className="text-[14px] font-mono font-semibold text-text tabular-nums">
+                      {formatSensorValue(b.value, undefined, t)}
+                      {b.unit && (
+                        <span className="text-text-tertiary font-normal text-[12px] ml-1">
+                          {b.unit}
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -215,23 +215,18 @@ function WeatherDetailContent({ equipment }: { equipment: EquipmentWithDetails }
       })),
   ];
 
-  // Outdoor variants share their key with the indoor variant. When both are
-  // bound, qualify the row label so the user can tell them apart. When only
-  // one variant is bound (typical: only the base station, or only outdoor),
-  // stay implicit — no suffix.
-  const hasTempIndoor = rows.some((r) => r.category === "temperature");
-  const hasTempOutdoor = rows.some((r) => r.category === "temperature_outdoor");
-  const tempAmbiguous = hasTempIndoor && hasTempOutdoor;
-  const hasHumIndoor = rows.some((r) => r.category === "humidity");
-  const hasHumOutdoor = rows.some((r) => r.category === "humidity_outdoor");
-  const humAmbiguous = hasHumIndoor && hasHumOutdoor;
-
+  // Temperature and humidity both have a documented indoor/outdoor pair
+  // (`*` vs `*_outdoor`). Always qualify the row label by the actual
+  // category so the user knows which is which, even when only one variant
+  // is bound today (a Netatmo with only the base station, or only the
+  // outdoor module). Other categories (wind, rain, pressure, co2, noise)
+  // are unambiguous by their physical source — no suffix.
   const labelFor = (r: WeatherRow): string => {
     const base = WEATHER_KEY_LABELS[r.key] ? t(WEATHER_KEY_LABELS[r.key]) : r.key;
-    if (tempAmbiguous && r.category === "temperature_outdoor") return `${base} (${t("weather.outdoor")})`;
-    if (tempAmbiguous && r.category === "temperature") return `${base} (${t("weather.indoor")})`;
-    if (humAmbiguous && r.category === "humidity_outdoor") return `${base} (${t("weather.outdoor")})`;
-    if (humAmbiguous && r.category === "humidity") return `${base} (${t("weather.indoor")})`;
+    if (r.category === "temperature_outdoor") return `${base} (${t("weather.outdoor")})`;
+    if (r.category === "temperature") return `${base} (${t("weather.indoor")})`;
+    if (r.category === "humidity_outdoor") return `${base} (${t("weather.outdoor")})`;
+    if (r.category === "humidity") return `${base} (${t("weather.indoor")})`;
     return base;
   };
 

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -183,6 +183,7 @@ const WEATHER_COMPUTED_ALIASES = ["rain_24h", "rain_1h"];
 interface WeatherRow {
   id: string;
   key: string;
+  category?: string;
   value: unknown;
   unit?: string;
 }
@@ -200,6 +201,7 @@ function WeatherDetailContent({ equipment }: { equipment: EquipmentWithDetails }
       .map((b): WeatherRow => ({
         id: `b-${b.id}`,
         key: b.key,
+        category: b.category,
         value: b.value,
         unit: b.unit ?? undefined,
       })),
@@ -213,12 +215,39 @@ function WeatherDetailContent({ equipment }: { equipment: EquipmentWithDetails }
       })),
   ];
 
+  // Outdoor variants share their key with the indoor variant. When both are
+  // bound, qualify the row label so the user can tell them apart. When only
+  // one variant is bound (typical: only the base station, or only outdoor),
+  // stay implicit — no suffix.
+  const hasTempIndoor = rows.some((r) => r.category === "temperature");
+  const hasTempOutdoor = rows.some((r) => r.category === "temperature_outdoor");
+  const tempAmbiguous = hasTempIndoor && hasTempOutdoor;
+  const hasHumIndoor = rows.some((r) => r.category === "humidity");
+  const hasHumOutdoor = rows.some((r) => r.category === "humidity_outdoor");
+  const humAmbiguous = hasHumIndoor && hasHumOutdoor;
+
+  const labelFor = (r: WeatherRow): string => {
+    const base = WEATHER_KEY_LABELS[r.key] ? t(WEATHER_KEY_LABELS[r.key]) : r.key;
+    if (tempAmbiguous && r.category === "temperature_outdoor") return `${base} (${t("weather.outdoor")})`;
+    if (tempAmbiguous && r.category === "temperature") return `${base} (${t("weather.indoor")})`;
+    if (humAmbiguous && r.category === "humidity_outdoor") return `${base} (${t("weather.outdoor")})`;
+    if (humAmbiguous && r.category === "humidity") return `${base} (${t("weather.indoor")})`;
+    return base;
+  };
+
+  // Outdoor variants sort before indoor for the same key (mirrors the compact
+  // widget layout where outdoor is on the left).
+  const outdoorRank = (r: WeatherRow): number =>
+    r.category === "temperature_outdoor" || r.category === "humidity_outdoor" ? 0 : 1;
+
   rows.sort((a, b) => {
     const ia = WEATHER_KEY_ORDER.indexOf(a.key);
     const ib = WEATHER_KEY_ORDER.indexOf(b.key);
-    if (ia !== -1 && ib !== -1) return ia - ib;
-    if (ia !== -1) return -1;
-    if (ib !== -1) return 1;
+    if (ia !== -1 && ib !== -1 && ia !== ib) return ia - ib;
+    if (ia !== -1 && ib === -1) return -1;
+    if (ib !== -1 && ia === -1) return 1;
+    const ro = outdoorRank(a) - outdoorRank(b);
+    if (ro !== 0) return ro;
     return a.key.localeCompare(b.key);
   });
 
@@ -232,9 +261,7 @@ function WeatherDetailContent({ equipment }: { equipment: EquipmentWithDetails }
       <div className="divide-y divide-border-light">
         {rows.map((r) => (
           <div key={r.id} className="flex items-baseline justify-between py-2">
-            <span className="text-[13px] text-text-secondary">
-              {WEATHER_KEY_LABELS[r.key] ? t(WEATHER_KEY_LABELS[r.key]) : r.key}
-            </span>
+            <span className="text-[13px] text-text-secondary">{labelFor(r)}</span>
             <span className="text-[14px] font-mono font-semibold text-text tabular-nums">
               {formatSensorValue(r.value, undefined, t)}
               {r.unit && (

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -14,7 +14,7 @@ const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> 
   switch: ["light_state"],
   sensor: ["temperature", "humidity", "pressure", "luminosity", "co2", "voc", "noise", "motion", "contact_door", "contact_window", "water_leak", "smoke"],
   button: ["action"],
-  weather: ["temperature", "humidity", "pressure", "wind", "rain", "noise"],
+  weather: ["temperature", "temperature_outdoor", "humidity", "humidity_outdoor", "pressure", "wind", "rain", "noise"],
   gate: ["generic", "contact_door"],
   heater: ["generic", "light_state"],
   energy_meter: ["energy", "power"],

--- a/ui/src/components/equipments/bindingUtils.test.ts
+++ b/ui/src/components/equipments/bindingUtils.test.ts
@@ -119,6 +119,34 @@ describe("findDataByCategory", () => {
   });
 });
 
+describe("weather equipment type relevance", () => {
+  it("accepts the Netatmo outdoor module categories (NAModule1)", () => {
+    // NAModule1 emits temperature_outdoor + humidity_outdoor; without these
+    // entries the outdoor module would be hidden from the weather creation
+    // flow and even a manual pick would yield 0 bindings.
+    expect(isRelevantData("temperature_outdoor", "weather")).toBe(true);
+    expect(isRelevantData("humidity_outdoor", "weather")).toBe(true);
+  });
+
+  it("still accepts indoor categories (base + indoor module)", () => {
+    expect(isRelevantData("temperature", "weather")).toBe(true);
+    expect(isRelevantData("humidity", "weather")).toBe(true);
+    expect(isRelevantData("pressure", "weather")).toBe(true);
+    expect(isRelevantData("noise", "weather")).toBe(true);
+  });
+
+  it("accepts wind, rain and battery", () => {
+    expect(isRelevantData("wind", "weather")).toBe(true);
+    expect(isRelevantData("rain", "weather")).toBe(true);
+    expect(isRelevantData("battery", "weather")).toBe(true);
+  });
+
+  it("ignores unrelated categories", () => {
+    expect(isRelevantData("light_state", "weather")).toBe(false);
+    expect(isRelevantData("shutter_position", "weather")).toBe(false);
+  });
+});
+
 describe("weather_forecast equipment type relevance", () => {
   it("treats Open-Meteo forecast categories as relevant", () => {
     expect(isRelevantData("weather_condition", "weather_forecast")).toBe(true);

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -107,7 +107,7 @@ const RELEVANT_DATA: Record<string, string[]> = {
   sensor: ["temperature", "humidity", "pressure", "luminosity", "co2", "voc", "noise", "motion", "contact_door", "contact_window", "water_leak", "smoke", "battery"],
   button: ["action", "battery"],
   thermostat: ["temperature", "generic"],
-  weather: ["temperature", "humidity", "pressure", "wind", "rain", "noise", "battery"],
+  weather: ["temperature", "temperature_outdoor", "humidity", "humidity_outdoor", "pressure", "wind", "rain", "noise", "battery"],
   weather_forecast: ["weather_condition", "temperature_outdoor", "rain", "wind"],
   gate: ["generic", "contact_door"],
   heater: ["generic", "light_state"],

--- a/ui/src/components/equipments/sensorUtils.tsx
+++ b/ui/src/components/equipments/sensorUtils.tsx
@@ -23,7 +23,9 @@ import type { DataBindingWithValue, DataCategory } from "../../types";
 /** Sensor data categories (excludes power, energy, etc.) */
 export const SENSOR_DATA_CATEGORIES: DataCategory[] = [
   "temperature",
+  "temperature_outdoor",
   "humidity",
+  "humidity_outdoor",
   "pressure",
   "luminosity",
   "motion",

--- a/ui/src/components/equipments/weather-utils.ts
+++ b/ui/src/components/equipments/weather-utils.ts
@@ -48,3 +48,26 @@ export function angleToCompass(angle: number): string {
   const idx = Math.round(normalized / 22.5) % 16;
   return COMPASS_FR[idx];
 }
+
+/**
+ * Find the indoor/outdoor temperature or humidity binding by data category.
+ *
+ * Lookup by category (not by key/alias) is mandatory because a single weather
+ * equipment can carry two bindings sharing the same key, e.g. both the Netatmo
+ * base station (`category: "temperature"`, indoor) and the outdoor module
+ * (`category: "temperature_outdoor"`) push a `temperature` key. The auto-binding
+ * deduplicates aliases (`temperature` / `temperature_2`) so the alias alone is
+ * ambiguous about which is which — only the category is stable.
+ */
+export function findTempOutdoor(bindings: DataBindingWithValue[]): DataBindingWithValue | undefined {
+  return bindings.find((b) => b.category === "temperature_outdoor");
+}
+export function findTempIndoor(bindings: DataBindingWithValue[]): DataBindingWithValue | undefined {
+  return bindings.find((b) => b.category === "temperature");
+}
+export function findHumidityOutdoor(bindings: DataBindingWithValue[]): DataBindingWithValue | undefined {
+  return bindings.find((b) => b.category === "humidity_outdoor");
+}
+export function findHumidityIndoor(bindings: DataBindingWithValue[]): DataBindingWithValue | undefined {
+  return bindings.find((b) => b.category === "humidity");
+}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -346,6 +346,9 @@
   "category.value.smoke.ok": "OK",
 
   "weather.outdoor": "Outdoor",
+  "weather.indoor": "Indoor",
+  "weather.outdoorShort": "Out.",
+  "weather.indoorShort": "In.",
   "weather.windSpeed": "Speed",
   "weather.windDirection": "Direction",
   "weather.gustSpeed": "Gusts",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -346,6 +346,9 @@
   "category.value.smoke.ok": "OK",
 
   "weather.outdoor": "Extérieur",
+  "weather.indoor": "Intérieur",
+  "weather.outdoorShort": "Ext.",
+  "weather.indoorShort": "Int.",
   "weather.windSpeed": "Vitesse",
   "weather.windDirection": "Direction",
   "weather.gustSpeed": "Rafales",


### PR DESCRIPTION
## Summary

Two commits, both centered on the Netatmo outdoor module:

1. **Fix**: make the outdoor module bindable on a `weather` equipment (it was previously hidden from the device selector and silently skipped by the auto-binding loop).
2. **Feat**: rework the dashboard weather widget to surface **outdoor + indoor temperatures side by side** when both modules are bound, and disambiguate them in the bottom sheet.

## Commit 1 — Auto-binding outdoor categories

The Netatmo outdoor module (NAModule1) emits `category: "temperature_outdoor"` and `category: "humidity_outdoor"`. The `weather` filter only listed the indoor variants:

```ts
// DeviceSelector.tsx
weather: ["temperature", "humidity", "pressure", "wind", "rain", "noise"],
// bindingUtils.ts
weather: ["temperature", "humidity", "pressure", "wind", "rain", "noise", "battery"],
```

Result: the outdoor module never matched, hidden from the selector, and even when force-picked yielded 0 bindings (silent skip). Added `temperature_outdoor` + `humidity_outdoor` to both lists and locked with 4 unit tests on `isRelevantData`.

## Commit 2 — Weather widget side-by-side temps

Now that both temperatures can coexist on one equipment, surface them:

**Compact widget (desktop + mobile)** — two large temperatures side by side with a thin divider when both modules are bound. Humidity removed from the compact view (we trade it for the second temperature, which is by far the more useful comparison signal). When only one variant is bound, fall back to a single centered temperature with no label (implicit).

**Bottom sheet (mobile detail)** — when both indoor and outdoor variants of `temperature` (or `humidity`) are present, qualify the row label with `(Extérieur)` / `(Intérieur)`. When only one is present, stay implicit. Outdoor rows sort before indoor rows to match the compact widget reading order. Other measurements (wind, rain, pressure, CO2, noise) are unambiguous by their physical source so no suffix is added.

**Lookup by category, not by key** — required because `NAMain` and `NAModule1` both emit `key: "temperature"` and the auto-binding dedupes aliases to `temperature` / `temperature_2` in arbitrary order. Only `category` is stable.

i18n: adds `weather.indoor`, `weather.outdoorShort` (`Ext.`), `weather.indoorShort` (`Int.`) in EN+FR. Existing `weather.outdoor` reused.

## Test plan

- [x] `npm run validate` — 726 tests pass (4 new ones on the relevance map), typecheck + lint clean
- [ ] On a Sowel instance with a Netatmo Weather Station (base + outdoor module): the outdoor module appears in the compatible-devices list when creating a weather equipment; both modules' temperature bindings are created; the dashboard widget renders both temperatures side by side; tapping the widget opens a bottom sheet with `Température (Intérieur)` and `Température (Extérieur)` rows; only one indoor or one outdoor → no label suffix anywhere