### PR TITLE
fix(equipments): button equipments are not offlined by silence

### DIFF
--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -374,7 +374,12 @@ export class EquipmentManager {
 
     // Spec 116: derive equipment status from bindings + backing devices.
     const devicesByBindingId = this.resolveDevicesForBindings(dataBindings);
-    const { status, reason } = deriveEquipmentStatus(dataBindings, devicesByBindingId);
+    const { status, reason } = deriveEquipmentStatus(
+      dataBindings,
+      devicesByBindingId,
+      Date.now(),
+      equipment.type,
+    );
 
     return {
       ...equipment,
@@ -393,7 +398,12 @@ export class EquipmentManager {
       const orderBindings = this.getOrderBindingsWithDetails(eq.id);
       const computedData = this.getComputedData(eq.id);
       const devicesByBindingId = this.resolveDevicesForBindings(dataBindings);
-      const { status, reason } = deriveEquipmentStatus(dataBindings, devicesByBindingId);
+      const { status, reason } = deriveEquipmentStatus(
+        dataBindings,
+        devicesByBindingId,
+        Date.now(),
+        eq.type,
+      );
       return {
         ...eq,
         dataBindings,

--- a/src/equipments/equipment-status.test.ts
+++ b/src/equipments/equipment-status.test.ts
@@ -214,3 +214,46 @@ describe("deriveEquipmentStatus", () => {
     expect(result.status).toBe("online");
   });
 });
+
+describe("deriveEquipmentStatus — button silence exemption (issue #348)", () => {
+  const NOW = Date.parse("2026-05-26T10:00:00Z");
+
+  it("button: all devices offline still derives 'online' (silence is normal)", () => {
+    const binding = makeBinding({ category: "action" });
+    const device = makeDevice({ status: "offline", name: "remote_elodie" });
+    const map = new Map([[binding.id, device]]);
+    const result = deriveEquipmentStatus([binding], map, NOW, "button");
+    expect(result.status).toBe("online");
+    expect(result.reason).toBeNull();
+  });
+
+  it("button: stale battery binding does not degrade", () => {
+    const action = makeBinding({ id: "b1", category: "action" });
+    const battery = makeBinding({
+      id: "b2",
+      alias: "battery",
+      category: "battery",
+      lastUpdated: "2026-05-25 08:00:00Z", // > 2h old
+    });
+    const device = makeDevice({ status: "online" });
+    const map = new Map([
+      [action.id, device],
+      [battery.id, device],
+    ]);
+    const result = deriveEquipmentStatus([action, battery], map, NOW, "button");
+    expect(result.status).toBe("online");
+  });
+
+  it("button: zero bindings still derives 'offline'", () => {
+    const result = deriveEquipmentStatus([], new Map(), NOW, "button");
+    expect(result.status).toBe("offline");
+  });
+
+  it("non-exempt type: all devices offline still derives 'offline' (regression)", () => {
+    const binding = makeBinding({});
+    const device = makeDevice({ status: "offline", name: "Capteur" });
+    const map = new Map([[binding.id, device]]);
+    const result = deriveEquipmentStatus([binding], map, NOW, "sensor");
+    expect(result.status).toBe("offline");
+  });
+});

--- a/src/equipments/equipment-status.ts
+++ b/src/equipments/equipment-status.ts
@@ -67,16 +67,38 @@ export function isStaleBinding(
  * @param devicesByBindingId Map from binding id to the Device behind it.
  * @param now                Injection point for tests; defaults to Date.now().
  */
+/**
+ * Equipment types whose devices are event-driven battery hardware (remotes,
+ * wireless buttons): they only transmit when actuated, so radio silence is
+ * their NORMAL operating mode. Deriving "offline" (integration availability
+ * timeouts fire on silence) or "degraded" (their sparse battery reports miss
+ * every streaming window) from that silence produces permanent false alarms
+ * — see issue #348, observed with both lora2mqtt (5 min timeout) and
+ * Zigbee2MQTT (25 h passive timeout). For these types the only honest
+ * derivation from silence is "online"; real health comes out of band
+ * (battery_low / vcc values).
+ *
+ * Trade-off, documented: a genuinely dead remote also shows online. With
+ * timeout-based availability the two cases are indistinguishable anyway —
+ * the previous behavior just labeled BOTH as broken instead of neither.
+ */
+const SILENCE_EXEMPT_EQUIPMENT_TYPES: ReadonlySet<string> = new Set(["button"]);
+
 export function deriveEquipmentStatus(
   bindings: DataBindingWithValue[],
   devicesByBindingId: Map<string, Device>,
   now: number = Date.now(),
+  equipmentType?: string,
 ): { status: EquipmentStatus; reason: EquipmentStatusReason | null } {
   if (bindings.length === 0) {
     return {
       status: "offline",
       reason: { offlineDevices: [], staleBindings: [], offlineSince: null },
     };
+  }
+
+  if (equipmentType && SILENCE_EXEMPT_EQUIPMENT_TYPES.has(equipmentType)) {
+    return { status: "online", reason: null };
   }
 
   // Collect unique devices behind the bindings (an equipment can bind to


### PR DESCRIPTION
## Summary

Fixes the core half of #348. Event-driven battery devices (remotes, wireless buttons) only transmit when actuated — silence is their normal operating mode. Integration availability timeouts fire on that silence (observed live: lora2mqtt marks nodes offline after 5 min, Zigbee2MQTT passive devices after 25 h), and the spec 116 derivation then surfaced healthy remotes as red "Déconnecté" badges. Their sparse battery reports also missed the 2 h streaming-staleness window.

`deriveEquipmentStatus` now receives the equipment type and derives `online` for silence-exempt types (`button`) whenever bindings exist — device-offline and streaming staleness both ignored for this class, since neither is meaningful for it. Recipes and automations reading `status` benefit too (no false offline).

Trade-off documented in the code comment: a genuinely dead remote also shows online — with timeout-based availability the two cases were indistinguishable anyway; the previous behavior labeled both as broken instead of neither. Real health signals (battery_low, vcc) remain the honest path, and a "probably dead after weeks" hint stays open in #348.

Companion source-side fix already deployed for the reporter's installation: lora2mqttpy per-node availability class (mchacher/lora2mqttpy#1, merged) — `event` nodes are never auto-offlined by the bridge.

## Test plan

- [x] 4 new tests: button + all devices offline → online; button + stale battery → online; button + zero bindings → offline (unchanged); non-exempt type + all offline → offline (regression)
- [x] Full backend suite: 1006 passed, tsc clean, eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)