### PR TITLE
fix(equipments): correct rain 1h/24h cumuls (stop summing rolling totals)

### DIFF
--- a/src/history/history-writer.test.ts
+++ b/src/history/history-writer.test.ts
@@ -63,6 +63,15 @@ describe("HistoryWriter.resolveHistorize", () => {
     expect(HistoryWriter.resolveHistorize(null, "energy_reverse", "energy")).toBe(false);
   });
 
+  it("excludes rolling rain cumulatives (sum_rain_1 / sum_rain_24) but keeps incremental rain", () => {
+    // Netatmo's rolling 1h/24h totals — historizing them makes the rain chart
+    // plot a flat cumulative and sum-of-cumuls the WeatherAggregator.
+    expect(HistoryWriter.resolveHistorize(null, "sum_rain_1", "rain")).toBe(false);
+    expect(HistoryWriter.resolveHistorize(null, "sum_rain_24", "rain")).toBe(false);
+    // The incremental per-period rain stays historized.
+    expect(HistoryWriter.resolveHistorize(null, "rain", "rain")).toBe(true);
+  });
+
   // ============================================================
   // Default OFF for unrelated categories
   // ============================================================

--- a/src/history/history-writer.ts
+++ b/src/history/history-writer.ts
@@ -43,11 +43,20 @@ const ALIAS_DEFAULTS_ON: ReadonlySet<string> = new Set(["setpoint", "power"]);
  * terms. They are needed as latest values (Live page) but writing them
  * as time-series points would pollute every category=energy aggregation
  * with the cumul (sum-of-cumuls), since the EnergyAggregator and the
- * downsampling tasks group on category, not alias. */
+ * downsampling tasks group on category, not alias.
+ *
+ * `sum_rain_1` / `sum_rain_24` are the same class of bug for rain: Netatmo's
+ * ROLLING 1h / 24h totals, re-reported at every poll. Historizing them makes
+ * the rain chart plot a flat rolling total ("11.9 mm every hour") and makes
+ * any `category == "rain"` |> sum() (WeatherAggregator) a sum-of-cumuls. The
+ * incremental `rain` alias stays historized; the live rolling totals are read
+ * from the equipment binding, not InfluxDB. */
 const ALIAS_DEFAULTS_OFF: ReadonlySet<string> = new Set([
   "demand_30min",
   "energy_forward",
   "energy_reverse",
+  "sum_rain_1",
+  "sum_rain_24",
   "wind_angle",
   "gust_strength",
   "gust_angle",

--- a/src/weather/weather-aggregator.test.ts
+++ b/src/weather/weather-aggregator.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { computeRainCumuls } from "./weather-aggregator.js";
+
+describe("computeRainCumuls", () => {
+  it("uses the native rolling cumulative (sum_rain_24) as-is, never summing samples", async () => {
+    const bindings = [
+      { alias: "rain", value: 0 },
+      { alias: "sum_rain_1", value: 0 },
+      { alias: "sum_rain_24", value: 11.9 },
+    ];
+    // 1392.3 is what the old buggy sum-of-cumuls path produced — must NOT be used.
+    const sumIncremental = vi.fn(async () => 1392.3);
+
+    const { rain1h, rain24h } = await computeRainCumuls(bindings, sumIncremental);
+
+    expect(rain24h).toBe(11.9);
+    expect(rain1h).toBe(0);
+    expect(sumIncremental).not.toHaveBeenCalled();
+  });
+
+  it("rounds the native value to one decimal", async () => {
+    const bindings = [
+      { alias: "sum_rain_24", value: 11.94 },
+      { alias: "sum_rain_1", value: 0.06 },
+    ];
+    const { rain1h, rain24h } = await computeRainCumuls(bindings, async () => null);
+    expect(rain24h).toBe(11.9);
+    expect(rain1h).toBe(0.1);
+  });
+
+  it("falls back to summing the incremental rain when no native cumulative exists", async () => {
+    const bindings = [{ alias: "rain", value: 0.2 }]; // incremental-only station (e.g. z2m)
+    const sumIncremental = vi.fn(async (w: "-1h" | "-24h") => (w === "-24h" ? 3.4 : 0.2));
+
+    const { rain1h, rain24h } = await computeRainCumuls(bindings, sumIncremental);
+
+    expect(rain24h).toBe(3.4);
+    expect(rain1h).toBe(0.2);
+    expect(sumIncremental).toHaveBeenCalledWith("-24h");
+    expect(sumIncremental).toHaveBeenCalledWith("-1h");
+  });
+
+  it("yields null (no fallback) when a native cumulative is present but non-numeric", async () => {
+    const bindings = [
+      { alias: "sum_rain_24", value: null },
+      { alias: "sum_rain_1", value: "x" },
+    ];
+    const sumIncremental = vi.fn(async () => 99);
+
+    const { rain1h, rain24h } = await computeRainCumuls(bindings, sumIncremental);
+
+    expect(rain24h).toBeNull();
+    expect(rain1h).toBeNull();
+    expect(sumIncremental).not.toHaveBeenCalled();
+  });
+});

--- a/src/weather/weather-aggregator.ts
+++ b/src/weather/weather-aggregator.ts
@@ -2,11 +2,17 @@
  * WeatherAggregator — Computes rain cumuls at equipment level.
  *
  * Listens to equipment.data.changed events for rain bindings as a trigger.
- * On trigger, queries InfluxDB (single source of truth) to compute:
- *   - rain_1h: sum of rain over the last 1 hour (mm)
- *   - rain_24h: sum of rain over the last 24 hours (mm)
+ * On trigger, computes:
+ *   - rain_1h: rain total over the last 1 hour (mm)
+ *   - rain_24h: rain total over the last 24 hours (mm)
  *
- * Follows the same pattern as EnergyAggregator.
+ * Prefers the station's NATIVE rolling cumulatives (Netatmo `sum_rain_1` /
+ * `sum_rain_24`) read from the live binding — those already ARE the 1h / 24h
+ * totals. Summing their historized samples would multiply them by the poll
+ * count (sum-of-cumuls; see the `sum_rain_*` note in history-writer). Only a
+ * station without a native cumulative falls back to summing the incremental
+ * `rain` series from InfluxDB.
+ *
  * Generic: works for any integration that writes rain data (Netatmo, z2m, etc.)
  */
 
@@ -26,6 +32,48 @@ interface RainCumuls {
   rain1h: number | null;
   rain24h: number | null;
   lastUpdated: string;
+}
+
+/** Rain aliases whose change should trigger a cumul refresh. */
+const RAIN_TRIGGER_ALIASES: ReadonlySet<string> = new Set(["rain", "sum_rain_1", "sum_rain_24"]);
+
+interface RainBinding {
+  alias: string;
+  value: unknown;
+}
+
+function roundTenth(v: number | null): number | null {
+  return v === null ? null : Math.round(v * 10) / 10;
+}
+
+/**
+ * Compute rain_1h / rain_24h for a weather equipment.
+ *
+ * Prefers the native rolling cumulatives (`sum_rain_1` / `sum_rain_24`): when a
+ * binding is present its live value IS the total, so it is used as-is (never
+ * summed). Only when a native cumulative is absent does it fall back to
+ * `sumIncrementalRain`, which sums the incremental `rain` series over the window.
+ */
+export async function computeRainCumuls(
+  bindings: RainBinding[],
+  sumIncrementalRain: (window: "-1h" | "-24h") => Promise<number | null>,
+): Promise<{ rain1h: number | null; rain24h: number | null }> {
+  // undefined → binding absent (fall back); null → present but no numeric value.
+  const nativeValue = (alias: string): number | null | undefined => {
+    const b = bindings.find((x) => x.alias === alias);
+    if (!b) return undefined;
+    if (b.value === null || b.value === undefined || b.value === "") return null;
+    const n = typeof b.value === "number" ? b.value : Number(b.value);
+    return Number.isFinite(n) ? n : null;
+  };
+
+  const native1h = nativeValue("sum_rain_1");
+  const native24h = nativeValue("sum_rain_24");
+
+  const rain1h = native1h !== undefined ? native1h : await sumIncrementalRain("-1h");
+  const rain24h = native24h !== undefined ? native24h : await sumIncrementalRain("-24h");
+
+  return { rain1h: roundTenth(rain1h), rain24h: roundTenth(rain24h) };
 }
 
 export class WeatherAggregator {
@@ -64,7 +112,7 @@ export class WeatherAggregator {
 
     // Initial load from InfluxDB
     for (const equipmentId of this.rainEquipmentIds) {
-      await this.refreshFromInfluxDB(equipmentId);
+      await this.refreshCumuls(equipmentId);
     }
 
     // Subscribe to equipment data changes — rain alias as trigger
@@ -82,8 +130,8 @@ export class WeatherAggregator {
         this.rainEquipmentIds.add(event.equipmentId);
       }
 
-      // Only trigger on rain-related alias changes
-      if (event.alias !== "rain") return;
+      // Only trigger on rain-related alias changes (incremental or rolling cumulative)
+      if (!RAIN_TRIGGER_ALIASES.has(event.alias)) return;
 
       this.scheduleRefresh(event.equipmentId);
     });
@@ -130,7 +178,7 @@ export class WeatherAggregator {
 
     const timer = setTimeout(() => {
       this.pendingRefresh.delete(equipmentId);
-      this.refreshFromInfluxDB(equipmentId).catch((err) =>
+      this.refreshCumuls(equipmentId).catch((err) =>
         this.logger.warn({ err, equipmentId }, "Failed to refresh rain cumuls from InfluxDB"),
       );
     }, DEBOUNCE_MS);
@@ -138,63 +186,53 @@ export class WeatherAggregator {
     this.pendingRefresh.set(equipmentId, timer);
   }
 
-  /** Query InfluxDB to compute rain_1h and rain_24h for an equipment. */
-  private async refreshFromInfluxDB(equipmentId: string): Promise<void> {
-    const client = this.influxClient.getClient();
-    const config = this.influxClient.getConfig();
-    if (!client || !config) return;
+  /** Compute rain_1h and rain_24h for an equipment and cache them. */
+  private async refreshCumuls(equipmentId: string): Promise<void> {
+    const bindings = this.equipmentManager.getDataBindingsWithValues(equipmentId);
+    const { rain1h, rain24h } = await computeRainCumuls(bindings, (window) =>
+      this.sumIncrementalRain(equipmentId, window),
+    );
 
-    const queryApi = client.getQueryApi(config.org);
-    const bucket = config.bucket;
-
-    // rain_1h: sum of rain values over last 1 hour
-    let rain1h: number | null = null;
-    const flux1h = `from(bucket: "${bucket}")
-  |> range(start: -1h)
-  |> filter(fn: (r) => r._measurement == "equipment_data")
-  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
-  |> filter(fn: (r) => r.category == "rain")
-  |> filter(fn: (r) => r._field == "value_number")
-  |> sum()`;
-
-    try {
-      for await (const { values, tableMeta } of queryApi.iterateRows(flux1h)) {
-        const row = tableMeta.toObject(values) as { _value: number };
-        rain1h = row._value;
-      }
-    } catch (err) {
-      this.logger.warn({ err, equipmentId }, "Failed to query rain_1h");
-    }
-
-    // rain_24h: sum of rain values over last 24 hours
-    let rain24h: number | null = null;
-    const flux24h = `from(bucket: "${bucket}")
-  |> range(start: -24h)
-  |> filter(fn: (r) => r._measurement == "equipment_data")
-  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
-  |> filter(fn: (r) => r.category == "rain")
-  |> filter(fn: (r) => r._field == "value_number")
-  |> sum()`;
-
-    try {
-      for await (const { values, tableMeta } of queryApi.iterateRows(flux24h)) {
-        const row = tableMeta.toObject(values) as { _value: number };
-        rain24h = row._value;
-      }
-    } catch (err) {
-      this.logger.warn({ err, equipmentId }, "Failed to query rain_24h");
-    }
-
-    // Round to 1 decimal
     const cumul: RainCumuls = {
-      rain1h: rain1h !== null ? Math.round(rain1h * 10) / 10 : null,
-      rain24h: rain24h !== null ? Math.round(rain24h * 10) / 10 : null,
+      rain1h,
+      rain24h,
       lastUpdated: new Date().toISOString(),
     };
-
     this.cumuls.set(equipmentId, cumul);
+    this.logger.debug({ equipmentId, ...cumul }, "Rain cumuls refreshed");
+  }
 
-    this.logger.debug({ equipmentId, ...cumul }, "Rain cumuls refreshed from InfluxDB");
+  /**
+   * Fallback for stations without a native rolling cumulative: sum the
+   * incremental `rain` alias over the window. Alias-scoped, so it never sums a
+   * cumulative series (`sum_rain_*`).
+   */
+  private async sumIncrementalRain(
+    equipmentId: string,
+    window: "-1h" | "-24h",
+  ): Promise<number | null> {
+    const client = this.influxClient.getClient();
+    const config = this.influxClient.getConfig();
+    if (!client || !config) return null;
+
+    const queryApi = client.getQueryApi(config.org);
+    const flux = `from(bucket: "${config.bucket}")
+  |> range(start: ${window})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => r.alias == "rain")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> sum()`;
+
+    let total: number | null = null;
+    try {
+      for await (const { values, tableMeta } of queryApi.iterateRows(flux)) {
+        total = (tableMeta.toObject(values) as { _value: number })._value;
+      }
+    } catch (err) {
+      this.logger.warn({ err, equipmentId, window }, "Failed to sum incremental rain");
+    }
+    return total;
   }
 
   /** Return computed data entries for a given equipment. */


### PR DESCRIPTION
## Summary

Fixes wildly inflated rain data on production. The `WeatherAggregator` computed `rain_1h`/`rain_24h` by summing **every** `category == "rain"` InfluxDB sample. Netatmo re-reports the **rolling** cumulatives `sum_rain_1` / `sum_rain_24` at every poll, so the sum multiplied them by the poll count.

Measured on prod (Station Météo, last 24h): raw `sum_rain_24` peaked at **11.9 mm** (the real total) but was sampled **183×** → the aggregator returned `rain_24h = 1392 mm`. This permanently tripped the Auto Watering rain-skip (any 0-50 mm threshold exceeded) and made the rain chart plot a flat "11.9 mm every hour".

## Root cause

- `category == "rain"` mixes the **incremental** `rain` (fine to sum per period) with the **rolling cumulatives** `sum_rain_1` / `sum_rain_24` (must never be summed).
- Same class of bug already fixed for energy (`energy_forward` / `energy_reverse` in `ALIAS_DEFAULTS_OFF`).

## Changes

- **`weather-aggregator.ts`**: `rain_1h`/`rain_24h` now read the native rolling cumulative from the **live binding** (`sum_rain_1` / `sum_rain_24`) as-is. Fallback to summing the **incremental `rain` alias** (alias-scoped, never the whole category) only for stations without a native cumulative. Extracted a pure `computeRainCumuls()` for testing; broadened the refresh trigger to the rain aliases.
- **`history-writer.ts`**: add `sum_rain_1` / `sum_rain_24` to `ALIAS_DEFAULTS_OFF` — stop historizing the rolling cumulatives (removes the misleading flat chart line). Incremental `rain` stays historized. Live weather-panel values are unaffected (they read device data, not InfluxDB).

## Impact / migration

- `rain_24h` becomes the real total again (0 mm now on prod), so Auto Watering resumes normally.
- No migration: existing polluted points age out of the 24h window on their own within ~24h.

## Tests

- [x] `computeRainCumuls`: native cumulative used as-is (never falls back), rounding, incremental fallback, null-value handling — new `weather-aggregator.test.ts`
- [x] `resolveHistorize`: `sum_rain_1`/`sum_rain_24` OFF, incremental `rain` ON
- [x] `npx vitest run` — 932 passed / 2 skipped
- [x] `tsc --noEmit` + `eslint` clean
