### PR TITLE
chore(registry): bump auto-watering to 1.1.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -315,7 +315,7 @@
     "icon": "Droplets",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-auto-watering",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "tags": ["watering", "irrigation", "garden", "rain", "automation"],
     "i18n": {
       "fr": {
@@ -325,7 +325,7 @@
     },
     "sowelVersion": ">=1.1.0",
     "owner": "mchacher",
-    "sha256": "d69958de468f76302da71987cbab371bdf1d07fa35feb03719dabdbfe61df295"
+    "sha256": "710e62e009ae3462ef1dbaa43609a50620fe550afa1368fd826288cbb849da60"
   },
   {
     "id": "pool-pump-schedule",


### PR DESCRIPTION
Bumps **auto-watering** to **v1.1.0** (sha256 `710e62e0…`, matches the built tarball).

Fixes valve opening on all valve types: the recipe now opens with a plain `{state:"ON"}` (accepted by Tuya irrigation valves that reject `on_time`), then best-effort `{state:"ON", on_time}` for hardware auto-off on capable valves, plus a software off-timer and resume-across-restart. Diagnosed and validated live on a real Tuya irrigation valve.