### PR TITLE
fix(notifications): boolean simple mappings notify on activation only

### DIFF
--- a/src/notifications/notification-publish-service.test.ts
+++ b/src/notifications/notification-publish-service.test.ts
@@ -164,3 +164,55 @@ describe("re-notify lifecycle (spec 128)", () => {
     h.svc.destroy();
   });
 });
+
+describe("boolean simple mappings notify on activation only", () => {
+  beforeEach(() => {
+    telegramSend.mockClear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T10:00:00.000Z"));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("does not notify when a boolean clears (washing-machine start regression)", () => {
+    const h = makeService({ sourceKey: "alarm" });
+
+    // End of cycle: alarm raises → one notification.
+    h.setState("alarm", true);
+    h.fire();
+    expect(telegramSend).toHaveBeenCalledTimes(1);
+
+    // Start of next cycle: alarm clears → must stay silent (this used to
+    // re-send the same "done" message on the falling edge).
+    vi.advanceTimersByTime(2000); // past the 1s recipe-event burst dedup
+    h.setState("alarm", false);
+    h.fire();
+    expect(telegramSend).toHaveBeenCalledTimes(1);
+
+    // Next end of cycle: raises again → notifies again.
+    vi.advanceTimersByTime(2000);
+    h.setState("alarm", true);
+    h.fire();
+    expect(telegramSend).toHaveBeenCalledTimes(2);
+    h.svc.destroy();
+  });
+
+  it("stays silent when the first observed boolean value is false", () => {
+    const h = makeService({ sourceKey: "alarm" });
+    h.setState("alarm", false);
+    h.fire();
+    expect(telegramSend).not.toHaveBeenCalled();
+    h.svc.destroy();
+  });
+
+  it("string transitions still notify on every change", () => {
+    const h = makeService({ sourceKey: "status" });
+    h.setState("status", "running");
+    h.fire();
+    expect(telegramSend).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(2000); // past the 1s recipe-event burst dedup
+    h.setState("status", "done");
+    h.fire();
+    expect(telegramSend).toHaveBeenCalledTimes(2);
+    h.svc.destroy();
+  });
+});

--- a/src/notifications/notification-publish-service.ts
+++ b/src/notifications/notification-publish-service.ts
@@ -248,7 +248,13 @@ export class NotificationPublishService {
 
       if (ref.repeatMs === null) {
         // No re-notify — existing change-based behaviour.
-        if (!this.shouldNotify(ref, value, effectivePrevious)) continue;
+        if (!this.shouldNotify(ref, value, effectivePrevious)) {
+          // A boolean falling edge is silent but must still be tracked:
+          // the next rising edge has to compare against `false`, not the
+          // stale `true` from the last notification.
+          if (typeof value === "boolean") this.lastValue.set(ref.mappingId, value);
+          continue;
+        }
         this.sendNotification(ref, formatNotificationContent(ref.message, value));
         this.lastSent.set(ref.mappingId, Date.now());
         this.lastValue.set(ref.mappingId, value);
@@ -369,8 +375,20 @@ export class NotificationPublishService {
     // Never notify if value hasn't changed
     if (value === previous) return false;
 
-    // Discrete state transitions (boolean, string enums): notify immediately on change
-    if (typeof value === "boolean" || typeof value === "string") {
+    // Booleans: notify on activation only. A mapping carries one fixed
+    // message, so firing it again on the falling edge sends the same text
+    // for the opposite condition (e.g. a recipe alarm bound to "washing
+    // machine done" also fired when the alarm cleared at cycle start).
+    // Matches the repeat path below, which is already silent on
+    // deactivation.
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    // Discrete string transitions (state enums): notify immediately on
+    // change — every transition is meaningful and the message can
+    // interpolate the new value.
+    if (typeof value === "string") {
       return true;
     }
 


### PR DESCRIPTION
## Summary

A change-based notification mapping (`repeatMs = null`) on a boolean source key fired its fixed message on **both** edges of the value. Diagnosed on production: a state-watch recipe on the washing machine (`state == "ready"`, permanent) keeps its alarm active the whole time the machine is idle, so the "Machine à laver terminée" web-push mapping on the recipe's `alarm` key fired:

- at **end of cycle** (`run → ready`, alarm raised, `value=true`) — intended;
- at **start of cycle** (`ready → run`, alarm cleared, `value=false`) — the same "done" message, wrong.

Production logs (2026-08-05): `10:50:07 state — alarm cleared → Notifications dispatched value=false sent=1` (cycle start), `11:15:07 ALARM: state=ready → Notifications dispatched value=true sent=1` (cycle end). Same pattern on every past cycle.

## Fix

In `shouldNotify`, boolean values now notify on the **rising edge only** — a mapping carries one fixed message, so firing it on the falling edge always sends the wrong text. This aligns the simple path with the repeat path (spec 128), which is already explicitly silent on deactivation. The silent falling edge still records `lastValue` so the next rising edge is detected (without this, a suppressed `true→false` left `lastValue=true` and the next `false→true` was seen as unchanged).

String mappings (state enums, message can interpolate the value) and numeric mappings (throttle-based) are unchanged.

## Tests

- New: boolean `true→false` stays silent, then `false→true` notifies again (the exact washer regression, with the 1s recipe-event burst dedup accounted for).
- New: first observed value `false` stays silent.
- New: string transitions still notify on every change.
- Full backend suite: 987 passed, tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)