### PR TITLE
feat(ui): align mobile drawer navigation with desktop sidebar (#373)

### DIFF
--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -25,10 +25,6 @@ import {
   User,
   Zap,
   X,
-  Calendar,
-  Plug,
-  Send,
-  Bell,
   BarChart3,
   ChevronRight,
   AlertTriangle,
@@ -51,6 +47,7 @@ import { UpdatesSheet } from "./UpdatesSheet";
 import { useAggregatedIssues } from "./useAggregatedIssues";
 import { useUpdateAvailable } from "../../hooks/useUpdateAvailable";
 import { usePluginUpdates } from "./usePluginUpdates";
+import { ADMIN_NAV_ITEMS, visibleAdminNavItems } from "./admin-nav-items";
 import { InstallPrompt } from "./InstallPrompt";
 import { UpdateOverlay } from "../system/UpdateOverlay";
 import { HomeSetupWizard } from "../setup/HomeSetupWizard";
@@ -495,6 +492,7 @@ function MobileDrawer({ onClose }: { onClose: () => void }) {
   const user = useAuth((s) => s.user);
   const isAdmin = user?.role === "admin";
   const logout = useAuth((s) => s.logout);
+  const pluginUpdateCount = usePluginUpdates(isAdmin ?? false);
 
   const go = (to: string) => {
     navigate(to);
@@ -539,7 +537,22 @@ function MobileDrawer({ onClose }: { onClose: () => void }) {
             onClick={() => go("/analyse")}
           />
 
-          {/* Admin section */}
+          {/* Consultation pages — visible to non-admins here since the
+              Administration section below is hidden for them */}
+          {!isAdmin &&
+            visibleAdminNavItems(false).map((item) => {
+              const Icon = item.icon;
+              return (
+                <DrawerLink
+                  key={item.to}
+                  icon={<Icon size={18} strokeWidth={1.5} />}
+                  label={t(item.labelKey)}
+                  onClick={() => go(item.to)}
+                />
+              );
+            })}
+
+          {/* Admin section — same items as the desktop sidebar */}
           {isAdmin && (
             <>
               <div className="pt-3 pb-1 px-2">
@@ -547,26 +560,25 @@ function MobileDrawer({ onClose }: { onClose: () => void }) {
                   {t("nav.administration")}
                 </span>
               </div>
-              <DrawerLink
-                icon={<Calendar size={18} strokeWidth={1.5} />}
-                label={t("nav.calendar")}
-                onClick={() => go("/calendar")}
-              />
-              <DrawerLink
-                icon={<Plug size={18} strokeWidth={1.5} />}
-                label={t("nav.integrations")}
-                onClick={() => go("/integrations")}
-              />
-              <DrawerLink
-                icon={<Send size={18} strokeWidth={1.5} />}
-                label={t("nav.mqttPublishers")}
-                onClick={() => go("/mqtt-publishers")}
-              />
-              <DrawerLink
-                icon={<Bell size={18} strokeWidth={1.5} />}
-                label={t("nav.notificationPublishers")}
-                onClick={() => go("/notification-publishers")}
-              />
+              {ADMIN_NAV_ITEMS.map((item) => {
+                const Icon = item.icon;
+                const showBadge = item.to === "/plugins" && pluginUpdateCount > 0;
+                return (
+                  <DrawerLink
+                    key={item.to}
+                    icon={<Icon size={18} strokeWidth={1.5} />}
+                    label={t(item.labelKey)}
+                    badge={
+                      showBadge ? (
+                        <span className="text-[10px] font-medium text-error bg-error/10 px-1.5 py-0.5 rounded-full">
+                          {pluginUpdateCount}
+                        </span>
+                      ) : undefined
+                    }
+                    onClick={() => go(item.to)}
+                  />
+                );
+              })}
             </>
           )}
 
@@ -611,10 +623,12 @@ function MobileDrawer({ onClose }: { onClose: () => void }) {
 function DrawerLink({
   icon,
   label,
+  badge,
   onClick,
 }: {
   icon: React.ReactNode;
   label: string;
+  badge?: React.ReactNode;
   onClick: () => void;
 }) {
   return (
@@ -624,6 +638,7 @@ function DrawerLink({
     >
       <span className="text-text-secondary">{icon}</span>
       <span className="text-[14px] font-medium flex-1">{label}</span>
+      {badge}
       <ChevronRight size={14} strokeWidth={1.5} className="text-text-tertiary" />
     </button>
   );

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -1,22 +1,12 @@
 import { useLocation } from "react-router-dom";
 import {
-  Radio,
-  Box,
-  Map,
-  Plug,
-  Package,
   Settings,
   Shield,
   Home,
   ChevronLeft,
   ChevronRight,
   Layers,
-  Calendar,
   BarChart3,
-  ScrollText,
-  DatabaseBackup,
-  Send,
-  Bell,
   LayoutDashboard,
   Zap,
   PlugZap,
@@ -36,21 +26,11 @@ import { useAuth } from "../../store/useAuth";
 import { useUpdateAvailable } from "../../hooks/useUpdateAvailable";
 import { useEnergy } from "../../store/useEnergy";
 import { usePluginUpdates } from "./usePluginUpdates";
+import { ADMIN_NAV_ITEMS } from "./admin-nav-items";
 
 type SidebarSection = "maison" | "modes" | "analyse" | "energy" | "admin";
 
-const ADMIN_ROUTES = [
-  "/devices",
-  "/equipments",
-  "/zones",
-  "/calendar",
-  "/integrations",
-  "/plugins",
-  "/mqtt-publishers",
-  "/notification-publishers",
-  "/logs",
-  "/backup",
-];
+const ADMIN_ROUTES = ADMIN_NAV_ITEMS.map((item) => item.to);
 
 function getSectionForPath(pathname: string): SidebarSection | null {
   if (pathname.startsWith("/home")) return "maison";
@@ -62,25 +42,6 @@ function getSectionForPath(pathname: string): SidebarSection | null {
 }
 
 const ICON_SIZE = 16;
-
-interface AdminItem {
-  to: string;
-  labelKey: string;
-  icon: React.ReactNode;
-}
-
-const ADMIN_ITEMS: AdminItem[] = [
-  { to: "/devices", labelKey: "nav.devices", icon: <Radio size={ICON_SIZE} strokeWidth={1.5} /> },
-  { to: "/equipments", labelKey: "nav.equipments", icon: <Box size={ICON_SIZE} strokeWidth={1.5} /> },
-  { to: "/zones", labelKey: "nav.zones", icon: <Map size={ICON_SIZE} strokeWidth={1.5} /> },
-  { to: "/calendar", labelKey: "nav.calendar", icon: <Calendar size={ICON_SIZE} strokeWidth={1.5} /> },
-  { to: "/integrations", labelKey: "nav.integrations", icon: <Plug size={ICON_SIZE} strokeWidth={1.5} /> },
-  { to: "/plugins", labelKey: "nav.plugins", icon: <Package size={ICON_SIZE} strokeWidth={1.5} /> },
-  { to: "/mqtt-publishers", labelKey: "nav.mqttPublishers", icon: <Send size={ICON_SIZE} strokeWidth={1.5} /> },
-  { to: "/notification-publishers", labelKey: "nav.notificationPublishers", icon: <Bell size={ICON_SIZE} strokeWidth={1.5} /> },
-  { to: "/logs", labelKey: "nav.logs", icon: <ScrollText size={ICON_SIZE} strokeWidth={1.5} /> },
-  { to: "/backup", labelKey: "nav.backup", icon: <DatabaseBackup size={ICON_SIZE} strokeWidth={1.5} /> },
-];
 
 export function Sidebar() {
   const { t } = useTranslation();
@@ -292,8 +253,9 @@ export function Sidebar() {
               />
               {expandedSection === "admin" && (
                 <nav className="space-y-0.5 pl-2 mt-1">
-                  {ADMIN_ITEMS.map((item) => {
+                  {ADMIN_NAV_ITEMS.map((item) => {
                     const showBadge = item.to === "/plugins" && pluginUpdateCount > 0;
+                    const Icon = item.icon;
                     return (
                       <SidebarItem
                         key={item.to}
@@ -301,7 +263,7 @@ export function Sidebar() {
                         label={t(item.labelKey)}
                         icon={
                           <span className="relative">
-                            {item.icon}
+                            <Icon size={ICON_SIZE} strokeWidth={1.5} />
                             {showBadge && (
                               <span className="absolute -top-1 -right-1 w-2 h-2 bg-error rounded-full" />
                             )}

--- a/ui/src/components/layout/admin-nav-items.test.ts
+++ b/ui/src/components/layout/admin-nav-items.test.ts
@@ -2,8 +2,24 @@ import { describe, it, expect, vi } from "vitest";
 
 // The backend CI job runs the root vitest suite without installing ui/
 // dependencies, so lucide-react is not resolvable there. Mock it: this test
-// only needs the icon fields to be defined, not real components.
-vi.mock("lucide-react", () => new Proxy({}, { get: () => () => null }));
+// only needs the icon fields to be defined, not real components. The mock
+// must be a plain object (a catch-all Proxy answers `.then` and hangs
+// vitest's await on the factory).
+vi.mock("lucide-react", () => {
+  const icon = () => null;
+  return {
+    Radio: icon,
+    Box: icon,
+    Map: icon,
+    Calendar: icon,
+    Plug: icon,
+    Package: icon,
+    Send: icon,
+    Bell: icon,
+    ScrollText: icon,
+    DatabaseBackup: icon,
+  };
+});
 
 import { ADMIN_NAV_ITEMS, visibleAdminNavItems } from "./admin-nav-items";
 

--- a/ui/src/components/layout/admin-nav-items.test.ts
+++ b/ui/src/components/layout/admin-nav-items.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { ADMIN_NAV_ITEMS, visibleAdminNavItems } from "./admin-nav-items";
+
+// Regression for issue #373: the mobile drawer used to hand-write a subset of
+// the admin navigation and drifted from the desktop sidebar. Both now render
+// ADMIN_NAV_ITEMS; these tests pin the contract of that shared list.
+describe("admin-nav-items", () => {
+  it("contains every admin page reachable from the desktop sidebar", () => {
+    expect(ADMIN_NAV_ITEMS.map((i) => i.to)).toEqual([
+      "/devices",
+      "/equipments",
+      "/zones",
+      "/calendar",
+      "/integrations",
+      "/plugins",
+      "/mqtt-publishers",
+      "/notification-publishers",
+      "/logs",
+      "/backup",
+    ]);
+  });
+
+  it("has unique routes and nav.* label keys", () => {
+    const routes = ADMIN_NAV_ITEMS.map((i) => i.to);
+    expect(new Set(routes).size).toBe(routes.length);
+    for (const item of ADMIN_NAV_ITEMS) {
+      expect(item.labelKey).toMatch(/^nav\./);
+      expect(item.icon).toBeTruthy();
+    }
+  });
+
+  it("marks exactly the consultation pages (equipments, zones) as visible to non-admins", () => {
+    // Must match the AdminRoute gating in App.tsx: /equipments and /zones are
+    // open to all roles, everything else redirects non-admins to the dashboard.
+    const openRoutes = ADMIN_NAV_ITEMS.filter((i) => !i.adminOnly).map((i) => i.to);
+    expect(openRoutes).toEqual(["/equipments", "/zones"]);
+  });
+
+  it("returns the full list for admins and only open pages otherwise", () => {
+    expect(visibleAdminNavItems(true)).toEqual(ADMIN_NAV_ITEMS);
+    expect(visibleAdminNavItems(false).map((i) => i.to)).toEqual(["/equipments", "/zones"]);
+  });
+});

--- a/ui/src/components/layout/admin-nav-items.test.ts
+++ b/ui/src/components/layout/admin-nav-items.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+// The backend CI job runs the root vitest suite without installing ui/
+// dependencies, so lucide-react is not resolvable there. Mock it: this test
+// only needs the icon fields to be defined, not real components.
+vi.mock("lucide-react", () => new Proxy({}, { get: () => () => null }));
+
 import { ADMIN_NAV_ITEMS, visibleAdminNavItems } from "./admin-nav-items";
 
 // Regression for issue #373: the mobile drawer used to hand-write a subset of

--- a/ui/src/components/layout/admin-nav-items.ts
+++ b/ui/src/components/layout/admin-nav-items.ts
@@ -1,0 +1,43 @@
+import {
+  Radio,
+  Box,
+  Map,
+  Calendar,
+  Plug,
+  Package,
+  Send,
+  Bell,
+  ScrollText,
+  DatabaseBackup,
+  type LucideIcon,
+} from "lucide-react";
+
+export interface AdminNavItem {
+  to: string;
+  labelKey: string;
+  icon: LucideIcon;
+  /** Mirrors the AdminRoute gating in App.tsx — non-admin users can still
+   *  consult equipments and zones, so those entries stay visible to them. */
+  adminOnly: boolean;
+}
+
+/** Single source of truth for the Administration navigation, rendered by both
+ *  the desktop Sidebar and the mobile drawer so the two menus cannot drift. */
+export const ADMIN_NAV_ITEMS: AdminNavItem[] = [
+  { to: "/devices", labelKey: "nav.devices", icon: Radio, adminOnly: true },
+  { to: "/equipments", labelKey: "nav.equipments", icon: Box, adminOnly: false },
+  { to: "/zones", labelKey: "nav.zones", icon: Map, adminOnly: false },
+  { to: "/calendar", labelKey: "nav.calendar", icon: Calendar, adminOnly: true },
+  { to: "/integrations", labelKey: "nav.integrations", icon: Plug, adminOnly: true },
+  { to: "/plugins", labelKey: "nav.plugins", icon: Package, adminOnly: true },
+  { to: "/mqtt-publishers", labelKey: "nav.mqttPublishers", icon: Send, adminOnly: true },
+  { to: "/notification-publishers", labelKey: "nav.notificationPublishers", icon: Bell, adminOnly: true },
+  { to: "/logs", labelKey: "nav.logs", icon: ScrollText, adminOnly: true },
+  { to: "/backup", labelKey: "nav.backup", icon: DatabaseBackup, adminOnly: true },
+];
+
+/** Items a given user may navigate to. Admins get the full list; other roles
+ *  only the consultation pages (equipments, zones). */
+export function visibleAdminNavItems(isAdmin: boolean): AdminNavItem[] {
+  return isAdmin ? ADMIN_NAV_ITEMS : ADMIN_NAV_ITEMS.filter((item) => !item.adminOnly);
+}


### PR DESCRIPTION
## Problem

On mobile / PWA, the "More" drawer only exposed Settings, Analyse, and 4 admin entries. Devices, Equipments, Zones, Plugins, Logs, and Backup were unreachable without typing the URL. The drawer links were hand-written and had drifted from the desktop sidebar's `ADMIN_ITEMS` list.

## Design

- New shared module `ui/src/components/layout/admin-nav-items.ts`: single source of truth for the Administration navigation (`ADMIN_NAV_ITEMS`), each entry carrying an `adminOnly` flag that mirrors the `AdminRoute` gating in `App.tsx` (`/equipments` and `/zones` stay open to all roles for consultation).
- Desktop `Sidebar` now renders that shared list (behavior unchanged, including the plugin-update badge); its `ADMIN_ROUTES` array is derived from the same list.
- `MobileDrawer` renders the full list under the Administration header for admins, with the plugin-update badge for parity with desktop. Non-admin users get the consultation pages (Equipments, Zones) in the main drawer section, since the Administration section is hidden for them.

## Tests

- `admin-nav-items.test.ts` pins the shared-list contract: full route coverage matching the desktop sidebar, unique routes and `nav.*` label keys, and the non-admin subset being exactly `/equipments` + `/zones` (matching route gating).
- Full validation green: backend + UI typecheck, eslint, 1090 tests.

Closes #373