### PR TITLE
release: v1.25.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,15 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.25.x: Éditeur de mappings de notification
+
+### v1.25.0 — 2026-07-01 { #v1-25-0 }
+
+- Fix (ui) : l'éditeur de mappings de notification restaure le filtre de zone à la ré-édition. Une recette ou un équipement choisi dans une zone précise (ex. un State Watch dans la cave) n'affiche plus « toutes les zones » avec une liste de sources non filtrée. (#291)
+- Feat (ui) : la liste déroulante des recettes affiche désormais le(s) équipement(s) ciblé(s) par chaque instance, ex. « State Watch (Machine à laver) », pour distinguer plusieurs instances d'une même recette. (#291)
+
+---
+
 ## 1.24.x: Notifications Web Push
 
 ### v1.24.3 — 2026-06-29 { #v1-24-3 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,15 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.25.x: Notification mapping editor
+
+### v1.25.0 — 2026-07-01 { #v1-25-0 }
+
+- Fix (ui): the notification mapping editor restores the zone filter when you re-edit a mapping. A recipe or equipment picked in a specific zone (e.g. a State Watch in the cave) no longer shows "all zones" with an unfiltered source list. (#291)
+- Feat (ui): the recipe source dropdown now shows the equipment(s) each recipe instance applies to, e.g. "State Watch (Machine à laver)", so several instances of the same recipe are distinguishable. (#291)
+
+---
+
 ## 1.24.x: Web Push notifications
 
 ### v1.24.3 — 2026-06-29 { #v1-24-3 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.24.3",
+  "version": "1.25.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.24.3",
+  "version": "1.25.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## v1.25.0 (minor)

Cuts the release for the notification mapping editor improvements merged in #291.

### Included
- **fix(ui): restore the zone filter on re-edit** of a notification mapping (#291)
- **feat(ui): show the target equipment(s) in the recipe source combo**, e.g. "State Watch (Machine à laver)" (#291)

### Release artifacts
- Version bump `package.json` + `ui/package.json` → 1.25.0
- Release notes added to `docs/release-notes.md` + `docs/release-notes.fr.md` with the `{ #v1-25-0 }` anchor (spec 108)

Merge, then tag `v1.25.0` on the merged commit to trigger the build.