### PR TITLE
Bubendorff/iDiamant shutter support: hide unsupported Stop + fix shutter auto-binding

### DIFF
--- a/src/equipments/binding-candidates.test.ts
+++ b/src/equipments/binding-candidates.test.ts
@@ -75,6 +75,61 @@ describe("computeBindingCandidates", () => {
     expect(result[0].dataKeys.sort()).toEqual(["shutter_position", "shutter_state"]);
   });
 
+  // Regression test for the bug found while setting up Bubendorff shutters
+  // (sowel-plugin-legrand-control): that integration's device data/orders
+  // are named current_position/target_position/state — NOT shutter_state/
+  // shutter_position — so extractShutterGroupKey() matched nothing and the
+  // "Create equipment" manual picker had zero candidates to auto-bind,
+  // silently creating an equipment with no bindings at all (shown as
+  // offline). The category-based fallback below fixes this without
+  // affecting the Tasmota-style indexed convention tested above.
+  it("shutter with Legrand/Bubendorff-style keys (current_position/target_position/state) → one candidate via category fallback", () => {
+    const orders = [
+      order("target_position", "number", { category: "set_shutter_position", min: 0, max: 100 }),
+      order("state", "text", { category: "shutter_move", enumValues: ["OPEN", "CLOSE"] }),
+    ];
+    const datas = [data("current_position", "number", { category: "shutter_position" })];
+    const result = computeBindingCandidates("shutter", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("shutter1");
+    expect(result[0].orderKeys.sort()).toEqual(["state", "target_position"]);
+    expect(result[0].dataKeys).toEqual(["current_position"]);
+  });
+
+  it("shutter with Legrand/Bubendorff-style keys but no position data → still binds the order-only candidate", () => {
+    // Some modules (none currently, but defensive) might expose only an
+    // order with no matching position data — should not be dropped.
+    const orders = [
+      order("target_position", "number", { category: "set_shutter_position", min: 0, max: 100 }),
+    ];
+    const result = computeBindingCandidates("shutter", [], orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].dataKeys).toEqual([]);
+    expect(result[0].orderKeys).toEqual(["target_position"]);
+  });
+
+  it("shutter with neither key-name nor category match → no candidates (unchanged behavior)", () => {
+    const orders = [order("foo", "number", { category: "generic" })];
+    const result = computeBindingCandidates("shutter", [], orders);
+    expect(result).toHaveLength(0);
+  });
+
+  it("shutter prefers the Tasmota-style key grouping over the category fallback when both are present", () => {
+    // If a device somehow matches the indexed key convention, that grouping
+    // wins and the category fallback never runs (byGroup.size > 0 guard).
+    const orders = [
+      order("shutter_state", "enum", { enumValues: ["OPEN", "CLOSE", "STOP"] }),
+      order("shutter_position", "number", { min: 0, max: 100 }),
+      // An unrelated category-matching order that would otherwise trigger
+      // the fallback if it ran — it must NOT be picked up here.
+      order("target_position", "number", { category: "set_shutter_position" }),
+    ];
+    const datas = [data("shutter_state", "enum"), data("shutter_position", "number")];
+    const result = computeBindingCandidates("shutter", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].orderKeys.sort()).toEqual(["shutter_position", "shutter_state"]);
+  });
+
   it("switch on a single-relay device → one candidate", () => {
     const orders = [order("R1", "enum", { enumValues: ["ON", "OFF"] })];
     const datas = [data("R1", "enum")];

--- a/src/equipments/binding-candidates.ts
+++ b/src/equipments/binding-candidates.ts
@@ -132,6 +132,9 @@ export function computeBindingCandidates(
     case "awning":
     case "shutter": {
       // Group orders by shutter index (e.g. shutter_state + shutter_position).
+      // This key-name convention (Tasmota-style: shutter_state/shutterN_state)
+      // is what lets a single physical device expose several independent
+      // shutter channels.
       const byGroup = new Map<string, { dataKeys: string[]; orderKeys: string[] }>();
       for (const o of deviceOrders) {
         const g = extractShutterGroupKey(o.key);
@@ -147,6 +150,30 @@ export function computeBindingCandidates(
         entry.dataKeys.push(d.key);
         byGroup.set(g, entry);
       }
+
+      // Category-first fallback (mirrors ShutterControl.tsx's own resolver)
+      // for integrations that don't use the shutter_*/shutterN_* key naming
+      // convention at all — e.g. Legrand/Bubendorff Home+Control
+      // (sowel-plugin-legrand-control), whose device exposes
+      // current_position / target_position / state. Before this fallback,
+      // such a device produced ZERO candidates here, so the "Create
+      // equipment" picker had nothing to auto-bind and the equipment was
+      // created with no bindings at all (shows as offline — spec 116 has
+      // nothing to derive status from). A device using this convention only
+      // ever exposes one shutter channel, so everything collapses into a
+      // single group instead of being indexed like the Tasmota case above.
+      if (byGroup.size === 0) {
+        const dataKeys = deviceData
+          .filter((d) => d.category === "shutter_position")
+          .map((d) => d.key);
+        const orderKeys = deviceOrders
+          .filter((o) => o.category === "set_shutter_position" || o.category === "shutter_move")
+          .map((o) => o.key);
+        if (orderKeys.length > 0) {
+          byGroup.set("1", { dataKeys, orderKeys });
+        }
+      }
+
       const candidates: BindingCandidate[] = [];
       for (const [g, entry] of byGroup) {
         if (entry.orderKeys.length === 0) continue;

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -349,6 +349,12 @@ function ShutterEquipmentWidget({
     [/^shutter\d*_state$/],
   );
   const hasState = !!moveBinding;
+  // Some bridges cannot actually stop the shutter mid-travel (e.g. Bubendorff
+  // shutters via an "iDiamant with Netatmo" bridge, sowel-plugin-legrand-
+  // control — confirmed live: a stop command only makes the motor pause
+  // briefly before it continues to its original target). The integration
+  // signals this by omitting "STOP" from the move order's enumValues.
+  const hasStop = !moveBinding?.enumValues || moveBinding.enumValues.some((v) => v.toUpperCase() === "STOP");
   const level = position !== null ? shutterLevel(position) : null;
 
   // Awning vocabulary swap (mirrors ShutterControl):
@@ -410,14 +416,16 @@ function ShutterEquipmentWidget({
           >
             {executing ? <Loader2 size={16} className="animate-spin" /> : <ChevronUp size={16} strokeWidth={2} />}
           </button>
-          <button
-            onClick={() => handleCommand("STOP")}
-            disabled={executing}
-            className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-text-tertiary hover:text-text hover:bg-border-light active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
-            title={t("controls.stop")}
-          >
-            <Square size={11} strokeWidth={2.5} />
-          </button>
+          {hasStop && (
+            <button
+              onClick={() => handleCommand("STOP")}
+              disabled={executing}
+              className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-text-tertiary hover:text-text hover:bg-border-light active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
+              title={t("controls.stop")}
+            >
+              <Square size={11} strokeWidth={2.5} />
+            </button>
+          )}
           <button
             onClick={() => handleCommand("CLOSE")}
             disabled={executing}
@@ -1277,6 +1285,13 @@ function PoolCoverEquipmentWidget({
   };
 
   const hasState = !!moveBinding;
+  // Some bridges cannot actually stop the cover/shutter mid-travel (e.g.
+  // Bubendorff shutters via an "iDiamant with Netatmo" bridge,
+  // sowel-plugin-legrand-control — confirmed live: a stop command only
+  // makes the motor pause briefly before it continues to its original
+  // target). The integration signals this by omitting "STOP" from the
+  // move order's enumValues.
+  const hasStop = !moveBinding?.enumValues || moveBinding.enumValues.some((v) => v.toUpperCase() === "STOP");
 
   return (
     <WidgetCard label={label}>
@@ -1320,14 +1335,16 @@ function PoolCoverEquipmentWidget({
           >
             {executing ? <Loader2 size={16} className="animate-spin" /> : <ChevronLeft size={16} strokeWidth={2} />}
           </button>
-          <button
-            onClick={() => handleCommand("STOP")}
-            disabled={executing}
-            className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-text-tertiary hover:text-text hover:bg-border-light active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
-            title={t("controls.stop")}
-          >
-            <Square size={11} strokeWidth={2.5} />
-          </button>
+          {hasStop && (
+            <button
+              onClick={() => handleCommand("STOP")}
+              disabled={executing}
+              className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-text-tertiary hover:text-text hover:bg-border-light active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
+              title={t("controls.stop")}
+            >
+              <Square size={11} strokeWidth={2.5} />
+            </button>
+          )}
           <button
             onClick={() => handleCommand("CLOSE")}
             disabled={executing}

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -1041,6 +1041,12 @@ function ShutterDetailContent({
     );
   const hasState = !!moveBinding;
   const hasPosition = !!positionOrderBinding;
+  // Some bridges cannot actually stop the shutter mid-travel (e.g. Bubendorff
+  // shutters via an "iDiamant with Netatmo" bridge, sowel-plugin-legrand-
+  // control — confirmed live: a stop command only makes the motor pause
+  // briefly before it continues to its original target). The integration
+  // signals this by omitting "STOP" from the move order's enumValues.
+  const hasStop = !moveBinding?.enumValues || moveBinding.enumValues.some((v) => v.toUpperCase() === "STOP");
 
   const handleCommand = async (command: "OPEN" | "STOP" | "CLOSE") => {
     if (executing || !moveBinding) return;
@@ -1106,13 +1112,15 @@ function ShutterDetailContent({
             >
               <OpenIcon size={20} strokeWidth={2} />
             </button>
-            <button
-              onClick={() => handleCommand("STOP")}
-              disabled={executing}
-              className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
-            >
-              <Square size={14} strokeWidth={2.5} />
-            </button>
+            {hasStop && (
+              <button
+                onClick={() => handleCommand("STOP")}
+                disabled={executing}
+                className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
+              >
+                <Square size={14} strokeWidth={2.5} />
+              </button>
+            )}
             <button
               onClick={() => handleCommand("CLOSE")}
               disabled={executing}

--- a/ui/src/components/equipments/ShutterControl.tsx
+++ b/ui/src/components/equipments/ShutterControl.tsx
@@ -44,6 +44,16 @@ export function ShutterControl({ equipment, onExecuteOrder, compact }: ShutterCo
 
   const hasState = !!moveBinding;
   const hasPositionOrder = !!positionOrderBinding;
+  // Some bridges cannot actually stop the shutter mid-travel even though
+  // they otherwise support the OPEN/CLOSE move order — confirmed live on a
+  // Bubendorff shutter driven through an "iDiamant with Netatmo" bridge
+  // (sowel-plugin-legrand-control): sending a stop command only makes the
+  // motor pause briefly before it continues on to its original target, so a
+  // Stop button there would silently lie about what just happened. The
+  // integration signals "no real stop" by omitting "STOP" from the move
+  // order's enumValues; when enumValues is undefined we keep the historical
+  // behavior (always show Stop) so existing integrations are unaffected.
+  const hasStop = !moveBinding?.enumValues || moveBinding.enumValues.some((v) => v.toUpperCase() === "STOP");
 
   // Pool covers slide horizontally → ←/→ arrows. Window shutters and awnings keep ↑/↓.
   const isHorizontal = equipment.type === "pool_cover";
@@ -130,14 +140,16 @@ export function ShutterControl({ equipment, onExecuteOrder, compact }: ShutterCo
             >
               <OpenIcon size={10} strokeWidth={2} />
             </button>
-            <button
-              onClick={(e) => handleCommand("STOP", e)}
-              disabled={executing}
-              className={sttClass}
-              title={t("controls.stop")}
-            >
-              <Square size={9} strokeWidth={0} fill="currentColor" />
-            </button>
+            {hasStop && (
+              <button
+                onClick={(e) => handleCommand("STOP", e)}
+                disabled={executing}
+                className={sttClass}
+                title={t("controls.stop")}
+              >
+                <Square size={9} strokeWidth={0} fill="currentColor" />
+              </button>
+            )}
             <button
               onClick={(e) => handleCommand("CLOSE", e)}
               disabled={executing}
@@ -197,14 +209,16 @@ export function ShutterControl({ equipment, onExecuteOrder, compact }: ShutterCo
             <OpenIcon size={16} strokeWidth={1.5} />
             {t(openKey)}
           </button>
-          <button
-            onClick={() => handleCommand("STOP")}
-            disabled={executing}
-            className="flex items-center gap-2 px-4 py-2 rounded-[6px] text-[13px] font-medium transition-colors duration-150 bg-border-light text-text-secondary hover:bg-border hover:text-text disabled:opacity-50"
-          >
-            <Square size={12} strokeWidth={2} />
-            {t("controls.stop")}
-          </button>
+          {hasStop && (
+            <button
+              onClick={() => handleCommand("STOP")}
+              disabled={executing}
+              className="flex items-center gap-2 px-4 py-2 rounded-[6px] text-[13px] font-medium transition-colors duration-150 bg-border-light text-text-secondary hover:bg-border hover:text-text disabled:opacity-50"
+            >
+              <Square size={12} strokeWidth={2} />
+              {t("controls.stop")}
+            </button>
+          )}
           <button
             onClick={() => handleCommand("CLOSE")}
             disabled={executing}

--- a/ui/src/lib/binding-candidates.ts
+++ b/ui/src/lib/binding-candidates.ts
@@ -117,6 +117,31 @@ export function computeBindingCandidates(
         entry.dataKeys.push(d.key);
         byGroup.set(g, entry);
       }
+
+      // Category-first fallback (mirrors ShutterControl.tsx's own resolver)
+      // for integrations that don't use the shutter_*/shutterN_* key naming
+      // convention at all — e.g. Legrand/Bubendorff Home+Control
+      // (sowel-plugin-legrand-control), whose device exposes
+      // current_position / target_position / state. Before this fallback,
+      // such a device produced ZERO candidates here, so the "Create
+      // equipment" picker had nothing to auto-bind and the equipment was
+      // created with no bindings at all (shows as offline). A device using
+      // this convention only ever exposes one shutter channel, so
+      // everything collapses into a single group instead of being indexed
+      // like the Tasmota case above. Kept in sync with
+      // src/equipments/binding-candidates.ts (the backend mirror).
+      if (byGroup.size === 0) {
+        const dataKeys = deviceData
+          .filter((d) => d.category === "shutter_position")
+          .map((d) => d.key);
+        const orderKeys = deviceOrders
+          .filter((o) => o.category === "set_shutter_position" || o.category === "shutter_move")
+          .map((o) => o.key);
+        if (orderKeys.length > 0) {
+          byGroup.set("1", { dataKeys, orderKeys });
+        }
+      }
+
       const candidates: BindingCandidate[] = [];
       for (const [g, entry] of byGroup) {
         if (entry.orderKeys.length === 0) continue;


### PR DESCRIPTION
## Summary

Two core-repo fixes found while setting up Bubendorff roller shutters
(via an "iDiamant with Netatmo" bridge) end-to-end against a real
9-shutter installation, alongside companion plugin PR
mchacher/sowel-plugin-legrand-control#1. Both were verified live on a
real Sowel dev instance, including on a real phone (Android).

### Commit 1 — `fix(ui): hide the Stop button when a shutter bridge doesn't support it`

Some shutter bridges (confirmed live: Bubendorff via iDiamant) cannot
actually stop the motor mid-travel — sending a stop command just
pauses it briefly before it continues to its original target. Every
place in the UI that renders shutter Open/Stop/Close buttons
(`ShutterControl.tsx` ×2 render paths, `EquipmentWidget.tsx` ×2 widget
variants, `WidgetDetailSheet.tsx`) rendered all three unconditionally,
with no way for an integration to say "no real Stop here". Added a
`hasStop` check (`enumValues` undefined → show Stop as before;
defined and omitting `"STOP"` → hide it) to all four render paths.
Fully backward compatible — every existing shutter integration leaves
`enumValues` undefined and is unaffected.

### Commit 2 — `fix(equipments): shutter auto-binding fails for non-Tasmota key names`

Found by manually adding a second real Bubendorff shutter via "Create
equipment": it came up with zero data/order bindings and showed as
offline, even though the device itself was online.
`computeBindingCandidates()`'s shutter/pool_cover/awning case only
recognizes Tasmota-style key names (`shutter_state`, `shutter_position`,
or indexed `shutterN_*`). Legrand/Bubendorff Home+Control uses
different names (`current_position`, `target_position`, `state`),
which matched nothing → zero candidates → nothing to auto-bind. Added
a category-based fallback (mirrors `ShutterControl.tsx`'s own
category-first resolver) that only kicks in when the key-name grouping
finds nothing, so it's additive and can't affect the existing Tasmota
convention. This bug is independent of Bubendorff specifically — it
would affect any Legrand NLV shutter added the same way, and predates
this session.

## Testing

- `npm run build` (backend `tsc`) — clean.
- `npx vitest run src/equipments/binding-candidates.test.ts` — 30/30
  passed (26 pre-existing + 4 new regression tests for commit 2).
- `npm test` (full backend suite) — **51 test files, 803 passed, 2
  skipped, 0 failed** — no regressions anywhere else.
- `cd ui && npm run build` (`tsc -b && vite build`) — clean, no type
  errors.
- No test file exists for `ShutterControl.tsx`, `EquipmentWidget.tsx`,
  or `WidgetDetailSheet.tsx` (verified — none turned up), and
  `ui/src/lib/binding-candidates.ts`'s own header says "tests live [in
  the backend]", so commit 1 and the frontend half of commit 2 were
  verified end-to-end on a real Sowel dev instance instead:
  - Deployed both fixes to a Sowel instance connected to a real
    "iDiamant with Netatmo" bridge (9 Bubendorff shutters).
  - Confirmed on Android across all three UI surfaces (zone equipment
    card, dashboard widget, dashboard widget detail sheet) that the
    Stop button is gone for the Bubendorff shutter while Open/Close
    still work, and that it's still present for other shutter/awning/
    pool-cover integrations (unaffected).
  - Reproduced the auto-binding bug live: created "Salle à manger Sud"
    (a second real Bubendorff shutter) via "Create equipment" —
    zero bindings, status offline. Deployed the fix, deleted that
    broken equipment, retried the exact same flow — came up correctly
    bound and connected.

## Test plan for the maintainer

- [ ] Merge alongside mchacher/sowel-plugin-legrand-control#1 (they're
      only fully effective together — this PR alone is a no-op for
      integrations that don't set `enumValues`/use non-Tasmota keys)
- [ ] Confirm existing shutter/awning/pool-cover integrations (Somfy
      RTS, Tasmota, Legrand NLV) are unaffected: Stop still shows,
      auto-binding via "Create equipment" still works exactly as before
- [ ] With the plugin PR also installed, confirm a Bubendorff shutter:
  - shows Open/Close but not Stop, in all three UI surfaces
  - auto-binds correctly via "Create equipment" (not just via
    `deviceIds`/API-driven creation)