### PR TITLE
release: v1.36.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,18 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.36.x: Catégories de plugins, recherche, mesures électriques live
+
+### v1.36.0 — 2026-08-09 { #v1-36-0 }
+
+- Feat (plugins) : la page Plugins **regroupe désormais les recettes par catégorie** (spec 137) — Éclairage, Chauffage et climatisation, Arrosage et piscine, Planification, Sécurité et surveillance, Énergie et affichage — dans les onglets Installés et Store, avec un **champ de recherche** qui filtre intégrations et recettes au fil de la saisie, en cherchant dans les noms, descriptions et mots-clés dans la langue affichée, accents ignorés. L'onglet Store affiche aussi enfin les noms et descriptions en français déjà écrits dans le catalogue (ils étaient perdus en route jusqu'ici). Les catégories viennent du catalogue de plugins : les installations existantes les récupèrent automatiquement, aucune mise à jour de recette nécessaire. (#375)
+- Feat (equipments) : **données électriques live sur les compteurs d'énergie** — la carte en vue zone de chaque type de compteur (consommation, principal, production) affiche désormais la puissance instantanée en direct à côté de la consommation du jour, que le compteur remonte une puissance directe ou une demande 5 minutes Legrand NLPC. La page de détail gagne un panneau **Mesures électriques** avec des tuiles live puissance, tension, courant et facteur de puissance, chacune affichée quand la donnée correspondante est associée ; le panneau « Consommation énergie » est inchangé. (#377)
+- Feat (ui) : le tiroir **« Plus » sur mobile** expose désormais la navigation Administration complète (Appareils, Équipements, Zones, Plugins, Logs, Sauvegarde, ...) depuis une source unique partagée avec la barre latérale desktop, badge de mise à jour des plugins compris. Les utilisateurs non admin retrouvent les pages de consultation (Équipements, Zones) dans la section principale. Auparavant, seuls Réglages, Analyse et quatre entrées admin étaient accessibles sur mobile. (#374)
+- Docs : nouvelle page **guide utilisateur Plugins** sur docs.sowel.org — les deux onglets, trouver un plugin, les niveaux de confiance, les sources personnelles et la confirmation par empreinte. (#371)
+- Chore (core) : le contexte d'exploitation propre à une installation quitte le dépôt public pour un dépôt compagnon privé ; nouveau skill agent pour le développement de recettes personnelles ; index des specs mis à jour. (#368, #370, #372)
+
+---
+
 ## 1.35.x: Sources personnelles de plugins
 
 ### v1.35.0 — 2026-08-08 { #v1-35-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,18 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.36.x: Plugin categories, search, energy live metering
+
+### v1.36.0 — 2026-08-09 { #v1-36-0 }
+
+- Feat (plugins): the Plugins page now **groups recipes by category** (spec 137) — Lighting, Heating and cooling, Watering and pool, Scheduling, Safety and monitoring, Energy and display — in both the Installed and Store tabs, with a **search field** that filters integrations and recipes as you type, matching names, descriptions and keywords in the displayed language and ignoring accents. The Store tab also finally displays the French names and descriptions already authored in the catalog (they were silently dropped before). Categories come from the plugin catalog: existing installations pick them up automatically, no recipe update needed. (#375)
+- Feat (equipments): **live electrical data on energy meters** — the zone-view card of every meter type (consumption, main, production) now shows the live instantaneous power next to the daily consumption, whether the meter reports a direct power reading or a Legrand NLPC 5-minute demand. The equipment detail page gains an **Electrical metering** panel with live power, voltage, current and power factor tiles, each shown when the corresponding data is bound; the "Energy consumption" cumuls panel is unchanged. (#377)
+- Feat (ui): the mobile **"More" drawer** now exposes the full Administration navigation (Devices, Equipments, Zones, Plugins, Logs, Backup, ...) from a single source of truth shared with the desktop sidebar, including the plugin-update badge. Non-admin users get the consultation pages (Equipments, Zones) in the main section. Previously only Settings, Analyse and four admin entries were reachable on mobile. (#374)
+- Docs: new **Plugins user guide** page on docs.sowel.org — the two tabs, finding a plugin, trust levels, personal sources, and the fingerprint confirmation flow. (#371)
+- Chore (core): installation-specific operations context moved out of the public repository into a private companion repo; new agent skill for personal recipe development; specs index updated. (#368, #370, #372)
+
+---
+
 ## 1.35.x: Personal plugin sources
 
 ### v1.35.0 — 2026-08-08 { #v1-35-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.35.0",
+  "version": "1.36.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump + release notes for v1.36.0.

Covers everything merged since v1.35.0:
- #375 — recipe categories + plugin search on the Plugins page (spec 137, closes #361)
- #377 — live power on energy meter cards + Electrical metering detail panel (closes #376)
- #374 — mobile drawer navigation aligned with the desktop sidebar (closes #373)
- #371 — Plugins user guide page
- #368, #370, #372 — docs/tooling (specs index, sowel-recipe-dev skill, private ops repo split)