### PR TITLE
fix(equipments): map boolean order values onto declared wire values

### DIFF
--- a/docs/technical/data-model/devices.md
+++ b/docs/technical/data-model/devices.md
@@ -72,8 +72,12 @@ interface DeviceOrder {
   max?: number;
   enumValues?: string[];
   unit?: string;
+  valueOn?: string | number | boolean; // Boolean orders: wire value for true (e.g. "ON")
+  valueOff?: string | number | boolean; // Boolean orders: wire value for false (e.g. "OFF")
 }
 ```
+
+For boolean orders, `valueOn` / `valueOff` carry the wire representation the device actually accepts (e.g. Zigbee2MQTT binary exposes expect `"ON"`/`"OFF"`). When declared by the integration at discovery time, `EquipmentManager.executeOrder` maps boolean-ish values onto them before dispatching to the plugin; orders without them are dispatched untouched (migration `014_device_orders_value_on_off.sql`).
 
 > **Note**: earlier versions exposed MQTT-specific fields (`mqttSetTopic`, `payloadKey`, `dispatch_config`) on `DeviceOrder`. These are no longer part of the runtime API. Migration `004_drop_dispatch_config.sql` deprecated them; the underlying SQLite columns remain (SQLite cannot drop columns without rebuilding the table) but are ignored. Order delivery is now fully delegated to the integration plugin via `IntegrationPlugin.executeOrder()`.
 

--- a/docs/technical/plugin-development.md
+++ b/docs/technical/plugin-development.md
@@ -458,6 +458,8 @@ interface DiscoveredDevice {
     max?: number;
     enumValues?: string[];
     unit?: string;
+    valueOn?: string | number | boolean;
+    valueOff?: string | number | boolean;
   }[];
 }
 
@@ -783,9 +785,13 @@ interface DiscoveredDevice {
     max?: number; // For numeric orders: maximum value
     enumValues?: string[]; // For enum orders: allowed values
     unit?: string; // Unit (e.g. "C")
+    valueOn?: string | number | boolean; // For boolean orders: wire value for true (e.g. "ON")
+    valueOff?: string | number | boolean; // For boolean orders: wire value for false (e.g. "OFF")
   }[];
 }
 ```
+
+**Boolean orders and wire values.** If the device does not accept JSON booleans on the wire (Zigbee2MQTT `binary` exposes expect `"ON"`/`"OFF"`, some locks expect `"LOCK"`/`"UNLOCK"`), declare `valueOn`/`valueOff` at discovery time. The core order dispatcher then maps boolean-ish values (`true`/`false`, `"on"`/`"off"`, `"true"`/`"false"`, `1`/`0`, and the wire values themselves case-insensitively) onto the declared wire representation before calling your `executeOrder()`, which can stay a pass-through. Orders without `valueOn`/`valueOff` receive the caller's value untouched.
 
 ### Example (from weather-forecast)
 

--- a/migrations/014_device_orders_value_on_off.sql
+++ b/migrations/014_device_orders_value_on_off.sql
@@ -1,0 +1,5 @@
+-- Wire representations for boolean orders (spec: issue #360).
+-- Declared by the integration at discovery time (e.g. Z2M binary expose
+-- value_on/value_off). JSON-encoded so string and boolean forms round-trip.
+ALTER TABLE device_orders ADD COLUMN value_on TEXT;
+ALTER TABLE device_orders ADD COLUMN value_off TEXT;

--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -17,6 +17,7 @@ function createTestDb(): Database.Database {
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
     "006_pool_runtime_and_category_override.sql",
+    "014_device_orders_value_on_off.sql",
   ]) {
     const sql = readFileSync(
       resolve(import.meta.dirname ?? ".", "../../migrations", file),
@@ -120,6 +121,47 @@ describe("DeviceManager", () => {
       expect(orders.find((o) => o.key === "brightness")?.min).toBe(0);
       expect(orders.find((o) => o.key === "brightness")?.max).toBe(254);
       expect(orders.find((o) => o.key === "state")?.enumValues).toEqual(["ON", "OFF", "TOGGLE"]);
+    });
+
+    it("persists and re-syncs order wire values (value_on/value_off)", () => {
+      const relay = {
+        friendlyName: "whd02_relay",
+        data: [{ key: "state", type: "boolean" as const, category: "light_state" as const }],
+        orders: [
+          {
+            key: "state",
+            type: "boolean" as const,
+            category: "light_toggle" as const,
+            valueOn: "ON",
+            valueOff: "OFF",
+          },
+        ],
+        rawExpose: [],
+      };
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", relay);
+
+      const device = manager.getAll()[0];
+      let order = manager.getDeviceOrders(device.id).find((o) => o.key === "state");
+      expect(order?.valueOn).toBe("ON");
+      expect(order?.valueOff).toBe("OFF");
+
+      // Re-discovery updates wire values in place (stable order id)
+      const updated = {
+        ...relay,
+        orders: [{ ...relay.orders[0], valueOn: true as const, valueOff: false as const }],
+      };
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", updated);
+      order = manager.getDeviceOrders(device.id).find((o) => o.key === "state");
+      expect(order?.valueOn).toBe(true);
+      expect(order?.valueOff).toBe(false);
+    });
+
+    it("leaves wire values undefined when not declared", () => {
+      manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", sampleLight);
+      const device = manager.getAll()[0];
+      const order = manager.getDeviceOrders(device.id).find((o) => o.key === "state");
+      expect(order?.valueOn).toBeUndefined();
+      expect(order?.valueOff).toBeUndefined();
     });
 
     it("emits device.discovered event", () => {

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -23,6 +23,7 @@ import type {
   OrderCategory,
 } from "../shared/types.js";
 import { PROPERTY_TO_CATEGORY } from "../shared/constants.js";
+import { parseWireValue } from "../shared/order-wire-value.js";
 
 export interface DiscoveredDevice {
   ieeeAddress?: string;
@@ -44,6 +45,8 @@ export interface DiscoveredDevice {
     max?: number;
     enumValues?: string[];
     unit?: string;
+    valueOn?: string | number | boolean;
+    valueOff?: string | number | boolean;
   }[];
   rawExpose?: unknown;
 }
@@ -121,11 +124,11 @@ export class DeviceManager {
         "SELECT * FROM device_orders WHERE device_id = ? AND key = ?",
       ),
       insertDeviceOrder: this.db.prepare(
-        `INSERT INTO device_orders (id, device_id, key, type, category, min_value, max_value, enum_values, unit)
-         VALUES (@id, @deviceId, @key, @type, @category, @min, @max, @enumValues, @unit)`,
+        `INSERT INTO device_orders (id, device_id, key, type, category, min_value, max_value, enum_values, unit, value_on, value_off)
+         VALUES (@id, @deviceId, @key, @type, @category, @min, @max, @enumValues, @unit, @valueOn, @valueOff)`,
       ),
       updateDeviceOrderDef: this.db.prepare(
-        "UPDATE device_orders SET type = ?, category = ?, min_value = ?, max_value = ?, enum_values = ?, unit = ? WHERE id = ?",
+        "UPDATE device_orders SET type = ?, category = ?, min_value = ?, max_value = ?, enum_values = ?, unit = ?, value_on = ?, value_off = ? WHERE id = ?",
       ),
       deleteDeviceOrderById: this.db.prepare("DELETE FROM device_orders WHERE id = ?"),
       getDeviceOrderIds: this.db.prepare("SELECT id, key FROM device_orders WHERE device_id = ?"),
@@ -246,6 +249,8 @@ export class DeviceManager {
             o.max ?? null,
             o.enumValues ? JSON.stringify(o.enumValues) : null,
             o.unit ?? null,
+            o.valueOn !== undefined ? JSON.stringify(o.valueOn) : null,
+            o.valueOff !== undefined ? JSON.stringify(o.valueOff) : null,
             existingOrder.id,
           );
         } else {
@@ -259,6 +264,8 @@ export class DeviceManager {
             max: o.max ?? null,
             enumValues: o.enumValues ? JSON.stringify(o.enumValues) : null,
             unit: o.unit ?? null,
+            valueOn: o.valueOn !== undefined ? JSON.stringify(o.valueOn) : null,
+            valueOff: o.valueOff !== undefined ? JSON.stringify(o.valueOff) : null,
           });
         }
       }
@@ -738,6 +745,8 @@ interface DeviceOrderRow {
   max_value: number | null;
   enum_values: string | null;
   unit: string | null;
+  value_on: string | null;
+  value_off: string | null;
 }
 
 function rowToDevice(row: DeviceRow): Device {
@@ -798,5 +807,7 @@ function rowToDeviceOrder(row: DeviceOrderRow): DeviceOrder {
     max: row.max_value ?? undefined,
     enumValues,
     unit: row.unit ?? undefined,
+    valueOn: parseWireValue(row.value_on),
+    valueOff: parseWireValue(row.value_off),
   };
 }

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -19,6 +19,7 @@ function createTestDb(): Database.Database {
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
     "006_pool_runtime_and_category_override.sql",
+    "014_device_orders_value_on_off.sql",
   ]) {
     db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
   }
@@ -47,6 +48,8 @@ function seedDevice(
       type?: string;
       category?: string;
       enumValues?: string[];
+      valueOn?: string | number | boolean;
+      valueOff?: string | number | boolean;
     }[];
   } = {},
 ) {
@@ -79,8 +82,8 @@ function seedDevice(
   for (const o of opts.orderKeys ?? []) {
     const id = o.id ?? crypto.randomUUID();
     db.prepare(
-      `INSERT INTO device_orders (id, device_id, key, type, category, enum_values)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO device_orders (id, device_id, key, type, category, enum_values, value_on, value_off)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       id,
       deviceId,
@@ -88,6 +91,8 @@ function seedDevice(
       o.type ?? "boolean",
       o.category ?? null,
       o.enumValues ? JSON.stringify(o.enumValues) : null,
+      o.valueOn !== undefined ? JSON.stringify(o.valueOn) : null,
+      o.valueOff !== undefined ? JSON.stringify(o.valueOff) : null,
     );
     orderIds.push(id);
   }
@@ -660,6 +665,82 @@ describe("EquipmentManager", () => {
 
       expect(mockPublished).toHaveLength(1);
       expect(JSON.parse(mockPublished[0].payload)).toEqual({ R1: "latch" });
+    });
+
+    it("maps boolean values onto declared wire values (issue #360)", async () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Relay", type: "light_onoff", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        name: "WHD02",
+        orderKeys: [{ key: "state", type: "boolean", valueOn: "ON", valueOff: "OFF" }],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      await manager.executeOrder(eq.id, "state", true);
+      await manager.executeOrder(eq.id, "state", false);
+
+      expect(mockPublished).toHaveLength(2);
+      expect(JSON.parse(mockPublished[0].payload)).toEqual({ state: "ON" });
+      expect(JSON.parse(mockPublished[1].payload)).toEqual({ state: "OFF" });
+    });
+
+    it("keeps accepting on/off strings when wire values are declared", async () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Relay", type: "light_onoff", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        name: "WHD02",
+        orderKeys: [{ key: "state", type: "boolean", valueOn: "ON", valueOff: "OFF" }],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      await manager.executeOrder(eq.id, "state", "ON");
+      await manager.executeOrder(eq.id, "state", "off");
+
+      expect(mockPublished).toHaveLength(2);
+      expect(JSON.parse(mockPublished[0].payload)).toEqual({ state: "ON" });
+      expect(JSON.parse(mockPublished[1].payload)).toEqual({ state: "OFF" });
+    });
+
+    it("maps booleans onto non-standard wire values (LOCK/UNLOCK)", async () => {
+      const zone = zoneManager.create({ name: "Entrée" });
+      const eq = manager.create({ name: "Serrure", type: "light_onoff", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        name: "Lock",
+        orderKeys: [{ key: "state", type: "boolean", valueOn: "LOCK", valueOff: "UNLOCK" }],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      await manager.executeOrder(eq.id, "state", true);
+
+      expect(JSON.parse(mockPublished[0].payload)).toEqual({ state: "LOCK" });
+    });
+
+    it("dispatches booleans untouched when no wire values are declared", async () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Cloud Switch", type: "light_onoff", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        name: "CloudPlug",
+        orderKeys: [{ key: "power", type: "boolean" }],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "power");
+
+      await manager.executeOrder(eq.id, "power", true);
+
+      expect(JSON.parse(mockPublished[0].payload)).toEqual({ power: true });
+    });
+
+    it("leaves non-boolean-ish values untouched even with wire values declared", async () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eq = manager.create({ name: "Relay", type: "light_onoff", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        name: "WHD02",
+        orderKeys: [{ key: "state", type: "boolean", valueOn: "ON", valueOff: "OFF" }],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+
+      await manager.executeOrder(eq.id, "state", "TOGGLE");
+
+      expect(JSON.parse(mockPublished[0].payload)).toEqual({ state: "TOGGLE" });
     });
 
     it("resolves enum value case-insensitively", async () => {

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -20,6 +20,7 @@ import type {
   OrderSource,
 } from "../shared/types.js";
 import { inferBindingCategory } from "./binding-candidates.js";
+import { parseWireValue, resolveWireValue } from "../shared/order-wire-value.js";
 import { deriveEquipmentStatus, isStaleBinding } from "./equipment-status.js";
 import type { Device } from "../shared/types.js";
 
@@ -238,7 +239,7 @@ export class EquipmentManager {
                 do2.device_id, d.name as device_name, do2.key, do2.type,
                 COALESCE(ob.category_override, do2.category) as category,
                 do2.min_value, do2.max_value,
-                do2.enum_values, do2.unit
+                do2.enum_values, do2.unit, do2.value_on, do2.value_off
          FROM order_bindings ob
          JOIN device_orders do2 ON ob.device_order_id = do2.id
          JOIN devices d ON do2.device_id = d.id
@@ -742,6 +743,15 @@ export class EquipmentManager {
 
       const orderKey = binding.key;
 
+      // Map boolean-ish values onto the wire representation the device
+      // declared at discovery (value_on/value_off), e.g. true -> "ON" for
+      // Z2M binary exposes. Orders without wire values dispatch untouched.
+      const dispatchValue = resolveWireValue(
+        resolvedValue,
+        parseWireValue(binding.value_on),
+        parseWireValue(binding.value_off),
+      );
+
       // Dispatch with 1 retry (2s delay) for transient failures
       let dispatched = false;
       for (let attempt = 1; attempt <= 2; attempt++) {
@@ -750,7 +760,7 @@ export class EquipmentManager {
             device.integrationId,
             device,
             orderKey,
-            resolvedValue,
+            dispatchValue,
           );
           dispatched = true;
           break;
@@ -1255,6 +1265,9 @@ interface OrderBindingJoinRow {
   max_value: number | null;
   enum_values: string | null;
   unit: string | null;
+  // Selected by getOrderBindingsByAlias only (order dispatch path).
+  value_on?: string | null;
+  value_off?: string | null;
 }
 
 interface DeviceOrderRow {

--- a/src/equipments/pool-runtime-tracker.test.ts
+++ b/src/equipments/pool-runtime-tracker.test.ts
@@ -19,6 +19,7 @@ function createTestDb(): Database.Database {
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
     "006_pool_runtime_and_category_override.sql",
+    "014_device_orders_value_on_off.sql",
   ]) {
     db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
   }

--- a/src/recipes/engine/recipe-manager.test.ts
+++ b/src/recipes/engine/recipe-manager.test.ts
@@ -34,6 +34,7 @@ function createTestDb(): Database.Database {
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
     "006_pool_runtime_and_category_override.sql",
+    "014_device_orders_value_on_off.sql",
   ];
   for (const file of migrations) {
     const sql = readFileSync(

--- a/src/shared/order-wire-value.test.ts
+++ b/src/shared/order-wire-value.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { parseWireValue, resolveWireValue } from "./order-wire-value.js";
+
+describe("resolveWireValue", () => {
+  it("maps booleans onto declared wire values", () => {
+    expect(resolveWireValue(true, "ON", "OFF")).toBe("ON");
+    expect(resolveWireValue(false, "ON", "OFF")).toBe("OFF");
+  });
+
+  it("maps the wire values themselves (identity, case-insensitive)", () => {
+    expect(resolveWireValue("ON", "ON", "OFF")).toBe("ON");
+    expect(resolveWireValue("off", "ON", "OFF")).toBe("OFF");
+    expect(resolveWireValue(" On ", "ON", "OFF")).toBe("ON");
+  });
+
+  it("accepts common boolean-ish strings and numbers", () => {
+    expect(resolveWireValue("true", "ON", "OFF")).toBe("ON");
+    expect(resolveWireValue("false", "ON", "OFF")).toBe("OFF");
+    expect(resolveWireValue("1", "ON", "OFF")).toBe("ON");
+    expect(resolveWireValue("0", "ON", "OFF")).toBe("OFF");
+    expect(resolveWireValue(1, "ON", "OFF")).toBe("ON");
+    expect(resolveWireValue(0, "ON", "OFF")).toBe("OFF");
+  });
+
+  it("supports non-standard wire values", () => {
+    expect(resolveWireValue(true, "LOCK", "UNLOCK")).toBe("LOCK");
+    expect(resolveWireValue("unlock", "LOCK", "UNLOCK")).toBe("UNLOCK");
+    expect(resolveWireValue(false, true, false)).toBe(false);
+  });
+
+  it("passes values through when wire values are not declared", () => {
+    expect(resolveWireValue(true, undefined, undefined)).toBe(true);
+    expect(resolveWireValue("ON", "ON", undefined)).toBe("ON");
+    expect(resolveWireValue(false, undefined, "OFF")).toBe(false);
+  });
+
+  it("passes non-boolean-ish values through untouched", () => {
+    expect(resolveWireValue("TOGGLE", "ON", "OFF")).toBe("TOGGLE");
+    expect(resolveWireValue(42, "ON", "OFF")).toBe(42);
+    expect(resolveWireValue(null, "ON", "OFF")).toBe(null);
+    expect(resolveWireValue({ state: true }, "ON", "OFF")).toEqual({ state: true });
+  });
+});
+
+describe("parseWireValue", () => {
+  it("parses JSON-encoded primitives", () => {
+    expect(parseWireValue('"ON"')).toBe("ON");
+    expect(parseWireValue("true")).toBe(true);
+    expect(parseWireValue("1")).toBe(1);
+  });
+
+  it("returns undefined for null/undefined and non-primitive JSON", () => {
+    expect(parseWireValue(null)).toBeUndefined();
+    expect(parseWireValue(undefined)).toBeUndefined();
+    expect(parseWireValue('{"a":1}')).toBeUndefined();
+  });
+
+  it("falls back to the raw string for unencoded values", () => {
+    expect(parseWireValue("ON")).toBe("ON");
+  });
+});

--- a/src/shared/order-wire-value.ts
+++ b/src/shared/order-wire-value.ts
@@ -1,0 +1,58 @@
+import type { OrderWireValue } from "./types";
+
+/**
+ * Wire-value resolution for boolean orders (issue #360).
+ *
+ * Integrations may declare `valueOn` / `valueOff` on a device order — the
+ * wire representations the device actually accepts (e.g. Zigbee2MQTT binary
+ * exposes expect "ON"/"OFF", some locks expect "LOCK"/"UNLOCK"). When both
+ * are declared, the dispatcher maps boolean-ish order values onto them so
+ * callers can send the boolean the order type advertises. Orders without
+ * declared wire values are dispatched untouched.
+ */
+export function resolveWireValue(
+  value: unknown,
+  valueOn: OrderWireValue | undefined,
+  valueOff: OrderWireValue | undefined,
+): unknown {
+  if (valueOn === undefined || valueOff === undefined) return value;
+  const on = coerceOnOff(value, valueOn, valueOff);
+  if (on === undefined) return value;
+  return on ? valueOn : valueOff;
+}
+
+function coerceOnOff(
+  value: unknown,
+  valueOn: OrderWireValue,
+  valueOff: OrderWireValue,
+): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (value === valueOn) return true;
+  if (value === valueOff) return false;
+  if (typeof value === "string") {
+    const s = value.trim().toLowerCase();
+    if (typeof valueOn === "string" && s === valueOn.toLowerCase()) return true;
+    if (typeof valueOff === "string" && s === valueOff.toLowerCase()) return false;
+    if (s === "on" || s === "true" || s === "1") return true;
+    if (s === "off" || s === "false" || s === "0") return false;
+    return undefined;
+  }
+  if (value === 1) return true;
+  if (value === 0) return false;
+  return undefined;
+}
+
+/** Parse a JSON-encoded wire value column (value_on / value_off). */
+export function parseWireValue(raw: string | null | undefined): OrderWireValue | undefined {
+  if (raw === null || raw === undefined) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === "string" || typeof parsed === "number" || typeof parsed === "boolean") {
+      return parsed;
+    }
+    return undefined;
+  } catch {
+    // Legacy/unencoded values are treated as plain strings.
+    return raw;
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -151,7 +151,13 @@ export interface DeviceOrder {
   max?: number;
   enumValues?: string[];
   unit?: string;
+  // Wire representations for boolean orders (e.g. Z2M binary "ON"/"OFF").
+  // When declared, the order dispatcher maps boolean-ish values onto them.
+  valueOn?: OrderWireValue;
+  valueOff?: OrderWireValue;
 }
+
+export type OrderWireValue = string | number | boolean;
 
 // ============================================================
 // Device with relations (API response)

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -20,6 +20,7 @@ function createTestDb(): Database.Database {
     "004_drop_dispatch_config.sql",
     "005_device_data_enum_values.sql",
     "006_pool_runtime_and_category_override.sql",
+    "014_device_orders_value_on_off.sql",
   ]) {
     db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
   }


### PR DESCRIPTION
Fixes #360. Core half of mchacher/sowel-plugin-zigbee2mqtt#4.

## Problem

Boolean order values are dispatched to integration plugins verbatim. A `POST /api/v1/equipments/<id>/orders/state` with `{"value": true}` reaches Zigbee2MQTT as `{"state": true}`, which Z2M silently discards for `binary` exposes (they expect `value_on`/`value_off`, i.e. `"ON"`/`"OFF"`) while the REST call still returns `200`. Every currently-working path (dashboard toggle, mode impacts, stored recipe actions) only survives because it sends `"ON"`/`"OFF"` strings, including a hard-coded `alias !== "state"` special case in the UI.

## Fix

Integrations can now declare the wire representation of a boolean order at discovery time, and core resolves values against it at dispatch, mirroring the existing enum resolution:

- `DeviceOrder.valueOn` / `valueOff` (`string | number | boolean`), persisted on `device_orders` via migration `014_device_orders_value_on_off.sql` (JSON-encoded, nullable, no backfill needed).
- `DeviceManager.upsertFromDiscovery` persists and re-syncs them like the other order metadata.
- `EquipmentManager.executeOrder` maps boolean-ish values (`true`/`false`, `"on"`/`"off"`, `"true"`/`"false"`, `1`/`0`, and the wire values themselves case-insensitively) onto the declared representation, per binding, just before dispatch. The `equipment.order.executed` event keeps the abstract value.
- Orders without `valueOn`/`valueOff` dispatch exactly as before: no behavior change for any existing integration.

Resolution logic lives in `src/shared/order-wire-value.ts` with unit tests.

## Follow-up (separate repo)

`sowel-plugin-zigbee2mqtt` will propagate the expose's `value_on`/`value_off` (already parsed, currently unread) onto discovered orders — that release closes the plugin issue #4, including non-standard binary exposes (`LOCK`/`UNLOCK`, literal booleans). Longer term the UI `alias === "state"` special cases can be removed.

## Tests

- `order-wire-value.test.ts`: mapping matrix (booleans, identity strings, boolean-ish strings/numbers, non-standard wire values, passthrough cases).
- `equipment-manager.test.ts`: end-to-end `executeOrder` with declared wire values (true→"ON", "off"→"OFF", LOCK/UNLOCK, passthrough without declaration, non-boolean-ish passthrough).
- `device-manager.test.ts`: discovery persistence + re-sync of wire values.
- `npm run validate` green (69 files, 1041 tests).
