### PR TITLE
feat(core): restored-data guardrail — inert start until takeover is confirmed

### DIFF
--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -223,6 +223,10 @@ Après restauration, Sowel renvoie `{ restartRequired: true }`. Vous devez redé
 docker compose restart sowel
 ```
 
+### Restaurer un backup d'un autre déploiement (issue #401)
+
+L'identifiant d'instance stocké dans la table settings voyage dans les backups. Quand une base restaurée porte l'identifiant d'un autre déploiement (backup de prod ouvert sur une machine de dev, migration vers un nouveau matériel), le moteur démarre **inerte** : intégrations sortantes, recettes, publishers et notifications restent désactivés, et un bandeau rouge s'affiche dans l'UI. Un admin confirme la reprise depuis ce bandeau (le moteur redémarre alors armé), ou vous pouvez pré-confirmer avec `SOWEL_TAKEOVER=1` dans l'environnement. Cela empêche une copie des données de production de se connecter vers l'extérieur et de perturber le déploiement d'origine (collisions de clientId MQTT, courses sur les refresh tokens OAuth).
+
 ### Contenu de l'archive
 
 Voir la section "Backup et restauration" dans [architecture.md](architecture.md) pour le format complet.

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -229,6 +229,10 @@ After restore, Sowel reports `{ restartRequired: true }`. You must restart the c
 docker compose restart sowel
 ```
 
+### Restoring a backup from another deployment (issue #401)
+
+The instance id stored in the settings table travels inside backups. When a restored database carries another deployment's id (a prod backup opened on a dev machine, a migration to new hardware), the engine starts **inert**: outbound integrations, recipes, publishers, and notifications stay disabled, and a red banner appears in the UI. An admin confirms the takeover from that banner (the engine then restarts armed), or you can pre-confirm with `SOWEL_TAKEOVER=1` in the environment. This prevents a copy of production data from dialing out and fighting the original deployment (MQTT client id collisions, OAuth refresh-token races).
+
 ### Archive contents
 
 See the "Backup & Restore" section in [architecture.md](architecture.md) for the full format.

--- a/src/api/routes/system.test.ts
+++ b/src/api/routes/system.test.ts
@@ -8,8 +8,12 @@ const logger = createLogger("silent").logger;
 
 interface BuildOpts {
   authed?: boolean;
+  role?: "admin" | "user" | "viewer";
   sunlight?: SunlightData;
   shadowMode?: boolean;
+  takeoverPending?: boolean;
+  confirmTakeover?: () => void;
+  requestRestart?: () => void;
 }
 
 async function buildApp(opts: BuildOpts = {}) {
@@ -27,7 +31,7 @@ async function buildApp(opts: BuildOpts = {}) {
 
   if (opts.authed) {
     app.addHook("preHandler", async (request) => {
-      request.auth = { userId: "u1", role: "admin" };
+      request.auth = { userId: "u1", role: opts.role ?? "admin" };
     });
   }
 
@@ -37,6 +41,9 @@ async function buildApp(opts: BuildOpts = {}) {
     tzInfo,
     sunlightManager,
     shadowMode: opts.shadowMode ?? false,
+    takeoverPending: opts.takeoverPending ?? false,
+    confirmTakeover: opts.confirmTakeover ?? (() => {}),
+    requestRestart: opts.requestRestart ?? (() => {}),
     logger,
   });
   await app.ready();
@@ -107,13 +114,56 @@ describe("GET /api/v1/system/mode", () => {
     openApp = await buildApp({ authed: true, shadowMode: false });
     const res = await openApp.inject({ method: "GET", url: "/api/v1/system/mode" });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ shadowMode: false });
+    expect(res.json()).toEqual({ shadowMode: false, takeoverPending: false });
   });
 
   it("returns shadowMode=true when the env var is set", async () => {
     openApp = await buildApp({ authed: true, shadowMode: true });
     const res = await openApp.inject({ method: "GET", url: "/api/v1/system/mode" });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ shadowMode: true });
+    expect(res.json()).toEqual({ shadowMode: true, takeoverPending: false });
+  });
+
+  it("surfaces takeoverPending (issue #401)", async () => {
+    openApp = await buildApp({ authed: true, shadowMode: true, takeoverPending: true });
+    const res = await openApp.inject({ method: "GET", url: "/api/v1/system/mode" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ shadowMode: true, takeoverPending: true });
+  });
+});
+
+// Issue #401 — adopt a restored database and restart.
+describe("POST /api/v1/system/takeover", () => {
+  let openApp: ReturnType<typeof Fastify> | null = null;
+
+  afterEach(async () => {
+    if (openApp) await openApp.close();
+    openApp = null;
+  });
+
+  it("rejects non-admin callers with 403", async () => {
+    openApp = await buildApp({ authed: true, role: "user", takeoverPending: true });
+    const res = await openApp.inject({ method: "POST", url: "/api/v1/system/takeover" });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 409 when no takeover is pending", async () => {
+    openApp = await buildApp({ authed: true, takeoverPending: false });
+    const res = await openApp.inject({ method: "POST", url: "/api/v1/system/takeover" });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("confirms the takeover and requests a restart", async () => {
+    const calls: string[] = [];
+    openApp = await buildApp({
+      authed: true,
+      takeoverPending: true,
+      confirmTakeover: () => calls.push("confirm"),
+      requestRestart: () => calls.push("restart"),
+    });
+    const res = await openApp.inject({ method: "POST", url: "/api/v1/system/takeover" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true, restarting: true });
+    expect(calls).toEqual(["confirm", "restart"]);
   });
 });

--- a/src/api/routes/system.ts
+++ b/src/api/routes/system.ts
@@ -17,6 +17,10 @@ interface SystemDeps {
   sunlightManager: SunlightManager;
   /** Spec 124 — surfaced via GET /api/v1/system/mode so the UI can render its banner. */
   shadowMode: boolean;
+  /** Issue #401 — true when the database was restored from another deployment. */
+  takeoverPending: boolean;
+  confirmTakeover: () => void;
+  requestRestart: () => void;
   logger: Logger;
 }
 
@@ -30,6 +34,9 @@ export function registerSystemRoutes(app: FastifyInstance, deps: SystemDeps): vo
     tzInfo,
     sunlightManager,
     shadowMode,
+    takeoverPending,
+    confirmTakeover,
+    requestRestart,
     logger: parentLogger,
   } = deps;
   const logger = parentLogger.child({ module: "system-routes" });
@@ -120,12 +127,29 @@ export function registerSystemRoutes(app: FastifyInstance, deps: SystemDeps): vo
 
   // GET /api/v1/system/mode — surfaces the shadow-mode flag so the UI
   // can render its sticky banner. Accessible to ANY authenticated user
-  // (read-only, no PII). Spec 124.
+  // (read-only, no PII). Spec 124. Issue #401 adds takeoverPending for
+  // the restored-data guardrail banner.
   app.get("/api/v1/system/mode", async (request, reply) => {
     if (!request.auth) {
       return reply.code(401).send({ error: "Authentication required" });
     }
-    return { shadowMode };
+    return { shadowMode, takeoverPending };
+  });
+
+  // POST /api/v1/system/takeover — adopt a database restored from another
+  // deployment (issue #401). Writes the local instance marker, then restarts
+  // the engine so every gated subsystem comes back armed. Admin only.
+  app.post("/api/v1/system/takeover", async (request, reply) => {
+    if (!request.auth || request.auth.role !== "admin") {
+      return reply.code(403).send({ error: "Admin access required" });
+    }
+    if (!takeoverPending) {
+      return reply.code(409).send({ error: "No takeover is pending" });
+    }
+    logger.warn({ userId: request.auth.userId }, "Takeover confirmed via API");
+    confirmTakeover();
+    requestRestart();
+    return { ok: true, restarting: true };
   });
 
   // GET /api/v1/system/sunlight — current server time + daylight state

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -113,6 +113,10 @@ interface ServerDeps {
   corsOrigins: string[];
   /** Spec 124 — exposed by GET /api/v1/system/mode for the UI banner. */
   shadowMode: boolean;
+  /** Issue #401 — restored-data guardrail state + takeover confirm hooks. */
+  takeoverPending: boolean;
+  confirmTakeover: () => void;
+  requestRestart: () => void;
 }
 
 export async function createServer(deps: ServerDeps) {
@@ -155,6 +159,9 @@ export async function createServer(deps: ServerDeps) {
     logger,
     corsOrigins,
     shadowMode,
+    takeoverPending,
+    confirmTakeover,
+    requestRestart,
   } = deps;
 
   const app = Fastify({
@@ -332,6 +339,9 @@ export async function createServer(deps: ServerDeps) {
     tzInfo,
     sunlightManager,
     shadowMode,
+    takeoverPending,
+    confirmTakeover,
+    requestRestart,
     logger,
   });
   registerLogRoutes(app, { logBuffer, logger });

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,5 +117,7 @@ export function loadConfig(): AppConfig {
       bucket: env("INFLUX_BUCKET", "sowel"),
     },
     shadowMode: envBool("SOWEL_SHADOW_MODE"),
+    dataDir,
+    takeoverConfirmed: envBool("SOWEL_TAKEOVER"),
   };
 }

--- a/src/core/instance-identity.test.ts
+++ b/src/core/instance-identity.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "./logger.js";
+import {
+  resolveInstanceIdentity,
+  confirmTakeover,
+  INSTANCE_ID_SETTING,
+  INSTANCE_MARKER_FILE,
+} from "./instance-identity.js";
+import type { SettingsManager } from "./settings-manager.js";
+
+const logger = createLogger("silent").logger;
+
+// Issue #401 — restored-data guardrail.
+
+function makeSettings(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    get: (key: string) => store.get(key),
+    set: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    _store: store,
+  } as unknown as SettingsManager & { _store: Map<string, string> };
+}
+
+describe("resolveInstanceIdentity", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "sowel-identity-"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  function marker(): string | null {
+    const p = join(dataDir, INSTANCE_MARKER_FILE);
+    return existsSync(p) ? readFileSync(p, "utf-8").trim() : null;
+  }
+
+  it("first boot mints an identity and writes both the setting and the marker", () => {
+    const settings = makeSettings();
+    const identity = resolveInstanceIdentity({
+      settingsManager: settings,
+      dataDir,
+      takeoverConfirmed: false,
+      logger,
+    });
+
+    expect(identity.takeoverPending).toBe(false);
+    expect(identity.instanceId).toBeTruthy();
+    expect(settings._store.get(INSTANCE_ID_SETTING)).toBe(identity.instanceId);
+    expect(marker()).toBe(identity.instanceId);
+  });
+
+  it("matching marker and setting boots normally", () => {
+    const settings = makeSettings({ [INSTANCE_ID_SETTING]: "id-A" });
+    writeFileSync(join(dataDir, INSTANCE_MARKER_FILE), "id-A\n");
+
+    const identity = resolveInstanceIdentity({
+      settingsManager: settings,
+      dataDir,
+      takeoverConfirmed: false,
+      logger,
+    });
+
+    expect(identity).toEqual({ instanceId: "id-A", takeoverPending: false });
+  });
+
+  it("restored database (marker from another deployment) triggers takeover pending", () => {
+    const settings = makeSettings({ [INSTANCE_ID_SETTING]: "prod-id" });
+    writeFileSync(join(dataDir, INSTANCE_MARKER_FILE), "dev-id\n");
+
+    const identity = resolveInstanceIdentity({
+      settingsManager: settings,
+      dataDir,
+      takeoverConfirmed: false,
+      logger,
+    });
+
+    expect(identity.takeoverPending).toBe(true);
+    // The marker must NOT be adopted silently.
+    expect(marker()).toBe("dev-id");
+  });
+
+  it("database with an id but no local marker triggers takeover pending", () => {
+    const settings = makeSettings({ [INSTANCE_ID_SETTING]: "prod-id" });
+
+    const identity = resolveInstanceIdentity({
+      settingsManager: settings,
+      dataDir,
+      takeoverConfirmed: false,
+      logger,
+    });
+
+    expect(identity.takeoverPending).toBe(true);
+    expect(marker()).toBe(null);
+  });
+
+  it("SOWEL_TAKEOVER pre-confirms the adoption and writes the marker", () => {
+    const settings = makeSettings({ [INSTANCE_ID_SETTING]: "prod-id" });
+    writeFileSync(join(dataDir, INSTANCE_MARKER_FILE), "dev-id\n");
+
+    const identity = resolveInstanceIdentity({
+      settingsManager: settings,
+      dataDir,
+      takeoverConfirmed: true,
+      logger,
+    });
+
+    expect(identity).toEqual({ instanceId: "prod-id", takeoverPending: false });
+    expect(marker()).toBe("prod-id");
+  });
+
+  it("confirmTakeover adopts the database id into the marker", () => {
+    const settings = makeSettings({ [INSTANCE_ID_SETTING]: "prod-id" });
+    writeFileSync(join(dataDir, INSTANCE_MARKER_FILE), "dev-id\n");
+
+    confirmTakeover({ settingsManager: settings, dataDir, logger });
+
+    expect(marker()).toBe("prod-id");
+    // Next boot is normal.
+    const identity = resolveInstanceIdentity({
+      settingsManager: settings,
+      dataDir,
+      takeoverConfirmed: false,
+      logger,
+    });
+    expect(identity.takeoverPending).toBe(false);
+  });
+});

--- a/src/core/instance-identity.ts
+++ b/src/core/instance-identity.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Logger } from "./logger.js";
+import type { SettingsManager } from "./settings-manager.js";
+
+// ============================================================
+// Issue #401 — restored-data guardrail
+//
+// A database restored from another deployment (a prod backup opened by a dev
+// instance, a migration to new hardware) carries that deployment's brokers,
+// OAuth grants, and notification channels. A fully armed instance on such
+// data fights the origin deployment (MQTT clientId takeover loops, OAuth
+// refresh-token rotation races — both observed on 2026-08-10).
+//
+// The instance id lives in the settings table and therefore travels inside
+// backups; the marker file lives next to the database and describes THIS
+// deployment. When they disagree, the data came from somewhere else: the
+// engine starts inert (spec 124 gates) until an admin confirms the takeover
+// in the UI, or SOWEL_TAKEOVER=1 pre-confirms it.
+// ============================================================
+
+export const INSTANCE_ID_SETTING = "system.instance_id";
+export const INSTANCE_MARKER_FILE = ".instance-id";
+
+export interface InstanceIdentity {
+  instanceId: string;
+  /** True when the database belongs to another deployment and no takeover was confirmed. */
+  takeoverPending: boolean;
+}
+
+function markerPath(dataDir: string): string {
+  return resolve(dataDir, INSTANCE_MARKER_FILE);
+}
+
+function readMarker(dataDir: string): string | null {
+  try {
+    if (!existsSync(markerPath(dataDir))) return null;
+    const raw = readFileSync(markerPath(dataDir), "utf-8").trim();
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the local deployment marker. Called on adoption and on takeover confirm. */
+export function writeInstanceMarker(dataDir: string, instanceId: string): void {
+  writeFileSync(markerPath(dataDir), instanceId + "\n");
+}
+
+export function resolveInstanceIdentity(opts: {
+  settingsManager: SettingsManager;
+  dataDir: string;
+  /** SOWEL_TAKEOVER env flag — pre-confirms a takeover without the UI. */
+  takeoverConfirmed: boolean;
+  logger: Logger;
+}): InstanceIdentity {
+  const { settingsManager, dataDir, takeoverConfirmed } = opts;
+  const logger = opts.logger.child({ module: "instance-identity" });
+
+  const dbId = settingsManager.get(INSTANCE_ID_SETTING);
+  const markerId = readMarker(dataDir);
+
+  // First boot ever (including the first boot after upgrading to this
+  // feature): mint an identity and adopt the data as ours. Pre-feature
+  // backups restored before their origin ever minted an id are
+  // indistinguishable from a first boot — documented limitation.
+  if (!dbId) {
+    const instanceId = randomUUID();
+    settingsManager.set(INSTANCE_ID_SETTING, instanceId);
+    writeInstanceMarker(dataDir, instanceId);
+    logger.info({ instanceId }, "Instance identity minted");
+    return { instanceId, takeoverPending: false };
+  }
+
+  if (markerId === dbId) {
+    return { instanceId: dbId, takeoverPending: false };
+  }
+
+  // The database carries another deployment's identity (restored backup),
+  // or the marker was lost. Either way this data is not provably ours.
+  if (takeoverConfirmed) {
+    writeInstanceMarker(dataDir, dbId);
+    logger.warn(
+      { instanceId: dbId, previousMarker: markerId },
+      "Takeover confirmed via SOWEL_TAKEOVER — adopting restored data",
+    );
+    return { instanceId: dbId, takeoverPending: false };
+  }
+
+  logger.warn(
+    { instanceId: dbId, localMarker: markerId },
+    "TAKEOVER PENDING — this database was restored from another deployment. Outbound services stay inert until an admin confirms the takeover (UI banner or SOWEL_TAKEOVER=1).",
+  );
+  return { instanceId: dbId, takeoverPending: true };
+}
+
+/** Adopt the current database as this deployment's own (UI confirm path). */
+export function confirmTakeover(opts: {
+  settingsManager: SettingsManager;
+  dataDir: string;
+  logger: Logger;
+}): void {
+  const { settingsManager, dataDir } = opts;
+  const logger = opts.logger.child({ module: "instance-identity" });
+  const dbId = settingsManager.get(INSTANCE_ID_SETTING) ?? randomUUID();
+  settingsManager.set(INSTANCE_ID_SETTING, dbId);
+  writeInstanceMarker(dataDir, dbId);
+  logger.warn({ instanceId: dbId }, "Takeover confirmed by admin — data adopted, restart required");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { BackupManager } from "./backup/backup-manager.js";
 import { UserManager } from "./auth/user-manager.js";
 import { AuthService } from "./auth/auth-service.js";
 import { SettingsManager } from "./core/settings-manager.js";
+import { resolveInstanceIdentity, confirmTakeover } from "./core/instance-identity.js";
 import { ModeManager } from "./modes/mode-manager.js";
 import { CalendarManager } from "./modes/calendar-manager.js";
 import { ButtonActionManager } from "./buttons/button-action-manager.js";
@@ -172,6 +173,26 @@ async function main() {
 
   // 4. Create Settings Manager
   const settingsManager = new SettingsManager(db);
+
+  // 4b. Issue #401 — restored-data guardrail. A database restored from
+  // another deployment (prod backup on a dev machine, hardware migration)
+  // must not dial out with the origin's brokers and OAuth grants. When the
+  // stored instance id disagrees with the local marker, force the spec 124
+  // shadow gates for this boot; the admin confirms the takeover in the UI
+  // (or via SOWEL_TAKEOVER=1) and restarts to arm the instance.
+  const identity = resolveInstanceIdentity({
+    settingsManager,
+    dataDir: config.dataDir,
+    takeoverConfirmed: config.takeoverConfirmed,
+    logger,
+  });
+  if (identity.takeoverPending && !config.shadowMode) {
+    config.shadowMode = true;
+    logger.warn(
+      { module: "instance-identity", hostname: hostname() },
+      "TAKEOVER PENDING — starting with shadow gates active: outbound integrations, recipes, publishers, notifications, and version checks are disabled until the takeover is confirmed.",
+    );
+  }
 
   // 5. Create Event Bus
   const eventBus = new EventBus(logger);
@@ -420,6 +441,17 @@ async function main() {
     logger,
     corsOrigins: config.cors.origins,
     shadowMode: config.shadowMode,
+    takeoverPending: identity.takeoverPending,
+    confirmTakeover: () => {
+      confirmTakeover({ settingsManager, dataDir: config.dataDir, logger });
+    },
+    requestRestart: () => {
+      logger.warn(
+        { module: "instance-identity" },
+        "Restarting to complete the takeover (docker restart policy will bring the engine back armed)",
+      );
+      setTimeout(() => process.exit(0), 500);
+    },
   });
 
   await server.listen({ port: config.api.port, host: config.api.host });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1231,6 +1231,14 @@ export interface AppConfig {
    * `SOWEL_SHADOW_MODE=1`.
    */
   shadowMode: boolean;
+  /** Directory holding the SQLite file, marker files, and logs. */
+  dataDir: string;
+  /**
+   * Issue #401 — pre-confirms adoption of a database restored from another
+   * deployment, skipping the inert takeover-pending boot. Set via
+   * `SOWEL_TAKEOVER=1`.
+   */
+  takeoverConfirmed: boolean;
 }
 
 // ============================================================

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -161,8 +161,18 @@ export async function getSystemTimezone(): Promise<SystemTimezoneInfo> {
 }
 
 // Spec 124 — surfaces the shadowMode flag for the ShadowBanner.
-export async function getSystemMode(): Promise<{ shadowMode: boolean }> {
+// Issue #401 — takeoverPending drives the TakeoverBanner.
+export async function getSystemMode(): Promise<{
+  shadowMode: boolean;
+  takeoverPending?: boolean;
+}> {
   return fetchJSON(`${API_BASE}/system/mode`);
+}
+
+// Issue #401 — adopt a database restored from another deployment. The
+// backend writes the local marker and restarts itself.
+export async function confirmTakeover(): Promise<{ ok: boolean; restarting: boolean }> {
+  return fetchJSON(`${API_BASE}/system/takeover`, { method: "POST" });
 }
 
 export async function triggerSystemRestart(): Promise<{ success: boolean; message: string }> {

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -9,6 +9,7 @@ import { useWebSocket } from "../../store/useWebSocket";
 import { useTimezone } from "../../store/useTimezone";
 import { useShadowMode } from "../../store/useShadowMode";
 import { ShadowBanner } from "./ShadowBanner";
+import { TakeoverBanner } from "./TakeoverBanner";
 import { useDevices } from "../../store/useDevices";
 import { useZones } from "../../store/useZones";
 import type { ZoneWithChildren } from "../../types";
@@ -115,6 +116,8 @@ export function AppLayout() {
     <div className="flex flex-col h-screen overflow-hidden">
       {/* Spec 124 — full-width shadow-mode stripe above sidebar + content. */}
       <ShadowBanner />
+      {/* Issue #401 — restored-data takeover stripe (red, admin confirm). */}
+      <TakeoverBanner />
       <div className="flex flex-1 min-h-0 overflow-hidden">
       {/* Sidebar — desktop only (lg: 1024px+, unreachable on phones) */}
       <div className="hidden lg:flex">

--- a/ui/src/components/layout/TakeoverBanner.tsx
+++ b/ui/src/components/layout/TakeoverBanner.tsx
@@ -1,0 +1,52 @@
+// Issue #401 — Sticky banner shown when the server reports
+// `takeoverPending === true`: the database was restored from another
+// deployment and every outbound subsystem is inert. Admins get a
+// confirm button that adopts the data and restarts the engine;
+// other roles see the explanation only. Non-dismissable on purpose.
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useShadowMode } from "../../store/useShadowMode";
+import { useAuth } from "../../store/useAuth";
+import { confirmTakeover } from "../../api";
+
+export function TakeoverBanner() {
+  const { t } = useTranslation();
+  const takeoverPending = useShadowMode((s) => s.takeoverPending);
+  const role = useAuth((s) => s.user?.role);
+  const [state, setState] = useState<"idle" | "confirming" | "restarting" | "error">("idle");
+
+  if (!takeoverPending) return null;
+
+  const onConfirm = async () => {
+    setState("confirming");
+    try {
+      await confirmTakeover();
+      setState("restarting");
+      // The engine exits right after answering; give it time to come
+      // back before reloading the app against the armed instance.
+      setTimeout(() => window.location.reload(), 8000);
+    } catch {
+      setState("error");
+    }
+  };
+
+  return (
+    <div
+      role="alert"
+      className="bg-red-600 text-white text-[12px] sm:text-[13px] font-medium px-4 py-1.5 text-center sticky top-0 z-50 shadow-sm flex items-center justify-center gap-3 flex-wrap"
+    >
+      <span>{state === "restarting" ? t("takeover.restarting") : t("takeover.banner")}</span>
+      {role === "admin" && state !== "restarting" && (
+        <button
+          onClick={onConfirm}
+          disabled={state === "confirming"}
+          className="bg-white text-red-700 rounded-md px-2.5 py-0.5 text-[12px] font-semibold hover:bg-red-50 disabled:opacity-60"
+        >
+          {state === "confirming" ? t("takeover.confirming") : t("takeover.confirm")}
+        </button>
+      )}
+      {state === "error" && <span>{t("takeover.error")}</span>}
+    </div>
+  );
+}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1,6 +1,5 @@
 {
   "app.name": "Sowel",
-
   "nav.home": "Home",
   "nav.devices": "Devices",
   "nav.equipments": "Equipments",
@@ -12,7 +11,6 @@
   "nav.settings": "Settings",
   "nav.mqttPublishers": "MQTT Publishers",
   "nav.maison": "Home",
-
   "auth.login": "Log in",
   "auth.logout": "Log out",
   "auth.username": "Username",
@@ -26,7 +24,6 @@
   "auth.passwordMismatch": "Passwords do not match",
   "auth.passwordTooShort": "Password must be at least 6 characters",
   "auth.admin": "admin",
-
   "common.save": "Save",
   "common.cancel": "Cancel",
   "common.delete": "Delete",
@@ -66,7 +63,6 @@
   "common.select": "Select...",
   "common.disabled": "Disabled",
   "common.all": "All",
-
   "status.online": "Online",
   "status.offline": "Offline",
   "status.unknown": "Unknown",
@@ -77,7 +73,6 @@
   "status.integrationWarning": "Disconnected: {{names}}",
   "status.error": "Error",
   "status.not_configured": "Not configured",
-
   "alarms.title": "Active alarms",
   "alarms.empty": "No active alarms.",
   "alarms.pill.title_one": "{{count}} active issue",
@@ -98,7 +93,11 @@
   "updates.error.generic": "Update failed",
   "restart.pill.title": "Restart required",
   "shadow.banner": "SHADOW MODE — outbound integrations and publishers are disabled. This instance does not affect production.",
-
+  "takeover.banner": "RESTORED DATA: this database comes from another deployment. Outbound integrations, recipes, publishers, and notifications are disabled until an admin confirms the takeover.",
+  "takeover.confirm": "Confirm takeover",
+  "takeover.confirming": "Confirming...",
+  "takeover.restarting": "Takeover confirmed. Restarting the engine, this page will reload shortly...",
+  "takeover.error": "Confirmation failed, check the logs.",
   "devices.title": "Devices",
   "devices.subtitle_one": "{{count}} device · {{online}} online",
   "devices.subtitle_other": "{{count}} devices · {{online}} online",
@@ -136,7 +135,6 @@
   "devices.col.range": "Range / Values",
   "devices.col.topic": "Topic",
   "devices.deleteConfirm": "Delete this device from Sowel? It will be re-discovered automatically if still active on the bridge.",
-
   "zones.title": "Home Topology",
   "zones.subtitle": "Define the topology of your home",
   "zones.count_one": "{{count}} zone",
@@ -183,7 +181,6 @@
   "zone.lead.allShuttersClosed": "all shutters closed",
   "zone.lead.shutterClosed": "shutter closed",
   "modes.activeBadge": "Active",
-
   "equipments.title": "Equipments",
   "equipments.filterPlaceholder": "Filter...",
   "equipments.addEquipment": "Add equipment",
@@ -222,7 +219,6 @@
   "equipments.form.selectZone": "Select a zone...",
   "equipments.form.deviceInstruction": "Select the device(s) to bind to this equipment. Only compatible devices are shown.",
   "equipments.form.nextDevices": "Next: Select devices",
-
   "equipments.type.light_onoff": "Light (On/Off)",
   "equipments.type.light_dimmable": "Light (Dimmable)",
   "equipments.type.light_color": "Light (Color)",
@@ -249,7 +245,6 @@
   "equipments.type.pool_heat_pump": "Pool heat pump",
   "equipments.type.display": "Sowel display",
   "equipments.type.camera": "Camera",
-
   "cameras.panel.title": "Camera",
   "cameras.panel.noData": "No bindings on this camera yet.",
   "cameras.snapshot.refresh": "Refresh",
@@ -266,7 +261,6 @@
   "cameras.lightMode.off": "Off",
   "cameras.siren.trigger": "Trigger siren",
   "cameras.lastDetection": "Last detection",
-
   "displays.panel.title": "Display state",
   "displays.panel.noData": "No telemetry from this display yet.",
   "displays.fields.firmware_version": "Firmware version",
@@ -279,7 +273,6 @@
   "displays.widget.onlineCount": "{{online}}/{{total}} online",
   "displays.card.off": "Off",
   "displays.card.brightness": "{{pct}} %",
-
   "water.open": "Open",
   "water.closed": "Closed",
   "water.closeAll": "Close all",
@@ -293,7 +286,6 @@
   "water.status.water_shortage": "Water shortage",
   "water.status.leak": "Leak detected",
   "water.status.fault": "Fault",
-
   "equipments.group.lights": "Lights",
   "equipments.group.shutters": "Shutters",
   "equipments.group.awnings": "Awnings",
@@ -309,10 +301,8 @@
   "equipments.group.displays": "Displays",
   "equipments.group.cameras": "Cameras",
   "equipments.group.other": "Other",
-
   "equipments.noEquipments": "No equipments",
   "equipments.noEquipmentsMessage": "{{name}} has no equipments yet. Add equipments in Settings > Equipments.",
-
   "binding.addData": "Add data binding",
   "binding.addOrder": "Add order binding",
   "binding.selectDevice": "Select a device to bind {{type}} from.",
@@ -325,7 +315,6 @@
   "binding.loadError": "Failed to load device details",
   "binding.addError": "Failed to add binding",
   "binding.addBinding": "Add binding",
-
   "controls.turnOn": "Turn on",
   "controls.turnOff": "Turn off",
   "controls.brightness": "Brightness",
@@ -346,20 +335,17 @@
   "controls.gate.unknown": "Moving",
   "controls.gate.toggle": "Toggle",
   "controls.gate.command": "Command",
-
   "controls.heater.comfort": "Comfort",
   "controls.heater.eco": "Eco",
   "controls.heater.switchComfort": "Switch to comfort",
   "controls.heater.switchEco": "Switch to eco",
   "controls.heater.relayOn": "Relay on",
   "controls.heater.relayOff": "Relay off",
-
   "sensors.title": "Sensors",
   "sensors.noData": "No sensor data.",
   "sensors.sources_one": "{{count}} source",
   "sensors.sources_other": "{{count}} sources",
   "sensors.battery": "Battery",
-
   "category.motion": "Motion",
   "category.temperature": "Temperature",
   "category.temperature_device": "Inverter temperature",
@@ -381,7 +367,6 @@
   "category.noise": "Noise",
   "category.action": "Action",
   "category.battery": "Battery",
-
   "category.value.motion.detected": "Detected",
   "category.value.motion.clear": "Clear",
   "category.value.contact.open": "Open",
@@ -390,7 +375,6 @@
   "category.value.water_leak.ok": "OK",
   "category.value.smoke.alert": "Alert!",
   "category.value.smoke.ok": "OK",
-
   "weather.outdoor": "Outdoor",
   "weather.indoor": "Indoor",
   "weather.outdoorShort": "Out.",
@@ -404,7 +388,6 @@
   "weather.rainCurrent": "Current rain",
   "weather.rain1h": "Rain 1h",
   "weather.rain24h": "Rain 24h",
-
   "aggregation.motion": "Motion",
   "aggregation.calm": "Calm",
   "aggregation.status": "Status",
@@ -414,14 +397,11 @@
   "aggregation.open_other": "{{count}} open",
   "aggregation.daylight": "Day",
   "aggregation.night": "Night",
-
   "time.min": "min",
   "time.hour": "h",
   "time.day": "d",
   "time.second": "s",
-
   "behaviors.title": "Behaviors",
-
   "modes.title": "Modes",
   "modes.subtitle": "Define operating modes for your home",
   "modes.active": "Active",
@@ -476,7 +456,6 @@
   "modes.triggerActivate": "Activates this mode",
   "modes.triggerToggle": "Toggles this mode",
   "modes.triggerToggleWith": "Toggles with \"{{name}}\"",
-
   "recipes.title": "Recipes",
   "recipes.addRecipe": "Add a recipe",
   "recipes.chooseRecipe": "Choose a recipe",
@@ -500,7 +479,6 @@
   "recipes.actions.set_mode.comfort": "Comfort",
   "recipes.actions.set_mode.cocoon": "Cocoon",
   "recipes.actions.set_mode.night": "Night",
-
   "setup.home.title": "Welcome to Sowel",
   "setup.home.subtitle": "One more step before you start",
   "setup.home.body": "Tell Sowel where your home is. The name shows up across the app; latitude and longitude are used to compute sunrise/sunset and to derive your timezone.",
@@ -516,7 +494,6 @@
   "home.zoneNotFound": "Zone not found",
   "home.zoneDeleted": "This zone may have been deleted.",
   "home.backToHome": "Back to Home",
-
   "deviceSelector.pickChannel": "Pick the channel to bind",
   "deviceSelector.channel": "Channel {{n}}",
   "deviceSelector.loading": "Loading devices...",
@@ -526,7 +503,6 @@
   "deviceSelector.compatible_other": "{{count}} compatible devices / {{total}} available",
   "deviceSelector.showCompatible": "Show compatible only",
   "deviceSelector.showAll": "Show all devices",
-
   "settings.title": "Settings",
   "settings.profile": "Profile",
   "settings.preferences": "Preferences",
@@ -568,7 +544,6 @@
   "settings.sunsetOffset": "Sunset offset (min)",
   "settings.sunriseOffsetHelp": "Minutes after sunrise before considering it daylight",
   "settings.sunsetOffsetHelp": "Minutes before sunset to anticipate night",
-
   "backup.title": "Backup / Restore",
   "backup.description": "Export or import the full Sowel configuration (zones, devices, equipments, users, recipes, integrations).",
   "backup.export": "Export",
@@ -582,7 +557,6 @@
   "backup.restored": "Backup restored successfully. Reloading...",
   "backup.confirmRestoreTitle": "Restore this backup?",
   "backup.confirmRestoreMessage": "This will replace all current data with the contents of {{filename}}. Continue?",
-
   "update.checkNow": "Check for updates",
   "update.dockerUnavailable": "Self-update unavailable: Docker socket not mounted. To enable, copy docker-compose.override.example.yml to docker-compose.override.yml and run `docker compose up -d`.",
   "update.notComposeManaged": "Self-update only available with docker compose. Update manually with: docker compose pull && docker compose up -d",
@@ -597,17 +571,14 @@
   "update.restartRequiredMessage": "Home location changed. Sowel needs to restart to re-derive the timezone.",
   "update.restartNow": "Restart now",
   "update.later": "Later",
-
   "settings.timezone": "Timezone",
   "settings.timezoneSourceAuto": "detected from your coordinates",
   "settings.timezoneSourceEnv": "set via TZ environment variable",
   "settings.timezoneSourceFallback": "not configured, UTC by default",
-
   "nav.analyse": "Analyse",
   "nav.integrations": "Integrations",
   "nav.logs": "Logs",
   "nav.backup": "Backup",
-
   "integrations.title": "Integrations",
   "integrations.subtitle": "Configure connections with your home automation systems.",
   "integrations.z2mDescription": "Zigbee to MQTT gateway",
@@ -645,7 +616,6 @@
   "integrations.oauthFillFirst": "Fill in the credentials above before connecting.",
   "integrations.oauthSuccess": "Samsung account connected successfully.",
   "integrations.oauthError": "Authorization failed",
-
   "calendar.title": "Calendar",
   "calendar.subtitle": "Schedule automatic mode activation throughout the week",
   "calendar.profiles": "Week profiles",
@@ -674,7 +644,6 @@
   "calendar.days.fri": "Fri",
   "calendar.days.sat": "Sat",
   "calendar.modeActionHint": "Click to cycle: ignored → ON → OFF",
-
   "thermostat.outside": "Outside",
   "thermostat.target": "Target",
   "thermostat.mode": "Mode",
@@ -698,7 +667,6 @@
   "thermostat.ecoMode": "Eco",
   "thermostat.ecoModes.powerful": "Powerful",
   "thermostat.ecoModes.quiet": "Quiet",
-
   "buttonActions.title": "Actions",
   "buttonActions.addEffect": "Add effect",
   "buttonActions.noEffects": "No effects configured",
@@ -724,7 +692,6 @@
   "buttonActions.zoneOrder.allThermostatsPowerOn": "Turn thermostats on",
   "buttonActions.zoneOrder.allThermostatsPowerOff": "Turn thermostats off",
   "buttonActions.zoneOrder.allThermostatsSetpoint": "Set thermostats setpoint",
-
   "stove.state.off": "Off",
   "stove.state.checking": "Checking",
   "stove.state.ignition_phase_1": "Ignition 1",
@@ -762,7 +729,6 @@
   "stove.pellet.almost_empty": "Almost empty",
   "stove.sparkPlug.ok": "OK",
   "stove.sparkPlug.worn": "Worn",
-
   "logs.title": "Engine Logs",
   "logs.subtitle": "Real-time engine log viewer",
   "logs.live": "Live",
@@ -777,7 +743,6 @@
   "logs.entries": "{{count}} entries",
   "logs.engineLevel": "Engine level",
   "logs.levelChanged": "Log level changed to {{level}}",
-
   "history.influxdb": "InfluxDB",
   "history.influxdbDescription": "Time-series database for data historization",
   "history.url": "URL",
@@ -826,7 +791,6 @@
   "history.setupComplete": "Configured",
   "history.setupIncomplete": "Not configured",
   "history.never": "Never",
-
   "analyse.title": "Analyse",
   "analyse.addSeries": "Add",
   "analyse.zone": "Zone",
@@ -868,7 +832,6 @@
   "analyse.bool.smoke.detected": "Detected",
   "analyse.bool.generic.off": "Off",
   "analyse.bool.generic.on": "On",
-
   "mqttPublishers.title": "MQTT Publishers",
   "mqttPublishers.subtitle": "Publish equipment, zone and recipe data to MQTT topics",
   "mqttPublishers.newPublisher": "New Publisher",
@@ -908,9 +871,7 @@
   "mqttPublishers.testResult": "{{count}} message(s) published",
   "mqttPublishers.onChangeOnly": "Publish only on value change",
   "mqttPublishers.onChangeOnlyBadge": "on change",
-
   "nav.notificationPublishers": "Notifications",
-
   "notifPublishers.title": "Notification Publishers",
   "notifPublishers.subtitle": "Send a notification (Telegram or Web Push) when an equipment, zone or recipe value changes",
   "notifPublishers.newPublisher": "New Publisher",
@@ -962,7 +923,6 @@
   "notifPublishers.test": "Test",
   "notifPublishers.testChannelOk": "Test message sent!",
   "notifPublishers.testResult": "{{count}} notification(s) sent",
-
   "nav.dashboard": "Dashboard",
   "dashboard.title": "Dashboard",
   "dashboard.emptyTitle": "No widgets configured",
@@ -991,12 +951,10 @@
   "dashboard.family.awnings": "Awnings",
   "dashboard.family.heating": "Heating",
   "dashboard.family.sensors": "Sensors",
-
   "app.offline": "You are offline",
   "app.installBanner": "Install Sowel for a better experience",
   "app.install": "Install",
   "app.notNow": "Not now",
-
   "settings.mobile": "Mobile app",
   "settings.mobileDescription": "Scan the QR code from your phone to connect",
   "settings.generateQr": "Generate QR code",
@@ -1006,17 +964,14 @@
   "settings.qrExpiry30d": "30 days",
   "settings.qrExpiryNever": "No expiry",
   "settings.qrInstructions": "1. Scan the QR code with your phone\n2. Add to home screen\n3. You're all set!",
-
   "qrLogin.connecting": "Connecting...",
   "qrLogin.invalidToken": "Invalid or expired token",
   "qrLogin.goToLogin": "Go to login page",
   "qrLogin.error": "Connection failed",
-
   "nav.energy": "Energy",
   "nav.energy.live": "Live",
   "nav.energy.consumption": "Consumption",
   "nav.energy.production": "Production",
-
   "energy.live": "Live",
   "energy.live.autoconso": "autoconso",
   "energy.live.configure": "Configure sources",
@@ -1069,7 +1024,6 @@
   "energy.unit.wh": "Wh",
   "energy.unit.eur": "€",
   "energy.unit.tariffMissing": "Configure HP/HC prices in Settings > Tariff",
-
   "tariff.title": "Energy tariffs",
   "tariff.unsavedBanner": "No tariff saved yet. These are suggested hours; click Save to apply them.",
   "tariff.priceHp": "Peak price (€/kWh)",
@@ -1082,9 +1036,7 @@
   "tariff.save": "Save",
   "tariff.saved": "Tariffs saved",
   "tariff.saveError": "Error saving tariffs",
-
   "nav.plugins": "Plugins",
-
   "plugins.title": "Plugins",
   "plugins.subtitle": "Install and manage extensions for Sowel.",
   "plugins.refreshRegistry": "Refresh",
@@ -1146,7 +1098,6 @@
   "plugins.category.safety": "Safety and monitoring",
   "plugins.category.energy": "Energy and display",
   "plugins.category.other": "Other",
-
   "settings.tabs.general": "General",
   "settings.tabs.account": "Account",
   "settings.tabs.system": "System",
@@ -1160,7 +1111,6 @@
   "settings.version.updateStarted": "Update started — Sowel will restart...",
   "settings.version.upToDate": "Sowel is up to date",
   "settings.version.noDocker": "Docker not available. Update manually:",
-
   "activity.title": "Activity",
   "activity.subtitle": "last 24 h",
   "activity.live": "live",
@@ -1168,7 +1118,6 @@
   "activity.empty": "No activity in the last 24 h",
   "activity.loading": "Loading activity…",
   "activity.loadError": "Failed to load activity",
-
   "activity.templates.order.executed": "<b>{{equipmentName}}</b> → {{value}}",
   "activity.templates.order.executed.multi": "<b>{{firstName}}</b> ×{{count}} → {{value}}",
   "activity.templates.motion.detected": "Motion detected on <b>{{equipmentName}}</b>",
@@ -1180,18 +1129,14 @@
   "activity.templates.sunlight.sunrise": "<b>Sunrise</b>",
   "activity.templates.sunlight.sunset": "<b>Sunset</b>",
   "activity.templates.alarm.raised": "<b>{{source}}</b>: {{message}}",
-
   "activity.source.recipe": "by {{recipeName}}",
   "activity.source.mode": "by mode {{modeName}}",
   "activity.source.manual": "manual",
   "activity.source.button": "via {{buttonLabel}}",
   "activity.source.external": "via {{channel}}",
-
   "activity.toggleDescendants.on": "Hide sub-zone activity",
   "activity.toggleDescendants.off": "Include sub-zone activity",
-
   "activity.bucket.now": "now",
-
   "equipment.status.online": "Online",
   "equipment.status.degraded": "Degraded",
   "equipment.status.offline": "Disconnected",
@@ -1200,13 +1145,10 @@
   "equipment.status.tooltip.staleBindings_one": "1 stale value:",
   "equipment.status.tooltip.staleBindings_other": "{{count}} stale values:",
   "equipment.status.tooltip.since": "Since {{when}}",
-
   "energy.cumul.lastLive": "Last live datapoint {{when}} ago",
   "energy.cumul.offlineSince": "Meter offline for {{when}}",
-
   "energy.live.dataStale": "Live data stale, last update {{when}} ago",
   "energy.live.metersOffline": "Meters disconnected for {{when}}",
-
   "zones.aggregate.unavailable_one": "(1 unavailable)",
   "zones.aggregate.unavailable_other": "({{count}} unavailable)"
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1,6 +1,5 @@
 {
   "app.name": "Sowel",
-
   "nav.home": "Maison",
   "nav.devices": "Appareils",
   "nav.equipments": "Équipements",
@@ -12,7 +11,6 @@
   "nav.settings": "Réglages",
   "nav.mqttPublishers": "Publications MQTT",
   "nav.maison": "Maison",
-
   "auth.login": "Se connecter",
   "auth.logout": "Se déconnecter",
   "auth.username": "Identifiant",
@@ -26,7 +24,6 @@
   "auth.passwordMismatch": "Les mots de passe ne correspondent pas",
   "auth.passwordTooShort": "Le mot de passe doit faire au moins 6 caractères",
   "auth.admin": "admin",
-
   "common.save": "Enregistrer",
   "common.cancel": "Annuler",
   "common.delete": "Supprimer",
@@ -66,7 +63,6 @@
   "common.select": "Sélectionner...",
   "common.disabled": "Désactivé",
   "common.all": "Tous",
-
   "status.online": "En ligne",
   "status.offline": "Hors ligne",
   "status.unknown": "Inconnu",
@@ -77,7 +73,6 @@
   "status.integrationWarning": "Déconnecté : {{names}}",
   "status.error": "Erreur",
   "status.not_configured": "Non configuré",
-
   "alarms.title": "Alarmes actives",
   "alarms.empty": "Aucune alarme.",
   "alarms.pill.title_one": "{{count}} problème actif",
@@ -98,7 +93,11 @@
   "updates.error.generic": "Échec de la mise à jour",
   "restart.pill.title": "Redémarrage requis",
   "shadow.banner": "MODE SHADOW — les intégrations sortantes et les publishers sont désactivés. Cette instance n'a aucun effet sur la production.",
-
+  "takeover.banner": "DONNÉES RESTAURÉES : cette base provient d'un autre déploiement. Intégrations sortantes, recettes, publishers et notifications sont désactivés tant qu'un admin n'a pas confirmé la reprise.",
+  "takeover.confirm": "Confirmer la reprise",
+  "takeover.confirming": "Confirmation...",
+  "takeover.restarting": "Reprise confirmée. Redémarrage du moteur, cette page va se recharger...",
+  "takeover.error": "Échec de la confirmation, consultez les logs.",
   "devices.title": "Appareils",
   "devices.subtitle_one": "{{count}} appareil · {{online}} en ligne",
   "devices.subtitle_other": "{{count}} appareils · {{online}} en ligne",
@@ -136,7 +135,6 @@
   "devices.col.range": "Plage / Valeurs",
   "devices.col.topic": "Topic",
   "devices.deleteConfirm": "Supprimer cet appareil de Sowel ? Il sera redécouvert automatiquement s'il est toujours actif sur le bridge.",
-
   "zones.title": "Topologie",
   "zones.subtitle": "Définissez la topologie de votre maison",
   "zones.count_one": "{{count}} zone",
@@ -183,7 +181,6 @@
   "zone.lead.allShuttersClosed": "tous les volets fermés",
   "zone.lead.shutterClosed": "volet fermé",
   "modes.activeBadge": "Actif",
-
   "equipments.title": "Équipements",
   "equipments.filterPlaceholder": "Filtrer...",
   "equipments.addEquipment": "Ajouter un équipement",
@@ -222,7 +219,6 @@
   "equipments.form.selectZone": "Sélectionner une zone...",
   "equipments.form.deviceInstruction": "Sélectionnez le(s) appareil(s) à lier à cet équipement. Seuls les appareils compatibles sont affichés.",
   "equipments.form.nextDevices": "Suivant : Sélectionner les appareils",
-
   "equipments.type.light_onoff": "Lumière (On/Off)",
   "equipments.type.light_dimmable": "Lumière (Dimmable)",
   "equipments.type.light_color": "Lumière (Couleur)",
@@ -249,7 +245,6 @@
   "equipments.type.pool_heat_pump": "Pompe à chaleur piscine",
   "equipments.type.display": "Afficheur Sowel",
   "equipments.type.camera": "Caméra",
-
   "cameras.panel.title": "Caméra",
   "cameras.panel.noData": "Aucune liaison sur cette caméra pour le moment.",
   "cameras.snapshot.refresh": "Actualiser",
@@ -266,7 +261,6 @@
   "cameras.lightMode.off": "Éteint",
   "cameras.siren.trigger": "Déclencher la sirène",
   "cameras.lastDetection": "Dernière détection",
-
   "displays.panel.title": "État de l'afficheur",
   "displays.panel.noData": "Aucune donnée encore remontée par cet afficheur.",
   "displays.fields.firmware_version": "Version du firmware",
@@ -279,7 +273,6 @@
   "displays.widget.onlineCount": "{{online}}/{{total}} en ligne",
   "displays.card.off": "Éteint",
   "displays.card.brightness": "{{pct}} %",
-
   "water.open": "Ouverte",
   "water.closed": "Fermée",
   "water.closeAll": "Fermer tout",
@@ -293,7 +286,6 @@
   "water.status.water_shortage": "Pénurie d'eau",
   "water.status.leak": "Fuite détectée",
   "water.status.fault": "Défaut",
-
   "equipments.group.lights": "Éclairages",
   "equipments.group.shutters": "Volets",
   "equipments.group.awnings": "Stores bannes",
@@ -309,10 +301,8 @@
   "equipments.group.displays": "Afficheurs",
   "equipments.group.cameras": "Caméras",
   "equipments.group.other": "Autres",
-
   "equipments.noEquipments": "Aucun équipement",
   "equipments.noEquipmentsMessage": "{{name}} n'a pas encore d'équipement. Ajoutez des équipements dans Réglages > Équipements.",
-
   "binding.addData": "Ajouter une liaison données",
   "binding.addOrder": "Ajouter une liaison commande",
   "binding.selectDevice": "Sélectionnez un appareil pour lier les {{type}}.",
@@ -325,7 +315,6 @@
   "binding.loadError": "Échec du chargement des détails de l'appareil",
   "binding.addError": "Échec de l'ajout de la liaison",
   "binding.addBinding": "Ajouter la liaison",
-
   "controls.turnOn": "Allumer",
   "controls.turnOff": "Éteindre",
   "controls.brightness": "Luminosité",
@@ -346,20 +335,17 @@
   "controls.gate.unknown": "En mouvement",
   "controls.gate.toggle": "Actionner",
   "controls.gate.command": "Actionner",
-
   "controls.heater.comfort": "Confort",
   "controls.heater.eco": "Éco",
   "controls.heater.switchComfort": "Passer en confort",
   "controls.heater.switchEco": "Passer en éco",
   "controls.heater.relayOn": "Relais activé",
   "controls.heater.relayOff": "Relais désactivé",
-
   "sensors.title": "Capteurs",
   "sensors.noData": "Aucune donnée capteur.",
   "sensors.sources_one": "{{count}} source",
   "sensors.sources_other": "{{count}} sources",
   "sensors.battery": "Batterie",
-
   "category.motion": "Mouvement",
   "category.temperature": "Température",
   "category.temperature_device": "Température onduleur",
@@ -381,7 +367,6 @@
   "category.noise": "Bruit",
   "category.action": "Action",
   "category.battery": "Batterie",
-
   "category.value.motion.detected": "Détecté",
   "category.value.motion.clear": "RAS",
   "category.value.contact.open": "Ouvert",
@@ -390,7 +375,6 @@
   "category.value.water_leak.ok": "OK",
   "category.value.smoke.alert": "Alerte !",
   "category.value.smoke.ok": "OK",
-
   "weather.outdoor": "Extérieur",
   "weather.indoor": "Intérieur",
   "weather.outdoorShort": "Ext.",
@@ -404,7 +388,6 @@
   "weather.rainCurrent": "Pluie actuelle",
   "weather.rain1h": "Pluie 1h",
   "weather.rain24h": "Pluie 24h",
-
   "aggregation.motion": "Mouvement",
   "aggregation.calm": "Calme",
   "aggregation.status": "Statut",
@@ -414,14 +397,11 @@
   "aggregation.open_other": "{{count}} ouvert(e)s",
   "aggregation.daylight": "Jour",
   "aggregation.night": "Nuit",
-
   "time.min": "min",
   "time.hour": "h",
   "time.day": "j",
   "time.second": "s",
-
   "behaviors.title": "Comportements",
-
   "modes.title": "Modes",
   "modes.subtitle": "Définissez les modes de fonctionnement de votre maison",
   "modes.active": "Actif",
@@ -476,7 +456,6 @@
   "modes.triggerActivate": "Active ce mode",
   "modes.triggerToggle": "Bascule ce mode",
   "modes.triggerToggleWith": "Bascule avec « {{name}} »",
-
   "recipes.title": "Recettes",
   "recipes.addRecipe": "Ajouter une recette",
   "recipes.chooseRecipe": "Choisir une recette",
@@ -500,7 +479,6 @@
   "recipes.actions.set_mode.comfort": "Confort",
   "recipes.actions.set_mode.cocoon": "Cocoon",
   "recipes.actions.set_mode.night": "Nuit",
-
   "setup.home.title": "Bienvenue sur Sowel",
   "setup.home.subtitle": "Une dernière étape avant de commencer",
   "setup.home.body": "Indiquez à Sowel où se trouve votre maison. Le nom apparaît partout dans l'app ; la latitude et la longitude servent à calculer le lever et le coucher du soleil et à déterminer le fuseau horaire.",
@@ -516,7 +494,6 @@
   "home.zoneNotFound": "Zone introuvable",
   "home.zoneDeleted": "Cette zone a peut-être été supprimée.",
   "home.backToHome": "Retour à l'accueil",
-
   "deviceSelector.pickChannel": "Choisir le canal à lier",
   "deviceSelector.channel": "Canal {{n}}",
   "deviceSelector.loading": "Chargement des appareils...",
@@ -526,7 +503,6 @@
   "deviceSelector.compatible_other": "{{count}} appareils compatibles / {{total}} disponibles",
   "deviceSelector.showCompatible": "Compatibles uniquement",
   "deviceSelector.showAll": "Tous les appareils",
-
   "settings.title": "Réglages",
   "settings.profile": "Profil",
   "settings.preferences": "Préférences",
@@ -568,7 +544,6 @@
   "settings.sunsetOffset": "Décalage coucher (min)",
   "settings.sunriseOffsetHelp": "Minutes après le lever avant de considérer qu'il fait jour",
   "settings.sunsetOffsetHelp": "Minutes avant le coucher pour anticiper la nuit",
-
   "backup.title": "Sauvegarde / Restauration",
   "backup.description": "Exportez ou importez la configuration complète de Sowel (zones, appareils, équipements, utilisateurs, recettes, intégrations).",
   "backup.export": "Exporter",
@@ -582,7 +557,6 @@
   "backup.restored": "Sauvegarde restaurée avec succès. Rechargement...",
   "backup.confirmRestoreTitle": "Restaurer cette sauvegarde ?",
   "backup.confirmRestoreMessage": "Cette action va remplacer toutes les données actuelles par celles de {{filename}}. Continuer ?",
-
   "update.checkNow": "Vérifier les mises à jour",
   "update.dockerUnavailable": "Mise à jour automatique indisponible : socket Docker non monté. Pour l'activer, copiez docker-compose.override.example.yml vers docker-compose.override.yml et relancez `docker compose up -d`.",
   "update.notComposeManaged": "Mise à jour automatique disponible uniquement avec docker compose. Mettez à jour manuellement avec : docker compose pull && docker compose up -d",
@@ -597,17 +571,14 @@
   "update.restartRequiredMessage": "La localisation a changé. Sowel doit redémarrer pour recalculer le fuseau horaire.",
   "update.restartNow": "Redémarrer maintenant",
   "update.later": "Plus tard",
-
   "settings.timezone": "Fuseau horaire",
   "settings.timezoneSourceAuto": "détecté depuis vos coordonnées",
   "settings.timezoneSourceEnv": "défini via la variable d'environnement TZ",
   "settings.timezoneSourceFallback": "non configuré, UTC par défaut",
-
   "nav.analyse": "Analyse",
   "nav.integrations": "Intégrations",
   "nav.logs": "Logs",
   "nav.backup": "Sauvegarde",
-
   "integrations.title": "Intégrations",
   "integrations.subtitle": "Configurez les connexions avec vos systèmes domotiques.",
   "integrations.z2mDescription": "Passerelle Zigbee vers MQTT",
@@ -645,7 +616,6 @@
   "integrations.oauthFillFirst": "Remplissez les champs ci-dessus avant de connecter.",
   "integrations.oauthSuccess": "Compte Samsung connecté avec succès.",
   "integrations.oauthError": "Échec de l'autorisation",
-
   "calendar.title": "Calendrier",
   "calendar.subtitle": "Planifiez l'activation automatique des modes selon la semaine",
   "calendar.profiles": "Profils de semaine",
@@ -674,7 +644,6 @@
   "calendar.days.fri": "Ven",
   "calendar.days.sat": "Sam",
   "calendar.modeActionHint": "Cliquer pour alterner : ignoré → ON → OFF",
-
   "thermostat.outside": "Extérieur",
   "thermostat.target": "Consigne",
   "thermostat.mode": "Mode",
@@ -698,7 +667,6 @@
   "thermostat.ecoMode": "Éco",
   "thermostat.ecoModes.powerful": "Puissant",
   "thermostat.ecoModes.quiet": "Silence",
-
   "buttonActions.title": "Actions",
   "buttonActions.addEffect": "Ajouter un effet",
   "buttonActions.noEffects": "Aucun effet configuré",
@@ -724,7 +692,6 @@
   "buttonActions.zoneOrder.allThermostatsPowerOn": "Allumer les thermostats",
   "buttonActions.zoneOrder.allThermostatsPowerOff": "Éteindre les thermostats",
   "buttonActions.zoneOrder.allThermostatsSetpoint": "Consigne des thermostats",
-
   "stove.state.off": "Éteint",
   "stove.state.checking": "Vérification",
   "stove.state.ignition_phase_1": "Allumage 1",
@@ -762,7 +729,6 @@
   "stove.pellet.almost_empty": "Presque vide",
   "stove.sparkPlug.ok": "OK",
   "stove.sparkPlug.worn": "Usée",
-
   "logs.title": "Logs moteur",
   "logs.subtitle": "Visualisation des logs moteur en temps réel",
   "logs.live": "Direct",
@@ -777,7 +743,6 @@
   "logs.entries": "{{count}} entrées",
   "logs.engineLevel": "Niveau moteur",
   "logs.levelChanged": "Niveau de log changé à {{level}}",
-
   "history.influxdb": "InfluxDB",
   "history.influxdbDescription": "Base de données time-series pour l'historisation des données",
   "history.url": "URL",
@@ -826,7 +791,6 @@
   "history.setupComplete": "Configuré",
   "history.setupIncomplete": "Non configuré",
   "history.never": "Jamais",
-
   "analyse.title": "Analyse",
   "analyse.addSeries": "Ajouter",
   "analyse.zone": "Zone",
@@ -868,7 +832,6 @@
   "analyse.bool.smoke.detected": "Détecté",
   "analyse.bool.generic.off": "Inactif",
   "analyse.bool.generic.on": "Actif",
-
   "mqttPublishers.title": "Publications MQTT",
   "mqttPublishers.subtitle": "Publier les données d'équipements, zones et recettes vers des topics MQTT",
   "mqttPublishers.newPublisher": "Nouveau publisher",
@@ -908,9 +871,7 @@
   "mqttPublishers.testResult": "{{count}} message(s) publié(s)",
   "mqttPublishers.onChangeOnly": "Publier uniquement sur changement de valeur",
   "mqttPublishers.onChangeOnlyBadge": "sur changement",
-
   "nav.notificationPublishers": "Notifications",
-
   "notifPublishers.title": "Notifications",
   "notifPublishers.subtitle": "Envoyer une notification (Telegram ou Web Push) lors d'un changement de valeur d'équipement, de zone ou de recette",
   "notifPublishers.newPublisher": "Nouveau publisher",
@@ -962,7 +923,6 @@
   "notifPublishers.test": "Test",
   "notifPublishers.testChannelOk": "Message de test envoyé !",
   "notifPublishers.testResult": "{{count}} notification(s) envoyée(s)",
-
   "nav.dashboard": "Dashboard",
   "dashboard.title": "Dashboard",
   "dashboard.emptyTitle": "Aucun widget configuré",
@@ -991,12 +951,10 @@
   "dashboard.family.awnings": "Stores bannes",
   "dashboard.family.heating": "Chauffage",
   "dashboard.family.sensors": "Capteurs",
-
   "app.offline": "Vous êtes hors ligne",
   "app.installBanner": "Installez Sowel pour une meilleure expérience",
   "app.install": "Installer",
   "app.notNow": "Plus tard",
-
   "settings.mobile": "Application mobile",
   "settings.mobileDescription": "Scannez le QR code depuis votre téléphone pour vous connecter",
   "settings.generateQr": "Générer un QR code",
@@ -1006,17 +964,14 @@
   "settings.qrExpiry30d": "30 jours",
   "settings.qrExpiryNever": "Sans expiration",
   "settings.qrInstructions": "1. Scannez le QR code avec votre téléphone\n2. Ajoutez à l'écran d'accueil\n3. C'est prêt !",
-
   "qrLogin.connecting": "Connexion en cours...",
   "qrLogin.invalidToken": "Token invalide ou expiré",
   "qrLogin.goToLogin": "Aller à la page de connexion",
   "qrLogin.error": "Échec de la connexion",
-
   "nav.energy": "Énergie",
   "nav.energy.live": "Live",
   "nav.energy.consumption": "Consommation",
   "nav.energy.production": "Production",
-
   "energy.live": "Live",
   "energy.live.autoconso": "autoconso",
   "energy.live.configure": "Configurer les sources",
@@ -1069,7 +1024,6 @@
   "energy.unit.wh": "Wh",
   "energy.unit.eur": "€",
   "energy.unit.tariffMissing": "Configurez les prix HP/HC dans Réglages > Tarif",
-
   "tariff.title": "Tarifs énergie",
   "tariff.unsavedBanner": "Aucun tarif enregistré pour le moment. Ces horaires sont une suggestion ; cliquez sur Enregistrer pour les appliquer.",
   "tariff.priceHp": "Prix HP (€/kWh)",
@@ -1082,9 +1036,7 @@
   "tariff.save": "Enregistrer",
   "tariff.saved": "Tarifs enregistrés",
   "tariff.saveError": "Erreur lors de l'enregistrement",
-
   "nav.plugins": "Plugins",
-
   "plugins.title": "Plugins",
   "plugins.subtitle": "Installez et gérez des extensions pour Sowel.",
   "plugins.refreshRegistry": "Rafraîchir",
@@ -1146,7 +1098,6 @@
   "plugins.category.safety": "Sécurité et surveillance",
   "plugins.category.energy": "Énergie et affichage",
   "plugins.category.other": "Autres",
-
   "settings.tabs.general": "Général",
   "settings.tabs.account": "Compte",
   "settings.tabs.system": "Système",
@@ -1160,7 +1111,6 @@
   "settings.version.updateStarted": "Mise à jour lancée — Sowel va redémarrer...",
   "settings.version.upToDate": "Sowel est à jour",
   "settings.version.noDocker": "Docker non disponible. Mettez à jour manuellement :",
-
   "activity.title": "Activité",
   "activity.subtitle": "dernières 24 h",
   "activity.live": "live",
@@ -1168,7 +1118,6 @@
   "activity.empty": "Aucune activité dans les dernières 24 h",
   "activity.loading": "Chargement de l'activité…",
   "activity.loadError": "Impossible de charger l'activité",
-
   "activity.templates.order.executed": "<b>{{equipmentName}}</b> → {{value}}",
   "activity.templates.order.executed.multi": "<b>{{firstName}}</b> ×{{count}} → {{value}}",
   "activity.templates.motion.detected": "Mouvement détecté sur <b>{{equipmentName}}</b>",
@@ -1180,18 +1129,14 @@
   "activity.templates.sunlight.sunrise": "<b>Lever du soleil</b>",
   "activity.templates.sunlight.sunset": "<b>Coucher du soleil</b>",
   "activity.templates.alarm.raised": "<b>{{source}}</b> : {{message}}",
-
   "activity.source.recipe": "par {{recipeName}}",
   "activity.source.mode": "par le mode {{modeName}}",
   "activity.source.manual": "manuel",
   "activity.source.button": "via {{buttonLabel}}",
   "activity.source.external": "via {{channel}}",
-
   "activity.toggleDescendants.on": "Masquer l'activité des sous-zones",
   "activity.toggleDescendants.off": "Inclure l'activité des sous-zones",
-
   "activity.bucket.now": "maintenant",
-
   "equipment.status.online": "En ligne",
   "equipment.status.degraded": "Dégradé",
   "equipment.status.offline": "Déconnecté",
@@ -1200,13 +1145,10 @@
   "equipment.status.tooltip.staleBindings_one": "1 valeur périmée :",
   "equipment.status.tooltip.staleBindings_other": "{{count}} valeurs périmées :",
   "equipment.status.tooltip.since": "Depuis {{when}}",
-
   "energy.cumul.lastLive": "Dernière donnée live il y a {{when}}",
   "energy.cumul.offlineSince": "Compteur hors ligne depuis {{when}}",
-
   "energy.live.dataStale": "Données figées depuis {{when}}",
   "energy.live.metersOffline": "Compteurs déconnectés depuis {{when}}",
-
   "zones.aggregate.unavailable_one": "(1 indispo.)",
   "zones.aggregate.unavailable_other": "({{count}} indispo.)"
 }

--- a/ui/src/store/useShadowMode.ts
+++ b/ui/src/store/useShadowMode.ts
@@ -6,18 +6,21 @@ import { getSystemMode } from "../api";
 
 interface ShadowState {
   shadowMode: boolean;
-  /** Fetch the flag once on app mount. Network errors leave the
-   * banner hidden — preferable to a spurious banner on a normal
+  /** Issue #401 — database restored from another deployment, engine inert. */
+  takeoverPending: boolean;
+  /** Fetch the flags once on app mount. Network errors leave the
+   * banners hidden — preferable to a spurious banner on a normal
    * instance during a flaky boot. */
   fetch: () => Promise<void>;
 }
 
 export const useShadowMode = create<ShadowState>((set) => ({
   shadowMode: false,
+  takeoverPending: false,
   fetch: async () => {
     try {
-      const { shadowMode } = await getSystemMode();
-      set({ shadowMode });
+      const { shadowMode, takeoverPending } = await getSystemMode();
+      set({ shadowMode, takeoverPending: takeoverPending ?? false });
     } catch {
       // Intentional: stay silent on errors.
     }


### PR DESCRIPTION
## Summary

Closes #401. A database restored from another deployment carries that deployment's MQTT brokers, OAuth grants, and notification channels. A fully armed instance on such data fights the origin deployment: the 2026-08-08/10 production disturbance (MQTT publisher clientId kick loop in #399, Netatmo refresh-token race) was caused by exactly this, a dev instance running on a restored prod backup.

## How it works

- **Identity**: `system.instance_id` lives in the settings table and therefore travels inside backups; `data/.instance-id` is a marker describing the local deployment. Both are minted on first boot (including the first boot after upgrading to this feature).
- **Detection**: on boot, a mismatch (or a database id with no local marker) means the data came from somewhere else. The engine then forces the spec 124 shadow gates for that boot: no outbound integrations, recipes, publishers, notifications, or version checks, plus a prominent `TAKEOVER PENDING` log line.
- **Confirm paths**: a red, non-dismissable UI banner (reusing the ShadowBanner pattern) explains the state to every user and offers an admin-only "Confirm takeover" button, which calls the new `POST /api/v1/system/takeover` (writes the marker, restarts the engine; the docker restart policy brings it back armed). `SOWEL_TAKEOVER=1` pre-confirms for headless or intentional setups (hardware migration, deliberate dev testing).
- **API**: `GET /api/v1/system/mode` now returns `{ shadowMode, takeoverPending }`.

Normal same-instance restores (disaster recovery on the same deployment) do not trigger the gate: the marker matches. Known limitation, documented: backups taken before this feature carry no instance id, so their first restore is indistinguishable from a first boot.

## Tests

- `instance-identity`: first-boot minting, matching boot, restored-database mismatch, missing-marker case, `SOWEL_TAKEOVER` pre-confirmation, admin confirm flow
- `system` routes: `takeoverPending` surfaced in GET mode; POST takeover is admin-only, 409 when nothing is pending, confirm + restart callbacks invoked in order

## Docs

Deployment guide (EN/FR): new "Restoring a backup from another deployment" section.