### PR TITLE
feat(equipments): metering-aware switch — power/energy on smart plugs (spec 129)

### DIFF
--- a/docs/user/equipments.md
+++ b/docs/user/equipments.md
@@ -137,9 +137,16 @@ Pool equipments work with the **Pool Pump Schedule** recipe (daily runtime tied 
 
 ### Other
 
-| Type              | Controls                    | Expected data  |
-| ----------------- | --------------------------- | -------------- |
-| **Switch / Plug** | Toggle ON/OFF + state badge | state (on/off) |
+| Type              | Controls                    | Expected data                         |
+| ----------------- | --------------------------- | ------------------------------------- |
+| **Switch / Plug** | Toggle ON/OFF + state badge | state (on/off); optional power/energy |
+
+A **metering plug** (e.g. SONOFF S60ZBTPF) is a `Switch / Plug` that also
+reports `power`/`energy`. Bind it as a switch and Sowel automatically captures
+the metering: the card shows live power next to the toggle, the consumption
+feeds the energy dashboard (history, HP/HC), and the plug appears in the live
+submeter breakdown — while keeping its ON/OFF control. A basic relay with no
+metering data behaves as a plain switch.
 
 ---
 

--- a/specs/129-switch-power-metering/architecture.md
+++ b/specs/129-switch-power-metering/architecture.md
@@ -1,0 +1,106 @@
+# Spec 129 — Architecture
+
+## Data model
+
+**No schema change.** No new `EquipmentType`, no new `DataCategory`, no
+migration.
+
+- `power`, `energy`, `voltage`, `current` already exist as `DataCategory`.
+- The `switch` equipment simply gains **optional** data bindings of those
+  categories, in addition to its on/off order binding.
+- "Metering switch" is not a stored flag — it is derived at runtime:
+  `type === "switch"` **and** has a `power` (and/or `energy`) binding.
+
+Shared predicate (new), used by both backend and UI so the definition stays in
+one place conceptually:
+
+```
+isMeteringSwitch(eq)      = eq.type === "switch" && hasBinding(eq, category "power" | "energy")
+isSubmeterEquipment(eq)   = eq.type === "energy_meter" || isMeteringSwitch(eq)
+```
+
+## Binding — `binding-candidates.ts` (`switch` case)
+
+Current: one candidate per on/off order, `dataKeys` = matching state key only.
+
+New: after collecting the on/off order candidates, **if there is exactly one
+on/off channel**, append the device's metering data keys (categories `power`,
+`energy`, `voltage`, `current`) to that single candidate's `dataKeys`.
+
+```
+switch case:
+  onOffOrders = deviceOrders.filter(isOnOffOrder)
+  candidates  = onOffOrders.map(o => { state data key + order key })
+  if candidates.length === 1:
+     meteringKeys = deviceData.filter(d => d.category ∈ {power,energy,voltage,current}).map(d => d.key)
+     candidates[0].dataKeys.push(...meteringKeys)   // deduped
+  return candidates
+```
+
+- Bare relay → no metering data → unchanged.
+- Multi-gang (≥2 on/off orders) → no metering attached (out of scope).
+- Binding alias defaults to the device data key (`power`, `energy`, …), which is
+  exactly what the energy pipeline keys off (`alias === "energy"`).
+
+## Energy history — no backend change
+
+`energy-aggregator.ts` triggers on `equipment.data.changed` where
+`alias === "energy"` and reads InfluxDB rows filtered by `category == "energy"`.
+`history-writer` persists bindings by category/`historize` flag, **not** by
+equipment type. So once a switch has an `energy` binding, energy points are
+written and aggregated identically to an `energy_meter`. **Verify** the `energy`
+category is historized by default; if not, ensure the binding is historized.
+
+## Power-only submeters — `power-submeter-integrator.ts`
+
+The integrator derives `energy` from `power` for submeters that report power but
+no energy. It currently filters `type === "energy_meter"` (lines ~142, ~196).
+
+Change: replace the `type === "energy_meter"` checks with `isSubmeterEquipment`
+so a **metering switch that reports power but not energy** also gets integrated
+energy. A metering switch that already reports `energy` is not integrated
+(it already has the alias, same guard as today for energy_meters that report
+energy directly).
+
+## UI — live power on the card
+
+`ui/src/components/home/CompactEquipmentCard.tsx`: today gated by
+`isEnergyMeter`. Add: for a `switch` with a `power` binding, render the live
+power headline (reuse the existing solar/energy value formatting: W below 1000,
+kW above). On/off toggle stays. Basic switch (no power binding) → unchanged.
+
+## UI — submeter breakdown
+
+`ui/src/components/energy/submeter-helpers.ts` `buildSubmeterRows` filters
+`eq.type === "energy_meter"`. Change the filter to `isSubmeterEquipment(eq)`
+(energy_meter OR metering switch). `readSubmeterPower` already reads the `power`
+binding, so it works unchanged for switches. `LiveSubmeterBreakdown` needs no
+change.
+
+## Event flow (metering plug)
+
+```
+z2m message (power/energy/state)
+  → z2m plugin → DeviceManager.updateDeviceData
+    → equipment.data.changed  (alias: power / energy / state)
+      → EquipmentManager (bindings incl. metering)
+      → history-writer  → InfluxDB (power, energy)
+      → energy-aggregator (alias=energy) → downsampled buckets
+      → power-submeter-integrator (if power-only) → derived energy
+    → WebSocket → UI: card power value + submeter donut slice
+```
+
+## Files changed
+
+| File | Change |
+| --- | --- |
+| `src/equipments/binding-candidates.ts` | `switch` case attaches metering data on single-channel plugs |
+| `src/equipments/metering.ts` (new, small) | `isMeteringSwitch` / `isSubmeterEquipment` helpers (shared, pure) |
+| `src/energy/power-submeter-integrator.ts` | use `isSubmeterEquipment` instead of `type === "energy_meter"` |
+| `ui/src/components/home/CompactEquipmentCard.tsx` | live power for a metering switch |
+| `ui/src/components/energy/submeter-helpers.ts` | include metering switches in `buildSubmeterRows` |
+| `ui/src/lib/metering.ts` (new, small) | UI mirror of the metering predicate |
+| `docs/user/equipments.md`, `docs/technical/data-model.md` | document metering-aware switch |
+
+No API route or WebSocket contract change (existing `equipment.data.changed`
+and equipment payloads already carry the bindings).

--- a/specs/129-switch-power-metering/plan.md
+++ b/specs/129-switch-power-metering/plan.md
@@ -1,0 +1,78 @@
+# Spec 129 — Implementation plan
+
+## Steps (in order)
+
+1. **Shared predicate** — `src/equipments/metering.ts`: `isMeteringSwitch(eq)`
+   and `isSubmeterEquipment(eq)` (pure, typed on `Equipment` + bindings). No
+   `any`.
+2. **Binding** — `src/equipments/binding-candidates.ts`: extend the `switch`
+   case to attach metering data keys (`power`/`energy`/`voltage`/`current`) to
+   the single on/off candidate. Leave multi-channel and bare-relay paths
+   unchanged.
+3. **Energy integrator** — `src/energy/power-submeter-integrator.ts`: swap the
+   `type === "energy_meter"` filters for `isSubmeterEquipment`. Keep the
+   "already reports energy → don't integrate" guard.
+4. **Verify history** — confirm the `energy`/`power` categories are historized by
+   default so a switch's energy reaches InfluxDB; adjust the binding default if
+   needed (no schema change).
+5. **Tests** (see test plan) — binding-candidates, metering predicate,
+   power-submeter-integrator.
+6. **UI predicate** — `ui/src/lib/metering.ts`: mirror `isMeteringSwitch` /
+   `isSubmeterEquipment` on `EquipmentWithDetails`.
+7. **UI card** — `CompactEquipmentCard.tsx`: render live power for a metering
+   switch (reuse solar/energy formatting), keep the toggle.
+8. **UI submeter** — `submeter-helpers.ts`: `buildSubmeterRows` uses
+   `isSubmeterEquipment`.
+9. **Docs** — update `docs/user/equipments.md` + `docs/technical/data-model.md`.
+
+## Task breakdown
+
+- [x] `metering.ts` predicate + unit test
+- [x] `binding-candidates.ts` switch metering attach + tests
+- [x] `power-submeter-integrator.ts` submeter predicate + tests
+- [x] history default verified (`power`/`energy` in `CATEGORY_DEFAULTS_ON`)
+- [x] `ui/lib/metering.ts` + test
+- [x] `CompactEquipmentCard` power display
+- [x] `submeter-helpers` filter + test
+- [x] docs
+
+## Test Plan
+
+### Modules to test
+
+- `src/equipments/metering.ts` (predicate)
+- `src/equipments/binding-candidates.ts` (switch metering binding)
+- `src/energy/power-submeter-integrator.ts` (submeter inclusion)
+- `ui/src/components/energy/submeter-helpers.ts` (`buildSubmeterRows`)
+
+### Scenarios
+
+| Module | Scenario | Expected |
+| --- | --- | --- |
+| metering | switch with power binding | `isMeteringSwitch` = true, `isSubmeterEquipment` = true |
+| metering | switch with energy but no power | `isMeteringSwitch` = true (energy counts) |
+| metering | bare switch (no metering) | both predicates false |
+| metering | energy_meter | `isMeteringSwitch` false, `isSubmeterEquipment` true |
+| binding-candidates | switch, device state+power+energy+voltage | one candidate: order `state` + dataKeys {state,power,energy,voltage} |
+| binding-candidates | switch, device state only (bare relay) | one candidate: order `state`, dataKeys {state} — unchanged |
+| binding-candidates | switch, device state+power only | candidate dataKeys include power |
+| binding-candidates | multi-gang (state_l1,state_l2,power) | 2 candidates, NO metering attached |
+| binding-candidates | light_onoff with power (regression) | unchanged — metering not attached to non-switch |
+| power-submeter-integrator | metering switch power-only | integrated into energy like an energy_meter submeter |
+| power-submeter-integrator | metering switch reporting energy | not integrated (already has energy) |
+| power-submeter-integrator | energy_meter (regression) | unchanged |
+| power-submeter-integrator | bare switch | ignored (not a submeter) |
+| submeter-helpers | energy_meter + metering switch + bare switch | rows contain energy_meter + metering switch, exclude bare switch |
+| submeter-helpers | metering switch power value | `readSubmeterPower` returns its power |
+
+### Retro-compat
+
+- Bare switches: identical binding, no card power, absent from energy views.
+- `energy_meter`, `main_energy_meter`, submeter donut, energy history: unchanged
+  for existing equipments.
+
+## Manual verification (friend's instance / demo)
+
+- Recreate a `switch` on a S60ZBTPF → card shows live power, plug appears in the
+  submeter donut, energy accrues in the dashboard, on/off still works.
+- A bare Zigbee relay switch is unchanged.

--- a/specs/129-switch-power-metering/spec.md
+++ b/specs/129-switch-power-metering/spec.md
@@ -1,0 +1,90 @@
+# Spec 129 — Metering-aware switch (power/energy on smart plugs)
+
+## Context
+
+Metering smart plugs (e.g. SONOFF **S60ZBTPF** via Zigbee2MQTT) are both a
+controllable **on/off switch** and an **energy meter**: they report `power`,
+`energy`, `voltage`, `current` alongside the `state` order.
+
+Today a plug modelled as a `switch` equipment **drops its metering**: the
+`switch` binding candidate only captures the on/off channel
+(`binding-candidates.ts`), the equipment card shows only on/off, and the plug is
+excluded from the energy views. Modelling it as `energy_meter` captures the
+metering but hides the on/off control. Neither type fits a metering plug.
+
+The Zigbee2MQTT categories are already correct (`power`/`energy`/`voltage`/
+`current`) — the gap is in the **core equipment model**, not the plugin.
+
+## Goal
+
+Make the `switch` type **metering-aware and polymorphic**: a basic relay keeps
+behaving exactly as today (on/off only), while a metering plug additionally
+surfaces its live power, feeds the energy history, and appears in the live
+submeter breakdown — all on a single equipment that keeps its on/off control.
+
+## Requirements
+
+1. **Polymorphic binding** — the `switch` auto-binding captures the on/off
+   channel **plus**, when the device exposes them, the metering data
+   (`power`, `energy`, `voltage`, `current`). A device with no metering data
+   binds exactly as today (no regression).
+2. **Live power on the card** — a `switch` equipment that has a `power` binding
+   shows its instantaneous power (W/kW) on the equipment card, in addition to
+   the on/off control. A switch without a power binding shows on/off only.
+3. **Energy in history** — a `switch` with an `energy` binding feeds the
+   existing energy history/aggregation pipeline (InfluxDB → daily/monthly,
+   HP/HC) exactly like an `energy_meter`, via the alias/category-driven path.
+4. **Live submeter breakdown** — a metering `switch` (has a `power` binding)
+   appears in the live per-equipment consumption donut, alongside
+   `energy_meter` submeters.
+5. **On/off control preserved** — the metering switch keeps its `state` order
+   and its toggle in the UI.
+6. **No regression for basic switches** — switches with no metering bindings are
+   unchanged in binding, display, energy views, and status.
+
+## Acceptance criteria
+
+- [x] Creating a `switch` equipment on a device that exposes `state` +
+      `power`/`energy` auto-suggests a candidate that binds the on/off channel
+      **and** the metering data.
+- [x] Creating a `switch` on a bare relay (state only) binds on/off only —
+      identical to current behaviour.
+- [x] The equipment card of a metering switch shows live power (W/kW) + the
+      on/off toggle; a basic switch shows only the toggle.
+- [x] A metering switch's `energy` binding produces energy history points and
+      appears in the energy dashboard (same as an `energy_meter`) — via the
+      default-historized `energy` category + alias-driven aggregator.
+- [x] A metering switch appears in the live submeter donut; a basic switch does
+      not.
+- [x] All existing `switch`, energy, and submeter tests still pass (920 pass).
+
+## Scope
+
+**In scope**
+- Metering-aware `switch` binding (single on/off channel + shared metering).
+- Live power on the switch equipment card.
+- Energy history for a switch that reports `energy`.
+- Inclusion of metering switches in the live submeter breakdown.
+- Power-only metering switches: fold them into the submeter power→energy
+  integrator so they also get energy history (a common plug variant that
+  reports `power` but not `energy`).
+
+**Out of scope**
+- New equipment type (`smart_plug`) — rejected in favour of extending `switch`.
+- New `DataCategory` or DB migration.
+- **Multi-gang** metering (per-channel `power1`/`power2`): a device with more
+  than one on/off channel does **not** auto-attach metering (kept as basic
+  per-channel switches; user can bind manually). Documented as a known gap.
+- Changes to the Zigbee2MQTT plugin (categories already correct).
+
+## Edge cases
+
+| Case | Expected |
+| --- | --- |
+| Device with `state` only (bare relay) | Binds on/off only; card shows toggle only; not in energy views. |
+| Device with `state` + `power` + `energy` | Binds all; card shows power; energy in history; in submeter donut. |
+| Device with `state` + `power` only (no energy) | Binds power; card shows power; integrator derives energy; in donut. |
+| Multi-gang plug (`state_l1`, `state_l2`, `power_l1`…) | Per-channel on/off switches; metering NOT auto-attached (out of scope). |
+| Metering switch turned OFF (power = 0) | Card shows 0 W; donut slice ~0; no anomaly. |
+| Switch with metering but `power` stops updating | Standard spec-116 stale/degraded behaviour on the streaming binding. |
+| Existing basic switches after upgrade | Unchanged — no metering bindings created retroactively. |

--- a/src/energy/power-submeter-integrator.test.ts
+++ b/src/energy/power-submeter-integrator.test.ts
@@ -122,6 +122,72 @@ describe("PowerSubmeterIntegrator", () => {
     integ.stop();
   });
 
+  it("integrates a metering switch reporting power but not energy (spec 129)", () => {
+    db.prepare(
+      `INSERT INTO equipments (id, name, zone_id, type, enabled) VALUES (?, ?, ?, ?, 1)`,
+    ).run("eq-plug", "Prise", "zone-1", "switch");
+    const equipmentManager = {
+      getById: vi.fn((id: string) =>
+        id === "eq-plug"
+          ? { id, name: "Prise", zoneId: "zone-1", type: "switch", enabled: true }
+          : null,
+      ),
+      getAll: vi.fn(() => [
+        { id: "eq-plug", name: "Prise", zoneId: "zone-1", type: "switch", enabled: true },
+      ]),
+      getDataBindingsWithValues: vi.fn(() => [{ alias: "power", category: "power", value: 1000 }]),
+    } as unknown as EquipmentManager;
+    const writePoint = vi.fn();
+    const influxClient = { isConnected: vi.fn(() => true), writePoint } as unknown as InfluxClient;
+
+    let now = 1_700_000_000_000;
+    const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {
+      now: () => now,
+      flushIntervalMs: 60_000,
+    });
+    integ.init();
+    integ.start();
+    emitPower(bus, "eq-plug", 1000);
+    now += 60_000;
+    emitPower(bus, "eq-plug", 1000);
+    integ.flushAll();
+    expect(writePoint).toHaveBeenCalledOnce();
+    integ.stop();
+  });
+
+  it("ignores a bare switch with no power binding (spec 129)", () => {
+    db.prepare(
+      `INSERT INTO equipments (id, name, zone_id, type, enabled) VALUES (?, ?, ?, ?, 1)`,
+    ).run("eq-relay", "Relais", "zone-1", "switch");
+    const equipmentManager = {
+      getById: vi.fn((id: string) =>
+        id === "eq-relay"
+          ? { id, name: "Relais", zoneId: "zone-1", type: "switch", enabled: true }
+          : null,
+      ),
+      getAll: vi.fn(() => [
+        { id: "eq-relay", name: "Relais", zoneId: "zone-1", type: "switch", enabled: true },
+      ]),
+      getDataBindingsWithValues: vi.fn(() => [{ alias: "state", category: "light_state", value: "ON" }]),
+    } as unknown as EquipmentManager;
+    const writePoint = vi.fn();
+    const influxClient = { isConnected: vi.fn(() => true), writePoint } as unknown as InfluxClient;
+
+    let now = 1_700_000_000_000;
+    const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {
+      now: () => now,
+      flushIntervalMs: 60_000,
+    });
+    integ.init();
+    integ.start();
+    emitPower(bus, "eq-relay", 1000);
+    now += 60_000;
+    emitPower(bus, "eq-relay", 1000);
+    integ.flushAll();
+    expect(writePoint).not.toHaveBeenCalled();
+    integ.stop();
+  });
+
   it("trapezoidal integration with rising power: prev=500, curr=1500, dt=60s → ~16.67 Wh", () => {
     const { equipmentManager, influxClient, writePoint } = makeStubs();
     let now = 1_700_000_000_000;

--- a/src/energy/power-submeter-integrator.test.ts
+++ b/src/energy/power-submeter-integrator.test.ts
@@ -168,7 +168,9 @@ describe("PowerSubmeterIntegrator", () => {
       getAll: vi.fn(() => [
         { id: "eq-relay", name: "Relais", zoneId: "zone-1", type: "switch", enabled: true },
       ]),
-      getDataBindingsWithValues: vi.fn(() => [{ alias: "state", category: "light_state", value: "ON" }]),
+      getDataBindingsWithValues: vi.fn(() => [
+        { alias: "state", category: "light_state", value: "ON" },
+      ]),
     } as unknown as EquipmentManager;
     const writePoint = vi.fn();
     const influxClient = { isConnected: vi.fn(() => true), writePoint } as unknown as InfluxClient;

--- a/src/energy/power-submeter-integrator.ts
+++ b/src/energy/power-submeter-integrator.ts
@@ -4,6 +4,7 @@ import type { EventBus } from "../core/event-bus.js";
 import type { Logger } from "../core/logger.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { InfluxClient } from "../core/influx-client.js";
+import { isSubmeterEquipment } from "../equipments/metering.js";
 
 /**
  * Power-only submeter integration.
@@ -139,7 +140,11 @@ export class PowerSubmeterIntegrator {
    * the energy counter moving when the device only reports on change.
    */
   private catchUpFromBindings(): void {
-    const equipments = this.equipmentManager.getAll().filter((e) => e.type === "energy_meter");
+    // energy_meter submeters + metering switches (spec 129). Bare switches are
+    // filtered out by isPowerOnlySubmeter (no power binding).
+    const equipments = this.equipmentManager
+      .getAll()
+      .filter((e) => e.type === "energy_meter" || e.type === "switch");
     for (const eq of equipments) {
       if (!this.isPowerOnlySubmeter(eq.id)) continue;
       const bindings = this.equipmentManager.getDataBindingsWithValues(eq.id);
@@ -193,8 +198,11 @@ export class PowerSubmeterIntegrator {
    */
   private isPowerOnlySubmeter(equipmentId: string): boolean {
     const eq = this.equipmentManager.getById(equipmentId);
-    if (!eq || eq.type !== "energy_meter" || !eq.enabled) return false;
+    if (!eq || !eq.enabled) return false;
     const bindings = this.equipmentManager.getDataBindingsWithValues(equipmentId);
+    // A dedicated energy_meter or a metering switch (spec 129) that reports
+    // power but not energy — derive its energy from power.
+    if (!isSubmeterEquipment(eq.type, bindings)) return false;
     const hasPower = bindings.some((b) => b.alias === "power" || b.category === "power");
     const hasEnergy = bindings.some((b) => b.alias === "energy" || b.category === "energy");
     return hasPower && !hasEnergy;

--- a/src/equipments/binding-candidates.test.ts
+++ b/src/equipments/binding-candidates.test.ts
@@ -109,6 +109,66 @@ describe("computeBindingCandidates", () => {
     expect(result).toHaveLength(0);
   });
 
+  // Spec 129 — metering-aware switch (SONOFF S60ZBTPF etc.)
+  it("metering plug (state + power/energy/voltage/current) → binds on/off + metering", () => {
+    const orders = [order("state", "boolean", { category: "light_toggle" })];
+    const datas = [
+      data("state", "boolean", { category: "light_state", value: "ON" }),
+      data("power", "number", { category: "power", value: 42 }),
+      data("energy", "number", { category: "energy", value: 1.5 }),
+      data("voltage", "number", { category: "voltage", value: 230 }),
+      data("current", "number", { category: "current", value: 0.2 }),
+      data("linkquality", "number", { category: "generic", value: 100 }),
+    ];
+    const result = computeBindingCandidates("switch", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].orderKeys).toEqual(["state"]);
+    expect(result[0].dataKeys.sort()).toEqual(["current", "energy", "power", "state", "voltage"]);
+  });
+
+  it("metering plug reporting power but not energy → binds power", () => {
+    const orders = [order("state", "boolean", { category: "light_toggle" })];
+    const datas = [
+      data("state", "boolean", { category: "light_state", value: "ON" }),
+      data("power", "number", { category: "power", value: 42 }),
+    ];
+    const result = computeBindingCandidates("switch", datas, orders);
+    expect(result[0].dataKeys.sort()).toEqual(["power", "state"]);
+  });
+
+  it("bare relay (state only) → no metering attached (unchanged)", () => {
+    const orders = [order("state", "boolean", { category: "light_toggle" })];
+    const datas = [data("state", "boolean", { category: "light_state", value: "OFF" })];
+    const result = computeBindingCandidates("switch", datas, orders);
+    expect(result[0].dataKeys).toEqual(["state"]);
+  });
+
+  it("multi-gang switch (2 channels) → metering NOT auto-attached", () => {
+    const orders = [
+      order("state_left", "boolean", { category: "light_toggle" }),
+      order("state_right", "boolean", { category: "light_toggle" }),
+    ];
+    const datas = [
+      data("state_left", "boolean", { category: "light_state" }),
+      data("state_right", "boolean", { category: "light_state" }),
+      data("power", "number", { category: "power", value: 10 }),
+    ];
+    const result = computeBindingCandidates("switch", datas, orders);
+    expect(result).toHaveLength(2);
+    expect(result.flatMap((c) => c.dataKeys)).not.toContain("power");
+  });
+
+  it("light_onoff with power data → metering NOT attached (switch-only feature)", () => {
+    const orders = [order("state", "enum", { enumValues: ["ON", "OFF"] })];
+    const datas = [
+      data("state", "enum", { category: "light_state" }),
+      data("power", "number", { category: "power", value: 5 }),
+    ];
+    const result = computeBindingCandidates("light_onoff", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].dataKeys).toEqual(["state"]);
+  });
+
   it("sensor on a multi-data device → one all-data candidate", () => {
     const datas = [
       data("temperature", "number", { category: "temperature" }),

--- a/src/equipments/binding-candidates.ts
+++ b/src/equipments/binding-candidates.ts
@@ -16,6 +16,7 @@
  */
 
 import type { DeviceData, DeviceOrder, EquipmentType, OrderCategory } from "../shared/types.js";
+import { METERING_CATEGORIES } from "./metering.js";
 
 export interface BindingCandidate {
   /** Stable id used by the UI picker (e.g. "power1", "shutter1", "all"). */
@@ -93,6 +94,18 @@ export function computeBindingCandidates(
           dataKeys: matchingData ? [matchingData.key] : [],
           orderKeys: [o.key],
         });
+      }
+      // Metering plug (spec 129): a single-channel switch also captures its
+      // power/energy/voltage/current so it can surface live power + feed the
+      // energy history. A bare relay (no metering data) is unchanged. Multi-gang
+      // plugs (>1 on/off channel) are left as basic switches — per-channel
+      // metering attribution is out of scope.
+      if (candidates.length === 1) {
+        const meteringKeys = deviceData
+          .filter((d) => METERING_CATEGORIES.has(d.category))
+          .map((d) => d.key)
+          .filter((k) => !candidates[0].dataKeys.includes(k));
+        candidates[0].dataKeys.push(...meteringKeys);
       }
       return candidates;
     }

--- a/src/equipments/metering.test.ts
+++ b/src/equipments/metering.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { hasMeteringBinding, isMeteringSwitch, isSubmeterEquipment } from "./metering.js";
+
+const power = [{ alias: "power", category: "power" }];
+const energy = [{ alias: "energy", category: "energy" }];
+const state = [{ alias: "state", category: "light_state" }];
+const battery = [{ alias: "battery", category: "battery" }];
+
+describe("metering helpers (spec 129)", () => {
+  it("hasMeteringBinding detects power or energy channels", () => {
+    expect(hasMeteringBinding(power)).toBe(true);
+    expect(hasMeteringBinding(energy)).toBe(true);
+    expect(hasMeteringBinding([...state, ...battery])).toBe(false);
+    expect(hasMeteringBinding([])).toBe(false);
+  });
+
+  it("isMeteringSwitch: switch with power/energy is a metering plug", () => {
+    expect(isMeteringSwitch("switch", power)).toBe(true);
+    expect(isMeteringSwitch("switch", energy)).toBe(true);
+    expect(isMeteringSwitch("switch", state)).toBe(false); // bare relay
+    expect(isMeteringSwitch("light_onoff", power)).toBe(false); // not a switch
+    expect(isMeteringSwitch("energy_meter", power)).toBe(false); // not a switch
+  });
+
+  it("isSubmeterEquipment: energy_meter OR metering switch", () => {
+    expect(isSubmeterEquipment("energy_meter", [])).toBe(true);
+    expect(isSubmeterEquipment("switch", power)).toBe(true);
+    expect(isSubmeterEquipment("switch", state)).toBe(false); // bare relay
+    expect(isSubmeterEquipment("main_energy_meter", power)).toBe(false); // house total, not a submeter
+    expect(isSubmeterEquipment("light_onoff", power)).toBe(false);
+  });
+});

--- a/src/equipments/metering.ts
+++ b/src/equipments/metering.ts
@@ -1,0 +1,56 @@
+// ============================================================
+// Metering-aware switch helpers (spec 129)
+// ============================================================
+//
+// A smart plug (e.g. SONOFF S60ZBTPF) is both an on/off `switch` and an energy
+// meter: it reports power/energy alongside its `state` order. The `switch` type
+// is polymorphic — a bare relay has no metering bindings and behaves as before,
+// while a metering plug additionally surfaces power/energy. These pure helpers
+// centralise "is this switch a metering plug?" and "does this equipment count
+// as a consumption submeter?" so the binding, energy, and UI layers agree.
+
+import type { DataCategory, EquipmentType } from "../shared/types.js";
+
+/** Device-data categories that make a plug a meter (bound in addition to on/off). */
+export const METERING_CATEGORIES: ReadonlySet<DataCategory> = new Set<DataCategory>([
+  "power",
+  "energy",
+  "voltage",
+  "current",
+]);
+
+interface BindingLike {
+  alias?: string | null;
+  category?: string | null;
+}
+
+/** True when the bindings carry a meaningful metering channel (power or energy). */
+export function hasMeteringBinding(bindings: readonly BindingLike[]): boolean {
+  return bindings.some(
+    (b) =>
+      b.category === "power" ||
+      b.category === "energy" ||
+      b.alias === "power" ||
+      b.alias === "energy",
+  );
+}
+
+/** A `switch` that also reports power/energy — a metering smart plug. */
+export function isMeteringSwitch(
+  type: EquipmentType,
+  bindings: readonly BindingLike[],
+): boolean {
+  return type === "switch" && hasMeteringBinding(bindings);
+}
+
+/**
+ * Equipments that count as per-equipment consumption submeters: dedicated
+ * `energy_meter`s and metering switches. (Not `main_energy_meter` /
+ * `energy_production_meter`, which are the house total and production.)
+ */
+export function isSubmeterEquipment(
+  type: EquipmentType,
+  bindings: readonly BindingLike[],
+): boolean {
+  return type === "energy_meter" || isMeteringSwitch(type, bindings);
+}

--- a/src/equipments/metering.ts
+++ b/src/equipments/metering.ts
@@ -36,10 +36,7 @@ export function hasMeteringBinding(bindings: readonly BindingLike[]): boolean {
 }
 
 /** A `switch` that also reports power/energy — a metering smart plug. */
-export function isMeteringSwitch(
-  type: EquipmentType,
-  bindings: readonly BindingLike[],
-): boolean {
+export function isMeteringSwitch(type: EquipmentType, bindings: readonly BindingLike[]): boolean {
   return type === "switch" && hasMeteringBinding(bindings);
 }
 

--- a/ui/src/components/energy/submeter-helpers.test.ts
+++ b/ui/src/components/energy/submeter-helpers.test.ts
@@ -108,13 +108,23 @@ describe("readSubmeterPower", () => {
 });
 
 describe("buildSubmeterRows", () => {
-  it("filters non-energy_meter equipments out", () => {
+  it("filters main/production meters out", () => {
     const rows = buildSubmeterRows([
       makeEquipment("a", "PAC", { power: 100 }),
       makeEquipment("b", "Shelly Grid", { type: "main_energy_meter", power: 200 }),
       makeEquipment("c", "Shelly Solar", { type: "energy_production_meter", power: 300 }),
     ]);
     expect(rows.map((r) => r.name)).toEqual(["PAC"]);
+  });
+
+  it("includes metering switches, excludes bare relays (spec 129)", () => {
+    const rows = buildSubmeterRows([
+      makeEquipment("a", "PAC", { power: 100 }),
+      makeEquipment("b", "Prise Bureau", { type: "switch", power: 40 }),
+      makeEquipment("c", "Relais nu", { type: "switch", power: null }),
+    ]);
+    // PAC (100) + metering switch (40), sorted by power desc; bare relay excluded.
+    expect(rows.map((r) => r.name)).toEqual(["PAC", "Prise Bureau"]);
   });
 
   it("assigns colors by sorted-id index (stable across power reorders)", () => {

--- a/ui/src/components/energy/submeter-helpers.ts
+++ b/ui/src/components/energy/submeter-helpers.ts
@@ -6,6 +6,7 @@
 
 import type { EquipmentStatus, EquipmentWithDetails } from "../../types";
 import { pickSubmeterColor } from "./submeterPalette";
+import { isSubmeterEquipment } from "../../lib/metering";
 
 export interface SubmeterRow {
   id: string;
@@ -35,7 +36,7 @@ export function readSubmeterPower(eq: EquipmentWithDetails): number | null {
 /**
  * Build the legend rows for the donut.
  * Steps:
- *   1. Filter to `energy_meter` equipments only.
+ *   1. Filter to submeters: `energy_meter`s + metering switches (spec 129).
  *   2. Sort by `id` ascending and assign a palette color by index — this is
  *      the SAME indexing rule the backend uses for the historical By-usage
  *      chart, so a given equipment gets the same color in both views.
@@ -46,7 +47,7 @@ export function buildSubmeterRows(
   equipments: EquipmentWithDetails[],
 ): SubmeterRow[] {
   const byId = [...equipments]
-    .filter((eq) => eq.type === "energy_meter")
+    .filter((eq) => isSubmeterEquipment(eq))
     .sort((a, b) => a.id.localeCompare(b.id));
 
   const rows: SubmeterRow[] = byId.map((eq, idx) => ({

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -97,6 +97,16 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
         return typeof p?.value === "number" ? p.value : null;
       })()
     : null;
+
+  // Metering switch (spec 129): a smart plug that reports power shows it live
+  // next to the on/off toggle. A bare relay has no power binding → null.
+  const switchPowerW =
+    isSwitch
+      ? (() => {
+          const p = equipment.dataBindings.find((b) => b.category === "power");
+          return typeof p?.value === "number" ? p.value : null;
+        })()
+      : null;
   const primaryBinding = !isKnownType
     ? equipment.dataBindings[0] ?? null
     : null;
@@ -200,13 +210,23 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
         </span>
       )}
 
-      {/* Light / switch controls (smart plug = ON/OFF relay, same surface) */}
+      {/* Light / switch controls (smart plug = ON/OFF relay, same surface).
+       * Metering plug (spec 129): show live power (amber) next to the toggle. */}
       {(isLight || isSwitch) && equipment.enabled && (
-        <LightControl
-          equipment={equipment}
-          onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
-          compact
-        />
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {switchPowerW !== null && (
+            <span className="text-[13px] font-semibold text-accent tabular-nums font-mono">
+              {switchPowerW >= 1000
+                ? `${(switchPowerW / 1000).toFixed(2)} kW`
+                : `${Math.round(switchPowerW)} W`}
+            </span>
+          )}
+          <LightControl
+            equipment={equipment}
+            onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
+            compact
+          />
+        </div>
       )}
 
       {/* Shutter / Awning controls (shared compact control with awning vocabulary swap) */}

--- a/ui/src/lib/metering.test.ts
+++ b/ui/src/lib/metering.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import type { EquipmentWithDetails } from "../types";
+import { isMeteringSwitch, isSubmeterEquipment } from "./metering";
+
+function eq(
+  type: EquipmentWithDetails["type"],
+  bindings: { alias: string; category?: string }[],
+): EquipmentWithDetails {
+  return {
+    id: "e",
+    name: "E",
+    zoneId: "z",
+    type,
+    enabled: true,
+    createdAt: "2026-05-01 00:00:00Z",
+    updatedAt: "2026-05-01 00:00:00Z",
+    dataBindings: bindings.map((b) => ({
+      id: "b-" + b.alias,
+      equipmentId: "e",
+      deviceDataId: "dd",
+      deviceId: "d",
+      deviceName: "D",
+      key: b.alias,
+      alias: b.alias,
+      type: "number",
+      category: (b.category ?? "generic") as EquipmentWithDetails["dataBindings"][number]["category"],
+      value: 0,
+      lastUpdated: null,
+      lastChanged: null,
+      stale: false,
+    })),
+    orderBindings: [],
+    status: "online",
+  } as EquipmentWithDetails;
+}
+
+describe("metering (UI) — spec 129", () => {
+  it("isMeteringSwitch: switch with power/energy only", () => {
+    expect(isMeteringSwitch(eq("switch", [{ alias: "power", category: "power" }]))).toBe(true);
+    expect(isMeteringSwitch(eq("switch", [{ alias: "energy", category: "energy" }]))).toBe(true);
+    expect(isMeteringSwitch(eq("switch", [{ alias: "state", category: "light_state" }]))).toBe(false);
+    expect(isMeteringSwitch(eq("light_onoff", [{ alias: "power", category: "power" }]))).toBe(false);
+  });
+
+  it("isSubmeterEquipment: energy_meter or metering switch", () => {
+    expect(isSubmeterEquipment(eq("energy_meter", []))).toBe(true);
+    expect(isSubmeterEquipment(eq("switch", [{ alias: "power", category: "power" }]))).toBe(true);
+    expect(isSubmeterEquipment(eq("switch", [{ alias: "state", category: "light_state" }]))).toBe(false);
+    expect(isSubmeterEquipment(eq("main_energy_meter", [{ alias: "power", category: "power" }]))).toBe(false);
+  });
+});

--- a/ui/src/lib/metering.ts
+++ b/ui/src/lib/metering.ts
@@ -1,0 +1,22 @@
+// Metering-aware switch helpers (spec 129) — UI mirror of
+// src/equipments/metering.ts. A `switch` with a power/energy binding is a
+// metering smart plug (e.g. SONOFF S60ZBTPF): it shows live power and counts
+// as a consumption submeter, while a bare relay stays a plain on/off switch.
+import type { EquipmentWithDetails } from "../types";
+
+export function isMeteringSwitch(eq: EquipmentWithDetails): boolean {
+  return (
+    eq.type === "switch" &&
+    eq.dataBindings.some(
+      (b) =>
+        b.category === "power" ||
+        b.category === "energy" ||
+        b.alias === "power" ||
+        b.alias === "energy",
+    )
+  );
+}
+
+export function isSubmeterEquipment(eq: EquipmentWithDetails): boolean {
+  return eq.type === "energy_meter" || isMeteringSwitch(eq);
+}


### PR DESCRIPTION
## Summary

A metering smart plug (SONOFF **S60ZBTPF** etc.) is both an on/off **switch** and an **energy meter**. Modelled as a `switch` it dropped its power/energy; as an `energy_meter` it lost the visible on/off control. This makes `switch` **polymorphic**: a bare relay behaves exactly as before, a metering plug additionally surfaces its power/energy — on a single equipment that keeps its ON/OFF control.

Found on a live instance where SONOFF plugs report `power`/`energy` over Zigbee2MQTT but Sowel ignored them.

## Changes

- **Binding** (`binding-candidates.ts`): a single-channel `switch` also binds `power`/`energy`/`voltage`/`current` when present. Bare relay unchanged; multi-gang metering out of scope.
- **Shared predicate** (`src/equipments/metering.ts` + `ui/src/lib/metering.ts`): `isMeteringSwitch` / `isSubmeterEquipment`.
- **Energy integrator** (`power-submeter-integrator.ts`): metering switches count as consumption submeters (power→energy for power-only plugs).
- **UI**: equipment card shows **live power** next to the toggle (`CompactEquipmentCard`); the **live submeter donut** includes metering switches (`submeter-helpers`).
- **Energy history**: works through the existing `alias=energy` pipeline — `power`/`energy` are historized by default. **No history-writer, schema, or migration change; no new EquipmentType/DataCategory.**
- Docs: `docs/user/equipments.md`. Spec: `specs/129-switch-power-metering/`.

## Test plan

- [x] `npx tsc --noEmit` (backend) + `cd ui && npx tsc -b --noEmit` — 0 errors
- [x] `npx vitest run` — 920 pass / 2 skip, incl. new: metering predicate (backend + UI), switch binding (bare / metering / power-only / multi-gang / light regression), submeter-integrator inclusion (+ bare-switch exclusion), submeter donut filter
- [x] `eslint` backend + UI — 0 errors
- [ ] Manual: recreate a `switch` on a S60ZBTPF → card shows live power, plug in the submeter donut, energy accrues, on/off still works; a bare relay is unchanged