### PR TITLE
chore(registry): bump zigbee2mqtt to 2.2.3 (Tuya relay binding fix)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -7,11 +7,11 @@
     "icon": "Radio",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-zigbee2mqtt",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "tags": ["zigbee", "mqtt", "z2m", "sensors", "lights", "switches"],
     "sowelVersion": ">=1.2.12",
     "owner": "mchacher",
-    "sha256": "bf08556038711d81f85d76f341f963fe14e0944db407b5b70760a02947323c2d"
+    "sha256": "2a5b0f905879046714751a9474f7515ce1b31819dc10a893a5feee1df2ec80db"
   },
   {
     "id": "lora2mqtt",


### PR DESCRIPTION
## Summary

Bumps the zigbee2mqtt plugin to [v2.2.3](https://github.com/mchacher/sowel-plugin-zigbee2mqtt/pull/3): Tuya relay modules (e.g. **WHD02**) whose z2m `state` is a top-level binary or an endpoint-suffixed `state_l1`/`state_left` are now categorised as `light_state` / `light_toggle`, so they can be associated with a light or switch equipment (they previously landed as `generic` with no on/off candidate).

- `sha256` computed from the published tarball and verified locally (manifest 2.2.3, `isRelayState` present in the built bundle, `shasum -a 256` matches)
- 9 unit tests, tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)