### PR TITLE
fix(logging): date-stamped daily log files + cross-container retention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ The Proxy does NOT protect against direct `require("better-sqlite3")`, `process.
 | `debug` | Developer troubleshooting detail                              |
 | `trace` | High-volume hot path (off in production)                      |
 
-Production logs go to both stdout (captured by Docker) and `data/logs/sowel-N.log` (daily rotation, 14 days kept). **File logs survive container recreation**, crucial for post-incident investigation.
+Production logs go to both stdout (captured by Docker) and `data/logs/sowel.<yyyy-MM-dd>.N.log` (daily rotation, 14 days kept, one predictable file per calendar day). **File logs survive container recreation**, crucial for post-incident investigation.
 
 ## Design system
 

--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -465,16 +465,22 @@ Logs JSON structurés pino avec sortie multistream (voir `src/core/logger.ts`) :
 
 - **Ring buffer** : buffer circulaire en mémoire pour le viewer de logs de l'UI (capture toujours au niveau debug)
 - **stdout** : JSON brut en production (capté par les Docker logs), pino-pretty en développement
-- **Transport fichier** : en production uniquement, via `pino-roll` vers `data/logs/sowel-N.log`, rotation journalière, conserve 14 fichiers
+- **Transport fichier** : en production uniquement, via `pino-roll` vers `data/logs/sowel.<yyyy-MM-dd>.N.log`, rotation journalière, conserve 14 fichiers (la rétention couvre aussi les fichiers laissés par les conteneurs précédents)
 
 ### Emplacement des fichiers de log
 
-`/app/data/logs/sowel-<N>.log` à l'intérieur du conteneur (sur le volume `sowel-data`). **Survit à la recréation du conteneur**, indispensable pour l'investigation post-incident après une auto-mise à jour.
+`/app/data/logs/sowel.<yyyy-MM-dd>.N.log` à l'intérieur du conteneur (sur le volume `sowel-data`). Un jour calendaire correspond à un fichier prévisible, même après redémarrages et auto-mises à jour. **Survit à la recréation du conteneur**, indispensable pour l'investigation post-incident après une auto-mise à jour.
 
 Exemple de récupération :
 
 ```bash
-docker exec sowel sh -c 'cat /app/data/logs/sowel.6.log | grep -E "2026-04-11T07:" | grep error'
+docker exec sowel sh -c 'cat /app/data/logs/sowel.2026-04-11.1.log | grep -E "2026-04-11T07:" | grep error'
+```
+
+Avant la v1.39, les fichiers étaient nommés `sowel.N.log` avec un numéro de rotation choisi par processus : plusieurs redémarrages dans la journée éclataient les plages horaires entre fichiers, et un même fichier pouvait couvrir plusieurs mois. Pour investiguer un incident antérieur au changement de format, grepper TOUS les fichiers `sowel.*.log` plutôt que de se fier à un seul. Les anciens fichiers numérotés ne sont pas couverts par la nouvelle rétention et peuvent être supprimés manuellement une fois devenus inutiles :
+
+```bash
+docker exec sowel sh -c 'rm /app/data/logs/sowel.[0-9]*.log'
 ```
 
 ### Conseils sur les niveaux de log
@@ -499,7 +505,7 @@ Conventions :
 
 - **Depuis l'UI** : page Admin → Logs (lit le ring buffer)
 - **Via API** : `GET /api/v1/logs?module=X&level=Y&limit=N` (ring buffer uniquement, perdu au redémarrage)
-- **Depuis le fichier** : `docker exec` dans `/app/data/logs/sowel-*.log` (persistant)
+- **Depuis le fichier** : `docker exec` dans `/app/data/logs/sowel.*.log` (persistant)
 - **Script helper** : `scripts/logs/fetch-logs.py <module> <level> <limit>` avec les variables d'env `SOWEL_URL` + `SOWEL_PASSWORD`
 
 ---

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -477,16 +477,22 @@ Pino structured JSON logging with multistream output (see `src/core/logger.ts`):
 
 - **Ring buffer** — in-memory circular buffer for UI log viewer (always captures debug level)
 - **stdout** — raw JSON in production (captured by Docker logs), pino-pretty in development
-- **File transport** — in production only, via `pino-roll` to `data/logs/sowel-N.log`, daily rotation, keep 14 files
+- **File transport** — in production only, via `pino-roll` to `data/logs/sowel.<yyyy-MM-dd>.N.log`, daily rotation, keep 14 files (retention also applies to files left by previous containers)
 
 ### Log file location
 
-`/app/data/logs/sowel-<N>.log` inside the container (on the `sowel-data` volume). **Survives container recreation** — essential for post-incident investigation after a self-update.
+`/app/data/logs/sowel.<yyyy-MM-dd>.N.log` inside the container (on the `sowel-data` volume). One calendar day maps to one predictable file, even across container restarts and self-updates. **Survives container recreation** — essential for post-incident investigation after a self-update.
 
 Example retrieval:
 
 ```bash
-docker exec sowel sh -c 'cat /app/data/logs/sowel.6.log | grep -E "2026-04-11T07:" | grep error'
+docker exec sowel sh -c 'cat /app/data/logs/sowel.2026-04-11.1.log | grep -E "2026-04-11T07:" | grep error'
+```
+
+Before v1.39, files were named `sowel.N.log` with a rotation number picked per process: several restarts a day interleaved time ranges across files, and one file could span months. When investigating an incident older than the format switch, grep ALL `sowel.*.log` files rather than trusting one. Legacy numbered files are not covered by the new retention and can be removed manually once no longer needed:
+
+```bash
+docker exec sowel sh -c 'rm /app/data/logs/sowel.[0-9]*.log'
 ```
 
 ### Log level guidance
@@ -511,7 +517,7 @@ Conventions:
 
 - **From UI** — Admin → Logs page (reads the ring buffer)
 - **Via API** — `GET /api/v1/logs?module=X&level=Y&limit=N` (ring buffer only, lost on restart)
-- **From file** — `docker exec` into `/app/data/logs/sowel-*.log` (persistent)
+- **From file** — `docker exec` into `/app/data/logs/sowel.*.log` (persistent)
 - **Helper script** — `scripts/logs/fetch-logs.py <module> <level> <limit>` with `SOWEL_URL` + `SOWEL_PASSWORD` env vars
 
 ---

--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -115,7 +115,7 @@ curl -s http://localhost:3000/api/v1/health | jq
 docker compose restart sowel
 ```
 
-Le ring buffer est en mémoire, le redémarrage le vide. Le log fichier (`data/logs/sowel-N.log`) survit.
+Le ring buffer est en mémoire, le redémarrage le vide. Le log fichier (`data/logs/sowel.<yyyy-MM-dd>.N.log`) survit.
 
 ### Stop / start
 

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -121,7 +121,7 @@ curl -s http://localhost:3000/api/v1/health | jq
 docker compose restart sowel
 ```
 
-The ring buffer is in-memory, so restart clears it. The file log (`data/logs/sowel-N.log`) survives.
+The ring buffer is in-memory, so restart clears it. The file log (`data/logs/sowel.<yyyy-MM-dd>.N.log`) survives.
 
 ### Stop / start
 

--- a/src/core/logger.test.ts
+++ b/src/core/logger.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import pino from "pino";
+import { mkdtempSync, rmSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileTransportOptions } from "./logger.js";
+
+// #400 — one calendar day must map to one predictable log file across restarts.
+
+const DATED_FILE_RE = /^sowel\.\d{4}-\d{2}-\d{2}(\.\d+)?\.log$/;
+
+function today(): string {
+  const d = new Date();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}`;
+}
+
+/** Spin a real pino-roll transport, write one line, close it. */
+async function writeOneLine(baseFile: string, message: string): Promise<void> {
+  const transport = pino.transport({
+    target: "pino-roll",
+    options: fileTransportOptions(baseFile),
+  });
+  const logger = pino(transport);
+  logger.info(message);
+  await new Promise<void>((resolve, reject) => {
+    transport.on("close", resolve);
+    transport.on("error", reject);
+    // flushSync is unavailable through the worker; end() flushes then closes.
+    transport.end();
+  });
+}
+
+describe("fileTransportOptions", () => {
+  it("uses daily frequency with a date-stamped name and cross-process retention", () => {
+    const opts = fileTransportOptions();
+    expect(opts.file).toBe("data/logs/sowel");
+    expect(opts.frequency).toBe("daily");
+    expect(opts.dateFormat).toBe("yyyy-MM-dd");
+    expect(opts.limit).toEqual({ count: 14, removeOtherLogFiles: true });
+    expect(opts.mkdir).toBe(true);
+  });
+});
+
+describe("pino-roll file naming (integration)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sowel-logger-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("names the active file with the current date", async () => {
+    await writeOneLine(join(dir, "sowel"), "hello");
+
+    const files = readdirSync(dir);
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(DATED_FILE_RE);
+    expect(files[0]).toContain(today());
+  });
+
+  it("a restarted process reuses the same day file instead of opening a new number", async () => {
+    await writeOneLine(join(dir, "sowel"), "first-process");
+    await writeOneLine(join(dir, "sowel"), "second-process");
+
+    const files = readdirSync(dir).filter((f) => DATED_FILE_RE.test(f));
+    expect(files.length).toBe(1);
+
+    const content = readFileSync(join(dir, files[0]), "utf-8");
+    expect(content).toContain("first-process");
+    expect(content).toContain("second-process");
+  });
+
+  it("cleanup ignores legacy numbered files and unrelated files", async () => {
+    // Legacy pre-#400 file and an unrelated log share the folder.
+    writeFileSync(join(dir, "sowel.3.log"), "legacy\n");
+    writeFileSync(join(dir, "backfill-rain.log"), "unrelated\n");
+
+    await writeOneLine(join(dir, "sowel"), "current");
+
+    const files = readdirSync(dir);
+    expect(files).toContain("sowel.3.log");
+    expect(files).toContain("backfill-rain.log");
+    expect(files.some((f) => DATED_FILE_RE.test(f))).toBe(true);
+  });
+});

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -28,6 +28,36 @@ export interface LoggerHandle {
 }
 
 /**
+ * pino-roll options for the production file transport (#400).
+ *
+ * Date-stamped names (`sowel.2026-08-11.1.log`) make one calendar day map to
+ * one predictable file across container restarts; bare rotation numbers used
+ * to interleave days between files, which produced apparent gaps during
+ * post-incident greps. `removeOtherLogFiles` makes the retention count apply
+ * to files left by previous containers too — pino-roll otherwise only counts
+ * files created by the current process, so old files were never cleaned.
+ * Cleanup only touches files matching the base name + date + number pattern;
+ * legacy `sowel.N.log` files and unrelated files in the folder are ignored.
+ *
+ * Exported for tests.
+ */
+export function fileTransportOptions(file = "data/logs/sowel"): {
+  file: string;
+  frequency: string;
+  dateFormat: string;
+  limit: { count: number; removeOtherLogFiles: boolean };
+  mkdir: boolean;
+} {
+  return {
+    file,
+    frequency: "daily",
+    dateFormat: "yyyy-MM-dd",
+    limit: { count: 14, removeOtherLogFiles: true },
+    mkdir: true,
+  };
+}
+
+/**
  * Creates the pino logger with multistream output:
  * - stdout (pino-pretty in dev, raw JSON in prod)
  * - ring buffer (in-memory, always at debug level)
@@ -82,12 +112,7 @@ export function createLogger(level: string, logBuffer?: LogRingBuffer): LoggerHa
     // 3. File transport via pino-roll (production only)
     const fileTransport = pino.transport({
       target: "pino-roll",
-      options: {
-        file: "data/logs/sowel",
-        frequency: "daily",
-        limit: { count: 14 },
-        mkdir: true,
-      },
+      options: fileTransportOptions(),
     });
     streams.push({
       stream: fileTransport,


### PR DESCRIPTION
## Summary

Two defects in the production file logging, both observed during the 2026-08-10 incident investigation (#400):

- **Interleaved days**: pino-roll picks its rotation number per process, so every container recreation could switch to a different `sowel.N.log`. With several deploys in one day, consecutive time ranges of the same day landed in different files (one file spanned April to August), and grepping a single file produced false "no logs at time T" conclusions.
- **Retention leak**: `limit.count` only applies to files created by the current process, so files left by previous containers were never cleaned. Production still holds June files in August, well past the 14-day policy.

## Changes

- `dateFormat: yyyy-MM-dd` — files are now `sowel.2026-08-11.1.log`; pino-roll reuses the existing file for the current day on restart, so one calendar day maps to one predictable file.
- `limit.removeOtherLogFiles: true` — retention now covers files from previous containers. The cleanup pattern-matches base name + date + number, so legacy `sowel.N.log` files and unrelated files (e.g. `backfill-rain.log`) are ignored (asserted by test).
- Docs updated (architecture EN/FR, deployment EN/FR, CLAUDE.md) including a migration note: legacy numbered files stay until removed manually.

`fetch-logs.py` needs no change (API-only, no filename assumptions).

## Tests

- Options shape (frequency, dateFormat, retention)
- Real pino-roll integration in a temp dir: active file is date-stamped; a second process the same day reuses the file (both lines present, single file); cleanup leaves legacy and unrelated files alone

Closes #400