### PR TITLE
chore(registry): bump zigbee2mqtt to 2.4.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -7,11 +7,11 @@
     "icon": "Radio",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-zigbee2mqtt",
-    "version": "2.3.1",
+    "version": "2.4.0",
     "tags": ["zigbee", "mqtt", "z2m", "sensors", "lights", "switches"],
-    "sowelVersion": ">=1.2.12",
+    "sowelVersion": ">=1.38.0",
     "owner": "mchacher",
-    "sha256": "a63bf3cefd980dec35fc8d0caeba1056f6d5960b6df3d3ad3a120c30ec397400"
+    "sha256": "68bfe4ce68607d7d1734f17ac0c902ed3052ed2c120a35b0225e6f0e09b3bdbf"
   },
   {
     "id": "lora2mqtt",


### PR DESCRIPTION
Zigbee2MQTT plugin **2.4.0** — multi-coordinator support ([sowel-plugin-zigbee2mqtt#8](https://github.com/mchacher/sowel-plugin-zigbee2mqtt/pull/8), by Adrien Jouve / computingify, plus the order-routing fix and cross-network collision warning).

- `version`: 2.3.1 → 2.4.0
- `sowelVersion`: `>=1.2.12` → `>=1.38.0` — the plugin pairs with core v1.38.0 (released today); older cores are not offered the update and refuse the install.
- `sha256`: backfilled via `scripts/backfill-registry-sha256.mjs` and verified against the published `sowel-plugin-zigbee2mqtt-2.4.0.tar.gz` asset (`68bfe4ce…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)