### PR TITLE
chore(registry): bump motion-light to 1.1.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -255,7 +255,7 @@
     "icon": "Lightbulb",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-motion-light",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "tags": ["automation", "motion", "light"],
     "i18n": {
       "fr": {
@@ -265,7 +265,7 @@
     },
     "sowelVersion": ">=0.10.0",
     "owner": "mchacher",
-    "sha256": "1e4503648a66d916489d371287bab665db82433ddbc836186cb11f7258df381a"
+    "sha256": "e8cd555c15e2a521cc6deb07b1d634e9518dcf20827c8de779f376bc3501cf00"
   },
   {
     "id": "state-trigger-light",


### PR DESCRIPTION
Bumps the `motion-light` recipe to **1.1.0** (presence-aware safety auto-off) with the sha256 of the released tarball.

- Plugin release: https://github.com/mchacher/sowel-recipe-motion-light/releases/tag/v1.1.0
- sha256 recomputed via `scripts/backfill-registry-sha256.mjs` from the v1.1.0 asset.

The failsafe (`maxOnDuration`) now resets on raw motion impulses (`device.data.updated`), so it no longer forces lights off while a person is actively present (the atelier 5-min cut-out), while still firing for a genuinely stuck/dead sensor.