### PR TITLE
chore(registry): remove netatmo-security (superseded by camera equipment type)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -112,20 +112,6 @@
     "sha256": "cd3904440ca875dd75fdfaea9aa2d74175c9a855c325eaf3c8e40ced91fb0552"
   },
   {
-    "id": "netatmo-security",
-    "type": "integration",
-    "name": "Netatmo Security",
-    "description": "Netatmo cameras (Welcome, Presence, Doorbell) — monitoring on/off",
-    "icon": "Camera",
-    "author": "mchacher",
-    "repo": "mchacher/sowel-plugin-netatmo-security",
-    "version": "0.5.0",
-    "tags": ["camera", "netatmo", "security"],
-    "sowelVersion": ">=0.10.0",
-    "owner": "mchacher",
-    "sha256": "37d550273e72e2a1414cc5c299e0510d5f9c44fcd1321af361494345defd9042"
-  },
-  {
     "id": "weather-forecast",
     "type": "integration",
     "name": "Weather Forecast",


### PR DESCRIPTION
## Summary

Removes the `netatmo-security` plugin (v0.5.0, monitoring on/off only) from the official registry. It is superseded by the `camera` equipment type (spec 133, #339) and the upcoming community plugin [alpitux/sowel-plugin-netatmo-camera](https://github.com/alpitux/sowel-plugin-netatmo-camera), which covers monitoring plus snapshot/live view.

## Impact on running instances

- Instances with the plugin already installed keep running it from disk; the store simply stops listing it and no further updates are offered.
- The spec 058 auto-redownload path (missing plugin on disk after a restore) will no longer find it in the registry — such instances should uninstall it or migrate to the camera plugin once published.
- Propagation via CDN within ~1h of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)