### PR TITLE
fix(ui): filter device picker + auto-bind for display equipments

### DIFF
--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -23,6 +23,14 @@ const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> 
   // Polytropic PAC matches via pool_water_temperature; Sonoff filtration relay
   // matches via light_state (used as the optional `filtration_state` binding).
   pool_heat_pump: ["pool_water_temperature", "light_state"],
+  // Spec 120 — Sowel-supervised displays (energy display, e-paper, ...).
+  // Any device that exposes one of the canonical display fields is a
+  // candidate. `firmware_version` / `uptime` would be too generic on
+  // their own (a future Zigbee plugin might emit them too), so the
+  // match keys on `display_brightness` / `language` first; if a vendor
+  // ships a passive single-screen display reporting only uptime, the
+  // user can still pick it via "Show all" toggle.
+  display: ["display_brightness", "language", "rssi"],
 };
 
 /** Maps EquipmentType to required data keys for filtering (when category alone is too broad). */

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -129,6 +129,17 @@ const RELEVANT_DATA: Record<string, string[]> = {
     "appliance_state",
     "light_state",
   ],
+  // Spec 120 — Sowel-supervised displays. `generic` catches the
+  // hostname / ip_address informational fields surfaced by the
+  // plugin alongside the canonical 5.
+  display: [
+    "firmware_version",
+    "uptime",
+    "rssi",
+    "language",
+    "display_brightness",
+    "generic",
+  ],
 };
 
 /** Maps equipment types to relevant order keys for auto-binding. */
@@ -182,6 +193,10 @@ const RELEVANT_ORDERS: Record<string, string[]> = {
     "shutter2_position",
   ],
   pool_heat_pump: ["setpoint"],
+  // Spec 120 — Sowel-supervised displays.  Order keys mirror what
+  // the displays plugin declares (see parse-state.ts of
+  // sowel-plugin-displays): the key IS the topic suffix.
+  display: ["language", "brightness"],
 };
 
 /**


### PR DESCRIPTION
Two gaps in [spec 120](https://github.com/mchacher/sowel/blob/main/specs/120-display-equipment/spec.md) surfaced when creating a real display equipment on demo:

## 1. Device picker shows every device

\`EQUIPMENT_TYPE_CATEGORIES\` in \`DeviceSelector\` had no \`display\` row. The fallthrough was "no filter → all devices listed". Added \`display: [\"display_brightness\", \"language\", \"rssi\"]\` so only devices supervised by sowel-plugin-displays (i.e., emitting at least one of the canonical display fields) are picked up. \"Show all\" still lets the user override.

## 2. Auto-binding does nothing on display equipments

\`autoCreateBindings\` consults \`RELEVANT_DATA\` / \`RELEVANT_ORDERS\` whitelists. Both maps had no \`display\` key, so the create-with-devices flow silently skipped every binding — the equipment landed empty in the UI, with the user expected to bind 5+ rows by hand.

Added:
- \`RELEVANT_DATA[\"display\"]\` = canonical 5 (firmware_version, uptime, rssi, language, display_brightness) + \`generic\` (catches hostname + ip_address informational rows surfaced by the plugin).
- \`RELEVANT_ORDERS[\"display\"]\` = \`[\"language\", \"brightness\"]\` — the topic-suffix keys the displays plugin declares.

## Validated

- [x] \`npx tsc --noEmit\` PASS
- [x] \`cd ui && npx tsc -b --noEmit\` PASS
- [x] \`npx vitest run\` 786 / 786 (2 skipped pre-existing)
- [ ] Manual on demo: create a display equipment, pick the supervised device, verify 5+ data bindings + 2 order bindings land automatically