### PR TITLE
chore(registry): bump smart-cooling to 1.1.0 (full-auto ON/OFF)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -501,7 +501,7 @@
     "icon": "Snowflake",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-smart-cooling",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "tags": ["cooling", "ac", "solar", "energy", "automation"],
     "i18n": {
       "fr": {
@@ -511,6 +511,6 @@
     },
     "sowelVersion": ">=1.31.1",
     "owner": "mchacher",
-    "sha256": "0da46667a5c4fa563947576480e3b1ef8c5c0dce63eae48a9666d408aa0e156a"
+    "sha256": "96c86f501ffc906d97472f4dd77d68a2609196844a55b47a515a17ddb7671e8a"
   }
 ]


### PR DESCRIPTION
## Summary

Bumps the smart-cooling recipe to [v1.1.0](https://github.com/mchacher/sowel-recipe-smart-cooling/releases/tag/v1.1.0): full-auto comfort ON/OFF (auto-on when indoor exceeds comfort+margin inside the sunrise→night window, auto-off on the banked cold), plus two design fixes caught by tests (night rollover could re-engage the AC at midnight; the open-windows suggestion could fire on cool evenings).

- `sha256` computed from the published tarball and verified locally
- 23 tests, tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)