### PR TITLE
fix(core): VAPID subject so Web Push works on iOS/Apple (v1.24.1)

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.24.x: Notifications Web Push
 
+### v1.24.1 — 2026-06-29 { #v1-24-1 }
+
+- Fix (core) : le Web Push fonctionne désormais sur iOS et Safari. La passerelle push d'Apple rejetait chaque notification (HTTP 403) car le sujet VAPID par défaut utilisait un domaine `.local`, refusé par Apple (Chrome et Android n'étaient pas affectés). Le défaut est maintenant un contact valide, et les instances existantes corrigent automatiquement la valeur stockée à la mise à jour, sans régénérer les clés, donc les appareils déjà abonnés continuent de fonctionner. (#287)
+
 ### v1.24.0 — 2026-06-29 { #v1-24-0 }
 
 Web Push comme canal de notification pour la PWA installée, plus deux correctifs d'affichage mobile :

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.24.x: Web Push notifications
 
+### v1.24.1 — 2026-06-29 { #v1-24-1 }
+
+- Fix (core): Web Push now works on iOS and Safari. Apple's push gateway rejected every notification (HTTP 403) because the default VAPID subject used a `.local` domain, which Apple refuses (Chrome and Android were unaffected). The default is now a valid contact, and existing instances self-heal the stored value on update without regenerating keys, so previously registered devices keep working. (#287)
+
 ### v1.24.0 — 2026-06-29 { #v1-24-0 }
 
 Web Push as a notification channel for the installed PWA, plus two mobile layout fixes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/src/notifications/vapid.test.ts
+++ b/src/notifications/vapid.test.ts
@@ -38,14 +38,22 @@ describe("ensureVapidKeys", () => {
 
   afterEach(() => db.close());
 
+  const DEFAULT_SUBJECT = "mailto:admin@sowel.org";
+
   it("generates and persists a key pair on first call", () => {
     const keys = ensureVapidKeys(settings, logger);
     expect(keys.publicKey).toBe("pub-1");
     expect(keys.privateKey).toBe("priv-1");
-    expect(keys.subject).toBe("mailto:admin@sowel.local");
+    expect(keys.subject).toBe(DEFAULT_SUBJECT);
     expect(settings.get("push.vapidPublicKey")).toBe("pub-1");
     expect(settings.get("push.vapidPrivateKey")).toBe("priv-1");
-    expect(settings.get("push.vapidSubject")).toBe("mailto:admin@sowel.local");
+    expect(settings.get("push.vapidSubject")).toBe(DEFAULT_SUBJECT);
+  });
+
+  it("uses a valid (non-.local) default subject Apple accepts", () => {
+    const keys = ensureVapidKeys(settings, logger);
+    expect(keys.subject).not.toContain(".local");
+    expect(keys.subject).toMatch(/^(mailto:|https:)/);
   });
 
   it("is idempotent: a second call reuses the stored keys", () => {
@@ -61,11 +69,23 @@ describe("ensureVapidKeys", () => {
     const keys = ensureVapidKeys(settings, logger);
     expect(generateCalls).toBe(0);
     expect(keys.publicKey).toBe("existing-pub");
-    expect(keys.subject).toBe("mailto:admin@sowel.local");
-    expect(settings.get("push.vapidSubject")).toBe("mailto:admin@sowel.local");
+    expect(keys.subject).toBe(DEFAULT_SUBJECT);
+    expect(settings.get("push.vapidSubject")).toBe(DEFAULT_SUBJECT);
   });
 
-  it("preserves a custom stored subject", () => {
+  it("heals a legacy .local subject on boot without touching the keys", () => {
+    settings.set("push.vapidPublicKey", "existing-pub");
+    settings.set("push.vapidPrivateKey", "existing-priv");
+    settings.set("push.vapidSubject", "mailto:admin@sowel.local");
+    const keys = ensureVapidKeys(settings, logger);
+    expect(generateCalls).toBe(0); // key pair untouched
+    expect(keys.publicKey).toBe("existing-pub");
+    expect(keys.privateKey).toBe("existing-priv");
+    expect(keys.subject).toBe(DEFAULT_SUBJECT);
+    expect(settings.get("push.vapidSubject")).toBe(DEFAULT_SUBJECT); // persisted
+  });
+
+  it("preserves a custom valid stored subject", () => {
     settings.set("push.vapidSubject", "mailto:owner@example.com");
     const keys = ensureVapidKeys(settings, logger);
     expect(keys.subject).toBe("mailto:owner@example.com");

--- a/src/notifications/vapid.ts
+++ b/src/notifications/vapid.ts
@@ -15,32 +15,48 @@ export interface VapidKeys {
 const KEY_PUBLIC = "push.vapidPublicKey";
 const KEY_PRIVATE = "push.vapidPrivateKey";
 const KEY_SUBJECT = "push.vapidSubject";
-const DEFAULT_SUBJECT = "mailto:admin@sowel.local";
+
+// Apple's Web Push gateway (web.push.apple.com) rejects the VAPID JWT with 403
+// when the `sub` claim is not a real mailto:/https: contact. The original
+// default used a `.local` domain, which Apple refuses (FCM is lenient and
+// accepted it, so Chrome/Android worked but iOS did not).
+const DEFAULT_SUBJECT = "mailto:admin@sowel.org";
+// Bad defaults shipped before the fix — replaced on boot so existing instances
+// self-heal. Changing only the subject is safe: it is a JWT claim, independent
+// of the key pair, so stored browser subscriptions keep working.
+const LEGACY_INVALID_SUBJECTS = new Set(["mailto:admin@sowel.local"]);
+
+function resolveSubject(stored: string | undefined): string {
+  return !stored || LEGACY_INVALID_SUBJECTS.has(stored) ? DEFAULT_SUBJECT : stored;
+}
 
 /**
  * Ensure a VAPID key pair exists in `settings`, generating + persisting one on
  * first call. The private key never leaves the server. Idempotent: a second
- * call reuses the stored keys.
+ * call reuses the stored keys. A missing or known-invalid subject is healed to
+ * `DEFAULT_SUBJECT` and persisted (the key pair is left untouched).
  */
 export function ensureVapidKeys(settings: SettingsManager, logger: Logger): VapidKeys {
   const log = logger.child({ module: "vapid" });
   const publicKey = settings.get(KEY_PUBLIC);
   const privateKey = settings.get(KEY_PRIVATE);
-  const subject = settings.get(KEY_SUBJECT);
+  const storedSubject = settings.get(KEY_SUBJECT);
+  const subject = resolveSubject(storedSubject);
 
   if (publicKey && privateKey) {
-    const subj = subject || DEFAULT_SUBJECT;
-    if (!subject) settings.set(KEY_SUBJECT, subj);
-    return { publicKey, privateKey, subject: subj };
+    if (subject !== storedSubject) {
+      settings.set(KEY_SUBJECT, subject);
+      log.info({ subject }, "Healed VAPID subject");
+    }
+    return { publicKey, privateKey, subject };
   }
 
   const generated = webpush.generateVAPIDKeys();
-  const subj = subject || DEFAULT_SUBJECT;
   settings.setMany({
     [KEY_PUBLIC]: generated.publicKey,
     [KEY_PRIVATE]: generated.privateKey,
-    [KEY_SUBJECT]: subj,
+    [KEY_SUBJECT]: subject,
   });
   log.info("Generated and stored a new VAPID key pair");
-  return { publicKey: generated.publicKey, privateKey: generated.privateKey, subject: subj };
+  return { publicKey: generated.publicKey, privateKey: generated.privateKey, subject };
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.24.0",
+  "version": "1.24.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Hotfix for v1.24.0: **Web Push was broken on iOS/Safari.** Apple's gateway (`web.push.apple.com`) returned HTTP **403** for every send because the default VAPID `sub` claim was `mailto:admin@sowel.local` — Apple rejects the `.local` domain. FCM (Chrome/Android) is lenient and accepted it, so the bug only surfaced on iOS.

Diagnosed from prod logs: same code/keys, FCM → 201, Apple → 403 on the `web.push.apple.com` endpoint.

## Changes

- Default VAPID subject is now a valid contact (`mailto:admin@sowel.org`).
- On boot, a stored legacy `.local` subject is **healed** to the new value and persisted. The key pair is untouched (the subject is an independent JWT claim), so **devices already subscribed keep working** — no re-subscription needed. Existing instances self-heal on update.
- Tests: legacy-subject healing without key regeneration; default is non-`.local`.

## Release

- Bumps `package.json` + `ui/package.json` → **1.24.1**
- Release notes added to `docs/release-notes.md` + `.fr.md` with `{ #v1-24-1 }` anchor (spec 108)

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 883 passed, 2 skipped (incl. 2 new VAPID tests)
- [x] `npx eslint src/ --ext .ts` — 0 errors
- [ ] Post-deploy: prod heals subject on boot → iPhone receives the test push (Apple returns 201)

Merge, then tag `v1.24.1` to build.