### PR TITLE
fix(ui): align solar dashboard widget with mobile + show P/I/U inline

### DIFF
--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -23,6 +23,7 @@ import { findTempIndoor, findTempOutdoor } from "../equipments/weather-utils";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
 import { SensorValues } from "../equipments/SensorValues";
 import { SolarPanelIcon } from "../icons/SolarPanelIcon";
+import { solarWidgetState } from "./solarWidget";
 import { createElement } from "react";
 import {
   LightBulbIcon,
@@ -81,7 +82,7 @@ export function EquipmentWidget({ widget, equipment, onExecuteOrder, onOpenDetai
   if (isGate) return <GateEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
   if (isHeater) return <HeaterEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
   if (isEnergyMeter) return <EnergyMeterEquipmentWidget label={label} equipment={equipment} />;
-  if (equipment.type === "solar_panel") return <SolarPanelEquipmentWidget label={label} equipment={equipment} onOpenDetail={onOpenDetail} />;
+  if (equipment.type === "solar_panel") return <SolarPanelEquipmentWidget label={label} equipment={equipment} />;
   if (isWeatherForecast) return <WeatherForecastWidget label={label} equipment={equipment} />;
   if (equipment.type === "weather") return <WeatherStationWidget label={label} equipment={equipment} onOpenDetail={onOpenDetail} />;
   if (isAppliance) return <ApplianceEquipmentWidget label={label} equipment={equipment} />;
@@ -834,44 +835,29 @@ function EnergyMeterEquipmentWidget({
 function SolarPanelEquipmentWidget({
   label,
   equipment,
-  onOpenDetail,
 }: {
   label: string;
   equipment: EquipmentWithDetails;
-  onOpenDetail?: () => void;
 }) {
   const { t } = useTranslation();
 
-  // Only the PV logo + the produced power, large. When the panel is not
-  // producing (night → device offline, or 0 W), show a muted logo + "Veille"
-  // rather than a fake live 0. Tapping the card opens the full data sheet.
-  const power = equipment.dataBindings.find((b) => b.category === "power");
-  const powerW = typeof power?.value === "number" ? power.value : null;
-  const producing = equipment.status !== "offline" && powerW !== null && powerW > 0;
+  // Centered layout matching the mobile card: PV logo on top, then power ·
+  // current · voltage right under it (no click-through). "Veille" when the panel
+  // is not producing (night/offline) rather than a fake live 0.
+  const { producing, lines } = solarWidgetState(equipment, t);
 
   return (
-    <WidgetCard
-      label={label}
-      onClick={onOpenDetail}
-      className={onOpenDetail ? "cursor-pointer" : ""}
-    >
-      <div className="flex-1 flex items-center justify-center gap-4">
+    <WidgetCard label={label}>
+      <div className="flex-1 flex flex-col items-center justify-center gap-4">
         <SolarPanelIcon
           strokeWidth={1.5}
-          className={`${producing ? "text-primary" : "text-text-tertiary opacity-50"} w-[76px] h-[76px] sm:w-[92px] sm:h-[92px]`}
+          className={`${producing ? "text-primary" : "text-text-tertiary opacity-50"} w-[84px] h-[84px] sm:w-[104px] sm:h-[104px]`}
         />
-        {producing ? (
-          <div className="flex items-baseline gap-1">
-            <span className="text-[40px] sm:text-[46px] font-bold text-success tabular-nums leading-none font-mono">
-              {powerW >= 1000 ? (powerW / 1000).toFixed(2) : Math.round(powerW)}
-            </span>
-            <span className="text-[15px] font-semibold text-text-tertiary">
-              {powerW >= 1000 ? "kW" : "W"}
-            </span>
-          </div>
-        ) : (
-          <span className="text-[22px] font-semibold text-text-tertiary">{t("solar.standby")}</span>
-        )}
+        <span
+          className={`text-[16px] font-semibold tabular-nums font-mono ${producing ? "text-text" : "text-text-tertiary"}`}
+        >
+          {lines.join("  ·  ")}
+        </span>
       </div>
     </WidgetCard>
   );

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -20,6 +20,7 @@ import {
 } from "./WidgetIcons";
 import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
 import { SolarPanelIcon } from "../icons/SolarPanelIcon";
+import { solarWidgetState } from "./solarWidget";
 import { parseForecastDays, CONDITION_ICONS, CONDITION_COLORS } from "../equipments/weatherForecastUtils";
 import { findTempIndoor, findTempOutdoor } from "../equipments/weather-utils";
 import { Cloud, WashingMachine, Tv } from "lucide-react";
@@ -333,9 +334,7 @@ function useMobileState(
   }
 
   if (equipment.type === "solar_panel") {
-    const power = equipment.dataBindings.find((b) => b.category === "power");
-    const powerW = typeof power?.value === "number" ? power.value : null;
-    const producing = equipment.status !== "offline" && powerW !== null && powerW > 0;
+    const { producing, lines } = solarWidgetState(equipment, t);
     return {
       icon: (
         <SolarPanelIcon
@@ -344,13 +343,7 @@ function useMobileState(
           className={producing ? "text-primary" : "text-text-tertiary opacity-50"}
         />
       ),
-      stateLines: [
-        producing
-          ? powerW >= 1000
-            ? `${(powerW / 1000).toFixed(2)} kW`
-            : `${Math.round(powerW)} W`
-          : t("solar.standby"),
-      ],
+      stateLines: lines,
     };
   }
 

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -50,8 +50,6 @@ import {
 } from "./WidgetIcons";
 import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
 import { BottomSheet } from "./BottomSheet";
-import { SolarPanelDataPanel } from "../equipments/SolarPanelDataPanel";
-import { SolarPanelIcon } from "../icons/SolarPanelIcon";
 
 // ============================================================
 // Equipment detail sheets
@@ -138,23 +136,6 @@ export function EquipmentDetailSheet({ widget, equipment, onExecuteOrder, onClos
         icon={customEntry ? <div className="scale-[0.35]">{createElement(customEntry.component, customEntry.previewProps)}</div> : undefined}
       >
         <SensorDetailContent equipment={equipment} visibleBindings={widget.config?.visibleBindings} />
-      </BottomSheet>
-    );
-  }
-
-  if (equipment.type === "solar_panel") {
-    return (
-      <BottomSheet
-        open
-        onClose={onClose}
-        title={label}
-        icon={<SolarPanelIcon size={20} className="text-primary" />}
-      >
-        <SolarPanelDataPanel
-          bindings={equipment.dataBindings}
-          status={equipment.status}
-          statusReason={equipment.statusReason}
-        />
       </BottomSheet>
     );
   }

--- a/ui/src/components/dashboard/solarWidget.ts
+++ b/ui/src/components/dashboard/solarWidget.ts
@@ -1,0 +1,31 @@
+import type { EquipmentWithDetails } from "../../types";
+
+/**
+ * Shared presentation state for the solar panel widget so the desktop and mobile
+ * dashboards render identically: the produced power, current and voltage under
+ * the panel logo, or "Veille" when the panel is not producing (night/offline).
+ */
+export function solarWidgetState(
+  equipment: EquipmentWithDetails,
+  t: (key: string) => string,
+): { producing: boolean; lines: string[] } {
+  const num = (category: string): number | null => {
+    const b = equipment.dataBindings.find((x) => x.category === category);
+    return typeof b?.value === "number" ? b.value : null;
+  };
+
+  const powerW = num("power");
+  if (powerW === null || powerW <= 0 || equipment.status === "offline") {
+    return { producing: false, lines: [t("solar.standby")] };
+  }
+
+  const lines: string[] = [
+    powerW >= 1000 ? `${(powerW / 1000).toFixed(2)} kW` : `${Math.round(powerW)} W`,
+  ];
+  const current = num("current");
+  if (current !== null) lines.push(`${current.toFixed(1)} A`);
+  const voltage = num("voltage");
+  if (voltage !== null) lines.push(`${voltage.toFixed(1)} V`);
+
+  return { producing: true, lines };
+}

--- a/ui/src/components/dashboard/widget-utils.ts
+++ b/ui/src/components/dashboard/widget-utils.ts
@@ -9,6 +9,5 @@ export function needsDetailSheet(equipmentType: string): boolean {
     "thermostat",
     "pool_heat_pump",
     "heater",
-    "solar_panel",
   ].includes(equipmentType);
 }


### PR DESCRIPTION
## Summary

Follow-up to spec 125 (#272) — polish the Solar Panel dashboard widget per feedback after live testing:

- **Desktop now matches mobile.** Both render the same centered layout (PV logo on top, values underneath) via a shared `solarWidgetState()` helper, so web and mobile are consistent.
- **Power · current · voltage shown inline** under the panel, instead of hiding the extra data behind a click.
- **Removed the click-to-detail sheet** on the dashboard widget (the equipment detail page still has the full read-out: power/energy/voltage/current/inverter temperature). `solar_panel` dropped from `needsDetailSheet` + its `WidgetDetailSheet` branch removed.
- `Veille` (muted logo + label) when the panel is not producing (night/offline).

## Changes

- New `ui/src/components/dashboard/solarWidget.ts` — shared `{ producing, lines }` state used by both the desktop `SolarPanelEquipmentWidget` and the mobile `MobileWidgetCard` solar branch.
- Desktop widget: centered logo + `power · current · voltage` line, no `onOpenDetail`.
- Mobile widget: same lines via the shared helper (was power only).
- `widget-utils.needsDetailSheet` / `WidgetDetailSheet`: solar branch removed.

## Test plan

- [x] `cd ui && npx tsc -b --noEmit` — clean
- [x] `npx vitest run` — 839 pass / 2 skipped
- [x] `npx eslint .` — 0 errors (2 pre-existing warnings)
- [x] Manual: desktop + mobile dashboard verified live against 3 real APsystems inverters — both show "94 W · 2.3 A · 40.2 V" centered under the logo, no click-through.