### PR TITLE
release: v1.17.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,14 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.17.x — Agrégation des historiques énergie par période
+
+### v1.17.0 — 2026-05-31 { #v1-17-0 }
+
+- Feat (backend/api) : `GET /api/v1/energy/history` et `GET /api/v1/energy/by-usage` renvoient désormais un nombre fixe de buckets pré-agrégés par période — 24 horaires en `day`, 7 quotidiens lundi à dimanche en `week`, 28 à 31 quotidiens en `month`, 12 mensuels janvier à décembre en `year`. Avant la spec 119, un appel `?period=week` renvoyait 168 points horaires et `?period=year` renvoyait environ 365 points journaliers, forçant chaque consommateur (le `EnergyBarChart.tsx` du web UI et le nouveau firmware sowel-energy-display iter 034) à ré-agréger côté client. L'agrégation se fait maintenant en une fois dans InfluxDB via `aggregateWindow(every: $resolution, location: $tz)`, avec des bornes de buckets alignées sur le fuseau local du serveur (`Europe/Paris` par défaut, journalisé au démarrage). La séparation tarifaire HP / HC est préservée sur chaque bucket. Les buckets vides sont retournés zéro-fillés pour que les consommateurs puissent itérer `0..N-1` sans gérer les trous. Le littéral `EnergyHistoryResponse.resolution` gagne `"1mo"` pour le bucket annuel. Spec 119.
+
+---
+
 ## 1.16.x — Améliorations des graphiques Analyse
 
 ### v1.16.0 — 2026-05-30 { #v1-16-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,14 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.17.x — Energy history per-period aggregation
+
+### v1.17.0 — 2026-05-31 { #v1-17-0 }
+
+- Feat (backend/api): `GET /api/v1/energy/history` and `GET /api/v1/energy/by-usage` now return a fixed number of pre-aggregated buckets per period — 24 hourly for `day`, 7 daily Mon-Sun for `week`, 28-31 daily for `month`, 12 monthly Jan-Dec for `year`. Pre-spec-119 a `?period=week` query returned 168 hourly points and `?period=year` returned ~365 daily points, forcing every consumer (web UI `EnergyBarChart.tsx` and the new sowel-energy-display firmware iter 034) to re-aggregate client-side. The aggregation now happens once in InfluxDB via Flux `aggregateWindow(every: $resolution, location: $tz)`, with bucket boundaries aligned to the server's local TZ (`Europe/Paris` by default; logged at startup). HP / HC tariff split is preserved on every bucket. Empty buckets are returned zero-filled so consumers iterate `0..N-1` without gap-handling code. `EnergyHistoryResponse.resolution` gains a new `"1mo"` literal for the yearly bucket. Spec 119.
+
+---
+
 ## 1.16.x — Analyse chart improvements
 
 ### v1.16.0 — 2026-05-30 { #v1-16-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.16.0",
+  "version": "1.17.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bump version 1.16.0 → 1.17.0.

Minor release. Single feature since v1.16.0:

- **Spec 119 (#246)** — `/api/v1/energy/history` and `/api/v1/energy/by-usage` now return a fixed N pre-aggregated buckets per period (24 / 7 / 28-31 / 12). Backend aggregates server-side via Flux `aggregateWindow(every: $resolution, location: $tz)`; HP / HC preserved; empties zero-filled. New `"1mo"` resolution literal.