### PR TITLE
release: v1.27.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,14 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.27.x: Prise avec métrologie
+
+### v1.27.0 — 2026-07-10 { #v1-27-0 }
+
+- Feat (équipements) : un Interrupteur / Prise remonte désormais la puissance et l'énergie quand l'appareil les fournit. Une prise connectée à métrologie (ex. SONOFF S60ZBTPF en Zigbee2MQTT) modélisée en Interrupteur affiche sa puissance instantanée à côté du bouton on/off, alimente le tableau de bord énergie (historique et HP/HC) et apparaît dans la répartition live par équipement, tout en gardant sa commande marche/arrêt. Un relais basique sans métrologie ne change pas. (#300)
+
+---
+
 ## 1.26.x: Re-notification
 
 ### v1.26.0 — 2026-07-07 { #v1-26-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,14 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.27.x: Metering-aware switch
+
+### v1.27.0 — 2026-07-10 { #v1-27-0 }
+
+- Feat (equipments): a Switch / Plug now surfaces power and energy when the device reports them. A metering smart plug (e.g. SONOFF S60ZBTPF over Zigbee2MQTT) modelled as a Switch shows its live power next to the on/off toggle, feeds the energy dashboard (history and HP/HC), and appears in the live submeter breakdown, while keeping its ON/OFF control. A basic relay with no metering behaves exactly as before. (#300)
+
+---
+
 ## 1.26.x: Notification re-notify
 
 ### v1.26.0 — 2026-07-07 { #v1-26-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.26.0",
+  "version": "1.27.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release **v1.27.0** — metering-aware switch (spec 129, #300).

- Version bump: `package.json` + `ui/package.json` → 1.27.0
- Release notes added in EN + FR with the `{ #v1-27-0 }` anchor (spec 108)

Merge, then the on-main commit is tagged `v1.27.0` to trigger the Docker build.