### PR TITLE
chore(registry): bump lora2mqtt to 2.1.2

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -21,11 +21,11 @@
     "icon": "Radio",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-lora2mqtt",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "tags": ["lora", "mqtt", "iot", "sensors"],
     "sowelVersion": ">=1.2.12",
     "owner": "mchacher",
-    "sha256": "fa44f024345c0fa7799de583d60f837cb5835ab3f3f1446681a8ed51c8504dd1"
+    "sha256": "2a6adf0037098adba19c538c0dfb80677ad66b66994bb92dfe90fbda5d60af1f"
   },
   {
     "id": "tasmota",


### PR DESCRIPTION
## Summary

- Bumps `lora2mqtt` plugin entry to v2.1.2 (SHA256 `2a6adf00…`).
- Surfaces the contact_door boolean coercion fix ([sowel-plugin-lora2mqtt#1](https://github.com/mchacher/sowel-plugin-lora2mqtt/pull/1)) so LoRa garage door / contact sensors stop being stuck on "unknown" in gate equipments.

## Test plan

- [ ] CI registry verification passes (SHA256 matches the published asset)
- [ ] After deploy, tchoupi (LoRa Node 50 garage door) shows real open/closed state on its `Porte Garage` equipment