### PR TITLE
feat(recipes): select slot type + ctx.helpers.getSunlight() (spec 126)

### DIFF
--- a/docs/technical/recipe-development.md
+++ b/docs/technical/recipe-development.md
@@ -141,6 +141,8 @@ slots: RecipeSlotDef[] = [
 
 **`select` slot (spec 126).** Provide `options: { value: string; label: string }[]`; `label` is the English fallback. Per-language option labels live in the recipe's i18n under `slots[<id>].options[<value>]`. The chosen option's `value` is stored as the param. Use it for a small closed list of named choices (e.g. "fixed time / sunrise / sunset").
 
+**Conditional greying (spec 126).** Any slot can declare `disabledWhen: { slot: "<otherSlotId>", equals: <value | value[]> }`. The recipe form greys out (disables) that slot when the referenced sibling's effective value (its param, or its `defaultValue` when untouched) matches. Pairs naturally with a `select`: e.g. a fixed-time picker `disabledWhen` the kind select is `["sunrise", "sunset"]`, and an offset `disabledWhen` it is `"time"`.
+
 ## Translations (i18n)
 
 Translations travel with the recipe, not in the platform locale files. This allows recipes to be hot-loaded without modifying `fr.json`/`en.json`.

--- a/docs/technical/recipe-development.md
+++ b/docs/technical/recipe-development.md
@@ -137,6 +137,9 @@ slots: RecipeSlotDef[] = [
 | `number`    | Numeric input  | Numeric value                      |
 | `time`      | Time picker    | `"HH:MM"` string (24h)             |
 | `boolean`   | Toggle         | `true` / `false`                   |
+| `select`    | Dropdown       | chosen option `value` (string)     |
+
+**`select` slot (spec 126).** Provide `options: { value: string; label: string }[]`; `label` is the English fallback. Per-language option labels live in the recipe's i18n under `slots[<id>].options[<value>]`. The chosen option's `value` is stored as the param. Use it for a small closed list of named choices (e.g. "fixed time / sunrise / sunset").
 
 ## Translations (i18n)
 
@@ -214,14 +217,17 @@ Reusable utilities in `src/recipes/engine/`:
 | `duration.ts`      | `parseDuration(value)`, `formatDuration(ms)`                                   |
 | `light-helpers.ts` | `isAnyLightOn()`, `turnOnLights()`, `turnOffLights()`, `setLightsBrightness()` |
 
+`ctx.helpers` also exposes `getSunlight(): { sunrise, sunset, isDaylight }` (spec 126) — the current sun times (`"HH:MM"`, offsets applied) for sun-aware scheduling. Pair it with the `sunlight.changed` event to re-sync across days; fields are `null` when sun times are not yet computed or no home coordinates are configured.
+
 ## Event Bus Events
 
 Key events recipes typically subscribe to:
 
-| Event                    | Payload                                                   |
-| ------------------------ | --------------------------------------------------------- |
-| `zone.data.changed`      | `{ zoneId, aggregatedData: { motion, luminosity, ... } }` |
-| `equipment.data.changed` | `{ equipmentId, alias, value, category }`                 |
+| Event                    | Payload                                                                                                   |
+| ------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `zone.data.changed`      | `{ zoneId, aggregatedData: { motion, luminosity, ... } }`                                                 |
+| `equipment.data.changed` | `{ equipmentId, alias, value, category }`                                                                 |
+| `sunlight.changed`       | (no payload) — sun times recomputed (new day / daylight transition); read via `ctx.helpers.getSunlight()` |
 
 ## Lifecycle
 

--- a/docs/technical/recipe-development.md
+++ b/docs/technical/recipe-development.md
@@ -141,7 +141,7 @@ slots: RecipeSlotDef[] = [
 
 **`select` slot (spec 126).** Provide `options: { value: string; label: string }[]`; `label` is the English fallback. Per-language option labels live in the recipe's i18n under `slots[<id>].options[<value>]`. The chosen option's `value` is stored as the param. Use it for a small closed list of named choices (e.g. "fixed time / sunrise / sunset").
 
-**Conditional greying (spec 126).** Any slot can declare `disabledWhen: { slot: "<otherSlotId>", equals: <value | value[]> }`. The recipe form greys out (disables) that slot when the referenced sibling's effective value (its param, or its `defaultValue` when untouched) matches. Pairs naturally with a `select`: e.g. a fixed-time picker `disabledWhen` the kind select is `["sunrise", "sunset"]`, and an offset `disabledWhen` it is `"time"`.
+**Conditional visibility (spec 126).** Any slot can declare `hiddenWhen: { slot: "<otherSlotId>", equals: <value | value[]> }`. The recipe form hides that slot (removes it from the layout, keeping the remaining fields aligned) when the referenced sibling's effective value (its param, or its `defaultValue` when untouched) matches. Pairs naturally with a `select`: e.g. a fixed-time picker `hiddenWhen` the kind select is `["sunrise", "sunset"]`, and an offset `hiddenWhen` it is `"time"`, so only the relevant field shows.
 
 ## Translations (i18n)
 

--- a/specs/126-recipe-select-slot-sunlight/architecture.md
+++ b/specs/126-recipe-select-slot-sunlight/architecture.md
@@ -1,0 +1,78 @@
+# Architecture — Spec 126
+
+## Flow diagram
+
+```
+Recipe definition (external plugin)
+  slots: [{ id, type: "select", options: [{value,label}...], defaultValue }]
+  i18n.fr.slots[id].options = { value: "Libellé FR" }
+        │
+        ▼  getRecipes() passes slots verbatim
+GET /api/v1/recipes ──► UI recipe form (ZoneRecipesSection.tsx)
+        │                    └─ slot.type === "select" → <select> dropdown
+        │                       label = recipeSlotOptionLabel(recipe, slot, value, lang)
+        ▼
+User picks an option → param value = option.value (string)
+        │
+        ▼  createInstance / updateInstance (existing path, JSON params)
+RecipeManager.buildContext(instance)
+  ctx.helpers.getSunlight() ──► SunlightManager.getSunlightData()
+                                  { sunrise, sunset, isDaylight }   (spec 023)
+        ▲
+        └─ recipe also subscribes to existing `sunlight.changed` to re-sync daily
+```
+
+## Components
+
+### Changed: `src/shared/types.ts`
+
+- `RecipeSlotDef.type` union gains `"select"`.
+- `RecipeSlotDef` gains `options?: { value: string; label: string }[]`.
+- `RecipeSlotI18n` gains `options?: Record<string, string>` (option value → translated label).
+- `RecipeHelpers` gains `getSunlight(): SunlightData`. (`SunlightData` already exists in `src/zones/sunlight-manager.ts`; re-export or mirror the `{ sunrise, sunset, isDaylight }` shape in `types.ts` to avoid a zones→shared import cycle — prefer declaring the return shape inline in `RecipeHelpers`.)
+
+### Changed: `src/recipes/engine/recipe-manager.ts`
+
+- Constructor receives `sunlightManager: SunlightManager`.
+- The `helpers` object gains `getSunlight: () => this.sunlightManager.getSunlightData()` (arrow keeps the read lazy, so it is safe even though `sunlightManager` is assigned in the constructor body).
+
+### Changed: `src/index.ts`
+
+- Pass the already-constructed `sunlightManager` into `new RecipeManager(...)` (it is created at line ~209, before the RecipeManager at ~249).
+
+### Changed: `ui/src/components/recipes/ZoneRecipesSection.tsx`
+
+- Add a `slot.type === "select"` branch in BOTH slot-render chains (create form ~line 793-950, edit form ~line 1806-1946): a Tailwind-styled `<select>` listing `slot.options`, value-bound to the slot param, default from `defaultValue`.
+
+### Changed: `ui/src/lib/recipe-i18n.ts`
+
+- Add `recipeSlotOptionLabel(recipe, slot, value, lang)`: resolves `i18n[lang].slots[slot.id].options[value] ?? slot.options.find(o => o.value === value)?.label ?? value`.
+
+### Unchanged (verified)
+
+- `RecipeInfo` serialization (`recipe-manager.ts` `slots: definition.slots`) — `options` rides along for free.
+- The recipe engine does no per-type slot-value validation, so `"select"` needs no engine validation change.
+- `ZoneAggregator` / `SunlightManager` / `sunlight.changed` — untouched; `getSunlight` only reads.
+
+## Data model
+
+No SQLite schema change. Recipe instance params remain a JSON blob; a select value is a string. No migration.
+
+## Events
+
+None new. Recipes that need day-to-day sun re-sync use the existing `sunlight.changed` event.
+
+## API
+
+No new endpoints. `GET /api/v1/recipes` payload gains `options` on select slots (passed through from the recipe definition).
+
+## Files changed
+
+| Domain  | File                                               | Change                                                                                                 |
+| ------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Core    | `src/shared/types.ts`                              | `RecipeSlotDef.type += "select"`, `options?`; `RecipeSlotI18n.options?`; `RecipeHelpers.getSunlight()` |
+| Recipes | `src/recipes/engine/recipe-manager.ts`             | Receive `SunlightManager`; add `getSunlight` helper                                                    |
+| Core    | `src/index.ts`                                     | Pass `sunlightManager` to `RecipeManager`                                                              |
+| UI      | `ui/src/components/recipes/ZoneRecipesSection.tsx` | Render `select` slot as a dropdown (2 sites)                                                           |
+| UI      | `ui/src/lib/recipe-i18n.ts`                        | `recipeSlotOptionLabel()` helper                                                                       |
+| UI      | `ui/src/types.ts`                                  | Mirror `RecipeSlotDef`/`RecipeSlotI18n` additions if duplicated there                                  |

--- a/specs/126-recipe-select-slot-sunlight/plan.md
+++ b/specs/126-recipe-select-slot-sunlight/plan.md
@@ -1,0 +1,64 @@
+# Implementation Plan — Spec 126
+
+## Slices
+
+### Slice A — Types (foundation)
+
+- A.1 — `src/shared/types.ts`: add `"select"` to `RecipeSlotDef.type`; add `options?: { value: string; label: string }[]` to `RecipeSlotDef`.
+- A.2 — `src/shared/types.ts`: add `options?: Record<string, string>` to `RecipeSlotI18n`.
+- A.3 — `src/shared/types.ts`: add `getSunlight(): { sunrise: string | null; sunset: string | null; isDaylight: boolean | null }` to `RecipeHelpers`.
+
+### Slice B — `getSunlight()` wiring (core)
+
+- B.1 — `src/recipes/engine/recipe-manager.ts`: add `sunlightManager: SunlightManager` constructor param + field; add `getSunlight: () => this.sunlightManager.getSunlightData()` to the `helpers` object.
+- B.2 — `src/index.ts`: pass `sunlightManager` to `new RecipeManager(...)`.
+
+### Slice C — UI `select` slot + option i18n
+
+- C.1 — `ui/src/lib/recipe-i18n.ts`: add `recipeSlotOptionLabel(recipe, slot, value, lang)` with the fallback chain.
+- C.2 — `ui/src/components/recipes/ZoneRecipesSection.tsx`: render a `<select>` for `slot.type === "select"` in both the create and edit slot-render chains; bind value to the slot param, honour `defaultValue`, label options via C.1.
+- C.3 — `ui/src/types.ts`: mirror the `RecipeSlotDef`/`RecipeSlotI18n` additions if the UI keeps its own copy.
+
+### Slice D — Tests
+
+- D.1 — Backend: `getSunlight` returns the injected sunlight data; a registered recipe with a `select` slot exposes `options` via `getRecipes()`.
+- D.2 — UI: `recipeSlotOptionLabel` resolution (i18n hit, English-label fallback, raw-value fallback, missing-language fallback).
+
+## Test Plan
+
+### Modules to test
+
+- `src/recipes/engine/recipe-manager.ts` — `getSunlight` helper wiring + `select` options serialization through `getRecipes()`.
+- `ui/src/lib/recipe-i18n.ts` — `recipeSlotOptionLabel` pure resolver.
+
+### Scenarios per module
+
+| Module         | Scenario                                                | Expected                                                                                |
+| -------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| recipe-manager | `ctx.helpers.getSunlight()` inside an instance          | returns the `SunlightManager.getSunlightData()` value `{ sunrise, sunset, isDaylight }` |
+| recipe-manager | sun not computed yet (manager returns nulls)            | `getSunlight()` returns `{ null, null, null }`, no throw                                |
+| recipe-manager | register a recipe with a `select` slot → `getRecipes()` | returned slot carries `type: "select"` and the full `options` array                     |
+| recipe-manager | existing non-select recipes                             | unchanged `RecipeInfo` (retro-compat)                                                   |
+| recipe-i18n    | option with FR i18n present                             | returns the FR label                                                                    |
+| recipe-i18n    | option missing FR i18n                                  | falls back to the option's English `label`                                              |
+| recipe-i18n    | option missing both i18n and label                      | falls back to the raw `value`                                                           |
+| recipe-i18n    | unknown lang                                            | falls back to English `label`                                                           |
+
+### Retro-compat
+
+- Non-select slots and all existing recipes behave exactly as before (`getSunlight` is additive; `options` is optional and ignored by non-select slots).
+
+## Validation Plan
+
+- `npx tsc --noEmit` (backend) + `cd ui && npx tsc -b --noEmit` (UI) — zero errors.
+- `npx vitest run` — all pass (incl. new D.1/D.2).
+- `npx eslint src/ --ext .ts` + `cd ui && npx eslint .` — zero errors.
+- Manual: side-load a throwaway recipe with a `select` slot on the test instance (localhost:3001), confirm the dropdown renders + persists, and that a recipe calling `ctx.helpers.getSunlight()` logs the current sunrise/sunset.
+
+## Follow-up (out of scope here)
+
+- `schedule-on-off` recipe v2 (own repo): per-boundary `select` (Fixed time / Sunrise / Sunset) + offset `number`, reading `ctx.helpers.getSunlight()` and re-arming on `sunlight.changed`, skipping a boundary on null-sun days. Will require a registry bump.
+
+## Commit scope
+
+`core` / `recipes` / `ui`.

--- a/specs/126-recipe-select-slot-sunlight/spec.md
+++ b/specs/126-recipe-select-slot-sunlight/spec.md
@@ -1,0 +1,55 @@
+# Spec 126 — Recipe `select` slot type + `getSunlight()` helper
+
+## Context
+
+Recipe slots today are limited to `zone | equipment | number | duration | time | boolean | text | data-key` (`RecipeSlotDef.type`). There is no native dropdown/select control, so a recipe cannot offer a small closed list of named choices with a clean UI — the only workarounds are free-text or stacks of booleans.
+
+This blocks the next evolution of the external `schedule-on-off` recipe (requested feature): letting each daily window boundary be a **fixed time, sunrise, or sunset** (with an offset). That is a 3-way choice that wants a dropdown.
+
+Sunlight data already exists (`SunlightManager`, spec 023) and is technically reachable by recipes today via `ctx.zoneAggregator.getByZoneId(ROOT_ZONE_ID)` — `state-trigger-light` already does this for its `nightOnly` filter (reads `isDaylight`; the same row also carries `sunrise`/`sunset`). A first-class helper avoids recipes hardcoding `ROOT_ZONE_ID` and returns the sun times directly.
+
+This spec covers the **core (main repo)** changes only. The `schedule-on-off` v2 recipe that consumes them is a follow-up in its own repo.
+
+## Goals
+
+1. Add a `select` recipe slot type: a closed list of `{ value, label }` options rendered as a dropdown in the recipe form, with per-language label translation carried in the recipe's own i18n (consistent with how slot names/descriptions are translated).
+2. Add `ctx.helpers.getSunlight(): { sunrise, sunset, isDaylight }`, a thin convenience over the existing `SunlightManager`, so recipes can read the sun times without hardcoding `ROOT_ZONE_ID`.
+
+## Non-Goals
+
+- The `schedule-on-off` v2 recipe itself (separate repo, follow-up).
+- Any new sunrise/sunset computation — `getSunlight()` reuses `SunlightManager.getSunlightData()` unchanged.
+- Generic engine-side validation of select values against `options` — each recipe's own `validate()` owns param validation (the engine already does no per-type slot validation).
+- A new SQLite table or migration — recipe instance params are already stored as JSON; a select value is just a string.
+
+## Functional Requirements
+
+### FR1 — `select` slot type
+
+- `RecipeSlotDef.type` gains `"select"`. `RecipeSlotDef` gains an optional `options?: { value: string; label: string }[]` field (`label` is the English fallback).
+- `RecipeSlotI18n` gains an optional `options?: Record<string, string>` map (option `value` → translated label).
+- The recipe form renders a `select` slot as a dropdown; the chosen option's `value` (a string) becomes the slot's param value. `defaultValue` pre-selects an option.
+- Option labels resolve with the fallback chain `i18n[lang].slots[slotId].options[value] → slot.options[].label → value`, mirroring the existing slot-name/description i18n helpers.
+- `options` round-trips through the existing `RecipeInfo` serialization to `GET /api/v1/recipes` (slots are passed through verbatim — no extra serialization work).
+
+### FR2 — `getSunlight()` helper
+
+- `RecipeHelpers` (`src/shared/types.ts`) gains `getSunlight(): SunlightData` where `SunlightData = { sunrise: string | null; sunset: string | null; isDaylight: boolean | null }`.
+- `RecipeManager` receives the `SunlightManager` instance and wires `getSunlight` to `sunlightManager.getSunlightData()`.
+- The helper reflects the same offsets and daily recompute the rest of Sowel uses; recipes pair it with the existing `sunlight.changed` event to re-sync across days.
+
+## Acceptance Criteria
+
+- [x] A recipe can declare a `type: "select"` slot with `options`, and the recipe form shows a working dropdown whose selection is persisted as the param value.
+- [x] Option labels are localized (FR/EN) via the recipe's `i18n.slots[id].options`, falling back to the English `label`, then the raw `value`.
+- [x] `GET /api/v1/recipes` returns `options` on select slots.
+- [x] `ctx.helpers.getSunlight()` returns the current `{ sunrise, sunset, isDaylight }` from `SunlightManager` inside a running recipe instance.
+- [x] Existing recipes and slot types are unaffected (no behavior change for non-select slots; `getSunlight` is additive).
+- [x] `tsc` (backend + UI), `eslint`, and `vitest` all pass.
+
+## Edge Cases
+
+- **`select` slot with no/empty `options`**: render nothing selectable (or an empty dropdown); the recipe author is responsible for providing options. Not a core crash.
+- **Selected value not in `options`** (e.g. stale param after an options change): the dropdown shows the raw stored value; the recipe's `validate()` is the gate that rejects unknown values.
+- **Missing option i18n for a language**: fall back to the English `label`, then the `value`.
+- **`getSunlight()` before sun is computed / no home coordinates**: returns `{ sunrise: null, sunset: null, isDaylight: null }` (whatever `SunlightManager` currently holds) — never throws. Consuming recipes decide how to handle nulls (the `schedule-on-off` v2 will skip a sun-based boundary on null days).

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,6 +252,7 @@ async function main() {
     equipmentManager,
     zoneManager,
     zoneAggregator,
+    sunlightManager, // spec 126 — exposes ctx.helpers.getSunlight() to recipes
     logger,
     config.shadowMode, // spec 124 — runtime gate on startInstance
   );

--- a/src/recipes/engine/recipe-manager.test.ts
+++ b/src/recipes/engine/recipe-manager.test.ts
@@ -10,7 +10,15 @@ import { EventBus } from "../../core/event-bus.js";
 import { createLogger } from "../../core/logger.js";
 import { RecipeManager, RecipeError } from "./recipe-manager.js";
 import { Recipe } from "./recipe.js";
-import type { RecipeSlotDef, EngineEvent } from "../../shared/types.js";
+import type { SunlightManager } from "../../zones/sunlight-manager.js";
+import type { RecipeSlotDef, EngineEvent, RecipeDefinition } from "../../shared/types.js";
+
+/** Captures `ctx.helpers.getSunlight()` from a running instance (spec 126). */
+let capturedSun: {
+  sunrise: string | null;
+  sunset: string | null;
+  isDaylight: boolean | null;
+} | null = null;
 
 // ============================================================
 // Test helpers
@@ -83,6 +91,7 @@ describe("RecipeManager", () => {
   let zoneManager: ZoneManager;
   let equipmentManager: EquipmentManager;
   let aggregator: ZoneAggregator;
+  let sunlightManager: SunlightManager;
   let manager: RecipeManager;
   let events: EngineEvent[];
 
@@ -100,7 +109,18 @@ describe("RecipeManager", () => {
       logger,
     );
     aggregator = new ZoneAggregator(zoneManager, equipmentManager, eventBus, logger);
-    manager = new RecipeManager(db, eventBus, equipmentManager, zoneManager, aggregator, logger);
+    sunlightManager = {
+      getSunlightData: () => ({ sunrise: "07:30", sunset: "21:00", isDaylight: true }),
+    } as unknown as SunlightManager;
+    manager = new RecipeManager(
+      db,
+      eventBus,
+      equipmentManager,
+      zoneManager,
+      aggregator,
+      sunlightManager,
+      logger,
+    );
     events = [];
     eventBus.on((event) => events.push(event));
   });
@@ -133,6 +153,61 @@ describe("RecipeManager", () => {
 
     const missing = manager.getRecipeById("nonexistent");
     expect(missing).toBeNull();
+  });
+
+  // ============================================================
+  // Spec 126 — `select` slot serialization + getSunlight helper
+  // ============================================================
+
+  it("serializes a `select` slot's options through getRecipes()", () => {
+    const def: RecipeDefinition = {
+      id: "select-def",
+      name: "Select Def",
+      description: "has a select slot",
+      slots: [
+        {
+          id: "kind",
+          name: "Kind",
+          description: "Pick a kind",
+          type: "select",
+          required: true,
+          defaultValue: "time",
+          options: [
+            { value: "time", label: "Fixed time" },
+            { value: "sunset", label: "Sunset" },
+          ],
+        },
+      ],
+      validate: () => {},
+      createInstance: () => ({ stop: () => {} }),
+    };
+    manager.registerExternal(def);
+
+    const recipe = manager.getRecipeById("select-def");
+    expect(recipe).not.toBeNull();
+    const slot = recipe!.slots.find((s) => s.id === "kind");
+    expect(slot?.type).toBe("select");
+    expect(slot?.options).toHaveLength(2);
+    expect(slot?.options?.[1]).toEqual({ value: "sunset", label: "Sunset" });
+  });
+
+  it("exposes ctx.helpers.getSunlight() to a running instance", () => {
+    const def: RecipeDefinition = {
+      id: "sun-def",
+      name: "Sun Def",
+      description: "reads sun times",
+      slots: [],
+      validate: () => {},
+      createInstance: (_params, ctx) => {
+        capturedSun = ctx.helpers.getSunlight();
+        return { stop: () => {} };
+      },
+    };
+    manager.registerExternal(def);
+
+    capturedSun = null;
+    manager.createInstance("sun-def", {});
+    expect(capturedSun).toEqual({ sunrise: "07:30", sunset: "21:00", isDaylight: true });
   });
 
   // ============================================================
@@ -204,6 +279,7 @@ describe("RecipeManager", () => {
       equipmentManager,
       zoneManager,
       aggregator,
+      sunlightManager,
       logger,
     );
     newManager.register(TestRecipe);

--- a/src/recipes/engine/recipe-manager.ts
+++ b/src/recipes/engine/recipe-manager.ts
@@ -5,6 +5,7 @@ import type { EventBus } from "../../core/event-bus.js";
 import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import type { ZoneAggregator } from "../../zones/zone-aggregator.js";
 import type { ZoneManager } from "../../zones/zone-manager.js";
+import type { SunlightManager } from "../../zones/sunlight-manager.js";
 import type {
   RecipeInfo,
   RecipeInstance,
@@ -51,6 +52,7 @@ export class RecipeManager {
   private equipmentManager: EquipmentManager;
   private zoneManager: ZoneManager;
   private zoneAggregator: ZoneAggregator;
+  private sunlightManager: SunlightManager;
   private logger: Logger;
   private stmts: ReturnType<typeof this.prepareStatements>;
   /** Spec 124 — when true, `startInstance` is a no-op so no recipe
@@ -63,6 +65,7 @@ export class RecipeManager {
     equipmentManager: EquipmentManager,
     zoneManager: ZoneManager,
     zoneAggregator: ZoneAggregator,
+    sunlightManager: SunlightManager,
     logger: Logger,
     shadowMode = false,
   ) {
@@ -71,6 +74,7 @@ export class RecipeManager {
     this.equipmentManager = equipmentManager;
     this.zoneManager = zoneManager;
     this.zoneAggregator = zoneAggregator;
+    this.sunlightManager = sunlightManager;
     this.logger = logger.child({ module: "recipe-manager" });
     this.stmts = this.prepareStatements();
     this.shadowMode = shadowMode;
@@ -516,6 +520,9 @@ export class RecipeManager {
     setLightsBrightness,
     parseDuration,
     formatDuration,
+    // Arrow keeps the read lazy: `sunlightManager` is assigned in the
+    // constructor body, but getSunlight is only ever called at recipe runtime.
+    getSunlight: () => this.sunlightManager.getSunlightData(),
   };
 
   private buildContext(instanceId: string, recipeId: string): RecipeContext {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -385,10 +385,23 @@ export interface RecipeSlotDef {
   id: string;
   name: string;
   description: string;
-  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean" | "text" | "data-key";
+  type:
+    | "zone"
+    | "equipment"
+    | "number"
+    | "duration"
+    | "time"
+    | "boolean"
+    | "text"
+    | "data-key"
+    | "select";
   required: boolean;
   list?: boolean;
   defaultValue?: unknown;
+  /** For `type: "select"` — the closed list of choices rendered as a dropdown.
+   *  `label` is the English fallback; per-language labels live in the recipe's
+   *  i18n under `slots[id].options[value]`. Spec 126. */
+  options?: { value: string; label: string }[];
   constraints?: {
     equipmentType?: EquipmentType | EquipmentType[];
     min?: number;
@@ -406,6 +419,8 @@ export interface RecipeSlotDef {
 export interface RecipeSlotI18n {
   name: string;
   description: string;
+  /** Per-language labels for a `select` slot's options, keyed by option value. Spec 126. */
+  options?: Record<string, string>;
 }
 
 export interface RecipeLangPack {
@@ -476,6 +491,11 @@ export interface RecipeHelpers {
   setLightsBrightness(lightIds: string[], ctx: RecipeCtx, brightness: number): string[];
   parseDuration(value: unknown): number;
   formatDuration(ms: number): string;
+  /** Current sunlight times (HH:MM) + daylight flag from the SunlightManager
+   *  (spec 023 offsets applied). Pair with the `sunlight.changed` event to
+   *  re-sync across days. Fields are null when not yet computed or no home
+   *  coordinates are configured. Spec 126. */
+  getSunlight(): { sunrise: string | null; sunset: string | null; isDaylight: boolean | null };
 }
 
 // ============================================================

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -402,6 +402,10 @@ export interface RecipeSlotDef {
    *  `label` is the English fallback; per-language labels live in the recipe's
    *  i18n under `slots[id].options[value]`. Spec 126. */
   options?: { value: string; label: string }[];
+  /** Grey out (disable) this slot in the recipe form when a sibling slot's
+   *  value matches. Lets a recipe disable a now-irrelevant field, e.g. disable
+   *  a fixed-time picker when a "kind" select is set to sunrise/sunset. Spec 126. */
+  disabledWhen?: { slot: string; equals: string | string[] };
   constraints?: {
     equipmentType?: EquipmentType | EquipmentType[];
     min?: number;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -402,10 +402,10 @@ export interface RecipeSlotDef {
    *  `label` is the English fallback; per-language labels live in the recipe's
    *  i18n under `slots[id].options[value]`. Spec 126. */
   options?: { value: string; label: string }[];
-  /** Grey out (disable) this slot in the recipe form when a sibling slot's
-   *  value matches. Lets a recipe disable a now-irrelevant field, e.g. disable
+  /** Hide this slot in the recipe form (removed from the layout) when a sibling
+   *  slot's value matches. Lets a recipe show only the relevant field, e.g. hide
    *  a fixed-time picker when a "kind" select is set to sunrise/sunset. Spec 126. */
-  disabledWhen?: { slot: string; equals: string | string[] };
+  hiddenWhen?: { slot: string; equals: string | string[] };
   constraints?: {
     equipmentType?: EquipmentType | EquipmentType[];
     min?: number;

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -8,7 +8,7 @@ import { useZoneAggregation } from "../../store/useZoneAggregation";
 import type { RecipeInfo, RecipeInstance, RecipeLogEntry, RecipeActionDef, EquipmentWithDetails, Zone, ZoneWithChildren } from "../../types";
 import type { EquipmentType } from "../../types";
 import { formatTime } from "../../lib/format";
-import { recipeName, recipeDescription, recipeSlotName, recipeSlotDescription, recipeGroupLabel } from "../../lib/recipe-i18n";
+import { recipeName, recipeDescription, recipeSlotName, recipeSlotDescription, recipeGroupLabel, recipeSlotOptionLabel } from "../../lib/recipe-i18n";
 import type { RecipeSlotDef } from "../../types";
 
 
@@ -820,6 +820,18 @@ function RecipeInstanceRow({
                                           </select>
                                         );
                                       })()
+                                    ) : slot.type === "select" ? (
+                                      <select
+                                        value={String(editParams[slot.id] ?? slot.defaultValue ?? "")}
+                                        onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
+                                        className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                                      >
+                                        {(slot.options ?? []).map((o) => (
+                                          <option key={o.value} value={o.value}>
+                                            {recipeSlotOptionLabel(recipe, slot, o.value, lang)}
+                                          </option>
+                                        ))}
+                                      </select>
                                     ) : slot.type === "time" ? (
                                       <TimeInput
                                         value={editParams[slot.id] ?? ""}
@@ -931,6 +943,18 @@ function RecipeInstanceRow({
                             onChange={(v) => setEditParams({ ...editParams, [slot.id]: v })}
                             placeholder={slot.defaultValue ? String(durationToMinutes(String(slot.defaultValue))) : undefined}
                           />
+                        ) : slot.type === "select" ? (
+                          <select
+                            value={String(editParams[slot.id] ?? slot.defaultValue ?? "")}
+                            onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
+                            className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                          >
+                            {(slot.options ?? []).map((o) => (
+                              <option key={o.value} value={o.value}>
+                                {recipeSlotOptionLabel(recipe, slot, o.value, lang)}
+                              </option>
+                            ))}
+                          </select>
                         ) : slot.type === "time" ? (
                           <TimeInput
                             value={editParams[slot.id] ?? ""}
@@ -1833,6 +1857,18 @@ function AddRecipeForm({
                                         </select>
                                       );
                                     })()
+                                  ) : slot.type === "select" ? (
+                                    <select
+                                      value={String(params[slot.id] ?? slot.defaultValue ?? "")}
+                                      onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
+                                      className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                                    >
+                                      {(slot.options ?? []).map((o) => (
+                                        <option key={o.value} value={o.value}>
+                                          {recipeSlotOptionLabel(selectedRecipe, slot, o.value, lang)}
+                                        </option>
+                                      ))}
+                                    </select>
                                   ) : slot.type === "time" ? (
                                     <TimeInput
                                       value={params[slot.id] ?? ""}
@@ -1943,6 +1979,18 @@ function AddRecipeForm({
                           onChange={(v) => setParams({ ...params, [slot.id]: v })}
                           placeholder={slot.defaultValue ? String(durationToMinutes(String(slot.defaultValue))) : undefined}
                         />
+                      ) : slot.type === "select" ? (
+                        <select
+                          value={String(params[slot.id] ?? slot.defaultValue ?? "")}
+                          onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
+                          className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
+                        >
+                          {(slot.options ?? []).map((o) => (
+                            <option key={o.value} value={o.value}>
+                              {recipeSlotOptionLabel(selectedRecipe, slot, o.value, lang)}
+                            </option>
+                          ))}
+                        </select>
                       ) : slot.type === "time" ? (
                         <TimeInput
                           value={params[slot.id] ?? ""}

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -9,7 +9,7 @@ import type { RecipeInfo, RecipeInstance, RecipeLogEntry, RecipeActionDef, Equip
 import type { EquipmentType } from "../../types";
 import { formatTime } from "../../lib/format";
 import { recipeName, recipeDescription, recipeSlotName, recipeSlotDescription, recipeGroupLabel, recipeSlotOptionLabel } from "../../lib/recipe-i18n";
-import { isSlotDisabled } from "../../lib/recipe-slots";
+import { isSlotHidden } from "../../lib/recipe-slots";
 import type { RecipeSlotDef } from "../../types";
 
 
@@ -781,13 +781,13 @@ function RecipeInstanceRow({
                           ))}
                           {/* Compact grid for non-list slots */}
                           {(() => {
-                            const compactSlots = chunk.slots.filter((s) => !(s.type === "equipment" && s.list));
+                            const compactSlots = chunk.slots.filter((s) => !(s.type === "equipment" && s.list) && !isSlotHidden(s, editParams, recipe.slots));
                             if (compactSlots.length === 0) return null;
-                            const cols = Math.min(compactSlots.length, 3);
+                            const cols = compactSlots.length <= 3 ? compactSlots.length : 2;
                             return (
                               <div className={`grid gap-1.5 ${cols === 1 ? "grid-cols-1" : cols === 2 ? "grid-cols-2" : "grid-cols-3"}`}>
                                 {compactSlots.map((slot) => (
-                                  <div key={slot.id} className={isSlotDisabled(slot, editParams, recipe.slots) ? "opacity-50 pointer-events-none" : ""}>
+                                  <div key={slot.id}>
                                     <label className={`block text-[10px] tracking-wider mb-0.5 ${isSlotChanged(slot.id) ? "text-success" : "text-text-tertiary"}`}>
                                       {recipeSlotName(recipe, slot, lang)}{slot.required && <span className="text-error ml-0.5">*</span>}
                                     </label>
@@ -859,8 +859,8 @@ function RecipeInstanceRow({
                       );
                     }
                     // Ungrouped — render each slot individually (original logic)
-                    return chunk.slots.map((slot) => (
-                      <div key={slot.id} className={`mb-2.5 pl-2 border-l-2 transition-colors duration-150 ${isSlotChanged(slot.id) ? "border-success" : "border-transparent"} ${isSlotDisabled(slot, editParams, recipe.slots) ? "opacity-50 pointer-events-none" : ""}`}>
+                    return chunk.slots.map((slot) => isSlotHidden(slot, editParams, recipe.slots) ? null : (
+                      <div key={slot.id} className={`mb-2.5 pl-2 border-l-2 transition-colors duration-150 ${isSlotChanged(slot.id) ? "border-success" : "border-transparent"}`}>
                         {slot.type === "boolean" ? (
                           <label className="flex items-center gap-2 px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text cursor-pointer hover:bg-border-light/30 transition-colors duration-150">
                             <input
@@ -1814,7 +1814,7 @@ function AddRecipeForm({
                         ))}
                         {/* Compact grid for non-list slots */}
                         {(() => {
-                          const compactSlots = chunk.slots.filter((s) => !(s.type === "equipment" && s.list));
+                          const compactSlots = chunk.slots.filter((s) => !(s.type === "equipment" && s.list) && !isSlotHidden(s, params, selectedRecipe.slots));
                           if (compactSlots.length === 0) return null;
                           const n = compactSlots.length;
                           const cols = n <= 3 ? n : n % 3 === 0 ? 3 : 2;
@@ -1828,7 +1828,7 @@ function AddRecipeForm({
                           return (
                             <div className={`grid gap-1.5 ${cols === 1 ? "grid-cols-1" : cols === 2 ? twoColClass : "grid-cols-3"}`}>
                               {compactSlots.map((slot) => (
-                                <div key={slot.id} className={`${slot.type === "number" ? "w-[100px]" : ""} ${isSlotDisabled(slot, params, selectedRecipe.slots) ? "opacity-50 pointer-events-none" : ""}`}>
+                                <div key={slot.id} className={slot.type === "number" ? "w-[100px]" : ""}>
                                   <label className="block text-[10px] tracking-wider mb-0.5 text-text-tertiary">
                                     {recipeSlotName(selectedRecipe, slot, lang)}{slot.required && <span className="text-error ml-0.5">*</span>}
                                   </label>
@@ -1899,8 +1899,8 @@ function AddRecipeForm({
                     );
                   }
                   // Ungrouped — render each slot individually
-                  return chunk.slots.map((slot) => (
-                    <div key={slot.id} className={`mb-3 ${isSlotDisabled(slot, params, selectedRecipe.slots) ? "opacity-50 pointer-events-none" : ""}`}>
+                  return chunk.slots.map((slot) => isSlotHidden(slot, params, selectedRecipe.slots) ? null : (
+                    <div key={slot.id} className="mb-3">
                       {slot.type === "boolean" ? (
                         <label className="flex items-center gap-2 px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text cursor-pointer hover:bg-border-light/30 transition-colors duration-150">
                           <input

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -840,7 +840,9 @@ function RecipeInstanceRow({
                                       />
                                     ) : (
                                       <input
-                                        type="text"
+                                        type={slot.type === "number" ? "number" : "text"}
+                                        min={slot.constraints?.min}
+                                        max={slot.constraints?.max}
                                         value={editParams[slot.id] ?? ""}
                                         onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
                                         placeholder={slot.constraints?.max ? `1-${slot.constraints.max}` : ""}
@@ -964,7 +966,9 @@ function RecipeInstanceRow({
                           />
                         ) : (
                           <input
-                            type="text"
+                            type={slot.type === "number" ? "number" : "text"}
+                            min={slot.constraints?.min}
+                            max={slot.constraints?.max}
                             value={editParams[slot.id] ?? ""}
                             onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
                             placeholder={slot.defaultValue ? String(slot.defaultValue) : recipeSlotDescription(recipe, slot, lang)}
@@ -1877,7 +1881,9 @@ function AddRecipeForm({
                                     />
                                   ) : (
                                     <input
-                                      type="text"
+                                      type={slot.type === "number" ? "number" : "text"}
+                                      min={slot.constraints?.min}
+                                      max={slot.constraints?.max}
                                       value={params[slot.id] ?? ""}
                                       onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
                                       placeholder={slot.constraints?.max ? `1-${slot.constraints.max}` : ""}
@@ -2000,7 +2006,9 @@ function AddRecipeForm({
                         />
                       ) : (
                         <input
-                          type="text"
+                          type={slot.type === "number" ? "number" : "text"}
+                          min={slot.constraints?.min}
+                          max={slot.constraints?.max}
                           value={params[slot.id] ?? ""}
                           onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
                           placeholder={slot.defaultValue ? String(slot.defaultValue) : recipeSlotDescription(selectedRecipe, slot, lang)}

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -1818,17 +1818,13 @@ function AddRecipeForm({
                           if (compactSlots.length === 0) return null;
                           const n = compactSlots.length;
                           const cols = n <= 3 ? n : n % 3 === 0 ? 3 : 2;
-                          // Use 1fr/auto only when a `number` slot wants a
-                          // narrow column (see per-slot w-[100px] below).
-                          // Otherwise give both columns equal width so two
-                          // time pickers (or any homogeneous pair) sit
-                          // side by side with the same size.
-                          const hasNarrowNumber = compactSlots.some((s) => s.type === "number");
-                          const twoColClass = hasNarrowNumber ? "grid-cols-[1fr_auto]" : "grid-cols-2";
+                          // Equal-width columns so a dropdown + its value field
+                          // (or two time pickers) sit side by side at the same
+                          // size and labels never wrap into a narrow column.
                           return (
-                            <div className={`grid gap-1.5 ${cols === 1 ? "grid-cols-1" : cols === 2 ? twoColClass : "grid-cols-3"}`}>
+                            <div className={`grid gap-1.5 ${cols === 1 ? "grid-cols-1" : cols === 2 ? "grid-cols-2" : "grid-cols-3"}`}>
                               {compactSlots.map((slot) => (
-                                <div key={slot.id} className={slot.type === "number" ? "w-[100px]" : ""}>
+                                <div key={slot.id}>
                                   <label className="block text-[10px] tracking-wider mb-0.5 text-text-tertiary">
                                     {recipeSlotName(selectedRecipe, slot, lang)}{slot.required && <span className="text-error ml-0.5">*</span>}
                                   </label>

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -9,6 +9,7 @@ import type { RecipeInfo, RecipeInstance, RecipeLogEntry, RecipeActionDef, Equip
 import type { EquipmentType } from "../../types";
 import { formatTime } from "../../lib/format";
 import { recipeName, recipeDescription, recipeSlotName, recipeSlotDescription, recipeGroupLabel, recipeSlotOptionLabel } from "../../lib/recipe-i18n";
+import { isSlotDisabled } from "../../lib/recipe-slots";
 import type { RecipeSlotDef } from "../../types";
 
 
@@ -786,7 +787,7 @@ function RecipeInstanceRow({
                             return (
                               <div className={`grid gap-1.5 ${cols === 1 ? "grid-cols-1" : cols === 2 ? "grid-cols-2" : "grid-cols-3"}`}>
                                 {compactSlots.map((slot) => (
-                                  <div key={slot.id}>
+                                  <div key={slot.id} className={isSlotDisabled(slot, editParams, recipe.slots) ? "opacity-50 pointer-events-none" : ""}>
                                     <label className={`block text-[10px] tracking-wider mb-0.5 ${isSlotChanged(slot.id) ? "text-success" : "text-text-tertiary"}`}>
                                       {recipeSlotName(recipe, slot, lang)}{slot.required && <span className="text-error ml-0.5">*</span>}
                                     </label>
@@ -857,7 +858,7 @@ function RecipeInstanceRow({
                     }
                     // Ungrouped — render each slot individually (original logic)
                     return chunk.slots.map((slot) => (
-                      <div key={slot.id} className={`mb-2.5 pl-2 border-l-2 transition-colors duration-150 ${isSlotChanged(slot.id) ? "border-success" : "border-transparent"}`}>
+                      <div key={slot.id} className={`mb-2.5 pl-2 border-l-2 transition-colors duration-150 ${isSlotChanged(slot.id) ? "border-success" : "border-transparent"} ${isSlotDisabled(slot, editParams, recipe.slots) ? "opacity-50 pointer-events-none" : ""}`}>
                         {slot.type === "boolean" ? (
                           <label className="flex items-center gap-2 px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text cursor-pointer hover:bg-border-light/30 transition-colors duration-150">
                             <input
@@ -1823,7 +1824,7 @@ function AddRecipeForm({
                           return (
                             <div className={`grid gap-1.5 ${cols === 1 ? "grid-cols-1" : cols === 2 ? twoColClass : "grid-cols-3"}`}>
                               {compactSlots.map((slot) => (
-                                <div key={slot.id} className={slot.type === "number" ? "w-[100px]" : ""}>
+                                <div key={slot.id} className={`${slot.type === "number" ? "w-[100px]" : ""} ${isSlotDisabled(slot, params, selectedRecipe.slots) ? "opacity-50 pointer-events-none" : ""}`}>
                                   <label className="block text-[10px] tracking-wider mb-0.5 text-text-tertiary">
                                     {recipeSlotName(selectedRecipe, slot, lang)}{slot.required && <span className="text-error ml-0.5">*</span>}
                                   </label>
@@ -1893,7 +1894,7 @@ function AddRecipeForm({
                   }
                   // Ungrouped — render each slot individually
                   return chunk.slots.map((slot) => (
-                    <div key={slot.id} className="mb-3">
+                    <div key={slot.id} className={`mb-3 ${isSlotDisabled(slot, params, selectedRecipe.slots) ? "opacity-50 pointer-events-none" : ""}`}>
                       {slot.type === "boolean" ? (
                         <label className="flex items-center gap-2 px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text cursor-pointer hover:bg-border-light/30 transition-colors duration-150">
                           <input

--- a/ui/src/lib/recipe-i18n.test.ts
+++ b/ui/src/lib/recipe-i18n.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { recipeSlotOptionLabel } from "./recipe-i18n";
+import type { RecipeInfo, RecipeSlotDef } from "../types";
+
+const slot: RecipeSlotDef = {
+  id: "kind",
+  name: "Kind",
+  description: "Pick a kind",
+  type: "select",
+  required: true,
+  options: [
+    { value: "time", label: "Fixed time" },
+    { value: "sunset", label: "Sunset" },
+  ],
+};
+
+function recipe(i18n?: RecipeInfo["i18n"]): RecipeInfo {
+  return { id: "r", name: "R", description: "d", slots: [slot], i18n } as RecipeInfo;
+}
+
+const FR_I18N: RecipeInfo["i18n"] = {
+  fr: {
+    name: "R",
+    description: "d",
+    slots: { kind: { name: "Type", description: "", options: { sunset: "Coucher du soleil" } } },
+  },
+};
+
+describe("recipeSlotOptionLabel", () => {
+  it("returns the per-language i18n label when present", () => {
+    expect(recipeSlotOptionLabel(recipe(FR_I18N), slot, "sunset", "fr")).toBe("Coucher du soleil");
+  });
+
+  it("falls back to the option's English label when no i18n is provided", () => {
+    expect(recipeSlotOptionLabel(recipe(), slot, "sunset", "fr")).toBe("Sunset");
+  });
+
+  it("falls back to the English label for a language with no translation", () => {
+    expect(recipeSlotOptionLabel(recipe(FR_I18N), slot, "sunset", "de")).toBe("Sunset");
+  });
+
+  it("falls back to the option's English label when only some options are translated", () => {
+    // `time` has no FR override in FR_I18N → English label.
+    expect(recipeSlotOptionLabel(recipe(FR_I18N), slot, "time", "fr")).toBe("Fixed time");
+  });
+
+  it("falls back to the raw value when neither i18n nor a matching option label exists", () => {
+    expect(recipeSlotOptionLabel(recipe(), slot, "unknown", "fr")).toBe("unknown");
+  });
+});

--- a/ui/src/lib/recipe-i18n.ts
+++ b/ui/src/lib/recipe-i18n.ts
@@ -39,3 +39,20 @@ export function recipeSlotDescription(recipe: RecipeInfo, slot: RecipeSlotDef, l
 export function recipeGroupLabel(recipe: RecipeInfo, groupKey: string, lang: string): string {
   return recipe.i18n?.[lang]?.groups?.[groupKey] ?? groupKey;
 }
+
+/**
+ * Resolve a `select` slot option's translated label for the given language (spec 126).
+ * Fallback chain: i18n option label -> the option's English `label` -> the raw value.
+ */
+export function recipeSlotOptionLabel(
+  recipe: RecipeInfo,
+  slot: RecipeSlotDef,
+  value: string,
+  lang: string,
+): string {
+  return (
+    recipe.i18n?.[lang]?.slots?.[slot.id]?.options?.[value] ??
+    slot.options?.find((o) => o.value === value)?.label ??
+    value
+  );
+}

--- a/ui/src/lib/recipe-slots.test.ts
+++ b/ui/src/lib/recipe-slots.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isSlotDisabled } from "./recipe-slots";
+import { isSlotHidden } from "./recipe-slots";
 import type { RecipeSlotDef } from "../types";
 
 const kind: RecipeSlotDef = {
@@ -20,7 +20,7 @@ const timeSlot: RecipeSlotDef = {
   description: "",
   type: "time",
   required: false,
-  disabledWhen: { slot: "k", equals: ["sunrise", "sunset"] },
+  hiddenWhen: { slot: "k", equals: ["sunrise", "sunset"] },
 };
 const offsetSlot: RecipeSlotDef = {
   id: "o",
@@ -28,32 +28,32 @@ const offsetSlot: RecipeSlotDef = {
   description: "",
   type: "number",
   required: false,
-  disabledWhen: { slot: "k", equals: "time" },
+  hiddenWhen: { slot: "k", equals: "time" },
 };
 const all = [kind, timeSlot, offsetSlot];
 
-describe("isSlotDisabled", () => {
-  it("returns false for a slot without disabledWhen", () => {
-    expect(isSlotDisabled(kind, { k: "sunset" }, all)).toBe(false);
+describe("isSlotHidden", () => {
+  it("returns false for a slot without hiddenWhen", () => {
+    expect(isSlotHidden(kind, { k: "sunset" }, all)).toBe(false);
   });
 
-  it("disables the time field when kind is sunset", () => {
-    expect(isSlotDisabled(timeSlot, { k: "sunset" }, all)).toBe(true);
+  it("hides the time field when kind is sunset", () => {
+    expect(isSlotHidden(timeSlot, { k: "sunset" }, all)).toBe(true);
   });
 
-  it("enables the time field when kind is a fixed time", () => {
-    expect(isSlotDisabled(timeSlot, { k: "time" }, all)).toBe(false);
+  it("shows the time field when kind is a fixed time", () => {
+    expect(isSlotHidden(timeSlot, { k: "time" }, all)).toBe(false);
   });
 
   it("uses the referenced slot's defaultValue when its param is untouched", () => {
-    // kind defaults to "time" -> offset (disabled when kind==time) is disabled
-    expect(isSlotDisabled(offsetSlot, {}, all)).toBe(true);
-    // ...and the time field is enabled by default
-    expect(isSlotDisabled(timeSlot, {}, all)).toBe(false);
+    // kind defaults to "time" -> offset (hidden when kind==time) is hidden,
+    // and the time field is shown.
+    expect(isSlotHidden(offsetSlot, {}, all)).toBe(true);
+    expect(isSlotHidden(timeSlot, {}, all)).toBe(false);
   });
 
-  it("disables the offset field only for fixed time", () => {
-    expect(isSlotDisabled(offsetSlot, { k: "sunset" }, all)).toBe(false);
-    expect(isSlotDisabled(offsetSlot, { k: "time" }, all)).toBe(true);
+  it("hides the offset field only for fixed time", () => {
+    expect(isSlotHidden(offsetSlot, { k: "sunset" }, all)).toBe(false);
+    expect(isSlotHidden(offsetSlot, { k: "time" }, all)).toBe(true);
   });
 });

--- a/ui/src/lib/recipe-slots.test.ts
+++ b/ui/src/lib/recipe-slots.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { isSlotDisabled } from "./recipe-slots";
+import type { RecipeSlotDef } from "../types";
+
+const kind: RecipeSlotDef = {
+  id: "k",
+  name: "Kind",
+  description: "",
+  type: "select",
+  required: true,
+  defaultValue: "time",
+  options: [
+    { value: "time", label: "Fixed time" },
+    { value: "sunset", label: "Sunset" },
+  ],
+};
+const timeSlot: RecipeSlotDef = {
+  id: "t",
+  name: "Time",
+  description: "",
+  type: "time",
+  required: false,
+  disabledWhen: { slot: "k", equals: ["sunrise", "sunset"] },
+};
+const offsetSlot: RecipeSlotDef = {
+  id: "o",
+  name: "Offset",
+  description: "",
+  type: "number",
+  required: false,
+  disabledWhen: { slot: "k", equals: "time" },
+};
+const all = [kind, timeSlot, offsetSlot];
+
+describe("isSlotDisabled", () => {
+  it("returns false for a slot without disabledWhen", () => {
+    expect(isSlotDisabled(kind, { k: "sunset" }, all)).toBe(false);
+  });
+
+  it("disables the time field when kind is sunset", () => {
+    expect(isSlotDisabled(timeSlot, { k: "sunset" }, all)).toBe(true);
+  });
+
+  it("enables the time field when kind is a fixed time", () => {
+    expect(isSlotDisabled(timeSlot, { k: "time" }, all)).toBe(false);
+  });
+
+  it("uses the referenced slot's defaultValue when its param is untouched", () => {
+    // kind defaults to "time" -> offset (disabled when kind==time) is disabled
+    expect(isSlotDisabled(offsetSlot, {}, all)).toBe(true);
+    // ...and the time field is enabled by default
+    expect(isSlotDisabled(timeSlot, {}, all)).toBe(false);
+  });
+
+  it("disables the offset field only for fixed time", () => {
+    expect(isSlotDisabled(offsetSlot, { k: "sunset" }, all)).toBe(false);
+    expect(isSlotDisabled(offsetSlot, { k: "time" }, all)).toBe(true);
+  });
+});

--- a/ui/src/lib/recipe-slots.ts
+++ b/ui/src/lib/recipe-slots.ts
@@ -1,0 +1,20 @@
+import type { RecipeSlotDef } from "../types";
+
+/**
+ * Whether a recipe-form slot should be greyed out (disabled) given the current
+ * param values (spec 126). A slot declares `disabledWhen: { slot, equals }`; it
+ * is disabled when the referenced sibling slot's effective value (its current
+ * param, or its `defaultValue` when untouched) is one of `equals`.
+ */
+export function isSlotDisabled(
+  slot: RecipeSlotDef,
+  params: Record<string, unknown>,
+  allSlots: readonly RecipeSlotDef[],
+): boolean {
+  const rule = slot.disabledWhen;
+  if (!rule) return false;
+  const ref = allSlots.find((s) => s.id === rule.slot);
+  const value = params[rule.slot] ?? ref?.defaultValue;
+  const expected = Array.isArray(rule.equals) ? rule.equals : [rule.equals];
+  return expected.includes(value as string);
+}

--- a/ui/src/lib/recipe-slots.ts
+++ b/ui/src/lib/recipe-slots.ts
@@ -1,17 +1,18 @@
 import type { RecipeSlotDef } from "../types";
 
 /**
- * Whether a recipe-form slot should be greyed out (disabled) given the current
- * param values (spec 126). A slot declares `disabledWhen: { slot, equals }`; it
- * is disabled when the referenced sibling slot's effective value (its current
- * param, or its `defaultValue` when untouched) is one of `equals`.
+ * Whether a recipe-form slot should be hidden (not rendered) given the current
+ * param values (spec 126). A slot declares `hiddenWhen: { slot, equals }`; it is
+ * hidden when the referenced sibling slot's effective value (its current param,
+ * or its `defaultValue` when untouched) is one of `equals`. Hidden slots are
+ * removed from the layout so the remaining fields stay cleanly aligned.
  */
-export function isSlotDisabled(
+export function isSlotHidden(
   slot: RecipeSlotDef,
   params: Record<string, unknown>,
   allSlots: readonly RecipeSlotDef[],
 ): boolean {
-  const rule = slot.disabledWhen;
+  const rule = slot.hiddenWhen;
   if (!rule) return false;
   const ref = allSlots.find((s) => s.id === rule.slot);
   const value = params[rule.slot] ?? ref?.defaultValue;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -506,6 +506,10 @@ export interface RecipeSlotDef {
    *  `label` is the English fallback; per-language labels live in the recipe's
    *  i18n under `slots[id].options[value]`. Spec 126. */
   options?: { value: string; label: string }[];
+  /** Grey out (disable) this slot in the recipe form when a sibling slot's
+   *  value matches (e.g. disable a fixed-time picker when a "kind" select is
+   *  sunrise/sunset). Spec 126. */
+  disabledWhen?: { slot: string; equals: string | string[] };
   constraints?: {
     equipmentType?: EquipmentType | EquipmentType[];
     min?: number;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -498,10 +498,14 @@ export interface RecipeSlotDef {
   id: string;
   name: string;
   description: string;
-  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean" | "text" | "data-key";
+  type: "zone" | "equipment" | "number" | "duration" | "time" | "boolean" | "text" | "data-key" | "select";
   required: boolean;
   list?: boolean;
   defaultValue?: unknown;
+  /** For `type: "select"` — the closed list of choices rendered as a dropdown.
+   *  `label` is the English fallback; per-language labels live in the recipe's
+   *  i18n under `slots[id].options[value]`. Spec 126. */
+  options?: { value: string; label: string }[];
   constraints?: {
     equipmentType?: EquipmentType | EquipmentType[];
     min?: number;
@@ -520,6 +524,8 @@ export interface RecipeSlotDef {
 export interface RecipeSlotI18n {
   name: string;
   description: string;
+  /** Per-language labels for a `select` slot's options, keyed by option value. Spec 126. */
+  options?: Record<string, string>;
 }
 
 export interface RecipeLangPack {

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -506,10 +506,10 @@ export interface RecipeSlotDef {
    *  `label` is the English fallback; per-language labels live in the recipe's
    *  i18n under `slots[id].options[value]`. Spec 126. */
   options?: { value: string; label: string }[];
-  /** Grey out (disable) this slot in the recipe form when a sibling slot's
-   *  value matches (e.g. disable a fixed-time picker when a "kind" select is
+  /** Hide this slot in the recipe form (removed from the layout) when a sibling
+   *  slot's value matches (e.g. hide a fixed-time picker when a "kind" select is
    *  sunrise/sunset). Spec 126. */
-  disabledWhen?: { slot: string; equals: string | string[] };
+  hiddenWhen?: { slot: string; equals: string | string[] };
   constraints?: {
     equipmentType?: EquipmentType | EquipmentType[];
     min?: number;


### PR DESCRIPTION
Core building blocks for **sun-aware recipe scheduling** (spec 126). This is the core part; the `schedule-on-off` v2 recipe that consumes it is a follow-up in its own repo.

## Summary

- **`select` recipe slot type** — a closed list of `{ value, label }` choices rendered as a dropdown in the recipe form, with per-language option labels carried in the recipe's own i18n. Fills a real gap (no native dropdown existed; `options` previously only lived on recipe *actions*).
- **`ctx.helpers.getSunlight(): { sunrise, sunset, isDaylight }`** — thin convenience over the existing `SunlightManager`, so recipes read sun times without hardcoding `ROOT_ZONE_ID`. Pair with the existing `sunlight.changed` event to re-sync across days.

## Changes

| Area | File | Change |
| --- | --- | --- |
| Core | `src/shared/types.ts` | `RecipeSlotDef.type += "select"` + `options?`; `RecipeSlotI18n.options?`; `RecipeHelpers.getSunlight()` |
| Recipes | `src/recipes/engine/recipe-manager.ts` | receive `SunlightManager`; wire `getSunlight` helper |
| Core | `src/index.ts` | pass `sunlightManager` to `RecipeManager` |
| UI | `ui/src/components/recipes/ZoneRecipesSection.tsx` | render `select` as a dropdown (create + edit, grouped + ungrouped) |
| UI | `ui/src/lib/recipe-i18n.ts` | `recipeSlotOptionLabel()` (i18n -> English label -> raw value) |
| UI | `ui/src/types.ts` | mirror the type additions |
| Docs | `docs/technical/recipe-development.md` | document the slot type + helper + event |
| Spec | `specs/126-recipe-select-slot-sunlight/` | spec + architecture + plan |

No DB/migration. Additive and backward-compatible: existing recipes and slot types are unchanged; the engine does no per-type slot validation (each recipe owns its value validation), and `options` rides through the existing `RecipeInfo` serialization to `GET /api/v1/recipes`.

## Test plan

- [x] Backend `tsc --noEmit`
- [x] UI `tsc -b --noEmit`
- [x] `vitest run` — 851 pass / 2 skip (new: recipe-manager getSunlight + select-options serialization; recipe-i18n option-label resolution)
- [x] `eslint src/` — zero errors; UI eslint clean on touched files
- [ ] Manual: dropdown renders + `getSunlight()` returns live sun times (will be exercised end-to-end by the `schedule-on-off` v2 recipe; can side-load a throwaway select-slot recipe on the test instance if desired)