### PR TITLE
release: v1.37.1

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,11 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.37.x: Tarif HP/HC pour les recettes
 
+### v1.37.1 — 2026-08-10 { #v1-37-1 }
+
+- Fix (ui) : les **sélecteurs d'équipements et de zones des recettes précisent désormais la zone**, pour distinguer les pièces et capteurs homonymes (spec 139). Une installation avec une salle de bain par étage listait « Salle de bain » plusieurs fois sans rien pour choisir, et les listes d'équipements affichaient le nom nu (les intégrations nomment tous les capteurs « Température »). Chaque option porte maintenant le plus court chemin d'ancêtres qui la rend unique, et le même helper nettoie les libellés de la vue Analyse. Contribution d'Adrien Jouve (computingify). (#386)
+- Fix (ui) : la **page Tarifs énergie n'affiche plus ses horaires par défaut comme s'ils étaient enregistrés** (#384). Sur une instance qui n'a jamais enregistré de tarif, le planning standard 06:00-22:00 HP / 22:00-06:00 HC semblait configuré alors qu'il ne l'était pas, faisant paraître cassées l'attribution des coûts et les recettes de délestage. Le formulaire propose toujours ces horaires par commodité, mais une bannière les signale comme une suggestion tant que vous n'avez pas cliqué sur Enregistrer. Signalé par Adrien Jouve (computingify). (#388)
+
 ### v1.37.0 — 2026-08-09 { #v1-37-0 }
 
 - Feat (recipes) : **les recettes peuvent lire le planning tarifaire HP/HC configuré** (spec 138). Une recette de délestage (chauffe-eau, pompe de piscine, recharge VE) n'a plus à redemander des heures creuses que l'instance connaît déjà : `ctx.helpers.getTariff()` retourne les créneaux heures creuses du jour et si l'heure courante est en heures creuses, directement depuis le planning configuré dans les Réglages. Lecture seule par construction, et les **prix ne sont volontairement pas exposés** aux packages de recettes — savoir quand l'énergie est bon marché suffit pour placer une charge. Les recettes gardent leurs propres créneaux en repli pour les instances sans tarif configuré. Contribution d'Adrien Jouve (computingify). (#379)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,11 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.37.x: Recipe tariff helper
 
+### v1.37.1 — 2026-08-10 { #v1-37-1 }
+
+- Fix (ui): **recipe equipment and zone pickers now spell out the zone**, so homonymous rooms and sensors can be told apart (spec 139). An installation with a bathroom per floor used to list "Salle de bain" several times with nothing to choose between, and equipment lists showed the bare name (integrations name every sensor "Température"). Each option now carries the shortest ancestor path that makes it unique, and the same helper tidies up the Analyse view labels. Contributed by Adrien Jouve (computingify). (#386)
+- Fix (ui): the **Energy tariff page no longer shows its default hours as if they were saved** (#384). On an instance that never saved a tariff, the standard 06:00-22:00 HP / 22:00-06:00 HC schedule looked configured while it was not, so energy cost attribution and load-shifting recipes appeared broken. The form still lands on those hours for convenience, but a banner now marks them as a suggestion until you click Save. Reported by Adrien Jouve (computingify). (#388)
+
 ### v1.37.0 — 2026-08-09 { #v1-37-0 }
 
 - Feat (recipes): **recipes can read the configured HP/HC tariff schedule** (spec 138). A load-shifting recipe (water heater, pool pump, EV charger) no longer has to re-ask for off-peak hours the instance already knows: `ctx.helpers.getTariff()` returns today's off-peak slots and whether the current time is off-peak, straight from the schedule configured under Settings. Read-only by construction, and tariff **prices are deliberately not exposed** to recipe packages — knowing when energy is cheap is enough to schedule a load. Recipes should keep their own time slots as a fallback for instances with no tariff configured. Contributed by Adrien Jouve (computingify). (#379)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.37.0",
+  "version": "1.37.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch release bundling the two UI fixes merged since v1.37.0.

## Included

- #386 — fix(ui): qualify recipe equipment/zone pickers with zone labels (spec 139). Contributed by Adrien Jouve.
- #388 — fix(ui): distinguish unsaved tariff proposal from a saved schedule (closes #384). Reported by Adrien Jouve.

## Release chores

- Version bump to `1.37.1` in `package.json` and `ui/package.json`.
- Release notes added to `docs/release-notes.md` and `docs/release-notes.fr.md` under the `1.37.x` section with the `{ #v1-37-1 }` anchor (spec 108).

No code change in this PR beyond the version bump — the fixes themselves are already on `main`.