### PR TITLE
notification mappings: restore zone filter on edit + show target equipment(s) in the recipe combo

### DIFF
--- a/ui/src/lib/notif-mapping.test.ts
+++ b/ui/src/lib/notif-mapping.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { deriveSourceZoneFilter } from "./notif-mapping";
+import type { EquipmentWithDetails, RecipeInstance } from "../types";
+
+const equipments = [
+  { id: "eq-washer", zoneId: "zone-cave" },
+  { id: "eq-lamp", zoneId: "zone-salon" },
+] as unknown as EquipmentWithDetails[];
+
+const recipeInstances = [
+  { id: "rec-washer", recipeId: "state-watch", params: { zone: "zone-cave" } },
+  { id: "rec-garage", recipeId: "state-watch", params: { zone: "zone-garage" } },
+] as unknown as RecipeInstance[];
+
+describe("deriveSourceZoneFilter", () => {
+  it("returns the recipe instance's zone (the reported cave bug)", () => {
+    expect(
+      deriveSourceZoneFilter(
+        { sourceType: "recipe", sourceId: "rec-washer" },
+        equipments,
+        recipeInstances,
+      ),
+    ).toBe("zone-cave");
+  });
+
+  it("returns the equipment's zone", () => {
+    expect(
+      deriveSourceZoneFilter(
+        { sourceType: "equipment", sourceId: "eq-lamp" },
+        equipments,
+        recipeInstances,
+      ),
+    ).toBe("zone-salon");
+  });
+
+  it("returns empty for a zone source (no filter needed)", () => {
+    expect(
+      deriveSourceZoneFilter(
+        { sourceType: "zone", sourceId: "zone-cave" },
+        equipments,
+        recipeInstances,
+      ),
+    ).toBe("");
+  });
+
+  it("returns empty when the source cannot be resolved (data not loaded yet)", () => {
+    expect(
+      deriveSourceZoneFilter(
+        { sourceType: "recipe", sourceId: "unknown" },
+        equipments,
+        recipeInstances,
+      ),
+    ).toBe("");
+    expect(deriveSourceZoneFilter({ sourceType: "equipment", sourceId: "unknown" }, [], [])).toBe(
+      "",
+    );
+  });
+
+  it("returns empty when a recipe instance has no zone param", () => {
+    const instances = [{ id: "rec-x", recipeId: "r", params: {} }] as unknown as RecipeInstance[];
+    expect(deriveSourceZoneFilter({ sourceType: "recipe", sourceId: "rec-x" }, [], instances)).toBe(
+      "",
+    );
+  });
+});

--- a/ui/src/lib/notif-mapping.test.ts
+++ b/ui/src/lib/notif-mapping.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { deriveSourceZoneFilter } from "./notif-mapping";
-import type { EquipmentWithDetails, RecipeInstance } from "../types";
+import {
+  deriveSourceZoneFilter,
+  recipeInstanceEquipmentNames,
+  recipeInstanceLabel,
+} from "./notif-mapping";
+import type { EquipmentWithDetails, RecipeInstance, RecipeInfo } from "../types";
 
 const equipments = [
   { id: "eq-washer", zoneId: "zone-cave" },
@@ -61,5 +65,64 @@ describe("deriveSourceZoneFilter", () => {
     expect(deriveSourceZoneFilter({ sourceType: "recipe", sourceId: "rec-x" }, [], instances)).toBe(
       "",
     );
+  });
+});
+
+describe("recipeInstanceEquipmentNames / recipeInstanceLabel", () => {
+  const eqs = [
+    { id: "eq-washer", name: "Machine à laver", zoneId: "zone-cave" },
+    { id: "eq-l1", name: "Plafonnier", zoneId: "zone-atelier" },
+    { id: "eq-l2", name: "Établi", zoneId: "zone-atelier" },
+  ] as unknown as EquipmentWithDetails[];
+
+  const recipes = [
+    {
+      id: "state-watch",
+      name: "State Watch",
+      slots: [
+        { id: "zone", type: "zone" },
+        { id: "equipment", type: "equipment" },
+        { id: "dataKey", type: "data-key" },
+      ],
+    },
+    {
+      id: "motion-light",
+      name: "Motion Light",
+      slots: [
+        { id: "zone", type: "zone" },
+        { id: "lights", type: "equipment", list: true },
+      ],
+    },
+  ] as unknown as RecipeInfo[];
+
+  it("resolves a single equipment slot to its name", () => {
+    const inst = {
+      id: "i1",
+      recipeId: "state-watch",
+      params: { zone: "zone-cave", equipment: "eq-washer" },
+    } as unknown as RecipeInstance;
+    expect(recipeInstanceEquipmentNames(inst, recipes, eqs)).toEqual(["Machine à laver"]);
+    expect(recipeInstanceLabel(inst, recipes, eqs)).toBe("State Watch (Machine à laver)");
+  });
+
+  it("resolves a list equipment slot to all names, deduped", () => {
+    const inst = {
+      id: "i2",
+      recipeId: "motion-light",
+      params: { zone: "zone-atelier", lights: ["eq-l1", "eq-l2", "eq-l1"] },
+    } as unknown as RecipeInstance;
+    expect(recipeInstanceEquipmentNames(inst, recipes, eqs)).toEqual(["Plafonnier", "Établi"]);
+    expect(recipeInstanceLabel(inst, recipes, eqs)).toBe("Motion Light (Plafonnier, Établi)");
+  });
+
+  it("falls back to the recipe name when no equipment is bound / unknown recipe", () => {
+    const noEq = {
+      id: "i3",
+      recipeId: "state-watch",
+      params: { zone: "zone-cave" },
+    } as unknown as RecipeInstance;
+    expect(recipeInstanceLabel(noEq, recipes, eqs)).toBe("State Watch");
+    const unknown = { id: "i4", recipeId: "ghost", params: {} } as unknown as RecipeInstance;
+    expect(recipeInstanceLabel(unknown, recipes, eqs)).toBe("ghost");
   });
 });

--- a/ui/src/lib/notif-mapping.ts
+++ b/ui/src/lib/notif-mapping.ts
@@ -1,4 +1,9 @@
-import type { NotificationPublisherMapping, EquipmentWithDetails, RecipeInstance } from "../types";
+import type {
+  NotificationPublisherMapping,
+  EquipmentWithDetails,
+  RecipeInstance,
+  RecipeInfo,
+} from "../types";
 
 /**
  * The zone dropdown in the notification mapping editor is only a selection aid —
@@ -19,4 +24,47 @@ export function deriveSourceZoneFilter(
     return typeof zone === "string" ? zone : "";
   }
   return "";
+}
+
+/**
+ * The equipment(s) a recipe instance targets, resolved to names. Reads the
+ * recipe template's `equipment`-typed slots and looks up the ids the instance
+ * bound to them. Deduplicated, order-preserving.
+ */
+export function recipeInstanceEquipmentNames(
+  inst: RecipeInstance,
+  recipes: RecipeInfo[],
+  equipments: EquipmentWithDetails[],
+): string[] {
+  const recipe = recipes.find((r) => r.id === inst.recipeId);
+  if (!recipe) return [];
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const slot of recipe.slots) {
+    if (slot.type !== "equipment") continue;
+    const raw = inst.params[slot.id];
+    const ids = Array.isArray(raw) ? raw : raw != null ? [raw] : [];
+    for (const id of ids) {
+      if (typeof id !== "string" || seen.has(id)) continue;
+      seen.add(id);
+      const eq = equipments.find((e) => e.id === id);
+      if (eq) names.push(eq.name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Dropdown label for a recipe instance: the recipe name plus the equipment(s)
+ * it applies to, so instances of the same recipe are distinguishable. E.g.
+ * "State Watch (Machine à laver)".
+ */
+export function recipeInstanceLabel(
+  inst: RecipeInstance,
+  recipes: RecipeInfo[],
+  equipments: EquipmentWithDetails[],
+): string {
+  const base = recipes.find((r) => r.id === inst.recipeId)?.name ?? inst.recipeId;
+  const eqNames = recipeInstanceEquipmentNames(inst, recipes, equipments);
+  return eqNames.length > 0 ? `${base} (${eqNames.join(", ")})` : base;
 }

--- a/ui/src/lib/notif-mapping.ts
+++ b/ui/src/lib/notif-mapping.ts
@@ -1,0 +1,22 @@
+import type { NotificationPublisherMapping, EquipmentWithDetails, RecipeInstance } from "../types";
+
+/**
+ * The zone dropdown in the notification mapping editor is only a selection aid —
+ * it is not stored on the mapping (which keeps sourceType/sourceId/sourceKey).
+ * Re-derive it from the mapping's source so re-editing shows the source's zone
+ * instead of defaulting to "all zones".
+ */
+export function deriveSourceZoneFilter(
+  mapping: Pick<NotificationPublisherMapping, "sourceType" | "sourceId">,
+  equipments: EquipmentWithDetails[],
+  recipeInstances: RecipeInstance[],
+): string {
+  if (mapping.sourceType === "equipment") {
+    return equipments.find((e) => e.id === mapping.sourceId)?.zoneId ?? "";
+  }
+  if (mapping.sourceType === "recipe") {
+    const zone = recipeInstances.find((i) => i.id === mapping.sourceId)?.params.zone;
+    return typeof zone === "string" ? zone : "";
+  }
+  return "";
+}

--- a/ui/src/pages/NotificationPublishersPage.tsx
+++ b/ui/src/pages/NotificationPublishersPage.tsx
@@ -40,6 +40,7 @@ import type {
   RecipeInfo,
 } from "../types";
 import { usePushSubscription } from "../hooks/usePushSubscription";
+import { deriveSourceZoneFilter } from "../lib/notif-mapping";
 
 const ZONE_AGG_KEYS = [
   "temperature",
@@ -71,11 +72,17 @@ function PushEnableCard() {
 
   let action: React.ReactNode;
   if (!supported) {
-    action = <span className="text-[12px] text-text-tertiary">{t("notifPublishers.pushUnsupported")}</span>;
+    action = (
+      <span className="text-[12px] text-text-tertiary">{t("notifPublishers.pushUnsupported")}</span>
+    );
   } else if (status === "insecure") {
-    action = <span className="text-[12px] text-text-tertiary">{t("notifPublishers.pushInsecure")}</span>;
+    action = (
+      <span className="text-[12px] text-text-tertiary">{t("notifPublishers.pushInsecure")}</span>
+    );
   } else if (status === "denied") {
-    action = <span className="text-[12px] text-text-tertiary">{t("notifPublishers.pushDenied")}</span>;
+    action = (
+      <span className="text-[12px] text-text-tertiary">{t("notifPublishers.pushDenied")}</span>
+    );
   } else if (status === "subscribed") {
     action = (
       <button
@@ -164,13 +171,9 @@ export function NotificationPublishersPage() {
       <div className="mb-6">
         <div className="flex items-center gap-2.5 mb-1">
           <Bell size={22} strokeWidth={1.5} className="text-text-secondary" />
-          <h1>
-            {t("notifPublishers.title")}
-          </h1>
+          <h1>{t("notifPublishers.title")}</h1>
         </div>
-        <p className="text-[13px] text-text-secondary mt-1">
-          {t("notifPublishers.subtitle")}
-        </p>
+        <p className="text-[13px] text-text-secondary mt-1">{t("notifPublishers.subtitle")}</p>
       </div>
 
       {/* Web Push — enable on this device (spec 127) */}
@@ -278,7 +281,10 @@ function PublisherForm({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="mb-4 p-4 bg-surface rounded-[10px] border border-border max-w-lg">
+    <form
+      onSubmit={handleSubmit}
+      className="mb-4 p-4 bg-surface rounded-[10px] border border-border max-w-lg"
+    >
       <div className="space-y-3">
         <div>
           <label className="block text-[12px] text-text-secondary mb-1">
@@ -343,7 +349,13 @@ function PublisherForm({
             disabled={saving || !canSubmit}
             className="px-4 py-1.5 bg-primary text-white text-[13px] rounded-[6px] hover:bg-primary-hover disabled:opacity-50"
           >
-            {saving ? <Loader2 size={14} className="animate-spin" /> : publisher ? t("common.save") : t("common.create")}
+            {saving ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : publisher ? (
+              t("common.save")
+            ) : (
+              t("common.create")
+            )}
           </button>
           <button
             type="button"
@@ -478,7 +490,9 @@ function PublisherCard({
   };
 
   return (
-    <div className={`p-4 bg-surface rounded-[10px] border ${publisher.enabled ? "border-border" : "border-border opacity-60"}`}>
+    <div
+      className={`p-4 bg-surface rounded-[10px] border ${publisher.enabled ? "border-border" : "border-border opacity-60"}`}
+    >
       {/* Header — stacks on mobile so the name stays readable and the
           actions sit on their own row instead of crushing into the title. */}
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-3">
@@ -493,9 +507,7 @@ function PublisherCard({
         </div>
         <div className="flex items-center gap-1 flex-wrap justify-end self-end sm:self-auto">
           {testChannelOk && (
-            <span className="text-[11px] text-green-500">
-              {t("notifPublishers.testChannelOk")}
-            </span>
+            <span className="text-[11px] text-green-500">{t("notifPublishers.testChannelOk")}</span>
           )}
           {testResult !== null && (
             <span className="text-[11px] text-green-500">
@@ -521,11 +533,7 @@ function PublisherCard({
             className="flex items-center gap-1 px-2 py-1 text-[11px] rounded-[6px] hover:bg-bg transition-colors text-text-secondary hover:text-accent disabled:opacity-40"
             title={t("notifPublishers.testPublisherHint")}
           >
-            {testingPub ? (
-              <Loader2 size={13} className="animate-spin" />
-            ) : (
-              <Zap size={13} />
-            )}
+            {testingPub ? <Loader2 size={13} className="animate-spin" /> : <Zap size={13} />}
             <span className="hidden sm:inline">{t("notifPublishers.test")}</span>
           </button>
           <button
@@ -638,7 +646,9 @@ function MappingRow({
   const [editing, setEditing] = useState(false);
   const [message, setMessage] = useState(mapping.message);
   const [sourceType, setSourceType] = useState<"equipment" | "zone" | "recipe">(mapping.sourceType);
-  const [filterZoneId, setFilterZoneId] = useState("");
+  const [filterZoneId, setFilterZoneId] = useState(() =>
+    deriveSourceZoneFilter(mapping, equipments, recipeInstances),
+  );
   const [sourceId, setSourceId] = useState(mapping.sourceId);
   const [sourceKey, setSourceKey] = useState(mapping.sourceKey);
   const [throttleMs, setThrottleMs] = useState(mapping.throttleMs);
@@ -737,7 +747,9 @@ function MappingRow({
             </label>
             <select
               value={sourceType}
-              onChange={(e) => handleSourceTypeChange(e.target.value as "equipment" | "zone" | "recipe")}
+              onChange={(e) =>
+                handleSourceTypeChange(e.target.value as "equipment" | "zone" | "recipe")
+              }
               className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
             >
               <option value="equipment">{t("notifPublishers.equipment")}</option>
@@ -859,9 +871,7 @@ function MappingRow({
             />
           </div>
         </div>
-        {error && (
-          <div className="mt-2 text-[11px] text-red-500">{error}</div>
-        )}
+        {error && <div className="mt-2 text-[11px] text-red-500">{error}</div>}
         <div className="flex items-center gap-2 mt-3">
           <button
             type="submit"
@@ -894,13 +904,20 @@ function MappingRow({
             [{mapping.sourceType}] {label}
           </span>
           <span className="text-[10px] text-text-tertiary shrink-0">
-            {t("notifPublishers.throttleMinutes", { minutes: Math.round(mapping.throttleMs / 60000) })}
+            {t("notifPublishers.throttleMinutes", {
+              minutes: Math.round(mapping.throttleMs / 60000),
+            })}
           </span>
         </div>
       </div>
       <div className="flex items-center gap-1 shrink-0">
         <button
-          onClick={() => setEditing(true)}
+          onClick={() => {
+            // Re-derive the zone filter from the source in case the equipment/
+            // recipe lists loaded after this row first mounted.
+            setFilterZoneId(deriveSourceZoneFilter(mapping, equipments, recipeInstances));
+            setEditing(true);
+          }}
           className="p-1 rounded hover:bg-surface transition-colors text-text-tertiary hover:text-text"
         >
           <Pencil size={12} />
@@ -1034,7 +1051,9 @@ function AddMappingForm({
           </label>
           <select
             value={sourceType}
-            onChange={(e) => handleSourceTypeChange(e.target.value as "equipment" | "zone" | "recipe")}
+            onChange={(e) =>
+              handleSourceTypeChange(e.target.value as "equipment" | "zone" | "recipe")
+            }
             className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
           >
             <option value="equipment">{t("notifPublishers.equipment")}</option>
@@ -1157,9 +1176,7 @@ function AddMappingForm({
           />
         </div>
       </div>
-      {error && (
-        <div className="mt-2 text-[11px] text-red-500">{error}</div>
-      )}
+      {error && <div className="mt-2 text-[11px] text-red-500">{error}</div>}
       <div className="flex items-center gap-2 mt-3">
         <button
           type="submit"

--- a/ui/src/pages/NotificationPublishersPage.tsx
+++ b/ui/src/pages/NotificationPublishersPage.tsx
@@ -40,7 +40,7 @@ import type {
   RecipeInfo,
 } from "../types";
 import { usePushSubscription } from "../hooks/usePushSubscription";
-import { deriveSourceZoneFilter } from "../lib/notif-mapping";
+import { deriveSourceZoneFilter, recipeInstanceLabel } from "../lib/notif-mapping";
 
 const ZONE_AGG_KEYS = [
   "temperature",
@@ -826,14 +826,11 @@ function MappingRow({
                 className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
               >
                 <option value="">{t("notifPublishers.selectSource")}</option>
-                {filteredRecipeInstances.map((inst) => {
-                  const recipe = recipes.find((r) => r.id === inst.recipeId);
-                  return (
-                    <option key={inst.id} value={inst.id}>
-                      {recipe?.name ?? inst.recipeId}
-                    </option>
-                  );
-                })}
+                {filteredRecipeInstances.map((inst) => (
+                  <option key={inst.id} value={inst.id}>
+                    {recipeInstanceLabel(inst, recipes, equipments)}
+                  </option>
+                ))}
               </select>
             </div>
           )}
@@ -1131,14 +1128,11 @@ function AddMappingForm({
               className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
             >
               <option value="">{t("notifPublishers.selectSource")}</option>
-              {filteredRecipeInstances.map((inst) => {
-                const recipe = recipes.find((r) => r.id === inst.recipeId);
-                return (
-                  <option key={inst.id} value={inst.id}>
-                    {recipe?.name ?? inst.recipeId}
-                  </option>
-                );
-              })}
+              {filteredRecipeInstances.map((inst) => (
+                <option key={inst.id} value={inst.id}>
+                  {recipeInstanceLabel(inst, recipes, equipments)}
+                </option>
+              ))}
             </select>
           </div>
         )}


### PR DESCRIPTION
Two UX improvements to the notification-mapping editor (same combo).

## 1. Restore the zone filter on re-edit (bug)
Re-editing a mapping whose source is a recipe/equipment picked in a specific zone showed the zone dropdown as "all zones" instead of the source's zone (e.g. a State Watch in the *cave*), and the source list came back unfiltered. Root cause: the zone dropdown (`filterZoneId`) is a selection aid that is not stored on the mapping, and it was never re-derived from the source on edit. Now derived from the source (recipe `params.zone` / equipment `zoneId`) at mount and when the edit button is clicked. Cosmetic (no data loss).

## 2. Show the target equipment(s) in the recipe combo (enhancement)
The recipe source dropdown showed only the recipe name, so several instances of the same recipe were indistinguishable. Now appends the equipment(s) the instance applies to, resolved from the recipe template's `equipment`-typed slots — e.g. **"State Watch (Machine à laver)"**.

Pure helpers extracted to `ui/src/lib/notif-mapping.ts` (`deriveSourceZoneFilter`, `recipeInstanceEquipmentNames`, `recipeInstanceLabel`).

## Test plan
- [x] `cd ui && npx tsc -b --noEmit` — 0 errors
- [x] `npx vitest run` — all pass (8 new tests in `notif-mapping.test.ts`)
- [x] `npx eslint` + `prettier --check` — clean
- [ ] Manual: recipe combo shows "Recipe (Equipment)"; re-editing a cave mapping shows "cave"

UI-only, no backend change.