### PR TITLE
chore(registry): bump smart-cooling to 1.2.0 (dedicated indoor sensor)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -501,7 +501,7 @@
     "icon": "Snowflake",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-smart-cooling",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "tags": ["cooling", "ac", "solar", "energy", "automation"],
     "i18n": {
       "fr": {
@@ -511,6 +511,6 @@
     },
     "sowelVersion": ">=1.31.1",
     "owner": "mchacher",
-    "sha256": "96c86f501ffc906d97472f4dd77d68a2609196844a55b47a515a17ddb7671e8a"
+    "sha256": "d4b632af817acbfaefb7be0c4ea54666e8088e3d0013bc78c40de2fcd12c336c"
   }
 ]


### PR DESCRIPTION
## Summary

Bumps smart-cooling to [v1.2.0](https://github.com/mchacher/sowel-recipe-smart-cooling/releases/tag/v1.2.0): optional dedicated indoor temperature sensor slot, fixing a live incident where the Panasonic AC's frozen-while-off indoor probe (26°C held for 11h, then jumped to the real 22°C) made the morning airing fire open-then-close within 24 minutes. Point the new slot at a continuous sensor (weather station indoor module) and T_int is read from there for airing and comfort auto on/off. Slots renamed to what they provide (Outdoor / Indoor temperature). Backward compatible (default = the AC's own probe).

- `sha256` recomputed from the republished tarball and verified locally (manifest 1.2.0, `indoorSensor` present in the built bundle, `shasum -a 256` matches)
- Note: the initial v1.2.0 tag briefly pointed at the wrong commit; the release was deleted and rebuilt from the correct commit before this bump.
- 26 tests, tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)