### PR TITLE
fix(ui): distinguish unsaved tariff proposal from a saved schedule (#384)

### DIFF
--- a/ui/src/components/settings/TariffSettings.tsx
+++ b/ui/src/components/settings/TariffSettings.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Zap, Plus, Trash2, Loader2 } from "lucide-react";
+import { Zap, Plus, Trash2, Loader2, Info } from "lucide-react";
 import { getTariffConfig, saveTariffConfig } from "../../api";
+import { isTariffSaved } from "../../lib/tariff";
 import type { TariffConfig, TariffSlot } from "../../types";
 
 const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
@@ -16,7 +17,13 @@ function defaultSlots(): TariffSlot[] {
   ];
 }
 
-function emptyConfig(): TariffConfig {
+/**
+ * Standard HP/HC schedule shown as a *proposal* before anything is saved.
+ * Deliberately not empty: a fresh install lands on sensible, ready-to-save
+ * hours. The unsaved banner (issue #384) tells this apart from a persisted
+ * tariff so the two are never confused.
+ */
+function proposedConfig(): TariffConfig {
   return {
     schedules: [{ days: [...ALL_DAYS], slots: defaultSlots() }],
     prices: { hp: 0, hc: 0 },
@@ -158,16 +165,23 @@ function TariffTimeline({ slots }: { slots: TariffSlot[] }) {
 
 export function TariffSettings() {
   const { t } = useTranslation();
-  const [config, setConfig] = useState<TariffConfig>(emptyConfig());
+  const [config, setConfig] = useState<TariffConfig>(proposedConfig());
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Whether a tariff is actually persisted. Until it is, the form shows the
+  // proposal and warns that nothing is saved (issue #384). The server returns
+  // an empty `schedules` array when `energy.tariff` is absent.
+  const [configured, setConfigured] = useState(false);
 
   useEffect(() => {
     getTariffConfig()
       .then((c) => {
-        if (c.schedules.length > 0) setConfig(c);
+        if (isTariffSaved(c)) {
+          setConfig(c);
+          setConfigured(true);
+        }
         setLoading(false);
       })
       .catch(() => setLoading(false));
@@ -187,6 +201,7 @@ export function TariffSettings() {
         schedules: [{ days: [...ALL_DAYS], slots }],
       };
       await saveTariffConfig(toSave);
+      setConfigured(true);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch (err) {
@@ -241,6 +256,19 @@ export function TariffSettings() {
         <Zap size={18} strokeWidth={1.5} className="text-text-secondary" />
         <h2 className="text-[15px] font-semibold text-text">{t("tariff.title")}</h2>
       </div>
+
+      {/* Issue #384 — the form is pre-filled with the standard schedule as a
+          proposal; without this banner an unsaved default looks identical to a
+          persisted tariff. Shown only until a tariff is actually saved. */}
+      {!configured && (
+        <div
+          role="status"
+          className="flex items-start gap-2 mb-4 px-3 py-2 rounded-md bg-accent/10 border border-accent/20 text-[12px] text-text-secondary"
+        >
+          <Info size={14} strokeWidth={1.5} className="mt-0.5 flex-shrink-0 text-accent" />
+          <span>{t("tariff.unsavedBanner")}</span>
+        </div>
+      )}
 
       {/* Prices */}
       <div className="grid grid-cols-2 gap-4 mb-5">

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1071,6 +1071,7 @@
   "energy.unit.tariffMissing": "Configure HP/HC prices in Settings > Tariff",
 
   "tariff.title": "Energy tariffs",
+  "tariff.unsavedBanner": "No tariff saved yet. These are suggested hours; click Save to apply them.",
   "tariff.priceHp": "Peak price (€/kWh)",
   "tariff.priceHc": "Off-peak price (€/kWh)",
   "tariff.priceRetroactiveHint": "These prices value all past and future consumption. Update them to reflect your current bill.",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1071,6 +1071,7 @@
   "energy.unit.tariffMissing": "Configurez les prix HP/HC dans Réglages > Tarif",
 
   "tariff.title": "Tarifs énergie",
+  "tariff.unsavedBanner": "Aucun tarif enregistré pour le moment. Ces horaires sont une suggestion ; cliquez sur Enregistrer pour les appliquer.",
   "tariff.priceHp": "Prix HP (€/kWh)",
   "tariff.priceHc": "Prix HC (€/kWh)",
   "tariff.priceRetroactiveHint": "Ces prix valorisent toute votre consommation passée et future. Modifiez-les pour refléter votre facture actuelle.",

--- a/ui/src/lib/tariff.test.ts
+++ b/ui/src/lib/tariff.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { isTariffSaved } from "./tariff";
+import type { TariffConfig } from "../types";
+
+const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
+
+describe("isTariffSaved (issue #384)", () => {
+  it("treats the server's empty-schedule response as not saved", () => {
+    // GET /api/v1/settings/energy/tariff when `energy.tariff` is absent.
+    const empty: TariffConfig = { schedules: [], prices: { hp: 0, hc: 0 } };
+    expect(isTariffSaved(empty)).toBe(false);
+  });
+
+  it("treats a stored schedule as saved", () => {
+    const stored: TariffConfig = {
+      schedules: [
+        {
+          days: [...ALL_DAYS],
+          slots: [
+            { start: "06:00", end: "22:00", tariff: "hp" },
+            { start: "22:00", end: "06:00", tariff: "hc" },
+          ],
+        },
+      ],
+      prices: { hp: 0, hc: 0 },
+    };
+    expect(isTariffSaved(stored)).toBe(true);
+  });
+
+  it("considers a saved schedule with zero prices still saved (hours are set, prices are a separate concern)", () => {
+    const hoursOnly: TariffConfig = {
+      schedules: [{ days: [...ALL_DAYS], slots: [{ start: "00:00", end: "00:00", tariff: "hc" }] }],
+      prices: { hp: 0, hc: 0 },
+    };
+    expect(isTariffSaved(hoursOnly)).toBe(true);
+  });
+});

--- a/ui/src/lib/tariff.ts
+++ b/ui/src/lib/tariff.ts
@@ -1,0 +1,16 @@
+import type { TariffConfig } from "../types";
+
+/**
+ * Whether a tariff is actually persisted, as opposed to the proposal the form
+ * shows before anything is saved (issue #384).
+ *
+ * `GET /api/v1/settings/energy/tariff` returns an **empty** `schedules` array
+ * when `energy.tariff` is absent from settings — that empty array is the "never
+ * saved" sentinel. The tariff form pre-fills the standard HP/HC hours as a
+ * convenience, so a non-empty local form is not evidence of a saved tariff; the
+ * server response is. This helper is the single place that reads that signal, so
+ * "displayed" and "saved" can never drift into looking the same again.
+ */
+export function isTariffSaved(config: TariffConfig): boolean {
+  return config.schedules.length > 0;
+}


### PR DESCRIPTION
## Summary

The Energy tariff settings page showed the standard `06:00–22:00 HP` /
`22:00–06:00 HC` schedule on instances where **no tariff had ever been saved**,
indistinguishable from a persisted one. A user reasonably concluded the tariff
was configured while `energy.tariff` was absent and `tariffConfigured` was
`false` — breaking energy cost attribution and making load-shifting recipes
(spec 138, `ctx.helpers.getTariff()` → `configured: false`) look broken.

The backend was correct: `GET /api/v1/settings/energy/tariff` returns an empty
`schedules` array when nothing is stored. The confusion was entirely in the UI.

## Root cause

`ui/src/components/settings/TariffSettings.tsx`:

- `emptyConfig()` seeded a **populated** schedule, so initial state already
  looked like a real tariff.
- The load effect only overwrote state when the server returned a non-empty
  schedule (`if (c.schedules.length > 0)`). With nothing stored, the guard was
  false and the seeded slots stayed on screen with no marker.

## Fix (default-as-proposal)

Keep the pre-filled proposal — a fresh install still lands on sensible,
one-click-to-save hours — but make "unsaved" visible:

- New `configured` state, set to `true` only when the server returns a saved
  schedule, or after a successful Save.
- Until then, a banner above the form marks the hours as a suggestion:
  *"No tariff saved yet. These are suggested hours; click Save to apply them."*
  (FR: *"Aucun tarif enregistré pour le moment…"*). Styled with the amber accent
  token, `role="status"`.
- `emptyConfig()` renamed to `proposedConfig()` — it was never empty, which was
  the whole trap.

The "empty schedules = never saved" signal now lives in one pure helper,
`ui/src/lib/tariff.ts#isTariffSaved`, so "displayed" and "saved" cannot silently
drift back into looking the same.

## Test plan

- [x] `cd ui && npx tsc -b --noEmit` — clean
- [x] `npx vitest run` (ui) — 223 passed, 3 new on `isTariffSaved`
      (empty response → not saved; stored schedule → saved; hours saved with
      zero prices → still saved)
- [x] `cd ui && npx eslint .` — 0 errors (the 2 warnings are pre-existing on
      `main`, unrelated files)
- [x] `cd ui && npx vite build` — clean

No React component-render test: the UI has no jsdom / testing-library setup, so
the fix's decision logic is extracted and unit-tested the same way spec 139's
`zone-path.ts` is.

UI only: no type, route, event, migration or backend change.

Closes #384
