### PR TITLE
fix(api): require admin role on GET /api/v1/settings/energy/tariff (#381)

### DIFF
--- a/src/api/routes/energy.test.ts
+++ b/src/api/routes/energy.test.ts
@@ -44,6 +44,9 @@ interface BuildOpts {
   envTz?: string | undefined;
   /** Spec 123 — inject a tariff config for cost-wiring tests. */
   tariff?: TariffConfig | null;
+  /** Issue #381 — role decorated on request.auth. Defaults to admin;
+   *  null leaves request.auth undefined (unauthenticated). */
+  authRole?: "admin" | "standard" | null;
 }
 
 async function buildApp(opts: BuildOpts = {}) {
@@ -101,6 +104,15 @@ async function buildApp(opts: BuildOpts = {}) {
   const settingsManager = {} as never;
 
   const app = Fastify({ logger: false });
+
+  // Stub auth: pre-decorate request.auth based on the test scenario (#381).
+  const authRole = opts.authRole === undefined ? "admin" : opts.authRole;
+  if (authRole !== null) {
+    app.addHook("preHandler", async (request) => {
+      request.auth = { userId: "u1", role: authRole };
+    });
+  }
+
   registerEnergyRoutes(app, {
     equipmentManager,
     influxClient: influxClient as never,
@@ -640,5 +652,44 @@ describe("Spec 123 — /api/v1/energy/status tariffConfigured", () => {
     });
     const r = await app.inject({ method: "GET", url: "/api/v1/energy/status" });
     expect(r.json().tariffConfigured).toBe(true);
+  });
+});
+
+// Issue #381 — the tariff GET carries prices and must be admin-only, like
+// GET /api/v1/settings. The spec 131 gate only covers mutating methods.
+describe("Issue #381 — GET /api/v1/settings/energy/tariff admin gate", () => {
+  let app: Awaited<ReturnType<typeof buildApp>> | null = null;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = null;
+  });
+
+  const TARIFF: TariffConfig = {
+    schedules: [
+      { days: [0, 1, 2, 3, 4, 5, 6], slots: [{ start: "22:00", end: "06:00", tariff: "hc" }] },
+    ],
+    prices: { hp: 0.2516, hc: 0.2068 },
+  };
+
+  it("returns 403 to a standard user, without leaking prices", async () => {
+    app = await buildApp({ tariff: TARIFF, authRole: "standard" });
+    const r = await app.inject({ method: "GET", url: "/api/v1/settings/energy/tariff" });
+    expect(r.statusCode).toBe(403);
+    expect(r.body).not.toContain("0.2516");
+    expect(r.body).not.toContain("0.2068");
+  });
+
+  it("returns 403 when request.auth is absent", async () => {
+    app = await buildApp({ tariff: TARIFF, authRole: null });
+    const r = await app.inject({ method: "GET", url: "/api/v1/settings/energy/tariff" });
+    expect(r.statusCode).toBe(403);
+  });
+
+  it("still returns the full config, prices included, to an admin", async () => {
+    app = await buildApp({ tariff: TARIFF, authRole: "admin" });
+    const r = await app.inject({ method: "GET", url: "/api/v1/settings/energy/tariff" });
+    expect(r.statusCode).toBe(200);
+    expect(r.json()).toEqual(TARIFF);
   });
 });

--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -392,9 +392,16 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
   });
 
   // ============================================================
-  // GET /api/v1/settings/energy/tariff
+  // GET /api/v1/settings/energy/tariff (admin only — carries prices)
   // ============================================================
-  app.get("/api/v1/settings/energy/tariff", async () => {
+  app.get("/api/v1/settings/energy/tariff", async (request, reply) => {
+    // Issue #381: the spec 131 role gate only covers mutating methods, so this
+    // GET needs its own check — same as GET /api/v1/settings. Recipes read the
+    // schedule (without prices) through ctx.helpers.getTariff() instead.
+    if (!request.auth || request.auth.role !== "admin") {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+
     const config = tariffClassifier.getConfig();
     return config ?? { schedules: [], prices: { hp: 0, hc: 0 } };
   });


### PR DESCRIPTION
## Root cause

The spec 131 role gate (`isMutationDeniedForStandard`) only covers mutating methods, and the tariff GET handler in `src/api/routes/energy.ts` had no handler-level role check — unlike `GET /api/v1/settings`, which checks admin explicitly. Any authenticated `standard` user could therefore read the full tariff configuration **including prices**, although the Settings page owning this data is admin-only. Found during review of #379.

## Fix

The handler now requires the admin role, same pattern and same error body as `GET /api/v1/settings`. Impact check:

- The only UI consumer is `TariffSettings.tsx`, on the admin-only settings tab — no non-admin flow breaks.
- Recipes are unaffected: `ctx.helpers.getTariff()` (spec 138) is the supported automation read path and deliberately withholds prices.
- `PUT /api/v1/settings/energy/tariff` was already covered by the fail-closed spec 131 gate.

## Tests

- 3 regression tests in `energy.test.ts`, verified to fail before the fix: 403 for a `standard` user with no price value leaking in the response body, 403 when unauthenticated, 200 with the full config for admin.
- The energy route test harness gains an `authRole` option (defaults to `admin`; the 23 existing tests are unchanged).
- `npm run validate` green (1145 tests).

Closes #381