### PR TITLE
chore(registry): bump displays to 0.2.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -415,7 +415,7 @@
     "icon": "Monitor",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-displays",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "tags": ["display", "mqtt", "energy-display", "supervision"],
     "i18n": {
       "fr": {
@@ -425,7 +425,7 @@
     },
     "sowelVersion": ">=1.19.0",
     "owner": "mchacher",
-    "sha256": "d7b47de176d5c7bdc563c31ab0724ec607cbaaeb3aa58c8402ae9656464bb169"
+    "sha256": "a7c03dd0654dcf937422818741d3f6a9ba6ac404ca3b774dad16b64aaf0142f5"
   },
   {
     "id": "presence-display",


### PR DESCRIPTION
## Summary

Bumps the `displays` plugin entry from 0.2.0 to 0.2.1.

The fix in v0.2.1: `maybeDeclareNewOrders` now actually re-upserts the device with the augmented schema when a previously-unseen order key appears in a state payload. Before, the new orders only existed in the plugin's in-memory `declaredOrders` Set and never reached Sowel's device DB.

User-visible impact: an existing display equipment now picks up new firmware capabilities (like `display_wake` advertised by iter 036) without needing a Sowel restart or equipment recreate.

## No Sowel release

Standard registry workflow — propagates within ~1h via the CDN cache.

## Test plan

- [x] Plugin v0.2.1 tagged and released ([github.com/mchacher/sowel-plugin-displays/releases/tag/v0.2.1](https://github.com/mchacher/sowel-plugin-displays/releases/tag/v0.2.1)).
- [x] SHA256 refreshed via `backfill-registry-sha256.mjs`.
- [ ] Post-merge: user refreshes plugin store on prod, updates displays to 0.2.1, verifies the recipe stops complaining about the missing `display_wake` order.