### PR TITLE
release: v1.32.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,14 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.32.x: Min/max météo du jour
+
+### v1.32.0 — 2026-08-05 { #v1-32-0 }
+
+- Feat (equipments) : les équipements station météo affichent désormais **les températures minimale et maximale mesurées aujourd'hui**, en petit sous chaque température — sur le widget du dashboard (PC et mobile) et sur la page de détail de l'équipement (modules extérieur et intérieur). Sowel calcule lui-même cette enveloppe à partir des mesures qu'il reçoit déjà : cela fonctionne avec toute station qui remonte une température, sans configuration et quel que soit le fabricant. L'enveloppe se remet à zéro à minuit local et survit aux redémarrages. À noter le premier jour après la mise à jour : le min/max démarre au moment de la mise à jour, il devient exact dès le lendemain. (#344)
+
+---
+
 ## 1.31.x: Équipement caméra
 
 ### v1.31.1 — 2026-08-05 { #v1-31-1 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,14 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.32.x: Weather daily min/max
+
+### v1.32.0 — 2026-08-05 { #v1-32-0 }
+
+- Feat (equipments): weather station equipments now show **today's measured minimum and maximum temperature** in small under each temperature reading — on the desktop dashboard widget, the mobile dashboard widget, and the equipment detail page (outdoor and indoor modules). Sowel tracks the envelope itself from the temperature samples it already receives, so it works with any station that reports a temperature, without configuration and regardless of vendor. The envelope resets at local midnight and survives restarts. Note for the first day after updating: the min/max starts counting from the update, so it becomes fully accurate the next day. (#344)
+
+---
+
 ## 1.31.x: Camera equipment
 
 ### v1.31.1 — 2026-08-05 { #v1-31-1 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sowel",
-  "version": "1.31.1",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sowel",
-      "version": "1.31.1",
+      "version": "1.32.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cors": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.31.1",
+  "version": "1.32.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "1.31.1",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "1.31.1",
+      "version": "1.32.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.31.1",
+  "version": "1.32.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Release v1.32.0: daily min/max temperature on weather equipments.

- feat(equipments): daily measured min/max under each temperature on the weather widgets and detail page, spec 134 (#344)
- Release notes added in both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-32-0 }` anchor (spec 108)
- Version bump 1.31.1 → 1.32.0, lockfiles synced

Pre-flight checks: backend tsc/eslint/vitest (1002 tests), UI tsc — all green. Feature validated end-to-end on a shadow instance seeded with prod data (envelope persistence across restart, API computedData, visual check on the three surfaces, mobile fit at 390px).

After merge: tag the on-main release commit as `v1.32.0` and push the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)