### PR TITLE
fix(ui): render display equipments in zone view, hide from dashboard widget picker

### DIFF
--- a/ui/src/components/dashboard/AddWidgetModal.tsx
+++ b/ui/src/components/dashboard/AddWidgetModal.tsx
@@ -98,10 +98,14 @@ export function AddWidgetModal({
               </div>
 
               {/* Equipment list filtered by zone */}
+              {/* Spec 120 — `display` is excluded from the dashboard picker.
+                  Displays are meta / control surfaces, not "things in the home"
+                  the dashboard is meant to summarise. They remain visible in
+                  the zone view and their equipment detail page. */}
               {eqZoneId && (
                 <div className="space-y-0.5">
                   {equipments
-                    .filter((eq) => eq.zoneId === eqZoneId)
+                    .filter((eq) => eq.zoneId === eqZoneId && eq.type !== "display")
                     .map((eq) => (
                       <button
                         key={eq.id}
@@ -115,7 +119,7 @@ export function AddWidgetModal({
                         <span className="ml-2 text-[11px] text-text-tertiary">{eq.type}</span>
                       </button>
                     ))}
-                  {equipments.filter((eq) => eq.zoneId === eqZoneId).length === 0 && (
+                  {equipments.filter((eq) => eq.zoneId === eqZoneId && eq.type !== "display").length === 0 && (
                     <p className="text-[13px] text-text-tertiary text-center py-4">{t("dashboard.noEquipmentsAvailable")}</p>
                   )}
                 </div>

--- a/ui/src/components/home/ZoneEquipmentsView.tsx
+++ b/ui/src/components/home/ZoneEquipmentsView.tsx
@@ -7,6 +7,7 @@ import {
   Thermometer,
   Zap,
   Tv,
+  Monitor,
   WashingMachine,
   Waves,
 } from "lucide-react";
@@ -37,6 +38,7 @@ const EQUIPMENT_GROUPS: EquipmentGroup[] = [
   { labelKey: "equipments.group.appliances", types: ["appliance"], icon: <WashingMachine size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.water", types: ["water_valve"], icon: <WaterValveIcon size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.pool", types: ["pool_pump", "pool_cover", "pool_heat_pump"], icon: <Waves size={14} strokeWidth={1.5} /> },
+  { labelKey: "equipments.group.displays", types: ["display"], icon: <Monitor size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.other", types: ["switch", "button", "gate"], icon: <ToggleRight size={14} strokeWidth={1.5} /> },
 ];
 

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -279,6 +279,7 @@
   "equipments.group.appliances": "Appliances",
   "equipments.group.water": "Water",
   "equipments.group.pool": "Pool",
+  "equipments.group.displays": "Displays",
   "equipments.group.other": "Other",
 
   "equipments.noEquipments": "No equipments",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -279,6 +279,7 @@
   "equipments.group.appliances": "Électroménager",
   "equipments.group.water": "Eau",
   "equipments.group.pool": "Piscine",
+  "equipments.group.displays": "Afficheurs",
   "equipments.group.other": "Autres",
 
   "equipments.noEquipments": "Aucun équipement",


### PR DESCRIPTION
## Two UI surfaces missed by spec 120

### 1. Zone view — display equipment invisible

[\`ZoneEquipmentsView.tsx\`](ui/src/components/home/ZoneEquipmentsView.tsx) groups equipments by a hardcoded \`EQUIPMENT_GROUPS\` table. Spec 120 added the \`display\` equipment type but did not extend this table, so any display in a zone was filtered out (no matching group) and silently invisible to the user.

Fix: add a \"displays\" group with a \`Monitor\` icon, between \"pool\" and \"other\". New i18n key \`equipments.group.displays\` (\"Afficheurs\" / \"Displays\").

### 2. Dashboard add-widget — display should not be a tile

Displays are meta / control surfaces. They make sense in the zone view and on their detail page, but not as standalone dashboard tiles (mismatch with the dashboard's role of summarising home state).

Fix: filter \`eq.type !== \"display\"\` on the equipment list inside [\`AddWidgetModal.tsx\`](ui/src/components/dashboard/AddWidgetModal.tsx). The Zone tab is unaffected — its \`FAMILIES\` array already excludes \`displays\` (and others like \`water\`, \`pool\`).

## Validated end-to-end on demo (domopi.local)

Sideloaded \`sowel-plugin-displays\` v0.1.0 + mosquitto sidecar, published a synthetic \`test-001\` display via \`mosquitto_pub\`, bound the canonical fields:

- ✅ Zone Maison → \"Afficheurs\" group renders \"Test Display\" + brightness 50%
- ✅ Equipment detail → DisplayPanel shows firmware 0.1.1, uptime 4 min, RSSI -50 dBm, language EN dropdown, brightness slider
- ✅ Dashboard → Add widget modal (zone = Maison) shows 7 of 8 equipments (the display is omitted)

Screenshots captured via Playwright if useful.

## Test plan

- [x] \`npx tsc --noEmit\` PASS (backend)
- [x] \`cd ui && npx tsc -b --noEmit\` PASS (UI)
- [x] \`npx vitest run\` — 786 / 786 (2 skipped pre-existing)
- [x] Visual: zone view shows display group (Playwright on domopi)
- [x] Visual: detail page renders DisplayPanel (Playwright on domopi)
- [x] Visual: dashboard widget picker omits display (Playwright on domopi)