### PR TITLE
release: v1.35.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,16 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.35.x: Sources personnelles de plugins
+
+### v1.35.0 — 2026-08-08 { #v1-35-0 }
+
+- Feat (plugins) : **sources personnelles de plugins** (spec 136). Ajoutez vos propres dépôts GitHub publics comme sources de plugins et installez vos propres intégrations et recettes sans passer par le registre central, ni pour la première publication ni pour les montées de version. Un troisième niveau de confiance apparaît à côté d'officiel et communautaire : les entrées personnelles portent un badge bleu **Perso**, et la confiance suit un modèle « au premier usage ». Sowel télécharge le tarball de la release, affiche sa version et son empreinte SHA256 dans une boîte de confirmation, puis épingle le hash ; tout changement de contenu ultérieur (mises à jour comprises) redemande confirmation avec la nouvelle empreinte, et les restaurations de sauvegarde vérifient les retéléchargements contre le hash épinglé. Le chemin d'installation du registre est inchangé, et les paquets personnels ont des gardes supplémentaires : le dépôt du manifest doit correspondre à la source, et un id de plugin ne peut pas masquer une entrée du registre. Tout se gère depuis la nouvelle section « Sources personnelles » de la page Plugins. (#367)
+- Chore (registry) : **plugin Zigbee2MQTT 2.3.1** : les topics de disponibilité par appareil sont désormais ignorés quand la fonction availability de Z2M est désactivée ; les messages retained périmés laissés sur le broker ne marquent plus des appareils fonctionnels hors ligne à chaque démarrage ou reconnexion. (#365)
+- Chore (registry) : **recette Schedule On/Off 2.0.1** : les équipements chauffe-eau (introduits en v1.34.0) sont désormais sélectionnables dans le slot équipements de la recette. (#366)
+
+---
+
 ## 1.34.x: Équipement chauffe-eau
 
 ### v1.34.0 — 2026-08-08 { #v1-34-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,16 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.35.x: Personal plugin sources
+
+### v1.35.0 — 2026-08-08 { #v1-35-0 }
+
+- Feat (plugins): **personal plugin sources** (spec 136). Add your own public GitHub repositories as plugin sources and install your own integrations and recipes without going through the central registry, neither for the first publication nor for version bumps. A third trust tier appears next to official and community: personal entries carry a blue **Personal** badge, and trust follows a trust-on-first-use model. Sowel downloads the release tarball, shows its version and SHA256 fingerprint in a confirmation dialog, then pins the hash; any later content change (updates included) asks again with the new fingerprint, and backup restores verify re-downloads against the pinned hash. The registry install path is unchanged, and personal packages get extra guards: the manifest repository must match the source, and a plugin id cannot shadow a registry entry. Everything is managed from the new "Personal sources" section of the Plugins page. (#367)
+- Chore (registry): **Zigbee2MQTT plugin 2.3.1**: per-device availability topics are now ignored when Z2M's availability feature is disabled, so stale retained availability messages left on the broker no longer mark working devices offline at every boot or reconnect. (#365)
+- Chore (registry): **Schedule On/Off recipe 2.0.1**: water heater equipments (introduced in v1.34.0) can now be picked in the recipe's equipment slot. (#366)
+
+---
+
 ## 1.34.x: Water heater equipment
 
 ### v1.34.0 — 2026-08-08 { #v1-34-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.34.0",
+  "version": "1.35.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Release v1.35.0: personal plugin sources (spec 136, #367) + registry bumps shipped since v1.34.0 (#365, #366).

Release notes added in both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-35-0 }` anchor (spec 108). Version bumped in `package.json` + `ui/package.json`.

After merge: tag `v1.35.0` on the merge commit and push the tag to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)