### PR TITLE
release: v1.15.8

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.15.x — Décomposition consommation live
 
+### v1.15.8 — 2026-05-30 { #v1-15-8 }
+
+- Correctif (UI/Analyse) : quand deux bindings du même équipement partagent une catégorie (par ex. un `temperature` Netatmo NAMain et un `temperature` polytropic PAC — tous les deux intérieurs par catégorie, mais physiquement distincts), le sélecteur de chips et la légende du graphe affichaient deux entrées « Température intérieure » impossibles à distinguer. Désormais on suffixe `(deviceName)` quand plusieurs bindings de la même catégorie coexistent sur l'équipement, en cohérence avec ce que faisait déjà le helper pour les autres catégories multi-instances comme la batterie.
+
 ### v1.15.7 — 2026-05-30 { #v1-15-7 }
 
 - Correctif (UI/Analyse) : dans les vues Année / Mois, l'axe des X répétait le même libellé de mois plusieurs fois (« mars mars mars … avr. avr. avr. »). Cause : l'axe X était câblé en mode catégorique (chaque point quotidien était sa propre catégorie). Passage à une échelle temporelle continue (epoch ms + `tickFormatter`) : Recharts espace désormais les ticks régulièrement dans le temps et le formatter ne rend « mars » qu'une fois là où un tick atterrit. `minTickGap` est désormais sensible à la période (60/70/80/90 px pour jour/sem/mois/année).

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.15.x — Live submeter breakdown
 
+### v1.15.8 — 2026-05-30 { #v1-15-8 }
+
+- Fix (UI/Analyse): when two bindings on the same equipment share a category (e.g. a Netatmo NAMain `temperature` and a polytropic PAC `temperature` — both indoor by category, but from physically different sources), the chip selector and the chart legend both showed two entries labelled "Température intérieure" with no way to tell them apart. Now appends `(deviceName)` when more than one binding of the same category exists on the equipment, in line with the helper's existing behaviour for other multi-instance categories like battery.
+
 ### v1.15.7 — 2026-05-30 { #v1-15-7 }
 
 - Fix (UI/Analyse): in the Année / Mois views, the X axis repeated the same month label many times ("mars mars mars … avr. avr. avr."). Root cause: the X axis was wired as categorical strings so every daily data point became its own X position. Switch to a continuous time scale (epoch ms + `tickFormatter`) so Recharts spaces ticks evenly by time and the formatter renders "mars" only where a tick actually lands. `minTickGap` is now period-aware (60/70/80/90 px for day/week/month/year).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.15.7",
+  "version": "1.15.8",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.15.7",
+  "version": "1.15.8",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Hotfix for #241 — same-category label disambiguation. Notes added with anchor { #v1-15-8 }.