### PR TITLE
release: v1.38.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,16 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.38.x: Plusieurs coordinateurs Zigbee
+
+### v1.38.0 — 2026-08-10 { #v1-38-0 }
+
+- Feat (settings) : **une instance Sowel peut désormais servir plusieurs coordinateurs Zigbee** (grande maison, dépendance hors de portée radio, limite d'appareils du coordinateur). Zigbee2MQTT pilote un coordinateur par instance : le réglage `base_topic` de l'intégration Zigbee2MQTT accepte donc une liste séparée par des virgules, une entrée par instance Z2M sur le broker MQTT partagé. Le core expose la liste au plugin, et une nouvelle section **« Plusieurs coordinateurs Zigbee »** du guide de préparation de l'hôte détaille toute la mise en place : un conteneur par coordinateur, les différences de configuration, et pourquoi les base topics et les canaux Zigbee doivent différer. Fonctionne avec le plugin Zigbee2MQTT **2.4.0**, qui requiert cette version. Contribution d'Adrien Jouve (computingify). (#395)
+- Fix (ui) : les sélecteurs des recettes **choisissent automatiquement une zone qui ne contient qu'un seul candidat** au lieu de laisser un menu à option unique, et les puces récapitulant un slot de liste d'équipements affichent zone puis équipement, dans l'ordre des contrôles qui les ont produites. Le prédicat de filtrage des candidats, écrit quatre fois en ligne, devient un helper unique et testé. (#390, #393)
+- Fix (packages) : le badge de mise à jour **ne propose plus une version que vous avez déjà sautée**. Les installations par source personnelle téléchargent la dernière release en direct, mais le badge lisait un cache d'une heure que rien n'invalidait après une installation : sautez une version, installez la suivante, et l'interface continuait de proposer un retour en arrière. Le cache est désormais invalidé après chaque installation ou mise à jour personnelle, et une version en cache plus ancienne que celle installée n'est jamais présentée comme une mise à jour. (#391)
+
+---
+
 ## 1.37.x: Tarif HP/HC pour les recettes
 
 ### v1.37.1 — 2026-08-10 { #v1-37-1 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,16 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.38.x: Several Zigbee coordinators
+
+### v1.38.0 — 2026-08-10 { #v1-38-0 }
+
+- Feat (settings): **one Sowel instance can now serve several Zigbee coordinators** (large houses, outbuildings out of radio range, coordinator device limits). Zigbee2MQTT drives one coordinator per instance, so the `base_topic` setting of the Zigbee2MQTT integration now accepts a comma-separated list, one entry per Z2M instance on the shared MQTT broker. The core exposes the parsed list to the plugin, and a new **"Several Zigbee coordinators"** section in the host setup guide walks through the whole setup: one container per coordinator, the configuration differences, and why base topics and Zigbee channels must differ. Pairs with the Zigbee2MQTT plugin **2.4.0**, which requires this version. Contributed by Adrien Jouve (computingify). (#395)
+- Fix (ui): recipe pickers now **auto-select a zone that holds exactly one candidate** instead of leaving a one-option dropdown, and the chips recapping a filled equipment-list slot read zone-then-equipment, matching the order of the controls that produced them. The candidate-filtering predicate, previously written four times inline, moves to a single tested helper. (#390, #393)
+- Fix (packages): the update badge **no longer offers a release you already leapfrogged**. Personal-source installs download the latest release live, but the badge read a 1-hour release cache that nothing invalidated after an install — skip a version, install the next one, and the UI kept proposing a downgrade. The cache is now invalidated after every personal install or update, and a cached version older than the installed one is never surfaced as an update. (#391)
+
+---
+
 ## 1.37.x: Recipe tariff helper
 
 ### v1.37.1 — 2026-08-10 { #v1-37-1 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.37.1",
+  "version": "1.38.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.37.1",
+  "version": "1.38.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## v1.38.0 — Several Zigbee coordinators

Covers everything merged since v1.37.1:

- feat(settings): expose every Zigbee2MQTT base topic, and document multi-coordinator setups (#395)
- fix(ui): auto-pick a single-candidate zone and align the recipe chips (#393, refs #390)
- fix(packages): stop offering a skipped release as an update (#391)

Release notes added in both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-38-0 }` anchor (spec 108).

After merge: tag `v1.38.0` on the merge commit, then Zigbee2MQTT plugin 2.4.0 release + registry bump (`sowelVersion: ">=1.38.0"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)