### PR TITLE
release: v1.23.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,21 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.23.x: Briques pour recettes solaires
+
+### v1.23.0 — 2026-06-24 { #v1-23-0 }
+
+Briques de formulaire pour la programmation horaire solaire (spec 126) :
+
+- Feat (recipes) : nouveau type de slot `select`, affiché en menu déroulant avec libellés d'options traduits. Une recette peut désormais proposer une petite liste fermée de choix nommés.
+- Feat (recipes) : nouveau `ctx.helpers.getSunlight()` qui expose aux recettes le lever, le coucher et l'indicateur de jour courants (depuis le gestionnaire de soleil existant, décalages appliqués), pour programmer sur les heures du soleil. À coupler à l'événement `sunlight.changed` pour se resynchroniser au fil des jours.
+- Feat (recipes) : nouvelle règle de slot `hiddenWhen` : le formulaire n'affiche que le champ pertinent (ex. un sélecteur d'heure pour « heure fixe », un décalage en minutes pour « lever/coucher ») ; le champ non pertinent est retiré de la mise en page, qui reste alignée.
+- Feat (ui) : les slots `number` s'affichent en champs numériques (avec min/max), pour saisir proprement un décalage positif ou négatif en minutes ; les grilles de slots utilisent des colonnes de largeur égale.
+
+Ces briques équipent la nouvelle recette **Programmation horaire** (créneaux heure fixe / lever / coucher du soleil), disponible depuis le store de plugins.
+
+---
+
 ## 1.22.x: Pilotage des prises et association Zigbee on/off
 
 ### v1.22.0 — 2026-06-23 { #v1-22-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,21 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.23.x: Sun-aware recipe building blocks
+
+### v1.23.0 — 2026-06-24 { #v1-23-0 }
+
+Recipe form building blocks for sun-aware scheduling (spec 126):
+
+- Feat (recipes): new `select` recipe slot type, rendered as a dropdown with per-language option labels. A recipe can now offer a small closed list of named choices.
+- Feat (recipes): new `ctx.helpers.getSunlight()` exposing the current sunrise, sunset and daylight flag to recipes (from the existing sunlight manager, offsets applied), so a recipe can schedule on sun times. Pairs with the `sunlight.changed` event to re-sync across days.
+- Feat (recipes): new `hiddenWhen` slot rule, so a recipe form shows only the relevant field (e.g. a fixed-time picker for "fixed time", a minute offset for "sunrise/sunset"); the irrelevant field is removed from the layout, keeping the form aligned.
+- Feat (ui): `number` recipe slots render as numeric inputs (with min/max), so values like a positive or negative minute offset can be entered cleanly; recipe slot grids use equal-width columns.
+
+These ship for the new **Schedule On/Off** recipe (fixed time / sunrise / sunset windows), available from the plugin store.
+
+---
+
 ## 1.22.x: Smart plug controls and Zigbee on/off binding
 
 ### v1.22.0 — 2026-06-23 { #v1-22-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.22.0",
+  "version": "1.23.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Cut **v1.23.0**. Bumps `package.json` + `ui/package.json` and adds release notes (EN + FR, spec 108).

## Included since v1.22.0

- #281 — feat(recipes): spec 126 — `select` slot type, `ctx.helpers.getSunlight()`, `hiddenWhen` conditional slot visibility, numeric recipe inputs, equal-width slot grid.

Building blocks for the sun-aware **Schedule On/Off** recipe v2 (fixed time / sunrise / sunset windows).

## After merge

Tag `v1.23.0` on the merged commit and push it -> CI builds the Docker image + GitHub release. (verify-release-notes anchor `{ #v1-23-0 }` present in both files.)