### PR TITLE
fix(ui): community plugin badge shows Users, not a warning triangle (#410)

### DIFF
--- a/ui/src/pages/PluginsPage.tsx
+++ b/ui/src/pages/PluginsPage.tsx
@@ -11,6 +11,7 @@ import {
   AlertTriangle,
   ShieldAlert,
   UserRound,
+  Users,
   FolderGit2,
   Plus,
   Search,
@@ -774,13 +775,16 @@ function StoreRow({
               {manifest.version}
             </span>
           )}
-          {/* Community badge — owner is not in OFFICIAL_OWNERS (spec 089 C1) */}
+          {/* Community badge — owner is not in OFFICIAL_OWNERS (spec 089 C1).
+              Users, not AlertTriangle: the tier means "third-party author,
+              integrity verified", not "hazard" (#410). The caution icon lives
+              in the install confirmation modal, where caution is the point. */}
           {tier === "community" && (
             <span
               className="text-[10px] px-1.5 py-0.5 bg-warning/10 text-warning rounded-[4px] font-medium shrink-0 inline-flex items-center gap-1"
               title={t("plugins.community.badge.tooltip")}
             >
-              <AlertTriangle size={10} strokeWidth={2} />
+              <Users size={10} strokeWidth={2} />
               {t("plugins.community.badge")}
             </span>
           )}


### PR DESCRIPTION
## Root cause

Spec 089's Community badge rendered `AlertTriangle` in amber, which universally reads as "hazard". The tier actually means "author outside `OFFICIAL_OWNERS`, SHA256 integrity verified", and the triangle stigmatized exactly the third-party contributions the project wants to encourage.

## Change

- Badge icon: `AlertTriangle` → `Users` (a group of people = community), consistent with the Personal badge's `UserRound` (spec 136).
- Amber tint kept: it still distinguishes the tier from official (no badge) and personal (blue) without shouting.
- The `AlertTriangle` in the community **install confirmation modal** is deliberately unchanged: that dialog is a genuine caution moment.

## Tests

None added: pure icon swap with no logic, and the repo's UI test suite is pure-logic only (no component render infrastructure); the sibling PersonalBadge has no render test either. Typecheck and lint pass.

Closes #410