### PR TITLE
release: v1.28.1

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.28.x: Arrosage par jour
 
+### v1.28.1 — 2026-07-18 { #v1-28-1 }
+
+- Fix (météo) : les cumuls de pluie pouvaient exploser (ex. 1392 mm sur 24h pour 11,9 mm réels), ce qui bloquait en permanence le saut de pluie de l'Arrosage Auto et affichait un plateau « 11,9 mm chaque heure » sur les graphes. Les cumuls roulants 1h / 24h de Netatmo (`sum_rain_1` / `sum_rain_24`) étaient sommés à chaque interrogation. Sowel les lit désormais comme les totaux qu'ils sont déjà, et ne les stocke plus comme séries temporelles. Les valeurs live ne changent pas ; les graphes de pluie existants se corrigent d'eux-mêmes sous ~24h. (#312)
+
 ### v1.28.0 — 2026-07-17 { #v1-28-0 }
 
 - Feat (recettes) : les formulaires de recette gèrent désormais les champs à choix multiple, affichés en pastilles plutôt qu'en simple liste déroulante. Cela apporte un nouveau sélecteur de **jours de la semaine** par créneau dans la recette Arrosage Auto (mettez la recette à jour en v1.2.0) : chaque créneau d'arrosage peut être limité à certains jours, et le laisser vide continue d'arroser tous les jours. Exemple : arroser à 07h30 les jours d'école et à 09h00 le mercredi et le week-end. Les planifications d'arrosage existantes ne changent pas. (#310, auto-watering #2)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.28.x: Watering weekdays
 
+### v1.28.1 — 2026-07-18 { #v1-28-1 }
+
+- Fix (weather): rain totals could balloon to absurd values (e.g. 1392 mm over 24h from an actual 11.9 mm), which permanently blocked the Auto Watering rain-skip and plotted a flat "11.9 mm every hour" on rain charts. Netatmo's rolling 1h / 24h totals (`sum_rain_1` / `sum_rain_24`) were summed at every poll. Sowel now reads them as the totals they already are, and no longer stores them as time series. Live weather values are unchanged; existing rain charts self-correct within ~24h. (#312)
+
 ### v1.28.0 — 2026-07-17 { #v1-28-0 }
 
 - Feat (recipes): recipe forms now support multi-select option fields, shown as toggle chips instead of a single dropdown. This powers a new per-slot **day of week** selector in the Auto Watering recipe (update the recipe to v1.2.0): each watering slot can be limited to chosen weekdays, and leaving it empty keeps watering every day. Example: water at 07:30 on school days and at 09:00 on Wednesday and the weekend. Existing watering schedules are unchanged. (#310, auto-watering #2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.28.0",
+  "version": "1.28.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## release: v1.28.1

Patch release for the rain-cumul fix (#312, already on main).

### Included
- **Fix (weather)**: `rain_1h`/`rain_24h` no longer sum Netatmo's rolling `sum_rain_1`/`sum_rain_24` cumulatives (prod showed `rain_24h = 1392 mm` for an actual 11.9 mm, blocking Auto Watering rain-skip and flat-lining rain charts). Reads the native cumulative live value; stops historizing the rolling totals.
- **Release notes** v1.28.1 in `docs/release-notes.md` + `.fr.md` (anchor `{ #v1-28-1 }`).

### Version
- `package.json`, `ui/package.json`: 1.28.0 → **1.28.1**

### After merge
Tag `v1.28.1` on main and push to trigger the Docker build.
