### PR TITLE
feat(equipments): water heater equipment type (spec 135)

### DIFF
--- a/docs/technical/data-model/equipments.md
+++ b/docs/technical/data-model/equipments.md
@@ -25,6 +25,7 @@ type EquipmentType =
   | "weather_forecast"
   | "gate"
   | "heater"
+  | "water_heater"
   | "energy_meter"
   | "main_energy_meter"
   | "energy_production_meter"

--- a/docs/user/equipments.fr.md
+++ b/docs/user/equipments.fr.md
@@ -106,6 +106,14 @@ Radiateur électrique individuel piloté par relais fil pilote.
 - **Contrôles :** Bascule Confort / Éco
 - **Données attendues :** état du relais (ON = éco, OFF = confort)
 
+#### Chauffe-eau
+
+Chauffe-eau / cumulus piloté par un relais on/off. Le canal on/off est lié automatiquement (ainsi que sa puissance/énergie si le relais les mesure).
+
+- **Contrôles :** Bascule Marche / Arrêt
+- **Données attendues :** état du relais on/off, température d'eau optionnelle (affichage seul, exclue de la moyenne de température ambiante de la zone), puissance/énergie optionnelles
+- La consigne réglable est volontairement hors périmètre (ce serait un thermostat). La planification ou le pilotage sur surplus solaire relèvent d'une recette, pas de l'équipement.
+
 ---
 
 ### Accès

--- a/docs/user/equipments.md
+++ b/docs/user/equipments.md
@@ -65,12 +65,13 @@ Awnings share the shutter control surface (same position binding, same OPEN/STOP
 
 ### Climate
 
-| Type           | Controls                                        | Expected data                                                            |
-| -------------- | ----------------------------------------------- | ------------------------------------------------------------------------ |
-| **Thermostat** | Temperature display, setpoint +/-, power on/off | current temperature, target setpoint, power state, optional mode/fan/eco |
-| **Heater**     | Comfort / Eco toggle                            | relay state (fil pilote: ON = eco, OFF = comfort)                        |
+| Type             | Controls                                        | Expected data                                                                        |
+| ---------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Thermostat**   | Temperature display, setpoint +/-, power on/off | current temperature, target setpoint, power state, optional mode/fan/eco             |
+| **Heater**       | Comfort / Eco toggle                            | relay state (fil pilote: ON = eco, OFF = comfort)                                    |
+| **Water Heater** | On/Off toggle                                   | on/off relay state, optional water temperature (display only), optional power/energy |
 
-Thermostat covers air conditioning, pellet stoves, and heat pumps. Heater covers individual electric heaters wired through a fil-pilote relay.
+Thermostat covers air conditioning, pellet stoves, and heat pumps. Heater covers individual electric heaters wired through a fil-pilote relay. Water Heater (chauffe-eau / cumulus) is an on/off relay for a hot-water tank: auto-binds the on/off channel (and its power/energy when the relay meters them); a water-temperature probe can be bound optionally and is shown but kept out of the room temperature average. Setpoint control is intentionally out of scope (that would be a thermostat). Scheduling / solar-surplus heating is a recipe, not the equipment.
 
 ### Access
 

--- a/specs/135-water-heater-equipment/architecture.md
+++ b/specs/135-water-heater-equipment/architecture.md
@@ -1,0 +1,61 @@
+# Architecture — Spec 135 Water heater
+
+Pure additive equipment type, modelled on `heater` / `switch`. No DB,
+event, or API change. Touch points (mirroring how spec 133 `camera` and
+`heater` thread through the layers):
+
+## Backend
+
+| File                                   | Change                                                                                                       |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `src/shared/types.ts`                  | Add `"water_heater"` to the `EquipmentType` union                                                            |
+| `src/equipments/equipment-manager.ts`  | Add `"water_heater"` to `VALID_EQUIPMENT_TYPES`                                                              |
+| `src/equipments/binding-candidates.ts` | Add `case "water_heater"` to the on/off relay branch (isOnOffOrder + metering attach), identical to `switch` |
+
+The `water_heater` candidate case reuses the exact `switch` logic: one
+on/off candidate per `isOnOffOrder` order; when a single candidate, attach
+metering data (`METERING_CATEGORIES`). Temperature is NOT a candidate
+discriminator (it's an optional extra binding), so it is not required for
+compatibility.
+
+## Frontend
+
+| File                                                                                                          | Change                                                                                                                                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ui/src/types.ts`                                                                                             | Mirror `EquipmentType`                                                                                                                                                                                                                                |
+| `ui/src/lib/binding-candidates.ts`                                                                            | Mirror the backend `water_heater` case (isOnOffOrder + metering)                                                                                                                                                                                      |
+| `ui/src/components/equipments/DeviceSelector.tsx`                                                             | `EQUIPMENT_TYPE_CATEGORIES.water_heater = ["light_state"]`; add to `CANDIDATE_BASED_TYPES`                                                                                                                                                            |
+| `ui/src/components/equipments/bindingUtils.ts`                                                                | `RELEVANT_DATA.water_heater = ["light_state","temperature","power","energy"]`; `RELEVANT_ORDERS.water_heater = ["state","on"]`; temperature aliased `water_temperature` via `DATA_CATEGORY_ALIASES` override for this type (or a per-type alias rule) |
+| `ui/src/components/equipments/EquipmentForm.tsx`                                                              | Add `{ value: "water_heater", labelKey: "equipments.type.water_heater" }`                                                                                                                                                                             |
+| `ui/src/components/dashboard/WidgetIcons.tsx`                                                                 | New `WaterHeaterIcon({ on })` — custom SVG, viewBox 56, 120px, `on ? text-active : text-primary`                                                                                                                                                      |
+| `ui/src/components/dashboard/widget-icons.ts`                                                                 | Register `water_heater` in `CUSTOM_ICON_REGISTRY`                                                                                                                                                                                                     |
+| `ui/src/components/dashboard/EquipmentWidget.tsx`                                                             | `WaterHeaterEquipmentWidget` (desktop): icon + on/off toggle + temp + power                                                                                                                                                                           |
+| `ui/src/components/dashboard/MobileWidgetCard.tsx`                                                            | Mobile branch: icon + on/off + temp summary                                                                                                                                                                                                           |
+| `ui/src/components/dashboard/widget-utils.ts` / `WidgetGrid.tsx` / `WidgetDetailSheet.tsx` / `ZoneWidget.tsx` | Route `water_heater` like `heater`/`switch` where these switch on type                                                                                                                                                                                |
+| `ui/src/components/equipments/EquipmentCard.tsx`, `useEquipmentState.ts`                                      | on/off state + label + icon for the zone list card                                                                                                                                                                                                    |
+| `ui/src/components/home/CompactEquipmentCard.tsx`, `ZoneEquipmentsView.tsx`                                   | zone view rendering                                                                                                                                                                                                                                   |
+| `ui/src/i18n/locales/{fr,en}.json`                                                                            | `equipments.type.water_heater`, widget labels (temp/power)                                                                                                                                                                                            |
+
+## The temperature-alias rule (key design point)
+
+The zone aggregator (`src/zones/zone-aggregator.ts`) only folds a
+`temperature`-category binding into the room average when its alias is
+exactly `"temperature"`. To keep a water heater's water temperature out of
+the room average, auto-binding (and the manual add) must alias it
+`water_temperature`. Implementation: in `bindingUtils.ts`, add a per-type
+alias override so that for `water_heater`, a `temperature`-category data
+binds as `water_temperature` (not `temperature`). The widget/card read the
+`water_temperature` alias for display.
+
+## Icon
+
+`WaterHeaterIcon` — a wall tank (cumulus): rounded rectangle body, top
+water pipe, a small heat/indicator glyph. `on` → amber/active fill +
+"heating" tint; `off` → neutral primary stroke. Mirrors the
+`LightBulbIcon` state convention (`text-active` vs `text-primary`).
+
+## Event flow
+
+Unchanged: `equipment.data.changed` (state / water_temperature / power)
+→ WS push → widget re-render. On/off order via the existing order
+dispatcher on the `state` alias (light_toggle), identical to `switch`.

--- a/specs/135-water-heater-equipment/plan.md
+++ b/specs/135-water-heater-equipment/plan.md
@@ -1,0 +1,65 @@
+# Plan — Spec 135 Water heater
+
+Branch `feat/water-heater-equipment`.
+
+## Implementation order
+
+1. **Types**: `EquipmentType` union (`src/shared/types.ts` + `ui/src/types.ts`),
+   `VALID_EQUIPMENT_TYPES` (equipment-manager).
+2. **Binding candidates**: `water_heater` case in
+   `src/equipments/binding-candidates.ts` and its UI mirror
+   `ui/src/lib/binding-candidates.ts` (isOnOffOrder + metering attach).
+3. **Binding config**: `DeviceSelector` (categories + candidate-based),
+   `bindingUtils` (RELEVANT_DATA/ORDERS + `water_temperature` alias rule).
+4. **Tests** (see Test Plan) — backend + UI candidate tests + alias rule.
+5. **Icon**: `WaterHeaterIcon` in `WidgetIcons.tsx` + registry entry.
+6. **Dashboard**: desktop `WaterHeaterEquipmentWidget`, mobile branch,
+   zone card, detail control, widget routing (widget-utils / grid / detail
+   sheet / zone widget).
+7. **Form + i18n**: EquipmentForm option, FR/EN labels.
+8. **Docs**: equipments.{md,fr.md}, data-model.md.
+9. Validate: backend tsc/eslint/vitest, UI tsc -b/eslint.
+10. Manual verification against the friend's real WHD02 water heaters
+    (shadow or live): create, auto-bind on/off, add temp, control, dashboard.
+
+## Test Plan
+
+### Modules to test
+
+- `binding-candidates.ts` (backend) + `ui/src/lib/binding-candidates.ts`
+  — the `water_heater` candidate case.
+- `bindingUtils.ts` — the `water_temperature` alias rule + RELEVANT filters
+  (via `autoCreateBindings`/`resolveAlias` if unit-testable; else covered
+  by the candidate tests + manual).
+
+### Scenarios
+
+| Module        | Scenario                                                  | Expected                                                                 |
+| ------------- | --------------------------------------------------------- | ------------------------------------------------------------------------ |
+| binding-cands | water_heater + boolean light_toggle `state`               | one on/off candidate                                                     |
+| binding-cands | water_heater + ON/OFF enum `state` (Tasmota)              | one on/off candidate                                                     |
+| binding-cands | water_heater single relay + power/energy/voltage/current  | metering attached to the single candidate                                |
+| binding-cands | water_heater + non-power boolean toggle only (child_lock) | zero candidates                                                          |
+| binding-cands | water_heater multi-gang (state_l1/state_l2)               | two candidates, no metering auto-attach                                  |
+| alias rule    | temperature-category data on a water_heater               | alias resolved to `water_temperature`                                    |
+| alias rule    | temperature aliased `water_temperature`                   | zone aggregator excludes it from room avg (existing guard, assert alias) |
+| retro-compat  | heater / switch candidates                                | unchanged                                                                |
+
+### Retro-compat
+
+- `heater` and `switch` cases untouched; existing candidate tests keep
+  passing.
+- Zone temperature aggregation unchanged (only alias `temperature` folds
+  in) — the alias rule keeps water heaters out by construction.
+
+## Tasks
+
+- [x] P1 Types + VALID_EQUIPMENT_TYPES
+- [x] P2 Binding candidates (backend + UI mirror) + tests
+- [x] P3 DeviceSelector + bindingUtils (alias rule) + tests
+- [x] P4 WaterHeaterIcon + registry
+- [x] P5 Dashboard desktop + mobile + zone card + detail + routing
+- [x] P6 Form + i18n FR/EN
+- [x] P7 Docs
+- [x] P8 Validation green (tsc/eslint/vitest, UI)
+- [ ] P9 Manual verification on real WHD02 water heaters (pending — shadow/live)

--- a/specs/135-water-heater-equipment/spec.md
+++ b/specs/135-water-heater-equipment/spec.md
@@ -1,0 +1,95 @@
+# Spec 135 — Water heater equipment type
+
+## Context
+
+Sowel has no equipment type for a **water heater** (chauffe-eau / cumulus /
+ballon d'eau chaude). Users currently model one as a bare `switch`, which
+loses the identity (icon, label) and offers no place for the water
+temperature. A real installation (the reporting user's friend) drives
+several water heaters through Zigbee relays (Tuya WHD02) plus, in some
+cases, a separate temperature probe (TYZGTH1CH-D1RF).
+
+## Goal
+
+Add a first-class `water_heater` equipment type: **ON/OFF control**, an
+**optional water-temperature display**, optional **power/energy** display
+when the relay meters it, **automatic binding**, a **custom state-aware
+icon**, and full **dashboard support (desktop + mobile)** — consistent
+with how `heater` / `switch` are handled.
+
+## Scope
+
+### In scope
+
+- New `EquipmentType`: `"water_heater"`.
+- ON/OFF actuation via the standard on/off channel (boolean `light_toggle`
+  order or ON/OFF enum — same rule as `switch`, so Zigbee relays work,
+  cf. spec that fixed the WHD02 candidate filter).
+- Optional **water temperature** display, bound under a distinct alias
+  (`water_temperature`) so it is NOT counted in the zone room-temperature
+  average (the zone aggregator only aggregates category `temperature` with
+  alias exactly `temperature`).
+- Optional **power / energy** auto-attached when the relay device exposes
+  them (metering water-heater plug), mirroring the metering-switch feature
+  (spec 129).
+- **Auto-binding**: creating a `water_heater` from a relay device binds
+  its on/off (+ metering if present) automatically; the temperature is an
+  optional extra binding (often on a separate device).
+- **Custom SVG icon** (`WaterHeaterIcon`), state-aware: heating = warm
+  (amber/active), off = neutral (primary/grey). Registered in the custom
+  icon registry like the light/shutter icons.
+- **Dashboard widget** (desktop `EquipmentWidget` + mobile
+  `MobileWidgetCard`): on/off toggle, temperature (if bound), power (if
+  bound). Zone view card + equipment detail control.
+- FR/EN i18n.
+- Docs: `docs/user/equipments.{md,fr.md}`,
+  `docs/technical/data-model.md`.
+
+### Out of scope
+
+- **Setpoint / target temperature control** — the temperature is
+  read-only. A settable setpoint would make this a thermostat variant;
+  deferred (few Zigbee water heaters expose it).
+- Scheduling / boost / HP-HC-aware heating logic — that is a **recipe**
+  concern (a future `water-heater-schedule` recipe can drive the on/off),
+  not the equipment type.
+- Solar-surplus water-heater optimization — future recipe, out of the
+  equipment scope.
+- No new DataCategory is introduced: reuse `light_state` (on/off),
+  `temperature` (probe, aliased `water_temperature`), `power`, `energy`.
+
+## Data model
+
+No SQLite migration, no new event, no new API route. `water_heater` is a
+new value of the existing `EquipmentType` union and the runtime
+`VALID_EQUIPMENT_TYPES` set. All plumbing (bindings, orders, WS, zone) is
+already type-agnostic.
+
+## Acceptance criteria
+
+- [x] AC1 — `water_heater` is a creatable equipment type (form, API,
+      persisted, restored).
+- [x] AC2 — Creating one from a Zigbee relay (boolean `state`
+      light_toggle) auto-binds the on/off channel; the device appears in
+      the picker (candidate-based, `isOnOffOrder`).
+- [x] AC3 — If the relay device also exposes power/energy, they are
+      auto-attached (single-channel only, like the metering switch).
+- [x] AC4 — A temperature reading can be bound (optionally, possibly from
+      another device) under alias `water_temperature`; it is displayed on
+      the widget/card and **excluded** from the zone temperature average.
+- [x] AC5 — ON/OFF works from the desktop widget, the mobile widget, the
+      zone card and the detail page.
+- [x] AC6 — A custom state-aware icon renders on all cards (heating vs
+      off visually distinct), desktop and mobile.
+- [x] AC7 — No regression on existing types (heater/switch unchanged).
+
+## Edge cases
+
+| Case                                          | Expected                                                                          |
+| --------------------------------------------- | --------------------------------------------------------------------------------- |
+| Relay device only (no temp probe)             | on/off works, no temperature shown                                                |
+| Temperature bound but relay offline           | equipment degraded/offline per spec 116, temp still shown if its device is online |
+| Metering absent on the relay                  | no power/energy shown, no error                                                   |
+| Temperature value null / non-number           | temperature hidden                                                                |
+| Water temp bound as alias `water_temperature` | NOT added to zone temperature average                                             |
+| Multi-gang relay used                         | one on/off candidate per channel (existing logic)                                 |

--- a/src/equipments/binding-candidates.test.ts
+++ b/src/equipments/binding-candidates.test.ts
@@ -254,6 +254,44 @@ describe("computeBindingCandidates", () => {
     expect(result).toHaveLength(0);
   });
 
+  // Spec 135 — water heater: same candidate shape as a switch.
+  it("water_heater on a Zigbee relay (boolean light_toggle `state`) → one candidate", () => {
+    const orders = [
+      order("state", "boolean", { category: "light_toggle" }),
+      order("power_on_behavior", "enum", { enumValues: ["off", "previous", "on"] }),
+    ];
+    const datas = [data("state", "boolean", { category: "light_state", value: "OFF" })];
+    const result = computeBindingCandidates("water_heater", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].orderKeys).toEqual(["state"]);
+    expect(result[0].dataKeys).toEqual(["state"]);
+  });
+
+  it("water_heater on a metering relay → attaches power/energy to the candidate", () => {
+    const orders = [order("state", "boolean", { category: "light_toggle" })];
+    const datas = [
+      data("state", "boolean", { category: "light_state", value: "ON" }),
+      data("power", "number", { category: "power", value: 1800 }),
+      data("energy", "number", { category: "energy", value: 12.4 }),
+    ];
+    const result = computeBindingCandidates("water_heater", datas, orders);
+    expect(result).toHaveLength(1);
+    expect(result[0].dataKeys.sort()).toEqual(["energy", "power", "state"]);
+  });
+
+  it("water_heater with an ON/OFF enum `state` (Tasmota relay) → one candidate", () => {
+    const orders = [order("state", "enum", { enumValues: ["ON", "OFF"] })];
+    const datas = [data("state", "enum", { category: "light_state" })];
+    const result = computeBindingCandidates("water_heater", datas, orders);
+    expect(result).toHaveLength(1);
+  });
+
+  it("water_heater ignores a device with no on/off channel", () => {
+    const orders = [order("child_lock", "boolean", { category: "toggle_lock" })];
+    const result = computeBindingCandidates("water_heater", [], orders);
+    expect(result).toHaveLength(0);
+  });
+
   it("sensor on a multi-data device → one all-data candidate", () => {
     const datas = [
       data("temperature", "number", { category: "temperature" }),

--- a/src/equipments/binding-candidates.ts
+++ b/src/equipments/binding-candidates.ts
@@ -81,6 +81,11 @@ export function computeBindingCandidates(
   deviceOrders: readonly DeviceOrder[],
 ): BindingCandidate[] {
   switch (equipmentType) {
+    // Spec 135 — a water heater is an on/off relay with the same candidate
+    // shape as a switch (on/off channel + metering attach). Its water
+    // temperature is an optional extra binding (often on another device),
+    // not a candidate discriminator, so it is not required for compatibility.
+    case "water_heater":
     case "switch": {
       // One candidate per on/off command channel: ON/OFF enum (Tasmota `power1`)
       // OR a boolean power-toggle order (Zigbee2MQTT plug/relay `state`).

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -44,6 +44,7 @@ const VALID_EQUIPMENT_TYPES: Set<string> = new Set([
   "weather_forecast",
   "gate",
   "heater",
+  "water_heater",
   "energy_meter",
   "main_energy_meter",
   "energy_production_meter",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -237,6 +237,8 @@ export type EquipmentType =
   | "weather_forecast"
   | "gate"
   | "heater"
+  // Spec 135 — water heater (chauffe-eau): on/off + optional water temp.
+  | "water_heater"
   | "energy_meter"
   | "main_energy_meter"
   | "energy_production_meter"

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -37,6 +37,7 @@ import {
   MultiSensorIcon,
   GateWidgetIcon,
   HeaterWidgetIcon,
+  WaterHeaterIcon,
   SlidingGateIcon,
   GarageDoorIcon,
   EnergyMeterIcon,
@@ -96,6 +97,7 @@ export function EquipmentWidget({ widget, equipment, onExecuteOrder, onOpenDetai
   if (isEnergyMeter) return <EnergyMeterEquipmentWidget label={label} equipment={equipment} />;
   if (equipment.type === "solar_panel") return <SolarPanelEquipmentWidget label={label} equipment={equipment} />;
   if (equipment.type === "switch") return <SwitchEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
+  if (equipment.type === "water_heater") return <WaterHeaterEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
   if (isWeatherForecast) return <WeatherForecastWidget label={label} equipment={equipment} />;
   if (equipment.type === "weather") return <WeatherStationWidget label={label} equipment={equipment} onOpenDetail={onOpenDetail} />;
   if (isAppliance) return <ApplianceEquipmentWidget label={label} equipment={equipment} />;
@@ -296,6 +298,104 @@ function SwitchEquipmentWidget({
       </div>
 
       {/* Zone 3: Bouton — toggle */}
+      {hasToggle && equipment.enabled && (
+        <div className="flex justify-center gap-3 mt-auto pt-1">
+          <button
+            onClick={handleToggle}
+            disabled={executing}
+            className={`w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed ${
+              isOn ? "!border-active/40 !text-active !bg-active/5" : ""
+            }`}
+            title={isOn ? t("controls.turnOff") : t("controls.turnOn")}
+          >
+            {executing ? <Loader2 size={16} className="animate-spin" /> : <Power size={16} strokeWidth={1.5} />}
+          </button>
+        </div>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ============================================================
+// Water heater equipment widget (spec 135)
+// ============================================================
+
+function WaterHeaterEquipmentWidget({
+  label,
+  equipment,
+  onExecuteOrder,
+  iconKey,
+}: {
+  label: string;
+  equipment: EquipmentWithDetails;
+  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+  iconKey?: string;
+}) {
+  const { t } = useTranslation();
+  const [executing, setExecuting] = useState(false);
+
+  const stateBinding = equipment.dataBindings.find(
+    (db) => db.alias === "state" || db.category === "light_state",
+  );
+  const isOn = stateBinding
+    ? stateBinding.value === true || String(stateBinding.value).toUpperCase() === "ON"
+    : false;
+
+  const toggleBinding = equipment.orderBindings.find(
+    (ob) => ob.type === "boolean" || (ob.alias === "state" && ob.type === "enum"),
+  );
+  const hasToggle = !!toggleBinding;
+
+  // Optional water temperature (aliased water_temperature so it is kept out of
+  // the zone room average) and optional power draw (metering relay).
+  const waterTemp = equipment.dataBindings.find((db) => db.alias === "water_temperature");
+  const tempValue = typeof waterTemp?.value === "number" ? waterTemp.value : null;
+  const powerBinding = equipment.dataBindings.find((db) => db.category === "power");
+  const powerValue = typeof powerBinding?.value === "number" ? powerBinding.value : null;
+
+  const handleToggle = async () => {
+    if (executing || !toggleBinding) return;
+    setExecuting(true);
+    try {
+      const alias = toggleBinding.alias;
+      const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
+      const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
+      const value =
+        toggleBinding.type === "boolean" && alias !== "state" ? !isOn : isOn ? offVal : onVal;
+      await onExecuteOrder(alias, value);
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  return (
+    <WidgetCard label={label}>
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
+        <div />
+        {resolveWidgetIcon(iconKey, <WaterHeaterIcon on={isOn} />)}
+        <div className="flex flex-col items-start gap-1 pl-2">
+          <span
+            className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
+              isOn ? "bg-active/10 text-active" : "bg-border-light text-text-tertiary"
+            }`}
+          >
+            {isOn ? "ON" : "OFF"}
+          </span>
+          {tempValue !== null && (
+            <span className="font-mono text-[13px] font-semibold text-text tabular-nums">
+              {tempValue.toFixed(1)}
+              <span className="text-[11px] text-text-tertiary font-normal ml-0.5">°C</span>
+            </span>
+          )}
+          {powerValue !== null && (
+            <span className="font-mono text-[12px] text-text-secondary tabular-nums">
+              {Math.round(powerValue)}
+              <span className="text-[10px] text-text-tertiary font-normal ml-0.5">W</span>
+            </span>
+          )}
+        </div>
+      </div>
+
       {hasToggle && equipment.enabled && (
         <div className="flex justify-center gap-3 mt-auto pt-1">
           <button

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -12,6 +12,7 @@ import {
   MultiSensorIcon,
   GateWidgetIcon,
   HeaterWidgetIcon,
+  WaterHeaterIcon,
   SlidingGateIcon,
   GarageDoorIcon,
   PlugWidgetIcon,
@@ -376,6 +377,20 @@ function useMobileState(
         ? createElement(customEntry.component, customEntry.previewProps)
         : <PlugWidgetIcon on={isOn} />,
       stateLines: [isOn ? "ON" : "OFF"],
+    };
+  }
+
+  if (equipment.type === "water_heater") {
+    const waterTemp = equipment.dataBindings.find((db) => db.alias === "water_temperature");
+    const tempValue = typeof waterTemp?.value === "number" ? waterTemp.value : null;
+    return {
+      icon: customEntry
+        ? createElement(customEntry.component, customEntry.previewProps)
+        : <WaterHeaterIcon on={isOn} />,
+      stateLines: [
+        isOn ? "ON" : "OFF",
+        ...(tempValue !== null ? [`${tempValue.toFixed(1)}°C`] : []),
+      ],
     };
   }
 

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -383,7 +383,7 @@ const WIDGET_FAMILY_TYPES: Record<string, string[]> = {
   awnings: ["awning"],
   heating: ["thermostat", "heater"],
   sensors: ["sensor"],
-  water: ["water_valve"],
+  water: ["water_valve", "water_heater"],
   pool: ["pool_pump", "pool_cover", "pool_heat_pump"],
 };
 

--- a/ui/src/components/dashboard/WidgetGrid.tsx
+++ b/ui/src/components/dashboard/WidgetGrid.tsx
@@ -562,10 +562,11 @@ function getMobileClickAction(
     return onOpenDetail;
   }
 
-  // Simple on/off (light_onoff, switch, pool_pump, water_valve) → direct toggle
+  // Simple on/off (light_onoff, switch, water_heater, pool_pump, water_valve) → direct toggle
   if (
     type === "light_onoff" ||
     type === "switch" ||
+    type === "water_heater" ||
     type === "pool_pump" ||
     type === "water_valve"
   ) {

--- a/ui/src/components/dashboard/WidgetIcons.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.tsx
@@ -75,6 +75,63 @@ export function LightBulbIcon({ on }: { on: boolean }) {
 // Shutter icon — 5 levels (0%, 25%, 50%, 75%, 100%)
 // ============================================================
 
+/**
+ * Spec 135 — water heater (chauffe-eau / cumulus). A wall tank with cold-in /
+ * hot-out pipes and a water gauge. `on` (heating): amber (`text-active`) with a
+ * warm glow and rising heat waves; off: neutral primary stroke.
+ */
+export function WaterHeaterIcon({ on }: { on: boolean }) {
+  const id = useId();
+  const bodyGrad = `wh-body-${id}`;
+  const waterGrad = `wh-water-${id}`;
+
+  return (
+    <svg width="120" height="120" viewBox="0 0 56 56" fill="none" className={on ? "text-active" : "text-primary"}>
+      <defs>
+        <linearGradient id={bodyGrad} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity={on ? 0.22 : 0.1} />
+          <stop offset="100%" stopColor="currentColor" stopOpacity={on ? 0.12 : 0.05} />
+        </linearGradient>
+        <linearGradient id={waterGrad} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity={on ? 0.45 : 0.22} />
+          <stop offset="100%" stopColor="currentColor" stopOpacity={on ? 0.28 : 0.12} />
+        </linearGradient>
+      </defs>
+
+      {on && <ellipse cx="28" cy="29" rx="20" ry="22" fill="currentColor" opacity="0.07" />}
+
+      {/* Cold-in / hot-out pipes */}
+      <g stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeOpacity="0.55">
+        <path d="M22 9V5.5a2 2 0 012-2h1" fill="none" />
+        <path d="M34 9V5.5a2 2 0 00-2-2h-1" fill="none" />
+      </g>
+
+      {/* Tank body */}
+      <rect x="16" y="9" width="24" height="39" rx="10" fill={`url(#${bodyGrad})`} stroke="currentColor" strokeWidth="1.4" strokeOpacity={on ? 0.65 : 0.4} />
+
+      {/* Water fill (lower ~55%) */}
+      <path d="M16 27v11a10 10 0 0010 10h4a10 10 0 0010-10V27z" fill={`url(#${waterGrad})`} />
+
+      {/* Heat waves (on) or gauge marks (off) */}
+      {on ? (
+        <g stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeOpacity="0.6" fill="none">
+          <path d="M24 36c0-2 2-2 2-4s-2-2-2-4" />
+          <path d="M28 37c0-2 2-2 2-4s-2-2-2-4" />
+          <path d="M32 36c0-2 2-2 2-4s-2-2-2-4" />
+        </g>
+      ) : (
+        <g stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeOpacity="0.3">
+          <line x1="34.5" y1="16" x2="34.5" y2="18" />
+          <line x1="34.5" y1="21" x2="34.5" y2="23" />
+        </g>
+      )}
+
+      {/* Thermostat / status dot */}
+      <circle cx="28" cy="20" r="2" fill="currentColor" opacity={on ? 0.8 : 0.4} />
+    </svg>
+  );
+}
+
 export function ShutterWidgetIcon({ level }: { level: number | null }) {
   const id = useId();
   const slatGradId = `shutter-slat-${id}`;

--- a/ui/src/components/dashboard/ZoneWidget.tsx
+++ b/ui/src/components/dashboard/ZoneWidget.tsx
@@ -34,7 +34,7 @@ const WIDGET_FAMILY_TYPES: Record<WidgetFamily, string[]> = {
   awnings: ["awning"],
   heating: ["thermostat", "heater"],
   sensors: ["sensor"],
-  water: ["water_valve"],
+  water: ["water_valve", "water_heater"],
   pool: ["pool_pump", "pool_cover", "pool_heat_pump"],
   displays: ["display"],
 };

--- a/ui/src/components/dashboard/widget-icons.ts
+++ b/ui/src/components/dashboard/widget-icons.ts
@@ -64,6 +64,7 @@ import {
   PressureSensorIcon,
   GateWidgetIcon,
   HeaterWidgetIcon,
+  WaterHeaterIcon,
   SlidingGateIcon,
   GarageDoorIcon,
   PlugWidgetIcon,
@@ -191,6 +192,12 @@ export const CUSTOM_ICON_REGISTRY: Record<string, CustomIconEntry> = {
     previewProps: { comfort: true },
     types: ["heater", "heating"],
   },
+  water_heater: {
+    label: "Chauffe-eau",
+    component: WaterHeaterIcon as ComponentType<Record<string, unknown>>,
+    previewProps: { on: true },
+    types: ["water_heater"],
+  },
   plug: {
     label: "Prise",
     component: PlugWidgetIcon as ComponentType<Record<string, unknown>>,
@@ -303,6 +310,7 @@ const EQUIPMENT_DEFAULT_ICONS: Partial<Record<EquipmentType, string>> = {
   solar_panel: "Sun",
   thermostat: "Thermometer",
   heater: "Flame",
+  water_heater: "Droplets",
   gate: "DoorOpen",
   switch: "ToggleLeft",
   button: "CircleDot",

--- a/ui/src/components/equipments/AddBindingModal.tsx
+++ b/ui/src/components/equipments/AddBindingModal.tsx
@@ -63,7 +63,11 @@ export function AddBindingModal({
 
   const handleSelectItem = (item: DeviceData | DeviceOrder) => {
     setSelectedItemId(item.id);
-    setAlias(equipmentType ? resolveAlias(item.key, equipmentType) : item.key);
+    setAlias(
+      equipmentType
+        ? resolveAlias(item.key, equipmentType, undefined, (item as { category?: string }).category)
+        : item.key,
+    );
     setError(null);
   };
 

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -14,6 +14,9 @@ const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> 
   light_color: ["light_state", "light_brightness", "light_color"],
   shutter: ["shutter_position"],
   switch: ["light_state"],
+  // Spec 135 — water heater: an on/off relay (light_state) is the
+  // discriminator; the water temperature is an optional extra binding.
+  water_heater: ["light_state"],
   sensor: ["temperature", "humidity", "pressure", "luminosity", "co2", "voc", "noise", "motion", "contact_door", "contact_window", "water_leak", "smoke"],
   button: ["action"],
   weather: ["temperature", "temperature_outdoor", "humidity", "humidity_outdoor", "pressure", "wind", "rain", "noise"],
@@ -91,6 +94,7 @@ const CANDIDATE_BASED_TYPES: ReadonlySet<EquipmentType> = new Set<EquipmentType>
   "light_dimmable",
   "light_color",
   "switch",
+  "water_heater",
   "shutter",
   "awning",
   // NOTE: water_valve is intentionally key-driven (EQUIPMENT_TYPE_DATA_KEYS +

--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -16,6 +16,7 @@ import {
   Monitor,
   WashingMachine,
   Waves,
+  Droplets,
   Camera,
 } from "lucide-react";
 import { ShutterClosedIcon } from "../icons/ShutterIcons";
@@ -45,6 +46,7 @@ const TYPE_ICONS: Record<EquipmentType, React.ReactNode> = {
   weather_forecast: <CloudSun size={18} strokeWidth={1.5} />,
   gate: <DoorOpen size={18} strokeWidth={1.5} />,
   heater: <Heater size={18} strokeWidth={1.5} />,
+  water_heater: <Droplets size={18} strokeWidth={1.5} />,
   energy_meter: <Zap size={18} strokeWidth={1.5} />,
   main_energy_meter: <Zap size={18} strokeWidth={1.5} />,
   energy_production_meter: <Zap size={18} strokeWidth={1.5} />,
@@ -73,6 +75,7 @@ const TYPE_LABELS: Record<EquipmentType, string> = {
   weather_forecast: "equipments.type.weather_forecast",
   gate: "equipments.type.gate",
   heater: "equipments.type.heater",
+  water_heater: "equipments.type.water_heater",
   energy_meter: "equipments.type.energy_meter",
   main_energy_meter: "equipments.type.main_energy_meter",
   energy_production_meter: "equipments.type.energy_production_meter",

--- a/ui/src/components/equipments/EquipmentForm.tsx
+++ b/ui/src/components/equipments/EquipmentForm.tsx
@@ -19,6 +19,7 @@ const EQUIPMENT_TYPE_KEYS: { value: EquipmentType; labelKey: string }[] = [
   { value: "weather_forecast", labelKey: "equipments.type.weather_forecast" },
   { value: "gate", labelKey: "equipments.type.gate" },
   { value: "heater", labelKey: "equipments.type.heater" },
+  { value: "water_heater", labelKey: "equipments.type.water_heater" },
   { value: "energy_meter", labelKey: "equipments.type.energy_meter" },
   { value: "main_energy_meter", labelKey: "equipments.type.main_energy_meter" },
   { value: "energy_production_meter", labelKey: "equipments.type.energy_production_meter" },

--- a/ui/src/components/equipments/bindingUtils.test.ts
+++ b/ui/src/components/equipments/bindingUtils.test.ts
@@ -238,6 +238,34 @@ describe("gate equipment type relevance (blind single-button RTS gate)", () => {
   });
 });
 
+describe("water_heater equipment type (spec 135)", () => {
+  it("on/off relay state is relevant, so is optional temperature/power/energy", () => {
+    expect(isRelevantData("light_state", "water_heater")).toBe(true);
+    expect(isRelevantData("temperature", "water_heater")).toBe(true);
+    expect(isRelevantData("power", "water_heater")).toBe(true);
+    expect(isRelevantData("energy", "water_heater")).toBe(true);
+    expect(isRelevantOrder("state", "water_heater")).toBe(true);
+  });
+
+  it("aliases a temperature reading to water_temperature (kept out of zone avg)", () => {
+    // The zone aggregator only folds category=temperature bindings with alias
+    // exactly "temperature" into the room average — a water heater's water
+    // temperature must land on `water_temperature` instead. The per-type rule
+    // applies whether or not a category map is passed (manual add path).
+    expect(resolveAlias("temperature", "water_heater", undefined, "temperature")).toBe(
+      "water_temperature",
+    );
+    // A different probe key resolves the same, driven by the category.
+    expect(resolveAlias("temperature_2", "water_heater", undefined, "temperature")).toBe(
+      "water_temperature",
+    );
+  });
+
+  it("does not touch a temperature on other types", () => {
+    expect(resolveAlias("temperature", "sensor", undefined, "temperature")).toBe("temperature");
+  });
+});
+
 // Spec 133 — camera equipment. Auto-binding is a deliberate SUBSET of what
 // the device may expose: snapshot/stream/monitoring auto-bind, light_mode/
 // siren/detection are opt-in only (privacy/bandwidth). Order relevance is

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -111,6 +111,10 @@ const RELEVANT_DATA: Record<string, string[]> = {
   weather_forecast: ["weather_condition", "temperature_outdoor", "rain", "wind"],
   gate: ["generic", "contact_door"],
   heater: ["generic", "light_state"],
+  // Spec 135 — water heater: on/off relay (light_state) + optional water
+  // temperature (aliased water_temperature so it stays out of the zone room
+  // average) + optional power/energy when the relay meters consumption.
+  water_heater: ["light_state", "temperature", "power", "energy"],
   energy_meter: ["energy", "power"],
   main_energy_meter: ["energy", "power"],
   energy_production_meter: ["energy", "power"],
@@ -163,6 +167,7 @@ const RELEVANT_ORDERS: Record<string, string[]> = {
   weather_forecast: [],
   gate: ["R1", "R2", "R3", "R4", "command", "gate_trigger"],
   heater: ["state", "on", "R1", "R2", "R3", "R4"],
+  water_heater: ["state", "on", "R1", "R2", "R3", "R4"],
   energy_meter: [],
   main_energy_meter: [],
   energy_production_meter: [],
@@ -298,6 +303,17 @@ const DATA_CATEGORY_ALIASES: Record<string, string> = {
 };
 
 /**
+ * Per-equipment-type category → alias overrides, applied before the global
+ * DATA_CATEGORY_ALIASES. Spec 135: on a water heater, a `temperature` reading
+ * is the WATER temperature, aliased `water_temperature` so the zone aggregator
+ * (which only folds category=temperature bindings with alias exactly
+ * "temperature" into the room average) leaves it out.
+ */
+const TYPE_DATA_CATEGORY_ALIASES: Partial<Record<EquipmentType, Record<string, string>>> = {
+  water_heater: { temperature: "water_temperature" },
+};
+
+/**
  * Resolve a device key to the standardized equipment alias for the given type.
  * Priority:
  *   1. Order / data category (plugin-agnostic)
@@ -310,7 +326,11 @@ export function resolveAlias(
   categoryMap?: Record<string, string>,
   category?: string,
 ): string {
-  if (category && categoryMap && categoryMap[category]) return categoryMap[category];
+  if (category) {
+    const perType = TYPE_DATA_CATEGORY_ALIASES[equipmentType as EquipmentType]?.[category];
+    if (perType) return perType;
+    if (categoryMap && categoryMap[category]) return categoryMap[category];
+  }
   return STANDARD_ALIASES[equipmentType]?.[key] ?? key;
 }
 
@@ -338,6 +358,9 @@ const CANDIDATE_BASED_TYPES: ReadonlySet<EquipmentType> = new Set<EquipmentType>
   "light_dimmable",
   "light_color",
   "switch",
+  // Spec 135 — water heater: on/off relay candidate (+ metering attach),
+  // like switch. Water temperature is a manual extra binding.
+  "water_heater",
   "shutter",
   "awning",
   // NOTE: water_valve is intentionally key-driven (RELEVANT_DATA/RELEVANT_ORDERS),

--- a/ui/src/components/equipments/useEquipmentState.ts
+++ b/ui/src/components/equipments/useEquipmentState.ts
@@ -38,6 +38,10 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
   // (toggle + light_state indicator), but kept as its own flag so it isn't
   // styled with the light "glow" tint.
   const isSwitch = equipment.type === "switch";
+  // Spec 135 — water heater: an on/off relay, driven exactly like a switch
+  // (light_state indicator + boolean/enum toggle), plus an optional water
+  // temperature. Kept as its own flag for icon/label/temperature handling.
+  const isWaterHeater = equipment.type === "water_heater";
 
   // State binding — `light_state` is the canonical ON/OFF data category
   // used by lights, heaters, switches, valves and pool pumps (plugins emit
@@ -169,6 +173,7 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
     isPoolCover,
     isPoolHeatPump,
     isSwitch,
+    isWaterHeater,
     stateBinding,
     isOn,
     shutterPosition,

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -50,6 +50,7 @@ const TYPE_TINTS: Record<EquipmentType, Tint> = {
   energy_production_meter: { bg: "bg-success/10",   text: "text-success" },
   solar_panel:             { bg: "bg-primary-light",  text: "text-primary" },
   heater:                  { bg: "bg-error/10",     text: "text-error" },
+  water_heater:            { bg: "bg-accent-light",  text: "text-accent" },
   pool_heat_pump:          { bg: "bg-error/10",     text: "text-error" },
   energy_meter:            { bg: "bg-accent-light", text: "text-accent" },
   main_energy_meter:       { bg: "bg-accent-light", text: "text-accent" },
@@ -66,6 +67,7 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
   const {
     isLight,
     isSwitch,
+    isWaterHeater,
     isShutterFamily,
     isSensor,
     isEnergyMeter,
@@ -91,7 +93,7 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
 
   // Find primary data value for generic equipments
   const isKnownType =
-    isLight || isSwitch || isSensor || isShutterFamily || isThermostat || isHeater || isGate ||
+    isLight || isSwitch || isWaterHeater || isSensor || isShutterFamily || isThermostat || isHeater || isGate ||
     isEnergyMeter || isWeatherForecast || isMediaPlayer || isAppliance ||
     isWaterValve || isPoolPump || isPoolCover || isPoolHeatPump || isSolar || isCamera;
 
@@ -109,12 +111,19 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
   // Metering switch (spec 129): a smart plug that reports power shows it live
   // next to the on/off toggle. A bare relay has no power binding → null.
   const switchPowerW =
-    isSwitch
+    isSwitch || isWaterHeater
       ? (() => {
           const p = equipment.dataBindings.find((b) => b.category === "power");
           return typeof p?.value === "number" ? p.value : null;
         })()
       : null;
+  // Water heater (spec 135): optional water temperature next to the toggle.
+  const waterHeaterTempC = isWaterHeater
+    ? (() => {
+        const p = equipment.dataBindings.find((b) => b.alias === "water_temperature");
+        return typeof p?.value === "number" ? p.value : null;
+      })()
+    : null;
   const primaryBinding = !isKnownType
     ? equipment.dataBindings[0] ?? null
     : null;
@@ -224,8 +233,13 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
 
       {/* Light / switch controls (smart plug = ON/OFF relay, same surface).
        * Metering plug (spec 129): show live power (amber) next to the toggle. */}
-      {(isLight || isSwitch) && equipment.enabled && (
+      {(isLight || isSwitch || isWaterHeater) && equipment.enabled && (
         <div className="flex items-center gap-2 flex-shrink-0">
+          {waterHeaterTempC !== null && (
+            <span className="text-[13px] font-semibold text-text-secondary tabular-nums font-mono">
+              {waterHeaterTempC.toFixed(1)}°C
+            </span>
+          )}
           {switchPowerW !== null && (
             <span className="text-[13px] font-semibold text-accent tabular-nums font-mono">
               {switchPowerW >= 1000

--- a/ui/src/components/home/ZoneEquipmentsView.tsx
+++ b/ui/src/components/home/ZoneEquipmentsView.tsx
@@ -39,7 +39,7 @@ const EQUIPMENT_GROUPS: EquipmentGroup[] = [
   { labelKey: "equipments.group.weather", types: ["weather", "weather_forecast"], icon: <CloudSun size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.media", types: ["media_player"], icon: <Tv size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.appliances", types: ["appliance"], icon: <WashingMachine size={14} strokeWidth={1.5} /> },
-  { labelKey: "equipments.group.water", types: ["water_valve"], icon: <WaterValveIcon size={14} strokeWidth={1.5} /> },
+  { labelKey: "equipments.group.water", types: ["water_valve", "water_heater"], icon: <WaterValveIcon size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.pool", types: ["pool_pump", "pool_cover", "pool_heat_pump"], icon: <Waves size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.displays", types: ["display"], icon: <Monitor size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.cameras", types: ["camera"], icon: <Camera size={14} strokeWidth={1.5} /> },

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -235,6 +235,7 @@
   "equipments.type.weather_forecast": "Weather Forecast",
   "equipments.type.gate": "Gate",
   "equipments.type.heater": "Electric Heater",
+  "equipments.type.water_heater": "Water Heater",
   "equipments.type.energy_meter": "Energy Meter (sub-meter)",
   "equipments.type.main_energy_meter": "Energy Meter (main)",
   "equipments.type.energy_production_meter": "Energy Meter (production)",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -235,6 +235,7 @@
   "equipments.type.weather_forecast": "Prévisions Météo",
   "equipments.type.gate": "Ouvrant",
   "equipments.type.heater": "Radiateur électrique",
+  "equipments.type.water_heater": "Chauffe-eau",
   "equipments.type.energy_meter": "Compteur d'Énergie (sous-compteur)",
   "equipments.type.main_energy_meter": "Compteur d'Énergie (principal)",
   "equipments.type.energy_production_meter": "Compteur d'Énergie (production)",

--- a/ui/src/lib/binding-candidates.ts
+++ b/ui/src/lib/binding-candidates.ts
@@ -56,6 +56,10 @@ export function computeBindingCandidates(
   deviceOrders: readonly DeviceOrder[],
 ): BindingCandidate[] {
   switch (equipmentType) {
+    // Spec 135 — water heater shares the switch candidate shape (on/off +
+    // metering attach). Its water temperature is an optional extra binding,
+    // not a candidate discriminator.
+    case "water_heater":
     case "switch": {
       // On/off channel: ON/OFF enum OR boolean power-toggle (Zigbee `state`).
       const candidates: BindingCandidate[] = [];

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -221,6 +221,7 @@ export type EquipmentType =
   | "weather_forecast"
   | "gate"
   | "heater"
+  | "water_heater"
   | "energy_meter"
   | "main_energy_meter"
   | "energy_production_meter"


### PR DESCRIPTION
## Summary

Adds a first-class **water heater** (`water_heater`) equipment type (spec 135) — ON/OFF control, optional water-temperature display, optional power/energy metering, auto-binding, a custom state-aware icon, and full dashboard support (desktop + mobile) + zone card. No migration, no new event/API/DataCategory.

## Design

- **Binding**: shares the `switch` candidate shape (`isOnOffOrder` + single-channel metering attach), so Zigbee relays (Tuya WHD02) bind out of the box — builds on the WHD02 candidate fix (#358). The water temperature is an optional extra binding (often on a separate probe device), not a candidate discriminator.
- **Temperature stays out of the room average**: bound under the alias `water_temperature` via a per-type rule in `resolveAlias`. The zone aggregator only folds `temperature`-category bindings whose alias is exactly `temperature`, so the water temperature is displayed but never counted as room temperature.
- **Icon**: custom `WaterHeaterIcon` (cumulus tank) — heating = amber, off = neutral. Approved by the reporter.
- **Control**: desktop widget (icon + toggle + temp + power), mobile card with tap-to-toggle, zone compact card (toggle + temp/power), detail page. Grouped under "Eau" in the zone view.
- Out of scope (documented): settable setpoint (→ thermostat), scheduling / solar-surplus heating (→ a recipe).

## Test plan

- [x] Backend + UI candidate tests: water_heater on a boolean `light_toggle` relay → 1 candidate; metering attach; ON/OFF enum; no on/off channel → 0
- [x] `resolveAlias` per-type rule: a `temperature` reading on a water_heater → `water_temperature`; untouched on other types
- [x] Full suite green: backend 1025 tests + eslint, UI 173 tests + `tsc -b`, backend `tsc`
- [x] Visual verification on a shadow instance: created a `water_heater` bound to a synthetic WHD02 relay (state ON, 54.5°C, 1850W) — desktop dashboard widget and zone compact card both render the amber heating icon, ON pill, temperature, power and a working toggle; the equipment is grouped under "Eau"

🤖 Generated with [Claude Code](https://claude.com/claude-code)