### PR TITLE
release: v1.28.2

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.28.x: Arrosage par jour
 
+### v1.28.2 — 2026-07-18 { #v1-28-2 }
+
+- Fix (ui) : sur le dashboard mobile, un capteur de contact (porte/fenêtre) modélisé en **Capteur** affiche désormais « Ouvert / Fermé » au lieu d'un simple « Oui / Non ». La carte widget mobile formatait les booléens de façon générique ; elle utilise maintenant les mêmes libellés selon la catégorie que la carte desktop et la vue zone (corrige aussi mouvement / fuite d'eau / fumée sur mobile). À noter : une porte/portail motorisé se modélise plutôt en **Ouvrant**, qui dérive déjà ouvert/fermé depuis un contact et s'affiche correctement partout. (#316)
+
 ### v1.28.1 — 2026-07-18 { #v1-28-1 }
 
 - Fix (météo) : les cumuls de pluie pouvaient exploser (ex. 1392 mm sur 24h pour 11,9 mm réels), ce qui bloquait en permanence le saut de pluie de l'Arrosage Auto et affichait un plateau « 11,9 mm chaque heure » sur les graphes. Les cumuls roulants 1h / 24h de Netatmo (`sum_rain_1` / `sum_rain_24`) étaient sommés à chaque interrogation. Sowel les lit désormais comme les totaux qu'ils sont déjà, et ne les stocke plus comme séries temporelles. Les valeurs live ne changent pas ; les graphes de pluie existants se corrigent d'eux-mêmes sous ~24h. (#312)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.28.x: Watering weekdays
 
+### v1.28.2 — 2026-07-18 { #v1-28-2 }
+
+- Fix (ui): on the mobile dashboard, a contact sensor (door/window) modelled as a **Capteur** now shows "Ouvert / Fermé" instead of a bare "Oui / Non". The mobile widget card was formatting boolean sensor values generically; it now uses the same category-aware labels as the desktop card and the zone view (also fixes motion / water-leak / smoke labels on mobile). Note: a motorised door/gate is best modelled as an **Ouvrant**, which already derives open/closed from a contact and displays correctly everywhere. (#316)
+
 ### v1.28.1 — 2026-07-18 { #v1-28-1 }
 
 - Fix (weather): rain totals could balloon to absurd values (e.g. 1392 mm over 24h from an actual 11.9 mm), which permanently blocked the Auto Watering rain-skip and plotted a flat "11.9 mm every hour" on rain charts. Netatmo's rolling 1h / 24h totals (`sum_rain_1` / `sum_rain_24`) were summed at every poll. Sowel now reads them as the totals they already are, and no longer stores them as time series. Live weather values are unchanged; existing rain charts self-correct within ~24h. (#312)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.28.1",
+  "version": "1.28.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch release for the mobile-dashboard contact-label fix (#316, issue #315).

- Fix (ui): a contact sensor modelled as a Capteur now shows Ouvert/Fermé on the mobile dashboard instead of Oui/Non.
- Release notes v1.28.2 (EN + FR), anchor `{ #v1-28-2 }`.
- Version 1.28.1 -> 1.28.2.

After merge: tag v1.28.2 on main to trigger the Docker build.