### PR TITLE
release: v1.29.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,15 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.29.x: Rôle Standard et parité du dashboard
+
+### v1.29.0 — 2026-07-19 { #v1-29-0 }
+
+- Feat (auth) : le rôle **Standard** est désormais limité à la consultation et au pilotage. Un utilisateur Standard peut parcourir le dashboard et les zones, voir l'état des équipements et actionner les équipements (ouvrir un portail ou une porte, allumer une lumière), mais ne peut plus créer, renommer ou supprimer d'équipements, de recettes, de zones ou de modes, ni modifier la moindre configuration. Toute la configuration est maintenant réservée aux administrateurs, masquée dans l'UI et bloquée côté serveur (une action interdite renvoie 403, donc impossible à contourner). Cela répond à la surprise qu'un compte Standard puisse modifier des équipements et des recettes par accident. Aucune migration nécessaire : les comptes Standard existants perdent simplement les actions de configuration qu'ils n'auraient pas dû avoir. (#319)
+- Fix (ui) : l'icône personnalisée d'un widget s'affiche désormais à l'identique sur navigateur PC et sur mobile. Le dashboard desktop ignorait l'icône personnalisée pour la plupart des types de widgets (une icône de pompe de piscine choisie pour une prise s'affichait sous Android mais repassait à l'icône de prise sur PC) ; il respecte maintenant l'icône choisie pour les lumières, prises, volets, stores, thermostats, chauffages, vannes d'eau et équipements de piscine, comme sur mobile. (#318)
+
+---
+
 ## 1.28.x: Arrosage par jour
 
 ### v1.28.2 — 2026-07-18 { #v1-28-2 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,15 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.29.x: Standard role and dashboard parity
+
+### v1.29.0 — 2026-07-19 { #v1-29-0 }
+
+- Feat (auth): the **Standard** role is now scoped to viewing and operating. A Standard user can browse the dashboard and zones, see equipment states, and actuate equipments (open a gate or a door, toggle a light), but can no longer create, rename or delete equipments, recipes, zones or modes, nor change any configuration. All configuration is now admin-only, hidden in the UI and enforced server-side (a blocked action returns 403, so it cannot be worked around). This answers the surprise that a Standard account could alter equipments and recipes by accident. No migration needed: existing Standard accounts simply lose the config actions they should not have had. (#319)
+- Fix (ui): a custom widget icon is now shown identically on a PC browser and on mobile. The desktop dashboard ignored the custom icon for most widget types (a pool-pump icon chosen for a plug showed on Android but reverted to the plug icon on desktop); it now honors the chosen icon for lights, switches, shutters, awnings, thermostats, heaters, water valves and pool equipment, matching mobile. (#318)
+
+---
+
 ## 1.28.x: Watering weekdays
 
 ### v1.28.2 — 2026-07-18 { #v1-28-2 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.28.2",
+  "version": "1.29.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.28.2",
+  "version": "1.29.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Release v1.29.0

Bundles the two changes already merged to `main` since v1.28.2.

### Included
- **feat(auth)**: Standard role scoped to view + operate; all configuration is admin-only, hidden in the UI and enforced server-side (spec 131, closes #319)
- **fix(ui)**: honor the custom widget icon on the desktop dashboard (#318, PR #322)

### Release notes
- `docs/release-notes.md` and `docs/release-notes.fr.md` updated with the `{ #v1-29-0 }` anchor (spec 108)

### Version
- `package.json` + `ui/package.json` -> 1.29.0

Once merged, tag `v1.29.0` on the merge commit and push it to trigger the Docker build.