### PR TITLE
feat(ui): show display brightness inline on the equipment card

### DIFF
--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -86,6 +86,24 @@ interface EquipmentCardProps {
   onExecuteOrder: (equipmentId: string, alias: string, value: unknown) => Promise<void>;
 }
 
+/**
+ * Spec 122 — surface the display's current brightness inline in the
+ * card subtitle so the zone view shows at-a-glance whether the panel
+ * is asleep (`Off`) or lit (`<pct> %`).  Returns null when the data
+ * binding is missing or the value is not numeric.
+ */
+function displayBrightnessSummary(
+  equipment: EquipmentWithDetails,
+  t: (key: string, opts?: Record<string, unknown>) => string,
+): string | null {
+  const binding = equipment.dataBindings.find((b) => b.category === "display_brightness");
+  if (!binding) return null;
+  const v = binding.value;
+  if (typeof v !== "number" || !Number.isFinite(v)) return null;
+  if (v <= 0) return t("displays.card.off");
+  return t("displays.card.brightness", { pct: Math.round(v) });
+}
+
 export function EquipmentCard({ equipment, onExecuteOrder }: EquipmentCardProps) {
   const { t } = useTranslation();
   const {
@@ -125,6 +143,8 @@ export function EquipmentCard({ equipment, onExecuteOrder }: EquipmentCardProps)
           {t(TYPE_LABELS[equipment.type])}
           {equipment.dataBindings.length === 0 && ` · ${t("equipments.noBindings")}`}
           {!equipment.enabled && ` · ${t("common.disabled")}`}
+          {equipment.type === "display" && equipment.enabled && displayBrightnessSummary(equipment, t) &&
+            ` · ${displayBrightnessSummary(equipment, t)}`}
         </div>
       </Link>
 

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -253,6 +253,8 @@
   "displays.widget.title": "Displays",
   "displays.widget.empty": "No displays",
   "displays.widget.onlineCount": "{{online}}/{{total}} online",
+  "displays.card.off": "Off",
+  "displays.card.brightness": "{{pct}} %",
 
   "water.open": "Open",
   "water.closed": "Closed",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -253,6 +253,8 @@
   "displays.widget.title": "Afficheurs",
   "displays.widget.empty": "Aucun afficheur",
   "displays.widget.onlineCount": "{{online}}/{{total}} en ligne",
+  "displays.card.off": "Éteint",
+  "displays.card.brightness": "{{pct}} %",
 
   "water.open": "Ouverte",
   "water.closed": "Fermée",


### PR DESCRIPTION
## Summary

In the zone view, a display equipment now surfaces its current state in the subtitle row alongside the type label:

- `Display · 30 %` when lit (rounded brightness percent)
- `Display · Off` when brightness is 0 (the recipe-driven sleep state)

Previously the user had to click into the equipment detail page to read the slider value to know whether the panel was asleep. The inline indicator surfaces it at a glance, mirroring how sensors / lights already show their state from the zone view.

## Changes

- `ui/src/components/equipments/EquipmentCard.tsx`: new `displayBrightnessSummary()` helper, rendered inline in the subtitle when `equipment.type === "display"` and the binding has a numeric value.
- `ui/src/i18n/locales/en.json` + `fr.json`: `displays.card.off` (`Off` / `Éteint`) + `displays.card.brightness` (`{{pct}} %`).

## Test plan

- [x] `npm run validate` (full backend + UI): typecheck + lint + format + 786 backend tests pass.
- [ ] Manual: install display equipment in a zone, change brightness via slider → card subtitle updates. Set brightness to 0 → subtitle shows `Off`.