### PR TITLE
chore(registry): bump state-watch to 2.0.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -195,7 +195,7 @@
     "icon": "Eye",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-state-watch",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "tags": ["automation", "monitoring", "alarm", "state"],
     "i18n": {
       "fr": {
@@ -205,7 +205,7 @@
     },
     "sowelVersion": ">=0.10.0",
     "owner": "mchacher",
-    "sha256": "2681cb43b3f591beb764eeb26696f9ef022691896ed0456795142c8f279650ec"
+    "sha256": "bda33aa647c4a4cbe75bcee8d7f733c4af3096afa0234e73157c509c48a81924"
   },
   {
     "id": "presence-heater",


### PR DESCRIPTION
Bumps the `state-watch` recipe to **2.0.0** (check window replaces the single check time) with the sha256 of the released tarball.

- Plugin release: https://github.com/mchacher/sowel-recipe-state-watch/releases/tag/v2.0.0
- sha256 recomputed via `scripts/backfill-registry-sha256.mjs`.

**BREAKING** for the recipe: the `checkTime` slot is removed in favour of an optional check window (`checkStart`/`checkEnd`, may cross midnight); monitoring is permanent by default. Instances that used `checkTime` must be reconfigured with a window after updating.