### PR TITLE
fix(equipments): bind display_wake order on display equipments (v1.19.1)

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.19.x — Action wake afficheur
 
+### v1.19.1 — 2026-06-02 { #v1-19-1 }
+
+- Fix (UI/équipements) : l'auto-binding ramasse désormais l'ordre `wake` sur les équipements display. Avant ce correctif, la whitelist `RELEVANT_ORDERS["display"]` dans `bindingUtils.ts` ne listait que `language` et `brightness`, donc même après que le firmware ait annoncé la nouvelle capacité `display_wake` (iter 036) et que le plugin displays v0.2.1 l'ait exposée sur le device, le flow de création d'équipement la filtrait silencieusement. Résultat : la recette presence-display v0.2.0 refusait de démarrer avec `Display "..." has no order of category "display_wake" — firmware too old`. Correctif : ajout de `wake` à la whitelist display. Compagnon de la spec 122. Note : le `CANDIDATE_BASED_TYPES` côté UI exclut encore `display` (asymétrie avec le `binding-candidates.ts` du backend qui traite display en "all"-candidate). L'alignement est un suivi ; ce correctif est le patch minimal pour le problème utilisateur.
+
 ### v1.19.0 — 2026-06-02 { #v1-19-0 }
 
 - Feat (core) : nouvelle catégorie d'ordre `display_wake` pour le type d'équipement afficheur. Action sans valeur qui demande à l'afficheur de restaurer la dernière luminosité choisie par l'utilisateur (stockée dans sa NVS locale). Spec 122. Utilisée par la recette de mise en veille sur absence (`sowel-recipe-presence-display` v0.2.0+) qui n'a donc plus besoin de connaître la luminosité préférée. Changements compagnons : `sowel-plugin-displays` v0.2.0 route l'ordre vers `<prefix>/<id>/cmd/wake` ; sowel-energy-display iter 035 sépare la NVS en `current_pct` + `user_pct`, restaure `user_pct` sur tap ou `cmd/wake`, et s'éteint automatiquement 2 minutes après un tap-wake si la recette n'a pas confirmé.

--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -16,6 +16,7 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 ### v1.19.1 — 2026-06-02 { #v1-19-1 }
 
 - Fix (UI/équipements) : l'auto-binding ramasse désormais l'ordre `wake` sur les équipements display. Avant ce correctif, la whitelist `RELEVANT_ORDERS["display"]` dans `bindingUtils.ts` ne listait que `language` et `brightness`, donc même après que le firmware ait annoncé la nouvelle capacité `display_wake` (iter 036) et que le plugin displays v0.2.1 l'ait exposée sur le device, le flow de création d'équipement la filtrait silencieusement. Résultat : la recette presence-display v0.2.0 refusait de démarrer avec `Display "..." has no order of category "display_wake" — firmware too old`. Correctif : ajout de `wake` à la whitelist display. Compagnon de la spec 122. Note : le `CANDIDATE_BASED_TYPES` côté UI exclut encore `display` (asymétrie avec le `binding-candidates.ts` du backend qui traite display en "all"-candidate). L'alignement est un suivi ; ce correctif est le patch minimal pour le problème utilisateur.
+- Feat (UI/afficheurs) : la carte d'équipement dans la vue zone fait désormais apparaître la luminosité courante de l'afficheur à côté du label de type — `Afficheur · 30 %` quand allumé, `Afficheur · Éteint` quand la luminosité vaut 0 (état de veille piloté par la recette). Avant, il fallait cliquer sur l'équipement pour lire la valeur du slider et savoir si le panneau était endormi.
 
 ### v1.19.0 — 2026-06-02 { #v1-19-0 }
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.19.x — Display wake action
 
+### v1.19.1 — 2026-06-02 { #v1-19-1 }
+
+- Fix (UI/equipments): the auto-binding flow now picks up the `wake` order on display equipments. Before this fix, the `RELEVANT_ORDERS["display"]` whitelist in `bindingUtils.ts` listed only `language` and `brightness`, so even after the firmware advertised the new `display_wake` capability (iter 036) and the displays plugin v0.2.1 exposed it on the device, the equipment creation flow silently filtered it out. Result: the presence-display recipe v0.2.0 refused to start with `Display "..." has no order of category "display_wake" — firmware too old`. Fix: add `wake` to the display whitelist. Companion to spec 122. Note: the UI's `CANDIDATE_BASED_TYPES` set still excludes `display` (asymmetry with the backend's `binding-candidates.ts` which treats display as an "all"-candidate type). Aligning those is a follow-up; the whitelist fix is the minimal patch for the user-visible issue.
+
 ### v1.19.0 — 2026-06-02 { #v1-19-0 }
 
 - Feat (core): new `display_wake` order category for the display equipment type. A no-value action that tells the display to restore its last user-chosen brightness from local NVS. Spec 122. Used by the presence-driven sleep recipe (`sowel-recipe-presence-display` v0.2.0+) so the recipe no longer needs to know the user's preferred brightness level. Companion changes: `sowel-plugin-displays` v0.2.0 routes the order to `<prefix>/<id>/cmd/wake`; sowel-energy-display iter 035 splits NVS into `current_pct` + `user_pct`, restores `user_pct` on tap-wake or `cmd/wake`, and auto-extinguishes 2 minutes after a tap-wake if the recipe has not confirmed the wake.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,7 @@ This page summarises every published version, newest first. For the full diff be
 ### v1.19.1 — 2026-06-02 { #v1-19-1 }
 
 - Fix (UI/equipments): the auto-binding flow now picks up the `wake` order on display equipments. Before this fix, the `RELEVANT_ORDERS["display"]` whitelist in `bindingUtils.ts` listed only `language` and `brightness`, so even after the firmware advertised the new `display_wake` capability (iter 036) and the displays plugin v0.2.1 exposed it on the device, the equipment creation flow silently filtered it out. Result: the presence-display recipe v0.2.0 refused to start with `Display "..." has no order of category "display_wake" — firmware too old`. Fix: add `wake` to the display whitelist. Companion to spec 122. Note: the UI's `CANDIDATE_BASED_TYPES` set still excludes `display` (asymmetry with the backend's `binding-candidates.ts` which treats display as an "all"-candidate type). Aligning those is a follow-up; the whitelist fix is the minimal patch for the user-visible issue.
+- Feat (UI/displays): the equipment card in the zone view now surfaces a display's current brightness inline next to the type label — `Display · 30 %` when lit, `Display · Off` when brightness is 0 (the recipe-driven sleep state). Previously the user had to click into the equipment detail page to read the slider value to know whether the panel was asleep.
 
 ### v1.19.0 — 2026-06-02 { #v1-19-0 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.19.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -196,7 +196,11 @@ const RELEVANT_ORDERS: Record<string, string[]> = {
   // Spec 120 — Sowel-supervised displays.  Order keys mirror what
   // the displays plugin declares (see parse-state.ts of
   // sowel-plugin-displays): the key IS the topic suffix.
-  display: ["language", "brightness"],
+  // Spec 122 — `wake` added: a no-value action that asks the firmware
+  // to restore its last user-chosen brightness via the cmd/wake MQTT
+  // topic.  Without this whitelist entry, the UI auto-binding would
+  // drop the wake order during equipment creation.
+  display: ["language", "brightness", "wake"],
 };
 
 /**


### PR DESCRIPTION
## Summary

The UI's `RELEVANT_ORDERS["display"]` whitelist in `ui/src/components/equipments/bindingUtils.ts` only listed `language` + `brightness`. So even after:

- Firmware iter 036 advertised `wake: true` in its state JSON
- Plugin displays v0.2.1 surfaced the `display_wake` order on the device
- User recreated the equipment

the auto-binding flow silently dropped the `wake` order. Result: the presence-display recipe v0.2.0 refused to start with `Display "Energy Display" has no order of category "display_wake" — firmware too old, upgrade to a build advertising "wake": true`.

## Fix

Add `"wake"` to `RELEVANT_ORDERS["display"]`. Minimal, surgical, no behaviour change elsewhere.

## Follow-up worth flagging

The UI's `CANDIDATE_BASED_TYPES` set in the same file does NOT include `display`, while the backend's `src/equipments/binding-candidates.ts` DOES treat display as an "all"-candidate (i.e. binds everything the device exposes). Asymmetry. The minimal whitelist patch is enough to unblock the user today; aligning the two should be a separate refactor.

## Test plan

- [x] `npm run validate`: full backend + UI (typecheck + lint + format + 786 tests) green.
- [ ] HW: refresh plugin store + Sowel update on prod → recreate Energy Display equipment → presence-display recipe creation succeeds.

## Release

Bumps to `v1.19.1` with matching FR + EN release notes. Tag only after explicit user GO.