### PR TITLE
release: v1.33.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,16 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.33.x: Corrections de fiabilité
+
+### v1.33.0 — 2026-08-07 { #v1-33-0 }
+
+- Fix (equipments) : les télécommandes et boutons sans fil à pile ne sont plus affichés « **Déconnecté** » simplement parce qu'ils sont restés silencieux. Ces appareils n'émettent qu'à l'appui : le silence est normal, le badge rouge était un faux positif (et il apprenait à ignorer les badges rouges, masquant les vraies déconnexions). Ils restent désormais en ligne ; une pile réellement faible reste signalée par la donnée de batterie. Valable pour toutes les intégrations (Zigbee, LoRa, ...). (#348)
+- Fix (recipes) : mettre à jour une recette depuis le store redémarre désormais immédiatement ses automatisations en cours. Avant, la nouvelle version était chargée et visible dans le formulaire, mais les instances actives continuaient d'exécuter l'ancienne logique jusqu'à un désactiver/réactiver manuel — un piège silencieux. (#349)
+- Fix (plugins) : le bouton **Rafraîchir** de la page Plugins affiche désormais un changement de catalogue tout juste publié en quelques secondes au lieu d'attendre plusieurs minutes. Il interrogeait une copie en cache qu'il ne pouvait pas contourner ; il lit maintenant la source à jour directement. (#353)
+
+---
+
 ## 1.32.x: Min/max météo du jour
 
 ### v1.32.0 — 2026-08-05 { #v1-32-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,16 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.33.x: Reliability fixes
+
+### v1.33.0 — 2026-08-07 { #v1-33-0 }
+
+- Fix (equipments): battery-powered remotes and wireless buttons are no longer shown as **"Disconnected"** just because they have been silent. These devices only transmit when pressed, so silence is normal — the red badge was a false alarm (and it trained users to ignore red badges, hiding real disconnections). They now stay online; genuine low battery still shows through the battery signal. Applies to every integration (Zigbee, LoRa, ...). (#348)
+- Fix (recipes): updating a recipe from the store now restarts its running automations immediately. Before, the new version was loaded and shown in the form, but running instances kept executing the previous version's logic until manually toggled off and on — a silent trap. (#349)
+- Fix (plugins): the **Refresh** button on the Plugins page now shows a just-published catalog change within seconds instead of waiting several minutes. It was hitting a cached copy that the refresh could not bypass; it now reads the up-to-date source directly. (#353)
+
+---
+
 ## 1.32.x: Weather daily min/max
 
 ### v1.32.0 — 2026-08-05 { #v1-32-0 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sowel",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sowel",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cors": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.32.0",
+  "version": "1.33.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Grouped reliability release.

- fix(equipments): battery remotes/buttons no longer badged "Disconnected" on silence (#348 / #350)
- fix(recipes): recipe store update restarts running instances immediately (#349 / #351)
- fix(plugins): Plugins Refresh reads the up-to-date registry via the GitHub Contents API, no CDN lag (#353 / #354)
- Release notes added in both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-33-0 }` anchor (spec 108)
- Version bump 1.32.0 → 1.33.0, lockfiles synced

Pre-flight: backend tsc/eslint/vitest (1012 tests), UI tsc — all green.

After merge: tag the on-main release commit as `v1.33.0` and push the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)