### PR TITLE
fix(ui): mobile time/sun in top bar + reachable Wh/€ toggle on Energy

### DIFF
--- a/ui/src/components/energy/EnergyPage.tsx
+++ b/ui/src/components/energy/EnergyPage.tsx
@@ -82,7 +82,7 @@ export function EnergyPage() {
       {/* Header — h1 hidden on mobile (title in topbar). PeriodSelector visible on both. */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4 sm:mb-6">
         <h1 className="hidden sm:block">{t("energy.consumption")}</h1>
-        <div className="flex items-center gap-3 sm:gap-4">
+        <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-4">
           <UnitToggle enabled={tariffConfigured} />
           <PeriodSelector />
         </div>

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -142,10 +142,15 @@ export function AppLayout() {
 
           {/* Right: pills (mock order: time → sun → conn → alarm → updates → avatar). */}
           <div className="flex items-center gap-2 flex-shrink-0">
-            {/* Time + sun hidden on mobile per mockup */}
+            {/* Time + sun — full pills on desktop */}
             <div className="hidden sm:flex items-center gap-2">
               <CurrentTimePill />
               <SunlightBanner data={rootAgg} />
+            </div>
+            {/* Time + sun — compact, space-saving variant on mobile (no seconds) */}
+            <div className="flex sm:hidden items-center gap-2">
+              <SunlightBanner data={rootAgg} compact />
+              <CurrentTimePill compact withSeconds={false} />
             </div>
             <ConnectionStatus />
             {issues.length > 0 && (

--- a/ui/src/components/layout/CurrentTimePill.tsx
+++ b/ui/src/components/layout/CurrentTimePill.tsx
@@ -10,17 +10,23 @@ import { useTimezone } from "../../store/useTimezone";
  * Refreshes every 30 seconds. Falls back to browser local time if the home TZ
  * is not yet loaded or invalid.
  */
-export function CurrentTimePill({ compact = false }: { compact?: boolean }) {
+export function CurrentTimePill({
+  compact = false,
+  withSeconds = true,
+}: {
+  compact?: boolean;
+  withSeconds?: boolean;
+}) {
   const tz = useTimezone((s) => s.tz);
   const loaded = useTimezone((s) => s.loaded);
-  const [now, setNow] = useState<string>(() => formatHomeTime(tz));
+  const [now, setNow] = useState<string>(() => formatHomeTime(tz, withSeconds));
 
   useEffect(() => {
-    const tick = () => setNow(formatHomeTime(tz));
+    const tick = () => setNow(formatHomeTime(tz, withSeconds));
     tick();
     const id = setInterval(tick, 1_000);
     return () => clearInterval(id);
-  }, [tz]);
+  }, [tz, withSeconds]);
 
   if (!loaded) return null;
 
@@ -39,22 +45,17 @@ export function CurrentTimePill({ compact = false }: { compact?: boolean }) {
   );
 }
 
-function formatHomeTime(tz: string): string {
+function formatHomeTime(tz: string, withSeconds = true): string {
+  const opts: Intl.DateTimeFormatOptions = {
+    hour: "2-digit",
+    minute: "2-digit",
+    ...(withSeconds ? { second: "2-digit" } : {}),
+    hour12: false,
+  };
   try {
-    return new Intl.DateTimeFormat(undefined, {
-      timeZone: tz,
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false,
-    }).format(new Date());
+    return new Intl.DateTimeFormat(undefined, { timeZone: tz, ...opts }).format(new Date());
   } catch {
     // Invalid TZ — fall back to browser local
-    return new Intl.DateTimeFormat(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false,
-    }).format(new Date());
+    return new Intl.DateTimeFormat(undefined, opts).format(new Date());
   }
 }

--- a/ui/src/components/layout/SunlightBanner.tsx
+++ b/ui/src/components/layout/SunlightBanner.tsx
@@ -25,7 +25,7 @@ export function SunlightBanner({ data, compact }: SunlightBannerProps) {
           ? <Sunrise size={12} strokeWidth={1.5} />
           : <Moon size={12} strokeWidth={1.5} />
         }
-        <span>{data.sunrise} — {data.sunset}</span>
+        <span>{data.sunrise} - {data.sunset}</span>
       </div>
     );
   }
@@ -45,7 +45,7 @@ export function SunlightBanner({ data, compact }: SunlightBannerProps) {
         ? <Sunrise size={13} strokeWidth={1.5} />
         : <Moon size={13} strokeWidth={1.5} />
       }
-      <span>{data.sunrise} — {data.sunset}</span>
+      <span>{data.sunrise} - {data.sunset}</span>
       <span className="text-[11px] opacity-70 lowercase">{isDay ? t("aggregation.daylight") : t("aggregation.night")}</span>
     </div>
   );


### PR DESCRIPTION
## Summary

Two mobile-only UI bugs reported before the release.

## Changes

1. **Top bar — time & sunrise/sunset missing on mobile.** They were gated behind `hidden sm:flex`. Added a compact mobile-only cluster (`flex sm:hidden`) showing the sun range + a seconds-less clock, sized for the tight phone header. Desktop pills unchanged.
2. **Energy > Consumption — Wh/€ toggle inaccessible on mobile.** The `UnitToggle` shared a single non-wrapping flex row with the wide `PeriodSelector`, overflowing the viewport and pushing the toggle off-screen. The header controls now stack vertically on mobile (`flex-col sm:flex-row`), matching the page's existing idiom. (Production page has no UnitToggle, so it was unaffected.)
3. **Minor:** replaced the em-dash in the sunrise/sunset range with a plain hyphen (house style).

## Test plan

- [x] `npx tsc --noEmit` (backend) + `cd ui && npx tsc -b --noEmit` — 0 errors
- [x] `npx vitest run` — 881 passed, 2 skipped
- [x] `npx eslint` (backend + changed UI files) — 0 errors
- [x] Manual: verified on the test instance at mobile width — both controls visible/reachable, desktop unchanged

No business logic changed (pure responsive layout), so no unit tests added per repo convention.