### PR TITLE
release: v1.30.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,14 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.30.x: Comptage triphasé
+
+### v1.30.0 — 2026-07-31 { #v1-30-0 }
+
+- Feat (energy) : la page Énergie → Live peut désormais afficher la répartition de puissance par phase pour les installations triphasées. Un équipement compteur principal peut porter des liaisons de données `power_l1` / `power_l2` / `power_l3` (une convention que toute intégration exposant la puissance par phase peut adopter), et dès que deux phases au moins sont liées, un panneau « Répartition par phase » affiche une barre par phase sous le diagramme de flux, ce qui rend visible d'un coup d'œil une phase déséquilibrée. Les installations monophasées ne sont pas concernées : sans ces liaisons, le panneau n'existe pas. Fonctionne avec le plugin Legrand Energy v2.1.0, qui découvre maintenant les compteurs triphasés Legrand Drivia with Netatmo (modules NLY, réf. 412175) sous forme d'un appareil « Total » plus un appareil par phase. Contribution de Romain (alpitux). (#336, legrand-energy #1)
+
+---
+
 ## 1.29.x: Rôle Standard et parité du dashboard
 
 ### v1.29.4 — 2026-07-26 { #v1-29-4 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,14 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.30.x: Three-phase metering
+
+### v1.30.0 — 2026-07-31 { #v1-30-0 }
+
+- Feat (energy): the Energy → Live page can now show a per-phase power breakdown for three-phase installations. A main energy meter equipment may carry `power_l1` / `power_l2` / `power_l3` data bindings (a convention any integration exposing per-phase power can adopt), and when at least two phases are bound, a "Phase breakdown" panel renders one bar per phase under the live flow diagram, making an unbalanced phase visible at a glance. Single-phase installations are unaffected: without those bindings the panel does not exist. Pairs with the Legrand Energy plugin v2.1.0, which now discovers Legrand Drivia with Netatmo three-phase meters (NLY modules, ref. 412175) as a "Total" device plus one device per phase. Contributed by Romain (alpitux). (#336, legrand-energy #1)
+
+---
+
 ## 1.29.x: Standard role and dashboard parity
 
 ### v1.29.4 — 2026-07-26 { #v1-29-4 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.29.4",
+  "version": "1.30.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.29.4",
+  "version": "1.30.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Release v1.30.0: three-phase metering support on Energy → Live.

- feat(energy): per-phase power breakdown on the Live page via `power_l{n}` binding convention (#336, contributed by @alpitux)
- Release notes added in both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-30-0 }` anchor (spec 108)
- Version bump 1.29.4 → 1.30.0 in `package.json` / `ui/package.json`

Companion plugin release: [sowel-plugin-legrand-energy v2.1.0](https://github.com/mchacher/sowel-plugin-legrand-energy/releases/tag/v2.1.0) (NLY three-phase meters), registry already bumped in #337.

Pre-flight checks run locally: backend tsc/eslint/vitest (963 tests), UI tsc/eslint — all green.

After merge: tag the on-main release commit as `v1.30.0` and push the tag to trigger the Docker build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)