### PR TITLE
feat(equipments): add display equipment type (spec 120 + 121)

### DIFF
--- a/specs/120-display-equipment/architecture.md
+++ b/specs/120-display-equipment/architecture.md
@@ -1,0 +1,223 @@
+# Architecture — Spec 120 — Display equipment type
+
+## Design decisions
+
+### D1 — New `DataCategory` values rather than overloading existing ones
+
+The 5 state fields a Sowel display reports do not match any current
+category cleanly:
+
+| New category         | Why it cannot reuse an existing one                                                |
+| -------------------- | ---------------------------------------------------------------------------------- |
+| `firmware_version`   | No existing semantic match; broadly useful (Zigbee / MQTT / Tasmota all expose it) |
+| `uptime`             | Same — generic device health, no existing category                                 |
+| `rssi`               | Same — applicable to any radio-attached device; we just have not had a slot for it |
+| `language`           | Niche but cleanly typed (ISO 639-1); no analogous string-enum category exists      |
+| `display_brightness` | `light_brightness` already exists with identical wire shape — but see D2 below     |
+
+These 5 are introduced as part of this spec because we need them today,
+but the first 3 (`firmware_version`, `uptime`, `rssi`) are intentionally
+generic so future device plugins can adopt them without a category churn.
+
+### D2 — `display_brightness` separated from `light_brightness`
+
+Both carry an identical wire shape (`number`, 0..100). A naive read of
+"reuse the existing category" is tempting and was the first instinct.
+The actual cost of reuse: a recipe filtered by category — "set
+`light_brightness` to 0 in zone Salon" — would touch the display too,
+which is wrong. Filtering at the equipment-type layer would force every
+recipe author to remember the carve-out.
+
+Forking the category at the wire layer (`display_brightness`) keeps the
+recipe DSL straightforward at the cost of one extra enum row. Same
+trade-off as D1 in spec 115 (`pool_cover_position` vs `shutter_position`,
+where pool covers got a dedicated category for safety reasons).
+
+### D3 — `EquipmentStatus` reuses spec 116 derivation, no new state machine
+
+`Device.status` is the authoritative online / offline flag for the
+underlying plugin entity. When the MQTT LWT fires, the plugin marks the
+device offline; `EquipmentStatus` (spec 116) derives "offline" from
+that, no change here. The detail card uses the existing `<OfflineOverlay>`
+component shared by every equipment type.
+
+### D4 — Polymorphic data + orders, validated by binding presence
+
+The plugin advertises only the orders a given display has honoured (see
+the plugin spec, separate repo). From Sowel's perspective, the
+`DeviceOrder` list on the device IS the source of truth — the detail
+card iterates `device.orders` and renders the matching control if the
+category appears. Nothing is hard-coded per equipment type beyond the
+"5 known categories" list for layout ordering.
+
+Concretely: the equipment-detail UI does not say "if equipment.type ===
+'display' then render brightness". It says "if any bound device has a
+data of category `display_brightness`, render the brightness row". The
+type's only job is to gate the layout (which rows in which order).
+
+### D5 — Widget family `displays`, no zone commands in v1
+
+Spec 115 (awning) added `allAwningsExtend / Stop / Retract` zone
+commands; we deliberately ship none for displays. Rationale: the most
+plausible zone commands ("set brightness to 0 across the zone", "switch
+language across the zone") are 1-equipment-per-zone in practice, and we
+do not want to commit to a vocabulary before we see the use case. Adding
+zone commands later is additive.
+
+### D6 — `rssi` is event-driven, not streaming
+
+`STREAMING_CATEGORIES` (spec 116) marks categories that update fast
+enough to warrant a separate "live" pipeline. RSSI on a display updates
+roughly once per minute — well within the regular `DeviceData` cadence.
+We do NOT add it to `STREAMING_CATEGORIES`.
+
+### D7 — No new `DeviceSource`
+
+The plugin will reuse `custom_mqtt` as its `DeviceSource` value. We
+considered `sowel_display` but plugins are supposed to be polymorphic
+on the wire format, not the entity type — a future bridge that publishes
+displays via a different protocol would carry a different source.
+
+## Data model
+
+### `src/shared/types.ts`
+
+```ts
+// Line ~7 — extend DataCategory
+export type DataCategory =
+  | "motion"
+  | ... // existing
+  | "pool_temperature_setpoint"
+  // Spec 120 — display equipment
+  | "firmware_version"
+  | "uptime"
+  | "rssi"
+  | "language"
+  | "display_brightness"
+  | "generic";
+
+// Line ~51 — extend OrderCategory
+export type OrderCategory =
+  | "light_toggle"
+  | ... // existing
+  | "set_pool_temperature_setpoint"
+  // Spec 120
+  | "set_language"
+  | "set_display_brightness";
+
+// Line ~190 — extend EquipmentType
+export type EquipmentType =
+  | "light_onoff"
+  | ... // existing
+  | "pool_heat_pump"
+  // Spec 120
+  | "display";
+
+// Line ~155 — extend ZoneAggregatedData
+export interface ZoneAggregatedData {
+  ... // existing fields
+  // Spec 120 — display family aggregation
+  displaysOnline: number;
+  displaysTotal: number;
+}
+```
+
+### `src/shared/constants.ts`
+
+```ts
+// WIDGET_FAMILY_TYPES: add a new family
+export const WIDGET_FAMILY_TYPES: Record<WidgetFamily, EquipmentType[]> = {
+  ... // existing
+  displays: ["display"],
+};
+
+// WidgetFamily type itself lives in types.ts — add "displays" there too.
+```
+
+`STREAMING_CATEGORIES` and `STREAMING_TIMEOUT_MS` are intentionally
+**not** modified (see D6).
+
+### Database / migrations
+
+No schema migration required. `Equipment.type` is a string column, no
+enum check at the DB layer; the application enforces the enum.
+`DataCategory` and `OrderCategory` are similarly string-typed in the
+SQLite schema.
+
+## Event flow
+
+Nothing new. The existing reactive pipeline already handles arbitrary
+categories and types:
+
+```
+MQTT message
+  → sowel-plugin-energy-display (parses LWT / state / cmd ack)
+    → DeviceManager.updateDeviceData(deviceId, key, value)
+      → EventBus: device.data.updated
+        → EquipmentManager (re-evaluates bindings + computed Data)
+          → EventBus: equipment.data.changed
+            → ZoneAggregator (counts displaysOnline)
+              → EventBus: zone.data.changed
+                → WebSocket → UI
+```
+
+`EquipmentStatus` is computed on every read; spec 116 covers the
+mechanics.
+
+## API contracts
+
+No new endpoints. Existing routes pick up the new enum values
+automatically:
+
+- `POST /api/v1/equipments` — accepts `type: "display"`.
+- `POST /api/v1/equipments/:id/bindings` — accepts the 5 new
+  `DataCategory` values.
+- `POST /api/v1/equipments/:id/orders` — accepts the 2 new
+  `OrderCategory` values.
+- `GET  /api/v1/equipments/:id` — emits a `DeviceWithDetails` whose
+  `data` and `orders` may contain the new entries.
+
+## File changes (rough — refined in plan.md)
+
+### Backend
+
+- `src/shared/types.ts` — extend `DataCategory`, `OrderCategory`,
+  `EquipmentType`, `WidgetFamily`, `ZoneAggregatedData`.
+- `src/shared/constants.ts` — add `displays` to `WIDGET_FAMILY_TYPES`.
+- `src/equipments/equipment-manager.ts` — add `display` to
+  `VALID_EQUIPMENT_TYPES`.
+- `src/equipments/binding-candidates.ts` — propose the 5 new
+  categories for `display`.
+- `src/zones/zone-aggregator.ts` — count `displaysOnline / Total`
+  in the accumulator + combiner + equality + projection.
+
+### Frontend
+
+- `ui/src/components/dashboard/widgets/DisplaysWidget.tsx` (new) —
+  family card.
+- `ui/src/components/zones/cards/DisplayCompactCard.tsx` (new) —
+  inline row.
+- `ui/src/components/equipments/cards/DisplayDetailCard.tsx` (new) —
+  full detail view.
+- `ui/src/components/equipments/AddEquipmentModal.tsx` — register
+  the new equipment type in the "Add equipment" picker.
+- `ui/src/i18n/{fr,en}.json` — new keys for the display strings.
+
+### Tests
+
+- `src/equipments/equipment-manager.test.ts` — accept / reject paths.
+- `src/equipments/binding-candidates.test.ts` — new categories
+  proposed for `display`, not for other types.
+- `src/zones/zone-aggregator.test.ts` — `displaysOnline / Total`
+  scenarios.
+- `src/api/routes/equipments.test.ts` — create / read / order path
+  with `type: "display"` (one happy + one reject scenario).
+
+## Risk register
+
+| Risk                                              | Mitigation                                                                                           |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Existing recipes accidentally trip `display_*`    | Categories are new — no recipe references them yet. Future recipe authors see them in the picker.    |
+| Plugin and Sowel diverge on enum values           | The 5 categories + 2 orders are listed in this spec; plugin spec re-quotes them verbatim.            |
+| UI ships before the plugin exists                 | Detail card hides every row whose binding is absent; family card lists 0 displays when none bound.   |
+| Brightness slider misfires on a powered-off panel | Plugin contract (separate spec) handles queue/discard; Sowel UI treats the order as fire-and-forget. |

--- a/specs/120-display-equipment/plan.md
+++ b/specs/120-display-equipment/plan.md
@@ -1,0 +1,166 @@
+# Plan — Spec 120 — Display equipment type
+
+One branch on Sowel core: `feat/display-equipment`. Single PR.
+
+The companion plugin (`sowel-plugin-energy-display`) ships from its own
+repo under a separate spec and is **not** required for this PR to merge
+— Sowel UI gracefully degrades to "no displays bound yet".
+
+---
+
+## A1 — Types and constants
+
+- [ ] `src/shared/types.ts`: extend `DataCategory` with the 5 new
+      values (`firmware_version`, `uptime`, `rssi`, `language`,
+      `display_brightness`) — keep `generic` last as the catch-all.
+- [ ] `src/shared/types.ts`: extend `OrderCategory` with `set_language` + `set_display_brightness`.
+- [ ] `src/shared/types.ts`: extend `EquipmentType` with `display`.
+- [ ] `src/shared/types.ts`: extend `WidgetFamily` with `displays`.
+- [ ] `src/shared/types.ts`: extend `ZoneAggregatedData` with
+      `displaysOnline` + `displaysTotal`.
+- [ ] `src/shared/constants.ts`: add `displays: ["display"]` to
+      `WIDGET_FAMILY_TYPES`.
+
+## A2 — Backend — equipment manager + binding candidates
+
+- [ ] `src/equipments/equipment-manager.ts`: add `"display"` to
+      `VALID_EQUIPMENT_TYPES`.
+- [ ] `src/equipments/binding-candidates.ts`: in the
+      `equipment.type === "display"` branch, propose data of the 5
+      new categories.
+- [ ] No `ZONE_COMMANDS` entry for display (see D5 in architecture.md).
+
+## A3 — Backend — zone aggregation
+
+- [ ] `src/zones/zone-aggregator.ts`: extend the accumulator with
+      `displaysOnline` + `displaysTotal` (init 0).
+- [ ] `src/zones/zone-aggregator.ts`: in the per-equipment walk,
+      branch on `equipment.type === "display"` — bump `displaysTotal`,
+      bump `displaysOnline` when the equipment's status is `"online"`.
+- [ ] `src/zones/zone-aggregator.ts`: update `aggregatedDataEqual` +
+      public projection to include the 2 new fields.
+
+## A4 — Backend tests
+
+- [ ] `src/equipments/equipment-manager.test.ts`:
+  - create({ type: "display" }) succeeds.
+  - create({ type: "displai" }) throws with a clear message.
+- [ ] `src/equipments/binding-candidates.test.ts`:
+  - a `display` equipment with devices exposing
+    `firmware_version` / `uptime` / `rssi` / `language` /
+    `display_brightness` sees all 5 in the candidate list.
+  - a `light_dimmable` equipment does NOT see the 5 new categories.
+- [ ] `src/zones/zone-aggregator.test.ts`:
+  - 2 displays, 1 online + 1 offline → `displaysOnline = 1`,
+    `displaysTotal = 2`.
+  - 0 displays in a zone → both counters = 0.
+  - Nested zones bubble the counters up correctly.
+- [ ] `src/api/routes/equipments.test.ts`:
+  - POST `type: "display"` returns 201 with the new equipment.
+  - POST `type: "displaaay"` returns 400.
+
+## B1 — UI — dashboard family card
+
+- [ ] `ui/src/components/dashboard/widgets/DisplaysWidget.tsx` (new):
+      list of bound displays, one row each with an online dot, name,
+      last-seen, firmware version. Mirrors the layout of
+      `WeatherWidget.tsx` for consistency.
+- [ ] `ui/src/components/dashboard/Dashboard.tsx`: register
+      `displays` in the family list.
+
+## B2 — UI — zone compact card
+
+- [ ] `ui/src/components/zones/cards/DisplayCompactCard.tsx` (new):
+      one row per display in the zone. Online dot + name + brightness
+      slider (rendered iff a `display_brightness` binding exists AND a
+      `set_display_brightness` order is available). Tiny enough that
+      the zone view does not blow up vertically.
+- [ ] `ui/src/components/zones/ZoneCardRenderer.tsx`: route
+      `display` to the new compact card.
+
+## B3 — UI — equipment detail card
+
+- [ ] `ui/src/components/equipments/cards/DisplayDetailCard.tsx` (new):
+      rows for firmware / uptime / RSSI / IP (if exposed by the plugin)
+      / language / brightness. Each row hides itself when the
+      corresponding binding is missing. Orders rendered when the matching
+      `DeviceOrder` exists on the bound device.
+- [ ] `ui/src/components/equipments/EquipmentDetailRenderer.tsx`:
+      route `display` to the new detail card.
+
+## B4 — UI — add-equipment modal + i18n
+
+- [ ] `ui/src/components/equipments/AddEquipmentModal.tsx`: add
+      `display` to the type picker with a Lucide icon (`Tv` or
+      `MonitorSmartphone` — final pick in the implementation PR).
+- [ ] `ui/src/i18n/fr.json` + `ui/src/i18n/en.json`: keys for
+  - equipment type display name + description
+  - family card title
+  - state field labels (firmware, uptime, rssi, language, brightness)
+  - order labels (set language, set brightness)
+
+## B5 — UI — manual smoke tests
+
+These are the manual checks that go in the PR test plan; they are
+documented here so the implementor does not re-discover them.
+
+- [ ] Create a `display` equipment via the modal — appears in the
+      zone view, with no data rows (no bindings yet).
+- [ ] Bind manually to a fake MQTT device exposing the 5 categories —
+      every row appears.
+- [ ] Drop the `language` binding — language row disappears, the
+      rest stay.
+- [ ] Mark the device offline in the plugin admin — equipment status
+      flips to `offline`, dashboard family card dims the row.
+- [ ] Send a `set_display_brightness` order from the slider — the
+      request hits the order route (verify via network panel).
+
+## Test plan (cross-cutting)
+
+### Modules to test
+
+| Module               | Scenarios                                                            |
+| -------------------- | -------------------------------------------------------------------- |
+| `equipment-manager`  | Create `display`; reject typo                                        |
+| `binding-candidates` | Propose 5 categories for `display`; don't propose for other types    |
+| `zone-aggregator`    | `displaysOnline / Total` in flat + nested zones, with mixed statuses |
+| `routes/equipments`  | API happy + reject paths                                             |
+
+### What NOT to test
+
+- The plugin: separate repo / spec.
+- The display firmware: separate repo / spec.
+- UI components: project convention skips React unit tests (CLAUDE.md).
+
+---
+
+## Phase 4 validation
+
+Before opening the PR:
+
+```bash
+npx tsc --noEmit                                                # backend
+cd ui && npx tsc -b --noEmit                                    # frontend
+cd /Users/mchacher/Documents/01_Geekerie/Sowel && npx vitest run
+npx eslint src/ --ext .ts
+```
+
+ZERO TS errors, ZERO ESLint errors, ALL vitest tests green.
+
+## Phase 5 — commit + PR
+
+- Conventional commit: `feat(equipments): add display equipment type (spec 120)`.
+- PR body: short summary + link to `specs/120-display-equipment/spec.md` +
+  the manual smoke list from B5 as a checklist.
+- No `Co-Authored-By` line.
+
+## Phase 6 — merge gate
+
+Wait for explicit user OK before `gh pr merge`.
+
+## Follow-ups (out of this spec, tracked separately)
+
+1. `sowel-plugin-energy-display` repo creation + first release.
+2. `sowel-energy-display` iter 035 (MQTT supervision firmware).
+3. Registry entry PR on this repo after the plugin tags v0.1.0.
+4. Future: "displays" recipe family ("turn off all displays at 22h").

--- a/specs/120-display-equipment/spec.md
+++ b/specs/120-display-equipment/spec.md
@@ -1,0 +1,141 @@
+# Spec 120 — Display equipment type
+
+## Context
+
+Sowel has no model for energy displays today. The `sowel-energy-display`
+firmware (Waveshare AMOLED 1.75, iter 030+) is a self-contained client
+that polls Sowel's REST API — Sowel cannot see it, name it, push config
+to it, or include it in scenarios.
+
+We are adding a `display` equipment type so any Sowel-supervised display
+(starting with the AMOLED firmware, later e-paper / ePOS / others) shows
+up as a first-class entity. Wire-protocol of choice is MQTT supervision
+(LWT + retained state + cmd topics), mirroring the existing
+`somfyrts2mqtt` / `zigbee2mqtt` / `lora2mqtt` pattern: any vendor that
+publishes to the agreed topic structure is auto-discovered by a
+companion plugin.
+
+This spec covers **Sowel core only**:
+
+- New equipment type, data categories, order categories.
+- New widget family + UI surfaces.
+- Zone aggregation.
+
+The companion plugin (`sowel-plugin-energy-display`) and the firmware
+work (sowel-energy-display iter 035) live in their own repos and ship
+under their own specs once this contract is frozen.
+
+## Goals
+
+1. Introduce a new `display` equipment type — sibling to `weather`,
+   `energy_meter`, etc. — observable in the dashboard, the zone view,
+   and the equipment detail page.
+2. Introduce 5 new `DataCategory` values that describe a display's
+   self-reported state: `firmware_version`, `uptime`, `rssi`,
+   `language`, `display_brightness`.
+3. Introduce 2 new `OrderCategory` values for actuation:
+   `set_language`, `set_display_brightness`.
+4. New widget family `displays`, ship the three UI cards expected of a
+   first-class equipment (dashboard family card, zone compact card,
+   equipment detail card).
+5. Aggregate `displaysOnline / displaysTotal` per zone so the zone
+   widget can render "1/2 online" alongside the other family counts.
+6. Online / offline status uses the existing `EquipmentStatus`
+   derivation (spec 116) — the plugin marks the underlying `Device`
+   offline when MQTT LWT fires, and Sowel cascades that to the
+   equipment for free.
+7. **Polymorphism** — none of the data fields or orders are mandatory.
+   A passive single-screen display that only reports
+   `firmware_version` + `uptime` is a valid Sowel display, fully
+   observable; the UI hides any field / order that the bound device
+   does not expose.
+
+## Non-Goals
+
+- The MQTT topic structure, JSON shape, and broker-side details
+  (`sowel-display/<id>/availability` etc.) — owned by the companion
+  plugin spec; this spec stays plugin-agnostic on purpose. Any
+  integration that emits the right categories binds to a `display`.
+- The companion plugin itself (`sowel-plugin-energy-display`,
+  separate repo).
+- The firmware-side implementation (sowel-energy-display iter 035,
+  separate repo).
+- `set_screen` / "switch screen" order. Confirmed with the user:
+  which screen the display is showing is **internal** to the
+  display's UX, not a Sowel concern. Displays may still expose
+  vendor-specific orders for it but Sowel does not standardise a
+  category.
+- OTA push from Sowel to the display — future iter once the equipment
+  ships and we know what we want to model.
+- A "displays" recipe family (e.g. "turn off all displays at 22h").
+  Recipes can be added once displays are visible and orderable; this
+  spec ships only the equipment.
+- Touching existing equipment types, recipes, or zone behaviour —
+  additive only.
+
+## Acceptance criteria
+
+### API
+
+- [ ] `POST /api/v1/equipments` with `{ type: "display", name, zoneId }`
+      succeeds and returns an `Equipment` with `type === "display"`.
+- [ ] `POST /api/v1/equipments` with `type: "displays"` (typo) returns
+      400 with a clear message.
+- [ ] Bindings to a device data of category `firmware_version`,
+      `uptime`, `rssi`, `language`, `display_brightness` succeed and
+      surface via `/api/v1/equipments/:id`.
+- [ ] `POST /api/v1/equipments/:id/orders` with
+      `category: "set_display_brightness"` and a 0..100 value
+      dispatches through the existing plugin order path.
+
+### Backend logic
+
+- [ ] `equipment-manager` accepts `display` in `VALID_EQUIPMENT_TYPES`
+      and rejects unknown types as before.
+- [ ] `binding-candidates` proposes the 5 new categories when binding
+      to a `display`.
+- [ ] `zone-aggregator` counts `displaysOnline` (where
+      `EquipmentStatus === "online"`) and `displaysTotal` in every
+      zone subtree.
+
+### UI
+
+- [ ] Dashboard "Displays" family card lists every display with an
+      online dot, name, last-seen, firmware version.
+- [ ] Zone compact card row renders one line per display with the
+      online dot + name + brightness slider (if the binding exists).
+- [ ] Equipment detail card renders firmware / uptime / RSSI /
+      language / brightness when bound, hides each row if unbound,
+      and exposes the language dropdown + brightness slider when the
+      matching orders are available on the device.
+- [ ] All new strings localised (FR + EN).
+
+### Tests
+
+- [ ] `equipment-manager.test.ts` covers create + reject paths.
+- [ ] `zone-aggregator.test.ts` covers `displaysOnline / displaysTotal`
+      across nested zones, including mixed online/offline devices.
+- [ ] `binding-candidates.test.ts` covers the new categories.
+
+## Edge cases
+
+- **Display with no language binding** — UI shows "—" in the language
+  row; the dropdown is hidden because there is no `set_language`
+  order on the device.
+- **Display reports `display_brightness` but no `set_display_brightness`
+  order** — slider is rendered read-only (greyed thumb), value shown
+  but not editable.
+- **Multiple displays in the same zone** — compact card renders one
+  row per display, ordered by `Equipment.createdAt`. Family card
+  count = sum across all zones.
+- **Display offline (no MQTT activity)** — `EquipmentStatus` falls to
+  `offline` (spec 116); detail card grays out the bar and shows
+  "Offline since X" using the existing offline overlay.
+- **Display brightness command issued while offline** — the order
+  request still resolves on the API side (status `pending`); the
+  plugin queues / discards per its own contract. Sowel does not
+  block the request locally — consistent with how lights / shutters
+  behave today.
+- **Display with only the mandatory fields (`firmware_version`,
+  `uptime`)** — detail card shows just those two rows; everything
+  else hides. Validates the polymorphism goal.

--- a/specs/121-plugin-energy-display/architecture.md
+++ b/specs/121-plugin-energy-display/architecture.md
@@ -1,0 +1,199 @@
+# Architecture — Spec 121 — `sowel-plugin-energy-display`
+
+## Design decisions
+
+### D1 — MQTT bridge plugin pattern (mirror of `sowel-plugin-somfy-rts`)
+
+The plugin shape is a straight copy of the existing
+`sowel-plugin-somfy-rts` (spec 115 work-stream B): a single
+long-running MQTT client owns the connection, dispatches inbound
+messages to the appropriate handler, and exposes
+`executeOrder(device, orderKey, value)` for the outbound path.
+There is no per-device state machine; the broker + retained
+`state` topic IS the state.
+
+No reinvention here on purpose — the user runs Mosquitto already,
+the Sowel plugin manager already understands MQTT plugins, and
+`mqtt.js` (which the existing plugins use) handles reconnect with
+backoff.
+
+### D2 — `topic_prefix` is a single setting, not per-display
+
+Multiple displays share one topic prefix (default `sowel-display`).
+Splitting per display would force the user to configure each one
+manually in Sowel Admin, defeating the auto-discovery goal.
+Operators who run truly heterogeneous deployments can run several
+brokers (or topic namespaces) and configure the plugin once per
+broker — but that is a self-inflicted setup, not the target case.
+
+### D3 — `DeviceOrder` declaration is plugin-driven
+
+Per spec 120 D4, the equipment detail UI hides an order control
+when the bound device has no matching `DeviceOrder`. The plugin
+declares the orders at device-creation time based on **which state
+field the display has reported at least once**:
+
+- Device reports `language` → plugin declares `set_language`.
+- Device reports `brightness` → plugin declares `set_display_brightness`.
+- Otherwise → no order declared, UI hides the control.
+
+This is the polymorphism payoff: a passive single-screen display
+that only reports `firmware_version + uptime` ends up with zero
+orders and zero controls in the UI — observability without UI
+noise.
+
+Concretely: in the state handler, after every `updateDeviceData`,
+check whether the matching order is already declared on the device;
+if not, append it via `deps.devices.declareOrder(deviceId, ...)`.
+
+### D4 — `availability` LWT drives `Device.status`, not equipment status
+
+`EquipmentStatus` (spec 116) derives "online" / "degraded" / "offline"
+from `Device.status` + streaming binding freshness. We do not touch
+`EquipmentStatus` here. The plugin's only job on the availability
+topic is to call `deps.devices.updateStatus(deviceId, "online" | "offline")`
+and let the equipment manager cascade.
+
+Keep-alive is set to 30 s on the MQTT client; LWT therefore fires
+~45-60 s after a hard disconnect, which matches the user's tolerance
+("see displays go offline within a minute").
+
+### D5 — Permissive JSON parser
+
+Every field in the `state` payload is parsed independently inside a
+try/catch — a malformed `rssi` does not poison the parse of
+`brightness`. Unknown extras pass through as `generic` data so a
+future firmware can extend the payload without a plugin upgrade.
+
+This is the same shape as `today_parse.cpp` in the firmware
+(zero-fill on missing fields, no parse error on partial schemas).
+Forward + backward compatibility for free.
+
+### D6 — `custom_mqtt` as `DeviceSource`
+
+No new `DeviceSource` enum value. Plugins are polymorphic on the
+wire format, not the entity type. A future bridge that publishes
+displays over a different protocol (e.g. CoAP) would set its own
+source — we do not commit Sowel to a "sowel_display" source value
+in `types.ts`.
+
+### D7 — Single PR for the plugin, separate PR for the registry entry
+
+Per the spec 089 supply-chain workflow:
+
+1. Plugin repo creation + first release tag.
+2. Registry entry PR on Sowel referencing the GH release tarball +
+   the matching SHA256 (computed by
+   `scripts/backfill-registry-sha256.mjs`).
+
+The plugin can be installed manually (point Sowel at a local
+tarball) before the registry entry lands; the registry PR is what
+turns it into a one-click install for other users.
+
+## Plugin manifest
+
+```json
+{
+  "id": "energy-display",
+  "name": "Sowel Energy Display",
+  "kind": "integration",
+  "version": "0.1.0",
+  "entry": "dist/index.js",
+  "description": "MQTT supervision for Sowel-supervised displays (energy display, e-paper, ...).",
+  "settings": {
+    "mqtt_broker_url": {
+      "type": "string",
+      "required": true,
+      "label": "MQTT broker URL (e.g. mqtt://192.168.0.230:1883)"
+    },
+    "mqtt_user": {
+      "type": "string",
+      "required": false,
+      "label": "MQTT username (optional)"
+    },
+    "mqtt_pass": {
+      "type": "secret",
+      "required": false,
+      "label": "MQTT password (optional)"
+    },
+    "topic_prefix": {
+      "type": "string",
+      "required": false,
+      "default": "sowel-display",
+      "label": "Topic prefix (default: sowel-display)"
+    }
+  }
+}
+```
+
+## File layout (plugin repo)
+
+```
+sowel-plugin-energy-display/
+├── src/
+│   ├── index.ts              # createPlugin entry — wires MQTT client to deps
+│   ├── mqtt-client.ts        # broker connect / subscribe / publish wrapper
+│   ├── parse-state.ts        # JSON state → DeviceData mapping
+│   ├── parse-state.test.ts
+│   ├── dispatch-order.ts     # Sowel order → MQTT publish
+│   ├── dispatch-order.test.ts
+│   └── availability.ts       # LWT handler → device.status
+├── manifest.json
+├── package.json
+├── tsconfig.json
+├── README.md
+├── .github/workflows/release.yml
+└── specs/001-initial-release/spec.md  (migrated copy of THIS doc)
+```
+
+The size estimate: ~600 LOC of TS in src/, ~200 LOC of tests, ~100
+LOC of release scaffolding. Total plugin ~1 KLOC, in line with the
+existing somfy-rts / tasmota plugins.
+
+## Data flow
+
+### Inbound (display → Sowel)
+
+```
+display publishes sowel-display/abc/state {...}
+  → mqtt-client.ts onMessage(topic, payload)
+    → parse-state.ts: split topic, parse JSON, map fields
+      → for each canonical field:
+          deps.devices.updateDeviceData(deviceId, key, value, category)
+        for orders not yet declared:
+          deps.devices.declareOrder(deviceId, orderCategory)
+      → emit system.integration.connected (first-seen heartbeat)
+```
+
+```
+display LWT publishes sowel-display/abc/availability "offline"
+  → mqtt-client.ts onMessage(topic, payload)
+    → availability.ts: parse "online"|"offline"
+      → deps.devices.updateStatus(deviceId, status)
+        → EventBus: device.status.changed
+          → EquipmentManager re-derives EquipmentStatus
+            → WebSocket → UI dims the display row
+```
+
+### Outbound (Sowel order → display)
+
+```
+User clicks "Set brightness 80%" on DisplayDetailCard
+  → POST /api/v1/equipments/<id>/orders { category: "set_display_brightness", value: 80 }
+    → EquipmentManager.dispatchOrder()
+      → plugin.executeOrder(device, "set_display_brightness", 80)
+        → dispatch-order.ts: map category → topic suffix
+          → mqtt-client.ts: publish sowel-display/abc/cmd/brightness "80"
+            → display receives, applies, republishes state with brightness=80
+              → loops back to inbound flow, UI sees the new value
+```
+
+## Risk register
+
+| Risk                                                    | Mitigation                                                                                                                                                                         |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plugin written against draft API and core drift         | Pin `@sowel/plugin-api` to a released version; bump in lockstep with breaking changes (rare since 053).                                                                            |
+| MQTT broker unreachable at install time                 | Plugin reports `disconnected` status; user fixes broker URL in Admin; reconnects automatically.                                                                                    |
+| Display publishes very chatty state (every 5 s)         | `DeviceManager.updateDeviceData` is idempotent on unchanged values; no event flood.                                                                                                |
+| Two displays accidentally share the same `id`           | `upsertFromDiscovery` matches by `(integrationId, sourceDeviceId)` → second display overwrites first. Surface a warning on duplicate first-seen if both have different `hostname`. |
+| LWT keep-alive too long (firmware sets keep-alive=300s) | Document the recommended firmware-side keep-alive (30 s) in the firmware spec (035). Plugin tolerates whatever the client picks.                                                   |

--- a/specs/121-plugin-energy-display/plan.md
+++ b/specs/121-plugin-energy-display/plan.md
@@ -1,0 +1,171 @@
+# Plan — Spec 121 — `sowel-plugin-energy-display`
+
+Two work-streams. P1 lives in the new plugin repo; P2 is a one-line
+registry change in this Sowel repo.
+
+Order: P1 ships first (tagged GH release) → P2 (registry PR with
+SHA256). Spec 120 must be merged before any of this lands.
+
+---
+
+## P1 — Plugin repo creation + initial release
+
+Repo: `mchacher/sowel-plugin-energy-display`, branch `feat/initial-release`.
+
+### P1.1 — Scaffolding
+
+- [ ] `gh repo create mchacher/sowel-plugin-energy-display --public --description "..."`
+- [ ] Copy the layout from `sowel-plugin-somfy-rts`: `package.json`,
+      `tsconfig.json`, `.github/workflows/release.yml`, `manifest.json`,
+      `README.md` template.
+- [ ] Trim irrelevant Somfy-specific bits (RF, pairing).
+- [ ] Pin `@sowel/plugin-api` to the version that ships spec 120.
+
+### P1.2 — `manifest.json`
+
+- [ ] Fill the manifest per architecture.md (id, kind, settings).
+
+### P1.3 — `src/index.ts` — entry point
+
+- [ ] `createPlugin(deps)` returns an `IntegrationPlugin`.
+- [ ] `start()`: read settings, instantiate `MqttClient`, wire
+      message handlers, emit `system.integration.connected` on connect.
+- [ ] `stop()`: close MQTT, emit `system.integration.disconnected`.
+- [ ] `executeOrder(device, key, value)`: delegate to
+      `dispatch-order.ts`.
+- [ ] `getStatus()`: return connected / disconnected.
+
+### P1.4 — `src/mqtt-client.ts`
+
+- [ ] Wrap `mqtt.js` with the project's existing patterns
+      (reconnect with backoff, keep-alive 30 s, topic subscription
+      helpers).
+- [ ] `subscribe("<prefix>/+/availability")`,
+      `subscribe("<prefix>/+/state")`.
+- [ ] `publish("<prefix>/<id>/cmd/<key>", payload, { qos: 1 })`.
+
+### P1.5 — `src/parse-state.ts` + tests
+
+- [ ] Pure function `parseState(payload: string): ParsedState | null`.
+- [ ] Map each canonical field to its `{ key, category, value }`.
+- [ ] Permissive: missing / null / wrong-type → field dropped, no
+      throw.
+- [ ] Tests: 5 fixtures listed in spec.md acceptance (full / mandatory
+      only / missing optional / unknown extras / malformed).
+
+### P1.6 — `src/dispatch-order.ts` + tests
+
+- [ ] Map `OrderCategory` → topic suffix + payload format.
+- [ ] Clamp `set_display_brightness` to 0..100.
+- [ ] Tests: 2 fixtures listed in spec.md acceptance.
+
+### P1.7 — `src/availability.ts` + tests
+
+- [ ] Parse `"online" | "offline"` (case-insensitive, trim).
+- [ ] Tests: 3 scenarios (online, offline, garbage payload).
+
+### P1.8 — Order declaration
+
+- [ ] In `src/index.ts` state handler, after every
+      `updateDeviceData`, check if the matching order exists on the
+      device — if not, declare it. Done once per device per order
+      category, then becomes a no-op.
+
+### P1.9 — `.github/workflows/release.yml`
+
+- [ ] On `v*` tag push: build `dist/index.js` (bundled), assemble
+      `sowel-plugin-energy-display-<version>.tar.gz`, attach to the
+      GH release.
+- [ ] Mirror the somfy-rts workflow.
+
+### P1.10 — README
+
+- [ ] Quickstart: how to install via Sowel Admin → Plugins.
+- [ ] MQTT contract reference (link to spec 121 once migrated into
+      the repo).
+- [ ] Troubleshooting: "no displays appear" / "orders not applied".
+
+### P1.11 — First release
+
+- [ ] Tag `v0.1.0` on `main`, GH workflow builds + attaches the
+      tarball.
+
+---
+
+## P2 — Registry entry on Sowel
+
+Repo: `mchacher/Sowel`, branch `feat/registry-energy-display`.
+
+### P2.1 — Registry JSON
+
+- [ ] `plugins/registry.json`: append an entry with
+      `id: "energy-display"`, `owner: "mchacher"`, `repo`, `version`.
+- [ ] Run `node scripts/backfill-registry-sha256.mjs` to populate
+      the SHA256.
+- [ ] Verify the entry matches the spec-089 schema (sha256 present,
+      owner whitelisted as official since `mchacher` is in
+      `OFFICIAL_OWNERS`).
+
+### P2.2 — Smoke test
+
+- [ ] Install the plugin via Sowel Admin → Plugins → Browse,
+      pointing at the registry entry. Verify it appears, settings page
+      opens, broker connect works.
+
+### P2.3 — PR
+
+- [ ] Commit message: `chore(registry): add energy-display plugin v0.1.0`.
+- [ ] PR description: link to the plugin repo + the spec 121 doc +
+      the smoke-test outcome.
+
+---
+
+## Phase 4 validation (P1 + P2)
+
+```bash
+# Plugin
+npm run build          # in plugin repo
+npm test               # all parse / dispatch / availability tests
+
+# Sowel
+node scripts/backfill-registry-sha256.mjs   # idempotent, verifies hash
+npx tsc --noEmit       # no breakage from the registry change (none expected)
+```
+
+## Test plan
+
+| Module           | Scenarios                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------- |
+| `parse-state`    | Full payload; mandatory-only; missing optional; unknown extras; malformed JSON                |
+| `dispatch-order` | set_language → topic+payload; set_display_brightness → topic+payload (clamped)                |
+| `availability`   | online; offline; garbage payload                                                              |
+| Integration      | mock broker, end-to-end: state arrives → device created → status flips on LWT → order publish |
+
+### What NOT to test
+
+- The `display` equipment type — covered in spec 120 tests.
+- The firmware — covered in spec 035 tests.
+- The Sowel core data flow — exercised by existing plugin tests
+  (somfy-rts, tasmota) so we know `updateDeviceData` /
+  `executeOrder` plumbing is solid.
+
+## Phase 5 — commit + PR (P1)
+
+- Conventional commit: `feat(initial-release): MQTT supervision plugin for sowel displays (spec 121)`.
+- PR description: link to spec 121, manual smoke test results.
+- No `Co-Authored-By` line.
+
+## Phase 6 — merge gate
+
+Wait for explicit user OK before merging P1; same for P2.
+
+## Follow-ups (out of this spec)
+
+1. spec 122+ — admin UI improvements (live list of supervised
+   displays under the plugin settings page).
+2. spec 12X — OTA push from Sowel to displays (orchestrated via
+   the plugin's MQTT channel).
+3. spec 12X — "displays" recipe family (turn off all displays at
+   22h, change language at boot, etc.).
+4. spec 12X — TLS / mutual auth on the broker channel, once the
+   broker is exposed beyond the LAN.

--- a/specs/121-plugin-energy-display/spec.md
+++ b/specs/121-plugin-energy-display/spec.md
@@ -1,0 +1,214 @@
+# Spec 121 — `sowel-plugin-energy-display` MQTT supervision plugin
+
+## Context
+
+Spec 120 introduces the `display` equipment type in Sowel. The
+equipment is plugin-agnostic on purpose: any integration that emits
+data of the right `DataCategory` values can bind to a `display`.
+This spec ships **the first such integration** — a thin MQTT
+supervision plugin that turns any "Sowel-supervised display"
+publishing to a known topic structure into a Sowel `Device`.
+
+The plugin reuses the exact same pattern as `sowel-plugin-somfy-rts`
+(spec 115, work-stream B): broker URL configured from Sowel Admin,
+LWT-based availability, JSON state payloads, command publishes
+triggered by Sowel orders.
+
+The first display vendor under supervision is the
+`sowel-energy-display` firmware (separate iter 035, separate repo).
+The contract documented here is the canonical MQTT wire format —
+any future display (e-paper, ePOS, OLED) only needs to publish to
+the same topics to be picked up; no Sowel or plugin change required.
+
+This spec lives in Sowel for now because the plugin repo does not
+exist yet and Sowel is where the registry tracks it. When the
+`sowel-plugin-energy-display` repo is created, the spec migrates to
+`specs/001-initial-release/` in that repo verbatim.
+
+## Goals
+
+1. Create a new GitHub repo `mchacher/sowel-plugin-energy-display`
+   following the spec-053+ plugin layout (manifest, `dist/index.js`,
+   release workflow, SHA256 in Sowel's registry).
+2. Connect to a user-configured MQTT broker (URL + optional
+   user/pass), driven by Sowel Admin → Plugins → Energy Display.
+3. Subscribe to `<topic_prefix>/+/availability` and
+   `<topic_prefix>/+/state` (default prefix `sowel-display`).
+4. Auto-discover devices: on the first `state` payload seen for an
+   unknown `<id>`, call `deps.devices.upsertFromDiscovery(...)` so
+   Sowel creates a `Device` named after `state.hostname` (or
+   `state.id` as fallback).
+5. Translate `state` JSON fields into `DeviceData` rows with the
+   canonical category mapping (spec 120):
+   - `version` → `firmware_version`
+   - `uptime_s` → `uptime`
+   - `rssi` → `rssi`
+   - `language` → `language`
+   - `brightness` → `display_brightness`
+   - any other field → `generic` with the JSON key as data key.
+6. Mark the underlying device offline within ~30 s when the
+   `availability` topic flips to `offline` (LWT fires) — so Sowel's
+   `EquipmentStatus` derivation (spec 116) cascades to the
+   `display` equipment.
+7. Translate Sowel orders to outbound publishes:
+   - `set_language` → publish `<topic_prefix>/<id>/cmd/language`,
+     payload = the order's value (`"fr"` / `"en"`).
+   - `set_display_brightness` → publish
+     `<topic_prefix>/<id>/cmd/brightness`, payload = integer string
+     (`"80"`).
+   - Future vendor-specific orders follow the same `cmd/<key>` shape.
+8. Emit `system.integration.connected` /
+   `system.integration.disconnected` events on broker connect /
+   disconnect, mirroring spec 111's allowed event list.
+9. Ship a manifest + README + minimal test suite + GitHub release
+   pipeline matching the patterns of `sowel-plugin-tasmota`.
+10. Add the registry entry to Sowel's `plugins/registry.json` once
+    the first plugin release is tagged (separate PR after the
+    plugin ships, per the spec 089 SHA256 workflow).
+
+## Non-Goals
+
+- The `display` equipment type, its data categories, or its UI —
+  owned by spec 120.
+- The firmware-side implementation — owned by sowel-energy-display
+  iter 035, separate repo.
+- TLS / mutual auth with the broker — local LAN only for v1.
+  Internet-exposed broker = its own iter.
+- OTA push from Sowel to displays — future iter.
+- Pairing / un-pairing displays from Sowel Admin. Displays are
+  self-registering via their `state` payload; admin gets a Devices
+  list, not a pairing UI.
+- Migrating an existing pre-MQTT display (the current AMOLED
+  firmware that polls the Sowel REST API). The polling path stays
+  alive in parallel until iter 035 lands and the user opts in to
+  MQTT supervision by configuring the broker in the captive portal.
+- `cmd/screen` (switch screen). Per spec 120, Sowel does not model
+  the display's current screen. A vendor that wants to expose it
+  may publish a `cmd/screen` topic and ignore the unknown order on
+  the plugin side — the plugin will not standardise it.
+
+## MQTT contract (canonical)
+
+Topic root: `<topic_prefix>/<id>/...` — `<topic_prefix>` defaults to
+`sowel-display` and is the only Sowel-side knob (one value shared by
+all supervised displays). `<id>` is each display's stable identifier
+(MAC-derived, generated firmware-side on first boot, stored in NVS).
+
+| Topic                        | Direction | Retained | Payload                                                |
+| ---------------------------- | --------- | -------- | ------------------------------------------------------ |
+| `<prefix>/<id>/availability` | sub       | yes      | `online` or `offline` (LWT publishes `offline`)        |
+| `<prefix>/<id>/state`        | sub       | yes      | JSON (see below), every ~30 s + on change              |
+| `<prefix>/<id>/cmd/<key>`    | pub       | no       | string / number / enum, per the order being dispatched |
+
+### `state` JSON (canonical)
+
+```json
+{
+  "id": "sowel-display-9a3b1c",
+  "version": "1.2.1",
+  "uptime_s": 12345,
+  "hostname": "sowel-display-9a3b1c",
+  "ip": "192.168.0.123",
+  "rssi": -55,
+  "language": "fr",
+  "brightness": 80
+}
+```
+
+| Field         | Tier            | DataCategory mapping                        |
+| ------------- | --------------- | ------------------------------------------- |
+| `id`          | mandatory       | not a data row — used as `sourceDeviceId`   |
+| `version`     | mandatory       | `firmware_version`                          |
+| `uptime_s`    | mandatory       | `uptime`                                    |
+| `hostname`    | recommended     | not a data row — used to seed `Device.name` |
+| `ip`          | recommended     | `generic`, key `ip_address`                 |
+| `rssi`        | recommended     | `rssi`                                      |
+| `language`    | recommended     | `language`                                  |
+| `brightness`  | vendor-specific | `display_brightness`                        |
+| anything else | vendor-specific | `generic`, key = the JSON field name        |
+
+The plugin is **permissive**: unknown / missing / null fields never
+fail the parse — each field is mapped independently inside a
+try/catch and a parse failure on one field is logged but does not
+poison the rest.
+
+### `cmd/<key>` payloads
+
+| Sowel `OrderCategory`    | Topic suffix     | Payload format        |
+| ------------------------ | ---------------- | --------------------- |
+| `set_language`           | `cmd/language`   | `"fr"` or `"en"`      |
+| `set_display_brightness` | `cmd/brightness` | integer 5..100, ASCII |
+| vendor-specific (future) | `cmd/<key>`      | string                |
+
+Vendor-specific orders are dispatched by the plugin only when the
+device declares the matching `DeviceOrder` — declaration is
+plugin-driven (see D3 in `architecture.md`).
+
+## Acceptance criteria
+
+### Wiring
+
+- [ ] Repo `mchacher/sowel-plugin-energy-display` exists with the
+      spec-053+ layout.
+- [ ] `pluginManifest.json` declares the integration with
+      `id: "energy-display"`, `kind: "integration"`, the required
+      settings (`mqtt_broker_url`, `mqtt_user?`, `mqtt_pass?`,
+      `topic_prefix?`).
+- [ ] GitHub Actions release workflow tags + builds + uploads the
+      tarball; SHA256 is added to Sowel's `plugins/registry.json`
+      via `scripts/backfill-registry-sha256.mjs`.
+
+### Behaviour
+
+- [ ] Plugin connects to the configured broker on `start()`, emits
+      `system.integration.connected`.
+- [ ] On broker disconnect, `system.integration.disconnected` is
+      emitted within ~5 s.
+- [ ] On first `state` payload for a new `<id>`, a `Device` is
+      auto-created with `source: "custom_mqtt"` and named after
+      `state.hostname`.
+- [ ] On every `state` payload, the canonical fields map to the
+      right `DataCategory` and `DeviceData.value` is updated.
+- [ ] On `availability=offline`, the device's `status` flips to
+      `"offline"` within ~30 s.
+- [ ] On Sowel order with category `set_language`, the plugin
+      publishes to `<prefix>/<id>/cmd/language` with the order
+      value.
+- [ ] On Sowel order with category `set_display_brightness`,
+      idem for `cmd/brightness`.
+
+### Tests
+
+- [ ] `parse-state.test.ts`: 5 fixtures (full payload, mandatory
+      only, missing optional, unknown extras, malformed JSON).
+- [ ] `dispatch-order.test.ts`: 2 fixtures (set_language,
+      set_display_brightness) — assert the published topic +
+      payload via a mock broker.
+- [ ] `availability.test.ts`: LWT flip → Device.status update.
+
+## Edge cases
+
+- **Broker reachable but no displays publishing yet** — plugin
+  reports `connected`, devices list stays empty. No error.
+- **Display publishes `state` with `id` missing** — drop the
+  message + log a warning (without `id`, we cannot key the device).
+- **Display publishes `state` then disconnects ungracefully** —
+  LWT fires `offline`, plugin marks device offline. When the
+  display reconnects, the next `state` re-flips it to online
+  (existing `Device` is reused via `upsertFromDiscovery`).
+- **User changes `topic_prefix` after devices were discovered** —
+  old devices keep their `sourceDeviceId`; new devices appear
+  under the new prefix. The plugin does not auto-migrate; the
+  user deletes the obsolete devices via Admin.
+- **Order issued while the device is offline** — plugin publishes
+  to `cmd/<key>` anyway. The display will not receive it (it is
+  disconnected); the order is fire-and-forget. The Sowel UI does
+  not block the request — consistent with the lights / shutters
+  behaviour.
+- **`brightness` value out of bounds** — plugin clamps to 0..100
+  before publishing. Out-of-range incoming state is logged and
+  ignored.
+- **Concurrent `state` from same `<id>` racing** — `DeviceManager`
+  is the synchronisation point; the plugin just calls
+  `updateDeviceData` in order. Last-writer-wins is the existing
+  Sowel semantic.

--- a/src/equipments/binding-candidates.test.ts
+++ b/src/equipments/binding-candidates.test.ts
@@ -95,6 +95,39 @@ describe("computeBindingCandidates", () => {
     expect(result[0].dataKeys).toEqual(["temperature", "humidity", "pressure"]);
     expect(result[0].orderKeys).toEqual([]);
   });
+
+  // Spec 120 — display equipment polymorphism.
+  it("display with all telemetry → one all-data candidate", () => {
+    const datas = [
+      data("version", "text", { category: "firmware_version" }),
+      data("uptime", "number", { category: "uptime" }),
+      data("rssi", "number", { category: "rssi" }),
+      data("language", "text", { category: "language" }),
+      data("brightness", "number", { category: "display_brightness" }),
+    ];
+    const orders = [order("set_language", "text"), order("set_brightness", "number")];
+    const result = computeBindingCandidates("display", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("all");
+    expect(result[0].dataKeys).toEqual(["version", "uptime", "rssi", "language", "brightness"]);
+    expect(result[0].orderKeys).toEqual(["set_language", "set_brightness"]);
+  });
+
+  it("display with only mandatory fields (version + uptime) → still bindable", () => {
+    const datas = [
+      data("version", "text", { category: "firmware_version" }),
+      data("uptime", "number", { category: "uptime" }),
+    ];
+    const result = computeBindingCandidates("display", datas, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].dataKeys).toEqual(["version", "uptime"]);
+    expect(result[0].orderKeys).toEqual([]);
+  });
+
+  it("display with no data + no orders → no candidate (cannot bind to nothing)", () => {
+    const result = computeBindingCandidates("display", [], []);
+    expect(result).toHaveLength(0);
+  });
 });
 
 describe("hasFreeCandidates", () => {

--- a/src/equipments/binding-candidates.ts
+++ b/src/equipments/binding-candidates.ts
@@ -152,8 +152,12 @@ export function computeBindingCandidates(
     case "energy_production_meter":
     case "button":
     case "appliance":
-    case "media_player": {
+    case "media_player":
+    case "display": {
       // Multi-value equipment: single candidate that groups everything.
+      // Spec 120 — `display` binds whatever telemetry the plugin exposes
+      // (firmware_version / uptime / rssi / language / display_brightness)
+      // + matching orders. Polymorphic: missing fields are fine.
       if (deviceData.length === 0 && deviceOrders.length === 0) return [];
       return [
         {

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -200,6 +200,18 @@ describe("EquipmentManager", () => {
       expect(eq.name).toBe("Store banne");
     });
 
+    // Spec 120 — display equipment.
+    it("creates a display equipment", () => {
+      const zone = zoneManager.create({ name: "Cuisine" });
+      const eq = manager.create({
+        name: "Cadran énergie",
+        type: "display",
+        zoneId: zone.id,
+      });
+      expect(eq.type).toBe("display");
+      expect(eq.name).toBe("Cadran énergie");
+    });
+
     it("rejects non-existent zone", () => {
       expect(() => {
         manager.create({ name: "Test", type: "light_onoff", zoneId: "non-existent" });

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -53,6 +53,7 @@ const VALID_EQUIPMENT_TYPES: Set<string> = new Set([
   "pool_pump",
   "pool_cover",
   "pool_heat_pump",
+  "display",
 ]);
 
 // ============================================================

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -173,6 +173,8 @@ export const WIDGET_FAMILY_TYPES: Record<WidgetFamily, EquipmentType[]> = {
   sensors: ["sensor"],
   water: ["water_valve"],
   pool: ["pool_pump", "pool_cover", "pool_heat_pump"],
+  // Spec 120 — Sowel-supervised displays.
+  displays: ["display"],
 };
 
 // ============================================================

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -46,6 +46,13 @@ export type DataCategory =
   | "appliance_state"
   | "pool_water_temperature"
   | "pool_temperature_setpoint"
+  // Spec 120 — display equipment (generic-ish telemetry that displays
+  // expose; some of these may be reused by other plugins later).
+  | "firmware_version"
+  | "uptime"
+  | "rssi"
+  | "language"
+  | "display_brightness"
   | "generic";
 
 export type OrderCategory =
@@ -64,7 +71,10 @@ export type OrderCategory =
   | "pool_pump_toggle"
   | "pool_cover_move"
   | "pool_cover_position"
-  | "set_pool_temperature_setpoint";
+  | "set_pool_temperature_setpoint"
+  // Spec 120 — display equipment.
+  | "set_language"
+  | "set_display_brightness";
 
 // ============================================================
 // Device
@@ -175,6 +185,13 @@ export interface ZoneAggregatedData {
   sunset: string | null;
   isDaylight: boolean | null;
   /**
+   * Spec 120 — count of `display` equipments in this zone (+ descendants)
+   * whose `EquipmentStatus === "online"` vs total. Powers the zone widget's
+   * "1/2 displays online" line.
+   */
+  displaysOnline: number;
+  displaysTotal: number;
+  /**
    * Per-DataCategory count of equipments in this zone (and descendants) that
    * were skipped from aggregation because their status === "offline" (spec 116).
    * Missing keys mean zero. Lets UI render "(N unavailable)" hints next to the
@@ -209,7 +226,9 @@ export type EquipmentType =
   | "water_valve"
   | "pool_pump"
   | "pool_cover"
-  | "pool_heat_pump";
+  | "pool_heat_pump"
+  // Spec 120 — Sowel-supervised display (energy display, e-paper, ...).
+  | "display";
 
 export interface Equipment {
   id: string;
@@ -992,7 +1011,9 @@ export type WidgetFamily =
   | "heating"
   | "sensors"
   | "water"
-  | "pool";
+  | "pool"
+  // Spec 120 — Sowel-supervised displays.
+  | "displays";
 
 export interface WidgetConfig {
   /** Sensor widget: list of binding aliases to display (undefined = show all) */

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -128,6 +128,8 @@ describe("ZoneAggregator", () => {
         sunrise: null,
         sunset: null,
         isDaylight: null,
+        displaysOnline: 0,
+        displaysTotal: 0,
         unavailableEquipmentsByCategory: {},
       });
     });
@@ -476,6 +478,67 @@ describe("ZoneAggregator", () => {
       expect(data?.shuttersTotal).toBe(0);
       expect(data?.shuttersOpen).toBe(0);
       expect(data?.averageShutterPosition).toBeNull();
+    });
+
+    // ──────────────────────────────────────────────────────────────
+    // Spec 120 — display equipment aggregation
+    // ──────────────────────────────────────────────────────────────
+
+    it("counts displays total and online (one online + one offline)", () => {
+      const zone = zoneManager.create({ name: "Cuisine" });
+
+      // Online display: bound to an online device with a fresh telemetry value.
+      const devOnline = seedDevice(db, {
+        name: "Cadran cuisine",
+        dataKeys: [
+          {
+            key: "version",
+            type: "text",
+            category: "firmware_version",
+            value: JSON.stringify("1.0.0"),
+          },
+        ],
+      });
+      const eqOnline = equipmentManager.create({
+        name: "Cadran cuisine",
+        type: "display",
+        zoneId: zone.id,
+      });
+      equipmentManager.addDataBinding(eqOnline.id, devOnline.dataIds[0], "version");
+
+      // Offline display: same shape but the device is offline.
+      const devOffline = seedDevice(db, {
+        name: "Cadran garage",
+        dataKeys: [
+          {
+            key: "version",
+            type: "text",
+            category: "firmware_version",
+            value: JSON.stringify("1.0.0"),
+          },
+        ],
+      });
+      db.prepare("UPDATE devices SET status = 'offline' WHERE id = ?").run(devOffline.deviceId);
+      const eqOffline = equipmentManager.create({
+        name: "Cadran garage",
+        type: "display",
+        zoneId: zone.id,
+      });
+      equipmentManager.addDataBinding(eqOffline.id, devOffline.dataIds[0], "version");
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.displaysTotal).toBe(2);
+      expect(data?.displaysOnline).toBe(1);
+    });
+
+    it("returns zero displays in a zone with none", () => {
+      const zone = zoneManager.create({ name: "Vide" });
+      aggregator.computeAll();
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.displaysTotal).toBe(0);
+      expect(data?.displaysOnline).toBe(0);
     });
 
     it("counts water valves total and open with state alias", () => {

--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -39,6 +39,9 @@ interface Accumulator {
   waterValvesTotal: number;
   waterFlowSum: number;
   waterFlowHasData: boolean;
+  /** Spec 120 — displays online (EquipmentStatus === "online") vs total. */
+  displaysOnline: number;
+  displaysTotal: number;
   /** Per-DataCategory count of equipments skipped because status === "offline" (spec 116). */
   unavailableByCategory: Partial<Record<DataCategory, number>>;
 }
@@ -67,6 +70,8 @@ function emptyAccumulator(): Accumulator {
     waterValvesTotal: 0,
     waterFlowSum: 0,
     waterFlowHasData: false,
+    displaysOnline: 0,
+    displaysTotal: 0,
     unavailableByCategory: {},
   };
 }
@@ -106,6 +111,8 @@ function mergeAccumulators(a: Accumulator, b: Accumulator): Accumulator {
     waterValvesTotal: a.waterValvesTotal + b.waterValvesTotal,
     waterFlowSum: a.waterFlowSum + b.waterFlowSum,
     waterFlowHasData: a.waterFlowHasData || b.waterFlowHasData,
+    displaysOnline: a.displaysOnline + b.displaysOnline,
+    displaysTotal: a.displaysTotal + b.displaysTotal,
     unavailableByCategory: mergeUnavailable(a.unavailableByCategory, b.unavailableByCategory),
   };
 }
@@ -141,6 +148,8 @@ function accumulatorToPublic(acc: Accumulator): ZoneAggregatedData {
     sunrise: null,
     sunset: null,
     isDaylight: null,
+    displaysOnline: acc.displaysOnline,
+    displaysTotal: acc.displaysTotal,
     unavailableEquipmentsByCategory: acc.unavailableByCategory,
   };
 }
@@ -170,6 +179,8 @@ function aggregatedDataEqual(a: ZoneAggregatedData, b: ZoneAggregatedData): bool
     a.sunrise === b.sunrise &&
     a.sunset === b.sunset &&
     a.isDaylight === b.isDaylight &&
+    a.displaysOnline === b.displaysOnline &&
+    a.displaysTotal === b.displaysTotal &&
     unavailableEqual(a.unavailableEquipmentsByCategory, b.unavailableEquipmentsByCategory)
   );
 }
@@ -486,6 +497,17 @@ export class ZoneAggregator {
       if (equipment.type === "weather") continue; // Exclude weather from zone aggregation
       const withDetails = this.equipmentManager.getByIdWithDetails(equipment.id);
       if (!withDetails) continue;
+
+      // Spec 120 — `display` zone counters are equipment-level (not
+      // binding-level), so they run before the offline early-out: total
+      // counts every display regardless of status, online counts only
+      // those with EquipmentStatus === "online" (degraded / offline excluded).
+      if (equipment.type === "display") {
+        acc.displaysTotal += 1;
+        if (withDetails.status === "online") {
+          acc.displaysOnline += 1;
+        }
+      }
 
       if (withDetails.status === "offline") {
         for (const binding of withDetails.dataBindings) {

--- a/ui/src/components/dashboard/ZoneWidget.tsx
+++ b/ui/src/components/dashboard/ZoneWidget.tsx
@@ -35,6 +35,7 @@ const WIDGET_FAMILY_TYPES: Record<WidgetFamily, string[]> = {
   sensors: ["sensor"],
   water: ["water_valve"],
   pool: ["pool_pump", "pool_cover", "pool_heat_pump"],
+  displays: ["display"],
 };
 
 interface ZoneWidgetProps {

--- a/ui/src/components/dashboard/widget-icons.ts
+++ b/ui/src/components/dashboard/widget-icons.ts
@@ -46,6 +46,7 @@ import {
   ToggleLeft,
   Settings,
   Radio,
+  Monitor,
   type LucideIcon,
 } from "lucide-react";
 import type { EquipmentType, WidgetFamily } from "../../types";
@@ -279,6 +280,7 @@ export const ICON_MAP: Record<string, LucideIcon> = {
   ToggleLeft,
   Settings,
   Radio,
+  Monitor,
 };
 
 export const ICON_CATEGORIES: { label: string; icons: string[] }[] = [
@@ -288,7 +290,7 @@ export const ICON_CATEGORIES: { label: string; icons: string[] }[] = [
   { label: "Security", icons: ["Shield", "ShieldCheck", "Camera", "Bell", "Eye", "AlertTriangle"] },
   { label: "Sensors", icons: ["Gauge", "Activity", "Zap", "Power", "Battery", "Signal", "Wifi"] },
   { label: "Rooms", icons: ["Home", "Sofa", "Bed", "CookingPot", "Bath", "Car", "Trees", "Flower2"] },
-  { label: "General", icons: ["Star", "Heart", "CircleDot", "ToggleLeft", "Settings", "Radio"] },
+  { label: "General", icons: ["Star", "Heart", "CircleDot", "ToggleLeft", "Settings", "Radio", "Monitor"] },
 ];
 
 const EQUIPMENT_DEFAULT_ICONS: Partial<Record<EquipmentType, string>> = {
@@ -307,6 +309,7 @@ const EQUIPMENT_DEFAULT_ICONS: Partial<Record<EquipmentType, string>> = {
   pool_pump: "Droplets",
   pool_cover: "ArrowUpDown",
   pool_heat_pump: "Thermometer",
+  display: "Monitor",
 };
 
 const FAMILY_DEFAULT_ICONS: Record<WidgetFamily, string> = {
@@ -317,6 +320,7 @@ const FAMILY_DEFAULT_ICONS: Record<WidgetFamily, string> = {
   sensors: "Gauge",
   water: "Droplets",
   pool: "Droplets",
+  displays: "Monitor",
 };
 
 export function getWidgetIcon(

--- a/ui/src/components/equipments/DisplayPanel.tsx
+++ b/ui/src/components/equipments/DisplayPanel.tsx
@@ -1,0 +1,176 @@
+import { useTranslation } from "react-i18next";
+import { Monitor, Wifi, Tag, Clock, Languages, Sun } from "lucide-react";
+import type {
+  DataBindingWithValue,
+  OrderBindingWithDetails,
+  DataCategory,
+  OrderCategory,
+} from "../../types";
+
+interface DisplayPanelProps {
+  dataBindings: DataBindingWithValue[];
+  orderBindings: OrderBindingWithDetails[];
+  equipmentId: string;
+  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+}
+
+const ROW_ORDER: DataCategory[] = [
+  "firmware_version",
+  "uptime",
+  "rssi",
+  "language",
+  "display_brightness",
+];
+
+function formatUptime(secs: number): string {
+  if (secs < 60) return `${Math.floor(secs)} s`;
+  if (secs < 3600) return `${Math.floor(secs / 60)} min`;
+  if (secs < 86400) {
+    const h = Math.floor(secs / 3600);
+    const m = Math.floor((secs % 3600) / 60);
+    return m === 0 ? `${h} h` : `${h} h ${m} min`;
+  }
+  const d = Math.floor(secs / 86400);
+  const h = Math.floor((secs % 86400) / 3600);
+  return h === 0 ? `${d} j` : `${d} j ${h} h`;
+}
+
+function iconFor(category: DataCategory) {
+  switch (category) {
+    case "firmware_version":
+      return <Tag size={16} strokeWidth={1.5} className="text-text-tertiary" />;
+    case "uptime":
+      return <Clock size={16} strokeWidth={1.5} className="text-text-tertiary" />;
+    case "rssi":
+      return <Wifi size={16} strokeWidth={1.5} className="text-text-tertiary" />;
+    case "language":
+      return <Languages size={16} strokeWidth={1.5} className="text-text-tertiary" />;
+    case "display_brightness":
+      return <Sun size={16} strokeWidth={1.5} className="text-text-tertiary" />;
+    default:
+      return <Monitor size={16} strokeWidth={1.5} className="text-text-tertiary" />;
+  }
+}
+
+function formatValue(category: DataCategory, value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  switch (category) {
+    case "uptime":
+      return typeof value === "number" ? formatUptime(value) : String(value);
+    case "rssi":
+      return typeof value === "number" ? `${value} dBm` : String(value);
+    case "display_brightness":
+      return typeof value === "number" ? `${value} %` : String(value);
+    default:
+      return String(value);
+  }
+}
+
+export function DisplayPanel({
+  dataBindings,
+  orderBindings,
+  onExecuteOrder,
+}: DisplayPanelProps) {
+  const { t } = useTranslation();
+
+  // Index bindings by category. A category may have multiple bindings (e.g.
+  // two displays merged into one equipment) — we render the first match, which
+  // matches the canonical 1-display-per-equipment convention.
+  const dataByCategory = new Map<DataCategory, DataBindingWithValue>();
+  for (const b of dataBindings) {
+    if (!dataByCategory.has(b.category)) dataByCategory.set(b.category, b);
+  }
+
+  const orderByCategory = new Map<OrderCategory, OrderBindingWithDetails>();
+  for (const o of orderBindings) {
+    if (o.category && !orderByCategory.has(o.category)) {
+      orderByCategory.set(o.category, o);
+    }
+  }
+
+  const visibleRows = ROW_ORDER.filter((c) => dataByCategory.has(c));
+  if (visibleRows.length === 0) {
+    return (
+      <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
+        <h3 className="text-[14px] font-semibold text-text flex items-center gap-2 mb-2">
+          <Monitor size={16} strokeWidth={1.5} className="text-text-tertiary" />
+          {t("displays.panel.title")}
+        </h3>
+        <p className="text-[13px] text-text-tertiary">{t("displays.panel.noData")}</p>
+      </div>
+    );
+  }
+
+  const brightnessOrder = orderByCategory.get("set_display_brightness");
+  const languageOrder = orderByCategory.get("set_language");
+  const languageBinding = dataByCategory.get("language");
+  const brightnessBinding = dataByCategory.get("display_brightness");
+
+  return (
+    <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
+      <h3 className="text-[14px] font-semibold text-text flex items-center gap-2 mb-4">
+        <Monitor size={16} strokeWidth={1.5} className="text-text-tertiary" />
+        {t("displays.panel.title")}
+      </h3>
+
+      <div className="divide-y divide-border-light">
+        {visibleRows.map((category) => {
+          const binding = dataByCategory.get(category);
+          if (!binding) return null;
+          const isInteractive =
+            (category === "language" && languageOrder) ||
+            (category === "display_brightness" && brightnessOrder);
+
+          return (
+            <div
+              key={category}
+              className="flex items-center gap-3 py-2 first:pt-0 last:pb-0"
+            >
+              {iconFor(category)}
+              <span className="flex-1 text-[13px] text-text">
+                {t(`displays.fields.${category}`)}
+              </span>
+              {!isInteractive && (
+                <span className="text-[13px] font-mono text-text-secondary">
+                  {formatValue(category, binding.value)}
+                </span>
+              )}
+              {category === "language" && languageBinding && languageOrder && (
+                <select
+                  className="text-[13px] bg-bg border border-border rounded-[6px] px-2 py-1"
+                  value={String(languageBinding.value ?? "")}
+                  onChange={(e) =>
+                    onExecuteOrder(languageOrder.alias, e.target.value)
+                  }
+                >
+                  <option value="fr">FR</option>
+                  <option value="en">EN</option>
+                </select>
+              )}
+              {category === "display_brightness" &&
+                brightnessBinding &&
+                brightnessOrder && (
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="range"
+                      min={5}
+                      max={100}
+                      step={5}
+                      value={Number(brightnessBinding.value ?? 0)}
+                      onChange={(e) =>
+                        onExecuteOrder(brightnessOrder.alias, Number(e.target.value))
+                      }
+                      className="w-24"
+                    />
+                    <span className="text-[13px] font-mono text-text-secondary w-12 text-right">
+                      {formatValue(category, brightnessBinding.value)}
+                    </span>
+                  </div>
+                )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -13,6 +13,7 @@ import {
   Heater,
   Zap,
   Tv,
+  Monitor,
   WashingMachine,
   Waves,
 } from "lucide-react";
@@ -51,6 +52,7 @@ const TYPE_ICONS: Record<EquipmentType, React.ReactNode> = {
   pool_pump: <Waves size={18} strokeWidth={1.5} />,
   pool_cover: <ShutterClosedIcon size={18} strokeWidth={1.5} />,
   pool_heat_pump: <Thermometer size={18} strokeWidth={1.5} />,
+  display: <Monitor size={18} strokeWidth={1.5} />,
 };
 
 const TYPE_LABELS: Record<EquipmentType, string> = {
@@ -76,6 +78,7 @@ const TYPE_LABELS: Record<EquipmentType, string> = {
   pool_pump: "equipments.type.pool_pump",
   pool_cover: "equipments.type.pool_cover",
   pool_heat_pump: "equipments.type.pool_heat_pump",
+  display: "equipments.type.display",
 };
 
 interface EquipmentCardProps {

--- a/ui/src/components/equipments/EquipmentForm.tsx
+++ b/ui/src/components/equipments/EquipmentForm.tsx
@@ -28,6 +28,7 @@ const EQUIPMENT_TYPE_KEYS: { value: EquipmentType; labelKey: string }[] = [
   { value: "pool_pump", labelKey: "equipments.type.pool_pump" },
   { value: "pool_cover", labelKey: "equipments.type.pool_cover" },
   { value: "pool_heat_pump", labelKey: "equipments.type.pool_heat_pump" },
+  { value: "display", labelKey: "equipments.type.display" },
 ];
 
 interface EquipmentFormProps {

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -51,6 +51,8 @@ const TYPE_TINTS: Record<EquipmentType, Tint> = {
   energy_meter:            { bg: "bg-accent-light", text: "text-accent" },
   main_energy_meter:       { bg: "bg-accent-light", text: "text-accent" },
   appliance:               { bg: "bg-border-light", text: "text-text-secondary" },
+  // Spec 120 — displays use the muted "info-only" tint, matching sensors.
+  display:                 { bg: "bg-sensor-50",    text: "text-sensor-500" },
 };
 
 export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: CompactEquipmentCardProps) {

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -241,6 +241,18 @@
   "equipments.type.pool_pump": "Pool pump",
   "equipments.type.pool_cover": "Pool cover",
   "equipments.type.pool_heat_pump": "Pool heat pump",
+  "equipments.type.display": "Sowel display",
+
+  "displays.panel.title": "Display state",
+  "displays.panel.noData": "No telemetry from this display yet.",
+  "displays.fields.firmware_version": "Firmware version",
+  "displays.fields.uptime": "Up since",
+  "displays.fields.rssi": "Wi-Fi signal",
+  "displays.fields.language": "Language",
+  "displays.fields.display_brightness": "Brightness",
+  "displays.widget.title": "Displays",
+  "displays.widget.empty": "No displays",
+  "displays.widget.onlineCount": "{{online}}/{{total}} online",
 
   "water.open": "Open",
   "water.closed": "Closed",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -241,6 +241,18 @@
   "equipments.type.pool_pump": "Pompe de piscine",
   "equipments.type.pool_cover": "Volet de piscine",
   "equipments.type.pool_heat_pump": "Pompe à chaleur piscine",
+  "equipments.type.display": "Afficheur Sowel",
+
+  "displays.panel.title": "État de l'afficheur",
+  "displays.panel.noData": "Aucune donnée encore remontée par cet afficheur.",
+  "displays.fields.firmware_version": "Version du firmware",
+  "displays.fields.uptime": "Démarré depuis",
+  "displays.fields.rssi": "Signal Wi-Fi",
+  "displays.fields.language": "Langue",
+  "displays.fields.display_brightness": "Luminosité",
+  "displays.widget.title": "Afficheurs",
+  "displays.widget.empty": "Aucun afficheur",
+  "displays.widget.onlineCount": "{{online}}/{{total}} en ligne",
 
   "water.open": "Ouverte",
   "water.closed": "Fermée",

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -14,6 +14,7 @@ import { PoolHeatPumpControl } from "../components/equipments/PoolHeatPumpContro
 import { SensorDataPanel } from "../components/equipments/SensorDataPanel";
 import { WeatherPanel } from "../components/equipments/WeatherPanel";
 import { WeatherForecastPanel } from "../components/equipments/WeatherForecastPanel";
+import { DisplayPanel } from "../components/equipments/DisplayPanel";
 import { AddBindingModal } from "../components/equipments/AddBindingModal";
 import { EquipmentStatusBadge } from "../components/equipments/EquipmentStatusBadge";
 import { DeviceSelector } from "../components/equipments/DeviceSelector";
@@ -355,7 +356,7 @@ export function EquipmentDetailPage() {
         <AppliancePanel equipment={equipment} />
       )}
 
-      {/* Sensor / Weather data */}
+      {/* Sensor / Weather / Display data */}
       {equipment.type === "weather_forecast" ? (
         <WeatherForecastPanel bindings={equipment.dataBindings} />
       ) : equipment.type === "weather" ? (
@@ -363,6 +364,13 @@ export function EquipmentDetailPage() {
           bindings={equipment.dataBindings}
           equipmentId={equipment.id}
           computedData={equipment.computedData}
+        />
+      ) : equipment.type === "display" ? (
+        <DisplayPanel
+          dataBindings={equipment.dataBindings}
+          orderBindings={equipment.orderBindings}
+          equipmentId={equipment.id}
+          onExecuteOrder={(alias, value) => executeOrder(equipment.id, alias, value)}
         />
       ) : isSensor ? (
         <SensorDataPanel bindings={equipment.dataBindings} equipmentId={equipment.id} />

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -46,6 +46,12 @@ export type DataCategory =
   | "appliance_state"
   | "pool_water_temperature"
   | "pool_temperature_setpoint"
+  // Spec 120 — display equipment telemetry.
+  | "firmware_version"
+  | "uptime"
+  | "rssi"
+  | "language"
+  | "display_brightness"
   | "generic";
 
 export type OrderCategory =
@@ -64,7 +70,10 @@ export type OrderCategory =
   | "pool_pump_toggle"
   | "pool_cover_move"
   | "pool_cover_position"
-  | "set_pool_temperature_setpoint";
+  | "set_pool_temperature_setpoint"
+  // Spec 120 — display equipment.
+  | "set_language"
+  | "set_display_brightness";
 
 // ============================================================
 // Device
@@ -169,6 +178,10 @@ export interface ZoneAggregatedData {
   sunrise: string | null;
   sunset: string | null;
   isDaylight: boolean | null;
+  /** Spec 120 — count of `display` equipments in this zone (+ descendants)
+   *  whose EquipmentStatus === "online" vs total. */
+  displaysOnline: number;
+  displaysTotal: number;
   /** Per-DataCategory count of equipments excluded from aggregation because
    *  status === "offline" (spec 116). Used by the UI to render "(N unavailable)"
    *  hints next to affected metrics. */
@@ -201,7 +214,9 @@ export type EquipmentType =
   | "water_valve"
   | "pool_pump"
   | "pool_cover"
-  | "pool_heat_pump";
+  | "pool_heat_pump"
+  // Spec 120 — Sowel-supervised display (energy display, e-paper, ...).
+  | "display";
 
 export interface Equipment {
   id: string;
@@ -853,7 +868,9 @@ export type WidgetFamily =
   | "heating"
   | "sensors"
   | "water"
-  | "pool";
+  | "pool"
+  // Spec 120 — Sowel-supervised displays.
+  | "displays";
 
 export interface WidgetConfig {
   /** Sensor widget: list of binding aliases to display (undefined = show all) */


### PR DESCRIPTION
## Summary

Introduces the `display` equipment type so Sowel-supervised displays
(starting with the AMOLED energy display, later e-paper / others) are
first-class entities: visible, with telemetry, with orders, observable
in zones and the dashboard.

Plugin-agnostic: any integration that emits the new categories binds.
The MQTT wire format itself lives in spec 121 (companion plugin
`sowel-plugin-energy-display`, separate repo) and the firmware-side
implementation in sowel-energy-display iter 035 (separate repo).

Specs included:
- [specs/120-display-equipment/spec.md](specs/120-display-equipment/spec.md)
- [specs/120-display-equipment/architecture.md](specs/120-display-equipment/architecture.md)
- [specs/120-display-equipment/plan.md](specs/120-display-equipment/plan.md)
- [specs/121-plugin-energy-display/spec.md](specs/121-plugin-energy-display/spec.md) (drafted here, migrates to the plugin repo at creation)

## Changes

### Backend

- `DataCategory` +5: `firmware_version`, `uptime`, `rssi`, `language`, `display_brightness`.
- `OrderCategory` +2: `set_language`, `set_display_brightness`.
- `EquipmentType` +1: `display`.
- `WidgetFamily` +1: `displays`.
- `ZoneAggregatedData` +2: `displaysOnline`, `displaysTotal` (counted before the spec-116 offline early-out so total includes offline).
- `binding-candidates`: `display` falls in the multi-data "all" pattern (polymorphic).
- `equipment-manager`: accepts `"display"` in `VALID_EQUIPMENT_TYPES`.

### UI

- `DisplayPanel.tsx` (new): renders firmware / uptime / RSSI / language / brightness rows from bindings, hides each row when missing. Inline language dropdown + brightness slider when the matching orders are available on the bound device.
- `EquipmentForm`: `display` in the type picker.
- `EquipmentCard` / `CompactEquipmentCard` / `widget-icons`: Monitor icon + sensor tint.
- `ZoneWidget` `WIDGET_FAMILY_TYPES` + `ui/src/types.ts` mirror.
- i18n FR + EN.

### Key design decisions (full rationale in architecture.md)

- `display_brightness` separated from `light_brightness` so recipes filtered by category never trip displays.
- No mandatory orders. A passive single-screen display is a valid Sowel display, fully observable.
- `EquipmentStatus` reused via spec-116 derivation (`Device.status` flipped by the MQTT LWT on the plugin side). No new state machine.
- No `set_screen` order — confirmed with the maintainer that the screen currently displayed is internal to each display's UX, not a Sowel concern.

## Test plan

- [x] `npx tsc --noEmit` PASS (backend)
- [x] `cd ui && npx tsc -b --noEmit` PASS (UI)
- [x] `npx vitest run` — 786/788 (2 skipped pre-existing)
- [x] `npx eslint src/ --ext .ts` — 0 errors
- [x] `cd ui && npx eslint .` — 0 errors (2 pre-existing warnings)
- [ ] Manual: create a `display` equipment via the form, verify icon + label render correctly
- [ ] Manual: bind a fake MQTT device exposing the 5 categories → every row appears in the detail panel
- [ ] Manual: drop the `language` binding → language row disappears
- [ ] Manual: mark the device offline → equipment status flips to `offline`
- [ ] Manual: trigger `set_display_brightness` order from the slider → request hits `/api/v1/equipments/:id/orders`

## Follow-ups (out of scope)

1. `sowel-plugin-energy-display` repo creation + first release (spec 121).
2. `sowel-energy-display` iter 035 — firmware MQTT supervision.
3. Registry entry PR on this repo after the plugin tags v0.1.0.
4. Future: "displays" recipe family ("turn off all displays at 22h").