### PR TITLE
fix(notifications): split Web Push into title + body (v1.24.3)

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.24.x: Notifications Web Push
 
+### v1.24.3 — 2026-06-29 { #v1-24-3 }
+
+- Fix (notifications) : les notifications Web Push sont séparées en un titre (le message) et un corps (la valeur). Une notification plus longue comme « Porte de garage ouverte depuis » suivie d'un horodatage se lit désormais sur deux lignes au lieu d'être tronquée sur une seule. Telegram conserve son format sur une ligne. À noter : la mention « from Sowel » sur la notification est ajoutée par le navigateur / le téléphone lui-même (il affiche toujours quelle app a envoyé le push) et ne peut pas être retirée.
+
 ### v1.24.2 — 2026-06-29 { #v1-24-2 }
 
 - Fix (notifications) : le bouton « Tester le canal » envoie désormais une vraie notification pour le canal Web Push. Auparavant il ne faisait que valider les clés VAPID sans rien envoyer, donc il semblait ne rien faire. Il renvoie aussi une erreur claire si aucun appareil n'a encore activé le push. (#288)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.24.x: Web Push notifications
 
+### v1.24.3 — 2026-06-29 { #v1-24-3 }
+
+- Fix (notifications): Web Push notifications are split into a title (the message) and a body (the value). A longer notification such as "Garage door open since" followed by a timestamp now reads on two lines instead of being truncated onto one. Telegram keeps its single-line format. Note: the "from Sowel" line on the notification is added by the browser/phone itself (it always shows which app sent the push) and cannot be removed.
+
 ### v1.24.2 — 2026-06-29 { #v1-24-2 }
 
 - Fix (notifications): the "Test channel" button now delivers a real notification for the Web Push channel. It previously only validated the VAPID keys without sending anything, so it looked like nothing happened. It also returns a clear error when no device has enabled push yet. (#288)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/src/notifications/channels/channel.ts
+++ b/src/notifications/channels/channel.ts
@@ -2,9 +2,20 @@
 // NotificationChannel — interface for channel providers
 // ============================================================
 
+/**
+ * A notification split into a heading and an optional detail line. Channels
+ * that support rich notifications (Web Push) render them as title + body so
+ * the text is readable instead of crammed onto one truncated line; plain-text
+ * channels (Telegram) flatten them back into a single message.
+ */
+export interface NotificationContent {
+  title: string;
+  body?: string;
+}
+
 export interface NotificationChannel {
-  /** Send a notification message. */
-  send(config: unknown, text: string): Promise<void>;
+  /** Send a notification. */
+  send(config: unknown, content: NotificationContent): Promise<void>;
 
   /** Test that the channel configuration is valid. */
   testConnection(config: unknown): Promise<void>;

--- a/src/notifications/channels/telegram.ts
+++ b/src/notifications/channels/telegram.ts
@@ -1,5 +1,5 @@
 import type { TelegramChannelConfig } from "../../shared/types.js";
-import type { NotificationChannel } from "./channel.js";
+import type { NotificationChannel, NotificationContent } from "./channel.js";
 
 // ============================================================
 // Telegram — Bot API channel provider
@@ -8,9 +8,12 @@ import type { NotificationChannel } from "./channel.js";
 const TELEGRAM_API = "https://api.telegram.org";
 
 export class TelegramChannel implements NotificationChannel {
-  async send(config: unknown, text: string): Promise<void> {
+  async send(config: unknown, content: NotificationContent): Promise<void> {
     const { botToken, chatId } = config as TelegramChannelConfig;
     const url = `${TELEGRAM_API}/bot${botToken}/sendMessage`;
+    // Telegram is plain text: flatten title + body into one message, keeping
+    // the historical "message : value" shape.
+    const text = content.body ? `${content.title} : ${content.body}` : content.title;
 
     const res = await fetch(url, {
       method: "POST",
@@ -25,6 +28,6 @@ export class TelegramChannel implements NotificationChannel {
   }
 
   async testConnection(config: unknown): Promise<void> {
-    await this.send(config, "Sowel — connexion OK");
+    await this.send(config, { title: "Sowel — connexion OK" });
   }
 }

--- a/src/notifications/channels/web-push.test.ts
+++ b/src/notifications/channels/web-push.test.ts
@@ -47,7 +47,7 @@ describe("WebPushChannel", () => {
     sendNotification.mockResolvedValue({ statusCode: 201 });
 
     const channel = new WebPushChannel(mgr, vapid, logger);
-    await channel.send({}, "Hello world");
+    await channel.send({}, { title: "Garage door open", body: "29/06/2026 18:30" });
 
     expect(sendNotification).toHaveBeenCalledTimes(2);
     const [pushSub, payload, options] = sendNotification.mock.calls[0];
@@ -55,7 +55,10 @@ describe("WebPushChannel", () => {
       endpoint: "https://push/1",
       keys: { p256dh: "p", auth: "a" },
     });
-    expect(JSON.parse(payload as string)).toEqual({ title: "Hello world" });
+    expect(JSON.parse(payload as string)).toEqual({
+      title: "Garage door open",
+      body: "29/06/2026 18:30",
+    });
     expect((options as { vapidDetails: VapidKeys }).vapidDetails).toEqual({
       subject: vapid.subject,
       publicKey: vapid.publicKey,
@@ -66,7 +69,7 @@ describe("WebPushChannel", () => {
   it("does nothing when there are no subscriptions", async () => {
     const mgr = createMockManager([]);
     const channel = new WebPushChannel(mgr, vapid, logger);
-    await channel.send({}, "Hi");
+    await channel.send({}, { title: "Hi" });
     expect(sendNotification).not.toHaveBeenCalled();
   });
 
@@ -75,7 +78,7 @@ describe("WebPushChannel", () => {
     sendNotification.mockRejectedValue({ statusCode: 410 });
 
     const channel = new WebPushChannel(mgr, vapid, logger);
-    await channel.send({}, "Hi");
+    await channel.send({}, { title: "Hi" });
 
     expect(mgr.deleteByEndpoint).toHaveBeenCalledWith("https://push/dead");
   });
@@ -85,7 +88,7 @@ describe("WebPushChannel", () => {
     sendNotification.mockRejectedValue({ statusCode: 404 });
 
     const channel = new WebPushChannel(mgr, vapid, logger);
-    await channel.send({}, "Hi");
+    await channel.send({}, { title: "Hi" });
 
     expect(mgr.deleteByEndpoint).toHaveBeenCalledWith("https://push/gone");
   });
@@ -97,7 +100,7 @@ describe("WebPushChannel", () => {
       .mockResolvedValueOnce({ statusCode: 201 });
 
     const channel = new WebPushChannel(mgr, vapid, logger);
-    await channel.send({}, "Hi");
+    await channel.send({}, { title: "Hi" });
 
     expect(mgr.deleteByEndpoint).not.toHaveBeenCalled();
     expect(sendNotification).toHaveBeenCalledTimes(2);

--- a/src/notifications/channels/web-push.ts
+++ b/src/notifications/channels/web-push.ts
@@ -1,6 +1,6 @@
 import webpush from "web-push";
 import type { Logger } from "../../core/logger.js";
-import type { NotificationChannel } from "./channel.js";
+import type { NotificationChannel, NotificationContent } from "./channel.js";
 import type { PushSubscriptionManager } from "../push-subscription-manager.js";
 import type { VapidKeys } from "../vapid.js";
 
@@ -26,18 +26,18 @@ export class WebPushChannel implements NotificationChannel {
     this.logger = logger.child({ module: "web-push-channel" });
   }
 
-  async send(_config: unknown, text: string): Promise<void> {
+  async send(_config: unknown, content: NotificationContent): Promise<void> {
     const subs = this.subscriptions.listAll();
     if (subs.length === 0) {
       this.logger.debug("No push subscriptions; nothing to send");
       return;
     }
 
-    // The message is the notification heading. We deliberately do NOT set a
-    // "Sowel" title: the installed PWA (and the browser/site chrome) already
-    // labels the notification with the app name, so a "Sowel" title would just
-    // be shown twice.
-    const payload = JSON.stringify({ title: text });
+    // title = message, body = value detail. The service worker renders them on
+    // separate lines so the text stays readable instead of being crammed onto
+    // one truncated line. We deliberately do NOT set a "Sowel" title: the
+    // installed PWA already labels the notification with the app name.
+    const payload = JSON.stringify({ title: content.title, body: content.body ?? "" });
     const vapidDetails = {
       subject: this.vapid.subject,
       publicKey: this.vapid.publicKey,
@@ -83,6 +83,6 @@ export class WebPushChannel implements NotificationChannel {
     if (this.subscriptions.listAll().length === 0) {
       throw new Error("No push subscriptions yet — enable push on a device first");
     }
-    await this.send(config, "Test notification");
+    await this.send(config, { title: "Test notification" });
   }
 }

--- a/src/notifications/notification-publish-service.ts
+++ b/src/notifications/notification-publish-service.ts
@@ -5,7 +5,7 @@ import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { ZoneAggregator } from "../zones/zone-aggregator.js";
 import type { RecipeManager } from "../recipes/engine/recipe-manager.js";
 import type { ZoneAggregatedData } from "../shared/types.js";
-import type { NotificationChannel } from "./channels/channel.js";
+import type { NotificationChannel, NotificationContent } from "./channels/channel.js";
 import { TelegramChannel } from "./channels/telegram.js";
 import { WebPushChannel } from "./channels/web-push.js";
 import type { PushSubscriptionManager } from "./push-subscription-manager.js";
@@ -207,8 +207,8 @@ export class NotificationPublishService {
         previous !== undefined ? previous : this.lastValue.get(ref.mappingId);
       if (!this.shouldNotify(ref, value, effectivePrevious)) continue;
 
-      const text = formatNotificationText(ref.message, value);
-      this.sendNotification(ref, text);
+      const content = formatNotificationContent(ref.message, value);
+      this.sendNotification(ref, content);
       this.lastSent.set(ref.mappingId, Date.now());
       this.lastValue.set(ref.mappingId, value);
       sent++;
@@ -243,14 +243,14 @@ export class NotificationPublishService {
 
   // ── Send notification ───────────────────────────────────────
 
-  private sendNotification(ref: MappingRef, text: string): void {
+  private sendNotification(ref: MappingRef, content: NotificationContent): void {
     const channel = this.channels[ref.channelType];
     if (!channel) {
       this.logger.warn({ channelType: ref.channelType }, "Unknown notification channel type");
       return;
     }
 
-    channel.send(ref.channelConfig, text).catch((err) => {
+    channel.send(ref.channelConfig, content).catch((err) => {
       this.logger.error(
         { err, publisherId: ref.publisherId, channelType: ref.channelType },
         "Notification send failed",
@@ -269,7 +269,7 @@ export class NotificationPublishService {
     const channel = this.channels.telegram;
     if (!channel) return;
 
-    channel.send(telegramPub.channelConfig, text).catch((err) => {
+    channel.send(telegramPub.channelConfig, { title: text }).catch((err) => {
       this.logger.error({ err }, "System alarm notification send failed");
     });
   }
@@ -303,8 +303,8 @@ export class NotificationPublishService {
       );
       if (value === undefined) continue;
 
-      const text = formatNotificationText(mapping.message, value);
-      await channel.send(publisher.channelConfig, text);
+      const content = formatNotificationContent(mapping.message, value);
+      await channel.send(publisher.channelConfig, content);
       sent++;
     }
 
@@ -347,12 +347,11 @@ export class NotificationPublishService {
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 
-function formatNotificationText(message: string, value: unknown): string {
-  // Booleans: just send the message, no value suffix
-  if (typeof value === "boolean") return message;
-  // null: just send the message
-  if (value === null) return message;
-  return `${message} : ${formatDisplayValue(value)}`;
+function formatNotificationContent(message: string, value: unknown): NotificationContent {
+  // Booleans / null carry no extra detail: the message stands alone.
+  if (typeof value === "boolean" || value === null) return { title: message };
+  // Otherwise the message is the heading and the value is the detail line.
+  return { title: message, body: formatDisplayValue(value) };
 }
 
 function formatDisplayValue(value: unknown): string {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.24.2",
+  "version": "1.24.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

A Web Push notification was sent as a single line (`message : value`). iOS truncates that in the banner, so a longer one like "Porte de garage ouverte depuis : 29/06/2026 18:30" was cut off ("porte de garage ouverte …").

## Fix

The channel interface now carries a structured `{ title, body }`:
- **Web Push**: title = the message, body = the value, rendered on two lines by the existing service worker (works with the SW already installed on devices — no PWA reinstall).
- **Telegram**: flattens back to its historical `message : value` single line (unchanged behaviour).

## Note on "from Sowel"
The "from Sowel" line on the notification is added by the browser/phone itself (web push always attributes the notification to the app/site that sent it). It is not in Sowel's payload and cannot be removed. The redundant "Sowel" *title* that Sowel used to add was removed in v1.24.2.

## Test plan

- [x] `npx tsc --noEmit` + `cd ui && npx tsc -b --noEmit` — 0 errors
- [x] `npx vitest run` — 884 passed, 2 skipped (web-push channel tests updated to `{title, body}`)
- [x] `npx eslint src/ --ext .ts` — 0 errors
- [ ] Post-deploy: garage notification shows the message + timestamp on two readable lines on iOS

Bumps to v1.24.3 (EN/FR release notes, `{ #v1-24-3 }` anchor).