### PR TITLE
feat(auth): config is admin-only, standard = view + actuate (spec 131, #319)

### DIFF
--- a/docs/technical/api-reference.md
+++ b/docs/technical/api-reference.md
@@ -52,6 +52,29 @@ Public endpoints -- no auth required for `status` and `setup`.
 
 ---
 
+## Roles & authorization
+
+Two roles exist: `admin` and `standard`. Reads (`GET`) are available to any
+authenticated user. **All configuration mutations are admin-only** (spec 131): a
+`standard` user gets `403 { "error": "Admin access required" }` on any
+`POST/PUT/PATCH/DELETE` except the usage/personal allowlist below. Sections tagged
+**(Admin)** require the admin role; the gate is fail-closed, so any mutating
+endpoint not in the allowlist is admin-only.
+
+**Standard write allowlist** (the only mutations a `standard` may perform):
+
+| Method        | Path                                                          | Purpose                |
+| ------------- | ------------------------------------------------------------- | ---------------------- |
+| POST          | `/api/v1/equipments/:id/orders/:alias`                        | Actuate an equipment   |
+| POST          | `/api/v1/zones/:id/orders/:orderKey`                          | Zone command           |
+| PUT           | `/api/v1/me`, `/api/v1/me/preferences`, `/api/v1/me/password` | Own account            |
+| POST / DELETE | `/api/v1/me/tokens[/:id]`                                     | Own API tokens         |
+| POST / DELETE | `/api/v1/push/subscriptions`                                  | Own push subscription  |
+| POST          | `/api/v1/auth/logout`                                         | End own session        |
+
+An API token inherits its creator's role, so a standard-scoped token is subject to
+the same gate (no privilege escalation).
+
 ## Current User (Me)
 
 Authenticated user's own profile and tokens.

--- a/specs/131-rbac-config-admin-only/architecture.md
+++ b/specs/131-rbac-config-admin-only/architecture.md
@@ -1,0 +1,103 @@
+# Architecture — Spec 131
+
+No data model change, no new event, no new endpoint. This adds a **role gate**
+on existing mutating endpoints (backend) and hides config actions (frontend).
+
+## 1. Backend — central fail-closed role gate
+
+### Where
+Extend the existing auth `onRequest` hook in
+`src/auth/auth-middleware.ts` (`registerAuthMiddleware`). It already resolves the
+token and sets `request.auth = { userId, role }`. Right after that, add the role
+gate for mutations.
+
+### Predicate (pure, exported, unit-tested)
+```ts
+const MUTATING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/** Route (method, path) templates a `standard` user is allowed to mutate.
+ *  Everything else that mutates is admin-only (fail-closed). */
+const STANDARD_WRITE_ALLOWLIST: ReadonlyArray<{ method: string; re: RegExp }> = [
+  { method: "POST",   re: /^\/api\/v1\/equipments\/[^/]+\/orders\/[^/]+$/ }, // actuate
+  { method: "POST",   re: /^\/api\/v1\/zones\/[^/]+\/orders\/[^/]+$/ },      // zone command
+  { method: "PUT",    re: /^\/api\/v1\/me$/ },
+  { method: "PUT",    re: /^\/api\/v1\/me\/preferences$/ },
+  { method: "PUT",    re: /^\/api\/v1\/me\/password$/ },
+  { method: "POST",   re: /^\/api\/v1\/me\/tokens$/ },
+  { method: "DELETE", re: /^\/api\/v1\/me\/tokens\/[^/]+$/ },
+  { method: "POST",   re: /^\/api\/v1\/push\/subscriptions$/ },
+  { method: "DELETE", re: /^\/api\/v1\/push\/subscriptions$/ },
+  { method: "POST",   re: /^\/api\/v1\/auth\/logout$/ },
+];
+
+export function isStandardWriteAllowed(method: string, path: string): boolean {
+  return STANDARD_WRITE_ALLOWLIST.some((e) => e.method === method && e.re.test(path));
+}
+```
+
+### Hook logic (added to the existing onRequest, after `request.auth` is set)
+```ts
+const method = request.method.toUpperCase();
+if (MUTATING.has(method) && request.auth?.role !== "admin") {
+  const path = request.url.split("?")[0];
+  if (!isStandardWriteAllowed(method, path)) {
+    return reply.code(403).send({ error: "Admin access required" });
+  }
+}
+```
+- Runs for every `/api/*` non-public route (public routes already `return` earlier).
+- `GET` / `HEAD` / `OPTIONS` are never gated → all reads stay open to `standard`.
+- Applies identically to JWT and API-token auth (role comes from `request.auth`),
+  so a standard-scoped token cannot escalate (AC6).
+
+### Existing `requireAdmin` calls
+`requireAdmin` in `users.ts`, `audit.ts`, `packages.ts` becomes redundant (the hook
+already denies non-admins there). **Keep them** as defense-in-depth and explicit
+intent — they are harmless (the hook 403s first for standard; for admin both pass).
+
+### Why a central hook, not per-route `requireAdmin`
+The standard-permitted set is tiny (10 templates) and the config set is large and
+grows over time. A per-route opt-in would eventually forget a new mutating endpoint,
+silently exposing it to `standard`. Default-deny is fail-closed: a new mutating
+route is admin-only until explicitly allowlisted. One place to read and to test.
+
+## 2. Frontend — hide configuration actions for `standard`
+
+Gate every configuration action behind `user?.role === "admin"`. Introduce a tiny
+`useIsAdmin()` selector (or reuse the existing `user?.role === "admin"` already used
+in `AppLayout` / `Sidebar`) and apply it to the config controls that today live in
+non-admin views:
+
+| Area | Component(s) | Gate |
+| --- | --- | --- |
+| Equipment add/edit/delete | `EquipmentsPage`, `EquipmentCard`, zone equipment lists, `EquipmentForm` entry points | hide add/edit/delete; keep the control widgets (actuation) |
+| Recipe add/edit/delete/toggle | `ZoneRecipesSection` | hide the "+", edit, delete, and the recipe on/off switch |
+| Zone add/edit/delete/reorder | zone tree / `ZonesPage` | hide add/edit/delete/reorder |
+| Modes (edit + activate toggles) | modes views | hide edit AND the activation toggles (modes = admin) |
+| Dashboard edit | dashboard page (`WidgetGrid`, `AddWidgetModal`, reorder, delete) | hide add/remove/reorder/edit widgets |
+| Charts | chart creation entry points | hide create/edit/delete |
+| Devices | `DevicesPage` | hide rename/delete |
+| Administration (users, audit, integrations, mqtt, plugins, backup, settings) | `Sidebar` / `AppLayout` | already gated by `isAdmin` — no change |
+
+Kept visible for `standard`: dashboard (read), zone views (read), equipment/zone
+**control** widgets (actuation), the personal account & preferences pages, theme
+toggle, push-notification opt-in.
+
+The backend `403` is the source of truth; UI hiding is UX (no button that would fail).
+
+## 3. Files changed
+
+| Layer | File | Change |
+| --- | --- | --- |
+| backend | `src/auth/auth-middleware.ts` | `isStandardWriteAllowed` + allowlist + role gate in the onRequest hook |
+| backend | `src/auth/auth-middleware.test.ts` | role-gate + allowlist tests |
+| ui | `ui/src/…` config components (see table §2) | gate config actions behind `role === "admin"` |
+| docs | `docs/technical/api-reference.md` | document the admin/standard role model + allowlist |
+| spec | `specs/131-rbac-config-admin-only/*` | this spec |
+
+## 4. Rollout / compatibility
+
+- No migration. Existing `admin` users unaffected. Existing `standard` users lose
+  the ability to mutate config (the intended change) but keep view + actuation.
+- Recovery for a home that only had a single `standard`-ish account: the first user
+  is always `admin` (setup), so there is always an admin to configure.

--- a/specs/131-rbac-config-admin-only/architecture.md
+++ b/specs/131-rbac-config-admin-only/architecture.md
@@ -55,6 +55,21 @@ if (MUTATING.has(method) && request.auth?.role !== "admin") {
 already denies non-admins there). **Keep them** as defense-in-depth and explicit
 intent — they are harmless (the hook 403s first for standard; for admin both pass).
 
+### Secret-bearing reads must also be admin-gated (added after review)
+
+The mutation gate deliberately does not touch `GET`. But a few config `GET`
+reads return **secrets** (MQTT broker plaintext passwords, notification channel
+config with the Telegram `botToken` / webhook URLs). Leaving them open to a
+`standard` user is an out-of-band escalation (read the broker password, then
+drive the broker directly). These whole prefixes are admin-only config areas, so
+they get a per-prefix `onRequest` `requireAdmin` hook (same pattern as
+`users.ts`), gating their reads and writes:
+
+- `src/api/routes/mqtt-brokers.ts`, `src/api/routes/mqtt-publishers.ts`,
+  `src/api/routes/notification-publishers.ts`.
+
+(`GET /settings` and `GET /integrations` already redact/gate their secrets.)
+
 ### Why a central hook, not per-route `requireAdmin`
 The standard-permitted set is tiny (10 templates) and the config set is large and
 grows over time. A per-route opt-in would eventually forget a new mutating endpoint,

--- a/specs/131-rbac-config-admin-only/plan.md
+++ b/specs/131-rbac-config-admin-only/plan.md
@@ -1,0 +1,79 @@
+# Plan — Spec 131
+
+## Implementation steps
+
+### A. Backend — role gate (`feat/rbac-config-admin-only`)
+1. `src/auth/auth-middleware.ts`: add `MUTATING`, `STANDARD_WRITE_ALLOWLIST`,
+   and the exported pure `isStandardWriteAllowed(method, path)`.
+2. In the `onRequest` hook, after `request.auth` is set, deny non-admin mutations
+   not in the allowlist with `403`.
+3. Keep the existing `requireAdmin` calls (defense in depth).
+4. `npx tsc --noEmit` + `eslint` clean.
+
+### B. Backend tests
+5. Extend `src/auth/auth-middleware.test.ts` with the scenarios in the test plan.
+
+### C. Frontend — hide config for standard
+6. Add `useIsAdmin()` (or reuse `user?.role === "admin"`).
+7. Gate config actions in the components listed in architecture.md §2 (equipment /
+   recipe / zone / mode / dashboard / chart / device edit + mode activation toggles).
+8. `cd ui && npx tsc -b --noEmit` + `eslint` clean.
+
+Order: A → B first (the security boundary), then C (UX). B is the gate that must be
+green; C is verified by tsc + manual (no React tests, per repo convention).
+
+## Test Plan
+
+### Modules to test
+- `src/auth/auth-middleware.ts` — `isStandardWriteAllowed` (pure) + the role gate.
+- Frontend config-hiding: no React tests in this project → tsc + manual check.
+
+### Scenarios (auth-middleware)
+
+| Scenario | Expected |
+| --- | --- |
+| `isStandardWriteAllowed("POST","/api/v1/equipments/abc/orders/state")` | true |
+| `isStandardWriteAllowed("POST","/api/v1/zones/z1/orders/allLightsOff")` | true |
+| `isStandardWriteAllowed("PUT","/api/v1/me/password")` | true |
+| `isStandardWriteAllowed("POST","/api/v1/me/tokens")` / `DELETE /me/tokens/x` | true |
+| `isStandardWriteAllowed("POST","/api/v1/push/subscriptions")` / DELETE | true |
+| `isStandardWriteAllowed("POST","/api/v1/auth/logout")` | true |
+| `isStandardWriteAllowed("PUT","/api/v1/equipments/abc")` | false |
+| `isStandardWriteAllowed("DELETE","/api/v1/equipments/abc")` | false |
+| `isStandardWriteAllowed("POST","/api/v1/equipments/abc/order-bindings")` | false (near-miss of the orders rule) |
+| `isStandardWriteAllowed("POST","/api/v1/modes/m1/activate")` | false (modes = admin) |
+| `isStandardWriteAllowed("POST","/api/v1/recipe-instances/r1/enable")` | false (recipes = admin) |
+| `isStandardWriteAllowed("POST","/api/v1/dashboard/widgets")` | false |
+| `isStandardWriteAllowed("PUT","/api/v1/settings")` | false |
+| `isStandardWriteAllowed("GET", anything)` | (not called for GET; assert gate ignores GET) |
+| Trailing query string on an allowed path | allowed (path is split on `?` before match) |
+
+### Scenarios (role gate in the hook — integration-style over the middleware)
+
+| Actor | Request | Expected |
+| --- | --- | --- |
+| standard | `GET /api/v1/equipments` | passes (read) |
+| standard | `POST /api/v1/equipments/x/orders/state` | passes (allowlist) |
+| standard | `POST /api/v1/equipments` | 403 |
+| standard | `DELETE /api/v1/zones/z1` | 403 |
+| standard | `POST /api/v1/modes/m/activate` | 403 |
+| standard | `PUT /api/v1/me/password` | passes |
+| admin | `POST /api/v1/equipments` | passes |
+| admin | any mutation | passes |
+| standard-scoped **API token** | `POST /api/v1/equipments` | 403 (role from token) |
+| standard-scoped API token | `POST /api/v1/equipments/x/orders/state` | passes |
+
+### Retro-compat
+- Admin behavior unchanged (all existing tests green).
+- Reads unchanged for all roles.
+
+## Tasks
+- [x] A1 allowlist + `isStandardWriteAllowed`
+- [x] A2 role gate in onRequest hook
+- [x] A3 backend tsc + eslint clean
+- [x] B1 auth-middleware tests (all scenarios above)
+- [x] C1 `useIsAdmin` + gate equipment/recipe/zone config actions
+- [x] C2 gate mode edit + activation toggles
+- [x] C3 gate dashboard/chart/device config actions
+- [x] C4 ui tsc + eslint clean
+- [x] D1 docs: role model in api-reference.md

--- a/specs/131-rbac-config-admin-only/spec.md
+++ b/specs/131-rbac-config-admin-only/spec.md
@@ -1,0 +1,126 @@
+# Spec 131 — RBAC: config is admin-only, standard = view + actuate
+
+## Context
+
+GitHub issue #319 (Romain / alpitux). Sowel has two roles, `admin` and `standard`
+(`UserRole` in `src/shared/types.ts`). Today only three areas are role-gated
+(`requireAdmin`): user management, audit log, and plugin install. **Everything
+else is open to a `standard` user** — including create / rename / delete of
+equipments, zones, recipes, modes, devices, dashboard, charts, and every
+settings/integration mutation. A `standard` account meant for consultative use
+(view the dashboard, see zone states, open a gate/door) can therefore, on purpose
+or by accident, break the whole configuration.
+
+Chosen direction (Option A, confirmed with the maintainer): **restrict `standard`
+to usage; make all configuration admin-only.** No new role is added.
+
+## Goal
+
+A `standard` user can:
+- **View** everything (all read endpoints).
+- **Actuate** equipments (execute orders) and run **zone commands** (all-lights-off, etc.).
+- Manage **their own account**: display name, preferences (theme/language), password,
+  their own API tokens, and their own push-notification subscription.
+
+A `standard` user cannot perform **any configuration mutation**. All create /
+update / delete / activate on shared infrastructure is **admin-only**: equipments,
+zones, recipes (incl. enable/disable/actions), modes (incl. activate/deactivate),
+dashboard widgets, charts, devices, settings, integrations, MQTT brokers/publishers,
+notification publishers, calendar, energy tariff, logs level, backup, system
+update/restart, plugins, users, audit.
+
+## Design in one line
+
+**Fail-closed default-deny**: after authentication, any mutating request
+(`POST/PUT/PATCH/DELETE`) from a non-admin is rejected with `403` unless its
+`(method, path)` matches an explicit **standard write allowlist**. Reads (`GET`)
+are never gated. This is centralised (one hook + one pure predicate) so a future
+new mutating endpoint is admin-only by default — no per-route opt-in to forget.
+
+## Standard write allowlist (the ONLY mutations a standard may do)
+
+| Method | Path (template) | Why |
+| --- | --- | --- |
+| POST | `/api/v1/equipments/:id/orders/:alias` | Actuate an equipment (open gate, toggle light) |
+| POST | `/api/v1/zones/:id/orders/:orderKey` | Zone command (all-lights-off, all-shutters-close) |
+| PUT | `/api/v1/me` | Own display name |
+| PUT | `/api/v1/me/preferences` | Own theme / language |
+| PUT | `/api/v1/me/password` | Own password |
+| POST | `/api/v1/me/tokens` | Own API token (inherits standard role, no escalation) |
+| DELETE | `/api/v1/me/tokens/:id` | Revoke own API token |
+| POST | `/api/v1/push/subscriptions` | Register own device for push |
+| DELETE | `/api/v1/push/subscriptions` | Unregister own device |
+| POST | `/api/v1/auth/logout` | End own session |
+
+Everything else that mutates → **admin only**.
+
+## UI
+
+For a `standard` user, configuration actions are **hidden** (not shown-but-blocked):
+add / edit / delete buttons for equipments, recipes, zones, modes (incl. the
+mode activation toggles), dashboard widgets, charts, devices, and the whole
+Administration section (already hidden). Kept visible: the dashboard, zone views,
+equipment/zone **controls** (actuation), and the personal account/preferences pages.
+
+The backend `403` is the source of truth; the UI hiding is UX so a standard user
+never sees a button that would fail.
+
+## Acceptance criteria
+
+- [x] AC1 — A `standard` user gets `403` on every mutation not in the allowlist
+      (verified per domain: equipments create/delete, recipe create/enable, mode
+      activate, zone create, dashboard widget add, settings, devices, etc.).
+- [x] AC2 — A `standard` user succeeds on every allowlisted usage mutation
+      (execute equipment order, zone command, own account/preferences/password,
+      own tokens, own push subscription, logout).
+- [x] AC3 — An `admin` user is unaffected: all mutations succeed as before.
+- [x] AC4 — All `GET` endpoints remain available to `standard` (no read is gated).
+- [x] AC5 — The allowlist matching is exact: `/equipments/:id/orders/:alias` is
+      allowed but `/equipments/:id` (PUT/DELETE) and `/equipments/:id/order-bindings`
+      are denied for standard.
+- [x] AC6 — API tokens carry the creator's role; a standard-scoped token is subject
+      to the exact same default-deny (no privilege escalation via token).
+- [x] AC7 — In the UI, a standard user sees no configuration buttons (equipment /
+      recipe / zone / mode / dashboard / chart edit), but can view and actuate.
+- [x] AC8 — First-run setup (no users yet) and login/refresh remain reachable.
+
+## Scope
+
+### In scope
+- Central role-enforcement hook + pure `isStandardWriteAllowed(method, path)` predicate.
+- Remove the now-redundant per-route `requireAdmin` calls OR keep them (defense in
+  depth) — decided in architecture.md.
+- UI: gate configuration actions behind `role === "admin"`.
+- Docs: note the role model in `docs/technical/api-reference.md`.
+
+### Out of scope
+- A third role (read-only "viewer" that cannot actuate) — noted as a possible
+  future addition; not needed for #319.
+- Per-zone / per-equipment ACLs.
+- Changing how roles are assigned (admin already sets a user's role at creation).
+
+### Future (noted by the maintainer) — per-user dashboards
+Today the dashboard and saved charts are **shared/global** (no `user_id` on
+`dashboard_widgets` / `chart_configs`), which is exactly why editing them is
+**admin-only** in this spec. A later phase may introduce **per-user dashboards**
+(each user, including `standard`, owns and arranges their own dashboard). When
+that lands, the owner's dashboard/chart mutations move to the standard allowlist,
+scoped to `ownerId === request.auth.userId`. The central hook makes this a
+one-line allowlist change; no other RBAC rework needed. Tracked separately.
+
+## Edge cases
+
+| Case | Expected |
+| --- | --- |
+| Standard executes an equipment order | Allowed (200) |
+| Standard runs a zone command | Allowed |
+| Standard renames/deletes an equipment | 403 |
+| Standard activates a mode | 403 (modes = admin) |
+| Standard enables/disables a recipe | 403 (recipes = admin) |
+| Standard edits the shared dashboard / creates a chart | 403 |
+| Standard changes own password / preferences | Allowed |
+| Standard creates/revokes own API token | Allowed |
+| Standard-scoped API token tries a config mutation | 403 (role from token = standard) |
+| Admin does any of the above | Allowed |
+| Any user does a GET | Allowed |
+| No users yet (setup) | `/auth/setup` reachable, others 403 setupRequired (unchanged) |

--- a/src/api/routes/mqtt-brokers.ts
+++ b/src/api/routes/mqtt-brokers.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import type { MqttBrokerManager } from "../../mqtt-publishers/mqtt-broker-manager.js";
 import { MqttBrokerError } from "../../mqtt-publishers/mqtt-broker-manager.js";
+import { requireAdmin } from "../../auth/auth-middleware.js";
 
 interface MqttBrokersDeps {
   mqttBrokerManager: MqttBrokerManager;
@@ -8,6 +9,12 @@ interface MqttBrokersDeps {
 
 export function registerMqttBrokerRoutes(app: FastifyInstance, deps: MqttBrokersDeps): void {
   const { mqttBrokerManager } = deps;
+
+  // Admin only: broker config carries plaintext passwords, so even the GET
+  // reads must be gated (spec 131 — the mutation gate does not cover reads).
+  app.addHook("onRequest", async (request, reply) => {
+    if (request.url.startsWith("/api/v1/mqtt-brokers")) requireAdmin(request, reply);
+  });
 
   // GET /api/v1/mqtt-brokers
   app.get("/api/v1/mqtt-brokers", async () => {

--- a/src/api/routes/mqtt-publishers.ts
+++ b/src/api/routes/mqtt-publishers.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { MqttPublisherManager } from "../../mqtt-publishers/mqtt-publisher-manager.js";
 import type { MqttPublishService } from "../../mqtt-publishers/mqtt-publish-service.js";
 import { MqttPublisherError } from "../../mqtt-publishers/mqtt-publisher-manager.js";
+import { requireAdmin } from "../../auth/auth-middleware.js";
 
 interface MqttPublishersDeps {
   mqttPublisherManager: MqttPublisherManager;
@@ -10,6 +11,11 @@ interface MqttPublishersDeps {
 
 export function registerMqttPublisherRoutes(app: FastifyInstance, deps: MqttPublishersDeps): void {
   const { mqttPublisherManager, mqttPublishService } = deps;
+
+  // Admin only: publisher/mapping config is infrastructure — gate reads too.
+  app.addHook("onRequest", async (request, reply) => {
+    if (request.url.startsWith("/api/v1/mqtt-publishers")) requireAdmin(request, reply);
+  });
 
   // GET /api/v1/mqtt-publishers
   app.get("/api/v1/mqtt-publishers", async () => {

--- a/src/api/routes/notification-publishers.ts
+++ b/src/api/routes/notification-publishers.ts
@@ -3,6 +3,7 @@ import type { NotificationPublisherManager } from "../../notifications/notificat
 import type { NotificationPublishService } from "../../notifications/notification-publish-service.js";
 import { NotificationPublisherError } from "../../notifications/notification-publisher-manager.js";
 import type { NotificationChannelType, NotificationChannelConfig } from "../../shared/types.js";
+import { requireAdmin } from "../../auth/auth-middleware.js";
 
 interface NotificationPublishersDeps {
   notificationPublisherManager: NotificationPublisherManager;
@@ -14,6 +15,12 @@ export function registerNotificationPublisherRoutes(
   deps: NotificationPublishersDeps,
 ): void {
   const { notificationPublisherManager, notificationPublishService } = deps;
+
+  // Admin only: channel config carries secrets (Telegram botToken, webhook
+  // URLs), so even the GET reads must be gated (spec 131).
+  app.addHook("onRequest", async (request, reply) => {
+    if (request.url.startsWith("/api/v1/notification-publishers")) requireAdmin(request, reply);
+  });
 
   // GET /api/v1/notification-publishers
   app.get("/api/v1/notification-publishers", async () => {

--- a/src/auth/auth-middleware.test.ts
+++ b/src/auth/auth-middleware.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Fastify from "fastify";
 import { createLogger } from "../core/logger.js";
-import { PUBLIC_ROUTES, isPublicRoute, registerAuthMiddleware } from "./auth-middleware.js";
+import {
+  PUBLIC_ROUTES,
+  isPublicRoute,
+  registerAuthMiddleware,
+  isStandardWriteAllowed,
+  isMutationDeniedForStandard,
+} from "./auth-middleware.js";
 import type { AuthService, JwtPayload } from "./auth-service.js";
 import type { UserManager } from "./user-manager.js";
 
@@ -190,6 +196,109 @@ describe("auth-middleware", () => {
         payload: {},
       });
       expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe("isStandardWriteAllowed / isMutationDeniedForStandard (spec 131)", () => {
+    it("allows the usage + personal write allowlist", () => {
+      expect(isStandardWriteAllowed("POST", "/api/v1/equipments/abc/orders/state")).toBe(true);
+      expect(isStandardWriteAllowed("POST", "/api/v1/zones/z1/orders/allLightsOff")).toBe(true);
+      expect(isStandardWriteAllowed("PUT", "/api/v1/me")).toBe(true);
+      expect(isStandardWriteAllowed("PUT", "/api/v1/me/preferences")).toBe(true);
+      expect(isStandardWriteAllowed("PUT", "/api/v1/me/password")).toBe(true);
+      expect(isStandardWriteAllowed("POST", "/api/v1/me/tokens")).toBe(true);
+      expect(isStandardWriteAllowed("DELETE", "/api/v1/me/tokens/tok-1")).toBe(true);
+      expect(isStandardWriteAllowed("POST", "/api/v1/push/subscriptions")).toBe(true);
+      expect(isStandardWriteAllowed("DELETE", "/api/v1/push/subscriptions")).toBe(true);
+      expect(isStandardWriteAllowed("POST", "/api/v1/auth/logout")).toBe(true);
+    });
+
+    it("denies config mutations, including near-misses of the orders rule", () => {
+      expect(isStandardWriteAllowed("POST", "/api/v1/equipments")).toBe(false);
+      expect(isStandardWriteAllowed("PUT", "/api/v1/equipments/abc")).toBe(false);
+      expect(isStandardWriteAllowed("DELETE", "/api/v1/equipments/abc")).toBe(false);
+      expect(isStandardWriteAllowed("POST", "/api/v1/equipments/abc/order-bindings")).toBe(false);
+      expect(isStandardWriteAllowed("POST", "/api/v1/modes/m1/activate")).toBe(false);
+      expect(isStandardWriteAllowed("POST", "/api/v1/recipe-instances/r1/enable")).toBe(false);
+      expect(isStandardWriteAllowed("POST", "/api/v1/dashboard/widgets")).toBe(false);
+      expect(isStandardWriteAllowed("PUT", "/api/v1/settings")).toBe(false);
+      expect(isStandardWriteAllowed("PUT", "/api/v1/devices/d1")).toBe(false);
+    });
+
+    it("a wrong method on an allowed path is not allowed", () => {
+      expect(isStandardWriteAllowed("DELETE", "/api/v1/equipments/abc/orders/state")).toBe(false);
+      expect(isStandardWriteAllowed("POST", "/api/v1/me")).toBe(false);
+    });
+
+    it("isMutationDeniedForStandard: admin and GET are never denied", () => {
+      expect(isMutationDeniedForStandard("POST", "/api/v1/equipments", "admin")).toBe(false);
+      expect(isMutationDeniedForStandard("DELETE", "/api/v1/zones/z1", "admin")).toBe(false);
+      expect(isMutationDeniedForStandard("GET", "/api/v1/equipments", "standard")).toBe(false);
+    });
+
+    it("isMutationDeniedForStandard: standard denied on config, allowed on usage", () => {
+      expect(isMutationDeniedForStandard("POST", "/api/v1/equipments", "standard")).toBe(true);
+      expect(isMutationDeniedForStandard("POST", "/api/v1/modes/m/activate", "standard")).toBe(true);
+      expect(isMutationDeniedForStandard("POST", "/api/v1/equipments/x/orders/state", "standard")).toBe(false);
+      expect(isMutationDeniedForStandard("PUT", "/api/v1/me/password", "standard")).toBe(false);
+    });
+  });
+
+  describe("role gate — request enforcement (spec 131)", () => {
+    let app: ReturnType<typeof Fastify>;
+    let role: "admin" | "standard";
+
+    beforeEach(async () => {
+      role = "standard";
+      const userManager = { hasUsers: () => true } as unknown as UserManager;
+      const authService = {
+        verifyAccessToken: () => ({ userId: "u1", role }),
+        verifyApiToken: () => ({ userId: "u1", role }),
+      } as unknown as AuthService;
+      app = Fastify({ logger: false });
+      registerAuthMiddleware(app, { authService, userManager, logger });
+      app.get("/api/v1/equipments", async () => ({ ok: true }));
+      app.post("/api/v1/equipments", async () => ({ ok: true }));
+      app.post("/api/v1/equipments/:id/orders/:alias", async () => ({ ok: true }));
+      app.delete("/api/v1/zones/:id", async () => ({ ok: true }));
+      app.post("/api/v1/modes/:id/activate", async () => ({ ok: true }));
+      app.put("/api/v1/me/password", async () => ({ ok: true }));
+      await app.ready();
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    const auth = { authorization: "Bearer header.payload.sig" };
+
+    it("standard: reads pass", async () => {
+      const res = await app.inject({ method: "GET", url: "/api/v1/equipments", headers: auth });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("standard: config mutations are 403", async () => {
+      expect((await app.inject({ method: "POST", url: "/api/v1/equipments", headers: auth })).statusCode).toBe(403);
+      expect((await app.inject({ method: "DELETE", url: "/api/v1/zones/z1", headers: auth })).statusCode).toBe(403);
+      expect((await app.inject({ method: "POST", url: "/api/v1/modes/m/activate", headers: auth })).statusCode).toBe(403);
+    });
+
+    it("standard: allowlisted usage mutations pass, even with a query string", async () => {
+      expect((await app.inject({ method: "POST", url: "/api/v1/equipments/e1/orders/state", headers: auth })).statusCode).toBe(200);
+      expect((await app.inject({ method: "POST", url: "/api/v1/equipments/e1/orders/state?foo=1", headers: auth })).statusCode).toBe(200);
+      expect((await app.inject({ method: "PUT", url: "/api/v1/me/password", headers: auth })).statusCode).toBe(200);
+    });
+
+    it("admin: every mutation passes", async () => {
+      role = "admin";
+      expect((await app.inject({ method: "POST", url: "/api/v1/equipments", headers: auth })).statusCode).toBe(200);
+      expect((await app.inject({ method: "DELETE", url: "/api/v1/zones/z1", headers: auth })).statusCode).toBe(200);
+    });
+
+    it("standard-scoped API token: config 403, usage 200 (no escalation)", async () => {
+      const tok = { authorization: "Bearer swl_standardtoken" };
+      expect((await app.inject({ method: "POST", url: "/api/v1/equipments", headers: tok })).statusCode).toBe(403);
+      expect((await app.inject({ method: "POST", url: "/api/v1/equipments/e1/orders/state", headers: tok })).statusCode).toBe(200);
     });
   });
 });

--- a/src/auth/auth-middleware.test.ts
+++ b/src/auth/auth-middleware.test.ts
@@ -238,8 +238,12 @@ describe("auth-middleware", () => {
 
     it("isMutationDeniedForStandard: standard denied on config, allowed on usage", () => {
       expect(isMutationDeniedForStandard("POST", "/api/v1/equipments", "standard")).toBe(true);
-      expect(isMutationDeniedForStandard("POST", "/api/v1/modes/m/activate", "standard")).toBe(true);
-      expect(isMutationDeniedForStandard("POST", "/api/v1/equipments/x/orders/state", "standard")).toBe(false);
+      expect(isMutationDeniedForStandard("POST", "/api/v1/modes/m/activate", "standard")).toBe(
+        true,
+      );
+      expect(
+        isMutationDeniedForStandard("POST", "/api/v1/equipments/x/orders/state", "standard"),
+      ).toBe(false);
       expect(isMutationDeniedForStandard("PUT", "/api/v1/me/password", "standard")).toBe(false);
     });
   });
@@ -278,27 +282,66 @@ describe("auth-middleware", () => {
     });
 
     it("standard: config mutations are 403", async () => {
-      expect((await app.inject({ method: "POST", url: "/api/v1/equipments", headers: auth })).statusCode).toBe(403);
-      expect((await app.inject({ method: "DELETE", url: "/api/v1/zones/z1", headers: auth })).statusCode).toBe(403);
-      expect((await app.inject({ method: "POST", url: "/api/v1/modes/m/activate", headers: auth })).statusCode).toBe(403);
+      expect(
+        (await app.inject({ method: "POST", url: "/api/v1/equipments", headers: auth })).statusCode,
+      ).toBe(403);
+      expect(
+        (await app.inject({ method: "DELETE", url: "/api/v1/zones/z1", headers: auth })).statusCode,
+      ).toBe(403);
+      expect(
+        (await app.inject({ method: "POST", url: "/api/v1/modes/m/activate", headers: auth }))
+          .statusCode,
+      ).toBe(403);
     });
 
     it("standard: allowlisted usage mutations pass, even with a query string", async () => {
-      expect((await app.inject({ method: "POST", url: "/api/v1/equipments/e1/orders/state", headers: auth })).statusCode).toBe(200);
-      expect((await app.inject({ method: "POST", url: "/api/v1/equipments/e1/orders/state?foo=1", headers: auth })).statusCode).toBe(200);
-      expect((await app.inject({ method: "PUT", url: "/api/v1/me/password", headers: auth })).statusCode).toBe(200);
+      expect(
+        (
+          await app.inject({
+            method: "POST",
+            url: "/api/v1/equipments/e1/orders/state",
+            headers: auth,
+          })
+        ).statusCode,
+      ).toBe(200);
+      expect(
+        (
+          await app.inject({
+            method: "POST",
+            url: "/api/v1/equipments/e1/orders/state?foo=1",
+            headers: auth,
+          })
+        ).statusCode,
+      ).toBe(200);
+      expect(
+        (await app.inject({ method: "PUT", url: "/api/v1/me/password", headers: auth })).statusCode,
+      ).toBe(200);
     });
 
     it("admin: every mutation passes", async () => {
       role = "admin";
-      expect((await app.inject({ method: "POST", url: "/api/v1/equipments", headers: auth })).statusCode).toBe(200);
-      expect((await app.inject({ method: "DELETE", url: "/api/v1/zones/z1", headers: auth })).statusCode).toBe(200);
+      expect(
+        (await app.inject({ method: "POST", url: "/api/v1/equipments", headers: auth })).statusCode,
+      ).toBe(200);
+      expect(
+        (await app.inject({ method: "DELETE", url: "/api/v1/zones/z1", headers: auth })).statusCode,
+      ).toBe(200);
     });
 
     it("standard-scoped API token: config 403, usage 200 (no escalation)", async () => {
       const tok = { authorization: "Bearer swl_standardtoken" };
-      expect((await app.inject({ method: "POST", url: "/api/v1/equipments", headers: tok })).statusCode).toBe(403);
-      expect((await app.inject({ method: "POST", url: "/api/v1/equipments/e1/orders/state", headers: tok })).statusCode).toBe(200);
+      expect(
+        (await app.inject({ method: "POST", url: "/api/v1/equipments", headers: tok })).statusCode,
+      ).toBe(403);
+      expect(
+        (
+          await app.inject({
+            method: "POST",
+            url: "/api/v1/equipments/e1/orders/state",
+            headers: tok,
+          })
+        ).statusCode,
+      ).toBe(200);
     });
   });
 });

--- a/src/auth/auth-middleware.ts
+++ b/src/auth/auth-middleware.ts
@@ -139,7 +139,9 @@ export function registerAuthMiddleware(
 
     // Role gate (spec 131): a non-admin may only run the allowlisted usage
     // mutations (actuate + own account); every other write is admin-only.
-    if (isMutationDeniedForStandard(request.method, request.url.split("?")[0], request.auth?.role)) {
+    if (
+      isMutationDeniedForStandard(request.method, request.url.split("?")[0], request.auth?.role)
+    ) {
       return reply.code(403).send({ error: "Admin access required" });
     }
   });

--- a/src/auth/auth-middleware.ts
+++ b/src/auth/auth-middleware.ts
@@ -37,6 +37,50 @@ export function isPublicRoute(url: string): boolean {
 }
 
 // ============================================================
+// Role gate (spec 131): config is admin-only, standard = usage
+// ============================================================
+
+const MUTATING_METHODS: ReadonlySet<string> = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * (method, path) templates a `standard` user is allowed to mutate. Everything
+ * else that mutates is admin-only — the gate is fail-closed, so a new mutating
+ * endpoint is admin-only until it is explicitly added here.
+ */
+const STANDARD_WRITE_ALLOWLIST: ReadonlyArray<{ method: string; re: RegExp }> = [
+  // Usage: actuate an equipment / run a zone command
+  { method: "POST", re: /^\/api\/v1\/equipments\/[^/]+\/orders\/[^/]+$/ },
+  { method: "POST", re: /^\/api\/v1\/zones\/[^/]+\/orders\/[^/]+$/ },
+  // Personal: own account, preferences, password, own API tokens
+  { method: "PUT", re: /^\/api\/v1\/me$/ },
+  { method: "PUT", re: /^\/api\/v1\/me\/preferences$/ },
+  { method: "PUT", re: /^\/api\/v1\/me\/password$/ },
+  { method: "POST", re: /^\/api\/v1\/me\/tokens$/ },
+  { method: "DELETE", re: /^\/api\/v1\/me\/tokens\/[^/]+$/ },
+  // Personal: own push-notification subscription
+  { method: "POST", re: /^\/api\/v1\/push\/subscriptions$/ },
+  { method: "DELETE", re: /^\/api\/v1\/push\/subscriptions$/ },
+  // Personal: end own session
+  { method: "POST", re: /^\/api\/v1\/auth\/logout$/ },
+];
+
+/** True if a non-admin (`standard`) may perform this mutating request. */
+export function isStandardWriteAllowed(method: string, path: string): boolean {
+  return STANDARD_WRITE_ALLOWLIST.some((e) => e.method === method && e.re.test(path));
+}
+
+/** Whether a request must pass the admin-only gate given its method + role. */
+export function isMutationDeniedForStandard(
+  method: string,
+  path: string,
+  role: string | undefined,
+): boolean {
+  if (!MUTATING_METHODS.has(method.toUpperCase())) return false;
+  if (role === "admin") return false;
+  return !isStandardWriteAllowed(method.toUpperCase(), path);
+}
+
+// ============================================================
 // Register auth middleware
 // ============================================================
 
@@ -91,6 +135,12 @@ export function registerAuthMiddleware(
       request.auth = payload;
     } catch {
       return reply.code(401).send({ error: "Invalid or expired token" });
+    }
+
+    // Role gate (spec 131): a non-admin may only run the allowlisted usage
+    // mutations (actuate + own account); every other write is admin-only.
+    if (isMutationDeniedForStandard(request.method, request.url.split("?")[0], request.auth?.role)) {
+      return reply.code(403).send({ error: "Admin access required" });
     }
   });
 }

--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -5,6 +5,7 @@ import { useRecipes } from "../../store/useRecipes";
 import { useEquipments } from "../../store/useEquipments";
 import { useZones } from "../../store/useZones";
 import { useZoneAggregation } from "../../store/useZoneAggregation";
+import { useAuth } from "../../store/useAuth";
 import type { RecipeInfo, RecipeInstance, RecipeLogEntry, RecipeActionDef, EquipmentWithDetails, Zone, ZoneWithChildren } from "../../types";
 import type { EquipmentType } from "../../types";
 import { formatTime } from "../../lib/format";
@@ -115,6 +116,7 @@ interface ZoneRecipesSectionProps {
 
 export function ZoneRecipesSection({ zoneId, zoneName }: ZoneRecipesSectionProps) {
   const { t } = useTranslation();
+  const isAdmin = useAuth((s) => s.user?.role === "admin");
   const recipes = useRecipes((s) => s.recipes);
   const instances = useRecipes((s) => s.instances);
   const fetchRecipes = useRecipes((s) => s.fetchRecipes);
@@ -164,6 +166,7 @@ export function ZoneRecipesSection({ zoneId, zoneName }: ZoneRecipesSectionProps
         <span className="text-[10.9px] text-text-tertiary opacity-65 ml-auto tabular-nums font-mono">
           {zoneInstances.length}
         </span>
+        {isAdmin && (
         <div ref={pickerWrapRef} className="relative ml-2">
           <button
             onClick={() => setShowPicker((v) => !v)}
@@ -181,6 +184,7 @@ export function ZoneRecipesSection({ zoneId, zoneName }: ZoneRecipesSectionProps
             />
           )}
         </div>
+        )}
       </div>
 
       {zoneInstances.length > 0 && (
@@ -194,12 +198,14 @@ export function ZoneRecipesSection({ zoneId, zoneName }: ZoneRecipesSectionProps
       {zoneInstances.length === 0 && !pickedRecipeId && (
         <div className="flex items-center justify-center gap-2 px-4 py-3 text-[12px] text-text-tertiary">
           <span>{t("recipes.noActiveRecipes", { name: zoneName })}</span>
-          <button
-            onClick={() => setShowPicker(true)}
-            className="text-primary hover:text-primary-hover transition-colors duration-150"
-          >
-            {t("recipes.addRecipe")}
-          </button>
+          {isAdmin && (
+            <button
+              onClick={() => setShowPicker(true)}
+              className="text-primary hover:text-primary-hover transition-colors duration-150"
+            >
+              {t("recipes.addRecipe")}
+            </button>
+          )}
         </div>
       )}
 
@@ -444,6 +450,7 @@ function RecipeInstanceRow({
 }) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language.startsWith("fr") ? "fr" : "en";
+  const isAdmin = useAuth((s) => s.user?.role === "admin");
   const deleteInstance = useRecipes((s) => s.deleteInstance);
   const updateInstance = useRecipes((s) => s.updateInstance);
   const enableInstance = useRecipes((s) => s.enableInstance);
@@ -695,9 +702,9 @@ function RecipeInstanceRow({
         {/* Row 1 col 2: name + inline pills */}
         <div className="col-start-2 row-start-1 flex items-center gap-2 min-w-0">
           <button
-            onClick={handleStartEdit}
-            className="flex-1 min-w-0 text-left hover:opacity-70 transition-opacity duration-150"
-            title="Edit"
+            onClick={isAdmin ? handleStartEdit : undefined}
+            className={`flex-1 min-w-0 text-left transition-opacity duration-150 ${isAdmin ? "hover:opacity-70 cursor-pointer" : "cursor-default"}`}
+            title={isAdmin ? "Edit" : undefined}
           >
             <div className="text-[14px] font-medium text-text truncate">
               {displayName}
@@ -727,7 +734,8 @@ function RecipeInstanceRow({
             />
           ))}
         </div>
-        {/* Row 1 col 3: toggle */}
+        {/* Row 1 col 3: toggle (admin only — enable/disable is config) */}
+        {isAdmin && (
         <button
           onClick={handleToggleEnabled}
           disabled={toggling}
@@ -742,7 +750,9 @@ function RecipeInstanceRow({
             style={{ transform: instance.enabled ? "translateX(14px)" : "translateX(0)" }}
           />
         </button>
-        {/* Row 2: compact action buttons (col 2-3 span, mock .recipe__action: 22x20, svg 12px) */}
+        )}
+        {/* Row 2: compact action buttons — admin only (log / duplicate / delete are config) */}
+        {isAdmin && (
         <div className="col-start-2 col-span-2 row-start-2 hidden sm:flex items-center gap-[2px]">
           <button
             onClick={handleShowLog}
@@ -767,6 +777,7 @@ function RecipeInstanceRow({
             <Trash2 size={12} strokeWidth={1.5} />
           </button>
         </div>
+        )}
       </div>
 
       {/* Duplicate modal */}

--- a/ui/src/pages/DeviceDetailPage.tsx
+++ b/ui/src/pages/DeviceDetailPage.tsx
@@ -13,6 +13,7 @@ import {
 import type { DeviceOrder, DeviceWithDetails } from "../types";
 import { getDevice, getDeviceRawExpose, deleteDevice } from "../api";
 import { useDevices } from "../store/useDevices";
+import { useAuth } from "../store/useAuth";
 import { DeviceNameEditor } from "../components/devices/DeviceNameEditor";
 import { DeviceDataTable } from "../components/devices/DeviceDataTable";
 import { sourceLabel } from "../lib/format";
@@ -24,6 +25,7 @@ export function DeviceDetailPage() {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const isAdmin = useAuth((s) => s.user?.role === "admin");
   const updateDeviceName = useDevices((s) => s.updateDeviceName);
 
   // Device from store (real-time updates)
@@ -122,10 +124,14 @@ export function DeviceDetailPage() {
             <Radio size={24} strokeWidth={1.5} className="text-primary" />
           </div>
           <div>
-            <DeviceNameEditor
-              name={device.name}
-              onSave={(name) => updateDeviceName(device.id, name)}
-            />
+            {isAdmin ? (
+              <DeviceNameEditor
+                name={device.name}
+                onSave={(name) => updateDeviceName(device.id, name)}
+              />
+            ) : (
+              <div className="text-[18px] font-semibold text-text">{device.name}</div>
+            )}
             <div className="flex items-center gap-3 mt-1.5">
               <StatusBadge status={device.status} />
               <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-border-light text-[11px] font-medium text-text-secondary">
@@ -139,6 +145,7 @@ export function DeviceDetailPage() {
             </div>
           </div>
         </div>
+        {isAdmin && (
         <button
           onClick={handleDelete}
           disabled={deleting}
@@ -147,6 +154,7 @@ export function DeviceDetailPage() {
           <Trash2 size={14} strokeWidth={1.5} />
           {deleting ? t("common.deleting") : t("common.delete")}
         </button>
+        )}
       </div>
 
       {/* Info bar */}

--- a/ui/src/pages/ModeDetailPage.tsx
+++ b/ui/src/pages/ModeDetailPage.tsx
@@ -12,6 +12,7 @@ import { useModes } from "../store/useModes";
 import { useEquipments } from "../store/useEquipments";
 import { useZones } from "../store/useZones";
 import { useRecipes } from "../store/useRecipes";
+import { useAuth } from "../store/useAuth";
 import { ModeForm } from "../components/modes/ModeForm";
 import type { ModeWithDetails, EquipmentWithDetails, ZoneModeImpactAction, CalendarSlot, ButtonActionBinding } from "../types";
 import { useWsSubscription } from "../hooks/useWsSubscription";
@@ -19,6 +20,7 @@ import { useWsSubscription } from "../hooks/useWsSubscription";
 export function ModeDetailPage() {
   useWsSubscription(["modes"]);
   const { t } = useTranslation();
+  const isAdmin = useAuth((s) => s.user?.role === "admin");
   const { id } = useParams();
   const navigate = useNavigate();
   const updateMode = useModes((s) => s.updateMode);
@@ -159,6 +161,7 @@ export function ModeDetailPage() {
             )}
           </div>
         </div>
+        {isAdmin && (
         <div className="flex items-center gap-2 flex-shrink-0">
           <button
             onClick={handleToggle}
@@ -188,6 +191,7 @@ export function ModeDetailPage() {
             <Trash2 size={14} strokeWidth={1.5} />
           </button>
         </div>
+        )}
       </div>
 
       <div className="space-y-6 max-w-[720px]">

--- a/ui/src/pages/ModesPage.tsx
+++ b/ui/src/pages/ModesPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { Layers, Plus, Loader2, AlertCircle, ToggleRight, ToggleLeft, Clock } from "lucide-react";
 import { useModes } from "../store/useModes";
+import { useAuth } from "../store/useAuth";
 import { getActiveCalendar } from "../api";
 import { ModeForm } from "../components/modes/ModeForm";
 import type { ModeWithDetails, CalendarSlot } from "../types";
@@ -16,6 +17,7 @@ export function ModesPage() {
   const loading = useModes((s) => s.loading);
   const fetchModes = useModes((s) => s.fetchModes);
   const createMode = useModes((s) => s.createMode);
+  const isAdmin = useAuth((s) => s.user?.role === "admin");
   const [showForm, setShowForm] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [calendarSlots, setCalendarSlots] = useState<CalendarSlot[]>([]);
@@ -75,6 +77,7 @@ export function ModesPage() {
           </p>
         </div>
         <div className="flex items-center gap-2 sm:gap-3">
+          {isAdmin && (
           <button
             onClick={() => setShowForm(true)}
             className="flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-2 bg-primary text-white text-[13px] font-medium rounded-[6px] hover:bg-primary-hover transition-colors duration-150"
@@ -82,6 +85,7 @@ export function ModesPage() {
             <Plus size={16} strokeWidth={1.5} />
             <span className="hidden sm:inline">{t("modes.addMode")}</span>
           </button>
+          )}
           <span className="text-[13px] font-medium text-primary bg-primary-light px-3 py-1.5 rounded-[6px] tabular-nums">
             {modes.length}
           </span>

--- a/ui/src/pages/ZoneDetailPage.tsx
+++ b/ui/src/pages/ZoneDetailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useZones } from "../store/useZones";
+import { useAuth } from "../store/useAuth";
 import { useRecipes } from "../store/useRecipes";
 import { getZone } from "../api";
 import { ZoneForm, flattenZoneTree } from "../components/zones/ZoneForm";
@@ -103,6 +104,7 @@ export function ZoneDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const tree = useZones((s) => s.tree);
+  const isAdmin = useAuth((s) => s.user?.role === "admin");
   const updateZone = useZones((s) => s.updateZone);
   const deleteZone = useZones((s) => s.deleteZone);
   const recipes = useRecipes((s) => s.recipes);
@@ -233,6 +235,7 @@ export function ZoneDetailPage() {
             <p className="text-[14px] text-text-secondary mt-1">{zone.description}</p>
           )}
         </div>
+        {isAdmin && (
         <div className="flex items-center gap-2">
           <button
             onClick={() => setShowEditForm(true)}
@@ -254,6 +257,7 @@ export function ZoneDetailPage() {
             </button>
           )}
         </div>
+        )}
       </div>
 
       {/* Child zones section */}

--- a/ui/src/pages/ZonesPage.tsx
+++ b/ui/src/pages/ZonesPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useZones } from "../store/useZones";
+import { useAuth } from "../store/useAuth";
 import { ZoneTree } from "../components/zones/ZoneTree";
 import { ZoneForm, flattenZoneTree } from "../components/zones/ZoneForm";
 import { Home, Loader2, Plus } from "lucide-react";
@@ -9,6 +10,7 @@ import { useWsSubscription } from "../hooks/useWsSubscription";
 export function ZonesPage() {
   useWsSubscription(["zones"]);
   const { t } = useTranslation();
+  const isAdmin = useAuth((s) => s.user?.role === "admin");
   const tree = useZones((s) => s.tree);
   const loading = useZones((s) => s.loading);
   const error = useZones((s) => s.error);
@@ -39,6 +41,7 @@ export function ZonesPage() {
         </div>
 
         <div className="flex items-center gap-3">
+          {isAdmin && (
           <button
             onClick={() => { setDefaultParentId(null); setShowForm(true); }}
             className="flex items-center gap-2 px-4 py-2 text-[13px] font-medium text-white bg-primary rounded-[6px] hover:bg-primary-hover transition-colors duration-150"
@@ -46,6 +49,7 @@ export function ZonesPage() {
             <Plus size={16} strokeWidth={1.5} />
             {t("zones.addZone")}
           </button>
+          )}
 
           <div className="flex items-center gap-2 px-3 py-1.5 rounded-[6px] bg-primary-light text-primary">
             <Home size={16} strokeWidth={1.5} />


### PR DESCRIPTION
## Summary

Implements **Option A** for issue #319: a `standard` user can **view + actuate**, but **all configuration is admin-only**. Spec: `specs/131-rbac-config-admin-only/`.

## Backend (the security boundary)

Central **fail-closed** role gate in the auth `onRequest` hook (`src/auth/auth-middleware.ts`): after auth, any `POST/PUT/PATCH/DELETE` from a non-admin returns `403` unless its `(method, path)` is in the **standard write allowlist**:

- `POST /equipments/:id/orders/:alias` (actuate), `POST /zones/:id/orders/:orderKey` (zone command)
- `PUT /me`, `/me/preferences`, `/me/password`, `POST/DELETE /me/tokens[/:id]`, `POST/DELETE /push/subscriptions`, `POST /auth/logout`

Everything else that mutates is admin-only. A new mutating endpoint is admin-only **by default** (no per-route opt-in to forget). API tokens inherit the creator's role → no escalation. Reads (`GET`) are never gated.

Exposed as pure, tested predicates: `isStandardWriteAllowed(method, path)` and `isMutationDeniedForStandard(method, path, role)`.

## Frontend (UX — hide what would 403)

Gated the config actions still visible to a standard user:
- **Recipes** (`ZoneRecipesSection`): add / edit / delete / enable-disable toggle.
- **Modes** (`ModesPage` / `ModeDetailPage`): create / edit / delete + activation toggle.

Already gated before this PR: equipment-add (HomePage), Dashboard, Settings, and the whole Administration sidebar section (`/equipments`, `/zones`, `/devices`, integrations, mqtt, notifications, plugins, backup, logs are admin nav routes). The backend `403` is the source of truth; UI hiding is polish.

## Not covered (follow-up, backend already blocks)
Minor deep-link surfaces (e.g. the equipment detail edit/delete on the admin-only `/equipments` page) still render their buttons if a standard user deep-links, but the backend returns 403. Can be tidied later.

## Tests
- [x] `auth-middleware`: allowlist matches, config denials, near-miss (`/orders` vs `/order-bindings`), admin bypass, GET never gated, standard-token no-escalation, query string — **28 tests**
- [x] `tsc --noEmit` (back + ui), `eslint`, `vitest run` (942 passed), `vite build` — all green
- [ ] Manual: log in as a standard user, confirm no config buttons + actuation works
