### PR TITLE
release: v1.29.1 — hide config actions from standard users (#319)

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.29.x: Rôle Standard et parité du dashboard
 
+### v1.29.1 — 2026-07-19 { #v1-29-1 }
+
+- Fix (auth) : suite du rôle Standard de la v1.29.0. Un compte Standard pouvait encore voir des contrôles de configuration que le serveur refuse avec un 403 (Modifier / Supprimer sur un équipement, le panneau Configuration d'un équipement, l'activation d'un mode, la sauvegarde / suppression de graphe, la pastille de mise à jour). Ils sont désormais masqués, et les pages purement de configuration (appareils, calendrier, intégrations, plugins, publishers MQTT / notifications, logs, sauvegarde) redirigent un compte Standard vers le tableau de bord. Le pilotage (lumières, portails, volets, commandes de zone) et les réglages personnels (profil, mot de passe, jetons API) ne changent pas. (#319)
+
 ### v1.29.0 — 2026-07-19 { #v1-29-0 }
 
 - Feat (auth) : le rôle **Standard** est désormais limité à la consultation et au pilotage. Un utilisateur Standard peut parcourir le dashboard et les zones, voir l'état des équipements et actionner les équipements (ouvrir un portail ou une porte, allumer une lumière), mais ne peut plus créer, renommer ou supprimer d'équipements, de recettes, de zones ou de modes, ni modifier la moindre configuration. Toute la configuration est maintenant réservée aux administrateurs, masquée dans l'UI et bloquée côté serveur (une action interdite renvoie 403, donc impossible à contourner). Cela répond à la surprise qu'un compte Standard puisse modifier des équipements et des recettes par accident. Aucune migration nécessaire : les comptes Standard existants perdent simplement les actions de configuration qu'ils n'auraient pas dû avoir. (#319)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.29.x: Standard role and dashboard parity
 
+### v1.29.1 — 2026-07-19 { #v1-29-1 }
+
+- Fix (auth): follow-up to the v1.29.0 Standard role. A Standard user could still see config controls that the server rejects with a 403 (Edit / Delete on an equipment, the equipment Configuration panel, mode activation, chart save / delete, the update pill). These are now hidden, and the config-only pages (devices, calendar, integrations, plugins, MQTT / notification publishers, logs, backup) redirect a Standard user to the dashboard. Actuation (lights, gates, shutters, zone commands) and personal settings (profile, password, API tokens) are unchanged. (#319)
+
 ### v1.29.0 — 2026-07-19 { #v1-29-0 }
 
 - Feat (auth): the **Standard** role is now scoped to viewing and operating. A Standard user can browse the dashboard and zones, see equipment states, and actuate equipments (open a gate or a door, toggle a light), but can no longer create, rename or delete equipments, recipes, zones or modes, nor change any configuration. All configuration is now admin-only, hidden in the UI and enforced server-side (a blocked action returns 403, so it cannot be worked around). This answers the surprise that a Standard account could alter equipments and recipes by accident. No migration needed: existing Standard accounts simply lose the config actions they should not have had. (#319)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.29.0",
+  "version": "1.29.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { AppLayout } from "./components/layout/AppLayout";
 import { ProtectedRoute } from "./components/auth/ProtectedRoute";
+import { AdminRoute } from "./components/auth/AdminRoute";
 import { LoginPage } from "./pages/LoginPage";
 import { SetupPage } from "./pages/SetupPage";
 import { DevicesPage } from "./pages/DevicesPage";
@@ -54,15 +55,19 @@ export default function App() {
           <Route path="/home/:zoneId" element={<HomePage />} />
 
           {/* Settings pages */}
-          <Route path="/devices" element={<DevicesPage />} />
-          <Route path="/devices/:id" element={<DeviceDetailPage />} />
+          {/* Admin-only config pages are wrapped in AdminRoute (standard users
+              are redirected to the dashboard). Equipments/zones/modes stay
+              reachable for consultation; their mutating controls are gated
+              per-button instead, since standard users can still view them. */}
+          <Route path="/devices" element={<AdminRoute><DevicesPage /></AdminRoute>} />
+          <Route path="/devices/:id" element={<AdminRoute><DeviceDetailPage /></AdminRoute>} />
           <Route path="/equipments" element={<EquipmentsPage />} />
           <Route path="/equipments/:id" element={<EquipmentDetailPage />} />
           <Route path="/zones" element={<ZonesPage />} />
           <Route path="/zones/:id" element={<ZoneDetailPage />} />
           <Route path="/modes" element={<ModesPage />} />
           <Route path="/modes/:id" element={<ModeDetailPage />} />
-          <Route path="/calendar" element={<CalendarPage />} />
+          <Route path="/calendar" element={<AdminRoute><CalendarPage /></AdminRoute>} />
           <Route path="/energy" element={<Navigate to="/energy/live" replace />} />
           <Route path="/energy/live" element={<LiveEnergyPage />} />
           <Route path="/energy/consumption" element={<EnergyPage />} />
@@ -70,12 +75,12 @@ export default function App() {
           <Route path="/analyse" element={<AnalysePage />} />
           <Route path="/analyse/:chartId" element={<AnalysePage />} />
           <Route path="/settings" element={<SettingsPage />} />
-          <Route path="/integrations" element={<IntegrationsPage />} />
-          <Route path="/plugins" element={<PluginsPage />} />
-          <Route path="/mqtt-publishers" element={<MqttPublishersPage />} />
-          <Route path="/notification-publishers" element={<NotificationPublishersPage />} />
-          <Route path="/logs" element={<LogsPage />} />
-          <Route path="/backup" element={<BackupPage />} />
+          <Route path="/integrations" element={<AdminRoute><IntegrationsPage /></AdminRoute>} />
+          <Route path="/plugins" element={<AdminRoute><PluginsPage /></AdminRoute>} />
+          <Route path="/mqtt-publishers" element={<AdminRoute><MqttPublishersPage /></AdminRoute>} />
+          <Route path="/notification-publishers" element={<AdminRoute><NotificationPublishersPage /></AdminRoute>} />
+          <Route path="/logs" element={<AdminRoute><LogsPage /></AdminRoute>} />
+          <Route path="/backup" element={<AdminRoute><BackupPage /></AdminRoute>} />
 
           {/* Default redirect to Dashboard */}
           <Route path="*" element={<Navigate to="/dashboard" replace />} />

--- a/ui/src/components/auth/AdminRoute.tsx
+++ b/ui/src/components/auth/AdminRoute.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../../store/useAuth";
+
+/**
+ * Route guard for admin-only pages. Renders its children only for admin users;
+ * standard users are redirected to the dashboard.
+ *
+ * Assumes it is nested inside ProtectedRoute, so authentication is already
+ * resolved and `user` is populated. While `user` is momentarily null we render
+ * nothing rather than redirecting, so a real admin is never bounced on a race.
+ *
+ * This is defence in depth: the server already rejects every config mutation
+ * from a standard user (see STANDARD_WRITE_ALLOWLIST in auth-middleware). The
+ * guard keeps standard users out of pages whose sole purpose is configuration
+ * (devices, calendar, integrations, plugins, publishers, logs, backup).
+ */
+export function AdminRoute({ children }: { children: React.ReactNode }) {
+  const user = useAuth((s) => s.user);
+  if (!user) return null;
+  if (user.role !== "admin") return <Navigate to="/dashboard" replace />;
+  return <>{children}</>;
+}

--- a/ui/src/components/history/AnalyseView.tsx
+++ b/ui/src/components/history/AnalyseView.tsx
@@ -29,6 +29,7 @@ import {
 } from "recharts";
 import { getEquipments, getZones, getHistoryBindings, getHistoryData, getChart } from "../../api";
 import { useCharts } from "../../store/useCharts";
+import { useAuth } from "../../store/useAuth";
 import type {
   EquipmentWithDetails,
   ZoneWithChildren,
@@ -162,6 +163,10 @@ export function AnalyseView() {
   const updateChartStore = useCharts((s) => s.updateChart);
   const deleteChartStore = useCharts((s) => s.deleteChart);
   const fetchCharts = useCharts((s) => s.fetchCharts);
+  // Saving/deleting charts is a config mutation (rejected server-side for
+  // standard users); hide those controls. Building and viewing a chart stays
+  // available to everyone (series add/remove are local until saved).
+  const canManageCharts = useAuth((s) => s.user?.role === "admin");
 
   // --- Data sources ---
   const [zones, setZones] = useState<ZoneWithChildren[]>([]);
@@ -684,6 +689,8 @@ export function AnalyseView() {
             >
               <Eraser size={14} strokeWidth={1.5} />
             </button>
+            {canManageCharts && (
+            <>
             <button
               type="button"
               onClick={handleSave}
@@ -716,6 +723,8 @@ export function AnalyseView() {
               >
                 <Trash2 size={14} strokeWidth={1.5} />
               </button>
+            )}
+            </>
             )}
           </div>
         )}

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -83,7 +83,11 @@ export function AppLayout() {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   // Updates pill: combines Sowel core + plugin updates into a single counter.
-  const totalUpdates = pluginUpdateCount + (sowelUpdateAvailable ? 1 : 0);
+  // Applying core/plugin updates is admin-only; hide the update pill (and its
+  // sheet trigger) from standard users. pluginUpdateCount is already 0 for
+  // non-admins, but the core update flag is not role-scoped, so gate here.
+  const totalUpdates =
+    user?.role === "admin" ? pluginUpdateCount + (sowelUpdateAvailable ? 1 : 0) : 0;
   // Alarms pill: red when at least one error, amber otherwise.
   const alarmTone = issues.some((i) => i.level === "error") ? "error" : "warning";
 

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -4,6 +4,7 @@ import { useParams, useNavigate, useLocation, Link } from "react-router-dom";
 import { useDevices } from "../store/useDevices";
 import { useEquipments } from "../store/useEquipments";
 import { useZones } from "../store/useZones";
+import { useAuth } from "../store/useAuth";
 import { getEquipment, getHistoryBindings, setHistorize } from "../api";
 import { EquipmentForm } from "../components/equipments/EquipmentForm";
 import { LightControl } from "../components/equipments/LightControl";
@@ -71,6 +72,7 @@ export function EquipmentDetailPage() {
   const fetchEquipments = useEquipments((s) => s.fetchEquipments);
   const tree = useZones((s) => s.tree);
   const fetchZones = useZones((s) => s.fetchZones);
+  const isAdmin = useAuth((s) => s.user?.role === "admin");
 
   const [equipment, setEquipment] = useState<EquipmentWithDetails | null>(null);
   const [loading, setLoading] = useState(true);
@@ -233,6 +235,7 @@ export function EquipmentDetailPage() {
             )}
           </div>
         </div>
+        {isAdmin && (
         <div className="flex items-center gap-2">
           <button
             onClick={() => setShowEditForm(true)}
@@ -252,6 +255,7 @@ export function EquipmentDetailPage() {
             <span className="hidden sm:inline">{deleting ? t("common.deleting") : t("common.delete")}</span>
           </button>
         </div>
+        )}
       </div>
 
       {/* Controls — light and switch (smart plug) share the ON/OFF toggle surface */}
@@ -394,15 +398,16 @@ export function EquipmentDetailPage() {
         />
       )}
 
-      {/* Button actions */}
-      {equipment.type === "button" && (
+      {/* Button actions — config, admin only */}
+      {equipment.type === "button" && isAdmin && (
         <ButtonActionsSection equipmentId={equipment.id} />
       )}
 
       {/* History charts */}
       <HistoryPanel equipmentId={equipment.id} bindings={historyBindings} />
 
-      {/* Configuration */}
+      {/* Configuration — admin only (bindings, devices, history config) */}
+      {isAdmin && (
       <div className="bg-surface rounded-[10px] border border-border mb-6 divide-y divide-border-light">
         <div className="flex items-center gap-2 p-4">
           <Settings size={16} strokeWidth={1.5} className="text-text-tertiary" />
@@ -540,6 +545,7 @@ export function EquipmentDetailPage() {
           )}
         </div>
       </div>
+      )}
 
       {/* Edit equipment modal */}
       {showEditForm && (

--- a/ui/src/pages/EquipmentsPage.tsx
+++ b/ui/src/pages/EquipmentsPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useEquipments } from "../store/useEquipments";
 import { useZones } from "../store/useZones";
+import { useAuth } from "../store/useAuth";
 import { EquipmentCard } from "../components/equipments/EquipmentCard";
 import { EquipmentForm } from "../components/equipments/EquipmentForm";
 import { Box, Loader2, Plus, Search, X } from "lucide-react";
@@ -21,6 +22,7 @@ export function EquipmentsPage() {
   const executeOrder = useEquipments((s) => s.executeOrder);
   const tree = useZones((s) => s.tree);
   const fetchZones = useZones((s) => s.fetchZones);
+  const isAdmin = useAuth((s) => s.user?.role === "admin");
 
   const [showForm, setShowForm] = useState(false);
   const [filter, setFilter] = useState("");
@@ -67,6 +69,7 @@ export function EquipmentsPage() {
             </div>
           )}
 
+          {isAdmin && (
           <button
             onClick={() => setShowForm(true)}
             className="flex items-center gap-2 px-4 py-2 text-[13px] font-medium text-white bg-primary rounded-[6px] hover:bg-primary-hover transition-colors duration-150"
@@ -74,6 +77,7 @@ export function EquipmentsPage() {
             <Plus size={16} strokeWidth={1.5} />
             {t("equipments.addEquipment")}
           </button>
+          )}
 
           <div className="flex items-center gap-2 px-3 py-1.5 rounded-[6px] bg-primary-light text-primary">
             <Box size={16} strokeWidth={1.5} />
@@ -92,7 +96,7 @@ export function EquipmentsPage() {
       ) : error ? (
         <ErrorState error={error} />
       ) : equipments.length === 0 ? (
-        <EmptyState onAdd={() => setShowForm(true)} />
+        <EmptyState onAdd={() => setShowForm(true)} canCreate={isAdmin} />
       ) : (
         <div className="space-y-6">
           {byZone.map(({ zoneName, equipments: zoneEquipments }) => (
@@ -185,7 +189,7 @@ function groupByZone(
     .map(([zoneName, eqs]) => ({ zoneName, equipments: eqs }));
 }
 
-function EmptyState({ onAdd }: { onAdd: () => void }) {
+function EmptyState({ onAdd, canCreate }: { onAdd: () => void; canCreate: boolean }) {
   const { t } = useTranslation();
   return (
     <div className="flex flex-col items-center justify-center py-20 text-center">
@@ -196,12 +200,14 @@ function EmptyState({ onAdd }: { onAdd: () => void }) {
       <p className="text-[13px] text-text-secondary max-w-[320px] mb-4">
         {t("equipments.empty.message")}
       </p>
-      <button
-        onClick={onAdd}
-        className="px-4 py-2 bg-primary text-white text-[13px] font-medium rounded-[6px] hover:bg-primary-hover transition-colors duration-150 ease-out"
-      >
-        {t("equipments.createEquipment")}
-      </button>
+      {canCreate && (
+        <button
+          onClick={onAdd}
+          className="px-4 py-2 bg-primary text-white text-[13px] font-medium rounded-[6px] hover:bg-primary-hover transition-colors duration-150 ease-out"
+        >
+          {t("equipments.createEquipment")}
+        </button>
+      )}
     </div>
   );
 }

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -201,7 +201,10 @@ export function HomePage() {
         <div className="space-y-6 min-w-0">
           {zoneId && (
             <Panel title={t("behaviors.title")}>
-              <ZoneModesSection zoneId={zoneId} />
+              {/* Modes are admin-only (activation and config both require admin);
+                  hide the whole management block from standard users. Recipes
+                  stay visible read-only, gated per-button inside the section. */}
+              {isAdmin && <ZoneModesSection zoneId={zoneId} />}
               <ZoneRecipesSection zoneId={zoneId} zoneName={currentZone.name} />
             </Panel>
           )}

--- a/ui/src/pages/ModesPage.tsx
+++ b/ui/src/pages/ModesPage.tsx
@@ -106,7 +106,7 @@ export function ModesPage() {
       ) : (
         <div className="space-y-2 max-w-[720px]">
           {modes.map((mode) => (
-            <ModeCard key={mode.id} mode={mode} calendarSlots={calendarSlots} onClick={() => navigate(`/modes/${mode.id}`)} />
+            <ModeCard key={mode.id} mode={mode} calendarSlots={calendarSlots} canToggle={isAdmin} onClick={() => navigate(`/modes/${mode.id}`)} />
           ))}
         </div>
       )}
@@ -123,7 +123,7 @@ export function ModesPage() {
   );
 }
 
-function ModeCard({ mode, calendarSlots, onClick }: { mode: ModeWithDetails; calendarSlots: CalendarSlot[]; onClick: () => void }) {
+function ModeCard({ mode, calendarSlots, canToggle, onClick }: { mode: ModeWithDetails; calendarSlots: CalendarSlot[]; canToggle: boolean; onClick: () => void }) {
   const { t } = useTranslation();
   const activateMode = useModes((s) => s.activateMode);
   const deactivateMode = useModes((s) => s.deactivateMode);
@@ -186,6 +186,7 @@ function ModeCard({ mode, calendarSlots, onClick }: { mode: ModeWithDetails; cal
           )}
         </div>
       </div>
+      {canToggle && (
       <button
         onClick={handleToggle}
         disabled={toggling}
@@ -200,6 +201,7 @@ function ModeCard({ mode, calendarSlots, onClick }: { mode: ModeWithDetails; cal
           style={{ transform: mode.active ? "translateX(16px)" : "translateX(0)" }}
         />
       </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## v1.29.1 — RBAC UI hardening

Follow-up to v1.29.0 (spec 131). Romain reported that a Standard user still saw Edit / Delete buttons on an equipment even though the server rejects the action (403). This closes the whole class of that gap.

### Source of truth
The backend allowlist (`STANDARD_WRITE_ALLOWLIST`) permits a Standard user only: equipment actuation, zone commands, and personal `/me` `/me/tokens` `/push`. The UI now matches it exactly.

### Changes
- **AdminRoute** guard: config-only pages (devices, calendar, integrations, plugins, MQTT / notification publishers, logs, backup) redirect a Standard user to the dashboard. Equipments / zones / modes stay reachable for consultation, gated per-button.
- **EquipmentDetailPage**: hide Edit / Delete, the Configuration panel (bindings, devices, history) and button-action config.
- **EquipmentsPage**: hide Add + empty-state CTA.
- **HomePage**: hide the mode-management block (mode activation + config are admin-only).
- **ModesPage**: gate the activate / deactivate toggle.
- **AnalyseView**: hide chart save / save-as / delete.
- **AppLayout**: hide the update pill (applying updates is admin-only).

Actuation controls (lights, gates, shutters, zone commands) and personal settings stay visible.

### Already-correct (verified, untouched)
DashboardPage edit mode, SettingsPage (admin tabs + TariffSettings behind the admin tab), Zones list/detail, ModeDetailPage, ZoneRecipesSection.

### Notes / follow-ups
- Standard users no longer see the current mode at all (mode block fully hidden). A read-only mode view could be a later enhancement.
- Chart save/delete is admin-only, matching the backend. Letting Standard users save their own charts would need a backend allowlist entry.

### Test plan
- [x] `tsc -b --noEmit`, `eslint`, `vite build` green
- [x] Release notes (EN + FR) with `{ #v1-29-1 }` anchor (spec 108)
- [ ] Manual: log in as Standard, confirm no Edit/Delete on equipment, admin pages redirect, actuation still works