### PR TITLE
fix(ui): mobile dashboard shows Ouvert/Fermé for contact sensors (#315)

### DIFF
--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -1,8 +1,9 @@
 import { createElement } from "react";
 import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import type { DashboardWidget, EquipmentWithDetails } from "../../types";
 import { useEquipmentState } from "../equipments/useEquipmentState";
-import { getSensorBindings, formatSensorValue } from "../equipments/sensorUtils";
+import { getSensorBindings, formatSensorValue, formatBooleanSensor } from "../equipments/sensorUtils";
 import {
   LightBulbIcon,
   ShutterWidgetIcon,
@@ -69,7 +70,7 @@ export function MobileWidgetCard({ widget, equipment, onClick, editMode }: Mobil
 function useMobileState(
   widget: DashboardWidget,
   equipment: EquipmentWithDetails,
-  t: (key: string) => string,
+  t: TFunction,
 ): { icon: React.ReactNode; stateLines: string[] } {
   const {
     isLight,
@@ -266,7 +267,14 @@ function useMobileState(
     const lines: string[] = [];
     for (const b of sensorBindings.slice(0, 2)) {
       if (b.value !== null && b.value !== undefined) {
-        lines.push(formatSensorValue(b.value, b.unit ?? undefined));
+        // Category-aware for booleans (contact_door -> Ouvert/Fermé, motion ->
+        // Détecté/…) like the desktop card; the generic formatter would render
+        // any boolean as a bare Oui/Non.
+        lines.push(
+          typeof b.value === "boolean"
+            ? formatBooleanSensor(b.category, b.value, t)
+            : formatSensorValue(b.value, b.unit ?? undefined, t),
+        );
       }
     }
     return { icon: sensorIcon, stateLines: lines };


### PR DESCRIPTION
Fixes #315. The mobile Dashboard widget card formatted boolean sensor bindings with the generic `formatSensorValue` (any boolean -> Oui/Non), whereas the desktop card and the Zone view use the category-aware `formatBooleanSensor` (contact_door -> Ouvert/Fermé). So a contact sensor (e.g. Sonoff SNZB-04P) modelled as a **Capteur** showed Oui/Non on the mobile dashboard while being correct everywhere else.

## Fix
`MobileWidgetCard` now uses `formatBooleanSensor(category, value, t)` for boolean bindings — also fixes motion / water_leak / smoke labels on the mobile dashboard.

## Notes
- Not Android-specific: it's the mobile (narrow-viewport) widget card; a narrow desktop window shows the same.
- The proper model for a door/gate remains the **Ouvrant** type (derives open/closed from the contact, incl. mobile). This fix only improves the Capteur fallback.
- Other generic-formatter spots exist (BindingsPicker config, WidgetDetailSheet detail list) — left out of scope; can follow up.

## Test
- [x] `tsc -b --noEmit`, `eslint`, `vite build` green