### PR TITLE
chore(registry): bump presence-display to 0.2.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -435,7 +435,7 @@
     "icon": "Monitor",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-presence-display",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "tags": ["automation", "display", "motion", "presence", "sleep", "energy"],
     "i18n": {
       "fr": {
@@ -445,6 +445,6 @@
     },
     "sowelVersion": ">=1.19.0",
     "owner": "mchacher",
-    "sha256": "ac22da1f83e97b6c398286ed422a9968870dba3160db15a54fb971e02273fd44"
+    "sha256": "3f6749e6d2328f91feccc52d5fb297afcee9a90f40c7838663a1ed8a23f9265f"
   }
 ]


### PR DESCRIPTION
## Summary

Pulls the v0.2.1 fix from sowel-recipe-presence-display.

The recipe used to default state="awake" on every restart/toggle and never re-dispatch a wake until a full absence cycle completed. If the panel was physically at brightness=0 from a previous sleep, the next motion=true arriving while state="waiting" would silently transition to "awake" without dispatching wake — panel stayed dark.

The new build dispatches one unconditional display_wake at instance start (idempotent for already-awake panels, recovery for asleep ones). Encountered live on the kitchen display this morning after a Sowel container restart at 04:43Z.

Release: https://github.com/mchacher/sowel-recipe-presence-display/releases/tag/v0.2.1
PR fix: https://github.com/mchacher/sowel-recipe-presence-display/pull/2

## Test plan

- [x] Recipe unit tests pass (23 tests including new regression).
- [ ] Post-merge, wait for CDN cache (~1h) then verify kitchen display wakes on next motion.