### PR TITLE
chore(registry): add smart-cooling recipe 1.0.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -492,5 +492,25 @@
     "sowelVersion": ">=1.2.12",
     "owner": "alpitux",
     "sha256": "6f50d7950c1157066090bd03e59a9898cd204d900b72d20a449ed62e8c84c11d"
+  },
+  {
+    "id": "smart-cooling",
+    "type": "recipe",
+    "name": "Smart Cooling",
+    "description": "Solar-aware AC optimizer: morning airing notifications, pre-cooling on solar surplus, comfort setpoint, fixed-time night cut",
+    "icon": "Snowflake",
+    "author": "mchacher",
+    "repo": "mchacher/sowel-recipe-smart-cooling",
+    "version": "1.0.0",
+    "tags": ["cooling", "ac", "solar", "energy", "automation"],
+    "i18n": {
+      "fr": {
+        "name": "Clim intelligente",
+        "description": "Optimise la climatisation avec le solaire : notifications d'aération le matin, pré-refroidissement sur surplus solaire, consigne confort, extinction nocturne à heure fixe."
+      }
+    },
+    "sowelVersion": ">=1.31.1",
+    "owner": "mchacher",
+    "sha256": "0da46667a5c4fa563947576480e3b1ef8c5c0dce63eae48a9666d408aa0e156a"
   }
 ]


### PR DESCRIPTION
## Summary

Adds the new [smart-cooling recipe](https://github.com/mchacher/sowel-recipe-smart-cooling) (v1.0.0) to the registry — solar-aware AC optimizer designed from 62 days of production data (spec 001 in the recipe repo): morning airing notifications, pre-cooling on sustained solar surplus during hot days, comfort restore, fixed-time night cut.

- `sha256` computed from the published `sowel-recipe-smart-cooling-1.0.0.tar.gz` release asset and verified locally (tarball contains manifest 1.0.0, `shasum -a 256` matches)
- `sowelVersion: ">=1.31.1"` — the openWindows/closeWindows notifications rely on the rising-edge-only boolean mapping behavior shipped in v1.31.1
- 18 test scenarios in the recipe repo, tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)