### PR TITLE
release: v1.15.5

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,11 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.15.x — Décomposition consommation live
 
+### v1.15.5 — 2026-05-30 { #v1-15-5 }
+
+- Correctif (history) : les bindings de température et d'humidité extérieures (catégories `temperature_outdoor` / `humidity_outdoor` — typiquement le module extérieur Netatmo) sont désormais historisés par défaut. La liste blanche `CATEGORY_DEFAULTS_ON` de `history-writer.ts` ne connaissait que les variantes intérieures, donc on-par-défaut tombait sur OFF et aucun point n'était jamais écrit dans InfluxDB. Les équipements existants reprennent automatiquement au prochain rafraîchissement du cache du history-writer (event `equipment.updated` ou démarrage). Premier fichier de tests unitaires sur `resolveHistorize` pour verrouiller le contrat.
+- Évolution (UI/historique) : remplace les aliases bruts (`temperature_2`, `humidity_2`, `battery_3`…) par des libellés humains équipement-level partout où une chip ou une légende de binding apparaît — sélecteur Analyse, pilules de séries, Tooltip et Légende du graphe, et fiche historique de la page équipement. La distinction intérieur / extérieur vient directement de la catégorie (`Température intérieure` vs `Température extérieure`) ; seules les catégories multi-instances sans frère sémantique (typiquement plusieurs batteries sur une station multi-modules) remontent un nom de device en discriminant (`Batterie Module Extérieur` / `Anémomètre` / `Pluviomètre`). Survol d'une chip = affichage de l'alias brut en tooltip pour les power users.
+
 ### v1.15.4 — 2026-05-29 { #v1-15-4 }
 
 - Correctif (UI/météo) : le module extérieur Netatmo (NAModule1) est désormais sélectionnable lors de la création d'un équipement `weather`. Le filtre du sélecteur ne listait que `temperature` / `humidity` (variantes intérieur), donc le module extérieur — celui qui porte précisément la température extérieure, ironiquement — était masqué de la liste des devices compatibles et silencieusement ignoré par la boucle d'auto-binding. Ajout de `temperature_outdoor` et `humidity_outdoor` dans le filtre, ainsi que dans `SENSOR_DATA_CATEGORIES` pour que la vue détail (bottom sheet) les voie aussi. Verrouillé par des tests unitaires.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,11 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.15.x — Live submeter breakdown
 
+### v1.15.5 — 2026-05-30 { #v1-15-5 }
+
+- Fix (history): outdoor temperature and humidity bindings (`temperature_outdoor` / `humidity_outdoor` categories — typically the Netatmo outdoor module) are now historized by default. The `CATEGORY_DEFAULTS_ON` whitelist in `history-writer.ts` only knew the indoor variants, so on-by-default fell through to OFF and no point was ever written to InfluxDB. Existing equipments pick up the change at next history-writer cache refresh (any `equipment.updated` event, or boot). First `resolveHistorize` unit-test file added to lock the contract for the on-by-default set.
+- Feat (UI/history): replace raw binding aliases (`temperature_2`, `humidity_2`, `battery_3`, …) with equipment-level human-readable labels everywhere a binding chip or legend appears — Analyse picker chips, series pills, chart Tooltip / Legend, and the History panel of the equipment detail page. Indoor / outdoor disambiguation comes from the data category itself (`Température intérieure` vs `Température extérieure`); only multi-instance categories with no semantic sibling (typically multiple batteries on a multi-module weather station) leak a device name as a disambiguator (`Batterie Module Extérieur` / `Anémomètre` / `Pluviomètre`). Hovering a chip still shows the raw alias as a tooltip for power users.
+
 ### v1.15.4 — 2026-05-29 { #v1-15-4 }
 
 - Fix (UI/weather): the Netatmo outdoor module (NAModule1) is now bindable on a `weather` equipment. The category filter in the device selector only listed `temperature` / `humidity` (indoor variants), so the outdoor module — the only one carrying the _outdoor_ temperature, ironically — was hidden from the compatible-devices list and silently skipped by the auto-binding loop. Add `temperature_outdoor` and `humidity_outdoor` to the filter, and to `SENSOR_DATA_CATEGORIES` so the bottom-sheet detail view picks them up too. Locked with unit tests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.15.4",
+  "version": "1.15.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Patch + UX release batching #234 and #235 since v1.15.4.

- **Fix (history, #234)**: outdoor temperature/humidity bindings are now historized by default — `CATEGORY_DEFAULTS_ON` no longer omits `temperature_outdoor` / `humidity_outdoor`. First unit-test file added on `resolveHistorize`.
- **Feat (UI/history, #235)**: equipment-level human labels everywhere a binding chip or legend appears in the History panel and the Analyse page (Tooltip + Legend included).

Release notes added in both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-15-5 }` anchor required by spec 108 CI.

## Test plan

- [x] `npm run validate` — 743 tests pass, typecheck + lint clean
- [ ] Squash-merge this PR, then push tag `v1.15.5` to trigger the GHCR multi-arch build