### PR TITLE
fix(packages): stop offering a skipped release as an update

### DIFF
--- a/src/api/routes/plugins.ts
+++ b/src/api/routes/plugins.ts
@@ -45,8 +45,7 @@ export function registerPluginRoutes(app: FastifyInstance, deps: PluginsDeps): v
       // Recipe packages (no runtime status — just manifest + enabled + latest version)
       const recipes = packageManager.getInstalledByType("recipe").map((pkg) => {
         // Spec 136: source-aware — personal packages check their source repo.
-        const latest = packageManager.getLatestVersionFor(pkg);
-        const hasUpdate = latest && latest !== pkg.manifest.version;
+        const update = packageManager.getAvailableUpdateFor(pkg);
         // Spec 137: resolve the display category (manifest → registry → "other")
         // at listing time — no re-release of recipe packages needed.
         const category = packageManager.resolvePackageCategory(pkg.manifest);
@@ -58,7 +57,7 @@ export function registerPluginRoutes(app: FastifyInstance, deps: PluginsDeps): v
           deviceCount: 0,
           offlineDeviceCount: 0,
           source: pkg.source,
-          ...(hasUpdate ? { latestVersion: latest } : {}),
+          ...(update ? { latestVersion: update } : {}),
         };
       });
 

--- a/src/packages/package-manager.test.ts
+++ b/src/packages/package-manager.test.ts
@@ -958,6 +958,52 @@ describe("PackageManager — spec 136 personal plugin sources", () => {
     expect(pkg.source).toBe("personal");
     expect(manager.getLatestVersionFor(pkg)).toBe("2.0.0");
   });
+
+  // ── Update badge (stale release cache regression) ─────────────
+
+  it("stops offering a skipped release once a newer one has been installed", async () => {
+    await addSourceAndInstall();
+
+    // v1.1.0 ships and lands in the release cache — the user ignores the badge.
+    writePersonalManifest({ version: "1.1.0" });
+    const v11Tarball = resolve(tmpDir, "personal-v1.1.0.tar.gz");
+    await buildTarball(pkgSrcDir, v11Tarball);
+    mockPersonalFetch(v11Tarball, "v1.1.0");
+    await manager.sources.fetchLatestRelease(PERSONAL_REPO);
+    expect(manager.getAvailableUpdateFor(manager.getById("mytest")!)).toBe("1.1.0");
+
+    // v2.0.0 ships before the 1h cache TTL expires. The update path reads
+    // releases/latest live, so it installs 2.0.0 while the cache still
+    // holds 1.1.0 — which used to be re-offered as an update forever.
+    const v2 = await publishV2();
+    await manager.updateFiles("mytest", { confirmed: true, expectedSha256: v2.sha });
+
+    expect(getRow("mytest")!.version).toBe("2.0.0");
+    expect(manager.getAvailableUpdateFor(manager.getById("mytest")!)).toBeUndefined();
+  });
+
+  it("never offers a cached release older than the installed version", async () => {
+    await addSourceAndInstall();
+
+    // Cache pinned to an older release with a fresh timestamp (no background
+    // refresh): the raw lookup still reports it, the update check must not.
+    const cache = (
+      manager.sources as unknown as {
+        releaseCache: Map<
+          string,
+          { release: { version: string; assetName: string }; time: number }
+        >;
+      }
+    ).releaseCache;
+    cache.set(PERSONAL_REPO, {
+      release: { version: "0.9.0", assetName: "sowel-plugin-mytest-0.9.0.tar.gz" },
+      time: Date.now(),
+    });
+
+    const pkg = manager.getById("mytest")!;
+    expect(manager.getLatestVersionFor(pkg)).toBe("0.9.0");
+    expect(manager.getAvailableUpdateFor(pkg)).toBeUndefined();
+  });
 });
 
 // ─── Spec 137 — Recipe categories + store passthrough ─────────────────────

--- a/src/packages/package-manager.ts
+++ b/src/packages/package-manager.ts
@@ -24,6 +24,7 @@ import type {
   PackageSource,
   PluginSource,
 } from "../shared/types.js";
+import { isNewerVersion } from "../shared/version.js";
 import {
   type RegistryEntry,
   type RecipeCategory,
@@ -486,6 +487,7 @@ export class PackageManager {
         pinnedSha256: expected,
       });
 
+      this.sources.invalidate(repo);
       this.logger.info(
         { packageId: manifest.id, version: manifest.version, type, repo, tier: "personal" },
         "Personal package installed",
@@ -718,6 +720,7 @@ export class PackageManager {
         row.id,
       );
 
+      this.sources.invalidate(repo);
       this.logger.info(
         { packageId: row.id, from: row.version, to: newManifest.version, tier: "personal" },
         "Personal package updated",
@@ -818,6 +821,20 @@ export class PackageManager {
       return this.sources.getCachedRelease(pkg.manifest.repo)?.version;
     }
     return this.getLatestVersions().get(pkg.manifest.id);
+  }
+
+  /**
+   * The version to offer as an update for an installed package, or
+   * undefined when it is already up to date. Unlike
+   * `getLatestVersionFor`, this compares semver instead of testing for
+   * inequality: a cached "latest" that is older than what is installed
+   * (a stale release cache, a rolled-back registry entry) is not an
+   * update and must never be offered — otherwise the UI proposes a
+   * downgrade to a version the user already skipped.
+   */
+  getAvailableUpdateFor(pkg: InstalledPackage): string | undefined {
+    const latest = this.getLatestVersionFor(pkg);
+    return latest && isNewerVersion(latest, pkg.manifest.version) ? latest : undefined;
   }
 
   /** Lookup repo URL from registry */

--- a/src/packages/personal-sources.ts
+++ b/src/packages/personal-sources.ts
@@ -125,6 +125,19 @@ export class PersonalSourceManager {
   }
 
   /**
+   * Drop the cached release for a repo and re-probe it in the
+   * background. Called after an install or update: those paths download
+   * `releases/latest` live, so once they succeed the cache — which may
+   * still hold whatever release was current up to an hour ago — is known
+   * to be behind reality. Leaving it in place makes the UI offer an
+   * "update" to the older release the user just leapfrogged.
+   */
+  invalidate(repo: string): void {
+    this.releaseCache.delete(repo);
+    this.refreshInBackground(repo);
+  }
+
+  /**
    * Fetch the latest release of a repo from the GitHub API and update
    * the cache. Returns undefined (and keeps any previous cache entry
    * usable) on any failure — a missing release is a normal state for a

--- a/src/plugins/plugin-loader.ts
+++ b/src/plugins/plugin-loader.ts
@@ -16,17 +16,6 @@ import {
   wrapPluginMethods,
 } from "./scoped-deps.js";
 
-/** Simple semver comparison: returns true if a > b */
-function isNewerVersion(a: string, b: string): boolean {
-  const pa = a.split(".").map(Number);
-  const pb = b.split(".").map(Number);
-  for (let i = 0; i < 3; i++) {
-    if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true;
-    if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false;
-  }
-  return false;
-}
-
 /**
  * Integration-specific plugin loader.
  * Uses PackageManager for distribution, handles integration lifecycle
@@ -242,7 +231,7 @@ export class PluginLoader {
       const offlineDevices = pluginDevices.filter((d) => d.status === "offline");
 
       // Spec 136: source-aware — personal packages check their source repo.
-      const latest = this.packageManager.getLatestVersionFor(pkg);
+      const update = this.packageManager.getAvailableUpdateFor(pkg);
 
       return {
         manifest: pkg.manifest,
@@ -252,9 +241,7 @@ export class PluginLoader {
         deviceCount: pluginDevices.length,
         offlineDeviceCount: offlineDevices.length,
         source: pkg.source,
-        ...(latest && isNewerVersion(latest, pkg.manifest.version)
-          ? { latestVersion: latest }
-          : {}),
+        ...(update ? { latestVersion: update } : {}),
       };
     });
   }

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,0 +1,14 @@
+/**
+ * Simple semver comparison: returns true if `a` is strictly newer than `b`.
+ * Shared by every "is an update available?" check so a stale or rolled-back
+ * remote version can never be advertised as an update (spec 136 fix).
+ */
+export function isNewerVersion(a: string, b: string): boolean {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true;
+    if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false;
+  }
+  return false;
+}


### PR DESCRIPTION
## Symptom

On a real instance, the personal recipe `vmc-humidity` is installed at **0.3.4** but the API reports `latestVersion: 0.3.3`, so the UI keeps offering an "update" to the very version the user had just skipped (in fact a downgrade).

```
vmc-humidity  recipe  installed 0.3.4  |  latestVersion: 0.3.3  |  source: personal
```

GitHub itself correctly returns `v0.3.4` on `releases/latest`.

## Cause

Two defects combine:

1. **Release cache never invalidated.** `PersonalSourceManager` caches `releases/latest` for 1 hour. The update path (`downloadTarball`) queries GitHub live, not the cache. So: 12:54 v0.3.3 published, cache = 0.3.3, badge shown, ignored. 13:56 v0.3.4 published, the cache still holds 0.3.3 (TTL not expired). The user clicks "update": 0.3.4 gets installed, but the cache stays on 0.3.3.
2. **Inequality comparison.** The recipe listing in `routes/plugins.ts` tested `latest !== version`, so 0.3.3 != 0.3.4 meant a badge. The integration listing already used `isNewerVersion`: the two paths diverged.

## Fix

- `PersonalSourceManager.invalidate(repo)`, called after every personal install/update: drops the now-stale entry and re-probes in the background.
- `PackageManager.getAvailableUpdateFor(pkg)` compares semver instead of testing inequality, and becomes the single point used by both the recipe and integration listings. A cached version older than the installed one can never be offered as an update.
- `isNewerVersion` moves from `plugin-loader.ts` to `src/shared/version.ts`.

## Tests

Two regression tests added in `package-manager.test.ts`, verified to fail without the fix:

- `stops offering a skipped release once a newer one has been installed`: replays the exact 1.0.0 -> (1.1.0 skipped) -> 2.0.0 scenario.
- `never offers a cached release older than the installed version`: guard on the comparison itself.

`npm run validate`: 1169 tests green.
