### PR TITLE
feat(ui): human-readable labels in history & analyse pickers

### DIFF
--- a/src/api/routes/history.ts
+++ b/src/api/routes/history.ts
@@ -74,6 +74,7 @@ export function registerHistoryRoutes(
           bindingId: b.id,
           alias: b.alias,
           category: b.category,
+          deviceName: b.deviceName,
           type: b.type,
           historize: b.historize ?? null,
           effectiveOn: HistoryWriter.resolveHistorize(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -263,6 +263,10 @@ export interface HistoryBindingState {
   bindingId: string;
   alias: string;
   category: DataCategory;
+  /** Name of the backing physical device, used as a disambiguator when an
+   * equipment has multiple bindings sharing the same category (e.g. several
+   * batteries on a multi-module weather station). */
+  deviceName: string;
   historize: number | null; // NULL = default, 1 = force ON, 0 = force OFF
   effectiveOn: boolean; // Resolved from override → alias default → category default
 }

--- a/ui/src/components/history/AnalyseView.tsx
+++ b/ui/src/components/history/AnalyseView.tsx
@@ -33,6 +33,7 @@ import type {
 import { TimeRangeSelector } from "./TimeRangeSelector";
 import { rangeToFrom } from "./history-utils";
 import type { TimeRange } from "./history-utils";
+import { humanBindingLabel, humanBindingLabelFromList } from "./binding-label";
 
 // ============================================================
 // Types
@@ -45,6 +46,14 @@ interface SeriesConfig {
   zoneName: string;
   alias: string;
   category: string;
+  /** Backing physical device name. Empty for saved charts loaded from
+   * `chart.config.series` (which only carries equipmentId + alias) until
+   * the bindings have been refetched. */
+  deviceName: string;
+  /** Number of bindings sharing this category on the source equipment.
+   * Used by humanBindingLabel to decide whether device-name disambiguation
+   * is needed. */
+  sameCategoryCount: number;
   color: string;
 }
 
@@ -225,6 +234,8 @@ export function AnalyseView() {
             zoneName: eq?.zoneId ? (zoneNameById.get(eq.zoneId) ?? "") : "",
             alias: sc.alias,
             category: "",
+            deviceName: "",
+            sameCategoryCount: 1,
             color: SERIES_COLORS[newSeries.length % SERIES_COLORS.length],
           });
         }
@@ -295,6 +306,10 @@ export function AnalyseView() {
     const id = `${selectedEquipmentId}:${binding.alias}`;
     if (series.some((s) => s.id === id)) return;
 
+    const sameCategoryCount = availableBindings.filter(
+      (b) => b.category === binding.category,
+    ).length;
+
     const newSeries: SeriesConfig = {
       id,
       equipmentId: selectedEquipmentId,
@@ -302,6 +317,8 @@ export function AnalyseView() {
       zoneName: zoneNameById.get(equipment.zoneId ?? "") ?? "",
       alias: binding.alias,
       category: binding.category,
+      deviceName: binding.deviceName,
+      sameCategoryCount,
       color: SERIES_COLORS[series.length % SERIES_COLORS.length],
     };
 
@@ -482,7 +499,15 @@ export function AnalyseView() {
             />
             {s.zoneName && <span className="text-text-tertiary">{s.zoneName} /</span>}
             <span className="text-text">{s.equipmentName}</span>
-            <span className="text-text-tertiary">/ {s.alias}</span>
+            <span className="text-text-tertiary">
+              /{" "}
+              {s.category
+                ? humanBindingLabel(
+                    { alias: s.alias, category: s.category, deviceName: s.deviceName, sameCategoryCount: s.sameCategoryCount },
+                    t,
+                  )
+                : s.alias}
+            </span>
             {CATEGORY_UNITS[s.category] && (
               <span className="text-text-tertiary">({CATEGORY_UNITS[s.category]})</span>
             )}
@@ -588,13 +613,14 @@ export function AnalyseView() {
                         type="button"
                         disabled={alreadyAdded}
                         onClick={() => addSeries(b)}
+                        title={b.alias}
                         className={`px-2.5 py-1 rounded-[4px] text-[12px] font-medium transition-colors cursor-pointer ${
                           alreadyAdded
                             ? "bg-border-light text-text-tertiary cursor-not-allowed"
                             : "bg-border-light/50 text-text hover:bg-primary-light hover:text-primary"
                         }`}
                       >
-                        {b.alias}
+                        {humanBindingLabelFromList(b, availableBindings, t)}
                         {CATEGORY_UNITS[b.category] && (
                           <span className="text-text-tertiary ml-1">({CATEGORY_UNITS[b.category]})</span>
                         )}
@@ -666,8 +692,14 @@ export function AnalyseView() {
                     const s = series.find((ser) => ser.id === name);
                     const unit = s ? CATEGORY_UNITS[s.category] : "";
                     const formatted = Number.isInteger(v) ? String(v) : v.toFixed(1);
+                    const metricLabel = s && s.category
+                      ? humanBindingLabel(
+                          { alias: s.alias, category: s.category, deviceName: s.deviceName, sameCategoryCount: s.sameCategoryCount },
+                          t,
+                        )
+                      : (s?.alias ?? (name ?? ""));
                     const label = s
-                      ? (s.zoneName ? `${s.zoneName} / ${s.equipmentName} / ${s.alias}` : `${s.equipmentName} / ${s.alias}`)
+                      ? (s.zoneName ? `${s.zoneName} / ${s.equipmentName} / ${metricLabel}` : `${s.equipmentName} / ${metricLabel}`)
                       : (name ?? "");
                     return [unit ? `${formatted} ${unit}` : formatted, label];
                   }}
@@ -676,9 +708,15 @@ export function AnalyseView() {
                   formatter={(value: string) => {
                     const s = series.find((ser) => ser.id === value);
                     if (!s) return value;
+                    const metricLabel = s.category
+                      ? humanBindingLabel(
+                          { alias: s.alias, category: s.category, deviceName: s.deviceName, sameCategoryCount: s.sameCategoryCount },
+                          t,
+                        )
+                      : s.alias;
                     return s.zoneName
-                      ? `${s.zoneName} / ${s.equipmentName} / ${s.alias}`
-                      : `${s.equipmentName} / ${s.alias}`;
+                      ? `${s.zoneName} / ${s.equipmentName} / ${metricLabel}`
+                      : `${s.equipmentName} / ${metricLabel}`;
                   }}
                   wrapperStyle={{ fontSize: "11px" }}
                 />

--- a/ui/src/components/history/HistoryPanel.tsx
+++ b/ui/src/components/history/HistoryPanel.tsx
@@ -8,6 +8,7 @@ import { rangeToFrom, isCumulativeBarChart } from "./history-utils";
 import type { TimeRange } from "./history-utils";
 import { TimeSeriesChart } from "./TimeSeriesChart";
 import { HistoryBarChart } from "./HistoryBarChart";
+import { humanBindingLabelFromList } from "./binding-label";
 
 /** Chart entry derived from a historized binding. */
 interface ChartEntry {
@@ -129,10 +130,11 @@ export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
   // Build chart list from historized bindings only
   // (computed data like rain_1h/rain_24h are snapshot values without their own
   // InfluxDB history — they show in the equipment card, not as charts)
-  const allCharts: ChartEntry[] = historizedBindings.map((b) => ({
+  const allCharts: (ChartEntry & { label: string })[] = historizedBindings.map((b) => ({
     alias: b.alias,
     category: b.category,
     unit: CATEGORY_UNITS[b.category],
+    label: humanBindingLabelFromList(b, historizedBindings, t),
   }));
 
   // Don't render if history is not enabled or no charts to show
@@ -182,8 +184,8 @@ export function HistoryPanel({ equipmentId, bindings }: HistoryPanelProps) {
                 }`}
               >
                 <div className="flex items-center gap-2">
-                  <span className="font-mono font-medium text-primary">{entry.alias}</span>
-                  <span className="text-text-tertiary">({entry.category})</span>
+                  <span className="font-medium text-primary" title={entry.alias}>{entry.label}</span>
+                  {unit && <span className="text-text-tertiary">({unit})</span>}
                 </div>
                 <BarChart3
                   size={12}

--- a/ui/src/components/history/binding-label.test.ts
+++ b/ui/src/components/history/binding-label.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { humanBindingLabel, humanBindingLabelFromList } from "./binding-label";
+import type { HistoryBindingState } from "../../types";
+
+// Mock t() that mirrors the FR translations the helper relies on.
+const t = ((key: string) =>
+  ({
+    "category.temperature": "Température",
+    "category.humidity": "Humidité",
+    "category.pressure": "Pression",
+    "category.noise": "Bruit",
+    "category.co2": "CO₂",
+    "category.battery": "Batterie",
+    "category.wind": "Vent",
+    "category.rain": "Pluie",
+    "weather.indoor": "Intérieure",
+    "weather.outdoor": "Extérieure",
+    "weather.windSpeed": "Vitesse du vent",
+    "weather.windDirection": "Direction du vent",
+    "weather.gustSpeed": "Rafales",
+    "weather.gustDirection": "Direction des rafales",
+    "weather.rainCurrent": "Pluie actuelle",
+    "weather.rain1h": "Pluie 1h",
+    "weather.rain24h": "Pluie 24h",
+  })[key] ?? key) as unknown as Parameters<typeof humanBindingLabel>[2];
+
+/** Build a HistoryBindingState quickly. */
+function b(
+  alias: string,
+  category: string,
+  deviceName = "",
+): HistoryBindingState {
+  return {
+    bindingId: alias,
+    alias,
+    category: category as HistoryBindingState["category"],
+    deviceName,
+    type: "number",
+    historize: null,
+    effectiveOn: true,
+  };
+}
+
+describe("humanBindingLabel — Netatmo weather station full set", () => {
+  // The exact 16-binding equipment shown in the user's screenshot.
+  const all: HistoryBindingState[] = [
+    b("temperature", "temperature", "Station Intérieure"),
+    b("temperature_2", "temperature_outdoor", "Module Extérieur"),
+    b("humidity", "humidity", "Station Intérieure"),
+    b("humidity_2", "humidity_outdoor", "Module Extérieur"),
+    b("pressure", "pressure", "Station Intérieure"),
+    b("noise", "noise", "Station Intérieure"),
+    b("co2", "co2", "Station Intérieure"),
+    b("wind_strength", "wind", "Anémomètre"),
+    b("gust_strength", "wind", "Anémomètre"),
+    b("wind_angle", "wind", "Anémomètre"),
+    b("gust_angle", "wind", "Anémomètre"),
+    b("rain", "rain", "Pluviomètre"),
+    b("sum_rain_1", "rain", "Pluviomètre"),
+    b("sum_rain_24", "rain", "Pluviomètre"),
+    b("battery", "battery", "Module Extérieur"),
+    b("battery_2", "battery", "Anémomètre"),
+    b("battery_3", "battery", "Pluviomètre"),
+  ];
+
+  const labelOf = (alias: string) => {
+    const binding = all.find((x) => x.alias === alias)!;
+    return humanBindingLabelFromList(binding, all, t);
+  };
+
+  it("indoor temperature and humidity are qualified by category (lowercased scope)", () => {
+    expect(labelOf("temperature")).toBe("Température intérieure");
+    expect(labelOf("humidity")).toBe("Humidité intérieure");
+  });
+
+  it("outdoor temperature and humidity are qualified by category (lowercased scope)", () => {
+    expect(labelOf("temperature_2")).toBe("Température extérieure");
+    expect(labelOf("humidity_2")).toBe("Humidité extérieure");
+  });
+
+  it("uses metric-specific labels for wind / gust / rain detail keys", () => {
+    expect(labelOf("wind_strength")).toBe("Vitesse du vent");
+    expect(labelOf("gust_strength")).toBe("Rafales");
+    expect(labelOf("wind_angle")).toBe("Direction du vent");
+    expect(labelOf("gust_angle")).toBe("Direction des rafales");
+    expect(labelOf("rain")).toBe("Pluie actuelle");
+    expect(labelOf("sum_rain_1")).toBe("Pluie 1h");
+    expect(labelOf("sum_rain_24")).toBe("Pluie 24h");
+  });
+
+  it("falls back to the plain category label for unambiguous single bindings", () => {
+    expect(labelOf("pressure")).toBe("Pression");
+    expect(labelOf("noise")).toBe("Bruit");
+    expect(labelOf("co2")).toBe("CO₂");
+  });
+
+  it("uses the device name to disambiguate multi-instance categories (battery)", () => {
+    expect(labelOf("battery")).toBe("Batterie Module Extérieur");
+    expect(labelOf("battery_2")).toBe("Batterie Anémomètre");
+    expect(labelOf("battery_3")).toBe("Batterie Pluviomètre");
+  });
+});
+
+describe("humanBindingLabel — fallback behaviour", () => {
+  it("returns the plain category label when only one binding of that category exists, even without deviceName", () => {
+    const all = [b("battery", "battery", "")];
+    expect(humanBindingLabelFromList(all[0], all, t)).toBe("Batterie");
+  });
+
+  it("falls back to the plain category label when multi-instance but no deviceName", () => {
+    const all = [b("battery", "battery", ""), b("battery_2", "battery", "")];
+    expect(humanBindingLabelFromList(all[0], all, t)).toBe("Batterie");
+    expect(humanBindingLabelFromList(all[1], all, t)).toBe("Batterie");
+  });
+
+  it("returns the raw category for unknown categories", () => {
+    const all = [b("something", "unknown_cat", "")];
+    expect(humanBindingLabelFromList(all[0], all, t)).toBe("category.unknown_cat");
+  });
+
+  it("low-level humanBindingLabel accepts a pre-computed sameCategoryCount", () => {
+    expect(
+      humanBindingLabel(
+        { alias: "battery", category: "battery", deviceName: "Module Extérieur", sameCategoryCount: 3 },
+        t,
+      ),
+    ).toBe("Batterie Module Extérieur");
+    expect(
+      humanBindingLabel(
+        { alias: "battery", category: "battery", deviceName: "Module Extérieur", sameCategoryCount: 1 },
+        t,
+      ),
+    ).toBe("Batterie");
+  });
+});

--- a/ui/src/components/history/binding-label.ts
+++ b/ui/src/components/history/binding-label.ts
@@ -1,0 +1,115 @@
+import type { TFunction } from "i18next";
+import type { HistoryBindingState } from "../../types";
+
+export interface BindingLabelInput {
+  alias: string;
+  category: string;
+  /** Backing physical device name. Used as a disambiguator when an equipment
+   * exposes several bindings sharing the same category (batteries, …). */
+  deviceName?: string;
+  /** How many bindings on the same equipment carry this binding's category.
+   * When > 1, the helper falls back to `${categoryLabel} ${deviceName}` to
+   * keep them distinguishable. Callers compute this from their binding list. */
+  sameCategoryCount?: number;
+}
+
+/**
+ * Derives a human-readable label for a binding that's about to appear in a
+ * chart-picker / legend / pill (Analyse page, History panel, etc.).
+ *
+ * The label is *equipment-level* by design: it expresses what the binding
+ * exposes from the equipment's point of view, not which physical device
+ * produces it. Going down to the device is reserved for the cases where the
+ * equipment abstraction has no way to disambiguate (typically: several
+ * batteries on a multi-module station — same category, no semantic sibling
+ * like temperature/temperature_outdoor to lean on).
+ *
+ * Lookup order:
+ *   1. Metric-specific key (wind_strength → "Vitesse du vent",
+ *      sum_rain_24 → "Pluie 24h", …) — the alias's _N dedup suffix is
+ *      stripped before lookup.
+ *   2. Indoor / outdoor disambiguation derived from the data category
+ *      itself (`temperature_outdoor`, `humidity_outdoor`, …).
+ *   3. If the category appears more than once on the equipment AND a
+ *      `deviceName` is available, suffix the device name (Batterie Module
+ *      Extérieur, …).
+ *   4. Plain category label (Pression, CO₂, …).
+ */
+
+/**
+ * Per-key labels for metrics where the category alone (e.g. "wind") is too
+ * coarse to distinguish the actual measurement (speed vs gust vs angle).
+ * Values are i18n keys.
+ */
+const METRIC_LABELS: Record<string, string> = {
+  wind_strength: "weather.windSpeed",
+  wind_angle: "weather.windDirection",
+  gust_strength: "weather.gustSpeed",
+  gust_angle: "weather.gustDirection",
+  rain: "weather.rainCurrent",
+  sum_rain_1: "weather.rain1h",
+  sum_rain_24: "weather.rain24h",
+  rain_1h: "weather.rain1h",
+  rain_24h: "weather.rain24h",
+};
+
+/** Categories that always have a clean i18n label and no inherent ambiguity. */
+function categoryLabel(category: string, t: TFunction): string {
+  // i18next falls back to the key if no translation exists, which is safer
+  // than throwing for an unknown category (e.g. an exotic plugin category).
+  return t(`category.${category}`);
+}
+
+export function humanBindingLabel(input: BindingLabelInput, t: TFunction): string {
+  const { alias, category, deviceName, sameCategoryCount = 1 } = input;
+
+  // 1. Metric-specific (overrides everything else). Try the alias direct
+  // first because some original keys carry a numeric suffix that looks like
+  // a dedup tag but isn't (e.g. `sum_rain_1`, `sum_rain_24`). Only then
+  // try the de-deduped form for cases like `temperature_2`. The alias
+  // de-dup counter starts at 2 (see uniqueAlias()), so `_1` is never a
+  // dedup tag and can safely live in METRIC_LABELS keys.
+  const directMetric = METRIC_LABELS[alias];
+  if (directMetric) return t(directMetric);
+  const strippedKey = alias.replace(/_\d+$/, "");
+  if (strippedKey !== alias && METRIC_LABELS[strippedKey]) {
+    return t(METRIC_LABELS[strippedKey]);
+  }
+
+  // 2. Indoor / outdoor disambiguation via the category itself
+  const indoor = t("weather.indoor").toLowerCase();
+  const outdoor = t("weather.outdoor").toLowerCase();
+  if (category === "temperature_outdoor") return `${t("category.temperature")} ${outdoor}`;
+  if (category === "temperature") return `${t("category.temperature")} ${indoor}`;
+  if (category === "humidity_outdoor") return `${t("category.humidity")} ${outdoor}`;
+  if (category === "humidity") return `${t("category.humidity")} ${indoor}`;
+
+  // 3. Multi-instance category → device name as disambiguator
+  if (sameCategoryCount > 1 && deviceName) {
+    return `${categoryLabel(category, t)} ${deviceName}`;
+  }
+
+  // 4. Plain category
+  return categoryLabel(category, t);
+}
+
+/**
+ * Convenience for callers that already hold a HistoryBindingState array:
+ * counts siblings on the fly. Use the lower-level `humanBindingLabel` when
+ * the count is already known (e.g. embedded in a SeriesConfig).
+ */
+export function humanBindingLabelFromList(
+  binding: HistoryBindingState,
+  allBindings: readonly HistoryBindingState[],
+  t: TFunction,
+): string {
+  return humanBindingLabel(
+    {
+      alias: binding.alias,
+      category: binding.category,
+      deviceName: binding.deviceName,
+      sameCategoryCount: allBindings.filter((b) => b.category === binding.category).length,
+    },
+    t,
+  );
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -304,6 +304,9 @@ export interface HistoryBindingState {
   bindingId: string;
   alias: string;
   category: DataCategory;
+  /** Name of the backing physical device. Used as a disambiguator when an
+   * equipment has multiple bindings sharing the same category. */
+  deviceName: string;
   type: string; // "number" | "boolean" | "enum"
   historize: number | null;
   effectiveOn: boolean;


### PR DESCRIPTION
## Summary

Surface friendly labels everywhere a binding chip / legend appears in the History panel and the Analyse page. Replaces opaque aliases (`temperature_2`, `humidity_2`, `battery_3`) with equipment-level semantic labels (`Température extérieure`, `Humidité extérieure`, `Batterie Module Extérieur`).

## Design

New `binding-label.ts` helper. Strict ordering:

1. **Metric-specific table** (wind/gust/rain detail keys): `wind_strength` → `Vitesse du vent`, `gust_strength` → `Rafales`, `sum_rain_24` → `Pluie 24h`, …
2. **Indoor/outdoor disambiguation** falls out of the category itself: `temperature` vs `temperature_outdoor` → `Température intérieure` vs `Température extérieure`. No device leak.
3. **Multi-instance category** (multiple batteries on one equipment) is the only case where the device name legitimately appears: `Batterie Module Extérieur` / `Batterie Anémomètre` / `Batterie Pluviomètre`. Single-instance categories never show the device.
4. Plain category label otherwise (`Pression`, `CO₂`, …).

The raw alias stays available as the chip `title` tooltip for power users / debugging.

### Before / After (Netatmo full station)

```
temperature       → Température intérieure
temperature_2     → Température extérieure
humidity          → Humidité intérieure
humidity_2        → Humidité extérieure
pressure          → Pression
noise             → Bruit
co2               → CO₂
wind_strength     → Vitesse du vent
gust_strength     → Rafales
wind_angle        → Direction du vent
gust_angle        → Direction des rafales
rain              → Pluie actuelle
sum_rain_1        → Pluie 1h
sum_rain_24       → Pluie 24h
battery           → Batterie Module Extérieur
battery_2         → Batterie Anémomètre
battery_3         → Batterie Pluviomètre
```

## Changes

- **Backend** (2 lines): add `deviceName` to `HistoryBindingState` (shared types) and populate it in `GET /api/v1/history/bindings/:equipmentId`.
- **UI types**: mirror the `deviceName` field.
- **New helper + tests**: `binding-label.ts` (~110 lines) with 9 unit tests covering the full Netatmo set + fallback edge cases.
- **Wiring**:
  - `AnalyseView.tsx`: picker chips, series pills, chart Tooltip, chart Legend
  - `HistoryPanel.tsx`: equipment-detail chip
  - `SeriesConfig` gains `deviceName` + `sameCategoryCount` so the helper has the disambiguator context after a series is added.

## Caveat

Saved charts loaded by id only carry `{equipmentId, alias}` in `chart.config`, so until they're re-enriched the pill falls back to `alias` (existing behaviour — no regression). Re-enriching on load is a small follow-up if needed.

## Test plan

- [x] `npm run validate` — 743 tests pass (9 new on `humanBindingLabel`), typecheck + lint clean
- [ ] On a Sowel instance with a Netatmo weather equipment: the picker chips in Analyse and the History panel chips show the human-readable labels per the table above; hovering a chip displays the raw alias as a tooltip; series pills + chart Tooltip + chart Legend all use the friendly label