### PR TITLE
fix(logging): purge pre-date-format log files automatically at boot

### DIFF
--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -477,11 +477,7 @@ Exemple de récupération :
 docker exec sowel sh -c 'cat /app/data/logs/sowel.2026-04-11.1.log | grep -E "2026-04-11T07:" | grep error'
 ```
 
-Avant la v1.39, les fichiers étaient nommés `sowel.N.log` avec un numéro de rotation choisi par processus : plusieurs redémarrages dans la journée éclataient les plages horaires entre fichiers, et un même fichier pouvait couvrir plusieurs mois. Pour investiguer un incident antérieur au changement de format, grepper TOUS les fichiers `sowel.*.log` plutôt que de se fier à un seul. Les anciens fichiers numérotés ne sont pas couverts par la nouvelle rétention et peuvent être supprimés manuellement une fois devenus inutiles :
-
-```bash
-docker exec sowel sh -c 'rm /app/data/logs/sowel.[0-9]*.log'
-```
+Avant la v1.39, les fichiers étaient nommés `sowel.N.log` avec un numéro de rotation choisi par processus : plusieurs redémarrages dans la journée éclataient les plages horaires entre fichiers, et un même fichier pouvait couvrir plusieurs mois. Pour investiguer un incident antérieur au changement de format, grepper TOUS les fichiers `sowel.*.log` plutôt que de se fier à un seul. Les anciens fichiers numérotés sont invisibles pour la nouvelle rétention : le moteur les purge automatiquement au démarrage dès qu'ils ont plus de 14 jours, aucune action manuelle n'est nécessaire.
 
 ### Conseils sur les niveaux de log
 

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -489,11 +489,7 @@ Example retrieval:
 docker exec sowel sh -c 'cat /app/data/logs/sowel.2026-04-11.1.log | grep -E "2026-04-11T07:" | grep error'
 ```
 
-Before v1.39, files were named `sowel.N.log` with a rotation number picked per process: several restarts a day interleaved time ranges across files, and one file could span months. When investigating an incident older than the format switch, grep ALL `sowel.*.log` files rather than trusting one. Legacy numbered files are not covered by the new retention and can be removed manually once no longer needed:
-
-```bash
-docker exec sowel sh -c 'rm /app/data/logs/sowel.[0-9]*.log'
-```
+Before v1.39, files were named `sowel.N.log` with a rotation number picked per process: several restarts a day interleaved time ranges across files, and one file could span months. When investigating an incident older than the format switch, grep ALL `sowel.*.log` files rather than trusting one. Legacy numbered files are invisible to the new retention, so the engine purges them automatically at boot once they are older than 14 days; no manual action is needed.
 
 ### Log level guidance
 

--- a/src/core/logger.test.ts
+++ b/src/core/logger.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import pino from "pino";
-import { mkdtempSync, rmSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, readdirSync, readFileSync, writeFileSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fileTransportOptions } from "./logger.js";
+import { fileTransportOptions, purgeLegacyLogFiles } from "./logger.js";
 
 // #400 — one calendar day must map to one predictable log file across restarts.
 
@@ -86,5 +86,59 @@ describe("pino-roll file naming (integration)", () => {
     expect(files).toContain("sowel.3.log");
     expect(files).toContain("backfill-rain.log");
     expect(files.some((f) => DATED_FILE_RE.test(f))).toBe(true);
+  });
+});
+
+// #400 follow-up — one-shot purge of pre-date-format files at boot.
+describe("purgeLegacyLogFiles", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sowel-legacy-purge-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function makeSpyLogger() {
+    const spy = { info: vi.fn(), warn: vi.fn() };
+    return spy;
+  }
+
+  function touch(name: string, ageDays: number): void {
+    const path = join(dir, name);
+    writeFileSync(path, "x\n");
+    const t = new Date(Date.now() - ageDays * 24 * 3600_000);
+    utimesSync(path, t, t);
+  }
+
+  it("removes only legacy-format files older than 14 days", () => {
+    touch("sowel.3.log", 20); // legacy, stale → removed
+    touch("sowel.11.log", 40); // legacy, stale → removed
+    touch("sowel.5.log", 3); // legacy, recent → kept
+    touch("sowel.2026-07-01.1.log", 40); // new format → pino-roll's job, kept
+    touch("backfill-rain.log", 400); // unrelated → kept
+
+    const spy = makeSpyLogger();
+    purgeLegacyLogFiles(spy as never, dir);
+
+    const files = readdirSync(dir).sort();
+    expect(files).toEqual(["backfill-rain.log", "sowel.2026-07-01.1.log", "sowel.5.log"]);
+    expect(spy.info.mock.calls.length).toBe(1);
+    expect(spy.info.mock.calls[0][0]).toMatchObject({ removed: 2 });
+  });
+
+  it("stays silent when there is nothing to purge", () => {
+    touch("sowel.2026-08-01.1.log", 5);
+    const spy = makeSpyLogger();
+    purgeLegacyLogFiles(spy as never, dir);
+    expect(spy.info.mock.calls.length).toBe(0);
+    expect(spy.warn.mock.calls.length).toBe(0);
+  });
+
+  it("does not throw on a missing directory", () => {
+    const spy = makeSpyLogger();
+    expect(() => purgeLegacyLogFiles(spy as never, join(dir, "absent"))).not.toThrow();
   });
 });

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,5 +1,7 @@
 import pino from "pino";
 import { Writable } from "node:stream";
+import { existsSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
 import type { LogRingBuffer } from "./log-buffer.js";
 
 export type Logger = pino.Logger;
@@ -55,6 +57,48 @@ export function fileTransportOptions(file = "data/logs/sowel"): {
     limit: { count: 14, removeOtherLogFiles: true },
     mkdir: true,
   };
+}
+
+/** Retention window matching `fileTransportOptions().limit.count` days. */
+const LEGACY_LOG_RETENTION_MS = 14 * 24 * 3600_000;
+
+/** Pre-#400 rotation format: sowel.<number>.log, no date segment. */
+const LEGACY_LOG_RE = /^sowel\.\d+\.log$/;
+
+/**
+ * One-shot migration purge (#400 follow-up): pino-roll's cleanup only
+ * pattern-matches the new date-stamped format, so files rotated by versions
+ * before the switch would sit on disk forever. Delete legacy-format files
+ * older than the normal retention window; recent ones are kept so the last
+ * two weeks of history stay greppable across the format change. Never
+ * throws — a purge failure must not block boot.
+ *
+ * Exported for tests.
+ */
+export function purgeLegacyLogFiles(logger: Logger, dir = "data/logs"): void {
+  try {
+    if (!existsSync(dir)) return;
+    const cutoff = Date.now() - LEGACY_LOG_RETENTION_MS;
+    let removed = 0;
+    let freedBytes = 0;
+    for (const name of readdirSync(dir)) {
+      if (!LEGACY_LOG_RE.test(name)) continue;
+      const path = join(dir, name);
+      const stats = statSync(path);
+      if (stats.mtimeMs >= cutoff) continue;
+      unlinkSync(path);
+      removed++;
+      freedBytes += stats.size;
+    }
+    if (removed > 0) {
+      logger.info(
+        { module: "logger", removed, freedMB: Math.round(freedBytes / 1_048_576) },
+        "Purged legacy log files past the retention window",
+      );
+    }
+  } catch (err) {
+    logger.warn({ module: "logger", err }, "Legacy log purge failed");
+  }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { resolve, dirname } from "node:path";
 import { existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { hostname } from "node:os";
 import { loadConfig } from "./config.js";
-import { createLogger } from "./core/logger.js";
+import { createLogger, purgeLegacyLogFiles } from "./core/logger.js";
 import { LogRingBuffer } from "./core/log-buffer.js";
 import { installProcessCrashHandlers } from "./core/process-crash-handlers.js";
 import { AuditLogger } from "./core/audit-logger.js";
@@ -107,6 +107,10 @@ async function main() {
   // Throws before this point are caught by the `main().catch()` block
   // at the bottom of this file (stderr JSON fallback).
   installProcessCrashHandlers(logger);
+
+  // #400 follow-up — pre-date-format log files are invisible to pino-roll's
+  // retention; drop the ones past the normal 14-day window.
+  purgeLegacyLogFiles(logger);
 
   // Flush deferred timezone diagnostics
   const tzLogger = logger.child({ module: "timezone" });


### PR DESCRIPTION
## Summary

Follow-up to #400 / #403. The new pino-roll retention only pattern-matches the date-stamped format, so legacy `sowel.N.log` files rotated by earlier versions would stay on disk forever unless removed by hand (production currently holds ~450 MB of them, some from June).

At boot, `purgeLegacyLogFiles()` deletes legacy-format files older than the same 14-day retention window. Recent legacy files are kept so the last two weeks of history stay greppable across the format switch; the purge disappears by itself once nothing matches. Strict pattern (`sowel.<number>.log`): date-stamped files and unrelated files (`backfill-rain.log`) are untouched, and a purge failure logs a warning without blocking boot.

Docs updated (EN/FR): the manual `rm` instruction is replaced by "purged automatically after 14 days".

## Tests

- removes only stale legacy files; keeps recent legacy, date-stamped, and unrelated files; logs one summary line with count
- silent when nothing to purge
- no throw on a missing directory