### PR TITLE
docs(user): add Plugins user guide page

### DIFF
--- a/docs/user/plugins.fr.md
+++ b/docs/user/plugins.fr.md
@@ -1,0 +1,75 @@
+# Plugins
+
+Tout ce que Sowel connecte -- et chaque recette d'automatisation qu'il exécute -- arrive sous forme de **plugin**. Une installation Sowel neuve n'a aucun plugin : vous choisissez dans le store les intégrations et recettes dont vous avez besoin, et seules celles-là tournent sur votre instance.
+
+Les plugins se gèrent depuis **Administration > Plugins** (admin uniquement).
+
+---
+
+## Les deux onglets
+
+**Installés** liste ce qui tourne sur votre instance :
+
+- Les **intégrations** affichent leur état de connexion et le nombre d'appareils qu'elles alimentent. Depuis cette liste, vous pouvez désactiver, réactiver, mettre à jour ou désinstaller chacune.
+- Les **recettes** sont les modèles d'automatisation disponibles quand vous créez des instances de recettes.
+
+**Store** liste ce que vous pouvez installer. Les entrées viennent du catalogue officiel Sowel, plus vos propres sources personnelles (voir plus bas). Le bouton **Rafraîchir** relit le catalogue immédiatement, utile juste après l'annonce d'un nouveau plugin ou d'une nouvelle version.
+
+Quand une version plus récente d'un plugin installé est disponible, un badge de mise à jour apparaît sur sa ligne (et dans le panneau de mises à jour de la barre du haut). La mise à jour conserve tous vos réglages, appareils, liaisons d'équipements et historiques : seul le code du plugin change.
+
+---
+
+## Niveaux de confiance
+
+Chaque entrée du store appartient à l'un des trois niveaux de confiance, pour que vous sachiez toujours quel code vous vous apprêtez à exécuter :
+
+| Niveau            | Badge               | Qui le publie                    | Ce que Sowel vérifie                                                                                  |
+| ----------------- | ------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| **Officiel**      | aucun               | Le mainteneur de Sowel           | Empreinte d'intégrité épinglée dans le catalogue officiel, code maintenu avec Sowel                   |
+| **Communautaire** | **Community** ambre | Un développeur tiers             | Empreinte d'intégrité épinglée dans le catalogue officiel ; le code lui-même n'est pas revu par Sowel |
+| **Personnel**     | **Perso** bleu      | Vous (vos propres dépôts GitHub) | Empreinte que vous approuvez vous-même à l'installation, puis épinglée (voir plus bas)                |
+
+Installer un plugin communautaire demande une confirmation unique. Installer ou mettre à jour un plugin personnel demande toujours une confirmation, en montrant exactement ce que vous allez exécuter.
+
+---
+
+## Sources personnelles
+
+Les sources personnelles permettent d'installer **vos propres plugins et recettes** sans les publier au catalogue officiel. Usages typiques : une recette écrite pour votre propre maison, ou l'essai d'un plugin que vous développez avant de le partager.
+
+### Prérequis
+
+Une source personnelle est un **dépôt GitHub public** qui a au moins une release avec un asset `sowel-*.tar.gz` -- le packaging standard des plugins Sowel. Si vous écrivez votre première recette, le [guide de développement de recettes](../technical/recipe-development.fr.md) explique comment produire exactement cela.
+
+### Ajouter une source
+
+1. Ouvrez **Administration > Plugins > Store** et descendez jusqu'à **Sources personnelles**.
+2. Saisissez le dépôt au format `owner/repo` (par exemple `jdoe/sowel-recipe-ma-recette`) et cliquez sur **Ajouter**.
+3. La source apparaît dans la liste avec la version de sa dernière release. Si le dépôt n'a pas encore de release, elle est conservée avec la mention « pas encore de release » et devient installable dès que vous en publiez une.
+
+Le plugin apparaît alors dans le store avec le badge bleu **Perso**.
+
+### Installer : la confirmation par empreinte
+
+Quand vous cliquez sur **Installer** pour un plugin personnel, Sowel télécharge la release, calcule son **empreinte SHA256**, et l'affiche dans une boîte de confirmation avec le dépôt et la version.
+
+- Confirmer installe exactement le contenu correspondant à cette empreinte et l'**épingle**. Si le fichier change un jour derrière la même version, Sowel le refuse.
+- Chaque **mise à jour** ultérieure réaffiche la même boîte avec la nouvelle version et la nouvelle empreinte, parce que le contenu a changé depuis votre dernière validation. Rien ne se met à jour dans votre dos.
+
+!!! warning "Vous faites confiance au propriétaire du dépôt"
+Personne ne relit le code d'un plugin personnel. Il s'exécute avec les mêmes privilèges que Sowel lui-même. N'ajoutez que des dépôts que vous possédez ou en qui vous avez pleinement confiance -- l'empreinte garantit que _ce que_ vous installez ne change jamais silencieusement, pas que le code est sûr.
+
+### Retirer une source
+
+Retirer une source ne désinstalle **pas** les plugins déjà installés depuis celle-ci : ils continuent de fonctionner. Cela bloque seulement les installations et mises à jour futures depuis ce dépôt. Ré-ajouter la source plus tard rétablit les mises à jour.
+
+---
+
+## Pour les auteurs de plugins et de recettes
+
+Envie d'en construire un ? Les guides techniques couvrent tout le parcours, du squelette à la publication :
+
+- [Développement de recettes](../technical/recipe-development.fr.md) -- modèles d'automatisation
+- [Développement de plugins](../technical/plugin-development.fr.md) -- intégrations d'appareils, packaging et releases
+
+Quand votre plugin mérite d'être partagé au-delà de chez vous, le niveau communautaire est l'étape suivante : une entrée au catalogue officiel, pour que n'importe quel utilisateur Sowel puisse l'installer depuis le store.

--- a/docs/user/plugins.md
+++ b/docs/user/plugins.md
@@ -1,0 +1,75 @@
+# Plugins
+
+Everything Sowel connects to -- and every automation recipe it runs -- comes as a **plugin**. A fresh Sowel install has zero plugins: you pick the integrations and recipes you need from the store, and only those run on your instance.
+
+Plugins are managed from **Administration > Plugins** (admin only).
+
+---
+
+## The two tabs
+
+**Installed** lists what runs on your instance:
+
+- **Integrations** show their connection status and how many devices they feed. From here you can disable, re-enable, update, or uninstall each one.
+- **Recipes** are the automation templates available when you create recipe instances.
+
+**Store** lists what you can install. Entries come from the official Sowel catalogue, plus your own personal sources (see below). The **Refresh** button re-reads the catalogue immediately, useful right after a new plugin or version is announced.
+
+When a newer version of an installed plugin is available, an update badge appears on its row (and in the topbar updates sheet). Updating keeps all your settings, devices, equipment bindings and history: only the plugin code changes.
+
+---
+
+## Trust levels
+
+Every store entry belongs to one of three trust levels, so you always know whose code you are about to run:
+
+| Level         | Badge               | Who publishes it                   | What Sowel checks                                                                         |
+| ------------- | ------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| **Official**  | none                | The Sowel maintainer               | Integrity hash pinned in the official catalogue, code maintained with Sowel itself        |
+| **Community** | amber **Community** | A third-party developer            | Integrity hash pinned in the official catalogue; the code itself is not reviewed by Sowel |
+| **Personal**  | blue **Personal**   | You (your own GitHub repositories) | Integrity hash you approve yourself at install, then pinned (see below)                   |
+
+Installing a community plugin asks for a one-time confirmation. Installing or updating a personal plugin always asks for confirmation, showing exactly what you are about to run.
+
+---
+
+## Personal sources
+
+Personal sources let you install **your own plugins and recipes** without publishing them to the official catalogue. Typical uses: a recipe you wrote for your own home, or trying out a plugin you are developing before sharing it.
+
+### Requirements
+
+A personal source is a **public GitHub repository** that has at least one release with a `sowel-*.tar.gz` asset -- the standard Sowel plugin packaging. If you are writing your first recipe, the [Recipe Development guide](../technical/recipe-development.md) walks through producing exactly that.
+
+### Adding a source
+
+1. Open **Administration > Plugins > Store** and scroll to **Personal sources**.
+2. Enter the repository as `owner/repo` (for example `jdoe/sowel-recipe-my-recipe`) and click **Add**.
+3. The source appears in the list with its latest release version. If the repository has no release yet, it is kept with a "no release yet" hint and becomes installable as soon as you publish one.
+
+The plugin then shows up in the store with the blue **Personal** badge.
+
+### Installing: the fingerprint confirmation
+
+When you click **Install** on a personal plugin, Sowel downloads the release, computes its **SHA256 fingerprint**, and shows it in a confirmation dialog together with the repository and version.
+
+- Confirming installs exactly the content matching that fingerprint and **pins** it. If the file ever changes behind the same version, Sowel refuses it.
+- Every later **update** shows the same dialog again with the new version and new fingerprint, because the content changed since you last approved it. Nothing updates behind your back.
+
+!!! warning "You are trusting the repository owner"
+Nobody reviews the code of a personal plugin. It runs with the same privileges as Sowel itself. Only add repositories you own or fully trust -- the fingerprint guarantees _what_ you install never changes silently, not that the code is safe.
+
+### Removing a source
+
+Removing a source does **not** uninstall plugins already installed from it: they keep running. It only stops future installs and updates from that repository. Re-adding the source later restores updates.
+
+---
+
+## For plugin and recipe authors
+
+Want to build one? The technical guides cover the full journey, from scaffolding to publishing:
+
+- [Recipe Development](../technical/recipe-development.md) -- automation templates
+- [Plugin Development](../technical/plugin-development.md) -- device integrations, packaging and releases
+
+Once your plugin is worth sharing beyond your own home, the community level is the next step: an entry in the official catalogue, so any Sowel user can install it from the store.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ plugins:
             Zones & Rooms: Zones et pièces
             Modes & Calendar: Modes et calendrier
             Recipes: Recettes
+            Plugins: Plugins
             Energy Monitoring: Suivi énergétique
             Remote Access: Accès distant
             Release Notes: Notes de version
@@ -131,6 +132,7 @@ nav:
     - Zones & Rooms: user/zones.md
     - Modes & Calendar: user/modes.md
     - Recipes: user/recipes.md
+    - Plugins: user/plugins.md
     - Energy Monitoring: user/energy.md
     - Remote Access: user/remote-access.md
     - Release Notes: release-notes.md


### PR DESCRIPTION
## Summary

New user guide page **Plugins** (EN + FR), filling a gap: the plugin store had no user-facing documentation at all, and the v1.35.0 personal sources feature needed one.

Covers:
- Installed / Store tabs, refresh, what an update preserves
- The three trust levels and their badges (official / community / personal)
- Personal sources end to end: requirements, adding a repo, the SHA256 fingerprint confirmation and hash pinning, update re-confirmation, removal semantics
- Author pointers to the technical recipe/plugin development guides

Registered in the mkdocs nav (User Guide, after Recipes) with the FR nav translation.

Note: no screenshots yet — the demo instance runs v1.34.0; they can be added through the standard anonymized-fixture pipeline once the demo is updated to v1.35.0.

## Test plan

- [x] `mkdocs build --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)