### PR TITLE
release: v1.29.2

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,11 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.29.x: Rôle Standard et parité du dashboard
 
+### v1.29.2 — 2026-07-20 { #v1-29-2 }
+
+- Fix (ui) : le bouton Stop d'un volet est désormais masqué quand le pont ne peut pas réellement arrêter le moteur en cours de course. Certains ponts (confirmé sur des volets Bubendorff via un pont iDiamant with Netatmo) ne font qu'une brève pause avant de repartir vers la cible initiale ; un bouton Stop y était donc trompeur. Une intégration le signale en omettant « STOP » de l'ordre de mouvement ; les volets qui gardent un vrai Stop ne changent pas. (#327)
+- Fix (equipments) : l'auto-liaison d'un volet fonctionne maintenant pour les intégrations qui n'utilisent pas les noms de clés à la Tasmota. Ajouter un volet dont l'appareil expose current_position / target_position / state (ex. Legrand / Bubendorff Home+Control) créait un équipement sans aucune liaison, affiché hors ligne ; une bascule basée sur la catégorie le lie désormais correctement. (#327)
+
 ### v1.29.1 — 2026-07-19 { #v1-29-1 }
 
 - Fix (auth) : suite du rôle Standard de la v1.29.0. Un compte Standard pouvait encore voir des contrôles de configuration que le serveur refuse avec un 403 (Modifier / Supprimer sur un équipement, le panneau Configuration d'un équipement, l'activation d'un mode, la sauvegarde / suppression de graphe, la pastille de mise à jour). Ils sont désormais masqués, et les pages purement de configuration (appareils, calendrier, intégrations, plugins, publishers MQTT / notifications, logs, sauvegarde) redirigent un compte Standard vers le tableau de bord. Le pilotage (lumières, portails, volets, commandes de zone) et les réglages personnels (profil, mot de passe, jetons API) ne changent pas. (#319)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,11 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.29.x: Standard role and dashboard parity
 
+### v1.29.2 — 2026-07-20 { #v1-29-2 }
+
+- Fix (ui): the shutter Stop button is now hidden when the bridge cannot actually stop the motor mid-travel. Some bridges (confirmed on Bubendorff shutters via an iDiamant with Netatmo bridge) only pause briefly before continuing to the original target, so a Stop button there was misleading. An integration signals this by omitting "STOP" from the move order; every shutter that keeps a real Stop is unaffected. (#327)
+- Fix (equipments): shutter auto-binding now works for integrations that do not use Tasmota-style key names. Adding a shutter whose device exposes current_position / target_position / state (e.g. Legrand / Bubendorff Home+Control) produced an equipment with no bindings, shown as offline; a category-based fallback now binds it correctly. (#327)
+
 ### v1.29.1 — 2026-07-19 { #v1-29-1 }
 
 - Fix (auth): follow-up to the v1.29.0 Standard role. A Standard user could still see config controls that the server rejects with a 403 (Edit / Delete on an equipment, the equipment Configuration panel, mode activation, chart save / delete, the update pill). These are now hidden, and the config-only pages (devices, calendar, integrations, plugins, MQTT / notification publishers, logs, backup) redirect a Standard user to the dashboard. Actuation (lights, gates, shutters, zone commands) and personal settings (profile, password, API tokens) are unchanged. (#319)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.29.1",
+  "version": "1.29.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## v1.29.2

Bundles the two shutter fixes from #327 (merged), needed by the companion plugin release `sowel-plugin-legrand-control@2.2.0`.

- **fix(ui)**: hide the shutter Stop button when the bridge cannot stop mid-travel (Bubendorff via iDiamant); signalled by omitting STOP from the move order. Backward compatible.
- **fix(equipments)**: category-based fallback so shutters with non-Tasmota key names (current_position / target_position / state) auto-bind instead of coming up empty/offline.

Release notes (EN + FR) added with the `{ #v1-29-2 }` anchor.

- [x] tsc / eslint / build green (verified on #327)
- [x] backend suite green on #327 (803 passed, +4 new binding-candidate tests)