### PR TITLE
fix(ui): auto-pick a single-candidate zone and align the recipe chips (#390)

### DIFF
--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -7,10 +7,9 @@ import { useZones } from "../../store/useZones";
 import { useZoneAggregation } from "../../store/useZoneAggregation";
 import { useAuth } from "../../store/useAuth";
 import type { RecipeInfo, RecipeInstance, RecipeLogEntry, RecipeActionDef, EquipmentWithDetails, ZoneWithChildren } from "../../types";
-import type { EquipmentType } from "../../types";
 import { formatTime } from "../../lib/format";
 import { recipeName, recipeDescription, recipeSlotName, recipeSlotDescription, recipeGroupLabel, recipeSlotOptionLabel } from "../../lib/recipe-i18n";
-import { isSlotHidden } from "../../lib/recipe-slots";
+import { isSlotHidden, matchesEquipmentType, equipmentCandidates } from "../../lib/recipe-slots";
 import { flattenZonesWithPath, zoneChainMap, equipmentLabelMap, type ZoneOption } from "../../lib/zone-path";
 import type { RecipeSlotDef } from "../../types";
 
@@ -87,11 +86,6 @@ function MultiSelectChips({
   );
 }
 
-
-function matchesEquipmentType(eqType: string, constraint: EquipmentType | EquipmentType[]): boolean {
-  const types = Array.isArray(constraint) ? constraint : [constraint];
-  return types.some((t) => t === eqType);
-}
 
 /** A chunk is either a single ungrouped slot or a group of slots sharing the same group key. */
 interface SlotChunk {
@@ -984,7 +978,6 @@ function RecipeInstanceRow({
                               onChange={(v) => setEditParams({ ...editParams, [slot.id]: v })}
                               equipments={getEquipmentOptions(slot.id)}
                               zones={allZones}
-                              matchesConstraint={() => true /* already filtered upstream */}
                             />
                           ) : (
                             <select
@@ -1475,42 +1468,40 @@ function TimeInput({
 // with constraints.crossZone or includeDescendants
 // ============================================================
 
+/**
+ * Zone dropdown then equipment dropdown, for a single-equipment slot whose scope
+ * is wider than the recipe's own zone (`crossZone` / `includeDescendants`).
+ *
+ * `equipments` arrives already filtered against the slot's constraints by the
+ * caller's `getEquipmentOptions`, so this picker only ever splits that list by
+ * zone.
+ */
 function SingleEquipmentZonePicker({
   value,
   onChange,
   equipments,
   zones,
-  matchesConstraint,
-  zoneIdsAllowed,
 }: {
   value: string;
   onChange: (value: string) => void;
   equipments: EquipmentWithDetails[];
   zones: ZoneOption[];
-  matchesConstraint: (eq: EquipmentWithDetails) => boolean;
-  /** When set, only zones in this set are listed. */
-  zoneIdsAllowed?: Set<string>;
 }) {
   const { t } = useTranslation();
 
   const selectedEq = value ? equipments.find((e) => e.id === value) : undefined;
   const [pickerZoneId, setPickerZoneId] = useState<string>(selectedEq?.zoneId ?? "");
 
-  // Zones that have at least one matching equipment (and are within
-  // the allowed scope when one is provided).
-  const zonesWithOptions = useMemo(() => {
-    return zones.filter((z) => {
-      if (zoneIdsAllowed && !zoneIdsAllowed.has(z.id)) return false;
-      return equipments.some((eq) => eq.zoneId === z.id && matchesConstraint(eq));
-    });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [zones, equipments, zoneIdsAllowed]);
+  // Zones that have at least one equipment to offer.
+  const zonesWithOptions = useMemo(
+    () => zones.filter((z) => equipmentCandidates(equipments, z.id).length > 0),
+    [zones, equipments],
+  );
 
-  const pickerOptions = useMemo(() => {
-    if (!pickerZoneId) return [];
-    return equipments.filter((eq) => eq.zoneId === pickerZoneId && matchesConstraint(eq));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pickerZoneId, equipments]);
+  const pickerOptions = useMemo(
+    () => equipmentCandidates(equipments, pickerZoneId),
+    [pickerZoneId, equipments],
+  );
 
   return (
     <div className="flex items-center gap-1.5">
@@ -1519,8 +1510,12 @@ function SingleEquipmentZonePicker({
         onChange={(e) => {
           const zid = e.target.value;
           setPickerZoneId(zid);
-          // Clear the equipment if it no longer belongs to the chosen zone
-          if (selectedEq && selectedEq.zoneId !== zid) onChange("");
+          const candidates = equipmentCandidates(equipments, zid);
+          // A zone holding a single candidate has already made the choice —
+          // opening a one-entry dropdown would only confirm it.
+          if (candidates.length === 1) onChange(candidates[0].id);
+          // Otherwise clear the equipment if it no longer belongs to the zone.
+          else if (selectedEq && selectedEq.zoneId !== zid) onChange("");
         }}
         className="flex-1 px-3 py-1.5 text-[13px] bg-surface border border-border rounded-[6px] text-text"
       >
@@ -1574,29 +1569,22 @@ function EquipmentListPicker({
   const { t } = useTranslation();
   const [pickerZoneId, setPickerZoneId] = useState("");
 
-  const selectedIds = value.split(",").filter(Boolean);
+  const selectedIds = useMemo(() => value.split(",").filter(Boolean), [value]);
+  const constraint = slot.constraints?.equipmentType;
 
-  const matchesConstraint = (eq: EquipmentWithDetails) => {
-    if (!slot.constraints?.equipmentType) return true;
-    return matchesEquipmentType(eq.type, slot.constraints.equipmentType);
-  };
+  // Zones that still have something to offer: matching and not already picked.
+  const zonesWithOptions = useMemo(
+    () =>
+      zones.filter(
+        (z) => equipmentCandidates(equipments, z.id, { constraint, excludeIds: selectedIds }).length > 0,
+      ),
+    [zones, equipments, selectedIds, constraint],
+  );
 
-  // Zones that have matching, non-selected equipments
-  const zonesWithOptions = useMemo(() => {
-    return zones.filter((z) =>
-      equipments.some((eq) => eq.zoneId === z.id && !selectedIds.includes(eq.id) && matchesConstraint(eq))
-    );
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [zones, equipments, selectedIds, slot.constraints?.equipmentType]);
-
-  // Equipments in picked zone matching constraints
-  const pickerOptions = useMemo(() => {
-    if (!pickerZoneId) return [];
-    return equipments.filter((eq) =>
-      eq.zoneId === pickerZoneId && !selectedIds.includes(eq.id) && matchesConstraint(eq)
-    );
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pickerZoneId, equipments, selectedIds, slot.constraints?.equipmentType]);
+  const pickerOptions = useMemo(
+    () => equipmentCandidates(equipments, pickerZoneId, { constraint, excludeIds: selectedIds }),
+    [pickerZoneId, equipments, selectedIds, constraint],
+  );
 
   const handleRemove = (eqId: string) => {
     const next = selectedIds.filter((id) => id !== eqId);
@@ -1609,14 +1597,15 @@ function EquipmentListPicker({
         {recipeSlotName(recipe, slot, lang)}
       </label>
 
-      {/* Selected items */}
+      {/* Selected items — zone then equipment, the reading order of the two
+          dropdowns underneath, so a chip lines up with the row that made it. */}
       {selectedIds.map((id) => {
         const eq = equipments.find((e) => e.id === id);
         const zone = eq ? zones.find((z) => z.id === eq.zoneId) : null;
         return (
           <div key={id} className="flex items-center gap-2 px-2 py-1 mb-1 text-[13px] bg-surface border border-border rounded-[6px]">
-            <span className="flex-1 text-text truncate">{eq?.name ?? id}</span>
-            {zone && <span className="text-[11px] text-text-tertiary truncate">{zone.label}</span>}
+            {zone && <span className="min-w-0 text-[11px] text-text-tertiary truncate">{zone.label}</span>}
+            <span className="flex-1 min-w-0 text-text truncate">{eq?.name ?? id}</span>
             <button type="button" onClick={() => handleRemove(id)} className="p-0.5 text-text-tertiary hover:text-error transition-colors">
               <X size={12} strokeWidth={1.5} />
             </button>
@@ -1629,7 +1618,18 @@ function EquipmentListPicker({
         <div className="flex items-center gap-1.5">
           <select
             value={pickerZoneId}
-            onChange={(e) => setPickerZoneId(e.target.value)}
+            onChange={(e) => {
+              const zid = e.target.value;
+              const candidates = equipmentCandidates(equipments, zid, { constraint, excludeIds: selectedIds });
+              // One candidate left in that zone: add it and drop back to the
+              // zone dropdown, exactly where picking it by hand would land.
+              if (candidates.length === 1) {
+                onChange([...selectedIds, candidates[0].id].join(","));
+                setPickerZoneId("");
+              } else {
+                setPickerZoneId(zid);
+              }
+            }}
             className="flex-1 px-2 py-1 text-[13px] bg-surface border border-border rounded-[6px] text-text"
           >
             <option value="">Zone…</option>
@@ -2061,7 +2061,6 @@ function AddRecipeForm({
                             onChange={(v) => setParams({ ...params, [slot.id]: v })}
                             equipments={getEquipmentOptions(slot.id)}
                             zones={allZones}
-                            matchesConstraint={() => true}
                           />
                         ) : (
                           <select

--- a/ui/src/lib/recipe-slots.test.ts
+++ b/ui/src/lib/recipe-slots.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isSlotHidden } from "./recipe-slots";
+import { isSlotHidden, matchesEquipmentType, equipmentCandidates } from "./recipe-slots";
 import type { RecipeSlotDef } from "../types";
 
 const kind: RecipeSlotDef = {
@@ -55,5 +55,76 @@ describe("isSlotHidden", () => {
   it("hides the offset field only for fixed time", () => {
     expect(isSlotHidden(offsetSlot, { k: "sunset" }, all)).toBe(false);
     expect(isSlotHidden(offsetSlot, { k: "time" }, all)).toBe(true);
+  });
+});
+
+describe("matchesEquipmentType", () => {
+  it("accepts a single-type constraint", () => {
+    expect(matchesEquipmentType("temperature", "temperature")).toBe(true);
+    expect(matchesEquipmentType("humidity", "temperature")).toBe(false);
+  });
+
+  it("accepts any type of a list constraint", () => {
+    expect(matchesEquipmentType("humidity", ["temperature", "humidity"])).toBe(true);
+    expect(matchesEquipmentType("light", ["temperature", "humidity"])).toBe(false);
+  });
+});
+
+describe("equipmentCandidates", () => {
+  const equipments = [
+    { id: "t-bath", type: "temperature", zoneId: "bath" },
+    { id: "h-bath", type: "humidity", zoneId: "bath" },
+    { id: "h-laundry", type: "humidity", zoneId: "laundry" },
+    { id: "l-laundry", type: "light", zoneId: "laundry" },
+  ];
+
+  it("keeps only the equipments of the picked zone", () => {
+    expect(equipmentCandidates(equipments, "laundry").map((e) => e.id)).toEqual([
+      "h-laundry",
+      "l-laundry",
+    ]);
+  });
+
+  it("returns nothing when no zone is picked", () => {
+    expect(equipmentCandidates(equipments, "")).toEqual([]);
+  });
+
+  it("returns nothing for a zone holding no equipment", () => {
+    expect(equipmentCandidates(equipments, "attic")).toEqual([]);
+  });
+
+  it("applies the slot's type constraint", () => {
+    expect(
+      equipmentCandidates(equipments, "bath", { constraint: "humidity" }).map((e) => e.id),
+    ).toEqual(["h-bath"]);
+    expect(
+      equipmentCandidates(equipments, "laundry", { constraint: ["humidity", "light"] }).map(
+        (e) => e.id,
+      ),
+    ).toEqual(["h-laundry", "l-laundry"]);
+  });
+
+  it("drops the equipments already selected", () => {
+    expect(
+      equipmentCandidates(equipments, "bath", { excludeIds: ["t-bath"] }).map((e) => e.id),
+    ).toEqual(["h-bath"]);
+    expect(equipmentCandidates(equipments, "bath", { excludeIds: ["t-bath", "h-bath"] })).toEqual(
+      [],
+    );
+  });
+
+  it("combines constraint and exclusion — the single-candidate case", () => {
+    const left = equipmentCandidates(equipments, "laundry", {
+      constraint: ["humidity", "light"],
+      excludeIds: ["l-laundry"],
+    });
+    expect(left).toHaveLength(1);
+    expect(left[0].id).toBe("h-laundry");
+  });
+
+  it("leaves the input array untouched", () => {
+    const before = [...equipments];
+    equipmentCandidates(equipments, "bath", { excludeIds: ["t-bath"] });
+    expect(equipments).toEqual(before);
   });
 });

--- a/ui/src/lib/recipe-slots.ts
+++ b/ui/src/lib/recipe-slots.ts
@@ -1,4 +1,4 @@
-import type { RecipeSlotDef } from "../types";
+import type { EquipmentType, RecipeSlotDef } from "../types";
 
 /**
  * Whether a recipe-form slot should be hidden (not rendered) given the current
@@ -18,4 +18,53 @@ export function isSlotHidden(
   const value = params[rule.slot] ?? ref?.defaultValue;
   const expected = Array.isArray(rule.equals) ? rule.equals : [rule.equals];
   return expected.includes(value as string);
+}
+
+/** Whether an equipment type satisfies a slot's `equipmentType` constraint. */
+export function matchesEquipmentType(
+  eqType: string,
+  constraint: EquipmentType | EquipmentType[],
+): boolean {
+  const types = Array.isArray(constraint) ? constraint : [constraint];
+  return types.some((t) => t === eqType);
+}
+
+/** The little an equipment picker needs to know about an equipment. */
+export interface EquipmentCandidate {
+  id: string;
+  type: string;
+  zoneId: string;
+}
+
+/**
+ * The equipments a zone/equipment picker may offer once a zone is picked: those
+ * sitting in that zone, satisfying the slot's type constraint when it has one,
+ * and not already taken by the slot.
+ *
+ * No zone picked means no candidates — the caller's second dropdown is empty and
+ * disabled, so an empty `zoneId` is a legitimate state rather than "any zone".
+ *
+ * The pickers used to inline this predicate, once to decide which zones are
+ * worth listing and once to fill the equipment dropdown, each closing over a
+ * freshly-built `matchesConstraint` that no dependency array could track. Naming
+ * it makes both call sites the same expression and lets the memos depend on
+ * plain values.
+ */
+export function equipmentCandidates<T extends EquipmentCandidate>(
+  equipments: readonly T[],
+  zoneId: string,
+  options: {
+    constraint?: EquipmentType | EquipmentType[];
+    /** Equipments already selected elsewhere in the slot. */
+    excludeIds?: readonly string[];
+  } = {},
+): T[] {
+  if (!zoneId) return [];
+  const excluded = options.excludeIds?.length ? new Set(options.excludeIds) : null;
+  return equipments.filter((eq) => {
+    if (eq.zoneId !== zoneId) return false;
+    if (excluded?.has(eq.id)) return false;
+    if (options.constraint && !matchesEquipmentType(eq.type, options.constraint)) return false;
+    return true;
+  });
 }


### PR DESCRIPTION
## What was wrong

Two frictions in the zone + equipment picker that fills a recipe's equipment slots.

**Chips read backwards.** The controls ask for the zone first and the equipment second; the chips listing what is already selected printed the equipment first and the zone second, so matching a chip against the row that produced it meant reversing the pair.

**A single-candidate zone still needed a second pick.** Choosing a zone holding exactly one matching equipment left a dropdown with one option in it. The user had to open it and pick the only entry — a click that could never go any other way.

## Root cause of the third item

Nothing was broken in the filtering itself, but the predicate deciding what a picker may offer existed four times inline: once per picker to decide which zones are worth listing, once per picker to fill the equipment dropdown. Each closed over a `matchesConstraint` rebuilt on every render, which no dependency array can track — hence the four `eslint-disable react-hooks/exhaustive-deps` that came with them. Adding the auto-pick would have meant a fifth copy.

## What changed

- `equipmentCandidates(equipments, zoneId, { constraint, excludeIds })` in `ui/src/lib/recipe-slots.ts` is now the single definition. An empty `zoneId` yields no candidates, which is what both pickers already meant by "no zone chosen yet".
- Both pickers call it for their zone list, their equipment list, and the new auto-pick. All four `exhaustive-deps` suppressions are gone; the memos depend on plain values.
- `matchesEquipmentType` moved from the component file to sit beside it.
- The chip renders zone then equipment, and both spans get `min-w-0` so `truncate` actually applies inside the flex row.
- `SingleEquipmentZonePicker` loses two dead props: `matchesConstraint` (both call sites passed `() => true`, the list being pre-filtered by `getEquipmentOptions`) and `zoneIdsAllowed` (never set by any caller).

Auto-pick in the list variant also resets the zone dropdown, since that zone is now exhausted — the same state a manual pick already produced.

## Tests

10 cases added to `ui/src/lib/recipe-slots.test.ts`: zone scoping, empty and unknown zone, single and array type constraints, exclusion of already-selected ids, the combined single-candidate case that drives the auto-pick, and non-mutation of the input.

Full `npm run validate` green — 1178 tests, 0 lint errors, typecheck clean. The two remaining lint warnings pre-exist on `main`.

Closes #390