### PR TITLE
chore(registry): add netatmo_camera 1.0.0 (community plugin)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -512,5 +512,19 @@
     "sowelVersion": ">=1.31.1",
     "owner": "mchacher",
     "sha256": "d4b632af817acbfaefb7be0c4ea54666e8088e3d0013bc78c40de2fcd12c336c"
+  },
+  {
+    "id": "netatmo_camera",
+    "type": "integration",
+    "name": "Netatmo Camera",
+    "description": "Netatmo Security cameras (Presence) — snapshot, live view, monitoring, spot light, detections",
+    "icon": "Camera",
+    "author": "alpitux",
+    "repo": "alpitux/sowel-plugin-netatmo-camera",
+    "version": "1.0.0",
+    "tags": ["netatmo", "camera", "security", "snapshot", "live-view", "motion-detection"],
+    "sowelVersion": ">=1.31.0",
+    "owner": "alpitux",
+    "sha256": "b26b62f2bc0c6ce2e4bf65c8b87148f9e0e98659b0547bc400030076a3a5c4d5"
   }
 ]


### PR DESCRIPTION
## Summary

Adds the `netatmo_camera` entry to `plugins/registry.json`, distributing [alpitux/sowel-plugin-netatmo-camera](https://github.com/alpitux/sowel-plugin-netatmo-camera) as a community plugin, following the flow you outlined on [alpitux/sowel-plugin-netatmo-camera#1](https://github.com/alpitux/sowel-plugin-netatmo-camera/pull/1) and the same pattern as `runtime-guard` (#331).

Netatmo Security cameras (Presence): snapshot, live view, monitoring toggle, spot light, motion detections — binds into the `camera` equipment type from #339.

## What's in this PR

- `owner: "alpitux"` (community, not `mchacher`) — per spec 089 the install flow badges it and shows the confirmation modal automatically.
- `sha256` computed via `node scripts/backfill-registry-sha256.mjs`, run against the published [v1.0.0 release](https://github.com/alpitux/sowel-plugin-netatmo-camera/releases/tag/v1.0.0) asset (`sowel-plugin-netatmo_camera-1.0.0.tar.gz`). Independently double-checked by hand (`shasum -a 256` against the same downloaded asset) before committing — both match: `b26b62f2bc0c6ce2e4bf65c8b87148f9e0e98659b0547bc400030076a3a5c4d5`.
- `sowelVersion: ">=1.31.0"` — the `camera` equipment type doesn't exist on older instances, so this correctly refuses install there.
- Plugin repo already has its release workflow in place (`.github/workflows/release.yml`, copied from `sowel-plugin-legrand-energy`), tag-triggered, produces the tarball shape `PackageManager` expects.

## Test plan

- [x] `node scripts/backfill-registry-sha256.mjs` — 1 updated (this entry), 29 skipped (already valid, untouched), 0 failed
- [x] `python3 -m json.tool plugins/registry.json` — valid JSON
- [x] `npm run validate` (full backend + UI: typecheck, lint, format:check, vitest, UI lint+typecheck) — clean; 68 test files, 1012 passed / 2 skipped; the 2 pre-existing eslint warnings in `DeviceSelector.tsx`/`ZoneRecipesSection.tsx` are unrelated to this change (registry JSON only)
- [x] sha256 manually re-verified against the actual downloaded GitHub release asset, independent of the backfill script's own computation