### PR TITLE
release: v1.34.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,18 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.34.x: Équipement chauffe-eau
+
+### v1.34.0 — 2026-08-08 { #v1-34-0 }
+
+- Feat (equipments) : nouveau type d'équipement **chauffe-eau** (spec 135). Commande ON/OFF via le canal on/off standard (les relais Zigbee comme le Tuya WHD02 fonctionnent directement), affichage optionnel de la **température de l'eau** liée sous son propre alias pour ne jamais fausser la moyenne de température de la zone, et affichage automatique puissance/énergie quand le relais mesure la consommation (comme les prises avec mesure). Créer un chauffe-eau depuis un relais lie tout automatiquement, et une icône dédiée indique quand il chauffe. Support complet du dashboard PC et mobile. (#359)
+- Fix (equipments) : les commandes on/off booléennes envoyées aux relais Zigbee via l'API REST ou par les automatisations étaient **silencieusement ignorées** : l'appel répondait succès, mais Zigbee2MQTT rejetait le message car les interrupteurs binaires attendent leur forme déclarée (`"ON"`/`"OFF"`), pas un booléen JSON. Les intégrations peuvent désormais déclarer la représentation « fil » d'un ordre booléen à la découverte, et Sowel traduit la valeur à l'envoi : `true` devient `"ON"`, ou `"LOCK"`, ou ce que l'appareil déclare. Fonctionne avec le plugin Zigbee2MQTT v2.3.0, qui déclare ces valeurs ; les ordres qui ne les déclarent pas sont envoyés exactement comme avant. (#360, #362)
+- Fix (equipments) : les modules relais exposant le on/off comme ordre booléen (Tuya WHD02 et similaires) ne pouvaient pas être associés à un équipement **lumière ou pompe de piscine** : la règle de candidats n'acceptait que les enums ON/OFF pour ces types, alors que le même relais se liait sans problème à un interrupteur. Les deux acceptent désormais les ordres on/off booléens, alignés sur la règle des interrupteurs. (#358)
+- Chore (registry) : ajout du plugin communautaire **caméra Netatmo** 1.0.0 (Netatmo Presence : instantané, vue en direct, surveillance on/off, projecteur, détections de mouvement), qui se lie au type d'équipement caméra introduit en v1.31.0. Par Romain (alpitux). (#356)
+- Chore (registry) : **plugin Zigbee2MQTT 2.3.0** : le compteur d'énergie bidirectionnel double pince Tuya PJ-1203A arrive désormais comme un appareil par voie alimentant la chaîne énergie (deltas d'énergie signés, même forme que le Shelly Pro 3EM), contribution d'Adrien Jouve (computingify) ; plus le correctif de liaison des relais Tuya et les déclarations de valeurs « fil » utilisées par le correctif d'ordres ci-dessus. (#357, #363)
+
+---
+
 ## 1.33.x: Corrections de fiabilité
 
 ### v1.33.0 — 2026-08-07 { #v1-33-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,18 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.34.x: Water heater equipment
+
+### v1.34.0 — 2026-08-08 { #v1-34-0 }
+
+- Feat (equipments): new **water heater** equipment type (spec 135). ON/OFF control through the standard on/off relay channel (Zigbee relays such as the Tuya WHD02 work out of the box), an optional **water temperature** display bound under its own alias so it never skews the zone's room-temperature average, and automatic power/energy display when the relay meters consumption (like metering switches). Creating one from a relay device binds everything automatically, and a custom state-aware icon shows when it is heating. Full desktop and mobile dashboard support. (#359)
+- Fix (equipments): boolean on/off commands sent to Zigbee relays through the REST API or by automations were **silently ignored**: the call returned success, but Zigbee2MQTT dropped the payload because binary switches expect their declared wire form (`"ON"`/`"OFF"`), not a JSON boolean. Integrations can now declare the wire representation of a boolean order at discovery time, and Sowel translates the value at dispatch: `true` becomes `"ON"`, or `"LOCK"`, or whatever the device declares. Pairs with the Zigbee2MQTT plugin v2.3.0, which declares those values; orders that do not declare them are dispatched exactly as before. (#360, #362)
+- Fix (equipments): relay modules exposing on/off as a boolean order (Tuya WHD02 and similar) could not be associated with a **light or pool pump** equipment: the binding candidate rule only accepted ON/OFF enums for those types, although the same relay bound fine as a switch. Both now accept boolean on/off orders, aligned with the switch rule. (#358)
+- Chore (registry): **Netatmo camera** community plugin 1.0.0 added (Netatmo Presence: snapshot, live view, monitoring toggle, spot light, motion detections), binding into the camera equipment type introduced in v1.31.0. By Romain (alpitux). (#356)
+- Chore (registry): **Zigbee2MQTT plugin 2.3.0**: the Tuya PJ-1203A bidirectional dual-channel energy meter now lands as one device per channel feeding the energy pipeline (signed energy deltas, same shape as the Shelly Pro 3EM), contributed by Adrien Jouve (computingify); plus the Tuya relay binding fix and the binary wire-value declarations used by the order fix above. (#357, #363)
+
+---
+
 ## 1.33.x: Reliability fixes
 
 ### v1.33.0 — 2026-08-07 { #v1-33-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.33.0",
+  "version": "1.34.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release v1.34.0. Covers everything merged since v1.33.0:

- feat(equipments): water heater equipment type (spec 135) (#359)
- fix(equipments): map boolean order values onto declared wire values (#360, #362)
- fix(equipments): light_onoff/pool_pump bind boolean on/off relays (#358)
- chore(registry): netatmo_camera 1.0.0 community plugin (spec 133) (#356)
- chore(registry): zigbee2mqtt 2.2.3 then 2.3.0 (PJ-1203A per-channel devices, binary wire values) (#357, #363)

Release notes added to both docs/release-notes.md and docs/release-notes.fr.md with the { #v1-34-0 } anchor (spec 108). After merge: tag the on-main commit v1.34.0 and push the tag to trigger the release build.