### PR TITLE
docs: carry the multi-coordinator rules into the pages that already cover Zigbee

### DIFF
--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -391,7 +391,7 @@ Un déploiement domestique typique sur un seul hôte ressemble à ceci :
 - **Version actuelle** : `docker logs sowel | grep "Sowel engine started"`
 - **Backups** : locaux dans `data/backups/` (auto), plus des téléchargements manuels conservés hors de l'hôte
 - **MQTT** : `mosquitto` externe tournant sur le même hôte (pas dans le compose), utilisé par les plugins `zigbee2mqtt` et `lora2mqtt`
-- **Zigbee2MQTT** : daemon externe sur le même hôte, pas géré par Sowel lui-même
+- **Zigbee2MQTT** : daemon externe sur le même hôte, pas géré par Sowel lui-même. Une instance par coordinateur Zigbee — plusieurs instances partagent le broker, chacune avec son base topic et son répertoire de données, et le plugin `zigbee2mqtt` les dessert toutes. Voir [Plusieurs coordinateurs Zigbee](../user/host-setup.md#plusieurs-coordinateurs-zigbee).
 
 Le graphe de connectivité :
 

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -397,7 +397,7 @@ A typical single-host home deployment looks like this:
 - **Current version**: `docker logs sowel | grep "Sowel engine started"`
 - **Backups**: local in `data/backups/` (auto), plus manual downloads kept off-host
 - **MQTT**: external `mosquitto` running on the same host (not in compose), used by the `zigbee2mqtt` and `lora2mqtt` plugins
-- **Zigbee2MQTT**: external daemon on the same host, not managed by Sowel itself
+- **Zigbee2MQTT**: external daemon on the same host, not managed by Sowel itself. One instance per Zigbee coordinator — several instances share the broker, each with its own base topic and data directory, and the `zigbee2mqtt` plugin serves them all. See [Several Zigbee coordinators](../user/host-setup.md#several-zigbee-coordinators).
 
 The connectivity graph:
 

--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -85,6 +85,20 @@ Each device gets a stable UUID generated from its `(integrationId, sourceDeviceI
 
 This sounds boring until the day you have to do it.
 
+### With several Zigbee coordinators
+
+A home with several Zigbee coordinators runs one Zigbee2MQTT instance per coordinator, all declared in a single plugin — see the "Several Zigbee coordinators" section of [Preparing the Host](host-setup.md). The first network in the list keeps its device names as-is; the following ones prefix theirs with their base topic, so that two networks can host a `kitchen_lamp` each without their devices merging.
+
+That prefix is **part of the source device ID**, so it falls under the rule above:
+
+- Adding a network **at the end** of the list leaves every existing device untouched.
+- Reordering the list, renaming a base topic, or adding or removing a prefix **changes the source device IDs** of the affected network. Those devices are recreated as new ones, and their equipment bindings are dropped.
+
+!!! tip "Decide the naming before you bind"
+Right after you declare a new network, its devices have no bindings yet — that is the one moment where changing your mind about the prefix costs nothing. Once you have built equipments on top, it does not.
+
+If your device names are unique across all your networks, dropping the prefix (`zigbee2mqtt_annex:`, with a trailing colon) keeps a single flat inventory sorted by name, rather than pushing a whole network to the bottom of the list under its base topic. The trade-off is that two devices sharing a name would then silently become one.
+
 ---
 
 ## Why it matters

--- a/docs/user/getting-started.fr.md
+++ b/docs/user/getting-started.fr.md
@@ -137,6 +137,9 @@ Une fois qu'une intégration est connectée, les devices apparaissent automatiqu
 
 Utilisez les onglets d'intégration en haut pour filtrer par source. Si les devices n'apparaissent pas, vérifiez que votre intégration est connectée (indicateur vert) et que les devices sont appairés à votre coordinateur ou enregistrés sur votre compte cloud.
 
+!!! tip "Les devices d'un second coordinateur Zigbee n'apparaissent pas"
+Chaque instance Zigbee2MQTT a son propre base topic, et le plugin n'écoute que ceux listés dans son réglage **Zigbee2MQTT Base Topic(s)**. Si tout un réseau manque, son base topic est probablement absent de cette liste — voir [Plusieurs coordinateurs Zigbee](host-setup.md#plusieurs-coordinateurs-zigbee). Si la liste est correcte, les devices sont bien là mais triés sous leur préfixe de base topic, tout en bas du tableau.
+
 ### Étape 4 : Créer la topologie de vos zones
 
 Allez dans **Administration > Topologie**.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -137,6 +137,9 @@ Once an integration connects, devices appear automatically. The table shows:
 
 Use the integration tabs at the top to filter by source. If devices do not appear, check that your integration is connected (green indicator) and that devices are paired with your coordinator or registered in your cloud account.
 
+!!! tip "Devices from a second Zigbee coordinator are missing"
+Each Zigbee2MQTT instance has its own base topic, and the plugin only listens to the topics you list in its **Zigbee2MQTT Base Topic(s)** setting. If a whole network is missing, its base topic is probably absent from that list — see [Several Zigbee coordinators](host-setup.md#several-zigbee-coordinators). If the list is right, the devices are there but sorted under their base topic prefix, at the bottom of the table.
+
 ### Step 4: Create your zone topology
 
 Go to **Administration > Topology**.


### PR DESCRIPTION
Follow-up to #395, which added the **Several Zigbee coordinators** section to the host-setup guide. Three other pages already talk about Zigbee coordinators and still described a single-instance world.

| Page | What changed |
| --- | --- |
| **Devices** | New *"With several Zigbee coordinators"* subsection under **Stable identity** |
| **Getting Started** (EN + FR) | The *"devices do not appear"* paragraph now covers a whole Zigbee network missing |
| **Deployment** (EN + FR) | Production topology: one Zigbee2MQTT instance per coordinator, sharing the broker |

## Why Devices, specifically

The prefix of a secondary network *is* part of the `sourceDeviceId`, so it belongs right next to "re-pair a device and it keeps its UUID" and "migrate to a new Zigbee2MQTT instance". The section now states the operational rule:

- appending a network **at the end** of the list leaves existing devices untouched;
- reordering the list, renaming a base topic, or adding/removing a prefix recreates the affected devices and **drops their equipment bindings**;
- the only free moment to change your mind is right after declaring a network, before equipments are built on top of it.

## Why Getting Started

Field feedback: the first thing an operator hits after adding a coordinator is not "no devices" but *"I can't find them"* — the devices are present, just sorted last under their `zigbee2mqtt_annex/` prefix, past the end of the first screen. The troubleshooting note names both causes.

## One deliberate inconsistency

The link from `devices.md` points at `host-setup.md` **without** an anchor, while the other pages link to `#several-zigbee-coordinators`.

`devices.md` has no French translation, so on the FR site it is served as-is and its relative link resolves to `host-setup.fr.md` — whose heading anchor is `#plusieurs-coordinateurs-zigbee`. `mkdocs build --strict` flagged exactly that. Pages that *do* have a FR twin (getting-started, deployment) keep their anchors, since each locale resolves to its own heading. Translating `devices.md` would remove the exception; that is out of scope here.

## Verification

`mkdocs build --strict` — clean. Both `#several-zigbee-coordinators` (EN build) and `#plusieurs-coordinateurs-zigbee` (FR build) are generated and reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)