### PR TITLE
fix(ui): disambiguate same-category labels in Analyse

### DIFF
--- a/ui/src/components/history/binding-label.test.ts
+++ b/ui/src/components/history/binding-label.test.ts
@@ -101,6 +101,39 @@ describe("humanBindingLabel — Netatmo weather station full set", () => {
   });
 });
 
+describe("humanBindingLabel — same-category disambiguation", () => {
+  // Real-world case on sowelox: a Netatmo NAMain `temperature` binding and a
+  // polytropic PAC `temperature` binding share category=temperature on the
+  // same Station Météo equipment. Without disambiguation both labels read
+  // "Température intérieure" and the user picks the wrong one in the chart
+  // selector.
+  const all: HistoryBindingState[] = [
+    b("temperature_2", "temperature", "Weather Station"),
+    b("insideTemperature", "temperature", "PAC"),
+    b("temperature", "temperature_outdoor", "Outdoor Module"),
+    b("outsideTemperature", "temperature_outdoor", "PAC"),
+  ];
+  const labelOf = (alias: string) =>
+    humanBindingLabelFromList(all.find((x) => x.alias === alias)!, all, t);
+
+  it("appends the device name when two indoor temperatures coexist", () => {
+    expect(labelOf("temperature_2")).toBe("Température intérieure (Weather Station)");
+    expect(labelOf("insideTemperature")).toBe("Température intérieure (PAC)");
+  });
+
+  it("appends the device name when two outdoor temperatures coexist", () => {
+    expect(labelOf("temperature")).toBe("Température extérieure (Outdoor Module)");
+    expect(labelOf("outsideTemperature")).toBe("Température extérieure (PAC)");
+  });
+
+  it("falls back to bare label when only one of the two exists (no ambiguity)", () => {
+    const onlyOne: HistoryBindingState[] = [b("temperature_2", "temperature", "Weather Station")];
+    expect(
+      humanBindingLabelFromList(onlyOne[0], onlyOne, t),
+    ).toBe("Température intérieure");
+  });
+});
+
 describe("humanBindingLabel — fallback behaviour", () => {
   it("returns the plain category label when only one binding of that category exists, even without deviceName", () => {
     const all = [b("battery", "battery", "")];

--- a/ui/src/components/history/binding-label.ts
+++ b/ui/src/components/history/binding-label.ts
@@ -76,18 +76,23 @@ export function humanBindingLabel(input: BindingLabelInput, t: TFunction): strin
     return t(METRIC_LABELS[strippedKey]);
   }
 
-  // 2. Indoor / outdoor disambiguation via the category itself
+  // 2. Indoor / outdoor disambiguation via the category itself.
+  // When several bindings share the same category on the equipment
+  // (typical: a Netatmo NAMain `temperature` + a polytropic PAC
+  // `temperature` — both indoor by category, but from physically
+  // different sources), append the device name so the chips/legend
+  // remain distinguishable. Otherwise the bare label is enough.
   const indoor = t("weather.indoor").toLowerCase();
   const outdoor = t("weather.outdoor").toLowerCase();
-  if (category === "temperature_outdoor") return `${t("category.temperature")} ${outdoor}`;
-  if (category === "temperature") return `${t("category.temperature")} ${indoor}`;
-  if (category === "humidity_outdoor") return `${t("category.humidity")} ${outdoor}`;
-  if (category === "humidity") return `${t("category.humidity")} ${indoor}`;
+  const ambiguous = sameCategoryCount > 1 && !!deviceName;
+  const withDevice = (base: string): string => (ambiguous ? `${base} (${deviceName})` : base);
+  if (category === "temperature_outdoor") return withDevice(`${t("category.temperature")} ${outdoor}`);
+  if (category === "temperature") return withDevice(`${t("category.temperature")} ${indoor}`);
+  if (category === "humidity_outdoor") return withDevice(`${t("category.humidity")} ${outdoor}`);
+  if (category === "humidity") return withDevice(`${t("category.humidity")} ${indoor}`);
 
   // 3. Multi-instance category → device name as disambiguator
-  if (sameCategoryCount > 1 && deviceName) {
-    return `${categoryLabel(category, t)} ${deviceName}`;
-  }
+  if (ambiguous) return `${categoryLabel(category, t)} ${deviceName}`;
 
   // 4. Plain category
   return categoryLabel(category, t);


### PR DESCRIPTION
Hotfix follow-up to #237. When two bindings share the same category on the same equipment (e.g. Netatmo NAMain temperature + polytropic PAC temperature), both ended up labelled "Température intérieure" — collision in the chip selector. Now appends `(deviceName)` when sameCategoryCount > 1 for the temperature/humidity branches, matching what the helper already does for other multi-instance categories like battery. 3 new tests on the real sowelox shape.