### PR TITLE
release: v1.22.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,20 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.22.x: Pilotage des prises et association Zigbee on/off
+
+### v1.22.0 — 2026-06-23 { #v1-22-0 }
+
+Corrections d'association des équipements on/off Zigbee et pilotage des prises :
+
+- Fix (equipments) : les prises et relais Zigbee2MQTT (Lidl, Legrand, ...) sont désormais proposés à l'association d'un équipement `switch` (prise). Leur commande on/off est un ordre booléen `light_toggle`, que le moteur ne reconnaissait qu'en énumération ON/OFF, donc seuls les Tasmota apparaissaient. (#276)
+- Feat (ui) : les équipements `switch` (prise) disposent maintenant de commandes on/off partout (carte compacte, carte équipement, page détail) et d'un widget dashboard dédié (picto prise murale et bouton ON/OFF), au lieu d'un simple badge en lecture seule. (#277)
+- Fix (equipments) : les vannes Zigbee (ex. SONOFF SWV) sont désormais proposées à l'association d'un équipement `water_valve`, et associent toute leur télémétrie (état, débit, batterie, irrigation) au lieu d'être ignorées. (#278)
+
+Nouvelle recette dans le store : **Programmation horaire**, jusqu'à 3 créneaux marche/arrêt par jour pour n'importe quel équipement on/off.
+
+---
+
 ## 1.21.x — Équipement panneau photovoltaïque
 
 ### v1.21.0 — 2026-06-12 { #v1-21-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,20 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.22.x: Smart plug controls and Zigbee on/off binding
+
+### v1.22.0 — 2026-06-23 { #v1-22-0 }
+
+Zigbee on/off equipment binding fixes and smart plug controls:
+
+- Fix (equipments): Zigbee2MQTT plugs and relays (Lidl, Legrand, ...) are now proposed when binding a `switch` (smart plug) equipment. Their on/off command is a boolean `light_toggle` order, which the binding matcher previously only recognised as an enum ON/OFF, so only Tasmota devices appeared. (#276)
+- Feat (ui): `switch` (smart plug) equipments now have on/off controls everywhere (compact card, equipment card, detail page) plus a dedicated dashboard widget with a wall-socket picto and ON/OFF toggle, instead of a read-only badge. (#277)
+- Fix (equipments): Zigbee water valves (e.g. SONOFF SWV) are now proposed when binding a `water_valve` equipment, and bind their full surface (state, flow, battery, irrigation) instead of being dropped. (#278)
+
+New recipe in the store: **Schedule On/Off** ("Programmation horaire"), up to 3 daily ON/OFF windows for any on/off equipment.
+
+---
+
 ## 1.21.x — Solar panel equipment
 
 ### v1.21.0 — 2026-06-12 { #v1-21-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.22.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Cut **v1.22.0**. Bumps `package.json` + `ui/package.json` and adds the
release-notes entry (EN + FR, spec 108).

## Included since v1.21.0

- #276 — fix(equipments): Zigbee boolean-toggle plugs proposed for `switch` binding
- #277 — feat(ui): switch (prise) controls (cards + detail) + dashboard socket widget
- #278 — fix(equipments): Zigbee water valves proposed (`water_valve` key-driven)
- #279 — chore(registry): schedule-on-off recipe entry (rides along)

## After merge

Tag `v1.22.0` on the merged commit and push it → triggers the Docker build +
GitHub release. (verify-release-notes anchor `{ #v1-22-0 }` present in both files.)