### PR TITLE
release: v1.26.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,14 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.26.x: Re-notification
+
+### v1.26.0 — 2026-07-07 { #v1-26-0 }
+
+- Feat (notifications) : les mappings de notification gagnent une option de re-notification explicite. Tant qu'une valeur mappée reste « active » (ex. l'alarme d'une surveillance d'état), la notification est renvoyée à intervalle régulier et s'arrête en silence une fois résolue. Choix par mapping : « Aucune », « Indéfiniment » ou « Limité à N rappels » — distinct de l'anti-spam. (#294)
+
+---
+
 ## 1.25.x: Éditeur de mappings de notification
 
 ### v1.25.0 — 2026-07-01 { #v1-25-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,14 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.26.x: Notification re-notify
+
+### v1.26.0 — 2026-07-07 { #v1-26-0 }
+
+- Feat (notifications): notification mappings gain an explicit re-notify option. While a mapped value stays "active" (e.g. a State Watch alarm), the notification is re-sent on a fixed cadence and stops silently once it clears. Pick "None", "Indefinitely" or "Limited to N reminders" per mapping — distinct from the anti-spam throttle. (#294)
+
+---
+
 ## 1.25.x: Notification mapping editor
 
 ### v1.25.0 — 2026-07-01 { #v1-25-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.25.0",
+  "version": "1.26.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## v1.26.0 (minor)

Cuts the release for the notification re-notify feature merged in #294.

### Included
- **feat(notifications): per-mapping re-notify (repeat) option** (spec 128, #294) — re-send a notification on a fixed cadence while the mapped value stays active, stop silently when it clears. Explicit mode: None / Forever / Limited N.

### Release artifacts
- Version bump → 1.26.0
- Release notes in `docs/release-notes.md` + `.fr.md` with `{ #v1-26-0 }` anchor (spec 108)

Merge, then tag `v1.26.0` to build.