### PR TITLE
fix(history): historize outdoor temperature and humidity

### DIFF
--- a/src/history/history-writer.test.ts
+++ b/src/history/history-writer.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { HistoryWriter } from "./history-writer.js";
+import type { DataCategory } from "../shared/types.js";
+
+describe("HistoryWriter.resolveHistorize", () => {
+  // ============================================================
+  // Explicit override
+  // ============================================================
+
+  it("returns true when historize=1 regardless of category", () => {
+    expect(HistoryWriter.resolveHistorize(1, "anything", "generic")).toBe(true);
+  });
+
+  it("returns false when historize=0 regardless of category", () => {
+    expect(HistoryWriter.resolveHistorize(0, "temperature", "temperature")).toBe(false);
+  });
+
+  // ============================================================
+  // Category defaults — indoor + outdoor temperature/humidity
+  // ============================================================
+
+  it("historizes indoor temperature and humidity by default", () => {
+    expect(HistoryWriter.resolveHistorize(null, "temperature", "temperature")).toBe(true);
+    expect(HistoryWriter.resolveHistorize(null, "humidity", "humidity")).toBe(true);
+  });
+
+  it("historizes outdoor temperature and humidity by default", () => {
+    expect(HistoryWriter.resolveHistorize(null, "temperature_2", "temperature_outdoor")).toBe(true);
+    expect(HistoryWriter.resolveHistorize(null, "humidity_2", "humidity_outdoor")).toBe(true);
+  });
+
+  it("historizes the rest of the on-by-default categories", () => {
+    const onByDefault: DataCategory[] = [
+      "pressure",
+      "luminosity",
+      "rain",
+      "wind",
+      "co2",
+      "voc",
+      "noise",
+      "shutter_position",
+      "battery",
+    ];
+    for (const cat of onByDefault) {
+      expect(HistoryWriter.resolveHistorize(null, cat, cat)).toBe(true);
+    }
+  });
+
+  // ============================================================
+  // Alias exclusions
+  // ============================================================
+
+  it("never historizes weather-forecast bindings (jN_* aliases)", () => {
+    // Even though temperature_outdoor is on by default, the jN_ alias prefix
+    // excludes forecast bindings from history (they update at hourly cadence
+    // and the values are predictions, not measurements).
+    expect(HistoryWriter.resolveHistorize(null, "j1_temp_max", "temperature_outdoor")).toBe(false);
+    expect(HistoryWriter.resolveHistorize(null, "j5_condition", "weather_condition")).toBe(false);
+  });
+
+  it("excludes raw cumulative energy counters (energy_forward / energy_reverse)", () => {
+    expect(HistoryWriter.resolveHistorize(null, "energy_forward", "energy")).toBe(false);
+    expect(HistoryWriter.resolveHistorize(null, "energy_reverse", "energy")).toBe(false);
+  });
+
+  // ============================================================
+  // Default OFF for unrelated categories
+  // ============================================================
+
+  it("does not historize generic or unknown categories by default", () => {
+    expect(HistoryWriter.resolveHistorize(null, "state", "generic")).toBe(false);
+    expect(HistoryWriter.resolveHistorize(null, "action", "action")).toBe(false);
+  });
+});

--- a/src/history/history-writer.ts
+++ b/src/history/history-writer.ts
@@ -15,7 +15,9 @@ import { Point } from "../core/influx-client.js";
 /** Categories historized ON by default. */
 const CATEGORY_DEFAULTS_ON: ReadonlySet<string> = new Set([
   "temperature",
+  "temperature_outdoor",
   "humidity",
+  "humidity_outdoor",
   "pressure",
   "luminosity",
   "power",
@@ -50,7 +52,9 @@ const ALIAS_DEFAULTS_OFF: ReadonlySet<string> = new Set([
 /** Deadband thresholds by category — skip writes if delta is below this. */
 const DEADBAND: Record<string, number> = {
   temperature: 0.2,
+  temperature_outdoor: 0.2,
   humidity: 1.0,
+  humidity_outdoor: 1.0,
   luminosity: 0.05, // 5% relative
   power: 5,
   energy: 0.01,


### PR DESCRIPTION
## Summary

- Add `temperature_outdoor` and `humidity_outdoor` to `CATEGORY_DEFAULTS_ON` in [history-writer.ts](src/history/history-writer.ts).
- Add matching `DEADBAND` entries (0.2°C, 1% RH) mirroring the indoor variants.
- Add the first unit test file for `resolveHistorize` (was previously uncovered).

## Root cause

`CATEGORY_DEFAULTS_ON` listed `temperature` and `humidity` but not their `*_outdoor` siblings. So for any binding whose category was `temperature_outdoor` or `humidity_outdoor` and whose `historize` flag was not explicitly forced ON, `resolveHistorize` fell through the cascade and returned `false`. The binding was never added to the `historizedBindings` cache and `writeBinding()` early-returned without writing anything to InfluxDB. Live values worked (event bus propagation is independent), but no historical chart was ever drawn.

This is the fourth omission of the same pattern, after:
- #229 — `RELEVANT_DATA` in the UI auto-binding map (forecast)
- #232 — `EQUIPMENT_TYPE_CATEGORIES` + `RELEVANT_DATA` (weather) + `SENSOR_DATA_CATEGORIES` (display)
- This PR — `CATEGORY_DEFAULTS_ON` + `DEADBAND` (history persistence)

## Test plan

- [x] `npm run validate` — 734 tests pass (8 new on `resolveHistorize`), typecheck + lint clean
- [ ] On a Sowel instance with a Netatmo weather equipment that has the outdoor module bound: after merge + image upgrade, the outdoor temperature and humidity should start appearing in the historical chart (history-writer refreshes its cache on any `equipment.updated` event, or at boot, so a Sowel restart picks it up immediately)