### PR TITLE
release: v1.31.1

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.31.x: Équipement caméra
 
+### v1.31.1 — 2026-08-05 { #v1-31-1 }
+
+- Fix (notifications) : une notification associée à une source on/off (typiquement l'alarme d'une recette) envoyait son message sur les deux transitions, si bien qu'un texte fixe comme « Machine à laver terminée » partait aussi au moment où l'alarme se résolvait — pour une surveillance de l'état repos, c'est précisément le démarrage d'un cycle. Ces notifications ne partent désormais qu'à l'activation de la source ; les notifications associées à des textes d'état (par ex. un nom de mode) ou à des valeurs numériques sont inchangées. (#342)
+
 ### v1.31.0 — 2026-08-05 { #v1-31-0 }
 
 - Feat (equipments) : nouveau type d'équipement **caméra**, indépendant du fabricant (spec 133). Un équipement caméra affiche un instantané rafraîchi périodiquement (page de détail et widget dashboard) et une vue en direct à la demande (HLS), plus, quand l'intégration les expose, des commandes de surveillance on/off, de mode d'éclairage et de sirène. Les médias transitent par le backend Sowel : le navigateur ne parle jamais directement à la caméra ou au relais du fabricant, et l'URL réelle de la caméra n'est jamais exposée. Chaque fonction s'active simplement en liant sa catégorie de donnée ou d'ordre, avec contrôle côté serveur. Aucune intégration caméra n'est incluse dans le cœur : ce sont les plugins qui fournissent les appareils (un plugin communautaire pour les caméras Netatmo est en préparation). Limitation connue : la vue en direct n'est pas encore disponible sur Safari iOS (l'instantané fonctionne partout). Contribution de Romain (alpitux). (#339)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.31.x: Camera equipment
 
+### v1.31.1 — 2026-08-05 { #v1-31-1 }
+
+- Fix (notifications): a notification mapped to an on/off source (typically a recipe alarm) fired its message on both transitions, so a fixed text like "washing machine done" was also sent the moment the alarm cleared — for a state-watch on the idle state, that is exactly when the machine starts a cycle. Such notifications now fire only when the source activates; notifications mapped to state texts (e.g. a mode name) or numeric values are unchanged. (#342)
+
 ### v1.31.0 — 2026-08-05 { #v1-31-0 }
 
 - Feat (equipments): new vendor-agnostic **camera** equipment type (spec 133). A camera equipment shows a periodically refreshed snapshot (equipment detail page and dashboard widget) and an on-demand live view (HLS), plus optional monitoring on/off, light mode and siren controls when the integration exposes them. Media is proxied through the Sowel backend, so the browser never talks to the camera or vendor relay directly and the camera's real URL is never exposed. Each feature is enabled by simply binding its data/order category, enforced server-side. No camera integration ships in core: vendor plugins provide the devices (a Netatmo camera community plugin is on its way). Known limitation: live view is not yet available on iOS Safari (snapshots work everywhere). Contributed by Romain (alpitux). (#339)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sowel",
-  "version": "1.30.0",
+  "version": "1.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sowel",
-      "version": "1.30.0",
+      "version": "1.31.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cors": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "1.30.0",
+  "version": "1.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "1.30.0",
+      "version": "1.31.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.31.0",
+  "version": "1.31.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Patch release: notification fix.

- fix(notifications): boolean simple mappings notify on activation only (#342) — stops the spurious "washing machine done" push at cycle start
- Release notes added in `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-31-1 }` anchor (spec 108)
- Version bump 1.31.0 → 1.31.1 in `package.json` / `ui/package.json`, lockfile versions resynced

Pre-flight checks run locally: backend tsc/eslint/vitest (987 tests), UI tsc/eslint — all green.

After merge: tag the on-main release commit as `v1.31.1` and push the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)