### PR TITLE
release: v1.28.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,14 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.28.x: Arrosage par jour
+
+### v1.28.0 — 2026-07-17 { #v1-28-0 }
+
+- Feat (recettes) : les formulaires de recette gèrent désormais les champs à choix multiple, affichés en pastilles plutôt qu'en simple liste déroulante. Cela apporte un nouveau sélecteur de **jours de la semaine** par créneau dans la recette Arrosage Auto (mettez la recette à jour en v1.2.0) : chaque créneau d'arrosage peut être limité à certains jours, et le laisser vide continue d'arroser tous les jours. Exemple : arroser à 07h30 les jours d'école et à 09h00 le mercredi et le week-end. Les planifications d'arrosage existantes ne changent pas. (#310, auto-watering #2)
+
+---
+
 ## 1.27.x: Prise avec métrologie
 
 ### v1.27.1 — 2026-07-10 { #v1-27-1 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,14 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.28.x: Watering weekdays
+
+### v1.28.0 — 2026-07-17 { #v1-28-0 }
+
+- Feat (recipes): recipe forms now support multi-select option fields, shown as toggle chips instead of a single dropdown. This powers a new per-slot **day of week** selector in the Auto Watering recipe (update the recipe to v1.2.0): each watering slot can be limited to chosen weekdays, and leaving it empty keeps watering every day. Example: water at 07:30 on school days and at 09:00 on Wednesday and the weekend. Existing watering schedules are unchanged. (#310, auto-watering #2)
+
+---
+
 ## 1.27.x: Metering-aware switch
 
 ### v1.27.1 — 2026-07-10 { #v1-27-1 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -315,7 +315,7 @@
     "icon": "Droplets",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-auto-watering",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "tags": ["watering", "irrigation", "garden", "rain", "automation"],
     "i18n": {
       "fr": {
@@ -325,7 +325,7 @@
     },
     "sowelVersion": ">=1.1.0",
     "owner": "mchacher",
-    "sha256": "710e62e009ae3462ef1dbaa43609a50620fe550afa1368fd826288cbb849da60"
+    "sha256": "8f05013245c7faaecc03c230bedf5da07d351613df6782f99fd094679c7c8603"
   },
   {
     "id": "pool-pump-schedule",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.27.1",
+  "version": "1.28.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## release: v1.28.0

Cuts the Sowel v1.28.0 release.

### Included
- **Multi-select recipe slots** (`select` + `list`) rendered as toggle chips in the recipe form — spec 130 (#310, already merged to main).
- **Registry**: `auto-watering` bumped to **1.2.0** with a verified `sha256` (matches the published release asset). This makes the new per-slot weekday recipe available to instances.
- **Release notes** v1.28.0 in `docs/release-notes.md` + `docs/release-notes.fr.md` (anchor `{ #v1-28-0 }`, required by the `verify-release-notes` CI job).

### Version
- `package.json`, `ui/package.json`: 1.27.1 → **1.28.0**

### After merge
Tag `v1.28.0` on the merged main commit and push the tag to trigger the Docker build.
