### PR TITLE
Hide bulk shutter/awning Stop button when any equipment can't stop (follow-up to #327)

### DIFF
--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -27,6 +27,7 @@ import type {
 import { executeZoneOrder } from "../../api";
 import { useEquipmentState } from "../equipments/useEquipmentState";
 import { findOrderByCategory } from "../equipments/bindingUtils";
+import { allSupportStop } from "../../lib/binding-utils";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
 import { SensorValues } from "../equipments/SensorValues";
 import {
@@ -605,6 +606,7 @@ function ZoneShuttersDetail({
   }, [equipments]);
 
   const level = avgPosition !== null ? shutterLevel(avgPosition) : null;
+  const hasStop = useMemo(() => allSupportStop(equipments), [equipments]);
 
   if (equipments.length === 0) return null;
 
@@ -633,14 +635,16 @@ function ZoneShuttersDetail({
         >
           {commandLoading === "allShuttersOpen" ? <Loader2 size={18} className="animate-spin" /> : <ChevronUp size={20} strokeWidth={2} />}
         </button>
-        <button
-          onClick={() => onCommand("allShuttersStop")}
-          disabled={commandLoading !== null}
-          className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
-          title={t("zones.commands.allShuttersStop")}
-        >
-          {commandLoading === "allShuttersStop" ? <Loader2 size={18} className="animate-spin" /> : <Square size={14} strokeWidth={2.5} />}
-        </button>
+        {hasStop && (
+          <button
+            onClick={() => onCommand("allShuttersStop")}
+            disabled={commandLoading !== null}
+            className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
+            title={t("zones.commands.allShuttersStop")}
+          >
+            {commandLoading === "allShuttersStop" ? <Loader2 size={18} className="animate-spin" /> : <Square size={14} strokeWidth={2.5} />}
+          </button>
+        )}
         <button
           onClick={() => onCommand("allShuttersClose")}
           disabled={commandLoading !== null}
@@ -677,6 +681,7 @@ function ZoneAwningsDetail({
     }
     return { deployedCount: deployed, total: equipments.length };
   }, [equipments]);
+  const hasStop = useMemo(() => allSupportStop(equipments), [equipments]);
 
   if (total === 0) return null;
 
@@ -704,14 +709,16 @@ function ZoneAwningsDetail({
         >
           {commandLoading === "allAwningsRetract" ? <Loader2 size={18} className="animate-spin" /> : <ChevronUp size={20} strokeWidth={2} />}
         </button>
-        <button
-          onClick={() => onCommand("allAwningsStop")}
-          disabled={commandLoading !== null}
-          className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
-          title={t("zones.commands.allAwningsStop")}
-        >
-          {commandLoading === "allAwningsStop" ? <Loader2 size={18} className="animate-spin" /> : <Square size={14} strokeWidth={2.5} />}
-        </button>
+        {hasStop && (
+          <button
+            onClick={() => onCommand("allAwningsStop")}
+            disabled={commandLoading !== null}
+            className="flex-1 h-12 flex items-center justify-center rounded-[6px] border border-border bg-surface text-text-secondary hover:bg-border-light transition-colors cursor-pointer active:scale-[0.97]"
+            title={t("zones.commands.allAwningsStop")}
+          >
+            {commandLoading === "allAwningsStop" ? <Loader2 size={18} className="animate-spin" /> : <Square size={14} strokeWidth={2.5} />}
+          </button>
+        )}
         <button
           onClick={() => onCommand("allAwningsExtend")}
           disabled={commandLoading !== null}

--- a/ui/src/components/dashboard/ZoneWidget.tsx
+++ b/ui/src/components/dashboard/ZoneWidget.tsx
@@ -14,6 +14,7 @@ import {
 import type { DashboardWidget, EquipmentWithDetails, ZoneWithChildren, WidgetFamily } from "../../types";
 import { executeZoneOrder, executeEquipmentOrder } from "../../api";
 import { findOrderByCategory } from "../equipments/bindingUtils";
+import { allSupportStop } from "../../lib/binding-utils";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
 import {
   LightBulbIcon,
@@ -315,6 +316,9 @@ function ZoneShutterWidget({
   }, [filteredEquipments]);
 
   const level = avgPosition !== null ? shutterLevel(avgPosition) : null;
+  // Hide the bulk Stop button if any shutter in this zone/subtree can't
+  // really stop mid-travel (e.g. Bubendorff) — see allSupportStop().
+  const hasStop = useMemo(() => allSupportStop(filteredEquipments), [filteredEquipments]);
 
   return (
     <ZoneWidgetCard label={label} empty={filteredEquipments.length === 0}>
@@ -348,14 +352,16 @@ function ZoneShutterWidget({
         >
           {commandLoading === "allShuttersOpen" ? <Loader2 size={16} className="animate-spin" /> : <ChevronUp size={16} strokeWidth={2} />}
         </button>
-        <button
-          onClick={() => onCommand("allShuttersStop")}
-          disabled={commandLoading !== null}
-          className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-text-tertiary hover:text-text hover:bg-border-light active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
-          title={t("zones.commands.allShuttersStop")}
-        >
-          {commandLoading === "allShuttersStop" ? <Loader2 size={16} className="animate-spin" /> : <Square size={11} strokeWidth={2.5} />}
-        </button>
+        {hasStop && (
+          <button
+            onClick={() => onCommand("allShuttersStop")}
+            disabled={commandLoading !== null}
+            className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-text-tertiary hover:text-text hover:bg-border-light active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
+            title={t("zones.commands.allShuttersStop")}
+          >
+            {commandLoading === "allShuttersStop" ? <Loader2 size={16} className="animate-spin" /> : <Square size={11} strokeWidth={2.5} />}
+          </button>
+        )}
         <button
           onClick={() => onCommand("allShuttersClose")}
           disabled={commandLoading !== null}
@@ -396,6 +402,7 @@ function ZoneAwningWidget({
     }
     return { deployedCount: deployed, total: filteredEquipments.length };
   }, [filteredEquipments]);
+  const hasStop = useMemo(() => allSupportStop(filteredEquipments), [filteredEquipments]);
 
   return (
     <ZoneWidgetCard label={label} empty={filteredEquipments.length === 0}>
@@ -435,14 +442,16 @@ function ZoneAwningWidget({
         >
           {commandLoading === "allAwningsRetract" ? <Loader2 size={16} className="animate-spin" /> : <ChevronUp size={16} strokeWidth={2} />}
         </button>
-        <button
-          onClick={() => onCommand("allAwningsStop")}
-          disabled={commandLoading !== null}
-          className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-text-tertiary hover:text-text hover:bg-border-light active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
-          title={t("zones.commands.allAwningsStop")}
-        >
-          {commandLoading === "allAwningsStop" ? <Loader2 size={16} className="animate-spin" /> : <Square size={11} strokeWidth={2.5} />}
-        </button>
+        {hasStop && (
+          <button
+            onClick={() => onCommand("allAwningsStop")}
+            disabled={commandLoading !== null}
+            className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-text-tertiary hover:text-text hover:bg-border-light active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
+            title={t("zones.commands.allAwningsStop")}
+          >
+            {commandLoading === "allAwningsStop" ? <Loader2 size={16} className="animate-spin" /> : <Square size={11} strokeWidth={2.5} />}
+          </button>
+        )}
         <button
           onClick={() => onCommand("allAwningsExtend")}
           disabled={commandLoading !== null}

--- a/ui/src/components/equipments/ButtonActionsSection.tsx
+++ b/ui/src/components/equipments/ButtonActionsSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Zap, Trash2, Plus, Pencil } from "lucide-react";
 import { getButtonActionBindings, addButtonActionBinding, updateButtonActionBinding, removeButtonActionBinding } from "../../api";
@@ -7,6 +7,7 @@ import { useEquipments } from "../../store/useEquipments";
 import { useRecipes } from "../../store/useRecipes";
 import { useZones } from "../../store/useZones";
 import type { ButtonActionBinding, ButtonEffectType, ZoneWithChildren } from "../../types";
+import { allSupportStop } from "../../lib/binding-utils";
 
 const DEFAULT_BUTTON_ACTIONS = ["single", "double", "hold"];
 
@@ -32,6 +33,31 @@ function flattenZones(tree: ZoneWithChildren[]): { id: string; name: string }[] 
   };
   walk(tree);
   return result;
+}
+
+/** Zone id itself plus every descendant, matching the backend's own
+ *  zone-order scope (POST /zones/:id/orders/:orderKey acts on the whole
+ *  subtree, not just the exact zone — see zoneManager.getDescendantIds). */
+function findZoneAndDescendantIds(tree: ZoneWithChildren[], zoneId: string): string[] {
+  const find = (nodes: ZoneWithChildren[]): ZoneWithChildren | null => {
+    for (const z of nodes) {
+      if (z.id === zoneId) return z;
+      const found = find(z.children);
+      if (found) return found;
+    }
+    return null;
+  };
+  const target = find(tree);
+  if (!target) return [zoneId];
+  const ids = [target.id];
+  const walk = (z: ZoneWithChildren) => {
+    for (const child of z.children ?? []) {
+      ids.push(child.id);
+      walk(child);
+    }
+  };
+  walk(target);
+  return ids;
 }
 
 interface ButtonActionsSectionProps {
@@ -176,6 +202,7 @@ export function ButtonActionsSection({ equipmentId }: ButtonActionsSectionProps)
                     modes={modes}
                     equipments={equipments}
                     zones={zones}
+                    zoneTree={zoneTree}
                     instances={instances}
                     actionValues={actionValues}
                     initial={binding}
@@ -215,6 +242,7 @@ export function ButtonActionsSection({ equipmentId }: ButtonActionsSectionProps)
           modes={modes}
           equipments={equipments}
           zones={zones}
+          zoneTree={zoneTree}
           instances={instances}
           actionValues={actionValues}
           onSubmit={handleAdd}
@@ -229,6 +257,7 @@ function AddEffectForm({
   modes,
   equipments,
   zones,
+  zoneTree,
   instances,
   actionValues,
   initial,
@@ -236,8 +265,9 @@ function AddEffectForm({
   onCancel,
 }: {
   modes: { id: string; name: string; active: boolean }[];
-  equipments: { id: string; name: string; type: string; zoneId: string; orderBindings: { alias: string; type?: string; enumValues?: string[]; min?: number; max?: number }[] }[];
+  equipments: { id: string; name: string; type: string; zoneId: string; orderBindings: { alias: string; type?: string; category?: string; enumValues?: string[]; min?: number; max?: number }[] }[];
   zones: { id: string; name: string }[];
+  zoneTree: ZoneWithChildren[];
   instances: { id: string; recipeId: string }[];
   actionValues: string[];
   initial?: ButtonActionBinding;
@@ -294,6 +324,23 @@ function AddEffectForm({
   const [zoValue, setZoValue] = useState(
     initial?.effectType === "zone_order" && initial.config.value != null ? String(initial.config.value) : "",
   );
+  // Hide allShuttersStop/allAwningsStop from the picker if the selected
+  // zone (+ its subtree, matching the backend's own zone-order scope)
+  // contains a shutter/awning that can't really stop mid-travel (e.g.
+  // Bubendorff) — assigning that action to a physical button would just
+  // fail at press time for that one equipment. See allSupportStop().
+  const visibleZoneOrderOptions = useMemo(() => {
+    if (!zoZoneId) return ZONE_ORDER_OPTIONS;
+    const scopeIds = new Set(findZoneAndDescendantIds(zoneTree, zoZoneId));
+    const inScope = equipments.filter((eq) => scopeIds.has(eq.zoneId));
+    const shutterStopOk = allSupportStop(inScope.filter((eq) => eq.type === "shutter"));
+    const awningStopOk = allSupportStop(inScope.filter((eq) => eq.type === "awning"));
+    return ZONE_ORDER_OPTIONS.filter((opt) => {
+      if (opt.key === "allShuttersStop") return shutterStopOk;
+      if (opt.key === "allAwningsStop") return awningStopOk;
+      return true;
+    });
+  }, [zoZoneId, zoneTree, equipments]);
   // recipe_toggle
   const [instanceId, setInstanceId] = useState(
     initial?.effectType === "recipe_toggle" ? String(initial.config.instanceId ?? "") : "",
@@ -659,7 +706,7 @@ function AddEffectForm({
                 className="w-full px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
               >
                 <option value="">{t("common.select")}</option>
-                {ZONE_ORDER_OPTIONS.map((opt) => (
+                {visibleZoneOrderOptions.map((opt) => (
                   <option key={opt.key} value={opt.key}>
                     {t(`buttonActions.zoneOrder.${opt.key}`)}
                   </option>

--- a/ui/src/components/home/ZoneCommands.tsx
+++ b/ui/src/components/home/ZoneCommands.tsx
@@ -20,6 +20,11 @@ type Category = "light" | "light-off" | "shutter";
 interface ZoneCommandsProps {
   hasLights: boolean;
   hasShutters: boolean;
+  /** False if at least one shutter in the zone can't really stop
+   *  mid-travel (e.g. a Bubendorff shutter) — hides the bulk Stop
+   *  button entirely rather than letting it silently fail for that
+   *  one shutter while working for the rest. Defaults to true. */
+  hasStoppableShutters?: boolean;
   loading: ZoneOrder | null;
   onCommand: (order: ZoneOrder) => void;
 }
@@ -58,7 +63,13 @@ function ZCmdsBtn({ cat, title, loading, disabled, onClick, children }: ZCmdsBtn
   );
 }
 
-export function ZoneCommands({ hasLights, hasShutters, loading, onCommand }: ZoneCommandsProps) {
+export function ZoneCommands({
+  hasLights,
+  hasShutters,
+  hasStoppableShutters = true,
+  loading,
+  onCommand,
+}: ZoneCommandsProps) {
   const { t } = useTranslation();
   const busy = loading !== null;
 
@@ -108,15 +119,17 @@ export function ZoneCommands({ hasLights, hasShutters, loading, onCommand }: Zon
           >
             <ChevronUp size={16} strokeWidth={2} />
           </ZCmdsBtn>
-          <ZCmdsBtn
-            cat="shutter"
-            title={t("zones.commands.allShuttersStop", { defaultValue: "Stop" })}
-            loading={loading === "allShuttersStop"}
-            disabled={busy}
-            onClick={() => onCommand("allShuttersStop")}
-          >
-            <Square size={14} strokeWidth={1.5} fill="currentColor" />
-          </ZCmdsBtn>
+          {hasStoppableShutters && (
+            <ZCmdsBtn
+              cat="shutter"
+              title={t("zones.commands.allShuttersStop", { defaultValue: "Stop" })}
+              loading={loading === "allShuttersStop"}
+              disabled={busy}
+              onClick={() => onCommand("allShuttersStop")}
+            >
+              <Square size={14} strokeWidth={1.5} fill="currentColor" />
+            </ZCmdsBtn>
+          )}
           <ZCmdsBtn
             cat="shutter"
             title={t("zones.commands.allShuttersClose")}

--- a/ui/src/lib/binding-utils.test.ts
+++ b/ui/src/lib/binding-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { freeCandidates, buildBoundDataKeysByDevice } from "./binding-utils";
+import { freeCandidates, buildBoundDataKeysByDevice, allSupportStop } from "./binding-utils";
 import type { BindingCandidate } from "./binding-candidates";
 import type { EquipmentWithDetails } from "../types";
 
@@ -66,5 +66,42 @@ describe("buildBoundDataKeysByDevice", () => {
     ] as unknown as EquipmentWithDetails[];
     const map = buildBoundDataKeysByDevice(equipments);
     expect([...map.inv].sort()).toEqual(["ch1_power", "inverter_temp"]);
+  });
+});
+
+describe("allSupportStop", () => {
+  it("true when no equipment has a move order at all", () => {
+    const equipments = [{ orderBindings: [] }] as unknown as EquipmentWithDetails[];
+    expect(allSupportStop(equipments)).toBe(true);
+  });
+
+  it("true when every move order's enumValues includes STOP", () => {
+    const equipments = [
+      { orderBindings: [{ alias: "state", category: "shutter_move", enumValues: ["OPEN", "CLOSE", "STOP"] }] },
+      { orderBindings: [{ alias: "state", category: "shutter_move", enumValues: ["OPEN", "CLOSE", "STOP"] }] },
+    ] as unknown as EquipmentWithDetails[];
+    expect(allSupportStop(equipments)).toBe(true);
+  });
+
+  it("true when enumValues is undefined (legacy/no-declaration integrations default to supporting Stop)", () => {
+    const equipments = [
+      { orderBindings: [{ alias: "state", category: "shutter_move" }] },
+    ] as unknown as EquipmentWithDetails[];
+    expect(allSupportStop(equipments)).toBe(true);
+  });
+
+  it("false when at least one equipment's enumValues omits STOP (e.g. Bubendorff/NBR)", () => {
+    const equipments = [
+      { orderBindings: [{ alias: "state", category: "shutter_move", enumValues: ["OPEN", "CLOSE", "STOP"] }] },
+      { orderBindings: [{ alias: "state", category: "shutter_move", enumValues: ["OPEN", "CLOSE"] }] },
+    ] as unknown as EquipmentWithDetails[];
+    expect(allSupportStop(equipments)).toBe(false);
+  });
+
+  it("resolves the move binding by alias/regex fallback when no shutter_move category is set", () => {
+    const equipments = [
+      { orderBindings: [{ alias: "shutter2_state", enumValues: ["OPEN", "CLOSE"] }] },
+    ] as unknown as EquipmentWithDetails[];
+    expect(allSupportStop(equipments)).toBe(false);
   });
 });

--- a/ui/src/lib/binding-utils.ts
+++ b/ui/src/lib/binding-utils.ts
@@ -1,6 +1,39 @@
 import type { EquipmentWithDetails } from "../types";
 import type { BindingCandidate } from "./binding-candidates";
 
+/** The minimal shape `allSupportStop` needs — deliberately looser than
+ *  `EquipmentWithDetails` so callers with a narrower/local equipment type
+ *  (e.g. a button-action form's own prop shape) don't need to cast. */
+interface EquipmentLikeForStopCheck {
+  orderBindings: readonly { alias: string; category?: string; enumValues?: string[] }[];
+}
+
+/**
+ * True unless at least one of the given equipments' shutter/pool-cover
+ * move order signals "no real Stop" by omitting "STOP" from its
+ * enumValues (see ShutterControl.tsx's own per-equipment `hasStop`
+ * check for the underlying convention — some bridges, e.g. Bubendorff
+ * shutters via an "iDiamant with Netatmo" bridge, cannot actually stop
+ * the motor mid-travel). Used to gate bulk "Stop all shutters"/"Stop
+ * all awnings" commands (zone toolbar, dashboard zone widget, zone
+ * widget detail sheet, and the button-action zone-order picker): if any
+ * one shutter in the group can't really stop, the bulk button/option is
+ * hidden entirely rather than silently failing for that one equipment
+ * while working for the rest.
+ */
+export function allSupportStop(equipments: readonly EquipmentLikeForStopCheck[]): boolean {
+  for (const eq of equipments) {
+    const moveBinding =
+      eq.orderBindings.find((ob) => ob.category === "pool_cover_move" || ob.category === "shutter_move") ??
+      eq.orderBindings.find((ob) => ob.alias === "state" || /shutter\d*_state/.test(ob.alias));
+    if (!moveBinding) continue; // no move order at all — irrelevant to Stop
+    if (moveBinding.enumValues && !moveBinding.enumValues.some((v) => v.toUpperCase() === "STOP")) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /** Build { deviceId → Set<device_order.key> } from all existing equipments.
  * Used by DeviceSelector to hide candidates whose order keys are already
  * consumed by another equipment. */

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -25,7 +25,7 @@ import { ZoneModesSection } from "../components/home/ZoneModesSection";
 import { ActivityPanel } from "../components/zones/ActivityPanel";
 import { EquipmentForm } from "../components/equipments/EquipmentForm";
 import { autoCreateBindings } from "../components/equipments/bindingUtils";
-import { buildBoundOrderKeysByDevice, buildBoundDataKeysByDevice } from "../lib/binding-utils";
+import { buildBoundOrderKeysByDevice, buildBoundDataKeysByDevice, allSupportStop } from "../lib/binding-utils";
 import { useWsSubscription } from "../hooks/useWsSubscription";
 import type { EquipmentType, ZoneAggregatedData, ZoneWithChildren } from "../types";
 
@@ -83,6 +83,16 @@ export function HomePage() {
   }, [equipments, zoneId]);
 
   const aggData = zoneId ? aggregationData[zoneId] : undefined;
+
+  // Bulk zone commands (allShuttersOpen/Stop/Close) act on the whole subtree
+  // (see collectZoneAndDescendantIds) — the Stop button must be hidden if
+  // any shutter in that scope can't really stop mid-travel (e.g. Bubendorff).
+  const hasStoppableShutters = useMemo(() => {
+    if (!currentZone) return true;
+    const scopeIds = new Set(collectZoneAndDescendantIds(currentZone));
+    const shutters = equipments.filter((eq) => eq.type === "shutter" && scopeIds.has(eq.zoneId));
+    return allSupportStop(shutters);
+  }, [currentZone, equipments]);
   const [commandLoading, setCommandLoading] = useState<ZoneOrder | null>(null);
 
   const handleZoneCommand = useCallback(async (orderKey: ZoneOrder) => {
@@ -164,6 +174,7 @@ export function HomePage() {
             <ZoneCommands
               hasLights={aggData.lightsTotal > 0}
               hasShutters={aggData.shuttersTotal > 0}
+              hasStoppableShutters={hasStoppableShutters}
               loading={commandLoading}
               onCommand={handleZoneCommand}
             />
@@ -483,6 +494,22 @@ function findZoneById(zones: ZoneWithChildren[], id: string): ZoneWithChildren |
     if (found) return found;
   }
   return null;
+}
+
+/** Zone ids reachable from `zone` itself plus every descendant, matching
+ *  the backend's own `zoneManager.getDescendantIds` scope used by
+ *  POST /zones/:id/orders/:orderKey — the bulk zone commands act on the
+ *  whole subtree, not just the exact zone. */
+function collectZoneAndDescendantIds(zone: ZoneWithChildren): string[] {
+  const ids = [zone.id];
+  const walk = (z: ZoneWithChildren) => {
+    for (const child of z.children ?? []) {
+      ids.push(child.id);
+      walk(child);
+    }
+  };
+  walk(zone);
+  return ids;
 }
 
 function getFirstLeafZone(zones: ZoneWithChildren[]): ZoneWithChildren | null {


### PR DESCRIPTION
## Summary

Follow-up to #327 (merged), found immediately after on the same real
installation: that PR hid the Stop button for a single shutter/awning
whose move order signals no real Stop support (`enumValues` omitting
`"STOP"` — e.g. Bubendorff/iDiamant shutters). But the **bulk**
"Stop all shutters"/"Stop all awnings" commands (zone toolbar, whole
house, dashboard zone widget, its detail sheet, and the physical
button-action picker) each had their own independent
`hasShutters`-style boolean with no per-equipment nuance, so they kept
offering Stop even when it would fail for one of the shutters in
scope. Confirmed live: pressing it correctly gets rejected server-side
for the Bubendorff shutter (`"Order dispatch failed: Volet bureau
state — Stop is not supported for this shutter"`, from #327's own
plugin-side fix) — no real harm, but a visibly broken/misleading
button and noisy failed-order logs on every press.

## Fix

Added `allSupportStop()` (`ui/src/lib/binding-utils.ts`) — same
category-first/alias-fallback resolution as the per-equipment
`hasStop` check, applied across a list: true unless at least one
equipment's move order explicitly excludes `"STOP"`. Wired into the
four remaining surfaces, each scoping the equipment set correctly for
its own bulk command (including the zone **subtree**, matching the
backend's own `zoneManager.getDescendantIds` scope for
`POST /zones/:id/orders/:orderKey` — not just the exact zone):

- `ZoneCommands` (zone/whole-house toolbar) + `HomePage.tsx`
- `ZoneWidget`'s `ZoneShutterWidget`/`ZoneAwningWidget` (dashboard)
- `WidgetDetailSheet`'s `ZoneShuttersDetail`/`ZoneAwningsDetail`
- `ButtonActionsSection`'s `AddEffectForm` zone-order picker (new
  `zoneTree` prop threaded down; previously only had the flattened
  zone list, not enough to resolve a subtree)

No behavior change where every shutter/awning supports Stop (the
common case). Full rationale, including why the subtree scope matters
and why `allSupportStop` intentionally takes the loosest possible
shape, is in the commit message.

## Testing

- `cd ui && npm run build` — clean, no type errors.
- `npx vitest run src/lib/binding-utils.test.ts` — 11/11 passed (6
  pre-existing + 5 new for `allSupportStop`).
- Verified live on the same installation as #327 (Android + desktop
  browser): bulk Stop is gone from the zone/house toolbar and the
  dashboard zone widget for a zone containing the Bubendorff shutter,
  and the `allShuttersStop` option is gone from the button-action
  zone-order picker for that zone.

**⚠️ One caveat, worth flagging explicitly**: the `ButtonActionsSection`
fix was only verified by inspecting the picker's rendered options —
the reporter doesn't own a physical Zigbee button/remote, so the full
end-to-end path (assign `allShuttersStop` to a real button press and
see it correctly fail vs. succeed for a valid action) was **not**
exercised live, unlike the other three surfaces. It shares the same
`allSupportStop()` logic already verified elsewhere, and the
pre-existing backend rejection from #327 is still the safety net if
this one path is ever wrong — but this component's live behavior is
unconfirmed. Flagged in the test plan below.

## Test plan for the maintainer

- [ ] Confirm no regression where all shutters/awnings support Stop —
      bulk Stop still shows and works everywhere
- [ ] With a non-stoppable shutter (`enumValues` excluding `"STOP"`)
      in a zone: confirm bulk Stop is hidden in the zone/house
      toolbar, dashboard zone widget, and widget detail sheet, for
      that zone and any ancestor zone
- [ ] **If possible**: verify the button-action zone-order picker
      with a real physical button — the one path not verified live
      in this PR