### PR TITLE
feat(ui): multi-select recipe slots (select + list) — spec 130

### DIFF
--- a/specs/130-watering-weekdays/architecture.md
+++ b/specs/130-watering-weekdays/architecture.md
@@ -1,0 +1,108 @@
+# Architecture — Spec 130
+
+Two repositories change. No database, no event, no API change.
+
+## 1. Core (this repo) — reusable multi-select `select` slot
+
+### Types
+
+No change. `RecipeSlotDef` (`src/shared/types.ts`) already declares `type: "select"`,
+`options`, and `list`. `RecipeSlotI18n.options` (spec 126) already carries per-option
+labels. We are only teaching the **renderer** to honor `list: true` on a `select`.
+
+### UI — `ui/src/components/recipes/ZoneRecipesSection.tsx`
+
+Today `slot.list` is only handled for `equipment` slots; a `select` always renders a
+single `<select>` (grouped path ~L824, ungrouped path ~L949). A `select` + `list`
+must instead render a **chip group** (one toggle button per option), storing the
+selected values the same way equipment lists do — a comma-joined string in
+`params[slot.id]` (`"mon,tue,thu,fri"`).
+
+Changes (mirrored in **both** render blocks — the edit block ~L744-978 and the add
+block ~L1800+):
+
+1. Add a shared render helper `renderMultiSelectChips(slot, value, onChange)` that
+   maps `slot.options` to toggle buttons, reading/writing the comma-joined value and
+   resolving labels via the existing `recipeSlotOptionLabel(recipe, slot, value, lang)`.
+2. **Grouped path**: a `select` + `list` slot renders **full-width** inside the group
+   (like the equipment-list block), placed after the compact Heure/Durée grid. It is
+   therefore excluded from the compact-grid filter (the filter that currently excludes
+   only `equipment && list`).
+3. **Ungrouped path**: the `slot.type === "select"` branch checks `slot.list` and
+   renders chips instead of a `<select>`.
+4. Styling: reuse Sowel tokens — selected chip = `bg-primary text-white`, unselected =
+   `bg-surface border-border`, Tailwind only, matches the approved mock.
+
+A `select` **without** `list` keeps its current single-dropdown rendering (no regression).
+
+## 2. Recipe — `sowel-recipe-auto-watering` (separate repo)
+
+### Mirrored types (`src/index.ts`)
+
+- Extend the local `RecipeSlotDef.type` union with `"select"`.
+- Add `options?: { value: string; label: string }[]` to the local `RecipeSlotDef`.
+- Add `options?: Record<string, string>` to the local `RecipeSlotI18n`.
+
+### Slots (`buildSlots`)
+
+Add, grouped with each créneau (`required: false`, so retro-compatible):
+
+```ts
+{ id: "slot1_days", name: "Days", description: "Days of week (empty = every day)",
+  type: "select", list: true, required: false, group: "slot1",
+  options: WEEKDAY_OPTIONS },   // mon,tue,wed,thu,fri,sat,sun
+```
+
+`WEEKDAY_OPTIONS = [{value:"mon",label:"Mon"}, …, {value:"sun",label:"Sun"}]`.
+Same for `slot2_days`, `slot3_days`.
+
+### Weekday model + scheduler
+
+- Token → JS `getDay()` map: `sun=0, mon=1, tue=2, wed=3, thu=4, fri=5, sat=6`.
+- `parseDays(raw): Set<number>` — accepts a comma string or an array, maps known
+  tokens to `getDay()` numbers, drops unknowns. **Empty set = every day.**
+- `TimeSlot` gains `days: Set<number>` (empty = all).
+- `msUntilTime(time, days, now = new Date()): number` — scan day offsets `0..7`; for
+  each, build the target at `HH:MM` on that date; return the first target that is
+  strictly in the future **and** whose `getDay()` is allowed (or any day when `days`
+  is empty). This subsumes the old today/tomorrow logic.
+- `findNextSlot(slots, now = new Date())` — unchanged shape, now day-aware via the new
+  `msUntilTime`.
+- `scheduleSlot` passes the slot's `days`; after a slot fires it reschedules, which
+  naturally computes the next allowed weekday.
+- Export `msUntilTime` / `findNextSlot` / `parseDays` for unit tests (or a small
+  `__test` bundle) — they take an explicit `now`, so tests are deterministic.
+
+Weekday uses process-local `getDay()`, consistent with the existing local-time
+`msUntilTime` (Sowel sets `TZ=Europe/Paris`).
+
+### Validation
+
+`validate` is unchanged except: day tokens, if present, are tolerated (unknown tokens
+ignored, never throw). No new required constraints.
+
+### i18n
+
+FR/EN labels for `slot{1,2,3}_days` (name "Jours" / "Days", description) and the 7
+day options via `RecipeLangPack.slots[id].options`.
+
+### Versioning / release (post-merge, separate step)
+
+- Recipe: `package.json` + `manifest.json` `1.1.0 → 1.2.0`, `npm run build`, publish
+  GitHub release with the `.tar.gz` asset, then `node scripts/backfill-registry-sha256.mjs`
+  in the Sowel repo and commit `plugins/registry.json` (spec 089). Do **not** release
+  Sowel just for the registry.
+- Core UI multi-select ships with the next Sowel release. **Coordinate**: the recipe's
+  new `select+list` slot only renders as chips on a core that has this change; on an
+  older core it degrades to a single dropdown (still functional, one day at a time).
+  Ship the core release at or before the recipe release.
+
+## File changes
+
+| Repo   | File                                               | Change                                                        |
+| ------ | -------------------------------------------------- | ------------------------------------------------------------- |
+| core   | `ui/src/components/recipes/ZoneRecipesSection.tsx` | Multi-select chip rendering for `select`+`list` (2 blocks)    |
+| core   | `specs/130-watering-weekdays/*`                    | This spec                                                     |
+| recipe | `src/index.ts`                                     | Mirrored types, `slotN_days` slots, day-aware scheduler, i18n |
+| recipe | `src/index.test.ts`                                | Weekday scheduler tests                                       |
+| recipe | `package.json`, `manifest.json`                    | Version bump (at release time)                                |

--- a/specs/130-watering-weekdays/plan.md
+++ b/specs/130-watering-weekdays/plan.md
@@ -1,0 +1,71 @@
+# Plan — Spec 130
+
+## Implementation steps
+
+### A. Core (this repo) — branch `feat/watering-weekdays`
+
+1. `ZoneRecipesSection.tsx`: add `renderMultiSelectChips(slot, value, onChange, recipe, lang)`.
+2. Grouped render path: render `select && list` slots full-width after the compact
+   grid; exclude them from the compact-grid filter.
+3. Ungrouped render path: `select` branch renders chips when `slot.list`.
+4. `cd ui && npx tsc -b --noEmit` clean.
+
+### B. Recipe (`sowel-recipe-auto-watering`) — branch `feat/weekdays`
+
+1. Mirrored types: add `select` to the type union, `options` on `RecipeSlotDef`, and
+   `options` on `RecipeSlotI18n`.
+2. `WEEKDAY_OPTIONS` + `DAY_TOKEN_TO_DOW` map + `parseDays()`.
+3. Add `slot{1,2,3}_days` slots in `buildSlots`; FR/EN i18n incl. option labels.
+4. `TimeSlot.days`; populate in `createInstance` from `parseDays(params[slotN_days])`.
+5. Rewrite `msUntilTime(time, days, now)` (day-aware, offset scan) and make
+   `findNextSlot(slots, now)` use it; thread `days` through `scheduleSlot`.
+6. Export helpers for tests.
+7. Tests (see plan below); `npm run build` + `npm test` clean.
+
+Order overall: do A (core) and B (recipe) independently; both are needed for the full
+UX but each compiles/tests on its own.
+
+## Test Plan
+
+### Modules to test
+
+- `sowel-recipe-auto-watering` `src/index.ts` — the day-aware scheduler
+  (`parseDays`, `msUntilTime`, `findNextSlot`) and end-to-end firing on allowed days.
+- Core `ZoneRecipesSection.tsx` — no React tests in this project (per convention);
+  verified by `tsc` + manual check in the running app against the approved mock.
+
+### Scenarios
+
+| Module                       | Scenario                                                      | Expected                                                                    |
+| ---------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| parseDays                    | `"mon,wed,fri"`                                               | `{1,3,5}`                                                                   |
+| parseDays                    | array `["sat","sun"]`                                         | `{6,0}`                                                                     |
+| parseDays                    | `""` / `undefined` / `[]`                                     | empty set (= every day)                                                     |
+| parseDays                    | `"mon,bogus,SUN"` (case/unknown)                              | known tokens only, unknown dropped                                          |
+| msUntilTime                  | empty days, time later today                                  | fires **today** at HH:MM (unchanged behavior)                               |
+| msUntilTime                  | empty days, time already passed                               | fires **tomorrow** (unchanged behavior)                                     |
+| msUntilTime                  | `now`=Wed, days={Mon,Tue,Thu,Fri}, time ahead                 | fires **Thu** (skips Wed)                                                   |
+| msUntilTime                  | `now`=Wed 08:00, days={Wed}, time 07:30 (passed)              | fires **next Wed** 07:30                                                    |
+| msUntilTime                  | `now`=Sat, days={Wed,Sat,Sun}, time ahead                     | fires **today (Sat)**                                                       |
+| msUntilTime                  | all 7 days selected                                           | same as empty (every day)                                                   |
+| findNextSlot                 | slot1 07:30 {Mon..Fri}, slot2 09:00 {Sat,Sun}, now=Fri 10:00  | next = slot2 Sat 09:00                                                      |
+| createInstance (fake timers) | Romain case: Wed, slot1 07:30 school-days, slot2 09:00 Wed/WE | slot1 does **not** fire Wed; slot2 fires Wed 09:00 → valves open then close |
+| createInstance               | slot with empty days                                          | fires daily exactly as before (retro-compat)                                |
+| createInstance               | rain skip still applies on an allowed day                     | slot skipped, status `skipped`                                              |
+| createInstance               | resume-after-restart                                          | unchanged (existing tests still green)                                      |
+
+### Retro-compat
+
+- All existing `src/index.test.ts` scenarios pass unchanged (empty days path == old
+  today/tomorrow path).
+
+## Tasks
+
+- [x] A1 core multi-select chip renderer (grouped + ungrouped)
+- [x] A2 core `tsc -b --noEmit` clean
+- [x] B1 recipe mirrored types + `select`
+- [x] B2 `parseDays` + weekday map
+- [x] B3 `slotN_days` slots + FR/EN i18n
+- [x] B4 day-aware `msUntilTime` / `findNextSlot` / `scheduleSlot`
+- [x] B5 weekday scheduler tests (all scenarios above)
+- [x] B6 recipe `build` + `test` clean; existing tests still green

--- a/specs/130-watering-weekdays/spec.md
+++ b/specs/130-watering-weekdays/spec.md
@@ -1,0 +1,75 @@
+# Spec 130 — Auto-watering per-slot weekdays (+ multi-select recipe slot)
+
+## Context
+
+GitHub issue #306 (Romain / alpitux). The `auto-watering` recipe schedules up to
+3 daily time slots (time + duration). Every slot fires **every day**. The user
+wants to water at different times depending on the day of the week — e.g. water
+at **07:30 on school days** but at **09:00 on Wednesday and the weekend**
+(the pump is audible from the bedrooms and would wake the children early).
+
+Today there is no way to restrict a slot to specific weekdays.
+
+## Goal
+
+Add an **optional** per-slot "days of week" selector to the `auto-watering`
+recipe. Selecting no day (the default) keeps the current behavior — water every
+day — so existing recipe instances are unchanged with no migration.
+
+This requires a small, reusable **core** addition: render a recipe `select` slot
+with `list: true` as a **multi-select** (day chips) in the recipe form. The
+`select` slot type already exists (spec 126); `list` is currently honored only
+for `equipment` slots.
+
+## Scope
+
+### In scope
+
+- **Core (this repo)**: `ZoneRecipesSection.tsx` renders a `select` + `list: true`
+  slot as a multi-select chip group, in both recipe render paths (edit an existing
+  recipe, add a new recipe). Value stored as a comma-joined list of option values,
+  reusing the existing list-value convention.
+- **Recipe (`sowel-recipe-auto-watering`)**:
+  - New optional slot `slot{1,2,3}_days` (type `select`, `list: true`, 7 weekday
+    options), grouped with its créneau.
+  - Scheduler restricts each slot to its selected weekdays; empty selection = all
+    days. Computes the next allowed occurrence.
+  - FR/EN i18n for the field and the day options.
+
+### Out of scope (explicitly excluded)
+
+- **Public holidays / school holidays.** Sowel has no holiday/vacation calendar
+  source; baking a country-specific calendar into a generic recipe is rejected.
+  Deferred; a later option is to drive it via Modes. Weekday selection already
+  covers the primary need (weekday vs Wednesday/weekend differentiation).
+- **Per-valve durations.** The single per-slot duration is unchanged.
+
+## Acceptance criteria
+
+- [x] AC1 — In the auto-watering recipe form, each créneau shows an optional
+      **Jours / Days** field rendered as 7 toggle chips (Mon…Sun).
+- [x] AC2 — Default = no day selected → the slot waters **every day**; existing
+      instances keep working with **no migration** and no behavior change.
+- [x] AC3 — When one or more days are selected, the slot triggers **only** on
+      those weekdays; the scheduler arms the next allowed occurrence.
+- [x] AC4 — Romain's case works end to end: slot1 `07:30` = Mon/Tue/Thu/Fri,
+      slot2 `09:00` = Wed/Sat/Sun.
+- [x] AC5 — Core renders a `select` + `list: true` slot as a multi-select chip
+      group in **both** recipe render paths; the value round-trips (save → reload
+      → same chips selected). A legacy/plain `select` (no `list`) is unchanged.
+- [x] AC6 — Rain skip, forecast skip, and resume-after-restart behavior are
+      unchanged.
+- [x] AC7 — Weekday is evaluated in the recipe process timezone, consistent with
+      the existing `msUntilTime` local-time behavior (Sowel sets `TZ=Europe/Paris`).
+
+## Edge cases
+
+| Case                                      | Expected                                                         |
+| ----------------------------------------- | ---------------------------------------------------------------- |
+| No day selected (empty / absent param)    | Every day (retro-compat)                                         |
+| All 7 days selected                       | Every day                                                        |
+| Days selected but slot time empty         | Slot inactive (unchanged: a slot needs time + duration)          |
+| Today is not an allowed day               | Next fire = the next allowed weekday at HH:MM                    |
+| Today is allowed but HH:MM already passed | Next fire = the next allowed weekday at HH:MM (may be next week) |
+| Invalid/unknown day token in params       | Ignored (filtered out)                                           |
+| Two slots, different day sets             | Scheduler fires each on its own next allowed occurrence          |

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -13,6 +13,54 @@ import { isSlotHidden } from "../../lib/recipe-slots";
 import type { RecipeSlotDef } from "../../types";
 
 
+/** Multi-select renderer for a `select` slot with `list: true`: one toggle chip
+ *  per option. Stores the selected option values as a comma-joined string, the
+ *  same convention used by equipment-list slots (e.g. "mon,tue,thu,fri"). An
+ *  empty value means "nothing selected" — recipes read that as their default. */
+function MultiSelectChips({
+  slot,
+  value,
+  onChange,
+  recipe,
+  lang,
+}: {
+  slot: RecipeSlotDef;
+  value: string;
+  onChange: (value: string) => void;
+  recipe: RecipeInfo;
+  lang: string;
+}) {
+  const selected = value.split(",").filter(Boolean);
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {(slot.options ?? []).map((o) => {
+        const on = selected.includes(o.value);
+        return (
+          <button
+            key={o.value}
+            type="button"
+            aria-pressed={on}
+            onClick={() => {
+              const next = on
+                ? selected.filter((v) => v !== o.value)
+                : [...selected, o.value];
+              onChange(next.join(","));
+            }}
+            className={`px-3 py-1.5 text-[12px] font-medium rounded-[6px] border transition-colors duration-150 ${
+              on
+                ? "bg-primary border-primary text-white"
+                : "bg-surface border-border text-text-secondary hover:border-primary"
+            }`}
+          >
+            {recipeSlotOptionLabel(recipe, slot, o.value, lang)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+
 function matchesEquipmentType(eqType: string, constraint: EquipmentType | EquipmentType[]): boolean {
   const types = Array.isArray(constraint) ? constraint : [constraint];
   return types.some((t) => t === eqType);
@@ -781,7 +829,7 @@ function RecipeInstanceRow({
                           ))}
                           {/* Compact grid for non-list slots */}
                           {(() => {
-                            const compactSlots = chunk.slots.filter((s) => !(s.type === "equipment" && s.list) && !isSlotHidden(s, editParams, recipe.slots));
+                            const compactSlots = chunk.slots.filter((s) => !((s.type === "equipment" || s.type === "select") && s.list) && !isSlotHidden(s, editParams, recipe.slots));
                             if (compactSlots.length === 0) return null;
                             const cols = compactSlots.length <= 3 ? compactSlots.length : 2;
                             return (
@@ -855,6 +903,22 @@ function RecipeInstanceRow({
                               </div>
                             );
                           })()}
+                          {/* Full-width multi-select slots (e.g. weekdays) — rendered as chips */}
+                          {chunk.slots.filter((s) => s.type === "select" && s.list && !isSlotHidden(s, editParams, recipe.slots)).map((slot) => (
+                            <div key={slot.id} className="mt-1.5">
+                              <label className={`block text-[10px] tracking-wider mb-1 ${isSlotChanged(slot.id) ? "text-success" : "text-text-tertiary"}`}>
+                                {recipeSlotName(recipe, slot, lang)}{slot.required && <span className="text-error ml-0.5">*</span>}
+                              </label>
+                              <MultiSelectChips
+                                slot={slot}
+                                value={editParams[slot.id] ?? ""}
+                                onChange={(v) => setEditParams({ ...editParams, [slot.id]: v })}
+                                recipe={recipe}
+                                lang={lang}
+                              />
+                              <p className="text-[10px] text-text-tertiary mt-0.5">{recipeSlotDescription(recipe, slot, lang)}</p>
+                            </div>
+                          ))}
                         </div>
                       );
                     }
@@ -947,6 +1011,15 @@ function RecipeInstanceRow({
                             placeholder={slot.defaultValue ? String(durationToMinutes(String(slot.defaultValue))) : undefined}
                           />
                         ) : slot.type === "select" ? (
+                          slot.list ? (
+                            <MultiSelectChips
+                              slot={slot}
+                              value={editParams[slot.id] ?? ""}
+                              onChange={(v) => setEditParams({ ...editParams, [slot.id]: v })}
+                              recipe={recipe}
+                              lang={lang}
+                            />
+                          ) : (
                           <select
                             value={String(editParams[slot.id] ?? slot.defaultValue ?? "")}
                             onChange={(e) => setEditParams({ ...editParams, [slot.id]: e.target.value })}
@@ -958,6 +1031,7 @@ function RecipeInstanceRow({
                               </option>
                             ))}
                           </select>
+                          )
                         ) : slot.type === "time" ? (
                           <TimeInput
                             value={editParams[slot.id] ?? ""}
@@ -1814,7 +1888,7 @@ function AddRecipeForm({
                         ))}
                         {/* Compact grid for non-list slots */}
                         {(() => {
-                          const compactSlots = chunk.slots.filter((s) => !(s.type === "equipment" && s.list) && !isSlotHidden(s, params, selectedRecipe.slots));
+                          const compactSlots = chunk.slots.filter((s) => !((s.type === "equipment" || s.type === "select") && s.list) && !isSlotHidden(s, params, selectedRecipe.slots));
                           if (compactSlots.length === 0) return null;
                           const n = compactSlots.length;
                           const cols = n <= 3 ? n : n % 3 === 0 ? 3 : 2;
@@ -1891,6 +1965,22 @@ function AddRecipeForm({
                             </div>
                           );
                         })()}
+                        {/* Full-width multi-select slots (e.g. weekdays) — rendered as chips */}
+                        {chunk.slots.filter((s) => s.type === "select" && s.list && !isSlotHidden(s, params, selectedRecipe.slots)).map((slot) => (
+                          <div key={slot.id} className="mt-1.5">
+                            <label className="block text-[10px] tracking-wider mb-1 text-text-tertiary">
+                              {recipeSlotName(selectedRecipe, slot, lang)}{slot.required && <span className="text-error ml-0.5">*</span>}
+                            </label>
+                            <MultiSelectChips
+                              slot={slot}
+                              value={params[slot.id] ?? ""}
+                              onChange={(v) => setParams({ ...params, [slot.id]: v })}
+                              recipe={selectedRecipe}
+                              lang={lang}
+                            />
+                            <p className="text-[10px] text-text-tertiary mt-0.5">{recipeSlotDescription(selectedRecipe, slot, lang)}</p>
+                          </div>
+                        ))}
                       </div>
                     );
                   }
@@ -1983,6 +2073,15 @@ function AddRecipeForm({
                           placeholder={slot.defaultValue ? String(durationToMinutes(String(slot.defaultValue))) : undefined}
                         />
                       ) : slot.type === "select" ? (
+                        slot.list ? (
+                          <MultiSelectChips
+                            slot={slot}
+                            value={params[slot.id] ?? ""}
+                            onChange={(v) => setParams({ ...params, [slot.id]: v })}
+                            recipe={selectedRecipe}
+                            lang={lang}
+                          />
+                        ) : (
                         <select
                           value={String(params[slot.id] ?? slot.defaultValue ?? "")}
                           onChange={(e) => setParams({ ...params, [slot.id]: e.target.value })}
@@ -1994,6 +2093,7 @@ function AddRecipeForm({
                             </option>
                           ))}
                         </select>
+                        )
                       ) : slot.type === "time" ? (
                         <TimeInput
                           value={params[slot.id] ?? ""}


### PR DESCRIPTION
## Summary

Renders a recipe `select` slot with `list: true` as a **multi-select chip group** in the recipe form (both the edit and add render paths), instead of a single dropdown. This is the reusable core primitive behind spec 130 — the Auto Watering per-slot **weekday** selector (issue #306).

No data model / API / event change: `RecipeSlotDef` already declares `select`, `options`, and `list` (spec 126); this only teaches the renderer to honor `list` on a `select`.

## Changes

- `ui/src/components/recipes/ZoneRecipesSection.tsx`
  - New `MultiSelectChips` component — toggle chips, value stored as a comma-joined string (same convention as equipment lists, so it round-trips on save/reload), labels resolved via the existing `recipeSlotOptionLabel`.
  - Grouped path: `select + list` slots render full-width after the compact grid (excluded from the compact-grid filter).
  - Ungrouped path: the `select` branch renders chips when `list`.
  - A plain `select` (no `list`) is unchanged.
- `specs/130-watering-weekdays/` — spec, architecture, plan (with test plan).

## Test plan

- [x] `cd ui && npx tsc -b --noEmit` — 0 errors
- [x] `npx tsc --noEmit` (backend) — 0 errors
- [x] `npx vitest run` — 927 passed / 2 skipped
- [x] `npx eslint src/ --ext .ts` — 0 errors; `eslint` on the changed UI file — 0 errors (1 pre-existing warning, unrelated)
- [x] `cd ui && npm run build` — OK
- [ ] Manual: open the Auto Watering recipe (with the companion recipe installed) and confirm the **Jours** chips render, toggle, and persist — matches the approved mock

## Companion

Recipe PR: mchacher/sowel-recipe-auto-watering#2 (adds the `slotN_days` slots + day-aware scheduler). Ship the core release at or before the recipe release so the field renders as chips.
