### PR TITLE
release: v1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.15.7",
+  "version": "1.16.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.15.7",
+  "version": "1.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump to v1.16.0 — ships [spec 118](https://github.com/mchacher/sowel/blob/main/specs/118-analyse-chart-improvements/spec.md) (Analyse chart improvements).

Highlights:
- Chart families (Measurements / Cumulative / States) with a family-locked series picker
- Min/max envelope band on slow-moving measurements at 1h / 1d resolution
- Bar chart for rain / energy, step chart on `[0, 1]` for boolean states
- Fix: cumulative-category queries read `mean` from downsampled buckets (rain chart now actually shows backfilled daily totals)
- Fix: sidebar nav reaches `/analyse` workspace from a saved-chart route
- UX: empty Analyse workspace opens the picker by default with the first zone preselected
- Wind direction & gust details stop being historized by default

Release notes: see [v1.16.0 in `docs/release-notes.md`](https://github.com/mchacher/sowel/blob/main/docs/release-notes.md#v1-16-0) and the FR counterpart.

## Test plan

- [ ] CI green
- [ ] PR merged to main
- [ ] Tag v1.16.0 pushed, GitHub Actions publishes `ghcr.io/mchacher/sowel:1.16.0` + `:latest`
- [ ] `cd /opt/sowel && docker compose pull && docker compose up -d` on sowelox
- [ ] "Pluie" chart on Mois mai 2026 shows the backfilled daily totals