### PR TITLE
release: v1.31.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,16 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.31.x: Équipement caméra
+
+### v1.31.0 — 2026-08-05 { #v1-31-0 }
+
+- Feat (equipments) : nouveau type d'équipement **caméra**, indépendant du fabricant (spec 133). Un équipement caméra affiche un instantané rafraîchi périodiquement (page de détail et widget dashboard) et une vue en direct à la demande (HLS), plus, quand l'intégration les expose, des commandes de surveillance on/off, de mode d'éclairage et de sirène. Les médias transitent par le backend Sowel : le navigateur ne parle jamais directement à la caméra ou au relais du fabricant, et l'URL réelle de la caméra n'est jamais exposée. Chaque fonction s'active simplement en liant sa catégorie de donnée ou d'ordre, avec contrôle côté serveur. Aucune intégration caméra n'est incluse dans le cœur : ce sont les plugins qui fournissent les appareils (un plugin communautaire pour les caméras Netatmo est en préparation). Limitation connue : la vue en direct n'est pas encore disponible sur Safari iOS (l'instantané fonctionne partout). Contribution de Romain (alpitux). (#339)
+- Fix (ui) : la règle du service worker censée garder les appels API en réseau seul ne s'appliquait en réalité jamais, le motif étant testé contre l'URL complète au lieu du chemin. Aucun impact utilisateur connu, corrigé par rigueur. (#339)
+- Chore (plugins) : l'ancien plugin Netatmo Security (surveillance on/off uniquement) est retiré du store, remplacé par le type d'équipement caméra et le futur plugin caméra Netatmo. Les instances qui l'ont déjà installé continuent de l'utiliser ; il n'est simplement plus listé ni mis à jour. (#340)
+
+---
+
 ## 1.30.x: Comptage triphasé
 
 ### v1.30.0 — 2026-07-31 { #v1-30-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,16 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.31.x: Camera equipment
+
+### v1.31.0 — 2026-08-05 { #v1-31-0 }
+
+- Feat (equipments): new vendor-agnostic **camera** equipment type (spec 133). A camera equipment shows a periodically refreshed snapshot (equipment detail page and dashboard widget) and an on-demand live view (HLS), plus optional monitoring on/off, light mode and siren controls when the integration exposes them. Media is proxied through the Sowel backend, so the browser never talks to the camera or vendor relay directly and the camera's real URL is never exposed. Each feature is enabled by simply binding its data/order category, enforced server-side. No camera integration ships in core: vendor plugins provide the devices (a Netatmo camera community plugin is on its way). Known limitation: live view is not yet available on iOS Safari (snapshots work everywhere). Contributed by Romain (alpitux). (#339)
+- Fix (ui): the service worker rule that keeps API calls network-only never actually matched, because the pattern was tested against the full URL instead of the path. No known user-facing impact, fixed for correctness. (#339)
+- Chore (plugins): the legacy Netatmo Security plugin (monitoring on/off only) is removed from the plugin store, superseded by the camera equipment type and the upcoming Netatmo camera plugin. Instances that already installed it keep running it; it is simply no longer listed or updated. (#340)
+
+---
+
 ## 1.30.x: Three-phase metering
 
 ### v1.30.0 — 2026-07-31 { #v1-30-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.31.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Release v1.31.0: camera equipment type.

- feat(equipments): vendor-agnostic camera equipment type, spec 133 (#339, contributed by @alpitux)
- chore(registry): netatmo-security removed from the store (#340)
- Release notes added in both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-31-0 }` anchor (spec 108)
- Version bump 1.30.0 → 1.31.0 in `package.json` / `ui/package.json`

Pre-flight checks run locally: backend tsc/eslint/vitest (984 tests), UI tsc/eslint — all green.

After merge: tag the on-main release commit as `v1.31.0` and push the tag to trigger the Docker build. This release unblocks the sowel-plugin-netatmo-camera publication (`sowelVersion: ">=1.31.0"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)