### PR TITLE
fix(equipments): bind blind single-button gates to the command alias

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -157,15 +157,15 @@
     "id": "somfy-rts",
     "type": "integration",
     "name": "Somfy RTS Bridge",
-    "description": "Somfy RTS shutters and awnings via a somfyrts2mqtt bridge (ESP32 + CC1101)",
+    "description": "Somfy RTS shutters, awnings and gates via a somfyrts2mqtt bridge (ESP32 + CC1101)",
     "icon": "Radio",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-somfy-rts",
-    "version": "1.0.3",
-    "tags": ["somfy", "rts", "mqtt", "shutter", "awning"],
+    "version": "1.1.0",
+    "tags": ["somfy", "rts", "mqtt", "shutter", "awning", "gate"],
     "sowelVersion": ">=1.12.0",
     "owner": "mchacher",
-    "sha256": "a3ffd69ff697a69aa82b737fc968666a6cc7e04661a60128f33f01167073b081"
+    "sha256": "a46f24efa46f080ba1944ad4f444863309705758cc6158e450b022fb8be10798"
   },
   {
     "id": "switch-light",

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -5,6 +5,7 @@ import type { DataCategory, EquipmentType } from "../../types";
 import { getDevices, type DeviceWithData } from "../../api";
 import { computeBindingCandidates, type BindingCandidate } from "../../lib/binding-candidates";
 import { freeCandidates } from "../../lib/binding-utils";
+import { isRelevantOrder } from "./bindingUtils";
 
 /** Maps EquipmentType to required DataCategories for filtering. */
 const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> = {
@@ -176,6 +177,17 @@ export function DeviceSelector({
             device.data.some((d) => categories.includes(d.category)),
           )
         : availableDevices;
+
+  // A blind single-button gate (RTS via somfyrts2mqtt) has no contact-sensor
+  // data — only a trigger order. The data-category filter above would hide it
+  // behind "show all", so also propose any device exposing a gate command order.
+  if (equipmentType === "gate") {
+    compatible = availableDevices.filter(
+      (device) =>
+        device.data.some((d) => (categories ?? []).includes(d.category)) ||
+        (device.orders ?? []).some((o) => isRelevantOrder(o.key, "gate")),
+    );
+  }
 
   // Exclude smart water valves from light/switch creation flows so they don't
   // pollute the list (their `state` is misclassified as `light_state`).

--- a/ui/src/components/equipments/bindingUtils.test.ts
+++ b/ui/src/components/equipments/bindingUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isRelevantData, isRelevantOrder } from "./bindingUtils";
+import { isRelevantData, isRelevantOrder, resolveAlias } from "./bindingUtils";
 import { findDataByCategory, findOrderByCategory } from "./bindingUtils";
 
 describe("findOrderByCategory", () => {
@@ -205,5 +205,35 @@ describe("water_valve equipment type relevance", () => {
   it("ignores unrelated categories/orders", () => {
     expect(isRelevantData("shutter_position", "water_valve")).toBe(false);
     expect(isRelevantOrder("color", "water_valve")).toBe(false);
+  });
+});
+
+describe("gate equipment type relevance (blind single-button RTS gate)", () => {
+  // A Somfy RTS gate (via somfyrts2mqtt) is blind: no contact-sensor data, only
+  // a `gate_trigger` order. GateControl drives the equipment through the
+  // `command` alias, so every path must land on that alias for such a gate.
+  it("auto-binds the gate_trigger order (legacy whitelist path)", () => {
+    expect(isRelevantOrder("gate_trigger", "gate")).toBe(true);
+    // R1..R4 relay gates and an already-standard `command` order still bind.
+    expect(isRelevantOrder("command", "gate")).toBe(true);
+    expect(isRelevantOrder("R1", "gate")).toBe(true);
+  });
+
+  it("manual binding (no category) resolves gate_trigger to the command alias", () => {
+    // AddBindingModal calls resolveAlias(key, type) without a category, so the
+    // fallback STANDARD_ALIASES must map gate_trigger → command.
+    expect(resolveAlias("gate_trigger", "gate")).toBe("command");
+    expect(resolveAlias("R1", "gate")).toBe("command");
+  });
+
+  it("auto binding (with category) also resolves to the command alias", () => {
+    expect(
+      resolveAlias("gate_trigger", "gate", { gate_trigger: "command" }, "gate_trigger"),
+    ).toBe("command");
+  });
+
+  it("ignores unrelated orders", () => {
+    expect(isRelevantOrder("position", "gate")).toBe(false);
+    expect(isRelevantOrder("color", "gate")).toBe(false);
   });
 });

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -155,7 +155,7 @@ const RELEVANT_ORDERS: Record<string, string[]> = {
   thermostat: ["power", "operationMode", "targetTemperature", "fanSpeed", "airSwingUD", "airSwingLR", "ecoMode", "nanoe", "profile", "resetAlarm"],
   weather: [],
   weather_forecast: [],
-  gate: ["R1", "R2", "R3", "R4", "command"],
+  gate: ["R1", "R2", "R3", "R4", "command", "gate_trigger"],
   heater: ["state", "on", "R1", "R2", "R3", "R4"],
   energy_meter: [],
   main_energy_meter: [],
@@ -217,6 +217,11 @@ const STANDARD_ALIASES: Record<string, Record<string, string>> = {
     insideTemperature: "temperature",
   },
   gate: {
+    // A blind single-button gate (e.g. Somfy RTS via somfyrts2mqtt) exposes a
+    // `gate_trigger` order. GateControl only reacts to the `command` alias, so
+    // both the manual AddBindingModal (no category → STANDARD_ALIASES) and any
+    // R1..R4 relay gate resolve to `command`.
+    gate_trigger: "command",
     R1: "command",
     R2: "command",
     R3: "command",


### PR DESCRIPTION
## Problem

A Somfy RTS gate (via the `somfyrts2mqtt` bridge) is **blind**: a single-button toggle with no contact-sensor feedback. The plugin discovers it with `data: []` and a single order `{ key: "gate_trigger", category: "gate_trigger" }`.

At a real install this failed on three fronts — the gate command never worked, even with a **manual** binding:

1. **Manual binding didn't command the gate.** `AddBindingModal` pre-fills the alias via `resolveAlias(key, type)` **without a category** → falls back to `STANDARD_ALIASES["gate"]`, which only mapped `R1..R4 → command`, not `gate_trigger`. So the alias defaulted to `gate_trigger`. But `GateControl` reacts **only** to `orderBindings.find(ob => ob.alias === "command")` → the binding existed but drove nothing.
2. **Auto-binding skipped the order.** `gate` is not candidate-based, so `autoCreateBindings` uses the legacy whitelist `RELEVANT_ORDERS["gate"]`, which lacked `gate_trigger`.
3. **Gate not proposed.** `DeviceSelector` filters gate candidates on **data category** (`generic`/`contact_door`) only; a command-only gate (no data) was hidden behind "show all".

## Fix (additive, UI only)

- `STANDARD_ALIASES["gate"]`: map `gate_trigger → command` (fixes the **manual** binding).
- `RELEVANT_ORDERS["gate"]`: add `gate_trigger` (fixes **auto**-binding).
- `DeviceSelector`: also propose gate devices that expose a gate command order, not just contact-sensor data (fixes **not proposed**).

Relay (R1..R4) gates and the contact-sensor gate model are unaffected — the change only adds the `gate_trigger` path. `resolveAlias`'s category branch already resolved `gate_trigger → command` for the auto path; this aligns the manual path and the whitelist/proposal with it.

## Tests

`bindingUtils.test.ts` — new `gate` block covering the auto whitelist, the manual (no-category) alias resolution, and the category-based alias resolution. `npx vitest run` green (29/29). `tsc -b --noEmit` clean; eslint 0 errors on changed files.

Companion to `somfyrts2mqtt` plugin v1.1.0 (single-button gate support). Plugin shape stays honest (`data: []`, `gate_trigger`); this makes Sowel model a blind command-only gate correctly.