### PR TITLE
release: v1.21.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,19 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.21.x — Équipement panneau photovoltaïque
+
+### v1.21.0 — 2026-06-12 { #v1-21-0 }
+
+Équipement Panneau Photovoltaïque + intégration APsystems (spec 125) :
+
+- Feat (equipments) : nouveau type d'équipement `solar_panel` (« Panneau Photovoltaïque »). Un équipement = un panneau = une voie d'onduleur ; lier un onduleur multi-voies propose un candidat par voie (Panel 1 / Panel 2), une voie déjà utilisée par un autre panneau n'est plus proposée, et la sélection est mono-appareil. Lecture seule.
+- Feat (core) : nouvelle catégorie de donnée générique `temperature_device` — la température interne d'un appareil (ex. un onduleur), distincte de `temperature` pour ne jamais polluer la moyenne de température d'une zone. Streaming (fraîcheur 15 min) et historisée par défaut.
+- Feat (ui) : widget dashboard solaire dédié — logo de panneau PV + puissance · courant · tension, identique sur desktop et mobile, « Veille » hors production. Nouveau groupe « Solaire » sur la vue Maison, et un panneau de détail en lecture seule (puissance / énergie / tension / courant / température onduleur).
+- Nouveau plugin : `apsystems` (lecture seule) — découvre les micro-onduleurs APsystems (DS3 / YC600 / QS1) via le pont MQTT [ESP32-ECU](https://github.com/mchacher/ESP32-ECU), un device par onduleur, en utilisant le Name du firmware comme identité stable pour qu'un remplacement matériel préserve la config Sowel (le serial est exposé comme donnée en lecture seule). Installez-le depuis le store de plugins.
+
+---
+
 ## 1.20.x — Valorisation des coûts énergie + mode shadow
 
 ### v1.20.0 — 2026-06-03 { #v1-20-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,19 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.21.x — Solar panel equipment
+
+### v1.21.0 — 2026-06-12 { #v1-21-0 }
+
+Solar Panel equipment + APsystems integration (spec 125):
+
+- Feat (equipments): new `solar_panel` ("Solar Panel" / "Panneau Photovoltaïque") equipment type. One equipment = one PV panel = one inverter channel; binding a multi-channel inverter offers one candidate per channel (Panel 1 / Panel 2), a channel already used by another panel is no longer offered, and selection is single-device. Read-only.
+- Feat (core): new generic `temperature_device` DataCategory — the internal temperature of a device (e.g. an inverter), distinct from `temperature` so it never pollutes a zone's room-temperature average. Streaming (15 min freshness) and historized by default.
+- Feat (ui): dedicated solar dashboard widget — PV panel logo + produced power · current · voltage, identical on desktop and mobile, "Veille" when not producing. New "Solar" group on the Maison view, and a read-only detail panel (power / energy / voltage / current / inverter temperature).
+- New plugin: `apsystems` (read-only) — discovers APsystems micro-inverters (DS3 / YC600 / QS1) from the [ESP32-ECU](https://github.com/mchacher/ESP32-ECU) MQTT bridge, one device per inverter, using the firmware Name as the stable identity so a hardware swap keeps the Sowel config (the serial is exposed as a read-only data point). Install it from the plugin store.
+
+---
+
 ## 1.20.x — Energy cost valuation + shadow mode
 
 ### v1.20.0 — 2026-06-03 { #v1-20-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.20.0",
+  "version": "1.21.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Sowel **v1.21.0** — Solar Panel equipment.

## Included (already on main)
- `#272` Solar Panel equipment type + `temperature_device` category (spec 125)
- `#273` solar dashboard widget (desktop/mobile aligned, power · current · voltage)
- `#274` `apsystems` plugin in the registry

## This PR
- Bump `package.json` + `ui/package.json` → `1.21.0`
- Release notes added to `docs/release-notes.md` and `docs/release-notes.fr.md` (anchor `{ #v1-21-0 }`, required by the `verify-release-notes` CI gate)

After merge: tag `v1.21.0` on main → the release workflow builds the multi-arch image and publishes the GitHub release. The `apsystems` plugin (`sowelVersion >=1.21.0`) becomes installable from the plugin store.