### PR TITLE
release: v1.37.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,16 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.37.x: Tarif HP/HC pour les recettes
+
+### v1.37.0 — 2026-08-09 { #v1-37-0 }
+
+- Feat (recipes) : **les recettes peuvent lire le planning tarifaire HP/HC configuré** (spec 138). Une recette de délestage (chauffe-eau, pompe de piscine, recharge VE) n'a plus à redemander des heures creuses que l'instance connaît déjà : `ctx.helpers.getTariff()` retourne les créneaux heures creuses du jour et si l'heure courante est en heures creuses, directement depuis le planning configuré dans les Réglages. Lecture seule par construction, et les **prix ne sont volontairement pas exposés** aux packages de recettes — savoir quand l'énergie est bon marché suffit pour placer une charge. Les recettes gardent leurs propres créneaux en repli pour les instances sans tarif configuré. Contribution d'Adrien Jouve (computingify). (#379)
+- Fix (api) : la lecture de la configuration tarifaire via l'API (`GET /api/v1/settings/energy/tariff`) exige désormais le **rôle admin**, comme le reste des réglages. Tout utilisateur authentifié pouvait auparavant lire le planning et les prix ; l'écriture était déjà réservée aux admins, et les recettes ne sont pas concernées puisqu'elles lisent via le nouveau helper. Découvert pendant la revue de la #379. (#382)
+- Docs : rattrapage de l'index des specs (specs 137/138) et traduction française de la nouvelle documentation tarifaire des recettes. (#380)
+
+---
+
 ## 1.36.x: Catégories de plugins, recherche, mesures électriques live
 
 ### v1.36.0 — 2026-08-09 { #v1-36-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,16 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.37.x: Recipe tariff helper
+
+### v1.37.0 — 2026-08-09 { #v1-37-0 }
+
+- Feat (recipes): **recipes can read the configured HP/HC tariff schedule** (spec 138). A load-shifting recipe (water heater, pool pump, EV charger) no longer has to re-ask for off-peak hours the instance already knows: `ctx.helpers.getTariff()` returns today's off-peak slots and whether the current time is off-peak, straight from the schedule configured under Settings. Read-only by construction, and tariff **prices are deliberately not exposed** to recipe packages — knowing when energy is cheap is enough to schedule a load. Recipes should keep their own time slots as a fallback for instances with no tariff configured. Contributed by Adrien Jouve (computingify). (#379)
+- Fix (api): reading the tariff configuration over the API (`GET /api/v1/settings/energy/tariff`) now requires the **admin role**, like the rest of the settings. Any authenticated user could previously read the schedule and the prices; writing was already admin-only, and recipes are unaffected since they read through the new helper. Found during review of #379. (#382)
+- Docs: specs index catch-up (specs 137/138) and French translation of the new recipe tariff documentation. (#380)
+
+---
+
 ## 1.36.x: Plugin categories, search, energy live metering
 
 ### v1.36.0 — 2026-08-09 { #v1-36-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.36.0",
+  "version": "1.37.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump + release notes for v1.37.0.

Covers everything merged since v1.36.0:
- #379 — recipes can read the HP/HC tariff schedule via ctx.helpers.getTariff() (spec 138, by computingify)
- #382 — GET /api/v1/settings/energy/tariff now requires the admin role (closes #381)
- #380 — specs index catch-up + FR recipe tariff docs