### PR TITLE
fix(recipes): restart running instances after a package update

### DIFF
--- a/src/recipes/engine/recipe-manager.test.ts
+++ b/src/recipes/engine/recipe-manager.test.ts
@@ -305,3 +305,125 @@ describe("RecipeManager", () => {
     expect(logs.some((l) => l.message === "Instance created")).toBe(true);
   });
 });
+
+// ============================================================
+// restartInstancesOfRecipe (issue #349)
+// ============================================================
+
+describe("restartInstancesOfRecipe", () => {
+  let db: Database.Database;
+  let eventBus: EventBus;
+  let manager: RecipeManager;
+
+  beforeEach(() => {
+    db = createTestDb();
+    eventBus = new EventBus(logger);
+    const zoneManager = new ZoneManager(db, eventBus, logger);
+    const mockIntegrationRegistry = { getById: () => undefined };
+    const deviceManager = new DeviceManager(db, eventBus, logger);
+    const equipmentManager = new EquipmentManager(
+      db,
+      eventBus,
+      mockIntegrationRegistry as any,
+      deviceManager,
+      logger,
+    );
+    const aggregator = new ZoneAggregator(zoneManager, equipmentManager, eventBus, logger);
+    const sunlightManager = {
+      getSunlightData: () => ({ sunrise: "07:30", sunset: "21:00", isDaylight: true }),
+    } as unknown as SunlightManager;
+    manager = new RecipeManager(
+      db,
+      eventBus,
+      equipmentManager,
+      zoneManager,
+      aggregator,
+      sunlightManager,
+      logger,
+    );
+  });
+
+  afterEach(() => {
+    manager.stopAll();
+    db.close();
+  });
+
+  function externalDef(marker: { started: number; stopped: number }): RecipeDefinition {
+    return {
+      id: "ext-recipe",
+      name: "Ext",
+      description: "external",
+      slots: [],
+      validate: () => {},
+      createInstance: () => {
+        marker.started++;
+        return {
+          stop: () => {
+            marker.stopped++;
+          },
+        };
+      },
+    };
+  }
+
+  it("restarts enabled instances with the newly registered definition", () => {
+    const v1 = { started: 0, stopped: 0 };
+    manager.registerExternal(externalDef(v1));
+    const inst = manager.createInstance("ext-recipe", {});
+    expect(v1.started).toBe(1);
+
+    // Package update: new definition registered under the same id.
+    const v2 = { started: 0, stopped: 0 };
+    manager.registerExternal(externalDef(v2));
+    const restarted = manager.restartInstancesOfRecipe("ext-recipe");
+
+    expect(restarted).toBe(1);
+    expect(v1.stopped).toBe(1); // old closure stopped
+    expect(v2.started).toBe(1); // new closure started
+    expect(manager.getInstances().find((i) => i.id === inst.id)?.enabled).toBe(true);
+  });
+
+  it("leaves disabled instances alone", () => {
+    const v1 = { started: 0, stopped: 0 };
+    manager.registerExternal(externalDef(v1));
+    const inst = manager.createInstance("ext-recipe", {});
+    manager.disableInstance(inst.id);
+    expect(v1.stopped).toBe(1);
+
+    const v2 = { started: 0, stopped: 0 };
+    manager.registerExternal(externalDef(v2));
+    const restarted = manager.restartInstancesOfRecipe("ext-recipe");
+
+    expect(restarted).toBe(0);
+    expect(v2.started).toBe(0);
+  });
+
+  it("returns 0 for an unknown recipe id", () => {
+    expect(manager.restartInstancesOfRecipe("nope")).toBe(0);
+  });
+
+  it("a failing new definition is logged, not thrown, and other instances still restart", () => {
+    const v1 = { started: 0, stopped: 0 };
+    manager.registerExternal(externalDef(v1));
+    manager.createInstance("ext-recipe", {});
+    manager.createInstance("ext-recipe", {});
+    expect(v1.started).toBe(2);
+
+    let calls = 0;
+    manager.registerExternal({
+      id: "ext-recipe",
+      name: "Ext",
+      description: "external",
+      slots: [],
+      validate: () => {},
+      createInstance: () => {
+        calls++;
+        if (calls === 1) throw new Error("boom");
+        return { stop: () => {} };
+      },
+    });
+
+    const restarted = manager.restartInstancesOfRecipe("ext-recipe");
+    expect(restarted).toBe(1); // second instance restarted despite first failing
+  });
+});

--- a/src/recipes/engine/recipe-manager.ts
+++ b/src/recipes/engine/recipe-manager.ts
@@ -146,6 +146,47 @@ export class RecipeManager {
     this.logger.info({ recipeId: definition.id }, "External recipe registered");
   }
 
+  /**
+   * Restart every enabled instance of a recipe with the currently registered
+   * definition (issue #349). Called by the RecipeLoader after a package
+   * update re-registers the definition: without this, running instances keep
+   * executing the previous version's closure until manually toggled, while
+   * the UI already shows the new version. Instance state (ctx.state) is
+   * persisted and survives, exactly as with enable/disable.
+   */
+  restartInstancesOfRecipe(recipeId: string): number {
+    const registered = this.registry.get(recipeId);
+    if (!registered) return 0;
+
+    const rows = this.stmts.getAllInstances.all() as InstanceRow[];
+    let restarted = 0;
+    for (const row of rows) {
+      if (row.recipe_id !== recipeId || row.enabled !== 1) continue;
+      this.stopInstance(row.id);
+      const instance = rowToInstance(row);
+      try {
+        const recipe = registered.create();
+        this.startInstance(recipe, instance);
+        restarted++;
+        this.writeLog(row.id, "Restarted with updated recipe package", "info");
+      } catch (err) {
+        this.logger.error(
+          { err, instanceId: row.id, recipeId },
+          "Failed to restart instance after recipe update",
+        );
+        this.writeLog(
+          row.id,
+          `Failed to restart after update: ${err instanceof Error ? err.message : String(err)}`,
+          "error",
+        );
+      }
+    }
+    if (restarted > 0) {
+      this.logger.info({ recipeId, restarted }, "Recipe instances restarted after package update");
+    }
+    return restarted;
+  }
+
   // ============================================================
   // Init — restore instances from DB
   // ============================================================

--- a/src/recipes/recipe-loader.ts
+++ b/src/recipes/recipe-loader.ts
@@ -45,7 +45,13 @@ export class RecipeLoader {
     const newManifest = await this.packageManager.updateFiles(recipeId);
     try {
       await this.loadRecipe(recipeId);
-      this.logger.info({ recipeId, version: newManifest.version }, "Recipe updated and reloaded");
+      // Issue #349: running instances would otherwise keep executing the
+      // previous version's closure while the UI already shows the update.
+      const restarted = this.recipeManager.restartInstancesOfRecipe(recipeId);
+      this.logger.info(
+        { recipeId, version: newManifest.version, restartedInstances: restarted },
+        "Recipe updated and reloaded",
+      );
     } catch (err) {
       this.logger.error({ err, recipeId }, "Recipe updated but failed to reload");
     }


### PR DESCRIPTION
## Summary

Closes #349. A recipe package update reloaded the definition (new slots immediately visible in the create/edit form) but **running instances kept executing the previous version's closure** until manually disabled/enabled — silently, while the UI claimed the update succeeded. Observed live during the smart-cooling 1.0.0 → 1.1.0 rollout.

- `RecipeManager.restartInstancesOfRecipe(recipeId)`: stops each enabled instance's old closure, starts a fresh one from the newly registered definition. Persisted `ctx.state` survives (daily latches, phase...), exactly as with the existing enable/disable path. One log line per restarted instance ("Restarted with updated recipe package") for the audit trail.
- `RecipeLoader.update()` calls it right after re-registering the definition and logs the restarted count.
- Disabled instances are left alone; a failing instance is logged and skipped without blocking the others.

## Test plan

- [x] 4 new tests: enabled instance restarted with the new closure (old stopped, new started, still enabled); disabled instance untouched; unknown recipeId → 0; failing new definition logged and skipped while sibling instances still restart
- [x] Full backend suite: 1010 passed, tsc clean, eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)