### PR TITLE
feat(energy): per-phase power breakdown on the Live page

### DIFF
--- a/specs/132-three-phase-live-breakdown/architecture.md
+++ b/specs/132-three-phase-live-breakdown/architecture.md
@@ -1,0 +1,76 @@
+# Architecture — Spec 132
+
+Single repository change (core UI only). No database, no event, no API change.
+
+## Data model
+
+No change to `EquipmentType` or the `DataBinding` schema. `addDataBinding`
+already accepts an arbitrary `alias` string (`src/api/routes/equipments.ts`,
+`POST /api/v1/equipments/:id/data-bindings`) — `power_l1`/`power_l2`/`power_l3`
+are just aliases like any other, bound by whichever plugin/operator chooses to
+expose per-phase power on a `main_energy_meter` equipment.
+
+## UI
+
+### `ui/src/components/energy/phase-helpers.ts` (new, pure logic)
+
+Extracted from the component so it can be unit-tested (per project
+convention: "no React tests in this project" — but pure helpers are tested,
+mirroring `submeter-helpers.ts` / `productionTotal.ts`).
+
+```ts
+export interface PhaseValue { n: number; power: number }
+
+export function extractPhases(equipments: EquipmentWithDetails[]): PhaseValue[]
+```
+
+Scans every `main_energy_meter`-eligible equipment's `dataBindings` for
+aliases matching `/^power_l(\d+)$/` with a numeric value, sums by phase
+number across equipments, returns sorted by `n`.
+
+### `ui/src/components/energy/PhaseBreakdown.tsx` (new)
+
+```tsx
+interface Props { gridEquipments: EquipmentWithDetails[] }
+export function PhaseBreakdown({ gridEquipments }: Props)
+```
+
+- `phases = extractPhases(gridEquipments)`; returns `null` if
+  `phases.length < 2`.
+- Renders one row per phase: label (`Phase {n}`), a proportional bar
+  (width = `power / maxPower`), formatted power value.
+- Styling matches `LiveSubmeterBreakdown.tsx` (same card container, same
+  `formatPower` convention: W below 1000, kW with 1 decimal above).
+
+### `ui/src/components/energy/LiveEnergyPage.tsx` (modified)
+
+Renders `<PhaseBreakdown gridEquipments={gridEqs} />` right after
+`<LiveDiagram />` and before `<LiveSubmeterBreakdown />`. `gridEqs` is the
+existing `equipments.filter(e => e.type === "main_energy_meter")` memo already
+computed on this page — no new data fetching.
+
+### i18n
+
+`ui/src/i18n/locales/{fr,en}.json`: `energy.live.phases.title`,
+`energy.live.phases.phase` (interpolated `{{n}}`).
+
+## Why not `energy_meter`
+
+See spec.md "Out of scope". Concretely: `submeter-helpers.ts`'s
+`isSubmeterEquipment()` filters on `type === "energy_meter"` (+ metering
+switches, spec 129), and `power-submeter-integrator.ts` independently
+integrates W→Wh for exactly that same equipment set into InfluxDB, which then
+feeds `/api/v1/energy/by-usage`'s residual computation
+(`Autre = Total − Σ submeters`). Binding phases through that type would pull
+them into both places, both wrongly.
+
+## File changes
+
+| File                                                     | Change                          |
+| --------------------------------------------------------- | -------------------------------- |
+| `ui/src/components/energy/phase-helpers.ts`                | New — pure extraction logic     |
+| `ui/src/components/energy/phase-helpers.test.ts`           | New — unit tests                |
+| `ui/src/components/energy/PhaseBreakdown.tsx`               | New — presentational component  |
+| `ui/src/components/energy/LiveEnergyPage.tsx`               | Render `<PhaseBreakdown />`      |
+| `ui/src/i18n/locales/fr.json`, `ui/src/i18n/locales/en.json` | New translation keys            |
+| `specs/132-three-phase-live-breakdown/*`                    | This spec                       |

--- a/specs/132-three-phase-live-breakdown/plan.md
+++ b/specs/132-three-phase-live-breakdown/plan.md
@@ -1,0 +1,61 @@
+# Plan — Spec 132
+
+## Implementation steps
+
+Branch `feat/three-phase-live-breakdown`.
+
+1. Extract `extractPhases()` (and the shared `formatPower` convention) into
+   `ui/src/components/energy/phase-helpers.ts`, typed against
+   `EquipmentWithDetails`.
+2. Write `phase-helpers.test.ts` covering the scenarios below.
+3. `PhaseBreakdown.tsx` consumes `phase-helpers.ts`, renders the bars, returns
+   `null` under the 2-phase threshold.
+4. Wire `<PhaseBreakdown gridEquipments={gridEqs} />` into `LiveEnergyPage.tsx`.
+5. Add `energy.live.phases.title` / `energy.live.phases.phase` to
+   `fr.json` / `en.json`.
+6. `cd ui && npx tsc -b --noEmit` clean.
+7. `cd ui && npx vitest run phase-helpers` clean.
+8. Manual verification against a real three-phase meter (dev instance): bind
+   `power_l1/l2/l3` on a real `main_energy_meter` equipment, confirm the panel
+   renders with correct values in the browser.
+
+## Test Plan
+
+### Modules to test
+
+- `phase-helpers.ts` (`extractPhases`) — pure logic, business rule for what
+  counts as a displayable phase set.
+- `PhaseBreakdown.tsx` — no React tests in this project (per convention);
+  covered by `tsc` + manual verification in the running app (step 8 above).
+
+### Scenarios
+
+| Module         | Scenario                                                        | Expected                                   |
+| --------------- | ----------------------------------------------------------------- | -------------------------------------------- |
+| extractPhases   | No equipment has any `power_l{n}` alias                            | `[]`                                        |
+| extractPhases   | One equipment, only `power_l1` bound                               | `[{n:1, power}]` (length 1 → caller hides)  |
+| extractPhases   | One equipment, `power_l1`/`power_l2`/`power_l3` bound              | 3 entries, sorted by `n`                    |
+| extractPhases   | A bound `power_l2` value is `null`                                 | Phase 2 excluded from the result             |
+| extractPhases   | Two `main_energy_meter` equipments both expose `power_l1`           | Their `power_l1` values are summed           |
+| extractPhases   | Alias `power_l10` (two-digit phase number)                          | Parsed as `n=10` (regex is digit-agnostic)  |
+| extractPhases   | Alias that doesn't match `power_l{n}` (e.g. `power`)                | Ignored                                      |
+| PhaseBreakdown  | `extractPhases` returns < 2 entries                                | Component renders `null`                    |
+| PhaseBreakdown  | `extractPhases` returns 3 entries                                  | 3 rows rendered (manual check)               |
+
+### Retro-compat
+
+- No existing test files reference `power_l{n}` — nothing to keep passing,
+  this is purely additive.
+- `LiveSubmeterBreakdown` and `/api/v1/energy/by-usage` are untouched by this
+  spec; their own existing tests are unaffected.
+
+## Tasks
+
+- [x] P1 `phase-helpers.ts` extracted with `extractPhases`
+- [x] P2 `phase-helpers.test.ts` — all scenarios above
+- [x] P3 `PhaseBreakdown.tsx` using the helper
+- [x] P4 Wired into `LiveEnergyPage.tsx`
+- [x] P5 FR/EN i18n added
+- [x] P6 `tsc -b --noEmit` clean
+- [x] P7 `vitest run` clean
+- [x] P8 Manual verification against a real three-phase meter

--- a/specs/132-three-phase-live-breakdown/spec.md
+++ b/specs/132-three-phase-live-breakdown/spec.md
@@ -1,0 +1,79 @@
+# Spec 132 — Per-phase power breakdown on Energy · Live
+
+## Context
+
+Companion to the `sowel-plugin-legrand-energy` NLY fix (three-phase Legrand
+Drivia with Netatmo meters, ref. 412175 — see that repo's own spec). Once a
+three-phase meter is discovered, its `main_energy_meter` equipment exposes an
+aggregate `power`/`energy`, but nothing surfaces the per-phase instantaneous
+power. Energy → Live today only renders the Grid/Solar/Maison flow diagram
+and the by-usage donut (submeters of type `energy_meter`).
+
+The user (Romain / alpitux) owns a real three-phase installation and wants to
+see the load split across L1/L2/L3 (useful to spot an unbalanced phase),
+directly in Sowel, without waiting for a historical view.
+
+## Goal
+
+Add an **optional** per-phase power breakdown panel to the Energy → Live page,
+driven by a **convention**, not a new equipment type: a `main_energy_meter`
+equipment may carry extra data-binding aliases `power_l1`, `power_l2`,
+`power_l3`. Any plugin able to expose per-phase power can adopt it (not
+Legrand-specific — e.g. a Shelly Pro 3EM's spare CT channel could use the
+same aliases).
+
+## Scope
+
+### In scope
+
+- New component `ui/src/components/energy/PhaseBreakdown.tsx`: one bar per
+  detected phase (instantaneous power + proportion), rendered under the
+  existing flow diagram on `LiveEnergyPage.tsx`.
+- Renders **nothing** when fewer than 2 `power_l{n}` aliases are bound on any
+  `main_energy_meter` equipment.
+- FR/EN i18n: `energy.live.phases.title`, `energy.live.phases.phase`.
+- Pure phase-extraction logic split into a testable helper module (mirrors
+  the existing `submeter-helpers.ts` / `productionTotal.ts` pattern).
+
+### Out of scope (explicitly excluded)
+
+- **Historical (Consumption page) per-phase breakdown.** The Netatmo/Legrand
+  `getMeasure` API only returns accumulated energy at the bridge
+  (whole-installation) level — never per phase, only instantaneous `power`
+  per phase via `homestatus`. A historical view would need a dedicated W→Wh
+  accumulation pipeline for phases, separate from the existing by-usage
+  submeter integrator (to avoid the residual-corruption issue below).
+  Deferred to a future spec if requested.
+- **Modeling phases as `energy_meter`-type equipments.** That type feeds the
+  by-usage donut (`Autre = Total − Σ submeters`, spec 091). Phases sum to
+  ~100% of the total rather than being a usage subset (PAC, Piscine, ...);
+  reusing that type would collapse "Autre" to ~0 and misrepresent phases as
+  usage categories. This was tried, the corruption risk caught before
+  shipping, and rejected in favor of the alias convention above.
+- Any change to `EquipmentType`, the DB schema, or the by-usage
+  (`/api/v1/energy/by-usage`) / history (`/api/v1/energy/history`) routes.
+
+## Acceptance criteria
+
+- [x] AC1 — On Energy → Live, a "Répartition par phase" / "Phase breakdown"
+      panel appears under the flow diagram when a `main_energy_meter`
+      equipment has ≥ 2 `power_l{n}` data bindings.
+- [x] AC2 — Each phase renders its instantaneous power and its proportion of
+      the largest phase (bar width).
+- [x] AC3 — The panel renders nothing (`null`) when 0 or 1 `power_l{n}`
+      aliases are bound — **zero visual change for single-phase installs**.
+- [x] AC4 — No change to the by-usage donut (`LiveSubmeterBreakdown`) or to
+      `/api/v1/energy/by-usage` behavior.
+- [x] AC5 — Works end to end against a real three-phase meter: values shown
+      match what the bound devices report (sanity: Σ phases ≈ Total).
+
+## Edge cases
+
+| Case                                              | Expected                                    |
+| -------------------------------------------------- | -------------------------------------------- |
+| No `power_l{n}` alias bound anywhere                | Panel absent (existing single-phase installs) |
+| Exactly 1 `power_l{n}` alias bound                  | Panel absent (need ≥ 2 to be meaningful)      |
+| 2 or 3 `power_l{n}` aliases bound, all numeric       | Panel renders one bar per phase               |
+| A bound phase value is `null` / non-number           | That phase excluded from the extracted set    |
+| Multiple `main_energy_meter` equipments              | Phase powers summed per phase number across them |
+| Phase power is 0 W                                   | Bar renders at 0 width, value still shown     |

--- a/ui/src/components/energy/LiveEnergyPage.tsx
+++ b/ui/src/components/energy/LiveEnergyPage.tsx
@@ -21,6 +21,7 @@ import { useEquipments } from "../../store/useEquipments";
 import type { EquipmentWithDetails } from "../../types";
 import { EnergyMobileNav } from "./EnergyMobileNav";
 import { LiveSubmeterBreakdown } from "./LiveSubmeterBreakdown";
+import { PhaseBreakdown } from "./PhaseBreakdown";
 import { useWsSubscription } from "../../hooks/useWsSubscription";
 
 // Sowel energy palette (matches EnergyBarChart.tsx + extends with grid colours)
@@ -192,6 +193,7 @@ export function LiveEnergyPage() {
       ) : (
         <>
           <LiveDiagram gridPower={gridPower} solarPower={solarPower} />
+          <PhaseBreakdown gridEquipments={gridEqs} />
           <LiveSubmeterBreakdown
             house={
               gridPower !== null || solarPower !== null

--- a/ui/src/components/energy/PhaseBreakdown.tsx
+++ b/ui/src/components/energy/PhaseBreakdown.tsx
@@ -1,0 +1,85 @@
+/**
+ * Per-phase power breakdown for a 3-phase main energy meter.
+ *
+ * Reads `power_l{n}` data-binding aliases bound directly on `main_energy_meter`
+ * equipments (convention: any plugin exposing per-phase power on a 3-phase
+ * meter binds it to the main meter equipment under this alias). Renders
+ * nothing when fewer than 2 phases are bound, so single-phase installs are
+ * unaffected — same additive pattern as LiveSubmeterBreakdown.
+ */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import type { EquipmentWithDetails } from "../../types";
+
+const PHASE_COLORS = ["#4F7BE8", "#6BCB77", "#F2A93B", "#E8677D"];
+
+interface PhaseValue {
+  n: number;
+  power: number;
+}
+
+function extractPhases(equipments: EquipmentWithDetails[]): PhaseValue[] {
+  const byPhase = new Map<number, number>();
+  for (const eq of equipments) {
+    for (const b of eq.dataBindings) {
+      const m = /^power_l(\d+)$/.exec(b.alias);
+      if (!m || typeof b.value !== "number") continue;
+      const n = Number(m[1]);
+      byPhase.set(n, (byPhase.get(n) ?? 0) + b.value);
+    }
+  }
+  return [...byPhase.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([n, power]) => ({ n, power }));
+}
+
+function formatPower(value: number): { num: string; unit: "W" | "kW" } {
+  const a = Math.abs(value);
+  if (a < 1000) return { num: String(Math.round(a / 5) * 5), unit: "W" };
+  return { num: (a / 1000).toFixed(1), unit: "kW" };
+}
+
+interface Props {
+  gridEquipments: EquipmentWithDetails[];
+}
+
+export function PhaseBreakdown({ gridEquipments }: Props) {
+  const { t } = useTranslation();
+  const phases = useMemo(() => extractPhases(gridEquipments), [gridEquipments]);
+
+  if (phases.length < 2) return null;
+
+  const maxPower = Math.max(1, ...phases.map((p) => Math.abs(p.power)));
+
+  return (
+    <div className="bg-surface border border-border rounded-[10px] p-4 sm:p-6 mt-4">
+      <h2 className="text-[14px] font-semibold text-text mb-4">
+        {t("energy.live.phases.title")}
+      </h2>
+      <div className="flex flex-col gap-3 max-w-[600px]">
+        {phases.map((p, i) => {
+          const f = formatPower(p.power);
+          const pct = Math.round((Math.abs(p.power) / maxPower) * 100);
+          const color = PHASE_COLORS[i % PHASE_COLORS.length];
+          return (
+            <div key={p.n} className="flex items-center gap-3">
+              <span className="text-[12px] font-semibold text-text-tertiary w-14 shrink-0">
+                {t("energy.live.phases.phase", { n: p.n })}
+              </span>
+              <div className="flex-1 h-2 rounded-full bg-border overflow-hidden">
+                <div
+                  className="h-full rounded-full transition-[width] duration-300"
+                  style={{ width: `${pct}%`, background: color }}
+                />
+              </div>
+              <span className="font-mono text-[13px] font-medium text-text-secondary w-16 text-right shrink-0">
+                {f.num} {f.unit}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/energy/PhaseBreakdown.tsx
+++ b/ui/src/components/energy/PhaseBreakdown.tsx
@@ -11,34 +11,9 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { EquipmentWithDetails } from "../../types";
+import { extractPhases, formatPhasePower } from "./phase-helpers";
 
 const PHASE_COLORS = ["#4F7BE8", "#6BCB77", "#F2A93B", "#E8677D"];
-
-interface PhaseValue {
-  n: number;
-  power: number;
-}
-
-function extractPhases(equipments: EquipmentWithDetails[]): PhaseValue[] {
-  const byPhase = new Map<number, number>();
-  for (const eq of equipments) {
-    for (const b of eq.dataBindings) {
-      const m = /^power_l(\d+)$/.exec(b.alias);
-      if (!m || typeof b.value !== "number") continue;
-      const n = Number(m[1]);
-      byPhase.set(n, (byPhase.get(n) ?? 0) + b.value);
-    }
-  }
-  return [...byPhase.entries()]
-    .sort(([a], [b]) => a - b)
-    .map(([n, power]) => ({ n, power }));
-}
-
-function formatPower(value: number): { num: string; unit: "W" | "kW" } {
-  const a = Math.abs(value);
-  if (a < 1000) return { num: String(Math.round(a / 5) * 5), unit: "W" };
-  return { num: (a / 1000).toFixed(1), unit: "kW" };
-}
 
 interface Props {
   gridEquipments: EquipmentWithDetails[];
@@ -59,7 +34,7 @@ export function PhaseBreakdown({ gridEquipments }: Props) {
       </h2>
       <div className="flex flex-col gap-3 max-w-[600px]">
         {phases.map((p, i) => {
-          const f = formatPower(p.power);
+          const f = formatPhasePower(p.power);
           const pct = Math.round((Math.abs(p.power) / maxPower) * 100);
           const color = PHASE_COLORS[i % PHASE_COLORS.length];
           return (

--- a/ui/src/components/energy/phase-helpers.test.ts
+++ b/ui/src/components/energy/phase-helpers.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import type { DataBindingWithValue, EquipmentWithDetails } from "../../types";
+import { extractPhases, formatPhasePower } from "./phase-helpers";
+
+function makeBinding(
+  partial: Partial<DataBindingWithValue> & { alias: string },
+): DataBindingWithValue {
+  return {
+    id: "b-" + partial.alias,
+    equipmentId: "eq",
+    deviceDataId: "dd-" + partial.alias,
+    deviceId: "d1",
+    deviceName: "Device",
+    key: partial.alias,
+    type: "number",
+    category: "power",
+    value: 0,
+    lastUpdated: "2026-07-30 08:00:00Z",
+    lastChanged: "2026-07-30 08:00:00Z",
+    stale: false,
+    ...partial,
+  };
+}
+
+function makeEquipment(
+  id: string,
+  bindings: DataBindingWithValue[],
+): EquipmentWithDetails {
+  return {
+    id,
+    name: id,
+    zoneId: "z",
+    type: "main_energy_meter",
+    enabled: true,
+    createdAt: "2026-07-01 00:00:00Z",
+    updatedAt: "2026-07-01 00:00:00Z",
+    dataBindings: bindings,
+    orderBindings: [],
+    status: "online",
+  };
+}
+
+describe("extractPhases", () => {
+  it("returns an empty array when no power_l{n} alias is bound anywhere", () => {
+    const eq = makeEquipment("main", [makeBinding({ alias: "power", value: 500 })]);
+    expect(extractPhases([eq])).toEqual([]);
+  });
+
+  it("returns a single entry when only power_l1 is bound", () => {
+    const eq = makeEquipment("main", [makeBinding({ alias: "power_l1", value: 300 })]);
+    expect(extractPhases([eq])).toEqual([{ n: 1, power: 300 }]);
+  });
+
+  it("returns all three phases sorted by phase number", () => {
+    const eq = makeEquipment("main", [
+      makeBinding({ alias: "power_l3", value: 15 }),
+      makeBinding({ alias: "power_l1", value: 268 }),
+      makeBinding({ alias: "power_l2", value: 197 }),
+    ]);
+    expect(extractPhases([eq])).toEqual([
+      { n: 1, power: 268 },
+      { n: 2, power: 197 },
+      { n: 3, power: 15 },
+    ]);
+  });
+
+  it("excludes a phase whose bound value is not a number", () => {
+    const eq = makeEquipment("main", [
+      makeBinding({ alias: "power_l1", value: 268 }),
+      makeBinding({ alias: "power_l2", value: null }),
+    ]);
+    expect(extractPhases([eq])).toEqual([{ n: 1, power: 268 }]);
+  });
+
+  it("sums the same phase across multiple main_energy_meter equipments", () => {
+    const eq1 = makeEquipment("main1", [makeBinding({ alias: "power_l1", value: 100 })]);
+    const eq2 = makeEquipment("main2", [makeBinding({ alias: "power_l1", value: 50 })]);
+    expect(extractPhases([eq1, eq2])).toEqual([{ n: 1, power: 150 }]);
+  });
+
+  it("parses multi-digit phase numbers", () => {
+    const eq = makeEquipment("main", [makeBinding({ alias: "power_l10", value: 42 })]);
+    expect(extractPhases([eq])).toEqual([{ n: 10, power: 42 }]);
+  });
+
+  it("ignores aliases that don't match the power_l{n} pattern", () => {
+    const eq = makeEquipment("main", [
+      makeBinding({ alias: "power", value: 500 }),
+      makeBinding({ alias: "energy", value: 1200 }),
+      makeBinding({ alias: "power_l1", value: 300 }),
+    ]);
+    expect(extractPhases([eq])).toEqual([{ n: 1, power: 300 }]);
+  });
+});
+
+describe("formatPhasePower", () => {
+  it("rounds sub-1000W values to the nearest 5W", () => {
+    expect(formatPhasePower(268)).toEqual({ num: "270", unit: "W" });
+  });
+
+  it("formats >=1000W values in kW with one decimal", () => {
+    expect(formatPhasePower(1234)).toEqual({ num: "1.2", unit: "kW" });
+  });
+});

--- a/ui/src/components/energy/phase-helpers.ts
+++ b/ui/src/components/energy/phase-helpers.ts
@@ -1,0 +1,38 @@
+/**
+ * Per-phase power extraction for 3-phase main energy meters (spec 132).
+ *
+ * Reads `power_l{n}` data-binding aliases bound on `main_energy_meter`
+ * equipments (convention: any plugin exposing per-phase power binds it under
+ * this alias — not Legrand-specific). Pure logic, split out from
+ * PhaseBreakdown.tsx so it can be unit-tested (mirrors submeter-helpers.ts).
+ */
+
+import type { EquipmentWithDetails } from "../../types";
+
+export interface PhaseValue {
+  n: number;
+  power: number;
+}
+
+const PHASE_ALIAS = /^power_l(\d+)$/;
+
+export function extractPhases(equipments: EquipmentWithDetails[]): PhaseValue[] {
+  const byPhase = new Map<number, number>();
+  for (const eq of equipments) {
+    for (const b of eq.dataBindings) {
+      const m = PHASE_ALIAS.exec(b.alias);
+      if (!m || typeof b.value !== "number") continue;
+      const n = Number(m[1]);
+      byPhase.set(n, (byPhase.get(n) ?? 0) + b.value);
+    }
+  }
+  return [...byPhase.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([n, power]) => ({ n, power }));
+}
+
+export function formatPhasePower(value: number): { num: string; unit: "W" | "kW" } {
+  const a = Math.abs(value);
+  if (a < 1000) return { num: String(Math.round(a / 5) * 5), unit: "W" };
+  return { num: (a / 1000).toFixed(1), unit: "kW" };
+}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1016,6 +1016,8 @@
   "energy.live.breakdown.noData": "no measurement",
   "energy.live.breakdown.houseIdle": "House idle",
   "energy.live.breakdown.overshoot": "Σ submeters ≥ house total",
+  "energy.live.phases.title": "Phase breakdown",
+  "energy.live.phases.phase": "Phase {{n}}",
   "energy.consumption": "Consumption",
   "energy.today": "Today",
   "energy.hour": "1h",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1016,6 +1016,8 @@
   "energy.live.breakdown.noData": "pas de mesure",
   "energy.live.breakdown.houseIdle": "Maison à l'arrêt",
   "energy.live.breakdown.overshoot": "Σ sous-compteurs ≥ total maison",
+  "energy.live.phases.title": "Répartition par phase",
+  "energy.live.phases.phase": "Phase {{n}}",
   "energy.consumption": "Consommation",
   "energy.today": "Aujourd'hui",
   "energy.hour": "1h",


### PR DESCRIPTION
## Summary

Companion to [mchacher/sowel-plugin-legrand-energy#1](https://github.com/mchacher/sowel-plugin-legrand-energy/pull/1),
which adds support for Legrand Drivia with Netatmo three-phase meters
(ref. 412175). Once a 3-phase meter is discovered, Energy → Live still
only showed the aggregate Grid/Solar/Maison flow + the by-usage donut —
nothing surfaced the per-phase power.

- New opt-in convention: a `main_energy_meter` equipment can carry extra
  data-binding aliases `power_l1`, `power_l2`, `power_l3`. Any plugin
  able to expose per-phase power can adopt it (not Legrand-specific —
  e.g. a Shelly Pro 3EM's extra CT channel could use the same aliases).
- New `PhaseBreakdown` component (`ui/src/components/energy/PhaseBreakdown.tsx`):
  renders a small bar per phase under the existing flow diagram, **only
  when ≥ 2 `power_l{n}` aliases are bound** — returns `null` otherwise.
- Wired into `LiveEnergyPage.tsx`, translations added to `fr.json`/`en.json`.

### Why not model phases as `energy_meter` equipments?

That type feeds the existing by-usage donut
(`Autre = Total − Σ submeters`, spec 091). Phases sum to ~100% of the
total rather than being a usage subset (PAC, Piscine, ...) — reusing it
would collapse "Autre" to ~0 and misrepresent phases as usage
categories. This was actually tried first, the corruption risk caught
before it reached production, and replaced with the alias convention
described above — no schema or equipment-type change needed.

### Impact on single-phase installs

None. `PhaseBreakdown` renders nothing unless ≥ 2 `power_l{n}` aliases
exist, which never happens unless a plugin explicitly binds them.

### Out of scope

Historical per-phase breakdown on the **Consumption** page. The
Netatmo/Legrand API only provides accumulated energy at the bridge
(whole-installation) level — never per phase, only instantaneous power.
A historical view would need a dedicated W→Wh accumulation pipeline for
phases, separate from the existing by-usage submeter integrator (to
avoid the same "Autre" corruption issue). Discussed and deliberately
deferred.

## Testing

Tested live against a real Legrand Drivia with Netatmo (412175)
three-phase meter on a dev Sowel instance:

1. Built the UI (`tsc -b && vite build`) cleanly — no TypeScript errors.
2. Deployed to the running instance, bound `power_l1/l2/l3` from the
   real meter's Phase 1/2/3 devices onto the main energy meter
   equipment.
3. Confirmed via API the bound values are consistent
   (L1=268 W, L2=197 W, L3=15 W, Total=470 W).
4. Visually confirmed in-browser that the breakdown renders correctly
   on Energy → Live.
5. Confirmed by code inspection that single-phase installs are
   unaffected (guard clause, no aliases ever bound without an opting-in
   plugin).