### PR TITLE
release: v1.29.4

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,11 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.29.x: Rôle Standard et parité du dashboard
 
+### v1.29.4 — 2026-07-26 { #v1-29-4 }
+
+- Fix (ui) : le tooltip du graphe de pluie affichait la mauvaise barre en vue 7 jours. Une fenêtre de 7 jours affiche 8 barres quotidiennes, donc le jour de semaine servant de clé se répétait et survoler une barre pouvait montrer la valeur d'un autre jour (ex. survoler la barre ~1 mm d'aujourd'hui affichait « dimanche 19 / 0 mm »). Les barres sont désormais indexées sur leur horodatage. (#334)
+- Fix (history) : les totaux de pluie tombaient à ~0 mm en vue 30 jours. La pluie est un cumul, mais l'historique journalier ne stockait que la moyenne (environ le total divisé par 24). Le total journalier est maintenant sommé à partir des données horaires, donc la vue 30 jours affiche les vrais totaux, cohérents avec les vues 24h et 7 jours (déjà correctes). (#334)
+
 ### v1.29.3 — 2026-07-21 { #v1-29-3 }
 
 - Fix (ui) : les commandes groupées « Arrêter tous les volets » / « Arrêter tous les stores » (barre de zone, maison entière, widget de zone du tableau de bord et sa feuille de détail, et le sélecteur d'action bouton) sont désormais masquées quand un volet du périmètre ne peut pas réellement s'arrêter en cours de course (ex. Bubendorff via iDiamant). Cela étend le correctif volet unique de la v1.29.2 aux commandes de groupe, qui agissent sur tout le sous-arbre de la zone. Les groupes dont tous les volets gèrent le Stop ne changent pas. (#332)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,11 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.29.x: Standard role and dashboard parity
 
+### v1.29.4 — 2026-07-26 { #v1-29-4 }
+
+- Fix (ui): the rain barchart tooltip showed the wrong bar on the 7-day view. A 7-day window renders 8 daily bars, so the weekday used as the chart key repeated and hovering one bar could show another day's value (e.g. hovering today's ~1 mm bar showed "Sunday 19 / 0 mm"). Bars are now keyed on their timestamp. (#334)
+- Fix (history): rain totals collapsed to ~0 mm on the 30-day view. Rain is a cumulative total but the daily history stored only the average (about the total divided by 24). Daily rain is now summed from the hourly data, so the 30-day view shows real totals, matching the 24h and 7-day views (which were already correct). (#334)
+
 ### v1.29.3 — 2026-07-21 { #v1-29-3 }
 
 - Fix (ui): the bulk "Stop all shutters" / "Stop all awnings" commands (zone toolbar, whole house, dashboard zone widget and its detail sheet, and the physical button-action picker) are now hidden when any shutter in scope cannot actually stop mid-travel (e.g. Bubendorff via iDiamant). This extends the single-shutter fix from v1.29.2 to grouped commands, which act on the whole zone subtree. Groups where every shutter supports Stop are unaffected. (#332)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.29.3",
+  "version": "1.29.4",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.29.3",
+  "version": "1.29.4",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## v1.29.4

Ships the two weather rain barchart fixes from #334 (merged).

- **fix(ui)**: rain barchart 7-day tooltip pointed at the wrong bar (duplicate weekday key) — now keyed on the unique timestamp.
- **fix(history)**: 30-day rain totals collapsed to ~0 mm (daily bucket stored the mean) — daily rain is now summed from the hourly data. No task change, no backfill; correct on deploy including past days.

Release notes (EN + FR) with the `{ #v1-29-4 }` anchor.

- [x] full suite 954 pass / 0 fail, tsc (backend+UI), eslint, build green on #334