### PR TITLE
fix(history): rain barchart tooltip (7d) + daily totals (30d)

### DIFF
--- a/src/history/history-query.test.ts
+++ b/src/history/history-query.test.ts
@@ -47,20 +47,24 @@ describe("buildFluxQuery", () => {
   });
 
   describe("downsampled bucket (F8)", () => {
-    it("reads the mean field directly from sowel-daily for cumulative categories", () => {
+    // Rain (cumulative, non-energy) reads the hourly-mean bucket and re-sums it
+    // into the target window — the daily bucket only stores the mean, which
+    // collapsed a day's rain total to ~total/24 (0mm on the 30d view).
+    it("re-sums the hourly mean into daily totals for cumulative categories", () => {
       const flux = buildFluxQuery({
         ...baseParams,
-        bucket: "sowel-daily",
+        bucket: "sowel-hourly",
         resolution: "1d",
         category: "rain",
         isDownsampled: true,
       });
       expect(flux).toContain('_field == "mean"');
+      expect(flux).toContain("aggregateWindow(every: 1d, fn: sum");
+      expect(flux).toContain('timeSrc: "_start"');
       expect(flux).not.toContain("value_number");
-      expect(flux).not.toContain("aggregateWindow");
     });
 
-    it("reads the mean field directly from sowel-hourly for cumulative categories", () => {
+    it("re-sums the hourly mean per hour for cumulative categories (hourly)", () => {
       const flux = buildFluxQuery({
         ...baseParams,
         bucket: "sowel-hourly",
@@ -69,14 +73,39 @@ describe("buildFluxQuery", () => {
         isDownsampled: true,
       });
       expect(flux).toContain('_field == "mean"');
-      expect(flux).not.toContain("value_number");
+      expect(flux).toContain("aggregateWindow(every: 1h, fn: sum");
+    });
+
+    it("reads the mean field directly for continuous categories (no re-aggregation)", () => {
+      const flux = buildFluxQuery({
+        ...baseParams,
+        bucket: "sowel-daily",
+        alias: "temperature",
+        resolution: "1d",
+        category: "temperature",
+        isDownsampled: true,
+      });
+      expect(flux).toContain('_field == "mean"');
       expect(flux).not.toContain("aggregateWindow");
+    });
+
+    it("does not re-sum energy (it uses its own pre-summed buckets)", () => {
+      const flux = buildFluxQuery({
+        ...baseParams,
+        bucket: "sowel-energy-daily",
+        alias: "energy_total",
+        resolution: "1d",
+        category: "energy",
+        isDownsampled: true,
+      });
+      expect(flux).toContain('_field == "mean"');
+      expect(flux).not.toContain("fn: sum");
     });
 
     it("includes the equipmentId and alias filters", () => {
       const flux = buildFluxQuery({
         ...baseParams,
-        bucket: "sowel-daily",
+        bucket: "sowel-hourly",
         resolution: "1d",
         category: "rain",
         isDownsampled: true,
@@ -88,7 +117,7 @@ describe("buildFluxQuery", () => {
     it("respects the from/to time window", () => {
       const flux = buildFluxQuery({
         ...baseParams,
-        bucket: "sowel-daily",
+        bucket: "sowel-hourly",
         resolution: "1d",
         category: "rain",
         isDownsampled: true,

--- a/src/history/history-query.ts
+++ b/src/history/history-query.ts
@@ -57,6 +57,13 @@ function resolveBucket(baseBucket: string, resolution: Resolution, category?: st
     if (resolution === "1d") return `${baseBucket}-energy-daily`;
     return baseBucket;
   }
+  // Non-energy cumulative categories (rain) always read the hourly-mean bucket
+  // and re-sum in the query. The daily bucket only stores the *mean*, which
+  // collapses a day's rain total to ~total/24 (0mm on the 30d view). The
+  // hourly bucket's 90-day retention covers the 30d window.
+  if (CUMULATIVE_CATEGORIES.has(category ?? "")) {
+    return resolution === "raw" ? baseBucket : `${baseBucket}-hourly`;
+  }
   if (resolution === "1h") return `${baseBucket}-hourly`;
   if (resolution === "1d") return `${baseBucket}-daily`;
   return baseBucket;
@@ -90,6 +97,22 @@ export function buildFluxQuery(params: {
   // there. Read the mean field directly — no aggregateWindow needed since the bucket
   // already matches the resolution.
   if (isDownsampled && resolution !== "raw") {
+    // Non-energy cumulative categories (rain): the resolved bucket is the
+    // hourly-mean bucket (see resolveBucket). Sum the hourly means into the
+    // target window so a day's total is the *sum*, not the mean (~total/24).
+    // Energy uses its own pre-summed buckets and keeps the direct mean read.
+    if (CUMULATIVE_CATEGORIES.has(category ?? "") && category !== "energy") {
+      const every = resolution === "1h" ? "1h" : "1d";
+      return `from(bucket: "${bucket}")
+  |> range(start: ${fromStr}, stop: ${toStr})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => r.alias == "${alias}")
+  |> filter(fn: (r) => r._field == "mean")
+  |> aggregateWindow(every: ${every}, fn: sum, createEmpty: false, timeSrc: "_start")
+  |> sort(columns: ["_time"])
+  |> limit(n: 500)`;
+    }
     return `from(bucket: "${bucket}")
   |> range(start: ${fromStr}, stop: ${toStr})
   |> filter(fn: (r) => r._measurement == "equipment_data")

--- a/ui/src/components/history/HistoryBarChart.test.ts
+++ b/ui/src/components/history/HistoryBarChart.test.ts
@@ -161,4 +161,25 @@ describe("formatLabel", () => {
     const r = formatLabel("2026-01-05T12:00:00.000Z", "30d");
     expect(r.line1).toBe("05/01");
   });
+
+  it("produces a duplicate weekday across an 8-day span — why the chart keys on time, not label", () => {
+    // A 7-day window renders 8 daily bars, so the weekday (`line1`) repeats
+    // (two Sundays here). Recharts previously keyed the bars on this label and
+    // resolved a hovered bar to the FIRST one sharing the weekday, so hovering
+    // "Sun 26" showed "Sun 19 / 0 mm". HistoryBarChart now keys the axis on the
+    // unique `time`; this guards the invariant that `label` alone is not unique.
+    const days = [
+      "2026-07-19T12:00:00.000Z", // Sunday
+      "2026-07-20T12:00:00.000Z",
+      "2026-07-21T12:00:00.000Z",
+      "2026-07-22T12:00:00.000Z",
+      "2026-07-23T12:00:00.000Z",
+      "2026-07-24T12:00:00.000Z",
+      "2026-07-25T12:00:00.000Z",
+      "2026-07-26T12:00:00.000Z", // Sunday again — duplicate weekday label
+    ];
+    const labels = days.map((d) => formatLabel(d, "7d").line1);
+    expect(new Set(labels).size).toBeLessThan(labels.length);
+    expect(new Set(days).size).toBe(days.length);
+  });
 });

--- a/ui/src/components/history/HistoryBarChart.tsx
+++ b/ui/src/components/history/HistoryBarChart.tsx
@@ -210,7 +210,13 @@ export function HistoryBarChart({ points, range, unit, height = 200 }: HistoryBa
       <BarChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
         <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light)" vertical={false} />
         <XAxis
-          dataKey="label"
+          // Use the unique timestamp as the category key. `label` (the weekday
+          // on 7d) is NOT unique — a 7-day window spans 8 daily bars, so the
+          // repeated weekday made Recharts resolve a hovered bar to the first
+          // bar sharing that label (e.g. hovering "Sun 26" showed "Sun 19").
+          // Tick labels are drawn by CustomTick via the row index, so switching
+          // the key does not change what the axis displays.
+          dataKey="time"
           interval={tickInterval}
           tickLine={false}
           axisLine={{ stroke: "var(--color-border)" }}


### PR DESCRIPTION
Two distinct bugs in the weather station rain barchart, both confirmed against prod data (v1.29.3).

## Bug 1 — 7d tooltip points to the wrong bar
On the 7-day view the chart renders **8** daily bars, so the weekday used as the X-axis key repeats (two "dim."). Recharts resolved a hovered bar to the **first** one sharing that key, so hovering the 26/07 bar (~1 mm) showed **"dimanche 19 juillet / Pluie : 0 mm"**.
- Fix: key the axis on the unique `time` instead of the weekday `label`. Tick labels are unchanged (drawn by `CustomTick` via row index).
- 24h was fine (unique `HH:MM`), 30d too (unique `DD/MM`).

## Bug 2 — rain totals collapse to ~0 on 30d
Rain is cumulative but its history went through the generic `sowel-daily` bucket, which only stores the **mean** (~total/24). Confirmed: 26/07 real total **0.97 mm** showed as the daily-mean **0.0018 → "0.0 mm"**. Energy avoids this with dedicated summed buckets.
- Fix: for non-energy cumulative categories (rain), read the **hourly-mean bucket** (90-day retention) and re-sum it into the target window with `fn: sum` — the same aggregation the 24h/7d views already do correctly. Energy path untouched.
- **No downsampling-task change and no backfill needed**: it reads existing hourly data, so it is correct immediately on deploy, including for past days.

## Tests
- `history-query.test.ts`: cumulative downsampled now re-sums (1h + 1d), continuous still reads mean directly, energy is not re-summed. (9 pass)
- `HistoryBarChart.test.ts`: guards that an 8-day span yields a duplicate weekday label but unique timestamps. (24 pass)
- Full backend suite: 954 pass / 2 skip / 0 fail. tsc (backend+UI), eslint, vite build all green.

Follow `/debug-bug`.