### PR TITLE
chore(registry): bump presence-display to 0.1.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -435,7 +435,7 @@
     "icon": "Monitor",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-presence-display",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "tags": ["automation", "display", "motion", "presence", "sleep", "energy"],
     "i18n": {
       "fr": {
@@ -445,6 +445,6 @@
     },
     "sowelVersion": ">=1.18.0",
     "owner": "mchacher",
-    "sha256": "9206f166792ef887d591fa5a30da67af17fb3d2a8bd2072fdb3b8f5cbe944086"
+    "sha256": "ceaa93d373f93bda1802a2f48df106cdf3238983ce71949a9c5a3c2bf9219350"
   }
 ]


### PR DESCRIPTION
## Summary

Bump `sowel-recipe-presence-display` from 0.1.0 to 0.1.1 with refreshed SHA256.

## Why

The 0.1.0 release exported the recipe as `export default recipe` which Sowel's RecipeLoader silently ignores — it expects a `createRecipe()` factory function (same pattern as every other recipe in the registry, see `sowel-recipe-motion-light-dimmable` et al.).

Symptom in prod: recipe installed and listed in the plugin store, but did not appear in zones containing a display equipment. Logs confirmed: `"Recipe package presence-display does not export a createRecipe function"`.

0.1.1 fixes the export so the recipe registers and shows up in compatible zones.

## Changes

- `plugins/registry.json`: presence-display entry — `version: 0.1.0 → 0.1.1`, SHA256 refreshed via `backfill-registry-sha256.mjs`.

## Test plan

- [x] `backfill-registry-sha256.mjs` confirmed the new asset SHA matches the 0.1.1 tarball
- [x] Recipe code change tested locally (createRecipe factory verified by 19 vitest scenarios in the recipe repo)
- [ ] Post-merge: refresh plugin store on production, update recipe to 0.1.1, verify it appears in zones with a display