### PR TITLE
chore(registry): bump zigbee2mqtt to 2.3.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -7,11 +7,11 @@
     "icon": "Radio",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-zigbee2mqtt",
-    "version": "2.2.3",
+    "version": "2.3.0",
     "tags": ["zigbee", "mqtt", "z2m", "sensors", "lights", "switches"],
     "sowelVersion": ">=1.2.12",
     "owner": "mchacher",
-    "sha256": "2a5b0f905879046714751a9474f7515ce1b31819dc10a893a5feee1df2ec80db"
+    "sha256": "023df0a4eeddac7d585bac2351c04c75837868a037ed934fe23e96b0ef52711d"
   },
   {
     "id": "lora2mqtt",


### PR DESCRIPTION
Bumps the zigbee2mqtt plugin to [v2.3.0](https://github.com/mchacher/sowel-plugin-zigbee2mqtt/releases/tag/v2.3.0):

- Tuya PJ-1203A bidirectional dual-channel energy meter mapped as one Sowel device per channel, feeding the energy pipeline (signed Wh deltas, Shelly Pro 3EM shape) — contributed by Adrien Jouve (computingify), plugin PR #5.
- Binary expose `value_on`/`value_off` propagated onto discovered orders, so Sowel core >= 1.34 can map boolean order values onto the device's wire format (plugin issue #4 / core #360), plugin PR #6.

sha256 verified against the published release asset:
`023df0a4eeddac7d585bac2351c04c75837868a037ed934fe23e96b0ef52711d`