### PR TITLE
fix(packages): forced registry refresh via GitHub Contents API

### DIFF
--- a/src/packages/package-manager.test.ts
+++ b/src/packages/package-manager.test.ts
@@ -382,3 +382,92 @@ describe("registry-types.isOfficial", () => {
     ).toBe(true);
   });
 });
+
+describe("PackageManager — forced registry refresh (issue #353)", () => {
+  let tmpDir: string;
+  let db: Database.Database;
+  let manager: PackageManager;
+  let originalCwd: string;
+
+  const REGISTRY = [
+    {
+      id: "smart-cooling",
+      type: "recipe",
+      name: "Smart Cooling",
+      description: "x",
+      icon: "Snowflake",
+      author: "mchacher",
+      repo: "mchacher/sowel-recipe-smart-cooling",
+      version: "1.2.0",
+      owner: "mchacher",
+      sha256: "d".repeat(64),
+      tags: [],
+    },
+  ];
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = mkdtempSync(resolve(tmpdir(), "sowel-pkg-refresh-"));
+    mkdirSync(resolve(tmpDir, "plugins"), { recursive: true });
+    process.chdir(tmpDir);
+    db = createTestDb();
+    manager = new PackageManager(db, logger);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    db.close();
+    try {
+      process.chdir(originalCwd);
+    } catch {
+      /* best effort */
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("forced refresh fetches the Contents API, not the raw CDN", async () => {
+    const urls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: URL | RequestInfo) => {
+        const url = typeof input === "string" ? input : input.toString();
+        urls.push(url);
+        return new Response(JSON.stringify(REGISTRY), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+
+    const result = await manager.refreshRegistryNow();
+    expect(result.source).toBe("remote");
+    expect(result.count).toBe(1);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]).toContain("api.github.com/repos/mchacher/sowel/contents/");
+    expect(urls[0]).not.toContain("raw.githubusercontent.com");
+  });
+
+  it("falls back to raw when the Contents API fails on a forced refresh", async () => {
+    const urls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: URL | RequestInfo) => {
+        const url = typeof input === "string" ? input : input.toString();
+        urls.push(url);
+        if (url.includes("api.github.com")) {
+          return new Response("rate limited", { status: 403 });
+        }
+        return new Response(JSON.stringify(REGISTRY), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+
+    const result = await manager.refreshRegistryNow();
+    expect(result.source).toBe("remote");
+    expect(result.count).toBe(1);
+    expect(urls.some((u) => u.includes("api.github.com"))).toBe(true);
+    expect(urls.some((u) => u.includes("raw.githubusercontent.com"))).toBe(true);
+  });
+});

--- a/src/packages/package-manager.ts
+++ b/src/packages/package-manager.ts
@@ -29,6 +29,13 @@ import {
 const execFile = promisify(execFileCb);
 
 const REGISTRY_URL = "https://raw.githubusercontent.com/mchacher/sowel/main/plugins/registry.json";
+// GitHub Contents API — reflects `main` immediately, with none of the ~5 min
+// Fastly CDN that raw.githubusercontent.com serves (and that a `?t=` query
+// string does NOT bypass). Used only by the manual "Refresh" button so a
+// registry merge is visible within seconds; the passive/background path stays
+// on raw to avoid the API's 60/h unauthenticated rate limit (issue #353).
+const REGISTRY_API_URL =
+  "https://api.github.com/repos/mchacher/sowel/contents/plugins/registry.json";
 const REGISTRY_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 const SHA256_HEX = /^[a-f0-9]{64}$/i;
 
@@ -439,12 +446,14 @@ export class PackageManager {
    * a cache-busting query string so we bypass the raw CDN's 5-min cache.
    */
   private async fetchRemoteRegistry(force: boolean): Promise<boolean> {
-    const url = force ? `${REGISTRY_URL}?t=${Date.now()}` : REGISTRY_URL;
+    // Force (manual Refresh) → Contents API, which is not behind raw's 5 min
+    // CDN. Passive → raw (cached, no API rate-limit exposure). See issue #353.
+    const url = force ? REGISTRY_API_URL : REGISTRY_URL;
+    const headers: Record<string, string> = force
+      ? { Accept: "application/vnd.github.raw" }
+      : { Accept: "application/json" };
     try {
-      const res = await fetch(url, {
-        headers: { Accept: "application/json", ...(force ? { "Cache-Control": "no-cache" } : {}) },
-        signal: AbortSignal.timeout(10_000),
-      });
+      const res = await fetch(url, { headers, signal: AbortSignal.timeout(10_000) });
       if (res.ok) {
         const entries = (await res.json()) as RegistryEntry[];
         if (Array.isArray(entries) && entries.length > 0) {
@@ -452,6 +461,27 @@ export class PackageManager {
           this.registryCacheTime = Date.now();
           this.logger.info({ count: entries.length, force }, "Remote registry loaded");
           return true;
+        }
+      }
+      // On a forced refresh, if the API path fails (rate limit, outage), retry
+      // once via raw before falling back to local — raw is usually only a few
+      // minutes stale, still better than the on-disk snapshot.
+      if (force) {
+        const rawRes = await fetch(REGISTRY_URL, {
+          headers: { Accept: "application/json" },
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (rawRes.ok) {
+          const entries = (await rawRes.json()) as RegistryEntry[];
+          if (Array.isArray(entries) && entries.length > 0) {
+            this.registryCache = entries;
+            this.registryCacheTime = Date.now();
+            this.logger.info(
+              { count: entries.length, force, via: "raw-fallback" },
+              "Remote registry loaded",
+            );
+            return true;
+          }
         }
       }
     } catch {


### PR DESCRIPTION
## Summary

Closes #353. The Plugins page **Refresh** button bypassed Sowel's own 1h cache but its underlying fetch hit `raw.githubusercontent.com`, whose ~5 min Fastly CDN ignores the `?t=` cache-buster and `Cache-Control: no-cache` — so a just-merged `registry.json` stayed invisible for minutes while the button reported success (observed live during the smart-cooling 1.2.0 bump).

The **force** path now fetches the GitHub Contents API (`Accept: application/vnd.github.raw`), which reflects `main` instantly with no CDN. On API failure (rate limit / outage) it retries once via raw, then falls back to local — the same degradation chain as before. The passive/background/periodic refresh keeps using raw (cached, no API rate-limit exposure).

## Test plan

- [x] 2 new tests: forced refresh hits the Contents API and not raw; on API 403 it falls back to raw and still loads
- [x] Full backend suite: 1008 passed, tsc clean, eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)