### PR TITLE
feat(ui): switch (prise) controls + dashboard socket widget

### DIFF
--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -27,6 +27,7 @@ import { solarWidgetState } from "./solarWidget";
 import { createElement } from "react";
 import {
   LightBulbIcon,
+  PlugWidgetIcon,
   ShutterWidgetIcon,
   AwningWidgetIcon,
   ThermometerIcon,
@@ -83,6 +84,7 @@ export function EquipmentWidget({ widget, equipment, onExecuteOrder, onOpenDetai
   if (isHeater) return <HeaterEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
   if (isEnergyMeter) return <EnergyMeterEquipmentWidget label={label} equipment={equipment} />;
   if (equipment.type === "solar_panel") return <SolarPanelEquipmentWidget label={label} equipment={equipment} />;
+  if (equipment.type === "switch") return <SwitchEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} />;
   if (isWeatherForecast) return <WeatherForecastWidget label={label} equipment={equipment} />;
   if (equipment.type === "weather") return <WeatherStationWidget label={label} equipment={equipment} onOpenDetail={onOpenDetail} />;
   if (isAppliance) return <ApplianceEquipmentWidget label={label} equipment={equipment} />;
@@ -192,6 +194,88 @@ function LightEquipmentWidget({
               {isOn ? "ON" : "OFF"}
             </span>
           )}
+        </div>
+      </div>
+
+      {/* Zone 3: Bouton — toggle */}
+      {hasToggle && equipment.enabled && (
+        <div className="flex justify-center gap-3 mt-auto pt-1">
+          <button
+            onClick={handleToggle}
+            disabled={executing}
+            className={`w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed ${
+              isOn ? "!border-active/40 !text-active !bg-active/5" : ""
+            }`}
+            title={isOn ? t("controls.turnOff") : t("controls.turnOn")}
+          >
+            {executing ? <Loader2 size={16} className="animate-spin" /> : <Power size={16} strokeWidth={1.5} />}
+          </button>
+        </div>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ============================================================
+// Switch (smart plug) widget — plug picto + ON/OFF state + toggle.
+// Mirrors LightEquipmentWidget without the brightness slider. The plug's
+// on/off command is a `light_toggle` order (enum ON/OFF or boolean state),
+// and the state indicator reads the `light_state` data binding.
+// ============================================================
+
+function SwitchEquipmentWidget({
+  label,
+  equipment,
+  onExecuteOrder,
+}: {
+  label: string;
+  equipment: EquipmentWithDetails;
+  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+}) {
+  const { t } = useTranslation();
+  const [executing, setExecuting] = useState(false);
+
+  const stateBinding = equipment.dataBindings.find(
+    (db) => db.alias === "state" || db.category === "light_state",
+  );
+  const isOn = stateBinding
+    ? stateBinding.value === true || String(stateBinding.value).toUpperCase() === "ON"
+    : false;
+
+  const toggleBinding = equipment.orderBindings.find(
+    (ob) => ob.type === "boolean" || (ob.alias === "state" && ob.type === "enum"),
+  );
+  const hasToggle = !!toggleBinding;
+
+  const handleToggle = async () => {
+    if (executing || !toggleBinding) return;
+    setExecuting(true);
+    try {
+      const alias = toggleBinding.alias;
+      const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
+      const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
+      const value =
+        toggleBinding.type === "boolean" && alias !== "state" ? !isOn : isOn ? offVal : onVal;
+      await onExecuteOrder(alias, value);
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  return (
+    <WidgetCard label={label}>
+      {/* Zone 2: Picto + état */}
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
+        <div />
+        <PlugWidgetIcon on={isOn} />
+        <div className="flex items-center gap-2 pl-2">
+          <span
+            className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
+              isOn ? "bg-active/10 text-active" : "bg-border-light text-text-tertiary"
+            }`}
+          >
+            {isOn ? "ON" : "OFF"}
+          </span>
         </div>
       </div>
 

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -788,14 +788,14 @@ export function GarageDoorIcon({ open }: { open: boolean }) {
 
 // ============================================================
 // Plug icon — prise connectée / wall socket. Recognizable European outlet:
-// rounded-square faceplate + recessed socket ring + 2 pin holes + earth clips.
+// rounded-square faceplate + recessed socket ring + 2 pin holes.
 // `on` lifts the opacities and adds a soft glow (text-active amber), `off`
 // renders a quiet ocean-blue outline.
 // ============================================================
 
 export function PlugWidgetIcon({ on }: { on: boolean }) {
   return (
-    <svg width="120" height="120" viewBox="0 0 24 24" fill="none" className={on ? "text-active" : "text-primary"}>
+    <svg width="108" height="108" viewBox="0 0 24 24" fill="none" className={on ? "text-active" : "text-primary"}>
       {/* Glow when powered */}
       {on && <circle cx="12" cy="12" r="11" fill="currentColor" opacity="0.08" />}
 
@@ -820,10 +820,6 @@ export function PlugWidgetIcon({ on }: { on: boolean }) {
         strokeWidth="1.5"
         strokeOpacity={on ? 0.55 : 0.3}
       />
-
-      {/* Earth clips (top + bottom) */}
-      <path d="M12 7.5V6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeOpacity={on ? 0.5 : 0.28} />
-      <path d="M12 18V16.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeOpacity={on ? 0.5 : 0.28} />
 
       {/* Pin holes */}
       <circle cx="10" cy="12" r="1" fill="currentColor" fillOpacity={on ? 0.9 : 0.55} />

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -787,22 +787,47 @@ export function GarageDoorIcon({ open }: { open: boolean }) {
 }
 
 // ============================================================
-// Plug icon — prise connectée / smart plug
+// Plug icon — prise connectée / wall socket. Recognizable European outlet:
+// rounded-square faceplate + recessed socket ring + 2 pin holes + earth clips.
+// `on` lifts the opacities and adds a soft glow (text-active amber), `off`
+// renders a quiet ocean-blue outline.
 // ============================================================
 
 export function PlugWidgetIcon({ on }: { on: boolean }) {
   return (
-    <svg width="120" height="120" viewBox="0 0 56 56" fill="none" className={on ? "text-active" : "text-primary"}>
-      {/* Plug body */}
-      <rect x="16" y="20" width="24" height="22" rx="4" fill="currentColor" fillOpacity={on ? 0.12 : 0.06} stroke="currentColor" strokeWidth="1.2" strokeOpacity="0.25" />
-      {/* Prongs */}
-      <rect x="22" y="10" width="3" height="12" rx="1.5" fill="currentColor" opacity="0.3" />
-      <rect x="31" y="10" width="3" height="12" rx="1.5" fill="currentColor" opacity="0.3" />
-      {/* Power indicator */}
-      {on && <circle cx="28" cy="31" r="4" fill="currentColor" opacity="0.2" />}
-      <circle cx="28" cy="31" r="2" fill="currentColor" opacity={on ? 0.5 : 0.15} />
-      {/* Cable */}
-      <path d="M28 42 L28 50" stroke="currentColor" strokeWidth="2" strokeOpacity="0.2" strokeLinecap="round" />
+    <svg width="120" height="120" viewBox="0 0 24 24" fill="none" className={on ? "text-active" : "text-primary"}>
+      {/* Glow when powered */}
+      {on && <circle cx="12" cy="12" r="11" fill="currentColor" opacity="0.08" />}
+
+      {/* Faceplate — rounded-square frame */}
+      <path
+        d="M2 12C2 7.28595 2 4.92893 3.46447 3.46447C4.92893 2 7.28595 2 12 2C16.714 2 19.0711 2 20.5355 3.46447C22 4.92893 22 7.28595 22 12C22 16.714 22 19.0711 20.5355 20.5355C19.0711 22 16.714 22 12 22C7.28595 22 4.92893 22 3.46447 20.5355C2 19.0711 2 16.714 2 12Z"
+        fill="currentColor"
+        fillOpacity={on ? 0.12 : 0.06}
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeOpacity={on ? 0.55 : 0.3}
+      />
+
+      {/* Recessed socket ring */}
+      <circle
+        cx="12"
+        cy="12"
+        r="6"
+        fill="currentColor"
+        fillOpacity={on ? 0.1 : 0.04}
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeOpacity={on ? 0.55 : 0.3}
+      />
+
+      {/* Earth clips (top + bottom) */}
+      <path d="M12 7.5V6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeOpacity={on ? 0.5 : 0.28} />
+      <path d="M12 18V16.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeOpacity={on ? 0.5 : 0.28} />
+
+      {/* Pin holes */}
+      <circle cx="10" cy="12" r="1" fill="currentColor" fillOpacity={on ? 0.9 : 0.55} />
+      <circle cx="14" cy="12" r="1" fill="currentColor" fillOpacity={on ? 0.9 : 0.55} />
     </svg>
   );
 }

--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -111,6 +111,7 @@ export function EquipmentCard({ equipment, onExecuteOrder }: EquipmentCardProps)
   const { t } = useTranslation();
   const {
     isLight,
+    isSwitch,
     isShutterFamily,
     isSensor,
     isThermostat,
@@ -159,8 +160,8 @@ export function EquipmentCard({ equipment, onExecuteOrder }: EquipmentCardProps)
         />
       )}
 
-      {/* Light quick control */}
-      {isLight && equipment.enabled && (
+      {/* Light / switch quick control (smart plug = ON/OFF relay, same surface) */}
+      {(isLight || isSwitch) && equipment.enabled && (
         <LightControl
           equipment={equipment}
           onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}

--- a/ui/src/components/equipments/useEquipmentState.ts
+++ b/ui/src/components/equipments/useEquipmentState.ts
@@ -34,6 +34,10 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
   const isPoolPump = equipment.type === "pool_pump";
   const isPoolCover = equipment.type === "pool_cover";
   const isPoolHeatPump = equipment.type === "pool_heat_pump";
+  // A switch (smart plug) is an ON/OFF relay: same control surface as a light
+  // (toggle + light_state indicator), but kept as its own flag so it isn't
+  // styled with the light "glow" tint.
+  const isSwitch = equipment.type === "switch";
 
   // State binding — `light_state` is the canonical ON/OFF data category
   // used by lights, heaters, switches, valves and pool pumps (plugins emit
@@ -164,6 +168,7 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
     isPoolPump,
     isPoolCover,
     isPoolHeatPump,
+    isSwitch,
     stateBinding,
     isOn,
     shutterPosition,

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -61,6 +61,7 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
 
   const {
     isLight,
+    isSwitch,
     isShutterFamily,
     isSensor,
     isEnergyMeter,
@@ -85,7 +86,7 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
 
   // Find primary data value for generic equipments
   const isKnownType =
-    isLight || isSensor || isShutterFamily || isThermostat || isHeater || isGate ||
+    isLight || isSwitch || isSensor || isShutterFamily || isThermostat || isHeater || isGate ||
     isEnergyMeter || isWeatherForecast || isMediaPlayer || isAppliance ||
     isWaterValve || isPoolPump || isPoolCover || isPoolHeatPump || isSolar;
 
@@ -199,8 +200,8 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
         </span>
       )}
 
-      {/* Light controls */}
-      {isLight && equipment.enabled && (
+      {/* Light / switch controls (smart plug = ON/OFF relay, same surface) */}
+      {(isLight || isSwitch) && equipment.enabled && (
         <LightControl
           equipment={equipment}
           onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -180,7 +180,7 @@ export function EquipmentDetailPage() {
     }
   };
 
-  const { isLight, isShutterFamily, isSensor, isThermostat, isHeater, isGate, actionBinding } = equipmentState;
+  const { isLight, isSwitch, isShutterFamily, isSensor, isThermostat, isHeater, isGate, actionBinding } = equipmentState;
 
   return (
     <div className="p-4 sm:p-6">
@@ -254,8 +254,8 @@ export function EquipmentDetailPage() {
         </div>
       </div>
 
-      {/* Controls */}
-      {isLight && equipment.enabled && (
+      {/* Controls — light and switch (smart plug) share the ON/OFF toggle surface */}
+      {(isLight || isSwitch) && equipment.enabled && (
         <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
           <h3 className="text-[14px] font-semibold text-text mb-3">{t("equipments.controls")}</h3>
           <LightControl


### PR DESCRIPTION
Follow-up to #276 (Zigbee plug binding). The `switch` equipment type had an
icon, label and binding support but was wired into **no control branch**, so a
smart plug rendered with no toggle and no state feedback anywhere.

## Changes

A switch is an ON/OFF relay with the same control surface as a light
(`light_toggle` order + `light_state` indicator), so it reuses the existing
`LightControl` via a new `isSwitch` flag:

- **Compact card** (zone/home view): ON/OFF toggle instead of a passive badge
- **Equipment card** (list): ON/OFF toggle
- **Equipment detail page**: a "Controls" section with the toggle
- **Dashboard**: a dedicated `SwitchEquipmentWidget` (socket picto + ON/OFF +
  toggle) instead of the read-only `GenericEquipmentWidget`

The dashboard plug icon was redrawn as a recognizable **wall socket**
(faceplate + recessed ring + 2 pin holes), styled to the widget conventions
(amber + soft glow when on, ocean-blue outline when off). Shared by the desktop
widget, mobile card and icon picker.

## Validation

- UI `tsc -b` clean, eslint clean
- Verified live on the local test instance against a real `LidlSmartPlug_00`