### PR TITLE
release: v1.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.19.1",
+  "version": "1.20.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump for v1.20.0 — bundles two features that both land in this release:

- **Spec 123 — Energy cost valuation** (merged in #269): Wh / € toggle on the Energy page, costs computed at read time on /energy/history and /energy/by-usage from the existing TariffPrices.
- **Spec 124 — Shadow mode** (merged in #270): `SOWEL_SHADOW_MODE=1` env var that gates every outbound subsystem at boot AND runtime, plus scripts/howto-shadow.md playbook.

Release notes for both are already on main under \`docs/release-notes.{md,fr.md}\` v1.20.0 with the \`{ #v1-20-0 }\` anchor required by the spec 108 verify-release-notes CI job.

Spec 124 was validated end-to-end on a local shadow seeded with a real sowelox backup (no plugin dialed out despite all enabled=1 in the restored SQLite). Spec 123 was then validated on the same shadow with real EDF prices and prod data: cost_hp = 0.9965 €, cost_hc = 0.2271 €, cost_total = 1.2236 € on today's consumption (math cross-checked manually).

## Test plan

- [x] tsc backend + UI clean
- [x] vitest 829 / 829 pass
- [x] eslint clean
- [x] Shadow rebuild on the rebased branch: spec 123 endpoints return the new cost fields against real prod data
- [ ] After merge: tag v1.20.0 → GitHub Actions builds ghcr.io/mchacher/sowel:1.20.0 + creates the release