### PR TITLE
release: v1.18.5 — presence-display recipe registry entry

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.18.x — Type d'équipement Afficheur
 
+### v1.18.5 — 2026-06-02 { #v1-18-5 }
+
+- Feat (plugins/registry) : ajout de la recette `presence-display` (v0.1.0, owner mchacher, officielle) — éteint les afficheurs supervisés par Sowel après une période d'absence dans une zone et les réveille au mouvement suivant. S'utilise avec le type d'équipement `display` (spec 120) et le plugin `displays` (v0.1.0) ; le firmware `sowel-energy-display` v1.3.0+ honore `set_display_brightness=0` comme extinction réelle du panel. Installable depuis Admin → Plugins → Parcourir, puis instanciable depuis la section Recettes d'une zone (choisir la zone + les afficheurs, défauts 5 min d'absence et 80 % au réveil ou ajuster).
+
 ### v1.18.4 — 2026-06-02 { #v1-18-4 }
 
 - Fix (UI/afficheur) : finition du curseur de luminosité. La mise en place v1.18.3 du clear basé sur l'echo serveur laissait une courte fenêtre où la valeur affichée pouvait flasher en arrière sur la valeur précédente, entre le relâchement et l'écho serveur. Remplacé par un hold plat de 1,5 s post-commit : le curseur reste fixé sur la cible utilisateur jusqu'à ce que l'aller-retour firmware soit arrivé à coup sûr, plus de flicker. Pas du curseur porté de 5 à 10 (`min=0 max=100 step=10` → 11 paliers bien espacés dont la position "Off" à 0), suite à un retour utilisateur (pas de 5 % trop fin et difficulté à toucher exactement 0).

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.18.x — Display equipment type
 
+### v1.18.5 — 2026-06-02 { #v1-18-5 }
+
+- Feat (plugins/registry): added `presence-display` recipe plugin (v0.1.0, owner mchacher, official) — turns Sowel-supervised displays off after a configurable absence in a zone, wakes them on the next motion event. Pairs with the `display` equipment type (spec 120) and the `displays` plugin (v0.1.0); the firmware on `sowel-energy-display` v1.3.0+ honours `set_display_brightness=0` as a true panel-off. Install from Admin → Plugins → Browse, then create an instance from a zone's Recipes section, pick the zone + displays, leave defaults (5 min absence, 80 % wake brightness) or tune.
+
 ### v1.18.4 — 2026-06-02 { #v1-18-4 }
 
 - Fix (UI/display): brightness slider polish. The v1.18.3 echo-driven draft clear left a short window where the rendered value could flash back to the previous binding value between the user release and the server echo. Replaced by a flat 1.5 s post-commit hold — the slider pins on the user's target until the firmware round-trip has reliably landed, no flicker. Slider step bumped from 5 to 10 (`min=0 max=100 step=10` → 11 well-spaced stops including the "Off" position at 0), per user feedback that the 5 % step felt too fine and the touch hit on 0 was unreliable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.18.4",
+  "version": "1.18.5",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -426,5 +426,25 @@
     "sowelVersion": ">=1.18.0",
     "owner": "mchacher",
     "sha256": "ea146ccffd50a3adbb2ce08a5c5a0f2506623984218ea75454c792fafe760551"
+  },
+  {
+    "id": "presence-display",
+    "type": "recipe",
+    "name": "Presence-driven display sleep",
+    "description": "Turns Sowel-supervised displays off after a configurable absence in a zone, wakes them on the next motion event.",
+    "icon": "Monitor",
+    "author": "mchacher",
+    "repo": "mchacher/sowel-recipe-presence-display",
+    "version": "0.1.0",
+    "tags": ["automation", "display", "motion", "presence", "sleep", "energy"],
+    "i18n": {
+      "fr": {
+        "name": "Veille afficheur sur absence",
+        "description": "Éteint les afficheurs supervisés par Sowel après une période d'absence dans une zone, les réveille au mouvement suivant."
+      }
+    },
+    "sowelVersion": ">=1.18.0",
+    "owner": "mchacher",
+    "sha256": "9206f166792ef887d591fa5a30da67af17fb3d2a8bd2072fdb3b8f5cbe944086"
   }
 ]

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.18.4",
+  "version": "1.18.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Adds the `presence-display` recipe plugin to the registry — sleeps Sowel displays on zone absence. See [v1.18.5](docs/release-notes.md#v1-18-5).