### PR TITLE
chore(release): prepare v1.18.0 — display equipment + plugin registry

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,15 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.18.x — Type d'équipement Afficheur
+
+### v1.18.0 — 2026-06-01 { #v1-18-0 }
+
+- Feat (équipements) : nouveau type d'équipement `display` pour les afficheurs supervisés par Sowel. Le plugin compagnon `sowel-plugin-displays` (repo séparé) découvre les afficheurs via MQTT (payload `state` retenu, disponibilité pilotée par le LWT) et les expose comme des devices Sowel à binder sur le nouvel équipement `display`. Le premier vendeur est le firmware AMOLED sowel-energy-display (iter 035, repo séparé) ; tout futur afficheur e-paper / OLED / ePOS suit le même contrat de format de message sans modification du plugin. Nouvelles catégories `DataCategory` : `firmware_version`, `uptime`, `rssi`, `language`, `display_brightness`. Nouvelles catégories `OrderCategory` : `set_language`, `set_display_brightness`. Nouvelle famille de widget `displays` (agrégation à la zone `displaysOnline / displaysTotal`). Nouveau `DisplayPanel.tsx` sur la page de détail de l'équipement, qui affiche les champs canoniques avec un menu langue et un curseur de luminosité en ligne, masqués si la liaison correspondante est absente. Le sélecteur de widget du dashboard masque les afficheurs — ce sont des surfaces de contrôle, pas des choses de la maison à résumer. Spec 120 + 121.
+- Feat (plugins/registry) : ajout du plugin `displays` (v0.1.0, owner mchacher, officiel) — installable depuis Admin → Plugins → Parcourir pour commencer à superviser des afficheurs. Le plugin expose `mqtt_url` / `mqtt_username` / `mqtt_password` / `topic_prefix` (défaut `sowel-display`) dans sa page de réglages.
+
+---
+
 ## 1.17.x — Agrégation des historiques énergie par période
 
 ### v1.17.0 — 2026-05-31 { #v1-17-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,15 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.18.x — Display equipment type
+
+### v1.18.0 — 2026-06-01 { #v1-18-0 }
+
+- Feat (equipments): new `display` equipment type for Sowel-supervised displays. Companion plugin `sowel-plugin-displays` (separate repo) discovers displays via MQTT (retained `state` payload, LWT-driven availability) and exposes them as Sowel devices that bind to the new `display` equipment. The first vendor is the sowel-energy-display AMOLED firmware (iter 035, separate repo); future e-paper / OLED / ePOS displays follow the same wire contract with zero plugin change. New `DataCategory` values: `firmware_version`, `uptime`, `rssi`, `language`, `display_brightness`. New `OrderCategory` values: `set_language`, `set_display_brightness`. New widget family `displays` (zone-level aggregation `displaysOnline / displaysTotal`). New `DisplayPanel.tsx` on the equipment detail page renders the canonical fields with an inline language dropdown and brightness slider, hidden when the matching binding is absent. The dashboard widget picker hides displays — they are meta / control surfaces, not "things in the home" to be summarised. Spec 120 + 121.
+- Feat (plugins/registry): added `displays` plugin (v0.1.0, owner mchacher, official) — install from Admin → Plugins → Browse to start supervising displays. The plugin exposes `mqtt_url` / `mqtt_username` / `mqtt_password` / `topic_prefix` (default `sowel-display`) in its settings page.
+
+---
+
 ## 1.17.x — Energy history per-period aggregation
 
 ### v1.17.0 — 2026-05-31 { #v1-17-0 }

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -406,5 +406,25 @@
     "sowelVersion": ">=1.4.0",
     "owner": "mchacher",
     "sha256": "3ce4c7a3fe3607ecf44fd6db5b7c5b4f7da3fd665f4a0c88815f3ee46164e1ac"
+  },
+  {
+    "id": "displays",
+    "type": "integration",
+    "name": "Sowel Displays",
+    "description": "MQTT supervision for Sowel-supervised displays (energy display, e-paper, ...)",
+    "icon": "Monitor",
+    "author": "mchacher",
+    "repo": "mchacher/sowel-plugin-displays",
+    "version": "0.1.0",
+    "tags": ["display", "mqtt", "energy-display", "supervision"],
+    "i18n": {
+      "fr": {
+        "name": "Afficheurs Sowel",
+        "description": "Supervision MQTT des afficheurs supervisés par Sowel (energy display, e-paper, ...)"
+      }
+    },
+    "sowelVersion": ">=1.18.0",
+    "owner": "mchacher",
+    "sha256": "ea146ccffd50a3adbb2ce08a5c5a0f2506623984218ea75454c792fafe760551"
   }
 ]


### PR DESCRIPTION
Release prep for **v1.18.0**.

## What lands

- \`docs/release-notes.md\` + \`docs/release-notes.fr.md\` — v1.18.0 entry under a new \"1.18.x\" section, describing spec 120 (display equipment type) and the companion plugin \`sowel-plugin-displays\` v0.1.0.
- \`plugins/registry.json\` — new \`displays\` entry (owner: mchacher, official), SHA256 backfilled from the published GH release tarball.

## What does NOT land here

- Version bump in \`package.json\` + \`ui/package.json\`. That happens via \`scripts/release.sh 1.18.0\` once this PR is on main, which auto-creates the \`release: v1.18.0\` commit, tags it, and pushes — triggering the GH workflow to build + push the docker image to ghcr.io.

## Validated

- [x] \`npx tsc --noEmit\` PASS
- [x] \`npx vitest run\` 786 / 786
- [x] Backfill script verified the SHA256 hash against the official tarball
- [x] End-to-end on demo (domopi.local): plugin sideloaded + smoke tested with mosquitto_pub (PR #248 + #249)

## Post-merge

1. \`git checkout main && git pull\`
2. \`scripts/release.sh 1.18.0\`
3. Watch the release workflow build + publish the image
4. Demo domopi.local can then pull 1.18.0 and install the displays plugin via Admin → Plugins