### PR TITLE
feat(ui): Analyse page navigator — Day / Week / Month / Year

### DIFF
--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -885,7 +885,14 @@ export interface SavedChartSeriesConfig {
 
 export interface SavedChartConfig {
   series: SavedChartSeriesConfig[];
-  timeRange: string;
+  /** Legacy relative window (`6h` / `24h` / `7d` / `30d`). Kept for backwards
+   * compatibility with charts saved before the period navigator landed —
+   * if `period` is present, it wins. */
+  timeRange?: string;
+  /** Absolute calendar period — present on charts saved with the new navigator. */
+  period?: "day" | "week" | "month" | "year";
+  /** Anchor date for the period (YYYY-MM-DD). Required when `period` is set. */
+  date?: string;
 }
 
 export interface SavedChart {

--- a/ui/src/components/history/AnalyseMobileNav.tsx
+++ b/ui/src/components/history/AnalyseMobileNav.tsx
@@ -1,0 +1,96 @@
+import { useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { LineChart, Plus } from "lucide-react";
+import { useCharts } from "../../store/useCharts";
+import { useUiState } from "../../store/useUiState";
+
+/**
+ * Analyse saved-charts drawer (mobile).
+ *
+ * Mirrors `EnergyMobileNav`: opens via the contextual burger in the
+ * topbar (wired in `AppLayout.MobileTopbarBurger`), lists the user's
+ * saved charts as nav items, plus a "New chart" entry.
+ */
+export function AnalyseMobileNav() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const charts = useCharts((s) => s.charts);
+  const fetchCharts = useCharts((s) => s.fetchCharts);
+  const open = useUiState((s) => s.analyseNavOpen);
+  const close = useUiState((s) => s.closeAnalyseNav);
+
+  useEffect(() => {
+    if (open) fetchCharts();
+  }, [open, fetchCharts]);
+
+  if (!open) return null;
+
+  const goto = (to: string) => {
+    navigate(to);
+    close();
+  };
+
+  const isNewActive = location.pathname === "/analyse";
+
+  return (
+    <div className="fixed inset-0 z-50 lg:hidden">
+      <div className="absolute inset-0 bg-black/40" onClick={close} />
+      <div className="absolute top-0 left-0 bottom-0 w-[260px] bg-surface animate-slide-left shadow-xl overflow-y-auto">
+        <div className="bg-surface flex-shrink-0" style={{ height: "env(safe-area-inset-top, 0px)" }} />
+        <div className="px-3 pt-4 pb-4 space-y-1">
+          <div className="px-2 pb-3">
+            <span className="text-[11px] font-semibold text-text-tertiary uppercase tracking-widest">
+              {t("analyse.title")}
+            </span>
+          </div>
+
+          {/* New chart */}
+          <button
+            type="button"
+            onClick={() => goto("/analyse")}
+            className={`flex items-center gap-3 w-full px-3 py-3 rounded-[10px] transition-colors duration-150 text-left ${
+              isNewActive ? "bg-primary-light text-primary" : "text-text hover:bg-border-light"
+            }`}
+          >
+            <span className={isNewActive ? "text-primary" : "text-text-secondary"}>
+              <Plus size={18} strokeWidth={1.5} />
+            </span>
+            <span className={`text-[14px] font-medium ${isNewActive ? "text-primary" : ""}`}>
+              {t("analyse.new")}
+            </span>
+          </button>
+
+          {/* Saved charts */}
+          {charts.length === 0 ? (
+            <p className="px-3 py-2 text-[12px] text-text-tertiary">
+              {t("analyse.noSavedCharts")}
+            </p>
+          ) : (
+            charts.map((chart) => {
+              const active = location.pathname === `/analyse/${chart.id}`;
+              return (
+                <button
+                  key={chart.id}
+                  type="button"
+                  onClick={() => goto(`/analyse/${chart.id}`)}
+                  className={`flex items-center gap-3 w-full px-3 py-3 rounded-[10px] transition-colors duration-150 text-left ${
+                    active ? "bg-primary-light text-primary" : "text-text hover:bg-border-light"
+                  }`}
+                >
+                  <span className={active ? "text-primary" : "text-text-secondary"}>
+                    <LineChart size={18} strokeWidth={1.5} />
+                  </span>
+                  <span className={`text-[14px] font-medium truncate ${active ? "text-primary" : ""}`}>
+                    {chart.name}
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/history/AnalyseView.tsx
+++ b/ui/src/components/history/AnalyseView.tsx
@@ -489,10 +489,10 @@ export function AnalyseView() {
 
   return (
     <div className="space-y-4">
-      {/* Header: title (left, hidden on mobile — topbar shows it) · period
-          navigator (center) · save actions (right). Wraps to a column on
-          narrow screens via flex-wrap + gap. */}
-      <div className="flex flex-wrap items-center gap-4 justify-between">
+      {/* Header — copies Energy's two-child flex layout (title left,
+          PeriodSelector right, justify-between). Save actions move to the
+          end of the series-pills row so the header stays clean. */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div className="hidden sm:flex items-center gap-3">
           <BarChart3 size={20} strokeWidth={1.5} className="text-primary" />
           <h1>{title}</h1>
@@ -503,98 +503,99 @@ export function AnalyseView() {
           onPeriodChange={setPeriod}
           onDateChange={setDate}
         />
-        <div className="flex items-center gap-1">
-          {series.length > 0 && (
-            <>
-              <button
-                type="button"
-                onClick={handleSave}
-                disabled={saving}
-                className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-[6px] text-[12px] font-medium
-                  bg-primary-light text-primary hover:bg-primary hover:text-white
-                  transition-colors cursor-pointer disabled:opacity-50"
-                title={t("analyse.save")}
-              >
-                <Save size={14} strokeWidth={1.5} />
-                {t("analyse.save")}
-              </button>
-              <button
-                type="button"
-                onClick={handleSaveAs}
-                disabled={saving}
-                className="flex items-center justify-center p-1.5 rounded-[6px] text-text-secondary
-                  hover:bg-border-light hover:text-text transition-colors cursor-pointer disabled:opacity-50"
-                title={t("analyse.saveAs")}
-              >
-                <Copy size={14} strokeWidth={1.5} />
-              </button>
-              {currentChart && (
-                <button
-                  type="button"
-                  onClick={() => setShowDeleteConfirm(true)}
-                  className="flex items-center justify-center p-1.5 rounded-[6px] text-text-secondary
-                    hover:bg-error/10 hover:text-error transition-colors cursor-pointer"
-                  title={t("analyse.deleteChart")}
-                >
-                  <Trash2 size={14} strokeWidth={1.5} />
-                </button>
-              )}
-            </>
-          )}
-        </div>
       </div>
 
-      {/* Series pills + add button */}
-      <div className="flex flex-wrap items-center gap-2">
-        {series.map((s) => (
-          <div
-            key={s.id}
-            className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[12px] font-medium bg-surface border border-border"
+      {/* Series pills + add button (left) — save / save-as / delete (right) */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          {series.map((s) => (
+            <div
+              key={s.id}
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[12px] font-medium bg-surface border border-border"
+            >
+              <span
+                className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                style={{ backgroundColor: s.color }}
+              />
+              {s.zoneName && <span className="text-text-tertiary">{s.zoneName} /</span>}
+              <span className="text-text">{s.equipmentName}</span>
+              <span className="text-text-tertiary">
+                /{" "}
+                {s.category
+                  ? humanBindingLabel(
+                      { alias: s.alias, category: s.category, deviceName: s.deviceName, sameCategoryCount: s.sameCategoryCount },
+                      t,
+                    )
+                  : s.alias}
+              </span>
+              {CATEGORY_UNITS[s.category] && (
+                <span className="text-text-tertiary">({CATEGORY_UNITS[s.category]})</span>
+              )}
+              <button
+                type="button"
+                onClick={() => removeSeries(s.id)}
+                className="ml-0.5 text-text-tertiary hover:text-error transition-colors cursor-pointer"
+              >
+                <X size={12} strokeWidth={2} />
+              </button>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            onClick={() => {
+              const next = !showAddForm;
+              setShowAddForm(next);
+              if (next && !selectedZoneId && flatZones.length > 0) {
+                setSelectedZoneId(flatZones[0].id);
+              }
+            }}
+            className="flex items-center gap-1 px-2.5 py-1 rounded-full text-[12px] font-medium
+              bg-primary-light text-primary hover:bg-primary hover:text-white
+              transition-colors cursor-pointer"
           >
-            <span
-              className="w-2.5 h-2.5 rounded-full flex-shrink-0"
-              style={{ backgroundColor: s.color }}
-            />
-            {s.zoneName && <span className="text-text-tertiary">{s.zoneName} /</span>}
-            <span className="text-text">{s.equipmentName}</span>
-            <span className="text-text-tertiary">
-              /{" "}
-              {s.category
-                ? humanBindingLabel(
-                    { alias: s.alias, category: s.category, deviceName: s.deviceName, sameCategoryCount: s.sameCategoryCount },
-                    t,
-                  )
-                : s.alias}
-            </span>
-            {CATEGORY_UNITS[s.category] && (
-              <span className="text-text-tertiary">({CATEGORY_UNITS[s.category]})</span>
-            )}
+            <Plus size={12} strokeWidth={2} />
+            {t("analyse.addSeries")}
+          </button>
+        </div>
+
+        {series.length > 0 && (
+          <div className="flex items-center gap-1">
             <button
               type="button"
-              onClick={() => removeSeries(s.id)}
-              className="ml-0.5 text-text-tertiary hover:text-error transition-colors cursor-pointer"
+              onClick={handleSave}
+              disabled={saving}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-[6px] text-[12px] font-medium
+                bg-primary-light text-primary hover:bg-primary hover:text-white
+                transition-colors cursor-pointer disabled:opacity-50"
+              title={t("analyse.save")}
             >
-              <X size={12} strokeWidth={2} />
+              <Save size={14} strokeWidth={1.5} />
+              <span className="hidden sm:inline">{t("analyse.save")}</span>
             </button>
+            <button
+              type="button"
+              onClick={handleSaveAs}
+              disabled={saving}
+              className="flex items-center justify-center p-1.5 rounded-[6px] text-text-secondary
+                hover:bg-border-light hover:text-text transition-colors cursor-pointer disabled:opacity-50"
+              title={t("analyse.saveAs")}
+            >
+              <Copy size={14} strokeWidth={1.5} />
+            </button>
+            {currentChart && (
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="flex items-center justify-center p-1.5 rounded-[6px] text-text-secondary
+                  hover:bg-error/10 hover:text-error transition-colors cursor-pointer"
+                title={t("analyse.deleteChart")}
+              >
+                <Trash2 size={14} strokeWidth={1.5} />
+              </button>
+            )}
           </div>
-        ))}
-
-        <button
-          type="button"
-          onClick={() => {
-            const next = !showAddForm;
-            setShowAddForm(next);
-            if (next && !selectedZoneId && flatZones.length > 0) {
-              setSelectedZoneId(flatZones[0].id);
-            }
-          }}
-          className="flex items-center gap-1 px-2.5 py-1 rounded-full text-[12px] font-medium
-            bg-primary-light text-primary hover:bg-primary hover:text-white
-            transition-colors cursor-pointer"
-        >
-          <Plus size={12} strokeWidth={2} />
-          {t("analyse.addSeries")}
-        </button>
+        )}
       </div>
 
       {/* Add series form */}

--- a/ui/src/components/history/AnalyseView.tsx
+++ b/ui/src/components/history/AnalyseView.tsx
@@ -489,10 +489,11 @@ export function AnalyseView() {
 
   return (
     <div className="space-y-4">
-      {/* Header: title (left) · period navigator (center) · save actions (right).
-          Wraps to a column on narrow screens via flex-wrap + gap. */}
+      {/* Header: title (left, hidden on mobile — topbar shows it) · period
+          navigator (center) · save actions (right). Wraps to a column on
+          narrow screens via flex-wrap + gap. */}
       <div className="flex flex-wrap items-center gap-4 justify-between">
-        <div className="flex items-center gap-3">
+        <div className="hidden sm:flex items-center gap-3">
           <BarChart3 size={20} strokeWidth={1.5} className="text-primary" />
           <h1>{title}</h1>
         </div>

--- a/ui/src/components/history/AnalyseView.tsx
+++ b/ui/src/components/history/AnalyseView.tsx
@@ -228,8 +228,9 @@ export function AnalyseView() {
     if (equipments.length === 0) return; // wait for equipments to resolve names
 
     setLoadingChart(true);
-    getChart(chartId)
-      .then((chart) => {
+    (async () => {
+      try {
+        const chart = await getChart(chartId);
         setCurrentChart(chart);
         loadedChartIdRef.current = chartId;
         // New format (period + date) takes precedence. Legacy charts saved
@@ -245,9 +246,32 @@ export function AnalyseView() {
           setPeriod(mapped);
           setDate(periodTodayStr());
         }
+
+        // Enrich saved series with category + deviceName + sameCategoryCount
+        // so humanBindingLabel can render friendly labels in pills, tooltip
+        // and legend. Without this, freshly-loaded charts fall back to raw
+        // aliases ("Bureau / THR / humidity") instead of the equipment-level
+        // label ("Humidité intérieure").
+        const uniqueEqIds = [...new Set(chart.config.series.map((s) => s.equipmentId))];
+        const bindingsPerEq = new Map<string, HistoryBindingState[]>();
+        await Promise.all(
+          uniqueEqIds.map(async (eqId) => {
+            try {
+              bindingsPerEq.set(eqId, await getHistoryBindings(eqId));
+            } catch {
+              // Best-effort: an equipment may have been deleted since save.
+            }
+          }),
+        );
+
         const newSeries: SeriesConfig[] = [];
         for (const sc of chart.config.series) {
           const eq = equipments.find((e) => e.id === sc.equipmentId);
+          const eqBindings = bindingsPerEq.get(sc.equipmentId) ?? [];
+          const binding = eqBindings.find((b) => b.alias === sc.alias);
+          const sameCategoryCount = binding
+            ? eqBindings.filter((b) => b.category === binding.category).length
+            : 1;
           const id = `${sc.equipmentId}:${sc.alias}`;
           newSeries.push({
             id,
@@ -255,20 +279,21 @@ export function AnalyseView() {
             equipmentName: eq?.name ?? sc.equipmentId,
             zoneName: eq?.zoneId ? (zoneNameById.get(eq.zoneId) ?? "") : "",
             alias: sc.alias,
-            category: "",
-            deviceName: "",
-            sameCategoryCount: 1,
+            category: binding?.category ?? "",
+            deviceName: binding?.deviceName ?? "",
+            sameCategoryCount,
             color: SERIES_COLORS[newSeries.length % SERIES_COLORS.length],
           });
         }
         setSeries(newSeries);
         setSeriesData({});
-      })
-      .catch(() => {
+      } catch {
         setCurrentChart(null);
         loadedChartIdRef.current = chartId;
-      })
-      .finally(() => setLoadingChart(false));
+      } finally {
+        setLoadingChart(false);
+      }
+    })();
   }, [chartId, equipments, zoneNameById]);
 
   const filteredEquipments = useMemo(() => {
@@ -464,13 +489,20 @@ export function AnalyseView() {
 
   return (
     <div className="space-y-4">
-      {/* Header with range selector + save buttons */}
-      <div className="flex items-center justify-between">
+      {/* Header: title (left) · period navigator (center) · save actions (right).
+          Wraps to a column on narrow screens via flex-wrap + gap. */}
+      <div className="flex flex-wrap items-center gap-4 justify-between">
         <div className="flex items-center gap-3">
           <BarChart3 size={20} strokeWidth={1.5} className="text-primary" />
           <h1>{title}</h1>
         </div>
-        <div className="flex items-center gap-2">
+        <PeriodSelector
+          period={period}
+          date={date}
+          onPeriodChange={setPeriod}
+          onDateChange={setDate}
+        />
+        <div className="flex items-center gap-1">
           {series.length > 0 && (
             <>
               <button
@@ -489,9 +521,8 @@ export function AnalyseView() {
                 type="button"
                 onClick={handleSaveAs}
                 disabled={saving}
-                className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-[6px] text-[12px] font-medium
-                  text-text-secondary hover:bg-border-light hover:text-text
-                  transition-colors cursor-pointer disabled:opacity-50"
+                className="flex items-center justify-center p-1.5 rounded-[6px] text-text-secondary
+                  hover:bg-border-light hover:text-text transition-colors cursor-pointer disabled:opacity-50"
                 title={t("analyse.saveAs")}
               >
                 <Copy size={14} strokeWidth={1.5} />
@@ -500,9 +531,8 @@ export function AnalyseView() {
                 <button
                   type="button"
                   onClick={() => setShowDeleteConfirm(true)}
-                  className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-[6px] text-[12px] font-medium
-                    text-text-secondary hover:bg-error/10 hover:text-error
-                    transition-colors cursor-pointer"
+                  className="flex items-center justify-center p-1.5 rounded-[6px] text-text-secondary
+                    hover:bg-error/10 hover:text-error transition-colors cursor-pointer"
                   title={t("analyse.deleteChart")}
                 >
                   <Trash2 size={14} strokeWidth={1.5} />
@@ -511,17 +541,6 @@ export function AnalyseView() {
             </>
           )}
         </div>
-      </div>
-
-      {/* Period navigator — own row, centered. Mirrors the Energy page's
-          PeriodSelector placement so the date scrubber has breathing room. */}
-      <div className="flex justify-center">
-        <PeriodSelector
-          period={period}
-          date={date}
-          onPeriodChange={setPeriod}
-          onDateChange={setDate}
-        />
       </div>
 
       {/* Series pills + add button */}

--- a/ui/src/components/history/AnalyseView.tsx
+++ b/ui/src/components/history/AnalyseView.tsx
@@ -510,13 +510,18 @@ export function AnalyseView() {
               )}
             </>
           )}
-          <PeriodSelector
-            period={period}
-            date={date}
-            onPeriodChange={setPeriod}
-            onDateChange={setDate}
-          />
         </div>
+      </div>
+
+      {/* Period navigator — own row, centered. Mirrors the Energy page's
+          PeriodSelector placement so the date scrubber has breathing room. */}
+      <div className="flex justify-center">
+        <PeriodSelector
+          period={period}
+          date={date}
+          onPeriodChange={setPeriod}
+          onDateChange={setDate}
+        />
       </div>
 
       {/* Series pills + add button */}

--- a/ui/src/components/history/AnalyseView.tsx
+++ b/ui/src/components/history/AnalyseView.tsx
@@ -30,9 +30,12 @@ import type {
   HistoryPoint,
   SavedChart,
 } from "../../types";
-import { TimeRangeSelector } from "./TimeRangeSelector";
-import { rangeToFrom } from "./history-utils";
-import type { TimeRange } from "./history-utils";
+import { PeriodSelector } from "./PeriodSelector";
+import {
+  periodTodayStr,
+  periodToWindow,
+  type Period,
+} from "./history-utils";
 import { humanBindingLabel, humanBindingLabelFromList } from "./binding-label";
 
 // ============================================================
@@ -113,15 +116,18 @@ function flattenZones(zones: ZoneWithChildren[]): { id: string; name: string; de
   return result;
 }
 
-function formatTime(iso: string, range: TimeRange): string {
+function formatTime(iso: string, period: Period): string {
   const d = new Date(iso);
-  if (range === "6h" || range === "24h") {
-    return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+  switch (period) {
+    case "day":
+      return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+    case "week":
+      return d.toLocaleDateString(undefined, { weekday: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+    case "month":
+      return d.toLocaleDateString(undefined, { day: "numeric", month: "short" });
+    case "year":
+      return d.toLocaleDateString(undefined, { month: "short" });
   }
-  if (range === "7d") {
-    return d.toLocaleDateString(undefined, { weekday: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
-  }
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
 function formatTooltipTime(iso: string): string {
@@ -153,7 +159,10 @@ export function AnalyseView() {
   const [loading, setLoading] = useState(true);
 
   // --- Selection state ---
-  const [range, setRange] = useState<TimeRange>("24h");
+  // Period + date drives the chart window (absolute, Energy-style navigator).
+  // Default: today as a day.
+  const [period, setPeriod] = useState<Period>("day");
+  const [date, setDate] = useState<string>(() => periodTodayStr());
   const [series, setSeries] = useState<SeriesConfig[]>([]);
   const [seriesData, setSeriesData] = useState<Record<string, SeriesData>>({});
 
@@ -208,7 +217,8 @@ export function AnalyseView() {
         setCurrentChart(null);
         setSeries([]);
         setSeriesData({});
-        setRange("24h");
+        setPeriod("day");
+        setDate(periodTodayStr());
         loadedChartIdRef.current = undefined;
       }
       return;
@@ -222,7 +232,19 @@ export function AnalyseView() {
       .then((chart) => {
         setCurrentChart(chart);
         loadedChartIdRef.current = chartId;
-        setRange((chart.config.timeRange as TimeRange) || "24h");
+        // New format (period + date) takes precedence. Legacy charts saved
+        // with `timeRange` are mapped to the closest period on today, so the
+        // user can pick the date back to whatever they had in mind.
+        if (chart.config.period && chart.config.date) {
+          setPeriod(chart.config.period);
+          setDate(chart.config.date);
+        } else {
+          const legacy = chart.config.timeRange;
+          const mapped: Period =
+            legacy === "30d" ? "month" : legacy === "7d" ? "week" : "day";
+          setPeriod(mapped);
+          setDate(periodTodayStr());
+        }
         const newSeries: SeriesConfig[] = [];
         for (const sc of chart.config.series) {
           const eq = equipments.find((e) => e.id === sc.equipmentId);
@@ -266,7 +288,9 @@ export function AnalyseView() {
   }, [selectedEquipmentId]);
 
   const fetchSeriesData = useCallback(
-    async (seriesList: SeriesConfig[], timeRange: TimeRange) => {
+    async (seriesList: SeriesConfig[], window: { from: Date; to: Date }) => {
+      const fromIso = window.from.toISOString();
+      const toIso = window.to.toISOString();
       for (const s of seriesList) {
         setSeriesData((prev) => ({
           ...prev,
@@ -274,7 +298,8 @@ export function AnalyseView() {
         }));
         try {
           const result = await getHistoryData(s.equipmentId, s.alias, {
-            from: rangeToFrom(timeRange),
+            from: fromIso,
+            to: toIso,
             aggregation: "auto",
           });
           setSeriesData((prev) => ({
@@ -292,11 +317,13 @@ export function AnalyseView() {
     [],
   );
 
+  const chartWindow = useMemo(() => periodToWindow(date, period), [date, period]);
+
   useEffect(() => {
     if (series.length > 0) {
-      fetchSeriesData(series, range);
+      fetchSeriesData(series, chartWindow);
     }
-  }, [series, range, fetchSeriesData]);
+  }, [series, chartWindow, fetchSeriesData]);
 
   // --- Actions ---
   const addSeries = (binding: HistoryBindingState) => {
@@ -337,7 +364,8 @@ export function AnalyseView() {
   // --- Save handlers ---
   const buildConfig = () => ({
     series: series.map((s) => ({ equipmentId: s.equipmentId, alias: s.alias })),
-    timeRange: range,
+    period,
+    date,
   });
 
   const handleSave = async () => {
@@ -414,10 +442,10 @@ export function AnalyseView() {
     const sorted = Array.from(timeMap.entries()).sort(([a], [b]) => a.localeCompare(b));
     return sorted.map(([time, values]) => ({
       time,
-      label: formatTime(time, range),
+      label: formatTime(time, period),
       ...values,
     }));
-  }, [series, seriesData, range]);
+  }, [series, seriesData, period]);
 
   const anyLoading = series.some((s) => seriesData[s.id]?.loading);
 
@@ -482,7 +510,12 @@ export function AnalyseView() {
               )}
             </>
           )}
-          <TimeRangeSelector value={range} onChange={setRange} />
+          <PeriodSelector
+            period={period}
+            date={date}
+            onPeriodChange={setPeriod}
+            onDateChange={setDate}
+          />
         </div>
       </div>
 

--- a/ui/src/components/history/PeriodSelector.tsx
+++ b/ui/src/components/history/PeriodSelector.tsx
@@ -65,7 +65,7 @@ export function PeriodSelector({ period, date, onPeriodChange, onDateChange }: P
             key={p.key}
             type="button"
             onClick={() => onPeriodChange(p.key)}
-            className={`px-3 py-1.5 text-[12px] font-medium transition-colors cursor-pointer ${
+            className={`min-w-[60px] px-3 py-1.5 text-[12px] font-medium text-center transition-colors cursor-pointer ${
               period === p.key
                 ? "bg-primary text-white"
                 : "bg-surface text-text-secondary hover:bg-border-light hover:text-text"

--- a/ui/src/components/history/PeriodSelector.tsx
+++ b/ui/src/components/history/PeriodSelector.tsx
@@ -1,0 +1,119 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  canGoForwardPeriod,
+  periodTodayStr,
+  shiftPeriod,
+  type Period,
+} from "./history-utils";
+
+interface PeriodSelectorProps {
+  period: Period;
+  date: string;
+  onPeriodChange: (period: Period) => void;
+  onDateChange: (date: string) => void;
+}
+
+const PERIODS: readonly { key: Period; labelKey: string }[] = [
+  { key: "day", labelKey: "analyse.periodDay" },
+  { key: "week", labelKey: "analyse.periodWeek" },
+  { key: "month", labelKey: "analyse.periodMonth" },
+  { key: "year", labelKey: "analyse.periodYear" },
+];
+
+function formatDateLabel(dateStr: string, period: Period, locale: string): string {
+  const d = new Date(dateStr + "T12:00:00");
+  switch (period) {
+    case "day":
+      return d.toLocaleDateString(locale, { day: "numeric", month: "long", year: "numeric" });
+    case "week": {
+      const start = new Date(d);
+      const dayOfWeek = start.getDay();
+      const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+      start.setDate(start.getDate() + mondayOffset);
+      const end = new Date(start);
+      end.setDate(end.getDate() + 6);
+      const startLabel = start.toLocaleDateString(locale, { day: "numeric", month: "short" });
+      const endLabel = end.toLocaleDateString(locale, { day: "numeric", month: "short", year: "numeric" });
+      return `${startLabel} – ${endLabel}`;
+    }
+    case "month":
+      return d.toLocaleDateString(locale, { month: "long", year: "numeric" });
+    case "year":
+      return d.getFullYear().toString();
+  }
+}
+
+/**
+ * Day/Week/Month/Year tab selector with prev/next date navigation and a
+ * "Today" reset button. Mirrors the navigator used on the Energy page; this
+ * copy lives under `history/` so the Analyse page owns its own UX without
+ * leaking the energy-specific Zustand store.
+ */
+export function PeriodSelector({ period, date, onPeriodChange, onDateChange }: PeriodSelectorProps) {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language || "fr-FR";
+  const today = periodTodayStr();
+  const canNext = canGoForwardPeriod(date, period);
+  const isToday = date === today;
+
+  return (
+    <div className="flex flex-col sm:flex-row items-center gap-3">
+      <div className="flex rounded-[6px] border border-border overflow-hidden">
+        {PERIODS.map((p) => (
+          <button
+            key={p.key}
+            type="button"
+            onClick={() => onPeriodChange(p.key)}
+            className={`px-3 py-1.5 text-[12px] font-medium transition-colors cursor-pointer ${
+              period === p.key
+                ? "bg-primary text-white"
+                : "bg-surface text-text-secondary hover:bg-border-light hover:text-text"
+            }`}
+          >
+            {t(p.labelKey)}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onDateChange(shiftPeriod(date, period, -1))}
+          className="p-1.5 rounded-[6px] text-text-tertiary hover:text-text-secondary hover:bg-border-light transition-colors cursor-pointer"
+          aria-label="previous"
+        >
+          <ChevronLeft size={16} strokeWidth={1.5} />
+        </button>
+        <span className="text-[13px] font-medium text-text min-w-[160px] text-center">
+          {formatDateLabel(date, period, locale)}
+        </span>
+        <button
+          type="button"
+          onClick={() => onDateChange(shiftPeriod(date, period, 1))}
+          disabled={!canNext}
+          className={`p-1.5 rounded-[6px] transition-colors ${
+            canNext
+              ? "text-text-tertiary hover:text-text-secondary hover:bg-border-light cursor-pointer"
+              : "text-border cursor-not-allowed"
+          }`}
+          aria-label="next"
+        >
+          <ChevronRight size={16} strokeWidth={1.5} />
+        </button>
+        <button
+          type="button"
+          onClick={() => onDateChange(today)}
+          disabled={isToday}
+          className={`ml-1 px-2 py-1 rounded-[6px] text-[11px] font-medium transition-colors ${
+            isToday
+              ? "text-text-tertiary bg-border-light cursor-default"
+              : "text-primary bg-primary-light hover:bg-primary hover:text-white cursor-pointer"
+          }`}
+        >
+          {t("analyse.today")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/history/history-utils.ts
+++ b/ui/src/components/history/history-utils.ts
@@ -40,3 +40,121 @@ export function rangeToDurationMs(range: TimeRange): number {
       return 30 * 24 * 60 * 60 * 1000;
   }
 }
+
+// ============================================================
+// Period-based navigation (Analyse page)
+// ============================================================
+//
+// Whereas TimeRange is a relative window ("last 24h"), Period+date is an
+// absolute window anchored on a calendar boundary ("May 2026"). Mirrors
+// the navigator on the Energy page so the user can scrub through any
+// past day/week/month/year.
+
+export type Period = "day" | "week" | "month" | "year";
+
+function todayStr(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Returns the start of the period that contains `dateStr`, in local time. */
+function periodStart(dateStr: string, period: Period): Date {
+  const d = new Date(dateStr + "T12:00:00"); // noon to avoid DST edge cases
+  switch (period) {
+    case "day":
+      d.setHours(0, 0, 0, 0);
+      return d;
+    case "week": {
+      const dayOfWeek = d.getDay(); // 0 = Sunday
+      const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+      d.setDate(d.getDate() + mondayOffset);
+      d.setHours(0, 0, 0, 0);
+      return d;
+    }
+    case "month":
+      d.setDate(1);
+      d.setHours(0, 0, 0, 0);
+      return d;
+    case "year":
+      d.setMonth(0, 1);
+      d.setHours(0, 0, 0, 0);
+      return d;
+  }
+}
+
+/** Returns the start of the period that immediately follows the one containing `dateStr`. */
+function periodEnd(dateStr: string, period: Period): Date {
+  const start = periodStart(dateStr, period);
+  const end = new Date(start);
+  switch (period) {
+    case "day":
+      end.setDate(end.getDate() + 1);
+      break;
+    case "week":
+      end.setDate(end.getDate() + 7);
+      break;
+    case "month":
+      end.setMonth(end.getMonth() + 1);
+      break;
+    case "year":
+      end.setFullYear(end.getFullYear() + 1);
+      break;
+  }
+  return end;
+}
+
+/** Compute the absolute [from, to) window the API should fetch for the given period+date. */
+export function periodToWindow(dateStr: string, period: Period): { from: Date; to: Date } {
+  return { from: periodStart(dateStr, period), to: periodEnd(dateStr, period) };
+}
+
+/** Convert period+date to a "from" string for the history API (ISO format). */
+export function periodToFrom(dateStr: string, period: Period): string {
+  return periodToWindow(dateStr, period).from.toISOString();
+}
+
+/** Convert period+date to a "to" string for the history API (ISO format). */
+export function periodToTo(dateStr: string, period: Period): string {
+  return periodToWindow(dateStr, period).to.toISOString();
+}
+
+/** Pick the closest TimeRange to a period, so chart components can keep their
+ *  existing tick-formatting logic without further parameterisation. */
+export function periodToClosestRange(period: Period): TimeRange {
+  switch (period) {
+    case "day":
+      return "24h";
+    case "week":
+      return "7d";
+    case "month":
+    case "year":
+      return "30d";
+  }
+}
+
+/** Whether advancing one period would go beyond today (= no future data). */
+export function canGoForwardPeriod(dateStr: string, period: Period): boolean {
+  const next = periodEnd(dateStr, period);
+  return next.getTime() <= Date.now();
+}
+
+/** Move `dateStr` forward (delta=+1) or backward (delta=-1) by one period. */
+export function shiftPeriod(dateStr: string, period: Period, delta: number): string {
+  const d = periodStart(dateStr, period);
+  switch (period) {
+    case "day":
+      d.setDate(d.getDate() + delta);
+      break;
+    case "week":
+      d.setDate(d.getDate() + delta * 7);
+      break;
+    case "month":
+      d.setMonth(d.getMonth() + delta);
+      break;
+    case "year":
+      d.setFullYear(d.getFullYear() + delta);
+      break;
+  }
+  return d.toISOString().slice(0, 10);
+}
+
+export const periodTodayStr = todayStr;

--- a/ui/src/components/history/history-utils.ts
+++ b/ui/src/components/history/history-utils.ts
@@ -52,8 +52,19 @@ export function rangeToDurationMs(range: TimeRange): number {
 
 export type Period = "day" | "week" | "month" | "year";
 
+/** YYYY-MM-DD in the **local** timezone — NOT UTC. `.toISOString().slice(0,10)`
+ *  is unsafe here because midnight local sits in the previous UTC day for
+ *  any positive timezone offset, causing date-string arithmetic to silently
+ *  fall back to "the previous local day" (no forward motion). */
+function toLocalDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
 function todayStr(): string {
-  return new Date().toISOString().slice(0, 10);
+  return toLocalDateStr(new Date());
 }
 
 /** Returns the start of the period that contains `dateStr`, in local time. */
@@ -154,7 +165,7 @@ export function shiftPeriod(dateStr: string, period: Period, delta: number): str
       d.setFullYear(d.getFullYear() + delta);
       break;
   }
-  return d.toISOString().slice(0, 10);
+  return toLocalDateStr(d);
 }
 
 export const periodTodayStr = todayStr;

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -32,7 +32,6 @@ import {
   AlertTriangle,
   RefreshCw,
   Power,
-  MoreVertical,
 } from "lucide-react";
 
 // Display name → 1-2 uppercase initials for the avatar pill.
@@ -186,15 +185,6 @@ export function AppLayout() {
                 </button>
               </div>
             )}
-            {/* Mobile ⋮ menu — opens drawer (same one bottom nav uses) */}
-            <button
-              onClick={() => setDrawerOpen(true)}
-              className="sm:hidden w-10 h-10 flex items-center justify-center rounded-[6px] text-text-secondary hover:bg-border-light/60 transition-colors duration-150"
-              aria-label={t("nav.more", "Plus")}
-              title={t("nav.more", "Plus")}
-            >
-              <MoreVertical size={20} strokeWidth={1.7} />
-            </button>
           </div>
         </header>
 

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -289,9 +289,11 @@ function MobileTopbarBurger() {
   const hasProduction = useEnergy((s) => s.hasProduction);
   const openZoneDrawer = useUiState((s) => s.openZoneDrawer);
   const openEnergyNav = useUiState((s) => s.openEnergyNav);
+  const openAnalyseNav = useUiState((s) => s.openAnalyseNav);
 
   const onZonePage = location.pathname === "/home" || location.pathname.startsWith("/home/");
   const onEnergyPage = location.pathname.startsWith("/energy");
+  const onAnalysePage = location.pathname.startsWith("/analyse");
 
   let onClick: (() => void) | null = null;
   let label = "";
@@ -301,6 +303,9 @@ function MobileTopbarBurger() {
   } else if (onEnergyPage && hasProduction) {
     onClick = openEnergyNav;
     label = t("nav.energy");
+  } else if (onAnalysePage) {
+    onClick = openAnalyseNav;
+    label = t("analyse.title");
   }
 
   if (onClick) {

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -797,6 +797,11 @@
   "analyse.noSavedCharts": "No saved charts",
   "analyse.saved": "Chart saved",
   "analyse.new": "New chart",
+  "analyse.periodDay": "Day",
+  "analyse.periodWeek": "Week",
+  "analyse.periodMonth": "Month",
+  "analyse.periodYear": "Year",
+  "analyse.today": "Today",
 
   "mqttPublishers.title": "MQTT Publishers",
   "mqttPublishers.subtitle": "Publish equipment, zone and recipe data to MQTT topics",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -797,6 +797,11 @@
   "analyse.noSavedCharts": "Aucun graphique sauvegardé",
   "analyse.saved": "Graphique enregistré",
   "analyse.new": "Nouveau graphique",
+  "analyse.periodDay": "Jour",
+  "analyse.periodWeek": "Sem",
+  "analyse.periodMonth": "Mois",
+  "analyse.periodYear": "Année",
+  "analyse.today": "Aujourd'hui",
 
   "mqttPublishers.title": "Publications MQTT",
   "mqttPublishers.subtitle": "Publier les données d'équipements, zones et recettes vers des topics MQTT",

--- a/ui/src/pages/AnalysePage.tsx
+++ b/ui/src/pages/AnalysePage.tsx
@@ -1,8 +1,10 @@
 import { AnalyseView } from "../components/history/AnalyseView";
+import { AnalyseMobileNav } from "../components/history/AnalyseMobileNav";
 
 export function AnalysePage() {
   return (
     <div className="max-w-[1200px] px-4 py-6">
+      <AnalyseMobileNav />
       <AnalyseView />
     </div>
   );

--- a/ui/src/store/useUiState.ts
+++ b/ui/src/store/useUiState.ts
@@ -7,6 +7,9 @@ interface UiState {
   energyNavOpen: boolean;
   openEnergyNav: () => void;
   closeEnergyNav: () => void;
+  analyseNavOpen: boolean;
+  openAnalyseNav: () => void;
+  closeAnalyseNav: () => void;
 }
 
 export const useUiState = create<UiState>((set) => ({
@@ -16,4 +19,7 @@ export const useUiState = create<UiState>((set) => ({
   energyNavOpen: false,
   openEnergyNav: () => set({ energyNavOpen: true }),
   closeEnergyNav: () => set({ energyNavOpen: false }),
+  analyseNavOpen: false,
+  openAnalyseNav: () => set({ analyseNavOpen: true }),
+  closeAnalyseNav: () => set({ analyseNavOpen: false }),
 }));

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -682,7 +682,14 @@ export interface SavedChartSeriesConfig {
 
 export interface SavedChartConfig {
   series: SavedChartSeriesConfig[];
-  timeRange: string;
+  /** Legacy relative window (`6h` / `24h` / `7d` / `30d`). Kept for backwards
+   * compatibility with charts saved before the period navigator landed —
+   * if `period` is present, it wins. */
+  timeRange?: string;
+  /** Absolute calendar period — present on charts saved with the new navigator. */
+  period?: "day" | "week" | "month" | "year";
+  /** Anchor date for the period (YYYY-MM-DD). Required when `period` is set. */
+  date?: string;
 }
 
 export interface SavedChart {


### PR DESCRIPTION
## Summary

Replace the four fixed relative buttons (6h / 24h / 7d / 30d) on the Analyse page with the same calendar navigator used on the Energy page: period tabs (Day / Week / Month / Year), prev/next chevrons, and a Today reset button.

This lets the user pick any absolute calendar window — see "May 2026", scroll back to "12 May 2026", compare last August year-over-year — instead of only "the last N hours/days ending right now". Especially useful right after a historical backfill (#1 on the netatmo-weather plugin repo).

## Changes

- New `ui/src/components/history/PeriodSelector.tsx` — analyse-specific, takes `period` + `date` + change handlers as plain props. Mirrors the energy/PeriodSelector UX but does **not** depend on `useEnergy` (no cross-feature coupling).
- New helpers in `history-utils.ts`: `Period` type, `periodToWindow`, `shiftPeriod`, `canGoForwardPeriod`, `periodTodayStr`. Tested implicitly via the chart fetch path.
- `AnalyseView.tsx`: replaces `range: TimeRange` state with `period: Period` + `date: string`. Uses absolute `from` / `to` ISO strings on `getHistoryData` (the API already supported this). Chart X-axis label formatting now keyed off period (Year → month tick, Month → day-month, Week → weekday + day, Day → time of day).
- `SavedChartConfig` (in both `src/shared/types.ts` and `ui/src/types.ts`): adds optional `period` + `date`; keeps `timeRange` as a legacy fallback. Charts saved with the new navigator emit `period+date`; charts saved before this PR keep loading via the legacy mapping (`24h`/`6h` → day, `7d` → week, `30d` → month, all anchored on today).
- New i18n keys `analyse.periodDay/Week/Month/Year` and `analyse.today` (FR + EN).

Energy code is intentionally untouched.

## Test plan

- [x] `npm run validate` — 743 tests pass, typecheck + lint clean (backend + UI)
- [ ] Manual: on a Sowel instance with backfilled historical data, navigate to /analyse, pick a weather equipment + temperature metric, switch between Day / Week / Month / Year, use prev/next arrows to scrub to a past month, click Today to reset. The chart re-fetches and renders the absolute window.
- [ ] Manual: open a chart saved before this PR (legacy `timeRange` field); confirm it loads cleanly with the mapped period anchored on today.