### PR TITLE
fix(ui): attach metering bindings on the switch candidate (spec 129)

### DIFF
--- a/ui/src/lib/binding-candidates.test.ts
+++ b/ui/src/lib/binding-candidates.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { computeBindingCandidates } from "./binding-candidates";
+import type { DeviceData, DeviceOrder } from "../types";
+
+function order(key: string, extra: Partial<DeviceOrder> = {}): DeviceOrder {
+  return { id: key, deviceId: "DEV", key, type: "boolean", ...extra };
+}
+function data(key: string, extra: Partial<DeviceData> = {}): DeviceData {
+  return {
+    id: key,
+    deviceId: "DEV",
+    key,
+    type: "number",
+    category: "generic",
+    value: null,
+    lastUpdated: null,
+    ...extra,
+  };
+}
+
+// SONOFF S60ZBTPF: single on/off `state` (light_toggle) + power/energy metering.
+describe("computeBindingCandidates — metering switch (spec 129)", () => {
+  it("binds on/off + power/energy/voltage/current on a metering plug", () => {
+    const orders = [
+      order("state", { category: "light_toggle" }),
+      order("max_power", { category: undefined }), // config order, ignored
+    ];
+    const datas = [
+      data("state", { type: "boolean", category: "light_state", value: "ON" }),
+      data("power", { category: "power", value: 42 }),
+      data("energy", { category: "energy", value: 1.5 }),
+      data("voltage", { category: "voltage", value: 238 }),
+      data("current", { category: "current", value: 0.2 }),
+      data("energy_today", { category: "generic", value: 0.3 }), // not a metering category
+      data("linkquality", { category: "generic", value: 120 }),
+    ];
+    const result = computeBindingCandidates("switch", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].orderKeys).toEqual(["state"]);
+    expect(result[0].dataKeys.sort()).toEqual(["current", "energy", "power", "state", "voltage"]);
+  });
+
+  it("bare relay (state only) → no metering attached", () => {
+    const orders = [order("state", { category: "light_toggle" })];
+    const datas = [data("state", { type: "boolean", category: "light_state", value: "OFF" })];
+    const result = computeBindingCandidates("switch", datas, orders);
+    expect(result[0].dataKeys).toEqual(["state"]);
+  });
+
+  it("multi-gang (2 channels) → metering NOT auto-attached", () => {
+    const orders = [
+      order("state_left", { category: "light_toggle" }),
+      order("state_right", { category: "light_toggle" }),
+    ];
+    const datas = [
+      data("state_left", { type: "boolean", category: "light_state" }),
+      data("state_right", { type: "boolean", category: "light_state" }),
+      data("power", { category: "power", value: 10 }),
+    ];
+    const result = computeBindingCandidates("switch", datas, orders);
+    expect(result).toHaveLength(2);
+    expect(result.flatMap((c) => c.dataKeys)).not.toContain("power");
+  });
+});

--- a/ui/src/lib/binding-candidates.ts
+++ b/ui/src/lib/binding-candidates.ts
@@ -10,6 +10,7 @@
  */
 
 import type { DeviceData, DeviceOrder, EquipmentType } from "../types";
+import { METERING_CATEGORIES } from "./metering";
 
 export interface BindingCandidate {
   id: string;
@@ -23,9 +24,7 @@ const ONOFF_TOKENS = new Set(["ON", "OFF", "TOGGLE"]);
 function isOnOffEnum(order: DeviceOrder): boolean {
   if (order.type !== "enum") return false;
   if (!order.enumValues || order.enumValues.length === 0) return false;
-  return order.enumValues.every(
-    (v) => typeof v === "string" && ONOFF_TOKENS.has(v.toUpperCase()),
-  );
+  return order.enumValues.every((v) => typeof v === "string" && ONOFF_TOKENS.has(v.toUpperCase()));
 }
 
 /** Order categories that denote a binary power/on-off command channel. */
@@ -38,7 +37,9 @@ const POWER_TOGGLE_CATEGORIES = new Set<string>(["light_toggle", "toggle_power"]
  */
 function isOnOffOrder(order: DeviceOrder): boolean {
   if (isOnOffEnum(order)) return true;
-  return order.type === "boolean" && !!order.category && POWER_TOGGLE_CATEGORIES.has(order.category);
+  return (
+    order.type === "boolean" && !!order.category && POWER_TOGGLE_CATEGORIES.has(order.category)
+  );
 }
 
 function extractShutterGroupKey(key: string): string | null {
@@ -67,6 +68,16 @@ export function computeBindingCandidates(
           dataKeys: matchingData ? [matchingData.key] : [],
           orderKeys: [o.key],
         });
+      }
+      // Metering plug (spec 129): a single-channel switch also binds
+      // power/energy/voltage/current so it surfaces live power + energy. Bare
+      // relay unchanged; multi-gang plugs keep basic per-channel switches.
+      if (candidates.length === 1) {
+        const meteringKeys = deviceData
+          .filter((d) => METERING_CATEGORIES.has(d.category))
+          .map((d) => d.key)
+          .filter((k) => !candidates[0].dataKeys.includes(k));
+        candidates[0].dataKeys.push(...meteringKeys);
       }
       return candidates;
     }

--- a/ui/src/lib/metering.ts
+++ b/ui/src/lib/metering.ts
@@ -4,6 +4,14 @@
 // as a consumption submeter, while a bare relay stays a plain on/off switch.
 import type { EquipmentWithDetails } from "../types";
 
+/** Device-data categories bound on a switch in addition to on/off (spec 129). */
+export const METERING_CATEGORIES: ReadonlySet<string> = new Set([
+  "power",
+  "energy",
+  "voltage",
+  "current",
+]);
+
 export function isMeteringSwitch(eq: EquipmentWithDetails): boolean {
   return (
     eq.type === "switch" &&


### PR DESCRIPTION
## Bug (found testing v1.27.0 on a live instance)

Creating a `switch` equipment on a SONOFF **S60ZBTPF** bound only `state` — power/energy stayed unbound, so none of the spec 129 metering (live power, energy history, submeter donut) kicked in.

Root cause: the metering-attach logic was added to the **backend** `src/equipments/binding-candidates.ts`, but that copy is only exercised by its own test. The **UI** has its own copy (`ui/src/lib/binding-candidates.ts`) that actually drives the binding flow (auto-bind on a single candidate), and it was not updated.

## Fix

Port the single-channel metering attach to the UI copy (`power`/`energy`/`voltage`/`current` added to the switch candidate's `dataKeys` when there is exactly one on/off channel). Add `METERING_CATEGORIES` to `ui/src/lib/metering.ts` and UI tests.

Bare relays and multi-gang plugs are unchanged.

## Note for existing equipments

Equipments bound **before** this fix keep their old `state`-only binding — the candidate is recomputed on (re)binding, not retroactively. After updating, re-create or re-bind the plug equipment to pick up power/energy.

## Test plan
- [x] `cd ui && npx tsc -b --noEmit` — 0 errors
- [x] `npx vitest run` — new UI binding-candidates tests (metering plug / bare relay / multi-gang) + existing pass
- [x] `eslint` UI — 0 errors