### PR TITLE
fix(equipments): propose Zigbee water valves (make water_valve key-driven)

### DIFF
--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -82,7 +82,10 @@ const CANDIDATE_BASED_TYPES: ReadonlySet<EquipmentType> = new Set<EquipmentType>
   "switch",
   "shutter",
   "awning",
-  "water_valve",
+  // NOTE: water_valve is intentionally key-driven (EQUIPMENT_TYPE_DATA_KEYS +
+  // RELEVANT_*), NOT candidate-based. Its open/close is a boolean `light_toggle`
+  // order the candidate path (enum ON/OFF only) ignores, and a valve must bind
+  // its full surface (state + flow + battery + irrigation), not just the relay.
   // Spec 125 — solar panel: one candidate per inverter channel (Panel 1 / Panel 2).
   "solar_panel",
 ]);

--- a/ui/src/components/equipments/bindingUtils.test.ts
+++ b/ui/src/components/equipments/bindingUtils.test.ts
@@ -179,3 +179,31 @@ describe("awning equipment type relevance", () => {
     expect(isRelevantOrder("color", "awning")).toBe(false);
   });
 });
+
+describe("water_valve equipment type relevance", () => {
+  // water_valve is key-driven (NOT candidate-based): a Zigbee valve like the
+  // SONOFF SWV exposes its open/close as a boolean `light_toggle` `state` order
+  // (which the candidate path, enum ON/OFF only, ignores), plus rich telemetry.
+  // The legacy RELEVANT_DATA/RELEVANT_ORDERS path must cover the full surface so
+  // the valve is proposed AND fully bound (state + flow + battery + irrigation).
+  it("accepts the SONOFF SWV data: state (light_state), battery and generic (flow/irrigation/status)", () => {
+    expect(isRelevantData("light_state", "water_valve")).toBe(true);
+    expect(isRelevantData("battery", "water_valve")).toBe(true);
+    // flow, irrigation_*, current_device_status are emitted as category "generic"
+    expect(isRelevantData("generic", "water_valve")).toBe(true);
+  });
+
+  it("accepts the SONOFF SWV orders: open/close + irrigation params", () => {
+    expect(isRelevantOrder("state", "water_valve")).toBe(true);
+    expect(isRelevantOrder("irrigation_duration", "water_valve")).toBe(true);
+    expect(isRelevantOrder("irrigation_interval", "water_valve")).toBe(true);
+    expect(isRelevantOrder("irrigation_capacity", "water_valve")).toBe(true);
+    expect(isRelevantOrder("auto_close_when_water_shortage", "water_valve")).toBe(true);
+    expect(isRelevantOrder("total_number", "water_valve")).toBe(true);
+  });
+
+  it("ignores unrelated categories/orders", () => {
+    expect(isRelevantData("shutter_position", "water_valve")).toBe(false);
+    expect(isRelevantOrder("color", "water_valve")).toBe(false);
+  });
+});

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -315,7 +315,10 @@ const CANDIDATE_BASED_TYPES: ReadonlySet<EquipmentType> = new Set<EquipmentType>
   "switch",
   "shutter",
   "awning",
-  "water_valve",
+  // NOTE: water_valve is intentionally key-driven (RELEVANT_DATA/RELEVANT_ORDERS),
+  // NOT candidate-based — see the matching note in DeviceSelector. It binds its
+  // full surface (state + flow + battery + irrigation), and its open/close is a
+  // boolean `light_toggle` order the candidate path (enum ON/OFF only) ignores.
   // Spec 125 — one candidate per inverter channel (ch<N>_*), so a 2-panel DS3
   // yields Panel 1 / Panel 2 and each equipment binds only its channel.
   "solar_panel",


### PR DESCRIPTION
Same class of bug as #276 (Zigbee plugs), one layer deeper.

## Problem

A `water_valve` (e.g. `SONOFF_WATER_VALVE_00`) is not proposed when creating a
valve equipment. `water_valve` had been added to `CANDIDATE_BASED_TYPES`, so the
selector + auto-binding go through `computeBindingCandidates`, which only
recognises **enum ON/OFF** orders. The valve's open/close is a **boolean
`light_toggle` `state` order**, so it yields zero candidates → never proposed.
Worse: even matched, the candidate path would bind only `state`, dropping the
valve's flow/battery/irrigation telemetry.

## Fix

Remove `water_valve` from both `CANDIDATE_BASED_TYPES` sets
(`DeviceSelector.tsx` + `bindingUtils.ts`), restoring its **key-driven** path
(`EQUIPMENT_TYPE_DATA_KEYS` + `RELEVANT_DATA`/`RELEVANT_ORDERS`) that the SONOFF
SWV support was designed around — `WaterValveControl` already accepts
`light_toggle`/`light_state`. The valve is now proposed (matches `flow`/
irrigation) and bound across its full surface (state + flow + battery +
irrigation). No backend change (the backend `computeBindingCandidates` is not
wired in production, only tested).

## Validation

- New regression tests in `bindingUtils.test.ts` (SONOFF SWV data/order keys
  covered by the key-driven path) — 25 pass
- UI `tsc -b` clean, eslint clean
- Verified live on the local test instance against real `SONOFF_WATER_VALVE_00`