### PR TITLE
feat(settings): expose every Zigbee2MQTT base topic, and document multi-coordinator setups

### DIFF
--- a/docs/user/host-setup.fr.md
+++ b/docs/user/host-setup.fr.md
@@ -116,6 +116,82 @@ mosquitto_pub -h <ip-de-l'hôte> -p 1883 -t test/hello -m "ok"
 
 Si le message arrive, le broker est joignable. Vous pouvez maintenant pointer le plugin Zigbee2MQTT de Sowel (et Z2M lui-même) vers `mqtt://<ip-de-l'hôte>:1883`.
 
+## Plusieurs coordinateurs Zigbee
+
+Un seul coordinateur Zigbee suffit à la plupart des maisons. Un deuxième devient nécessaire quand le bâtiment est trop grand pour un seul maillage, quand une dépendance est hors de portée, ou quand vous atteignez la limite d'appareils du coordinateur.
+
+Zigbee2MQTT pilote **un coordinateur par instance**. Deux coordinateurs, c'est donc deux instances Z2M — mais toujours **un seul broker MQTT**, et **un seul** plugin Zigbee2MQTT dans Sowel.
+
+!!! warning "Chaque instance a besoin de son propre base topic"
+Ne donnez jamais le même `base_topic` à deux instances. `bridge/devices`, `bridge/info` et `bridge/state` sont des topics retenus : les instances écraseraient mutuellement leur liste d'appareils, et Sowel verrait les réseaux apparaître et disparaître à tour de rôle.
+
+### Un conteneur par coordinateur
+
+Chaque instance a besoin de son propre volume de données, base topic, port de frontend et canal Zigbee :
+
+```yaml
+services:
+  zigbee2mqtt:
+    image: koenkk/zigbee2mqtt
+    restart: unless-stopped
+    volumes:
+      - ./z2m-data:/app/data
+    ports:
+      - 8080:8080
+
+  zigbee2mqtt-annexe:
+    image: koenkk/zigbee2mqtt
+    restart: unless-stopped
+    volumes:
+      - ./z2m-annexe-data:/app/data # volume séparé — ne jamais le partager
+    ports:
+      - 8081:8080
+```
+
+Puis, dans le `data/configuration.yaml` de chaque instance :
+
+```yaml
+# instance 1                     # instance 2
+mqtt:                            mqtt:
+  base_topic: zigbee2mqtt          base_topic: zigbee2mqtt_annexe
+  server: mqtt://<ip-hôte>:1883    server: mqtt://<ip-hôte>:1883
+serial:                          serial:
+  port: tcp://<ip-coord1>:6638     port: tcp://<ip-coord2>:6638
+  adapter: zstack                  adapter: zstack
+advanced:                        advanced:
+  channel: 11                      channel: 25
+frontend:                        frontend:
+  port: 8080                       port: 8080
+```
+
+Ces mêmes réglages sont accessibles depuis l'interface web de Z2M, sous **Paramètres → MQTT**, **Avancé** et **Port série**, ce qui évite d'éditer le fichier à la main.
+
+!!! tip "Utilisez des canaux Zigbee différents"
+Deux réseaux sur le même canal et à portée radio l'un de l'autre se partagent le temps d'antenne et se dégradent mutuellement. Choisissez des canaux éloignés — 11, 15, 20 et 25 sont les valeurs habituelles. Réglez le canal **avant d'appairer les appareils** : le changer ensuite peut vous obliger à ré-appairer une partie du réseau.
+
+### Déclarer les réseaux dans Sowel
+
+Dans **Administration → Intégrations → Zigbee2MQTT**, listez les base topics dans le champ **Zigbee2MQTT Base Topic(s)**, séparés par des virgules :
+
+```
+zigbee2mqtt, zigbee2mqtt_annexe
+```
+
+Le premier réseau conserve les noms d'appareils tels quels. Les appareils des réseaux suivants sont préfixés par leur base topic — `zigbee2mqtt_annexe/lampe_cuisine` — afin que deux réseaux puissent héberger le même nom sans que leurs appareils ne fusionnent dans Sowel.
+
+!!! warning "L'ordre de la liste fait partie de l'identité des appareils"
+Les identifiants d'appareils dérivent de cette liste. La réordonner, ou renommer un base topic, orpheline les appareils concernés et supprime leurs liaisons d'équipement. Ajoutez les nouveaux réseaux à la fin.
+
+Si vous savez que les noms sont uniques sur l'ensemble de vos réseaux, vous pouvez supprimer le préfixe d'un réseau donné en terminant son entrée par deux-points :
+
+```
+zigbee2mqtt, zigbee2mqtt_annexe:
+```
+
+Deux appareils portant le même nom deviennent alors silencieusement un seul appareil Sowel : ne le faites que si vous maîtrisez le nommage.
+
+Ajouter un troisième coordinateur plus tard, ce sont les mêmes trois étapes : un nouveau conteneur avec son volume, son port, son base topic et son canal, puis ce base topic ajouté à la fin de la liste.
+
 ## Dépannage
 
 ### `Error: cannot reach the Docker daemon`

--- a/docs/user/host-setup.md
+++ b/docs/user/host-setup.md
@@ -116,6 +116,82 @@ mosquitto_pub -h <host-ip> -p 1883 -t test/hello -m "ok"
 
 If the message arrives, the broker is reachable. You can now point the Sowel Zigbee2MQTT plugin (and Z2M itself) to `mqtt://<host-ip>:1883`.
 
+## Several Zigbee coordinators
+
+A single Zigbee coordinator covers most homes. You need a second one when the house is too large for one mesh, when an outbuilding is out of range, or when you hit the coordinator's device limit.
+
+Zigbee2MQTT drives **one coordinator per instance**. Two coordinators therefore means two Z2M instances — but still **one MQTT broker**, and **one** Zigbee2MQTT plugin in Sowel.
+
+!!! warning "Each instance needs its own base topic"
+Do not give two instances the same `base_topic`. `bridge/devices`, `bridge/info` and `bridge/state` are retained topics: the instances would overwrite each other's device list, and Sowel would see the networks appear and disappear in turn.
+
+### Run one container per coordinator
+
+Each instance needs its own data volume, base topic, frontend port and Zigbee channel:
+
+```yaml
+services:
+  zigbee2mqtt:
+    image: koenkk/zigbee2mqtt
+    restart: unless-stopped
+    volumes:
+      - ./z2m-data:/app/data
+    ports:
+      - 8080:8080
+
+  zigbee2mqtt-annex:
+    image: koenkk/zigbee2mqtt
+    restart: unless-stopped
+    volumes:
+      - ./z2m-annex-data:/app/data # separate volume — never share it
+    ports:
+      - 8081:8080
+```
+
+Then, in each instance's `data/configuration.yaml`:
+
+```yaml
+# instance 1                     # instance 2
+mqtt:                            mqtt:
+  base_topic: zigbee2mqtt          base_topic: zigbee2mqtt_annex
+  server: mqtt://<host-ip>:1883    server: mqtt://<host-ip>:1883
+serial:                          serial:
+  port: tcp://<coord1-ip>:6638     port: tcp://<coord2-ip>:6638
+  adapter: zstack                  adapter: zstack
+advanced:                        advanced:
+  channel: 11                      channel: 25
+frontend:                        frontend:
+  port: 8080                       port: 8080
+```
+
+The same settings are reachable from the Z2M web interface under **Settings → MQTT**, **Advanced** and **Serial port**, which avoids editing the file by hand.
+
+!!! tip "Use different Zigbee channels"
+Two networks on the same channel within radio range of each other share airtime and both degrade. Pick channels far apart — 11, 15, 20 and 25 are the usual choices. Set the channel **before pairing devices**: changing it later may force you to re-pair part of the network.
+
+### Declare the networks in Sowel
+
+In **Administration → Integrations → Zigbee2MQTT**, list the base topics in **Zigbee2MQTT Base Topic(s)**, separated by commas:
+
+```
+zigbee2mqtt, zigbee2mqtt_annex
+```
+
+The first network keeps its device names as-is. Devices of the following networks are prefixed with their base topic — `zigbee2mqtt_annex/kitchen_lamp` — so that two networks can host the same friendly name without their devices merging in Sowel.
+
+!!! warning "The order of the list is part of the device identity"
+Device identifiers derive from this list. Reordering it, or renaming a base topic, orphans the affected devices and drops their equipment bindings. Append new networks at the end.
+
+If friendly names are known to be unique across all your networks, you can drop the prefix for a given network by suffixing its entry with a colon:
+
+```
+zigbee2mqtt, zigbee2mqtt_annex:
+```
+
+Two devices sharing a name then silently become a single Sowel device, so only do this if you control the naming.
+
+Adding a third coordinator later is the same three steps: a new container with its own volume, port, base topic and channel, then that base topic appended to the list.
+
 ## Troubleshooting
 
 ### `Error: cannot reach the Docker daemon`

--- a/src/core/settings-manager.test.ts
+++ b/src/core/settings-manager.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { SettingsManager } from "./settings-manager.js";
+
+describe("SettingsManager.getZ2mConfig", () => {
+  let settings: SettingsManager;
+
+  beforeEach(() => {
+    const db = new Database(":memory:");
+    db.exec(
+      "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL DEFAULT (datetime('now')))",
+    );
+    settings = new SettingsManager(db);
+  });
+
+  const setTopic = (value: string): void =>
+    settings.set("integration.zigbee2mqtt.base_topic", value);
+
+  it("defaults to the single zigbee2mqtt topic when unset", () => {
+    expect(settings.getZ2mConfig()).toEqual({
+      baseTopic: "zigbee2mqtt",
+      baseTopics: ["zigbee2mqtt"],
+    });
+  });
+
+  it("reads a single configured topic", () => {
+    setTopic("z2m_home");
+    expect(settings.getZ2mConfig()).toEqual({ baseTopic: "z2m_home", baseTopics: ["z2m_home"] });
+  });
+
+  it("splits the list of one Zigbee2MQTT instance per coordinator", () => {
+    setTopic("zigbee2mqtt, zigbee2mqtt_annex ,zigbee2mqtt_garage");
+    expect(settings.getZ2mConfig()).toEqual({
+      baseTopic: "zigbee2mqtt",
+      baseTopics: ["zigbee2mqtt", "zigbee2mqtt_annex", "zigbee2mqtt_garage"],
+    });
+  });
+
+  it("keeps only the topic part of a topic:prefix entry", () => {
+    setTopic("zigbee2mqtt, zigbee2mqtt_annex:annex, zigbee2mqtt_garage:");
+    expect(settings.getZ2mConfig().baseTopics).toEqual([
+      "zigbee2mqtt",
+      "zigbee2mqtt_annex",
+      "zigbee2mqtt_garage",
+    ]);
+  });
+
+  it("drops blanks, duplicates and trailing slashes rather than yielding an empty topic", () => {
+    setTopic(" , zigbee2mqtt/ , zigbee2mqtt, ,zigbee2mqtt_annex");
+    expect(settings.getZ2mConfig()).toEqual({
+      baseTopic: "zigbee2mqtt",
+      baseTopics: ["zigbee2mqtt", "zigbee2mqtt_annex"],
+    });
+  });
+
+  it("falls back to the default when the setting holds only separators", () => {
+    setTopic(" , , ");
+    expect(settings.getZ2mConfig()).toEqual({
+      baseTopic: "zigbee2mqtt",
+      baseTopics: ["zigbee2mqtt"],
+    });
+  });
+});

--- a/src/core/settings-manager.ts
+++ b/src/core/settings-manager.ts
@@ -94,10 +94,29 @@ export class SettingsManager {
     };
   }
 
-  /** Get Zigbee2mqtt config from settings. */
-  getZ2mConfig(): { baseTopic: string } {
-    return {
-      baseTopic: this.get("integration.zigbee2mqtt.base_topic") ?? "zigbee2mqtt",
-    };
+  /**
+   * Get Zigbee2mqtt config from settings.
+   *
+   * Zigbee2MQTT drives one coordinator per instance, so a home with several
+   * coordinators runs several instances on one broker and the setting holds a
+   * comma-separated list of their base topics. `baseTopics` is that list;
+   * `baseTopic` is its first entry, i.e. the primary network, kept so callers
+   * written for a single network keep working.
+   */
+  getZ2mConfig(): { baseTopic: string; baseTopics: string[] } {
+    const raw = this.get("integration.zigbee2mqtt.base_topic") ?? "zigbee2mqtt";
+    const baseTopics = [
+      ...new Set(
+        raw
+          // Each entry is `topic` or `topic:device-prefix` — only the topic part
+          // addresses MQTT.
+          .split(",")
+          .map((entry) => entry.split(":")[0]!.trim().replace(/\/+$/, ""))
+          .filter((topic) => topic !== ""),
+      ),
+    ];
+    if (baseTopics.length === 0) baseTopics.push("zigbee2mqtt");
+
+    return { baseTopic: baseTopics[0]!, baseTopics };
   }
 }

--- a/src/plugins/__fixtures__/test-helpers.ts
+++ b/src/plugins/__fixtures__/test-helpers.ts
@@ -72,9 +72,14 @@ export function makeMockSettings(initial: Record<string, string> = {}): Settings
       password: store.get("integration.zigbee2mqtt.mqtt_password"),
       clientId: store.get("integration.zigbee2mqtt.mqtt_client_id") ?? "sowel",
     })),
-    getZ2mConfig: vi.fn(() => ({
-      baseTopic: store.get("integration.zigbee2mqtt.base_topic") ?? "zigbee2mqtt",
-    })),
+    getZ2mConfig: vi.fn(() => {
+      const raw = store.get("integration.zigbee2mqtt.base_topic") ?? "zigbee2mqtt";
+      const baseTopics = raw
+        .split(",")
+        .map((entry) => entry.split(":")[0]!.trim())
+        .filter(Boolean);
+      return { baseTopic: baseTopics[0] ?? "zigbee2mqtt", baseTopics };
+    }),
   } as unknown as SettingsManager;
 }
 


### PR DESCRIPTION
Core-side counterpart of [sowel-plugin-zigbee2mqtt#8](https://github.com/mchacher/sowel-plugin-zigbee2mqtt/pull/8), which teaches the plugin to serve several Zigbee coordinators.

## Context

Zigbee2MQTT drives **one coordinator per instance**, so a home with several coordinators runs several Z2M instances — each with its own `base_topic`, all on one MQTT broker. Sharing a base topic is not an option: `bridge/devices`, `bridge/info` and `bridge/state` are retained, so the instances would overwrite each other's device list. With the plugin change, `integration.zigbee2mqtt.base_topic` holds a comma-separated list.

## `getZ2mConfig()`

It returned that raw setting as a single `baseTopic`, so a caller would receive `"zigbee2mqtt, zigbee2mqtt_annex"` as if it were one topic. Nothing calls it today — neither the core nor any of the official plugins (grepped across all plugin and recipe repos) — but it is exposed to the zigbee2mqtt plugin through the spec 111 scoped proxy, so it stays a trap for whoever reaches for it next.

It now returns `baseTopics` (the parsed list) alongside `baseTopic` (its first entry, i.e. the primary network) so any single-network caller keeps working. Entries of the form `topic:device-prefix` are reduced to their topic part, and blanks, duplicates and trailing slashes are dropped rather than yielding an empty topic.

## Documentation

New **"Several Zigbee coordinators"** section in `docs/user/host-setup.md` and its FR translation: one container per coordinator with its own data volume and frontend port, the `configuration.yaml` differences side by side, why base topics must differ, why channels should too, and how to declare the networks in Sowel — including the ordering constraint (device ids derive from the list, so reordering it orphans devices).

No screenshots: per the docs workflow, public docs are never shot on a production instance.

## Tests

`npx tsc --noEmit` clean. New `src/core/settings-manager.test.ts` — 6 cases on `getZ2mConfig`; `scoped-deps` suite still green (50 passing across both files).

`mkdocs build --strict` was **not** run — mkdocs is not installed in this environment. The change adds no page, no nav entry and no relative link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)