### PR TITLE
fix(mqtt): unique publisher clientId per process + reconnect warn throttling

### DIFF
--- a/src/mqtt-publishers/mqtt-publish-service.test.ts
+++ b/src/mqtt-publishers/mqtt-publish-service.test.ts
@@ -22,10 +22,8 @@ const fakeClient = {
 
 vi.mock("mqtt", () => ({
   default: {
-    connect: () => {
-      // Reset publish mock between tests by binding to the same fakeClient across the suite.
-      return fakeClient;
-    },
+    // Reset publish mock between tests by binding to the same fakeClient across the suite.
+    connect: vi.fn(() => fakeClient),
   },
 }));
 
@@ -199,6 +197,145 @@ describe("MqttPublishService — disabled mappings are skipped", () => {
     );
     expect(tliveCalls.length).toBeGreaterThan(0);
     expect(toffCalls.length).toBe(0);
+
+    await service.destroy();
+  });
+});
+
+// Issue #399 — deterministic clientId collided across instances sharing a DB copy.
+describe("MqttPublishService — clientId uniqueness and reconnect log throttling", () => {
+  let db: Database.Database;
+  let eventBus: EventBus;
+  let brokerManager: MqttBrokerManager;
+  let publisherManager: MqttPublisherManager;
+  let brokerId: string;
+
+  const equipmentManager = {
+    getDataBindingsWithValues: vi.fn(() => []),
+  } as unknown as import("../equipments/equipment-manager.js").EquipmentManager;
+  const zoneAggregator = {
+    getAll: vi.fn(() => ({})),
+  } as unknown as import("../zones/zone-aggregator.js").ZoneAggregator;
+  const recipeManager = {
+    getInstanceState: vi.fn(() => ({})),
+  } as unknown as import("../recipes/engine/recipe-manager.js").RecipeManager;
+
+  function makeSpyLogger() {
+    const spy = {
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      trace: vi.fn(),
+      child: vi.fn(),
+    };
+    spy.child.mockReturnValue(spy);
+    return spy;
+  }
+
+  beforeEach(async () => {
+    const mqttMod = (await import("mqtt")).default;
+    vi.mocked(mqttMod.connect).mockClear();
+    fakeClient.on.mockClear();
+    fakeClient.publish.mockClear();
+    db = createTestDb();
+    eventBus = new EventBus(logger);
+    brokerManager = new MqttBrokerManager(db, eventBus, logger);
+    publisherManager = new MqttPublisherManager(db, eventBus, logger);
+    const broker = brokerManager.create({
+      name: "B",
+      url: "mqtt://x",
+      username: null,
+      password: null,
+    });
+    brokerId = broker.id;
+  });
+
+  async function buildService(spyLogger: ReturnType<typeof makeSpyLogger>) {
+    const { MqttPublishService } = await import("./mqtt-publish-service.js");
+    const service = new MqttPublishService(
+      eventBus,
+      brokerManager,
+      publisherManager,
+      equipmentManager,
+      zoneAggregator,
+      recipeManager,
+      spyLogger as unknown as ReturnType<typeof createLogger>["logger"],
+    );
+    service.init();
+    return service;
+  }
+
+  it("generates a unique clientId per connection, prefixed by the broker id", async () => {
+    const mqttMod = (await import("mqtt")).default;
+    const serviceA = await buildService(makeSpyLogger());
+    const serviceB = await buildService(makeSpyLogger());
+
+    const calls = vi.mocked(mqttMod.connect).mock.calls;
+    expect(calls.length).toBe(2);
+    const idA = (calls[0][1] as { clientId: string }).clientId;
+    const idB = (calls[1][1] as { clientId: string }).clientId;
+    const prefix = `sowel-publisher-${brokerId.slice(0, 8)}-`;
+    expect(idA.startsWith(prefix)).toBe(true);
+    expect(idB.startsWith(prefix)).toBe(true);
+    expect(idA).not.toBe(idB);
+
+    await serviceA.destroy();
+    await serviceB.destroy();
+  });
+
+  it("throttles reconnect warns to one per window and counts suppressed ones", async () => {
+    vi.useFakeTimers();
+    try {
+      const spyLogger = makeSpyLogger();
+      const service = await buildService(spyLogger);
+
+      const reconnectHandler = fakeClient.on.mock.calls
+        .filter((c) => c[0] === "reconnect")
+        .at(-1)?.[1] as () => void;
+      expect(reconnectHandler).toBeDefined();
+
+      for (let i = 0; i < 5; i++) reconnectHandler();
+      const warns = spyLogger.warn.mock.calls.filter(
+        (c) => c[1] === "MQTT publish broker reconnecting...",
+      );
+      expect(warns.length).toBe(1);
+      expect(warns[0][0]).toMatchObject({ suppressedSinceLastLog: 0 });
+
+      vi.advanceTimersByTime(61_000);
+      reconnectHandler();
+      const warnsAfter = spyLogger.warn.mock.calls.filter(
+        (c) => c[1] === "MQTT publish broker reconnecting...",
+      );
+      expect(warnsAfter.length).toBe(2);
+      expect(warnsAfter[1][0]).toMatchObject({ suppressedSinceLastLog: 4 });
+
+      await service.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("logs connected at info only on first connect, debug afterwards", async () => {
+    const spyLogger = makeSpyLogger();
+    const service = await buildService(spyLogger);
+
+    const connectHandler = fakeClient.on.mock.calls
+      .filter((c) => c[0] === "connect")
+      .at(-1)?.[1] as () => void;
+    expect(connectHandler).toBeDefined();
+
+    connectHandler();
+    connectHandler();
+
+    const infoConnected = spyLogger.info.mock.calls.filter(
+      (c) => c[1] === "MQTT publish broker connected",
+    );
+    const debugReconnected = spyLogger.debug.mock.calls.filter(
+      (c) => c[1] === "MQTT publish broker reconnected",
+    );
+    expect(infoConnected.length).toBe(1);
+    expect(debugReconnected.length).toBe(1);
 
     await service.destroy();
   });

--- a/src/mqtt-publishers/mqtt-publish-service.ts
+++ b/src/mqtt-publishers/mqtt-publish-service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import mqtt, { type MqttClient } from "mqtt";
 import type { Logger } from "../core/logger.js";
 import type { EventBus } from "../core/event-bus.js";
@@ -28,6 +29,9 @@ interface MappingRef {
 const TRUTHY = new Set<unknown>([true, "ON", "open"]);
 const FALSY = new Set<unknown>([false, "OFF", "closed"]);
 
+/** Minimum interval between two "reconnecting" warn lines per broker. */
+const RECONNECT_LOG_WINDOW_MS = 60_000;
+
 function toMqttValue(value: unknown): unknown {
   if (TRUTHY.has(value)) return 1;
   if (FALSY.has(value)) return 0;
@@ -52,6 +56,9 @@ export class MqttPublishService {
 
   /** Cache of last published values — key = "brokerId:topic:publishKey" */
   private lastPublished: Map<string, unknown> = new Map();
+
+  /** Reconnect warn throttling per broker — a connection flap must not flood the logs. */
+  private reconnectLog: Map<string, { lastWarn: number; suppressed: number }> = new Map();
 
   constructor(
     private readonly eventBus: EventBus,
@@ -106,7 +113,11 @@ export class MqttPublishService {
     this.disconnectBroker(brokerId);
 
     const client = mqtt.connect(broker.url, {
-      clientId: `sowel-publisher-${brokerId.slice(0, 8)}`,
+      // Unique per process: a deterministic id collides with any other instance
+      // running on a copy of the same DB (same broker row), and the broker then
+      // kicks the two clients in a takeover loop (#399). clean:true means no
+      // session state depends on a stable id.
+      clientId: `sowel-publisher-${brokerId.slice(0, 8)}-${randomUUID().slice(0, 8)}`,
       username: broker.username,
       password: broker.password,
       clean: true,
@@ -115,16 +126,29 @@ export class MqttPublishService {
 
     let firstConnect = true;
     client.on("connect", () => {
-      this.logger.info({ brokerId, brokerUrl: broker.url }, "MQTT publish broker connected");
       // Only publish snapshot on first connect, not on every reconnect
       if (firstConnect) {
+        this.logger.info({ brokerId, brokerUrl: broker.url }, "MQTT publish broker connected");
         this.publishInitialSnapshotForBroker(brokerId);
         firstConnect = false;
+      } else {
+        this.logger.debug({ brokerId, brokerUrl: broker.url }, "MQTT publish broker reconnected");
       }
     });
 
     client.on("reconnect", () => {
-      this.logger.warn({ brokerId }, "MQTT publish broker reconnecting...");
+      const state = this.reconnectLog.get(brokerId) ?? { lastWarn: 0, suppressed: 0 };
+      const now = Date.now();
+      if (now - state.lastWarn >= RECONNECT_LOG_WINDOW_MS) {
+        this.logger.warn(
+          { brokerId, suppressedSinceLastLog: state.suppressed },
+          "MQTT publish broker reconnecting...",
+        );
+        this.reconnectLog.set(brokerId, { lastWarn: now, suppressed: 0 });
+      } else {
+        state.suppressed += 1;
+        this.reconnectLog.set(brokerId, state);
+      }
     });
 
     client.on("error", (err) => {


### PR DESCRIPTION
## Summary

- Append a random per-connection suffix to the MQTT publisher clientId. The previous deterministic id (`sowel-publisher-<brokerId8>`) collided with any other instance running on a copy of the same database (dev instance on a restored prod backup), causing a mutual-kick takeover loop: 5,700 reconnects/day observed on production on 2026-08-10. With `clean: true` no session state depends on a stable id.
- Throttle the `reconnecting...` warn to one line per minute per broker, with a `suppressedSinceLastLog` counter, and demote post-first `connected` logs to debug, so a future flap cannot flood the log files.

## Tests

- clientId is unique per connection and keeps the `sowel-publisher-<brokerId8>-` prefix
- reconnect warns throttled inside the window, suppressed count reported on the next window
- connected logged at info only on first connect, debug afterwards

Closes #399
