### PR TITLE
Propose new community recipe: Runtime Guard (motor/pump overrun protection)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -495,7 +495,7 @@
     "icon": "ShieldAlert",
     "author": "alpitux",
     "repo": "alpitux/sowel-recipe-runtime-guard",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "tags": ["safety", "pump", "motor", "power", "protection", "automation"],
     "i18n": {
       "fr": {
@@ -505,6 +505,6 @@
     },
     "sowelVersion": ">=1.2.12",
     "owner": "alpitux",
-    "sha256": "7dda57b8f2f8aad295add8e03560d0f68f9ab0b2f765934ed8fce557d58dabbe"
+    "sha256": "6f50d7950c1157066090bd03e59a9898cd204d900b72d20a449ed62e8c84c11d"
   }
 ]

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -486,5 +486,25 @@
     "sowelVersion": ">=1.23.0",
     "owner": "mchacher",
     "sha256": "0a3789ce25a0ca3758631bd54976bdfd4999268e7ae660ddf6b73dc33f72857f"
+  },
+  {
+    "id": "runtime-guard",
+    "type": "recipe",
+    "name": "Runtime Guard",
+    "description": "Cuts power to a motor/pump if it runs continuously past a safe duration, with optional legitimate-use overrides (e.g. an open watering valve)",
+    "icon": "ShieldAlert",
+    "author": "alpitux",
+    "repo": "alpitux/sowel-recipe-runtime-guard",
+    "version": "1.0.0",
+    "tags": ["safety", "pump", "motor", "power", "protection", "automation"],
+    "i18n": {
+      "fr": {
+        "name": "Protection moteur",
+        "description": "Coupe l'alimentation d'un moteur/d'une pompe s'il fonctionne en continu au-delà d'une durée jugée sûre, avec des conditions optionnelles de fonctionnement légitime (ex: une vanne d'arrosage ouverte)."
+      }
+    },
+    "sowelVersion": ">=1.2.12",
+    "owner": "alpitux",
+    "sha256": "7dda57b8f2f8aad295add8e03560d0f68f9ab0b2f765934ed8fce557d58dabbe"
   }
 ]


### PR DESCRIPTION
## Summary

Proposing a new community recipe for the plugin store:
[`alpitux/sowel-recipe-runtime-guard`](https://github.com/alpitux/sowel-recipe-runtime-guard)
v1.0.0 — **"Runtime Guard"** / *"Protection moteur"*.

### What it does

Cuts power to a motor/pump if it runs continuously past a safe
duration, protecting hardware from running unattended (a stuck valve,
a failed pressure switch, a jammed float switch, or any other fault
that keeps a load powered on far longer than it should be) — detected
purely from the equipment's own metering (power/current), no extra
sensor needed.

It grew out of a concrete need I ran into myself: a garden water pump
behind an ordinary Sonoff-style smart plug should only draw significant
power in short, on-demand bursts. But the same pump also runs
legitimately for much longer whenever a proper watering recipe
(`sowel-recipe-auto-watering`) opens a valve feeding it — a 90-minute
watering slot must never be treated as abnormal, while an unexplained
90-minute run with no valve open should be cut off well before that.

To resolve this, the recipe supports up to **3 optional "suppression
conditions"** (each: an equipment + a data key + an expected value —
e.g. a valve's `state` data equals `ON`). While any one holds:

- the runtime allowance is kept topped up, so a long legitimate run
  never trips the guard, no matter how it compares to the configured
  max runtime;
- the moment it stops holding (the valve closes) while the equipment is
  *still* drawing power, the guard doesn't trip instantly on whatever
  time already elapsed — it starts a full **fresh** runtime window from
  that point, avoiding nuisance trips right at the boundary of a
  legitimate session (many pumps draw power for a few extra seconds
  after a valve closes).

Once tripped, the recipe never re-powers the equipment itself and never
re-trips repeatedly — it stays off until the equipment's own on/off
state is observed going back to `ON` by any means (Sowel UI, physical
button, another automation), then monitoring resumes cleanly. This is a
deliberate safety choice: auto-retrying a load that just tripped a
protective cutoff risks repeatedly re-engaging a real fault rather than
giving a human the chance to check on it.

Full design rationale, the complete slot reference, and the exposed
state model are documented in the recipe's own
[README](https://github.com/alpitux/sowel-recipe-runtime-guard#readme).

## Testing behind this submission

**16 unit tests** in the recipe repo (mocked `RecipeContext`, vitest):
threshold detection, no-trip-before-limit, trip-at-limit, normal-stop
reset, no-repeat-trip-while-tripped + manual recovery, a suppression
condition holding for 90 minutes against a 30-minute limit (never
trips), a fresh window starting once suppression ends (then tripping
if still unexplained), all 3 suppression slots checked independently,
restart resumption (including immediate trip if resuming already past
the limit), and full parameter validation — plus a regression test for
a real race condition (below).

Beyond the unit tests, I validated this end-to-end against a real Sowel
instance and a real installation — a Sonoff-style smart plug powering a
rainwater-cistern garden pump, and a Tuya-style smart valve feeding it,
both already Zigbee2MQTT-integrated:

1. Baseline trip/recovery cycle using `voltage` as a fast, repeatable
   stand-in signal (present the instant the plug is on, without needing
   the pump to physically run): detected running, tripped exactly at
   the configured 1-minute limit with a real `state: OFF` order,
   confirmed no repeat-trip while already tripped, confirmed manual
   recovery on turning the plug back on.
2. **Real power draw, real watering, suppression active**: while
   manually running a real watering cycle (pump drawing ~700-730 W,
   confirmed live), configured a suppression condition on the valve's
   `state` == `ON`. The pump ran **90+ seconds past a 1-minute limit**
   without tripping — the ongoing watering was never interrupted.
3. **Real power draw, real watering, no suppression — the actual
   cutoff**: same real watering session, no suppression condition this
   time. Tripped exactly at the configured limit and **the real,
   actively-running pump was physically cut off** — confirmed via the
   plug's own reported `state: OFF` / `power: 0`, not a simulated
   result.
4. **A real race condition, found and fixed live**: the very first
   attempt at (3) showed the trip firing, immediately followed — within
   2 ms — by a spurious "manual re-enable" log line, itself immediately
   followed by the real `OFF` order. The physical outcome was still
   correct, but the recipe's internal state briefly and incorrectly
   flipped through `running` before settling, because a `state` event
   reporting `ON` (almost certainly a device/integration echo, not a
   real user action) arrived within milliseconds of the trip. Fixed
   with a 5-second grace period on `state` events right after tripping
   — **the same technique `sowel-recipe-motion-light` already uses**
   (`turnOffGraceUntil`) for the identical class of race. Re-verified
   live after the fix: clean trip, no spurious recovery log, consistent
   internal state matching the equipment's real `state: OFF`. Added a
   corresponding unit test so this doesn't regress.
5. A second full real cutoff after the fix, on genuine power draw with
   no suppression, confirmed clean (no spurious recovery log this
   time).

Every one of these is documented in the recipe's README with exact
timestamps, log lines, and wattages — not just asserted, so the
reasoning and evidence behind each design decision is auditable.

## Registry entry

- `owner`/`author`: `"alpitux"` — not in `OFFICIAL_OWNERS`, so
  `isOfficial()` correctly resolves to `false` and installing it will
  surface the community-plugin confirmation prompt (spec 089 C1), as
  intended for a third-party contribution.
- `sha256` matches the `v1.0.0` release tarball
  (`sowel-recipe-runtime-guard-1.0.0.tar.gz`) — verified against the
  published GitHub release asset before adding this entry.
- `sowelVersion: ">=1.2.12"` — no core APIs newer than the general
  external-recipe baseline are used (`equipmentManager`,
  `eventBus.onType("equipment.data.changed")`, `ctx.state`,
  `ctx.helpers.parseDuration`/`formatDuration` — all already used by
  existing recipes like `state-watch` and `auto-watering`).

## Test plan for the maintainer

- [ ] Review the recipe source and README for design fit
      (`alpitux/sowel-recipe-runtime-guard`)
- [ ] Install from the store on a test instance, confirm the
      community-plugin confirmation prompt appears (unofficial owner)
- [ ] Configure it against any switch-type equipment with a power/
      current data binding, confirm the slots render as expected
      (including the 3 optional suppression-condition groups)
- [ ] Optional: confirm behavior against a real load if convenient —
      happy to provide more real-world logs/detail if useful