### PR TITLE
fix(equipments): propose Zigbee boolean-toggle plugs for switch binding

### DIFF
--- a/src/equipments/binding-candidates.test.ts
+++ b/src/equipments/binding-candidates.test.ts
@@ -83,6 +83,32 @@ describe("computeBindingCandidates", () => {
     expect(result[0].id).toBe("R1");
   });
 
+  // Regression: Zigbee2MQTT plugs (e.g. LidlSmartPlug) expose their on/off
+  // command as a boolean `state` order (category light_toggle), not an ON/OFF
+  // enum. Such devices must still yield a switch candidate.
+  it("switch on a Zigbee plug (boolean light_toggle `state`) → one candidate", () => {
+    const orders = [
+      order("state", "boolean", { category: "light_toggle" }),
+      order("indicator_mode", "enum", { enumValues: ["off", "off/on", "on/off", "on"] }),
+      order("power_on_behavior", "enum", { enumValues: ["off", "previous", "on"] }),
+    ];
+    const datas = [data("state", "boolean", { category: "light_state", value: "OFF" })];
+    const result = computeBindingCandidates("switch", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("state");
+    expect(result[0].orderKeys).toEqual(["state"]);
+    expect(result[0].dataKeys).toEqual(["state"]);
+  });
+
+  it("switch ignores boolean config toggles (no / non power-toggle category)", () => {
+    const orders = [
+      order("power_alarm", "boolean"),
+      order("mute", "boolean", { category: "toggle_mute" }),
+    ];
+    const result = computeBindingCandidates("switch", [], orders);
+    expect(result).toHaveLength(0);
+  });
+
   it("sensor on a multi-data device → one all-data candidate", () => {
     const datas = [
       data("temperature", "number", { category: "temperature" }),

--- a/src/equipments/binding-candidates.ts
+++ b/src/equipments/binding-candidates.ts
@@ -38,6 +38,24 @@ function isOnOffEnum(order: DeviceOrder): boolean {
   return order.enumValues.every((v) => typeof v === "string" && ONOFF_TOKENS.has(v.toUpperCase()));
 }
 
+/** Order categories that denote a binary power/on-off command channel. */
+const POWER_TOGGLE_CATEGORIES = new Set<OrderCategory>(["light_toggle", "toggle_power"]);
+
+/**
+ * True for an on/off command channel. Two shapes are accepted:
+ *  - an ON/OFF enum order (`["ON","OFF"]`, e.g. Tasmota `power1`)
+ *  - a boolean power-toggle order (Zigbee2MQTT exposes plug/relay `state` as a
+ *    boolean with category `light_toggle`/`toggle_power`)
+ * Boolean orders of any other category (config toggles like `power_alarm`,
+ * `eco_mode`, …) are intentionally excluded.
+ */
+function isOnOffOrder(order: DeviceOrder): boolean {
+  if (isOnOffEnum(order)) return true;
+  return (
+    order.type === "boolean" && !!order.category && POWER_TOGGLE_CATEGORIES.has(order.category)
+  );
+}
+
 /**
  * Extract the numeric suffix from a key like "power1" → 1, "shutter_state" → null.
  * Used to group shutter orders that share an index.
@@ -62,8 +80,24 @@ export function computeBindingCandidates(
   deviceOrders: readonly DeviceOrder[],
 ): BindingCandidate[] {
   switch (equipmentType) {
+    case "switch": {
+      // One candidate per on/off command channel: ON/OFF enum (Tasmota `power1`)
+      // OR a boolean power-toggle order (Zigbee2MQTT plug/relay `state`).
+      const candidates: BindingCandidate[] = [];
+      for (const o of deviceOrders) {
+        if (!isOnOffOrder(o)) continue;
+        const matchingData = deviceData.find((d) => d.key === o.key);
+        candidates.push({
+          id: o.key,
+          label: o.key,
+          dataKeys: matchingData ? [matchingData.key] : [],
+          orderKeys: [o.key],
+        });
+      }
+      return candidates;
+    }
+
     case "pool_pump":
-    case "switch":
     case "light_onoff":
     case "water_valve": {
       // One candidate per ON/OFF enum order; attach matching data if same key.

--- a/ui/src/lib/binding-candidates.ts
+++ b/ui/src/lib/binding-candidates.ts
@@ -28,6 +28,19 @@ function isOnOffEnum(order: DeviceOrder): boolean {
   );
 }
 
+/** Order categories that denote a binary power/on-off command channel. */
+const POWER_TOGGLE_CATEGORIES = new Set<string>(["light_toggle", "toggle_power"]);
+
+/**
+ * True for an on/off command channel: an ON/OFF enum order (Tasmota `power1`)
+ * or a boolean power-toggle order (Zigbee2MQTT plug/relay `state`). Boolean
+ * orders of any other category (config toggles) are excluded.
+ */
+function isOnOffOrder(order: DeviceOrder): boolean {
+  if (isOnOffEnum(order)) return true;
+  return order.type === "boolean" && !!order.category && POWER_TOGGLE_CATEGORIES.has(order.category);
+}
+
 function extractShutterGroupKey(key: string): string | null {
   const indexed = /^shutter(\d+)_(state|position|move)$/.exec(key);
   if (indexed) return indexed[1];
@@ -42,8 +55,23 @@ export function computeBindingCandidates(
   deviceOrders: readonly DeviceOrder[],
 ): BindingCandidate[] {
   switch (equipmentType) {
+    case "switch": {
+      // On/off channel: ON/OFF enum OR boolean power-toggle (Zigbee `state`).
+      const candidates: BindingCandidate[] = [];
+      for (const o of deviceOrders) {
+        if (!isOnOffOrder(o)) continue;
+        const matchingData = deviceData.find((d) => d.key === o.key);
+        candidates.push({
+          id: o.key,
+          label: o.key,
+          dataKeys: matchingData ? [matchingData.key] : [],
+          orderKeys: [o.key],
+        });
+      }
+      return candidates;
+    }
+
     case "pool_pump":
-    case "switch":
     case "light_onoff":
     case "water_valve": {
       const candidates: BindingCandidate[] = [];


### PR DESCRIPTION
## Problem

When creating a **prise** (`switch`) equipment, the device selector does not propose Zigbee2MQTT plugs/relays such as `LidlSmartPlug_00` (also affects Legrand switches — **27 devices in production**).

## Root cause

`computeBindingCandidates("switch", …)` only recognised an on/off channel when the order was an **ON/OFF enum** (`["ON","OFF"]`, Tasmota `power1`) via `isOnOffEnum`. But Zigbee2MQTT exposes a plug/relay's on/off command as a **boolean `state` order** (category `light_toggle`), so `isOnOffEnum` returned `false`, the device yielded **0 candidates**, and `DeviceSelector` filtered it out.

Verified against production `LidlSmartPlug_00`:
```
ORDER state            → type=boolean  category=light_toggle  enumValues=null   (was ignored)
ORDER indicator_mode   → enum [off, off/on, on/off, on]   (not ON/OFF)
ORDER power_on_behavior→ enum [off, previous, on]         (not ON/OFF)
```

## Fix

Add `isOnOffOrder`: an order is an on/off channel if it is an ON/OFF enum **OR** a boolean order whose category is a power-toggle (`light_toggle` / `toggle_power`). Boolean **config** toggles (`power_alarm`, `eco_mode`, `auto_close_when_water_shortage`, …) keep being excluded thanks to the category gate.

Applied to the `switch` case only — backend (`src/equipments/binding-candidates.ts`) + UI mirror (`ui/src/lib/binding-candidates.ts`). The `light_*` types share the same latent issue but are intentionally left untouched to keep scope minimal.

## Tests

- New regression test: a Zigbee plug (boolean `light_toggle` `state`) → exactly 1 switch candidate.
- New guard test: boolean config toggles (no / non power-toggle category) → 0 candidates.
- Full suite green (841 passed), backend + UI `tsc` clean, eslint clean.