### PR TITLE
chore(registry): bump schedule-on-off to 2.0.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -461,7 +461,7 @@
     "icon": "CalendarClock",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-schedule-on-off",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "tags": ["schedule", "timer", "on-off", "sunrise", "sunset", "automation"],
     "i18n": {
       "fr": {
@@ -471,7 +471,7 @@
     },
     "sowelVersion": ">=1.23.0",
     "owner": "mchacher",
-    "sha256": "0a3789ce25a0ca3758631bd54976bdfd4999268e7ae660ddf6b73dc33f72857f"
+    "sha256": "086862005bcf1555bbd284ddf8cfeab90acd31a9dc4802b8cb6cbca4c7491ffc"
   },
   {
     "id": "runtime-guard",


### PR DESCRIPTION
Schedule On/Off v2.0.1 adds `water_heater` (spec 135) to the `equipments` slot type list, so water heaters appear in the recipe's equipment picker.

- `version`: 2.0.0 -> 2.0.1
- `sha256`: verified against the published release asset `sowel-recipe-schedule-on-off-2.0.1.tar.gz` (`086862005bcf...91ffc`)

Recipe release: https://github.com/mchacher/sowel-recipe-schedule-on-off/releases/tag/v2.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)