### PR TITLE
chore(registry): bump zigbee2mqtt to 2.2.2

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -7,11 +7,11 @@
     "icon": "Radio",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-zigbee2mqtt",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "tags": ["zigbee", "mqtt", "z2m", "sensors", "lights", "switches"],
     "sowelVersion": ">=1.2.12",
     "owner": "mchacher",
-    "sha256": "825e122af377e4a771f29e1e318c76988afe011ab59615a47cb9824972aaadb5"
+    "sha256": "bf08556038711d81f85d76f341f963fe14e0944db407b5b70760a02947323c2d"
   },
   {
     "id": "lora2mqtt",


### PR DESCRIPTION
Bumps **zigbee2mqtt** to **v2.2.2** (sha256 `bf085560…`, matches the built tarball).

Fixes contact-sensor categorisation: `contact` is now categorised `contact_door` (was `contact`, unrecognised by core), so gate open/closed state and the zone openDoors count work for Zigbee door/window sensors (SNZB-04P, etc.). Existing devices re-categorise on next discovery — no re-pairing.