### PR TITLE
feat(core): add display_wake order category (spec 122)

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,14 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.19.x — Action wake afficheur
+
+### v1.19.0 — 2026-06-02 { #v1-19-0 }
+
+- Feat (core) : nouvelle catégorie d'ordre `display_wake` pour le type d'équipement afficheur. Action sans valeur qui demande à l'afficheur de restaurer la dernière luminosité choisie par l'utilisateur (stockée dans sa NVS locale). Spec 122. Utilisée par la recette de mise en veille sur absence (`sowel-recipe-presence-display` v0.2.0+) qui n'a donc plus besoin de connaître la luminosité préférée. Changements compagnons : `sowel-plugin-displays` v0.2.0 route l'ordre vers `<prefix>/<id>/cmd/wake` ; sowel-energy-display iter 035 sépare la NVS en `current_pct` + `user_pct`, restaure `user_pct` sur tap ou `cmd/wake`, et s'éteint automatiquement 2 minutes après un tap-wake si la recette n'a pas confirmé.
+
+---
+
 ## 1.18.x — Type d'équipement Afficheur
 
 ### v1.18.4 — 2026-06-02 { #v1-18-4 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,14 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.19.x — Display wake action
+
+### v1.19.0 — 2026-06-02 { #v1-19-0 }
+
+- Feat (core): new `display_wake` order category for the display equipment type. A no-value action that tells the display to restore its last user-chosen brightness from local NVS. Spec 122. Used by the presence-driven sleep recipe (`sowel-recipe-presence-display` v0.2.0+) so the recipe no longer needs to know the user's preferred brightness level. Companion changes: `sowel-plugin-displays` v0.2.0 routes the order to `<prefix>/<id>/cmd/wake`; sowel-energy-display iter 035 splits NVS into `current_pct` + `user_pct`, restores `user_pct` on tap-wake or `cmd/wake`, and auto-extinguishes 2 minutes after a tap-wake if the recipe has not confirmed the wake.
+
+---
+
 ## 1.18.x — Display equipment type
 
 ### v1.18.4 — 2026-06-02 { #v1-18-4 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.18.4",
+  "version": "1.19.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/specs/122-display-wake-action/architecture.md
+++ b/specs/122-display-wake-action/architecture.md
@@ -1,0 +1,156 @@
+# Architecture — Spec 122
+
+## Data model
+
+### Sowel `OrderCategory` (src/shared/types.ts)
+
+```typescript
+export type OrderCategory =
+  | ...existing...
+  | "set_language"
+  | "set_display_brightness"
+  | "display_wake"; // new
+```
+
+Mirrored in `ui/src/types.ts`. No other core type changes.
+
+### Firmware NVS layout
+
+| Key (NVS namespace `sowel-disp`) | Type   | Range   | Semantics                                            |
+| -------------------------------- | ------ | ------- | ---------------------------------------------------- |
+| `bright`                         | u8     | 0..100  | Current applied brightness (existing). 0 = panel off |
+| `user_bright`                    | u8 NEW | 10..100 | Last user-chosen brightness, default 80              |
+
+`user_bright` is created lazily on first user-driven set (slider, gesture, MQTT cmd ≥ 1). Until then, accessors return the firmware default (80).
+
+### MQTT wire (spec 121 addendum)
+
+| Sowel `OrderCategory` | Topic suffix | Payload |
+| --------------------- | ------------ | ------- |
+| `display_wake`        | `cmd/wake`   | (empty) |
+
+State JSON gets a new optional field:
+
+```json
+{
+  "id": "sowel-display-9a3b1c",
+  ...,
+  "brightness": 0,
+  "wake": true
+}
+```
+
+`wake: true` is a static capability advertisement — the firmware always sends it; it tells the plugin to expose the `display_wake` order on the device. Absence = the display does not support `cmd/wake` (older firmware, or vendor that does not implement the wake-to-preference behaviour).
+
+## Event flow
+
+### Recipe-driven sleep / wake (motion path)
+
+```
+Motion stops in the zone (no movement for absence_threshold)
+  → recipe: goWaiting() → setTimeout(goSleep, absence_threshold)
+    → timer expires → goSleep()
+      → dispatchOrder(displayId, "brightness", 0)
+        → EquipmentManager.executeOrder
+          → plugin displays: dispatchOrder("brightness", 0)
+            → MQTT publish <prefix>/<id>/cmd/brightness "0"
+              → firmware: on_cmd_brightness(0)
+                → brightness::set(0)
+                  → cancel any pending auto-resleep timer (defensive — already cancelled)
+                  → current_pct=0 persisted, user_pct unchanged
+
+Motion resumes in the zone
+  → recipe: goAwake() from sleeping
+    → dispatchOrder(displayId, "wake", null)
+      → plugin displays: dispatchOrder("wake", null) → cmd/wake topic
+        → firmware: on_cmd_wake
+          → brightness::set(user_pct) [via lv_async_call]
+            → cancel any pending auto-resleep timer
+            → current_pct=user_pct persisted
+```
+
+### Firmware-driven re-sleep (tap on dead panel, no motion)
+
+```
+User taps panel @ brightness=0 (recipe in `sleeping`, no motion)
+  → firmware: screen_manager::on_press
+    → brightness::wake_to_user_with_resleep_armed()
+      → brightness::set(user_pct) [panel lights up]
+      → auto_resleep::arm() [2 min timer started]
+
+(2 minutes pass with no cmd/wake, no cmd/brightness, no local gesture)
+
+  → auto_resleep::on_expire()
+    → brightness::set(0) [panel off]
+      → current_pct=0 persisted, user_pct unchanged
+```
+
+### Firmware-driven cancellation (tap then motion)
+
+```
+User taps panel @ brightness=0
+  → wake + arm 2-min timer (as above)
+
+Within 2 min:
+Motion arrives in the zone
+  → recipe: goAwake() from sleeping
+    → dispatchOrder(displayId, "wake", null) → cmd/wake
+      → firmware: on_cmd_wake
+        → brightness::set(user_pct) → cancels auto-resleep timer
+```
+
+## File changes
+
+### `sowel` (core)
+
+- `src/shared/types.ts` — add `"display_wake"` to `OrderCategory`.
+- `ui/src/types.ts` — mirror.
+- `package.json` + `ui/package.json` — bump to `1.19.0`.
+- `docs/release-notes.md` + `docs/release-notes.fr.md` — add `v1.19.0` entry.
+- `plugins/registry.json` — bump `displays` plugin entry to `>=1.19.0`, bump `presence-display` recipe entry similarly.
+
+### `sowel-plugin-displays` (v0.2.0)
+
+- `src/parse-state.ts` — read `obj.wake` (boolean). If `true`, push an `OrderField` with `key: "wake"`, `category: "display_wake"`.
+- `src/dispatch-order.ts` — add a case for `orderKey === "wake"` → publish to `cmd/wake` with empty payload.
+- `src/parse-state.test.ts` — add fixture with `wake: true`.
+- `src/dispatch-order.test.ts` — add test case `display_wake`.
+- `manifest.json` — bump to `0.2.0`.
+
+### `sowel-energy-display` (iter 035)
+
+- `src/config.h` + `src/config.cpp` — add `user_brightness_pct()` / `set_user_brightness_pct(uint8_t)` accessors.
+- `src/brightness.cpp` —
+  - `init()`: if NVS `current_pct = 0`, restore from `user_pct` (or 80 fallback). Update `user_pct` if it was unset.
+  - `set(pct)`: persist `user_pct` only when `pct >= MIN_PCT` (10..100); persist `current_pct` always. **Cancels any pending auto-resleep timer**.
+  - `step(delta)`: existing logic + **cancels any pending auto-resleep timer**.
+  - New `wake_to_user_with_resleep_armed()` entry point: sets to `user_pct` AND arms the auto-resleep timer. Used only by `screen_manager::on_press`.
+- `src/auto_resleep.{h,cpp}` — new module owning the timer:
+  - `arm()`: schedules `lv_timer` for `AUTO_RESLEEP_MS = 2 * 60 * 1000` (single-shot). Replaces any previous pending timer.
+  - `cancel()`: deletes the pending timer if any. Safe to call when none armed.
+  - `on_expire()`: calls `brightness::set(0)` and clears the handle.
+  - State: single `static lv_timer_t* timer = nullptr`. Not armed at boot.
+- `src/screen_manager.cpp` — `on_press` (panel was off branch) calls `brightness::wake_to_user_with_resleep_armed()` instead of `brightness::set(WAKE_FROM_OFF_PCT)`.
+- `src/mqtt_supervision.cpp` — add `on_cmd_wake` handler (marshalled via `lv_async_call`) → calls `brightness::set(user_pct)`. Update `on_message` topic dispatch. Publish `"wake": true` in `mqtt_supervision_state::build`.
+- `src/mqtt_supervision_state.{h,cpp}` — add static `wake` flag to the State struct + JSON serialiser.
+- `test/test_brightness/` — new native test covering the NVS split.
+- `test/test_auto_resleep/` — new native test covering arm/cancel/expire semantics.
+- `platformio.ini` — no change.
+
+### `sowel-recipe-presence-display` (v0.2.0)
+
+- `src/index.ts` —
+  - Remove `wake_brightness` from slots, defaults, and i18n.
+  - Remove `WAKE_MIN`/`WAKE_MAX`/`DEFAULT_WAKE` constants.
+  - `validate()`: require each display to expose an order with category `display_wake` (in addition to the existing `set_display_brightness` check).
+  - Replace `dispatch(wakeBrightness, "wake")` with `dispatchWake(displayId)` that resolves the `display_wake` alias on the equipment.
+  - **Keep the state machine minimal**: `awake / waiting / sleeping`. No `manual_wake`, no `equipment.data.changed` subscription — the firmware self-extinguishes on tap-wake without recipe involvement.
+  - `stop()`: drop the "wake to wake_brightness" safety branch (no longer applicable).
+- `src/index.test.ts` —
+  - Update existing tests (remove `wake_brightness` slot, switch dispatch assertions to `display_wake`).
+  - Add validation refusal test when `display_wake` order is missing.
+- `package.json` — bump to `0.2.0`.
+
+## Soft-isolation impact (spec 111)
+
+None. The new order category is dispatched through the existing `EquipmentManager.executeOrder` path; the plugin remains scoped to its own settings (`integration.displays.*`) and only emits the allowed event types. No allowlist change in `src/plugins/scoped-deps.ts`.

--- a/specs/122-display-wake-action/plan.md
+++ b/specs/122-display-wake-action/plan.md
@@ -1,0 +1,213 @@
+# Plan — Spec 122
+
+## Implementation order
+
+The four repos depend on each other:
+
+1. **Sowel core first** — without `"display_wake"` in `OrderCategory`, the plugin and recipe TS won't typecheck.
+2. **Plugin displays second** — needs the new core type.
+3. **Firmware third** — independent of the TS chain, but the plugin needs the `wake: true` state field to be useful; ship them together.
+4. **Recipe last** — needs both the new core type and the plugin to advertise the order on devices.
+
+Each repo: feature branch → implement → tests → PR → CI → merge → tag/release.
+
+## Sowel core (PR 1)
+
+- Branch: `feat/122-display-wake-action`
+- Files: `src/shared/types.ts`, `ui/src/types.ts`, `package.json`, `ui/package.json`, `docs/release-notes.md`, `docs/release-notes.fr.md`, `plugins/registry.json` (defer registry to PR 2/4 so each plugin bump is its own commit).
+- Validate: `npm run validate` (full).
+- Release: `scripts/release.sh 1.19.0` after merge.
+
+## Plugin sowel-plugin-displays (PR 2)
+
+- Branch: `feat/display-wake-order`
+- Implement `parseState.wake` declaration + `dispatchOrder("wake", ...)`.
+- Tests: extend `parse-state.test.ts` and `dispatch-order.test.ts`.
+- Validate: `npm run validate` in the plugin repo.
+- Release: tag `v0.2.0`, GitHub Actions builds tarball.
+- Then: PR back to Sowel `plugins/registry.json` to bump SHA256 (no Sowel release).
+
+## Firmware sowel-energy-display iter 035 (PR 3)
+
+- Branch: `feat/035-display-wake-user-pref`
+- Spec folder: `specs/035-display-wake-user-pref/spec.md` per the `sowel-display-iterate` skill.
+- Implement: NVS split, `cmd/wake` handler, wake-on-touch update, state JSON `wake: true`.
+- Validate: `pio run -e esp32-s3-touch-amoled-1_75` clean, `pio test -e native` green.
+- HW test: flash + verify on the panel (slider sets brightness, panel goes to 0 via Sowel slider, click wakes to slider value).
+- Release: tag `v1.X.0` (current version + minor bump).
+
+## Recipe sowel-recipe-presence-display (PR 4)
+
+- Branch: `feat/manual-wake-state`
+- Implement: slot removal, validation update, `display_wake` dispatch, `manual_wake` state machine.
+- Tests: update existing + add manual-wake scenarios.
+- Release: tag `v0.2.0`.
+- Then: PR back to Sowel `plugins/registry.json` to bump version + SHA256 + `sowelVersion: ">=1.19.0"` (no Sowel release).
+
+## Test Plan
+
+### Modules to test
+
+| Repo                            | Module                                | New / changed scenarios                                                  |
+| ------------------------------- | ------------------------------------- | ------------------------------------------------------------------------ |
+| sowel (core)                    | Nothing functional                    | Existing test suite must still pass (typecheck + lint validate the type) |
+| sowel-plugin-displays           | `parse-state.ts`, `dispatch-order.ts` | `wake: true` parsing; `wake` dispatch                                    |
+| sowel-energy-display (firmware) | `brightness.cpp`, `config.cpp`        | NVS split, boot recovery, set(0) does not touch user_pct                 |
+| sowel-recipe-presence-display   | `index.ts`                            | Slot removal, validation, manual_wake transitions                        |
+
+### Scenarios
+
+#### Plugin parse-state.ts
+
+| Scenario             | Expected                                                             |
+| -------------------- | -------------------------------------------------------------------- |
+| `state.wake = true`  | Output `orders` contains `{ key: "wake", category: "display_wake" }` |
+| `state.wake` absent  | Output `orders` does NOT include a wake entry                        |
+| `state.wake = false` | Output `orders` does NOT include a wake entry                        |
+
+#### Plugin dispatch-order.ts
+
+| Scenario                               | Expected                                           |
+| -------------------------------------- | -------------------------------------------------- |
+| `dispatchOrder(prefix, id, "wake", ?)` | `{ topic: "<prefix>/<id>/cmd/wake", payload: "" }` |
+
+#### Firmware brightness.cpp (native test)
+
+| Scenario                                               | Expected                                       |
+| ------------------------------------------------------ | ---------------------------------------------- |
+| Cold boot, NVS empty                                   | `current_pct = 80`, `user_pct = 80`            |
+| Boot with `current_pct = 0`, `user_pct = 30`           | After `init()`: `current_pct = 30`             |
+| Boot with `current_pct = 0`, `user_pct` absent         | After `init()`: `current_pct = 80` (fallback)  |
+| `set(0)` after `set(30)`                               | `current_pct = 0`, `user_pct = 30` (preserved) |
+| `set(50)` after `set(30)`                              | `current_pct = 50`, `user_pct = 50` (updated)  |
+| `set(5)` (clamped to 10)                               | `current_pct = 10`, `user_pct = 10`            |
+| `wake_to_user_with_resleep_armed()` when `user_pct=30` | `current_pct = 30`, timer pending              |
+
+#### Firmware auto_resleep (native test)
+
+| Scenario                                             | Expected                                          |
+| ---------------------------------------------------- | ------------------------------------------------- |
+| `arm()` then wait 2 min                              | `brightness::set(0)` invoked once                 |
+| `arm()` then `cancel()` before expiry                | No `brightness::set(0)` invocation                |
+| `arm()` then `arm()` again                           | Only one timer pending, expires once              |
+| `cancel()` when not armed                            | No-op, no crash                                   |
+| `arm()` then `brightness::set(50)` (MQTT cmd)        | Timer cancelled (suppression on explicit set)     |
+| `arm()` then `brightness::step(+10)` (gesture)       | Timer cancelled (suppression on explicit gesture) |
+| `arm()` then `brightness::set(0)` (recipe sleep cmd) | Timer cancelled; panel re-extinguishes (no-op)    |
+
+#### Recipe state machine
+
+| Scenario                                           | Expected                                                      |
+| -------------------------------------------------- | ------------------------------------------------------------- |
+| Validate without `wake_brightness` slot            | OK (slot does not exist anymore)                              |
+| Validate with display lacking `display_wake` order | Throw, descriptive error                                      |
+| Motion=true while sleeping                         | Dispatch `display_wake` (no value), state → awake             |
+| Motion=true while awake                            | No dispatch (already awake)                                   |
+| Motion=false while awake                           | State → waiting, timer starts                                 |
+| Timer expires                                      | Dispatch `set_display_brightness 0`, state → sleeping         |
+| Motion=true during waiting                         | Timer cancelled, state → awake, NO dispatch (panel still lit) |
+| Recipe stop() while sleeping                       | No dispatch (firmware owns the wake; recipe stays out of it)  |
+
+## Robustness test plan
+
+Beyond the per-module unit tests above, the feature must survive a set of stress / failure-injection scenarios. These run as a mix of native tests (where possible) and HW-in-the-loop manual scenarios (signed off in the firmware iter spec or this spec's checklist).
+
+### R1 — NVS persistence under power loss
+
+Goal: a power cut during a brightness write must not leave the firmware with an inconsistent state (e.g. `current_pct=50` persisted but `user_pct=0` corrupted).
+
+| Scenario                                                                                   | Expected                                                                                                         | How                                                            |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Power cut during `set(30)` between `current` and `user` writes                             | Either both values are old, or both are new — never a mismatch                                                   | Native test with mocked NVS writer faulting between key writes |
+| Power cut during slider drag (multiple set() in flight, debounced NVS timer not yet fired) | After reboot, NVS holds either the pre-drag value or some intermediate the user actually crossed — never garbage | HW: drag slider, yank power, reboot                            |
+| NVS holds out-of-range value (`user_pct=255`, flash garbage)                               | `init()` clamps to MAX_PCT=100 and persists the clamped value                                                    | Native test                                                    |
+
+### R2 — Command flood (slider drag)
+
+Goal: a 10-second slider drag at 60Hz (600+ cmd/brightness publishes) does not crash, leak FreeRTOS handles, or desync the state.
+
+| Scenario                                                    | Expected                                                                                                              | How                                      |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| 600 cmd/brightness publishes in 10 s via mosquitto_pub loop | Firmware applies the LATEST value (coalescing via `lv_async_call`), no crash, single NVS write at debounce window end | HW: scripted MQTT flood + serial monitor |
+| Concurrent cmd/wake during a flood                          | Wake either races a brightness value (idempotent — both restore user_pct effectively) or is preempted; never crashes  | HW: scripted flood + wake interlace      |
+
+### R3 — Network resilience
+
+Goal: MQTT broker disconnects, reconnects, and lossy networks do not break the sleep/wake cycle.
+
+| Scenario                                                            | Expected                                                                                                                         | How                                           |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Broker dies while recipe sends cmd/brightness 0                     | Order is fire-and-forget; firmware does not receive, panel stays lit (LWT will fire offline on plugin side)                      | Manual: kill mosquitto, observe               |
+| Broker reconnect after a long outage                                | Display republishes `online` + state with `wake: true`; plugin re-derives the `display_wake` order                               | Manual: restart mosquitto, observe state JSON |
+| Display loses WiFi, reconnects                                      | After LWT fires, EquipmentStatus turns degraded. Once back online, the recipe's next motion-driven dispatch reaches the display. | Manual: airplane mode toggle                  |
+| Recipe dispatch while display equipment is `unavailable` (spec 116) | `executeOrder` does NOT throw; the order is queued at plugin level, dropped if not delivered. Recipe logs `warn`.                | Manual                                        |
+
+### R4 — Recipe restart / state recovery
+
+Goal: Sowel restart in the middle of a sleep cycle leaves the system in a consistent state on next boot.
+
+| Scenario                                                  | Expected                                                                                                                                                                                                                            | How                                             |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| Sowel restart while recipe is in `sleeping`               | Recipe re-initialises: reads current zone motion (false). Initial sync → `waiting` → expires → `sleeping`. Dispatches `set_display_brightness 0` (already 0, no-op visible).                                                        | Manual: stop sowel, restart, check logs         |
+| Sowel restart while user has just tapped a sleeping panel | Recipe doesn't know or care about the tap. Firmware auto-resleep timer continues running (firmware-internal). If no motion arrives, panel auto-extinguishes. If motion arrives, recipe dispatches `display_wake` and timer cancels. | Manual: tap display, restart sowel within 2 min |
+| Sowel restart while recipe is in `awake`                  | Recipe re-initialises: motion=true → state=awake. No dispatch — panel already lit (unless firmware booted in the meantime, but it kept current_pct=user_pct from NVS, so panel is also lit).                                        | Manual                                          |
+| Recipe deactivated (user disables it) while in `sleeping` | `stop()` does NOT dispatch. Display stays at brightness=0. User can recover via tap (firmware wake-on-touch restores user_pct, auto-resleeps after 2 min).                                                                          | Recipe unit test + manual                       |
+| Recipe deactivated while in `awake`                       | `stop()` cancels recipe timer, does NOT dispatch. Display stays lit. Firmware does not auto-resleep (no tap-wake event). Display stays lit indefinitely until external action.                                                      | Recipe unit test                                |
+
+### R5 — Multi-display robustness
+
+Goal: a recipe instance bound to N displays handles partial failures gracefully.
+
+| Scenario                                    | Expected                                                                                                                                                                                                                         | How                                                                               |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| 2 displays, 1 offline                       | Recipe dispatches to both; the offline one logs `warn` but the online one is served. State transitions still happen on the recipe side.                                                                                          | Manual (or recipe unit test with mocked executeOrder rejecting for one displayId) |
+| 2 displays, only one publishes `wake: true` | `validate()` refuses to start the recipe instance (all selected displays must declare the order).                                                                                                                                | Recipe unit test                                                                  |
+| 2 displays, user taps display A only        | Display A wakes locally, A's auto-resleep timer arms. Display B stays off. If no motion arrives within 2 min, A auto-resleeps independently. Each display owns its own firmware-side timer; the recipe state remains `sleeping`. | HW + serial inspection                                                            |
+
+### R6 — State machine soak
+
+Goal: 24h continuous cycling of motion / no-motion / timer expiry does not leak memory, timers, or event subscriptions.
+
+| Scenario                                                          | Expected                                                                            | How                                                                             |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | --- | ------------------- |
+| Recipe instance running 24h with simulated motion every 5 min     | Memory flat, no orphan timers, no event-listener leak                               | Manual: leave running overnight, inspect `process.memoryUsage()` deltas via API |
+| Recipe alternating sleep / wake / sleep every minute              | No state stuck, no double-dispatch, exactly one recipe timer at all times           | Recipe instrumentation test (assert `timer===null                               |     | state==='waiting'`) |
+| Firmware alternating tap-wake / auto-resleep repeatedly (no MQTT) | No timer leak on the firmware side either; serial logs show clean arm/expire cycles | HW: scripted tap simulation over an hour                                        |
+
+### R7 — Firmware boot recovery matrix
+
+Goal: every possible NVS state at boot resolves to a usable panel.
+
+| NVS state              | Expected after `init()`                                   |
+| ---------------------- | --------------------------------------------------------- |
+| Empty (first boot)     | `current = 80`, `user = 80`                               |
+| `current=50, user=50`  | `current = 50`, `user = 50` (no change)                   |
+| `current=0, user=30`   | `current = 30`, `user = 30` (recovery to user)            |
+| `current=0, user=0`    | `current = 80`, `user = 80` (double fallback)             |
+| `current=0, user=5`    | `current = 10`, `user = 10` (recovery + clamp to MIN_PCT) |
+| `current=255, user=80` | `current = 100`, `user = 80` (clamp current to MAX_PCT)   |
+| `current=80, user=255` | `current = 80`, `user = 100` (clamp user)                 |
+
+Covered by R1 (NVS test) + R7 (init test).
+
+### Robustness sign-off checklist
+
+Final acceptance gate before merging the Sowel core PR:
+
+- [ ] R1 — NVS power-loss native test green; HW power-cut smoke test signed off.
+- [ ] R2 — Slider flood test on HW: 600+ cmds, no crash, NVS quiet.
+- [ ] R3 — Broker kill + reconnect cycle: state recovers, recipe resumes.
+- [ ] R4 — Sowel restart in each of the 3 recipe states: no spurious dispatch.
+- [ ] R5 — Multi-display: offline display does not block the others.
+- [ ] R6 — 24h soak: memory flat, no leaks.
+- [ ] R7 — Boot recovery matrix fully covered by native tests.
+
+## Validation gates (per repo)
+
+Each PR must pass:
+
+- **Sowel**: `npm run validate` (typecheck + lint + format:check + test + validate:ui).
+- **Plugin displays**: `npm run validate` (typecheck + tests).
+- **Firmware**: `pio run` clean, `pio test -e native` all green, HW smoke test signed off in spec.
+- **Recipe**: `npm run validate` (typecheck + tests).
+- **Spec 122 robustness sign-off**: every item in the "Robustness sign-off checklist" above is `[x]`.

--- a/specs/122-display-wake-action/spec.md
+++ b/specs/122-display-wake-action/spec.md
@@ -1,0 +1,99 @@
+# Spec 122 — Display wake action + user-preferred brightness
+
+## Context
+
+Spec 120 introduced the `display` equipment type with a single brightness order (`set_display_brightness`). The presence-driven sleep recipe (`sowel-recipe-presence-display`) currently dispatches `set_display_brightness 0` to sleep and `set_display_brightness <wake_brightness>` to wake — where `wake_brightness` is a recipe slot defaulting to 80%.
+
+Two issues surfaced in real use:
+
+1. **Wake brightness ignores the user's preference.** When the user has dialled the display to 30% on the slider, the recipe still wakes it at the slot's value (default 80%). The firmware also hardcodes the wake-on-touch fallback at 80%. Both contradict the principle "the user owns the display brightness, the recipe owns the on/off cycle".
+
+2. **Manual user override is not respected.** If the user wakes a sleeping display (by clicking it, or by moving the slider via the equipment panel), the recipe stays in `sleeping` state because it only watches motion. The display stays lit indefinitely, with no auto re-sleep after the configured absence.
+
+This spec adds the missing capability to the `display` equipment type — a dedicated wake action that restores the firmware's last user-chosen brightness — and pushes the "re-sleep after a user-initiated wake" responsibility down to the firmware itself via a hardcoded 2-minute auto-resleep timer. The recipe stays a pure motion-driven state machine; no UI-event observation, no `manual_wake` state. The firmware self-extinguishes after a tap-wake if no MQTT confirmation arrives — which makes the system robust even when Sowel is down.
+
+## Goals
+
+1. Add `"display_wake"` to Sowel's `OrderCategory` union (core type), so a `display` equipment can advertise a no-value wake order alongside `set_display_brightness` and `set_language`.
+
+2. Document the canonical MQTT wire mapping for `display_wake` in spec 121: order → `<prefix>/<id>/cmd/wake` topic, empty payload, fire-and-forget.
+
+3. In `sowel-plugin-displays`:
+   - Parse `wake` from the firmware's state JSON (when present) and expose a matching `display_wake` order on the device. Polymorphic: a display that does not publish `"wake": true` in its state simply does not get the order, no failure.
+   - Route the `display_wake` order key to `cmd/wake` in `dispatch-order.ts`.
+
+4. In `sowel-energy-display` firmware:
+   - Split NVS into two values: `current_pct` (last applied brightness, can be 0) and `user_pct` (last user-chosen brightness ≥ MIN_PCT=10, default 80). The two are written independently: a remote `cmd/brightness 0` updates `current_pct` only; any user-driven set (slider, gesture, MQTT cmd ≥ 1) updates both.
+   - Add `cmd/wake` MQTT handler → restores `brightness::set(user_pct)` and cancels any pending auto-resleep timer.
+   - Wake-on-touch in `screen_manager` switches from the hardcoded 80% to `user_pct` AND arms a 2-minute auto-resleep timer.
+   - **Auto-resleep mechanism (new)**: when the panel is woken locally by a tap on an off panel, the firmware starts a hardcoded 2-minute timer. If the timer expires without any `cmd/wake` / `cmd/brightness` / local gesture arriving, the panel auto-extinguishes (`brightness::set(0)`). Any incoming `cmd/wake`, `cmd/brightness`, or local gesture (`brightness::step`) cancels the timer. **Default at boot: no timer pending** (a freshly-booted display does not auto-sleep just because nobody talks to it).
+   - Boot recovery (when NVS `current_pct=0`) restores to `user_pct` if available, falling back to 80.
+   - Publish `"wake": true` in state JSON so the plugin can expose the order.
+
+5. In `sowel-recipe-presence-display`:
+   - Remove the `wake_brightness` slot entirely.
+   - On wake (motion resumed): dispatch `display_wake` (no value) instead of `set_display_brightness <N>`.
+   - **No `manual_wake` state, no `equipment.data.changed` subscription.** The recipe stays a pure motion-driven state machine (`awake / waiting / sleeping`). The "user tap on a sleeping panel" case is handled entirely by the firmware's auto-resleep mechanism: the panel lights up locally and re-extinguishes on its own after 2 min if motion never arrives. If motion does arrive within that window, the recipe sends `display_wake` and the firmware cancels its auto-resleep timer.
+
+## Non-Goals
+
+- New display data field. The user preference stays inside the firmware (NVS); it is not surfaced as a Sowel data row. (Considered briefly, rejected as "more telemetry pollution than benefit".)
+- Multi-tenancy of `user_pct`. The firmware tracks a single user preference; there is no per-user, per-zone, or per-recipe variant.
+- Backwards-compatible fallback in the recipe for older firmware that does not declare `display_wake`. The recipe's `validate()` will refuse to start if any selected display lacks the order — same way it already refuses if `set_display_brightness` is missing.
+
+## Acceptance criteria
+
+### Sowel core
+
+- [ ] `OrderCategory` includes `"display_wake"` in both `src/shared/types.ts` and `ui/src/types.ts`.
+- [ ] `npm run validate` (full) passes — no other code change needed in core; the routing by OrderCategory is generic.
+
+### Plugin `sowel-plugin-displays` v0.2.0+
+
+- [ ] `parse-state.ts` declares a `display_wake` order when `state.wake === true`.
+- [ ] `dispatch-order.ts` routes orderKey `wake` to `<prefix>/<id>/cmd/wake` with empty payload.
+- [ ] New tests: `parse-state.test.ts` adds a fixture with `wake: true`; `dispatch-order.test.ts` adds a `wake_display` dispatch case.
+- [ ] Released, registry entry bumped + SHA256 refreshed (no Sowel release for the registry alone).
+
+### Firmware `sowel-energy-display` iter 035
+
+- [ ] NVS split: `config::brightness_pct()` (current) + new `config::user_brightness_pct()` (preference).
+- [ ] `brightness::set(0)` writes only `current_pct`; `brightness::set(N>=10)` writes both.
+- [ ] `brightness::set(1..9)` clamps to 10 and writes both (existing behaviour preserved).
+- [ ] New `brightness::wake_to_user_with_resleep_armed()` entry point used by `screen_manager::on_press`: sets to `user_pct` AND arms the 2-min auto-resleep timer.
+- [ ] `brightness::set` and `brightness::step` cancel any pending auto-resleep timer (so MQTT cmds and gestures naturally suppress the firmware-initiated resleep).
+- [ ] New `mqtt_supervision::on_cmd_wake` handler → calls `brightness::set(user_pct)` (which cancels the timer naturally), marshalled via `lv_async_call`.
+- [ ] `screen_manager::on_press` wake-on-touch uses `user_pct` (via `wake_to_user_with_resleep_armed`) instead of hardcoded 80%.
+- [ ] **Auto-resleep timer (2 min hardcoded)** fires `brightness::set(0)` on expiry. Default at boot: not armed.
+- [ ] Boot recovery: if `current_pct=0` at init, restore `user_pct` (or 80 fallback).
+- [ ] State JSON publishes `"wake": true`.
+- [ ] `pio test -e native` covers the NVS split logic AND the auto-resleep timer behaviour.
+
+### Recipe `sowel-recipe-presence-display` v0.2.0+
+
+- [ ] `wake_brightness` slot removed from the slot list and from i18n.
+- [ ] `validate()` checks every selected display exposes a `display_wake` order binding; refuses otherwise.
+- [ ] `createInstance` dispatches `display_wake` (value ignored) on motion-resumed.
+- [ ] State machine stays minimal (`awake / waiting / sleeping`) — no `manual_wake`, no `equipment.data.changed` subscription.
+- [ ] Unit tests cover the validation refusal when `display_wake` is missing, the `display_wake` dispatch on motion-resumed, and the existing sleep cycle.
+- [ ] Released, registry entry bumped + SHA256 refreshed (registry update PR rides on the Sowel core release, since the recipe requires `sowelVersion: ">=1.19.0"`).
+
+### Robustness
+
+- [ ] All R1..R7 robustness scenarios in `plan.md` are executed (native tests automated, HW scenarios manually signed off in this spec). The "Robustness sign-off checklist" in `plan.md` must be fully ticked before the Sowel core PR is merged.
+
+## Edge cases
+
+- **Display has not yet sent its first state payload after upgrade** — the plugin has not yet declared the `display_wake` order; the recipe instance refuses to start. User retries once the display has reconnected. Same semantic as today for `set_display_brightness`.
+
+- **Display has `user_pct=0` in NVS somehow** (corrupt config, manual reset) — firmware's boot recovery and `cmd/wake` handler fall back to 80. Hard floor at MIN_PCT=10 means the panel cannot stay dark on wake.
+
+- **User taps the sleeping panel, then no motion for 30 min** — firmware wakes locally, arms the 2-min timer, no `cmd/wake` arrives (recipe still in `sleeping`), timer fires, panel re-extinguishes. The display is autonomous; Sowel/recipe presence is not required.
+
+- **User taps the sleeping panel, motion arrives 30 seconds later** — firmware wakes locally + arms timer. Motion → recipe transitions `sleeping → awake`, dispatches `display_wake`. Firmware cancels its auto-resleep timer. Panel stays on as long as motion continues.
+
+- **User taps the sleeping panel, then nudges the slider (in Sowel UI) within the 2 min** — the slider sends `cmd/brightness <N>`. Firmware applies it AND cancels the auto-resleep timer (any explicit `set` cancels). Panel stays on until the recipe's normal absence cycle kicks in.
+
+- **Recipe in `awake` (motion present), user nudges brightness to 0 via slider** — the recipe does NOT dispatch wake. The user explicitly chose to turn it off; the recipe respects that until motion changes again. State stays `awake`, but the next motion=false → `waiting` → timer fires `goSleep` which dispatches `set_display_brightness 0` (already 0, no-op visible).
+
+- **Display freshly booted, no recipe interaction yet** — `user_pct` defaults to 80, panel is at 80. No auto-resleep timer pending (the auto-resleep mechanism only engages after a tap-wake on a previously-off panel). Recipe init eventually arrives, sees motion=false → waits absence_threshold → dispatches sleep. Normal cycle.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -74,7 +74,11 @@ export type OrderCategory =
   | "set_pool_temperature_setpoint"
   // Spec 120 — display equipment.
   | "set_language"
-  | "set_display_brightness";
+  | "set_display_brightness"
+  // Spec 122 — display wake action. No value: the firmware restores its
+  // own last user-chosen brightness. Used by presence-driven recipes so
+  // the recipe does not need to know the user's preferred level.
+  | "display_wake";
 
 // ============================================================
 // Device

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.18.4",
+  "version": "1.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -73,7 +73,11 @@ export type OrderCategory =
   | "set_pool_temperature_setpoint"
   // Spec 120 — display equipment.
   | "set_language"
-  | "set_display_brightness";
+  | "set_display_brightness"
+  // Spec 122 — display wake action. No value: the firmware restores its
+  // own last user-chosen brightness. Used by presence-driven recipes so
+  // the recipe does not need to know the user's preferred level.
+  | "display_wake";
 
 // ============================================================
 // Device


### PR DESCRIPTION
## Summary

Spec 122 — adds the `"display_wake"` value to the `OrderCategory` union in both `src/shared/types.ts` and `ui/src/types.ts`. No behavioural change in core: the routing by `OrderCategory` is generic. This unlocks the companion changes:

- **sowel-plugin-displays v0.2.0** routes `display_wake` orders to `<prefix>/<id>/cmd/wake` (empty payload).
- **sowel-energy-display iter 035** splits NVS into `current_pct` + `user_pct`, restores `user_pct` on tap-wake or `cmd/wake`, auto-extinguishes 2 min after a tap-wake if no recipe confirmation arrives.
- **sowel-recipe-presence-display v0.2.0** drops the `wake_brightness` slot and dispatches `display_wake` on motion-resumed; the recipe no longer needs to know the user's preferred brightness.

See [specs/122-display-wake-action/](specs/122-display-wake-action/) for the full design, file changes, test plan, and the R1-R7 robustness checklist.

## Changes

- `src/shared/types.ts`: `OrderCategory += "display_wake"`
- `ui/src/types.ts`: same (mirror)
- `package.json` + `ui/package.json`: bump to `1.19.0`
- `docs/release-notes.md` + `docs/release-notes.fr.md`: `v1.19.0` entry per spec 108
- `specs/122-display-wake-action/`: spec + architecture + plan (incl. robustness test plan)

## Test plan

- [x] `npm run validate` (typecheck + lint + format:check + test + validate:ui) green locally
- [x] 786 backend tests pass, 2 skipped
- [x] UI typecheck + lint green (only 2 pre-existing warnings unrelated to this PR)
- [ ] Companion PRs (plugin / firmware / recipe) merged before consumers see any change

## Notes

- This PR ships only the type addition + release plumbing. The actual functional pipeline (plugin route + firmware behaviour + recipe dispatch) is delivered in the 3 companion PRs.
- After merge: `scripts/release.sh 1.19.0` → CI publishes `ghcr.io/mchacher/sowel:1.19.0`.
- The plugin/recipe registry entries will be bumped in follow-up PRs once the companion repos tag their `v0.2.0` releases. Those follow-up PRs do NOT trigger another Sowel release.