### PR TITLE
fix(equipments): light_onoff/pool_pump bind boolean on/off relays

### DIFF
--- a/src/equipments/binding-candidates.test.ts
+++ b/src/equipments/binding-candidates.test.ts
@@ -224,6 +224,36 @@ describe("computeBindingCandidates", () => {
     expect(result[0].dataKeys).toEqual(["state"]);
   });
 
+  // A Zigbee relay (Tuya WHD02) exposes on/off as a boolean `state` order
+  // (category light_toggle), not an ON/OFF enum. It bound to `switch` but was
+  // silently excluded from `light_onoff` (isOnOffEnum-only) → could not drive
+  // a light. Now accepted, same rule as `switch`.
+  it("light_onoff on a Zigbee relay (boolean light_toggle `state`) → one candidate", () => {
+    const orders = [
+      order("state", "boolean", { category: "light_toggle" }),
+      order("power_on_behavior", "enum", { enumValues: ["off", "previous", "on"] }),
+    ];
+    const datas = [data("state", "boolean", { category: "light_state", value: "OFF" })];
+    const result = computeBindingCandidates("light_onoff", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].orderKeys).toEqual(["state"]);
+    expect(result[0].dataKeys).toEqual(["state"]);
+  });
+
+  it("pool_pump on a Zigbee relay (boolean light_toggle `state`) → one candidate", () => {
+    const orders = [order("state", "boolean", { category: "light_toggle" })];
+    const datas = [data("state", "boolean", { category: "light_state", value: "OFF" })];
+    const result = computeBindingCandidates("pool_pump", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].orderKeys).toEqual(["state"]);
+  });
+
+  it("light_onoff ignores a non-power boolean toggle (config switch)", () => {
+    const orders = [order("child_lock", "boolean", { category: "toggle_lock" })];
+    const result = computeBindingCandidates("light_onoff", [], orders);
+    expect(result).toHaveLength(0);
+  });
+
   it("sensor on a multi-data device → one all-data candidate", () => {
     const datas = [
       data("temperature", "number", { category: "temperature" }),

--- a/src/equipments/binding-candidates.ts
+++ b/src/equipments/binding-candidates.ts
@@ -113,10 +113,16 @@ export function computeBindingCandidates(
     case "pool_pump":
     case "light_onoff":
     case "water_valve": {
-      // One candidate per ON/OFF enum order; attach matching data if same key.
+      // One candidate per on/off command: an ON/OFF enum order (Tasmota
+      // `power1`) OR a boolean power-toggle order (Zigbee2MQTT relay/light
+      // `state`, category light_toggle/toggle_power) — same rule as `switch`.
+      // isOnOffEnum alone silently excluded every Zigbee relay (e.g. Tuya
+      // WHD02) from light_onoff/pool_pump (boolean `state`, not enum),
+      // though it bound fine to a `switch`. Kept in sync with
+      // ui/src/lib/binding-candidates.ts.
       const candidates: BindingCandidate[] = [];
       for (const o of deviceOrders) {
-        if (!isOnOffEnum(o)) continue;
+        if (!isOnOffOrder(o)) continue;
         const matchingData = deviceData.find((d) => d.key === o.key);
         candidates.push({
           id: o.key,

--- a/ui/src/lib/binding-candidates.test.ts
+++ b/ui/src/lib/binding-candidates.test.ts
@@ -62,3 +62,33 @@ describe("computeBindingCandidates — metering switch (spec 129)", () => {
     expect(result.flatMap((c) => c.dataKeys)).not.toContain("power");
   });
 });
+
+describe("computeBindingCandidates — light_onoff accepts boolean relays", () => {
+  // A Zigbee relay (Tuya WHD02) drives a light via a boolean `state`
+  // (category light_toggle), not an ON/OFF enum. It must yield a candidate
+  // for light_onoff (it already did for `switch`).
+  it("boolean light_toggle `state` → one light_onoff candidate", () => {
+    const orders = [
+      order("state", { type: "boolean", category: "light_toggle" }),
+      order("power_on_behavior", { type: "enum", enumValues: ["off", "previous", "on"] }),
+    ];
+    const datas = [data("state", { type: "boolean", category: "light_state", value: "OFF" })];
+    const result = computeBindingCandidates("light_onoff", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].orderKeys).toEqual(["state"]);
+    expect(result[0].dataKeys).toEqual(["state"]);
+  });
+
+  it("ON/OFF enum `state` still yields a candidate (Tasmota)", () => {
+    const orders = [order("state", { type: "enum", enumValues: ["ON", "OFF"] })];
+    const datas = [data("state", { type: "enum", category: "light_state" })];
+    const result = computeBindingCandidates("light_onoff", datas, orders);
+    expect(result).toHaveLength(1);
+  });
+
+  it("a non-power boolean toggle is not a light candidate", () => {
+    const orders = [order("child_lock", { type: "boolean", category: "toggle_lock" })];
+    const result = computeBindingCandidates("light_onoff", [], orders);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/ui/src/lib/binding-candidates.ts
+++ b/ui/src/lib/binding-candidates.ts
@@ -85,9 +85,16 @@ export function computeBindingCandidates(
     case "pool_pump":
     case "light_onoff":
     case "water_valve": {
+      // Accept BOTH an ON/OFF enum order (Tasmota `power1`) and a boolean
+      // power-toggle order (Zigbee2MQTT relay/light `state`, category
+      // light_toggle/toggle_power) — same rule as the `switch` case above.
+      // Using isOnOffEnum alone here silently excluded every Zigbee relay
+      // (e.g. Tuya WHD02) from light_onoff/pool_pump: its `state` is a
+      // boolean, not an enum, so it produced zero candidates and could not
+      // be bound to a light, while it bound fine to a `switch`.
       const candidates: BindingCandidate[] = [];
       for (const o of deviceOrders) {
-        if (!isOnOffEnum(o)) continue;
+        if (!isOnOffOrder(o)) continue;
         const matchingData = deviceData.find((d) => d.key === o.key);
         candidates.push({
           id: o.key,


### PR DESCRIPTION
## Problem

A Zigbee2MQTT relay (reported: **Tuya WHD02**) could not be associated with a **light** equipment, even though its `state` was correctly categorised (`light_state` data / `light_toggle` order). It bound fine to a **switch**.

## Root cause (confirmed live on the reporter's instance)

`computeBindingCandidates` gated the `light_onoff` / `pool_pump` / `water_valve` case on **`isOnOffEnum`** (ON/OFF *enum* orders only, e.g. Tasmota `power1`), while the `switch` case used **`isOnOffOrder`** (enum **or** a boolean `light_toggle`/`toggle_power` order). A Zigbee relay's `state` is a **boolean** order, not an enum, so it yielded zero candidates for `light_onoff` → the device was filtered out of the picker and auto-binding produced nothing.

The device categories were never the issue (the WHD02 exposes `state` under a z2m `switch` grouping → `light_state`/`light_toggle` already). The block was purely this candidate filter.

## Fix

The `light_onoff` / `pool_pump` / `water_valve` case now uses `isOnOffOrder`, same as `switch`. Applied to the runtime resolver (`ui/src/lib/binding-candidates.ts`) and its backend mirror (`src/equipments/binding-candidates.ts`).

## Test plan

- [x] New tests (both files): boolean `light_toggle` `state` → 1 light_onoff candidate; boolean relay → pool_pump candidate; ON/OFF enum still works; a non-power boolean toggle (child_lock) yields no candidate
- [x] `npx vitest run` — 1018 passed; backend tsc + eslint clean; `cd ui && tsc -b` clean

## Note

A companion plugin change (zigbee2mqtt v2.2.3) broadened relay `state` categorisation for genuinely top-level / endpoint-suffixed (`state_lN`) states — a real improvement for multi-gang modules (e.g. TMZ02), but NOT what blocked the WHD02→light binding. This core fix is the actual cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)