### PR TITLE
chore(registry): bump displays + presence-display to 0.2.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -415,7 +415,7 @@
     "icon": "Monitor",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-displays",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "tags": ["display", "mqtt", "energy-display", "supervision"],
     "i18n": {
       "fr": {
@@ -423,28 +423,28 @@
         "description": "Supervision MQTT des afficheurs supervisés par Sowel (energy display, e-paper, ...)"
       }
     },
-    "sowelVersion": ">=1.18.0",
+    "sowelVersion": ">=1.19.0",
     "owner": "mchacher",
-    "sha256": "ea146ccffd50a3adbb2ce08a5c5a0f2506623984218ea75454c792fafe760551"
+    "sha256": "d7b47de176d5c7bdc563c31ab0724ec607cbaaeb3aa58c8402ae9656464bb169"
   },
   {
     "id": "presence-display",
     "type": "recipe",
     "name": "Presence-driven display sleep",
-    "description": "Turns Sowel-supervised displays off after a configurable absence in a zone, wakes them on the next motion event.",
+    "description": "Turns Sowel-supervised displays off after a configurable absence in a zone, wakes them at the user's last-chosen brightness on the next motion event.",
     "icon": "Monitor",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-presence-display",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "tags": ["automation", "display", "motion", "presence", "sleep", "energy"],
     "i18n": {
       "fr": {
         "name": "Veille afficheur sur absence",
-        "description": "Éteint les afficheurs supervisés par Sowel après une période d'absence dans une zone, les réveille au mouvement suivant."
+        "description": "Éteint les afficheurs supervisés par Sowel après une période d'absence dans une zone, les réveille à la dernière luminosité choisie par l'utilisateur au mouvement suivant."
       }
     },
-    "sowelVersion": ">=1.18.0",
+    "sowelVersion": ">=1.19.0",
     "owner": "mchacher",
-    "sha256": "ceaa93d373f93bda1802a2f48df106cdf3238983ce71949a9c5a3c2bf9219350"
+    "sha256": "ac22da1f83e97b6c398286ed422a9968870dba3160db15a54fb971e02273fd44"
   }
 ]


### PR DESCRIPTION
## Summary

Bumps both displays-related entries in `plugins/registry.json` to consume the new `display_wake` OrderCategory shipped in Sowel core v1.19.0 (spec 122):

- **displays**: 0.1.0 → 0.2.0, sowelVersion `>=1.19.0`. Parses `wake: true` from the firmware state JSON, routes the `display_wake` order to `<prefix>/<id>/cmd/wake`.
- **presence-display**: 0.1.1 → 0.2.0, sowelVersion `>=1.19.0`. Drops the `wake_brightness` slot, dispatches `display_wake` on motion-resumed (firmware restores its NVS user_pct).

Both SHA256 refreshed via `scripts/backfill-registry-sha256.mjs` against the freshly-tagged GitHub releases.

## No Sowel release

This is a pure registry update — no Sowel core change. Per the standard registry workflow, the new entries propagate to all Sowel instances within ~1h (CDN cache).

## Test plan

- [x] `scripts/backfill-registry-sha256.mjs` confirmed both SHA256 against the new tarballs.
- [x] Format check passes (prettier).
- [ ] Post-merge: refresh plugin store on the production instance, update both plugin + recipe to 0.2.0, verify the recipe shows up + wakes the panel to the user-set brightness.