### PR TITLE
release: v1.24.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,18 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.24.x: Notifications Web Push
+
+### v1.24.0 — 2026-06-29 { #v1-24-0 }
+
+Web Push comme canal de notification pour la PWA installée, plus deux correctifs d'affichage mobile :
+
+- Feat (core) : nouveau canal de notification **Web Push** en complément de Telegram. La PWA installée (en HTTPS) peut recevoir des notifications natives. Les clés VAPID sont générées au premier démarrage, les abonnements sont par utilisateur, et les abonnements expirés sont purgés automatiquement. À configurer dans Réglages > Notifications : activez le push sur un appareil, puis mappez un publisher « Web Push » sur une valeur d'équipement, de zone ou de recette. (#284)
+- Fix (ui) : sur mobile, l'heure et le lever/coucher du soleil s'affichent désormais dans la barre du haut (auparavant réservés au bureau). (#285)
+- Fix (ui) : sur mobile, le sélecteur Wh / € de Énergie > Consommation est de nouveau accessible ; il ne déborde plus hors de l'écran à côté du sélecteur de période. (#285)
+
+---
+
 ## 1.23.x: Briques pour recettes solaires
 
 ### v1.23.0 — 2026-06-24 { #v1-23-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,18 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.24.x: Web Push notifications
+
+### v1.24.0 — 2026-06-29 { #v1-24-0 }
+
+Web Push as a notification channel for the installed PWA, plus two mobile layout fixes:
+
+- Feat (core): new **Web Push** notification channel alongside Telegram. The installed PWA (over HTTPS) can receive native push notifications. VAPID keys are generated and stored on first boot, subscriptions are per user, and expired endpoints are pruned automatically. Configure it from Settings > Notifications: enable push on a device, then map a "Web Push" publisher to any equipment, zone or recipe value. (#284)
+- Fix (ui): on mobile, the current time and sunrise/sunset are now shown in the top bar (they were desktop-only). (#285)
+- Fix (ui): on mobile, the Wh / € toggle on Energy > Consumption is now reachable; it no longer overflows off-screen next to the period selector. (#285)
+
+---
+
 ## 1.23.x: Sun-aware recipe building blocks
 
 ### v1.23.0 — 2026-06-24 { #v1-23-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.24.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## v1.24.0

Cuts the release for the changes already merged to `main` since v1.23.0.

### Included
- **feat(core): Web Push notifications for the installed PWA** (spec 127, #284) — new push channel alongside Telegram, per-user subscriptions, server-global VAPID.
- **fix(ui): mobile top bar time + sunrise/sunset** (#285)
- **fix(ui): reachable Wh/€ toggle on Energy > Consumption (mobile)** (#285)

### Release artifacts
- Version bump `package.json` + `ui/package.json` → 1.24.0
- Release notes added to `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-24-0 }` anchor (spec 108)

Merge, then tag `v1.24.0` on the merged commit to trigger the CI build.