### PR TITLE
feat(equipments): daily min/max temperature on weather equipments (spec 134)

### DIFF
--- a/docs/user/equipments.fr.md
+++ b/docs/user/equipments.fr.md
@@ -138,6 +138,7 @@ Capteur météo extérieur qui fournit les conditions actuelles.
 
 - **Contrôles :** Affichage multi-valeurs
 - **Données typiques :** température, humidité, pression, pluie, vent, bruit, batterie
+- Les températures (extérieure et intérieure) affichent en dessous le minimum et le maximum mesurés depuis minuit, sur le widget du dashboard comme sur la page de détail. Fonctionne avec toute station qui remonte une température, sans configuration.
 
 #### Prévision météo
 

--- a/docs/user/equipments.md
+++ b/docs/user/equipments.md
@@ -83,12 +83,12 @@ You can choose a specific icon for gates on the dashboard: standard gate, slidin
 
 ### Sensors
 
-| Type                 | Controls / Display                          | Expected data                                                                                             |
-| -------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| **Sensor**           | Read-only multi-value display, auto-adapted | temperature, humidity, pressure, CO2, VOC, luminosity, noise, battery, motion, contact, water leak, smoke |
-| **Weather Station**  | Multi-value display                         | temperature, humidity, pressure, rain, wind, noise, battery                                               |
-| **Weather Forecast** | Day-by-day forecast cards (J+1 to J+5)      | weather condition, temperature min/max, rain probability, wind gusts                                      |
-| **Button / Remote**  | Not directly controlled (used as trigger)   | action events (single press, double press, long press)                                                    |
+| Type                 | Controls / Display                          | Expected data                                                                                                |
+| -------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Sensor**           | Read-only multi-value display, auto-adapted | temperature, humidity, pressure, CO2, VOC, luminosity, noise, battery, motion, contact, water leak, smoke    |
+| **Weather Station**  | Multi-value display                         | temperature (with today's measured min/max shown underneath), humidity, pressure, rain, wind, noise, battery |
+| **Weather Forecast** | Day-by-day forecast cards (J+1 to J+5)      | weather condition, temperature min/max, rain probability, wind gusts                                         |
+| **Button / Remote**  | Not directly controlled (used as trigger)   | action events (single press, double press, long press)                                                       |
 
 The generic **Sensor** type adapts its display automatically. Boolean sensors (motion, contact, water leak, smoke) get appropriate badges; numeric sensors get values with the right unit and icon.
 

--- a/migrations/013_weather_temp_extremes.sql
+++ b/migrations/013_weather_temp_extremes.sql
@@ -1,0 +1,13 @@
+-- Spec 134 — daily min/max temperature envelope for weather equipments.
+-- One row per (equipment, temperature binding alias), always holding the
+-- current day's envelope; midnight rollover overwrites in place. Long-term
+-- history stays in InfluxDB — this table only survives restarts.
+CREATE TABLE IF NOT EXISTS weather_temp_extremes (
+  equipment_id TEXT NOT NULL,
+  alias        TEXT NOT NULL,
+  day          TEXT NOT NULL,
+  min_value    REAL NOT NULL,
+  max_value    REAL NOT NULL,
+  updated_at   TEXT NOT NULL,
+  PRIMARY KEY (equipment_id, alias)
+);

--- a/specs/134-weather-daily-min-max/architecture.md
+++ b/specs/134-weather-daily-min-max/architecture.md
@@ -1,0 +1,96 @@
+# Architecture — Spec 134
+
+Follows the `PoolWaterTempTracker` pattern (spec 121): an event-driven
+tracker with SQLite persistence exposing `ComputedDataEntry[]` per
+equipment. No new API route, no new WebSocket message — `computedData`
+already flows through `EquipmentWithDetails` on REST and WS pushes.
+
+## Data model
+
+New table (migration `NNN_weather_temp_extremes.sql`, next sequential
+number at implementation time):
+
+```sql
+CREATE TABLE IF NOT EXISTS weather_temp_extremes (
+  equipment_id TEXT NOT NULL,
+  alias        TEXT NOT NULL,
+  day          TEXT NOT NULL,   -- local date "YYYY-MM-DD"
+  min_value    REAL NOT NULL,
+  max_value    REAL NOT NULL,
+  updated_at   TEXT NOT NULL,
+  PRIMARY KEY (equipment_id, alias)
+);
+```
+
+One row per (equipment, temperature binding alias) — always the current
+day's envelope; rollover overwrites in place. No history kept here
+(history is InfluxDB's job).
+
+## Tracker
+
+`src/equipments/weather-temp-extremes-tracker.ts`
+
+- Subscribes to `equipment.data.changed`. Guard chain:
+  `equipment.type === "weather"` → binding category in
+  `{"temperature", "temperature_outdoor"}` → `typeof value === "number"`.
+- Local day string from the server timezone (same convention as the
+  energy day boundaries; spec 061 owns TZ correctness).
+- On sample: if stored `day !== today` → reset envelope to the sample;
+  else `min = Math.min`, `max = Math.max`. Persist synchronously
+  (better-sqlite3), update in-memory map.
+- Midnight is lazy: no timer needed for correctness (the first sample of
+  the new day resets), but a light interval (aligned with the pool
+  tracker's) re-emits so the UI does not show yesterday's envelope
+  before the first morning sample. On rollover with no sample yet, the
+  computed entries return null → hidden in UI.
+- `getComputedData(equipmentId): ComputedDataEntry[]` — returns, per
+  tracked alias with a row for today:
+  - `{ alias: "<alias>_min_today", value, unit: "°C", category: <source binding category>, lastUpdated }`
+  - `{ alias: "<alias>_max_today", ... }`
+- Cleanup on `equipment.removed` (same hook as pool trackers).
+
+Wiring in `src/index.ts`: instantiate next to `PoolWaterTempTracker`,
+register its `getComputedData` with the equipment manager's computed-data
+providers (same mechanism the pool and energy cumul entries use).
+
+## UI
+
+Matching is by **category** (aliases vary: prod shows outdoor =
+`temperature` with category `temperature_outdoor`, indoor =
+`temperature_2` with category `temperature`). Helper in
+`ui/src/components/equipments/weather-utils.ts`:
+
+```ts
+export function findTempExtremes(
+  equipment: EquipmentWithDetails,
+  category: "temperature" | "temperature_outdoor",
+): { min: number; max: number } | null;
+```
+
+Resolution: find the source binding of that category, then look up
+`computedData` entries `<binding.alias>_min_today` / `_max_today`.
+Returns null unless both are numbers.
+
+| File                   | Change                                                                 |
+| ---------------------- | ---------------------------------------------------------------------- |
+| `EquipmentWidget.tsx`  | `WeatherStationWidget`: outdoor `↓ n° ↑ n°` line under hero temp       |
+| `MobileWidgetCard.tsx` | Outdoor min/max in the weather summary + rows in the bottom sheet      |
+| `WeatherPanel.tsx`     | Min/max row in outdoor module section and indoor section               |
+| `weather-utils.ts`     | `findTempExtremes` helper (unit-tested)                                |
+| `fr.json` / `en.json`  | `weather.minToday`, `weather.maxToday` (or arrow glyphs + aria labels) |
+
+Display convention: Lucide `ArrowDown`/`ArrowUp` 12px + `n°` values,
+`text-text-tertiary`, JetBrains Mono for values — consistent with the
+spec 114 widget styles.
+
+## Event flow
+
+```
+plugin poll → device.data.updated → equipment.data.changed (temperature)
+  → WeatherTempExtremesTracker (update envelope, persist)
+  → equipment computed data refresh → WS push equipment payload
+  → UI stores update → widgets re-render
+```
+
+No extra WS event: the tracker piggybacks the equipment refresh path the
+pool trackers already use.

--- a/specs/134-weather-daily-min-max/plan.md
+++ b/specs/134-weather-daily-min-max/plan.md
@@ -1,0 +1,63 @@
+# Plan — Spec 134
+
+Branch `feat/weather-daily-min-max`.
+
+## Implementation steps
+
+1. Migration `NNN_weather_temp_extremes.sql` (next sequential number).
+2. `src/equipments/weather-temp-extremes-tracker.ts` — tracker class
+   (event subscription, envelope logic, SQLite persistence, computed
+   data provider, cleanup).
+3. `weather-temp-extremes-tracker.test.ts` — full test plan below.
+4. Wire in `src/index.ts` (instantiate + register provider + destroy on
+   shutdown), mirroring `PoolWaterTempTracker`.
+5. UI helper `findTempExtremes` in `weather-utils.ts` + unit tests.
+6. `WeatherStationWidget` (EquipmentWidget.tsx), `MobileWidgetCard`,
+   `WeatherPanel` — display wiring.
+7. i18n FR/EN.
+8. Validation: backend `tsc` + `eslint` + `vitest`; UI `tsc -b` +
+   `eslint` + `vitest`.
+9. Manual verification against prod-like data (dev instance or shadow):
+   bind a weather station, observe envelope building, verify widgets.
+
+## Test Plan
+
+### Modules to test
+
+- `weather-temp-extremes-tracker.ts` (backend — all business logic)
+- `weather-utils.ts` `findTempExtremes` (UI helper — pure logic)
+
+### Scenarios
+
+| Module  | Scenario                                             | Expected                                          |
+| ------- | ---------------------------------------------------- | ------------------------------------------------- |
+| tracker | First temperature sample of the day                  | min = max = sample, row persisted                 |
+| tracker | Lower then higher samples same day                   | min/max update independently                      |
+| tracker | Sample with stored day != today (rollover)           | Envelope reset to the new sample                  |
+| tracker | Restart: constructor reloads today's rows            | Envelope continues from persisted values          |
+| tracker | Restart: persisted row from a past day               | Ignored/reset on next sample                      |
+| tracker | Non-numeric / null value                             | Ignored, no row                                   |
+| tracker | Equipment type != weather                            | Ignored                                           |
+| tracker | Binding category not temperature/temperature_outdoor | Ignored                                           |
+| tracker | Two temperature bindings (indoor + outdoor)          | Tracked independently per alias                   |
+| tracker | `getComputedData` with no row for today              | No entries (empty array)                          |
+| tracker | Equipment removed                                    | State + rows deleted, no further computed entries |
+| helper  | Outdoor binding + both computed entries present      | `{min, max}` returned                             |
+| helper  | Computed entries missing or non-numeric              | null                                              |
+| helper  | Category not bound on the equipment                  | null                                              |
+
+### Retro-compat
+
+- Non-weather equipments: no behavioural change (guard tested).
+- `computedData` consumers (pool, energy) untouched — additive provider.
+
+## Tasks
+
+- [x] P1 Migration
+- [x] P2 Tracker + tests
+- [x] P3 Wiring in index.ts
+- [x] P4 UI helper + tests
+- [x] P5 Widget/panel display + i18n
+- [x] P6 Full validation green
+- [ ] P7 Manual verification (pending — needs a live weather station; to be
+      done on the shadow/demo instance or right after deploy)

--- a/specs/134-weather-daily-min-max/spec.md
+++ b/specs/134-weather-daily-min-max/spec.md
@@ -1,0 +1,88 @@
+# Spec 134 — Daily min/max temperature on weather equipments
+
+## Context
+
+Spec 114 (Weather station UX) reworked the weather widgets but explicitly
+deferred daily min/max temperature ("would require additional history
+queries — kept for a later spec"). This is that spec.
+
+The user wants to see today's measured minimum and maximum temperature on
+the dashboard widgets and on the equipment detail panel of a weather
+station equipment.
+
+Design decision (user): this is a **core feature**, not a plugin one. A
+weather equipment is vendor-agnostic — the Netatmo API happens to provide
+`min_temp`/`max_temp`, but other stations (Ecowitt, WeatherFlow, DIY MQTT
+sensors) do not. Sowel therefore tracks the extremes itself from the
+temperature samples it already receives, following the existing
+computed-data tracker pattern (`PoolWaterTempTracker`, spec 121).
+
+## Goal
+
+Track, per `weather` equipment and per temperature binding, the minimum
+and maximum value observed since local midnight, and expose them as
+computed data entries so the existing UI data flow (REST + WebSocket)
+carries them to the dashboard and detail views with no new endpoint.
+
+## Scope
+
+### In scope
+
+- New core tracker `WeatherTempExtremesTracker` in `src/equipments/`:
+  listens to `equipment.data.changed`, tracks min/max since local
+  midnight for every binding of category `temperature` or
+  `temperature_outdoor` on equipments of type `weather` (covers indoor
+  and outdoor modules).
+- SQLite persistence so a restart mid-day does not lose the morning
+  minimum.
+- Computed data entries `<alias>_min_today` / `<alias>_max_today`
+  (unit `°C`, category = source binding category).
+- UI:
+  - Desktop dashboard `WeatherStationWidget`: outdoor min/max next to
+    the hero temperature.
+  - Mobile dashboard `MobileWidgetCard`: outdoor min/max line + rows in
+    the bottom sheet.
+  - `WeatherPanel` (equipment detail): min/max in the outdoor module
+    section and in the indoor section.
+- FR/EN i18n.
+
+### Out of scope
+
+- Zone view `CompactEquipmentCard` (user chose not to include it).
+- Min/max for non-weather equipment types (thermostats, pool, ...) —
+  the tracker is scoped to `type === "weather"`; generalizing is a
+  possible future spec.
+- Timestamps of the min/max ("min at 06:42") — value only for now.
+- Seeding from InfluxDB history on first install — the envelope starts
+  from the first sample after the feature ships; it self-corrects the
+  next day.
+- Outlier filtering (a sensor glitch becomes the min/max of the day).
+
+## Acceptance criteria
+
+- [x] AC1 — A `weather` equipment exposes `<alias>_min_today` and
+      `<alias>_max_today` computed entries for each bound temperature
+      (indoor and outdoor) once at least one sample was observed today.
+- [x] AC2 — The values reset at local midnight (server timezone): the
+      first sample of a new day becomes both min and max.
+- [x] AC3 — A Sowel restart during the day preserves the current
+      envelope (SQLite-backed).
+- [x] AC4 — Desktop widget, mobile widget and WeatherPanel display the
+      outdoor min/max; WeatherPanel also displays the indoor min/max.
+- [x] AC5 — A station whose temperature binding never updates shows no
+      min/max (no placeholder noise), and non-weather equipments are
+      untouched.
+- [x] AC6 — Deleting the equipment removes its persisted rows.
+
+## Edge cases
+
+| Case                                          | Expected                                   |
+| --------------------------------------------- | ------------------------------------------ |
+| Non-numeric / null temperature sample         | Ignored                                    |
+| First sample of the day                       | min = max = sample                         |
+| Sample arrives with day != stored day         | Envelope reset to that sample (rollover)   |
+| Restart mid-day                               | Envelope reloaded from SQLite              |
+| Several temperature bindings on one equipment | Tracked independently per alias            |
+| Equipment removed                             | State and rows deleted                     |
+| Equipment type != weather                     | Ignored by the tracker                     |
+| Binding category not temperature\*            | Ignored (humidity, rain, wind, battery...) |

--- a/src/equipments/weather-temp-extremes-tracker.test.ts
+++ b/src/equipments/weather-temp-extremes-tracker.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import crypto from "node:crypto";
+import { EquipmentManager } from "./equipment-manager.js";
+import { WeatherTempExtremesTracker } from "./weather-temp-extremes-tracker.js";
+import { DeviceManager } from "../devices/device-manager.js";
+import { ZoneManager } from "../zones/zone-manager.js";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+
+const MIGRATIONS_DIR = resolve(import.meta.dirname ?? ".", "../../migrations");
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  for (const file of readdirSync(MIGRATIONS_DIR).sort()) {
+    if (file.endsWith(".sql")) db.exec(readFileSync(resolve(MIGRATIONS_DIR, file), "utf-8"));
+  }
+  return db;
+}
+
+const logger = createLogger("silent").logger;
+
+function seedDevice(
+  db: Database.Database,
+  dataKeys: { key: string; category: string }[],
+): { dataIds: string[] } {
+  const deviceId = crypto.randomUUID();
+  db.prepare(
+    `INSERT INTO devices (id, mqtt_base_topic, mqtt_name, name, source, status, integration_id, source_device_id)
+     VALUES (?, ?, ?, ?, 'zigbee2mqtt', 'online', 'zigbee2mqtt', ?)`,
+  ).run(deviceId, `z2m/weather`, "Weather", "Weather", "Weather");
+
+  const dataIds: string[] = [];
+  for (const d of dataKeys) {
+    const id = crypto.randomUUID();
+    db.prepare(
+      `INSERT INTO device_data (id, device_id, key, type, category) VALUES (?, ?, ?, 'number', ?)`,
+    ).run(id, deviceId, d.key, d.category);
+    dataIds.push(id);
+  }
+  return { dataIds };
+}
+
+describe("WeatherTempExtremesTracker", () => {
+  let db: Database.Database;
+  let eventBus: EventBus;
+  let zoneManager: ZoneManager;
+  let deviceManager: DeviceManager;
+  let equipmentManager: EquipmentManager;
+  let tracker: WeatherTempExtremesTracker;
+
+  beforeEach(() => {
+    db = createTestDb();
+    eventBus = new EventBus(logger);
+    zoneManager = new ZoneManager(db, eventBus, logger);
+    deviceManager = new DeviceManager(db, eventBus, logger);
+    equipmentManager = new EquipmentManager(
+      db,
+      eventBus,
+      { getById: () => null, dispatchOrder: async () => {} } as never,
+      deviceManager,
+      logger,
+    );
+  });
+
+  afterEach(() => {
+    tracker?.stop();
+    db.close();
+    vi.useRealTimers();
+  });
+
+  function createWeatherEquipment(opts?: { type?: string }): {
+    eqId: string;
+    aliases: string[];
+  } {
+    const zone = zoneManager.create({ name: "Jardin" });
+    const eq = equipmentManager.create({
+      name: "Station",
+      type: (opts?.type ?? "weather") as never,
+      zoneId: zone.id,
+    });
+    const { dataIds } = seedDevice(db, [
+      { key: "temperature", category: "temperature_outdoor" },
+      { key: "temperature_in", category: "temperature" },
+      { key: "humidity", category: "humidity" },
+    ]);
+    equipmentManager.addDataBinding(eq.id, dataIds[0], "temperature");
+    equipmentManager.addDataBinding(eq.id, dataIds[1], "temperature_2");
+    equipmentManager.addDataBinding(eq.id, dataIds[2], "humidity");
+    return { eqId: eq.id, aliases: ["temperature", "temperature_2", "humidity"] };
+  }
+
+  function startTracker(): void {
+    tracker = new WeatherTempExtremesTracker(db, eventBus, equipmentManager, logger);
+    tracker.start();
+  }
+
+  function emitSample(eqId: string, alias: string, value: unknown): void {
+    eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: eqId,
+      alias,
+      value,
+      previous: null,
+    });
+  }
+
+  function entriesOf(eqId: string): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const e of tracker.getComputedDataForEquipment(eqId)) out[e.alias] = e.value;
+    return out;
+  }
+
+  it("first sample of the day sets min = max = sample and persists", () => {
+    const { eqId } = createWeatherEquipment();
+    startTracker();
+    emitSample(eqId, "temperature", 21.5);
+
+    expect(entriesOf(eqId)).toEqual({
+      temperature_min_today: 21.5,
+      temperature_max_today: 21.5,
+    });
+    const row = db
+      .prepare(`SELECT * FROM weather_temp_extremes WHERE equipment_id = ? AND alias = ?`)
+      .get(eqId, "temperature") as { min_value: number; max_value: number };
+    expect(row.min_value).toBe(21.5);
+    expect(row.max_value).toBe(21.5);
+  });
+
+  it("min and max update independently over the day", () => {
+    const { eqId } = createWeatherEquipment();
+    startTracker();
+    emitSample(eqId, "temperature", 20);
+    emitSample(eqId, "temperature", 17.2);
+    emitSample(eqId, "temperature", 26.8);
+    emitSample(eqId, "temperature", 22); // inside envelope — no change
+
+    expect(entriesOf(eqId)).toEqual({
+      temperature_min_today: 17.2,
+      temperature_max_today: 26.8,
+    });
+  });
+
+  it("resets the envelope on day rollover", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T23:50:00"));
+    const { eqId } = createWeatherEquipment();
+    startTracker();
+    emitSample(eqId, "temperature", 15);
+    emitSample(eqId, "temperature", 25);
+
+    vi.setSystemTime(new Date("2026-08-06T00:10:00"));
+    emitSample(eqId, "temperature", 18);
+
+    expect(entriesOf(eqId)).toEqual({
+      temperature_min_today: 18,
+      temperature_max_today: 18,
+    });
+  });
+
+  it("hides yesterday's envelope before the first sample of the new day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T23:50:00"));
+    const { eqId } = createWeatherEquipment();
+    startTracker();
+    emitSample(eqId, "temperature", 15);
+
+    vi.setSystemTime(new Date("2026-08-06T00:10:00"));
+    expect(entriesOf(eqId)).toEqual({});
+  });
+
+  it("reloads today's envelope from SQLite on restart", () => {
+    const { eqId } = createWeatherEquipment();
+    startTracker();
+    emitSample(eqId, "temperature", 12.5);
+    emitSample(eqId, "temperature", 24);
+    tracker.stop();
+
+    // New instance simulating a process restart on the same DB.
+    tracker = new WeatherTempExtremesTracker(db, eventBus, equipmentManager, logger);
+    tracker.start();
+    emitSample(eqId, "temperature", 20); // inside envelope
+
+    expect(entriesOf(eqId)).toEqual({
+      temperature_min_today: 12.5,
+      temperature_max_today: 24,
+    });
+  });
+
+  it("does not load a persisted row from a past day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T12:00:00"));
+    const { eqId } = createWeatherEquipment();
+    startTracker();
+    emitSample(eqId, "temperature", 15);
+    tracker.stop();
+
+    vi.setSystemTime(new Date("2026-08-06T08:00:00"));
+    tracker = new WeatherTempExtremesTracker(db, eventBus, equipmentManager, logger);
+    tracker.start();
+
+    expect(entriesOf(eqId)).toEqual({});
+    emitSample(eqId, "temperature", 9);
+    expect(entriesOf(eqId)).toEqual({
+      temperature_min_today: 9,
+      temperature_max_today: 9,
+    });
+  });
+
+  it("ignores non-numeric and non-finite values", () => {
+    const { eqId } = createWeatherEquipment();
+    startTracker();
+    emitSample(eqId, "temperature", null);
+    emitSample(eqId, "temperature", "22");
+    emitSample(eqId, "temperature", NaN);
+
+    expect(entriesOf(eqId)).toEqual({});
+  });
+
+  it("ignores non-weather equipments", () => {
+    const { eqId } = createWeatherEquipment({ type: "sensor" });
+    startTracker();
+    emitSample(eqId, "temperature", 21);
+
+    expect(tracker.getComputedDataForEquipment(eqId)).toEqual([]);
+    const rows = db.prepare(`SELECT * FROM weather_temp_extremes`).all();
+    expect(rows).toHaveLength(0);
+  });
+
+  it("ignores bindings whose category is not temperature*", () => {
+    const { eqId } = createWeatherEquipment();
+    startTracker();
+    emitSample(eqId, "humidity", 55);
+
+    expect(entriesOf(eqId)).toEqual({});
+  });
+
+  it("tracks indoor and outdoor bindings independently with their categories", () => {
+    const { eqId } = createWeatherEquipment();
+    startTracker();
+    emitSample(eqId, "temperature", 27.5);
+    emitSample(eqId, "temperature", 14);
+    emitSample(eqId, "temperature_2", 22);
+    emitSample(eqId, "temperature_2", 25.5);
+
+    expect(entriesOf(eqId)).toEqual({
+      temperature_min_today: 14,
+      temperature_max_today: 27.5,
+      temperature_2_min_today: 22,
+      temperature_2_max_today: 25.5,
+    });
+    const cats = new Map(
+      tracker.getComputedDataForEquipment(eqId).map((e) => [e.alias, e.category]),
+    );
+    expect(cats.get("temperature_min_today")).toBe("temperature_outdoor");
+    expect(cats.get("temperature_2_max_today")).toBe("temperature");
+  });
+
+  it("removes state and rows when the equipment is deleted", () => {
+    const { eqId } = createWeatherEquipment();
+    startTracker();
+    emitSample(eqId, "temperature", 21);
+    equipmentManager.delete(eqId);
+
+    expect(tracker.getComputedDataForEquipment(eqId)).toEqual([]);
+    const rows = db.prepare(`SELECT * FROM weather_temp_extremes`).all();
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/src/equipments/weather-temp-extremes-tracker.ts
+++ b/src/equipments/weather-temp-extremes-tracker.ts
@@ -1,0 +1,248 @@
+/**
+ * Weather daily temperature extremes tracker (spec 134).
+ *
+ * Tracks, per `weather` equipment and per temperature binding, the minimum
+ * and maximum value observed since local midnight, and exposes them as
+ * computed data entries `<alias>_min_today` / `<alias>_max_today`.
+ *
+ * Vendor-agnostic by design: some stations (Netatmo) report daily min/max
+ * themselves, most don't — Sowel derives the envelope from the temperature
+ * samples it already receives, so any station that reports a temperature
+ * gets min/max for free.
+ *
+ * Midnight rollover is lazy: the first sample of a new day resets the
+ * envelope, and `getComputedDataForEquipment` hides rows from past days,
+ * so no timer is required for correctness. Persistence (SQLite) keeps the
+ * envelope across restarts; long-term history remains InfluxDB's job.
+ */
+
+import type Database from "better-sqlite3";
+import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
+import type { ComputedDataEntry, DataCategory } from "../shared/types.js";
+import type { EquipmentManager } from "./equipment-manager.js";
+
+interface ExtremesRow {
+  equipment_id: string;
+  alias: string;
+  day: string;
+  min_value: number;
+  max_value: number;
+  updated_at: string;
+}
+
+interface Envelope {
+  day: string;
+  min: number;
+  max: number;
+  category: DataCategory;
+  updatedAt: string;
+}
+
+const TRACKED_CATEGORIES = new Set<DataCategory>(["temperature", "temperature_outdoor"]);
+
+/** Local calendar day of the server timezone (same convention as energy day boundaries). */
+function localDay(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export class WeatherTempExtremesTracker {
+  private readonly db: Database.Database;
+  private readonly eventBus: EventBus;
+  private readonly equipmentManager: EquipmentManager;
+  private readonly logger: Logger;
+
+  /** equipmentId → alias → envelope */
+  private readonly state = new Map<string, Map<string, Envelope>>();
+  private unsubscribeData: (() => void) | null = null;
+  private unsubscribeRemoved: (() => void) | null = null;
+  private readonly stmts;
+
+  constructor(
+    db: Database.Database,
+    eventBus: EventBus,
+    equipmentManager: EquipmentManager,
+    logger: Logger,
+  ) {
+    this.db = db;
+    this.eventBus = eventBus;
+    this.equipmentManager = equipmentManager;
+    this.logger = logger.child({ module: "weather-temp-extremes" });
+    this.stmts = {
+      upsert: this.db.prepare(
+        `INSERT INTO weather_temp_extremes (equipment_id, alias, day, min_value, max_value, updated_at)
+         VALUES (@equipmentId, @alias, @day, @minValue, @maxValue, @updatedAt)
+         ON CONFLICT(equipment_id, alias) DO UPDATE SET
+           day = excluded.day,
+           min_value = excluded.min_value,
+           max_value = excluded.max_value,
+           updated_at = excluded.updated_at`,
+      ),
+      selectAll: this.db.prepare(`SELECT * FROM weather_temp_extremes`),
+      deleteEquipment: this.db.prepare(`DELETE FROM weather_temp_extremes WHERE equipment_id = ?`),
+    };
+  }
+
+  start(): void {
+    this.loadFromDb();
+
+    this.unsubscribeData = this.eventBus.on((event) => {
+      if (event.type !== "equipment.data.changed") return;
+      try {
+        this.handleSample(event.equipmentId, event.alias, event.value);
+      } catch (err) {
+        this.logger.error(
+          { err, equipmentId: event.equipmentId, alias: event.alias },
+          "weather-temp-extremes: handler error",
+        );
+      }
+    });
+
+    this.unsubscribeRemoved = this.eventBus.on((event) => {
+      if (event.type !== "equipment.removed") return;
+      this.state.delete(event.equipmentId);
+      this.stmts.deleteEquipment.run(event.equipmentId);
+    });
+
+    this.logger.info({ equipments: this.state.size }, "Weather temp extremes tracker started");
+  }
+
+  stop(): void {
+    this.unsubscribeData?.();
+    this.unsubscribeData = null;
+    this.unsubscribeRemoved?.();
+    this.unsubscribeRemoved = null;
+  }
+
+  /**
+   * ComputedDataProvider entry — daily extremes for `weather` equipments.
+   * Rows from past days are hidden (pre-first-sample mornings show nothing
+   * rather than yesterday's envelope).
+   */
+  getComputedDataForEquipment(equipmentId: string): ComputedDataEntry[] {
+    const eq = this.equipmentManager.getById(equipmentId);
+    if (!eq || eq.type !== "weather") return [];
+    const perAlias = this.state.get(equipmentId);
+    if (!perAlias) return [];
+
+    const today = localDay(new Date());
+    const entries: ComputedDataEntry[] = [];
+    for (const [alias, env] of perAlias) {
+      if (env.day !== today) continue;
+      entries.push(
+        {
+          alias: `${alias}_min_today`,
+          value: env.min,
+          unit: "°C",
+          category: env.category,
+          lastUpdated: env.updatedAt,
+        },
+        {
+          alias: `${alias}_max_today`,
+          value: env.max,
+          unit: "°C",
+          category: env.category,
+          lastUpdated: env.updatedAt,
+        },
+      );
+    }
+    return entries;
+  }
+
+  // ────────────────────────────────────────────────────────────────
+
+  private handleSample(equipmentId: string, alias: string, value: unknown): void {
+    if (typeof value !== "number" || !Number.isFinite(value)) return;
+    // Ignore our own computed aliases (safety against feedback loops).
+    if (alias.endsWith("_min_today") || alias.endsWith("_max_today")) return;
+
+    const eq = this.equipmentManager.getById(equipmentId);
+    if (!eq || eq.type !== "weather") return;
+
+    const binding = this.equipmentManager
+      .getDataBindingsWithValues(equipmentId)
+      .find((b) => b.alias === alias);
+    if (!binding || !TRACKED_CATEGORIES.has(binding.category)) return;
+
+    const now = new Date();
+    const today = localDay(now);
+    const updatedAt = now.toISOString();
+
+    let perAlias = this.state.get(equipmentId);
+    if (!perAlias) {
+      perAlias = new Map();
+      this.state.set(equipmentId, perAlias);
+    }
+
+    const current = perAlias.get(alias);
+    let env: Envelope;
+    if (!current || current.day !== today) {
+      // First sample of the day (or of ever): the envelope starts here.
+      env = { day: today, min: value, max: value, category: binding.category, updatedAt };
+    } else if (value < current.min || value > current.max) {
+      env = {
+        ...current,
+        min: Math.min(current.min, value),
+        max: Math.max(current.max, value),
+        updatedAt,
+      };
+    } else {
+      return; // inside the envelope — nothing to update or persist
+    }
+
+    perAlias.set(alias, env);
+    this.stmts.upsert.run({
+      equipmentId,
+      alias,
+      day: env.day,
+      minValue: env.min,
+      maxValue: env.max,
+      updatedAt: env.updatedAt,
+    });
+
+    // Re-emit the computed aliases so the WebSocket layer pushes a fresh
+    // equipment payload (same convention as the pool trackers). handleSample
+    // ignores *_min_today / *_max_today, so this cannot loop.
+    for (const [computedAlias, computedValue] of [
+      [`${alias}_min_today`, env.min],
+      [`${alias}_max_today`, env.max],
+    ] as const) {
+      this.eventBus.emit({
+        type: "equipment.data.changed",
+        equipmentId,
+        alias: computedAlias,
+        value: computedValue,
+        previous: null,
+      });
+    }
+  }
+
+  private loadFromDb(): void {
+    const rows = this.stmts.selectAll.all() as ExtremesRow[];
+    const today = localDay(new Date());
+    for (const row of rows) {
+      // Past-day rows are left in place (overwritten on the next sample) but
+      // not loaded — getComputedDataForEquipment would hide them anyway.
+      if (row.day !== today) continue;
+      const binding = this.equipmentManager
+        .getDataBindingsWithValues(row.equipment_id)
+        .find((b) => b.alias === row.alias);
+      const category: DataCategory = binding?.category ?? "temperature";
+      let perAlias = this.state.get(row.equipment_id);
+      if (!perAlias) {
+        perAlias = new Map();
+        this.state.set(row.equipment_id, perAlias);
+      }
+      perAlias.set(row.alias, {
+        day: row.day,
+        min: row.min_value,
+        max: row.max_value,
+        category,
+        updatedAt: row.updated_at,
+      });
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { EquipmentManager } from "./equipments/equipment-manager.js";
 import { EquipmentStatusTracker } from "./equipments/equipment-status-tracker.js";
 import { PoolRuntimeTracker } from "./equipments/pool-runtime-tracker.js";
 import { PoolWaterTempTracker } from "./equipments/pool-water-temp-tracker.js";
+import { WeatherTempExtremesTracker } from "./equipments/weather-temp-extremes-tracker.js";
 import { ZoneAggregator } from "./zones/zone-aggregator.js";
 import { SunlightManager } from "./zones/sunlight-manager.js";
 import { RecipeManager } from "./recipes/engine/recipe-manager.js";
@@ -204,6 +205,18 @@ async function main() {
   const poolWaterTempTracker = new PoolWaterTempTracker(db, eventBus, equipmentManager, logger);
   equipmentManager.registerComputedDataProvider((eqId) =>
     poolWaterTempTracker.getComputedDataForEquipment(eqId),
+  );
+
+  // 9d. Weather temp extremes tracker (spec 134) — daily min/max per temperature
+  // binding on weather equipments, exposed as computed data.
+  const weatherTempExtremesTracker = new WeatherTempExtremesTracker(
+    db,
+    eventBus,
+    equipmentManager,
+    logger,
+  );
+  equipmentManager.registerComputedDataProvider((eqId) =>
+    weatherTempExtremesTracker.getComputedDataForEquipment(eqId),
   );
 
   // 10. Create Zone Aggregator + Sunlight Manager
@@ -447,6 +460,9 @@ async function main() {
   // 17c. Start pool water temp tracker (gates water temp by filtration/mode)
   poolWaterTempTracker.start();
 
+  // 17d. Start weather temp extremes tracker (spec 134)
+  weatherTempExtremesTracker.start();
+
   // 18. Initialize history writer (connects to InfluxDB if configured, subscribes to events)
   historyWriter.init();
 
@@ -557,6 +573,11 @@ async function main() {
       poolWaterTempTracker.stop();
     } catch (err) {
       logger.error({ err }, "Error stopping pool water temp tracker");
+    }
+    try {
+      weatherTempExtremesTracker.stop();
+    } catch (err) {
+      logger.error({ err }, "Error stopping weather temp extremes tracker");
     }
     try {
       notificationPublishService.destroy();

--- a/ui/src/components/TempExtremes.tsx
+++ b/ui/src/components/TempExtremes.tsx
@@ -1,0 +1,39 @@
+import { ArrowDown, ArrowUp } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Compact "today's min/max" line for a temperature reading (spec 134).
+ * Rendered small, under the main temperature value — ocean-blue arrow for
+ * the minimum, amber arrow for the maximum (Sowel palette), values in
+ * tabular mono to align with the other weather figures.
+ */
+export function TempExtremes({
+  min,
+  max,
+  large = false,
+}: {
+  min: number;
+  max: number;
+  /** 2x sizing for the mobile widget icon slot (rendered at 50% scale). */
+  large?: boolean;
+}) {
+  const { t } = useTranslation();
+  const arrow = large ? 22 : 11;
+  const text = large ? "text-[24px]" : "text-[12px]";
+  return (
+    <div className={`flex items-center justify-center leading-none ${large ? "gap-4" : "gap-2"}`}>
+      <span className="flex items-center gap-0.5" aria-label={t("weather.minToday")}>
+        <ArrowDown size={arrow} strokeWidth={2} className="text-primary/70 shrink-0" />
+        <span className={`font-mono ${text} font-medium tabular-nums text-text-tertiary`}>
+          {min.toFixed(1)}°
+        </span>
+      </span>
+      <span className="flex items-center gap-0.5" aria-label={t("weather.maxToday")}>
+        <ArrowUp size={arrow} strokeWidth={2} className="text-accent shrink-0" />
+        <span className={`font-mono ${text} font-medium tabular-nums text-text-tertiary`}>
+          {max.toFixed(1)}°
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/ui/src/components/TempExtremes.tsx
+++ b/ui/src/components/TempExtremes.tsx
@@ -18,23 +18,28 @@ export function TempExtremes({
   large?: boolean;
 }) {
   const { t } = useTranslation();
-  const arrow = large ? 20 : 11;
-  const text = large ? "text-[22px]" : "text-[12px]";
-  // The large (mobile 2x) variant drops the decimal: the icon slot is narrow
-  // and clips a full "↓17.4° ↑32.6°" line; whole degrees are plenty there.
-  const fmt = (v: number) => (large ? String(Math.round(v)) : v.toFixed(1));
+  // The large (mobile 2x) variant must fit "↓17.4° ↑32.6°" inside a narrow
+  // scaled icon slot: smaller arrows/text and minimal gaps, decimals kept.
+  const arrow = large ? 14 : 11;
+  const text = large ? "text-[18px]" : "text-[12px]";
   return (
-    <div className={`flex items-center justify-center leading-none ${large ? "gap-3" : "gap-2"}`}>
-      <span className="flex items-center gap-0.5" aria-label={t("weather.minToday")}>
+    <div className={`flex items-center justify-center leading-none ${large ? "gap-1.5" : "gap-2"}`}>
+      <span
+        className={`flex items-center ${large ? "" : "gap-0.5"}`}
+        aria-label={t("weather.minToday")}
+      >
         <ArrowDown size={arrow} strokeWidth={2} className="text-primary/70 shrink-0" />
         <span className={`font-mono ${text} font-medium tabular-nums text-text-tertiary`}>
-          {fmt(min)}°
+          {min.toFixed(1)}°
         </span>
       </span>
-      <span className="flex items-center gap-0.5" aria-label={t("weather.maxToday")}>
+      <span
+        className={`flex items-center ${large ? "" : "gap-0.5"}`}
+        aria-label={t("weather.maxToday")}
+      >
         <ArrowUp size={arrow} strokeWidth={2} className="text-accent shrink-0" />
         <span className={`font-mono ${text} font-medium tabular-nums text-text-tertiary`}>
-          {fmt(max)}°
+          {max.toFixed(1)}°
         </span>
       </span>
     </div>

--- a/ui/src/components/TempExtremes.tsx
+++ b/ui/src/components/TempExtremes.tsx
@@ -18,20 +18,23 @@ export function TempExtremes({
   large?: boolean;
 }) {
   const { t } = useTranslation();
-  const arrow = large ? 22 : 11;
-  const text = large ? "text-[24px]" : "text-[12px]";
+  const arrow = large ? 20 : 11;
+  const text = large ? "text-[22px]" : "text-[12px]";
+  // The large (mobile 2x) variant drops the decimal: the icon slot is narrow
+  // and clips a full "↓17.4° ↑32.6°" line; whole degrees are plenty there.
+  const fmt = (v: number) => (large ? String(Math.round(v)) : v.toFixed(1));
   return (
-    <div className={`flex items-center justify-center leading-none ${large ? "gap-4" : "gap-2"}`}>
+    <div className={`flex items-center justify-center leading-none ${large ? "gap-3" : "gap-2"}`}>
       <span className="flex items-center gap-0.5" aria-label={t("weather.minToday")}>
         <ArrowDown size={arrow} strokeWidth={2} className="text-primary/70 shrink-0" />
         <span className={`font-mono ${text} font-medium tabular-nums text-text-tertiary`}>
-          {min.toFixed(1)}°
+          {fmt(min)}°
         </span>
       </span>
       <span className="flex items-center gap-0.5" aria-label={t("weather.maxToday")}>
         <ArrowUp size={arrow} strokeWidth={2} className="text-accent shrink-0" />
         <span className={`font-mono ${text} font-medium tabular-nums text-text-tertiary`}>
-          {max.toFixed(1)}°
+          {fmt(max)}°
         </span>
       </span>
     </div>

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -21,7 +21,8 @@ import type { DashboardWidget } from "../../types";
 import { useEquipmentState, formatValue } from "../equipments/useEquipmentState";
 import { useCameraSnapshot } from "../../hooks/useCameraSnapshot";
 import { findOrderByCategory } from "../equipments/bindingUtils";
-import { findTempIndoor, findTempOutdoor } from "../equipments/weather-utils";
+import { findTempExtremes, findTempIndoor, findTempOutdoor } from "../equipments/weather-utils";
+import { TempExtremes } from "../TempExtremes";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
 import { SensorValues } from "../equipments/SensorValues";
 import { SolarPanelIcon } from "../icons/SolarPanelIcon";
@@ -804,6 +805,8 @@ function WeatherStationWidget({
 
   const outdoor = findTempOutdoor(equipment.dataBindings);
   const indoor = findTempIndoor(equipment.dataBindings);
+  const outdoorExtremes = findTempExtremes(equipment, "temperature_outdoor");
+  const indoorExtremes = findTempExtremes(equipment, "temperature");
 
   const fmt = (b: typeof outdoor) =>
     b && typeof b.value === "number" ? b.value.toFixed(1) : "—";
@@ -822,14 +825,14 @@ function WeatherStationWidget({
       <div className="flex items-stretch justify-center flex-1 min-h-0">
         {both ? (
           <div className="flex items-stretch gap-4 sm:gap-6">
-            <WeatherTempColumn label={t("weather.outdoor")} value={fmt(outdoor)} />
+            <WeatherTempColumn label={t("weather.outdoor")} value={fmt(outdoor)} extremes={outdoorExtremes} />
             <div className="w-px bg-border self-stretch" />
-            <WeatherTempColumn label={t("weather.indoor")} value={fmt(indoor)} />
+            <WeatherTempColumn label={t("weather.indoor")} value={fmt(indoor)} extremes={indoorExtremes} />
           </div>
         ) : outdoor ? (
-          <WeatherTempColumn label={t("weather.outdoor")} value={fmt(outdoor)} />
+          <WeatherTempColumn label={t("weather.outdoor")} value={fmt(outdoor)} extremes={outdoorExtremes} />
         ) : indoor ? (
-          <WeatherTempColumn label={t("weather.indoor")} value={fmt(indoor)} />
+          <WeatherTempColumn label={t("weather.indoor")} value={fmt(indoor)} extremes={indoorExtremes} />
         ) : (
           <WeatherTempColumn label={null} value="—" />
         )}
@@ -838,7 +841,15 @@ function WeatherStationWidget({
   );
 }
 
-function WeatherTempColumn({ label, value }: { label: string | null; value: string }) {
+function WeatherTempColumn({
+  label,
+  value,
+  extremes,
+}: {
+  label: string | null;
+  value: string;
+  extremes?: { min: number; max: number } | null;
+}) {
   return (
     <div className="flex flex-col items-center justify-center gap-1">
       {label && (
@@ -852,6 +863,7 @@ function WeatherTempColumn({ label, value }: { label: string | null; value: stri
         </span>
         <span className="text-text-tertiary font-medium text-[14px] sm:text-[16px] leading-none ml-1">°C</span>
       </div>
+      {extremes && <TempExtremes min={extremes.min} max={extremes.max} />}
     </div>
   );
 }

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -23,7 +23,8 @@ import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
 import { SolarPanelIcon } from "../icons/SolarPanelIcon";
 import { solarWidgetState } from "./solarWidget";
 import { parseForecastDays, CONDITION_ICONS, CONDITION_COLORS } from "../equipments/weatherForecastUtils";
-import { findTempIndoor, findTempOutdoor } from "../equipments/weather-utils";
+import { findTempExtremes, findTempIndoor, findTempOutdoor } from "../equipments/weather-utils";
+import { TempExtremes } from "../TempExtremes";
 import { Cloud, WashingMachine, Tv, Camera } from "lucide-react";
 
 interface MobileWidgetCardProps {
@@ -203,6 +204,8 @@ function useMobileState(
   if (equipment.type === "weather") {
     const outdoor = findTempOutdoor(equipment.dataBindings);
     const indoor = findTempIndoor(equipment.dataBindings);
+    const outdoorExtremes = findTempExtremes(equipment, "temperature_outdoor");
+    const indoorExtremes = findTempExtremes(equipment, "temperature");
     const fmt = (b: typeof outdoor) =>
       b && typeof b.value === "number" ? `${b.value.toFixed(1)}°` : "—";
     const both = !!outdoor && !!indoor;
@@ -211,7 +214,11 @@ function useMobileState(
     // captions. Single: one temperature with its explicit scope label —
     // never implicit, since reading just "20.5°" leaves the user wondering
     // which one this is.
-    const singleColumn = (b: typeof outdoor, captionKey: string) => (
+    const singleColumn = (
+      b: typeof outdoor,
+      captionKey: string,
+      extremes: { min: number; max: number } | null,
+    ) => (
       <div className="flex flex-col items-center gap-1 leading-none whitespace-nowrap">
         <span className="text-[18px] uppercase tracking-wide text-text-tertiary font-medium">
           {t(captionKey)}
@@ -219,6 +226,7 @@ function useMobileState(
         <span className="font-mono font-bold text-[56px] text-text tabular-nums leading-none">
           {fmt(b)}
         </span>
+        {extremes && <TempExtremes min={extremes.min} max={extremes.max} large />}
       </div>
     );
     return {
@@ -231,6 +239,9 @@ function useMobileState(
             <span className="font-mono font-bold text-[48px] text-text tabular-nums leading-none">
               {fmt(outdoor)}
             </span>
+            {outdoorExtremes && (
+              <TempExtremes min={outdoorExtremes.min} max={outdoorExtremes.max} large />
+            )}
           </div>
           <div className="w-px self-stretch bg-border" />
           <div className="flex flex-col items-center gap-1">
@@ -240,12 +251,15 @@ function useMobileState(
             <span className="font-mono font-bold text-[48px] text-text tabular-nums leading-none">
               {fmt(indoor)}
             </span>
+            {indoorExtremes && (
+              <TempExtremes min={indoorExtremes.min} max={indoorExtremes.max} large />
+            )}
           </div>
         </div>
       ) : outdoor ? (
-        singleColumn(outdoor, "weather.outdoorShort")
+        singleColumn(outdoor, "weather.outdoorShort", outdoorExtremes)
       ) : indoor ? (
-        singleColumn(indoor, "weather.indoorShort")
+        singleColumn(indoor, "weather.indoorShort", indoorExtremes)
       ) : (
         <div className="flex flex-col items-center gap-1 leading-none whitespace-nowrap">
           <span className="font-mono font-bold text-[56px] text-text tabular-nums">—</span>

--- a/ui/src/components/equipments/WeatherPanel.tsx
+++ b/ui/src/components/equipments/WeatherPanel.tsx
@@ -3,6 +3,7 @@ import { Wind, CloudRain, Thermometer } from "lucide-react";
 import type { ComputedDataEntry, DataBindingWithValue } from "../../types";
 import { getBatteryIcon, getBatteryColor, formatSensorValue } from "./sensorUtils";
 import { angleToCompass, syntheticBindingFromComputed } from "./weather-utils";
+import { TempExtremes } from "../TempExtremes";
 
 interface WeatherPanelProps {
   bindings: DataBindingWithValue[];
@@ -167,6 +168,7 @@ export function WeatherPanel({ bindings, equipmentId, computedData }: WeatherPan
           kind={dev.kind}
           sensorBindings={dev.sensorBindings}
           batteryBinding={dev.batteryBinding ?? null}
+          computedData={computedData}
         />
       ))}
     </div>
@@ -178,11 +180,13 @@ function WeatherDeviceCard({
   kind,
   sensorBindings,
   batteryBinding,
+  computedData,
 }: {
   deviceName: string;
   kind: DeviceKind;
   sensorBindings: DataBindingWithValue[];
   batteryBinding: DataBindingWithValue | null;
+  computedData?: ComputedDataEntry[];
 }) {
   const { t } = useTranslation();
   const batteryLevel =
@@ -193,6 +197,21 @@ function WeatherDeviceCard({
   // Find the primary (hero) binding
   const primaryKey = PRIMARY_KEY[kind] ?? PRIMARY_KEY.default;
   const primaryBinding = sensorBindings.find((b) => b.key === primaryKey);
+
+  // Today's min/max envelope (spec 134) — only meaningful when the hero is a
+  // temperature; the tracker's computed aliases derive from the binding alias.
+  const heroExtremes = (() => {
+    if (
+      !primaryBinding ||
+      (primaryBinding.category !== "temperature" &&
+        primaryBinding.category !== "temperature_outdoor")
+    ) {
+      return null;
+    }
+    const min = computedData?.find((c) => c.alias === `${primaryBinding.alias}_min_today`)?.value;
+    const max = computedData?.find((c) => c.alias === `${primaryBinding.alias}_max_today`)?.value;
+    return typeof min === "number" && typeof max === "number" ? { min, max } : null;
+  })();
 
   // For the wind module, surface direction next to the hero (arrow + compass label).
   const windAngleBinding =
@@ -261,6 +280,11 @@ function WeatherDeviceCard({
               </span>
             )}
           </div>
+          {heroExtremes && (
+            <div className="mt-1.5 flex justify-center">
+              <TempExtremes min={heroExtremes.min} max={heroExtremes.max} />
+            </div>
+          )}
           <div className="text-[12px] text-text-tertiary mt-1">
             {KEY_LABELS[primaryBinding.key]
               ? t(KEY_LABELS[primaryBinding.key])

--- a/ui/src/components/equipments/weather-utils.test.ts
+++ b/ui/src/components/equipments/weather-utils.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { DataBindingWithValue, EquipmentWithDetails } from "../../types";
+import { findTempExtremes } from "./weather-utils";
+
+function binding(alias: string, category: string): DataBindingWithValue {
+  return {
+    id: "b-" + alias,
+    equipmentId: "eq",
+    deviceDataId: "dd-" + alias,
+    deviceId: "d1",
+    deviceName: "Station",
+    alias,
+    key: alias,
+    type: "number",
+    category: category as DataBindingWithValue["category"],
+    value: 20,
+    unit: "°C",
+    lastUpdated: "2026-08-05 10:00:00Z",
+    lastChanged: "2026-08-05 10:00:00Z",
+    stale: false,
+  };
+}
+
+function equipment(
+  bindings: DataBindingWithValue[],
+  computed: { alias: string; value: unknown }[],
+): EquipmentWithDetails {
+  return {
+    id: "eq",
+    name: "Station",
+    zoneId: "z",
+    type: "weather",
+    enabled: true,
+    createdAt: "2026-08-01 00:00:00Z",
+    updatedAt: "2026-08-01 00:00:00Z",
+    dataBindings: bindings,
+    orderBindings: [],
+    computedData: computed.map((c) => ({ ...c, lastUpdated: "2026-08-05 10:00:00Z" })),
+    status: "online",
+  };
+}
+
+describe("findTempExtremes", () => {
+  it("resolves outdoor extremes via the source binding's alias", () => {
+    const eq = equipment(
+      [binding("temperature", "temperature_outdoor"), binding("temperature_2", "temperature")],
+      [
+        { alias: "temperature_min_today", value: 14.2 },
+        { alias: "temperature_max_today", value: 27.5 },
+        { alias: "temperature_2_min_today", value: 21 },
+        { alias: "temperature_2_max_today", value: 25.5 },
+      ],
+    );
+    expect(findTempExtremes(eq, "temperature_outdoor")).toEqual({ min: 14.2, max: 27.5 });
+    expect(findTempExtremes(eq, "temperature")).toEqual({ min: 21, max: 25.5 });
+  });
+
+  it("returns null when a bound temperature has no computed extremes yet", () => {
+    const eq = equipment([binding("temperature", "temperature_outdoor")], []);
+    expect(findTempExtremes(eq, "temperature_outdoor")).toBeNull();
+  });
+
+  it("returns null when one bound is missing or non-numeric", () => {
+    const eq = equipment(
+      [binding("temperature", "temperature_outdoor")],
+      [
+        { alias: "temperature_min_today", value: 14.2 },
+        { alias: "temperature_max_today", value: null },
+      ],
+    );
+    expect(findTempExtremes(eq, "temperature_outdoor")).toBeNull();
+  });
+
+  it("returns null when the category is not bound on the equipment", () => {
+    const eq = equipment(
+      [binding("temperature_2", "temperature")],
+      [{ alias: "temperature_min_today", value: 14.2 }],
+    );
+    expect(findTempExtremes(eq, "temperature_outdoor")).toBeNull();
+  });
+});

--- a/ui/src/components/equipments/weather-utils.ts
+++ b/ui/src/components/equipments/weather-utils.ts
@@ -1,4 +1,4 @@
-import type { ComputedDataEntry, DataBindingWithValue } from "../../types";
+import type { ComputedDataEntry, DataBindingWithValue, EquipmentWithDetails } from "../../types";
 
 /**
  * Build a synthetic DataBindingWithValue from a ComputedDataEntry so the
@@ -70,4 +70,26 @@ export function findHumidityOutdoor(bindings: DataBindingWithValue[]): DataBindi
 }
 export function findHumidityIndoor(bindings: DataBindingWithValue[]): DataBindingWithValue | undefined {
   return bindings.find((b) => b.category === "humidity");
+}
+
+/**
+ * Today's measured min/max for the indoor or outdoor temperature (spec 134).
+ *
+ * The backend tracker exposes `<alias>_min_today` / `<alias>_max_today`
+ * computed entries per temperature binding. The alias is derived from the
+ * source binding (which varies: `temperature`, `temperature_2`, ...), so we
+ * resolve the source binding by category first, then look its computed
+ * extremes up by alias. Returns null unless both bounds are numbers.
+ */
+export function findTempExtremes(
+  equipment: EquipmentWithDetails,
+  category: "temperature" | "temperature_outdoor",
+): { min: number; max: number } | null {
+  const source = equipment.dataBindings.find((b) => b.category === category);
+  if (!source) return null;
+  const computed = equipment.computedData ?? [];
+  const min = computed.find((c) => c.alias === `${source.alias}_min_today`)?.value;
+  const max = computed.find((c) => c.alias === `${source.alias}_max_today`)?.value;
+  if (typeof min !== "number" || typeof max !== "number") return null;
+  return { min, max };
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -393,6 +393,8 @@
   "weather.indoor": "Indoor",
   "weather.outdoorShort": "Out.",
   "weather.indoorShort": "In.",
+  "weather.minToday": "Today's minimum",
+  "weather.maxToday": "Today's maximum",
   "weather.windSpeed": "Speed",
   "weather.windDirection": "Direction",
   "weather.gustSpeed": "Gusts",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -393,6 +393,8 @@
   "weather.indoor": "Intérieur",
   "weather.outdoorShort": "Ext.",
   "weather.indoorShort": "Int.",
+  "weather.minToday": "Minimum du jour",
+  "weather.maxToday": "Maximum du jour",
   "weather.windSpeed": "Vitesse",
   "weather.windDirection": "Direction",
   "weather.gustSpeed": "Rafales",


### PR DESCRIPTION
## Summary

Implements spec 134 — the daily measured min/max temperature deferred by spec 114 ("kept for a later spec").

A new core tracker (`WeatherTempExtremesTracker`, following the `PoolWaterTempTracker` pattern) listens to `equipment.data.changed` for temperature-category bindings (`temperature`, `temperature_outdoor`) on `weather` equipments, keeps the min/max envelope since local midnight, persists it in SQLite (restart-proof), and exposes `<alias>_min_today` / `<alias>_max_today` as computed data. Vendor-agnostic: works with any station that reports a temperature — no plugin change, no new API route (computedData already flows over REST + WS).

## Changes

- `migrations/013_weather_temp_extremes.sql` — envelope table (one row per equipment × binding, current day only)
- `src/equipments/weather-temp-extremes-tracker.ts` + wiring in `index.ts` (provider registration, start/stop)
- UI: shared `TempExtremes` component (↓ min in ocean blue, ↑ max in amber, tabular mono, small under the hero temperature) rendered on:
  - desktop dashboard `WeatherStationWidget` (outdoor + indoor columns)
  - mobile `MobileWidgetCard` (2x sizing for the scaled icon slot)
  - `WeatherPanel` module cards (outdoor and indoor heroes)
- `findTempExtremes` helper (category-based resolution — aliases vary per install)
- i18n FR/EN (aria labels), user docs updated (EN + FR)

## Test plan

- [x] 11 new tracker tests (first sample, envelope updates, midnight rollover, restart reload, past-day row ignored, non-numeric ignored, non-weather ignored, non-temperature category ignored, indoor/outdoor independence, empty computed data, equipment deletion cleanup)
- [x] 4 new UI helper tests (alias resolution by category, missing/non-numeric bounds, unbound category)
- [x] Backend: 1002 tests pass, `tsc --noEmit` clean, eslint 0 errors/0 warnings
- [x] UI: `tsc -b` clean, eslint 0 errors (2 pre-existing warnings)
- [ ] Manual verification against a live weather station (pending — will build its envelope from the first samples after deploy; can be verified on the demo instance before release if desired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)