### PR TITLE
release: v1.39.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,21 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.39.x: Arbitrage du surplus énergie
+
+### v1.39.0 — 2026-08-11 { #v1-39-0 }
+
+- Feat (energy) : **l'arbitre de surplus énergie** (spec 140). Un arbitre central distribue le surplus solaire à vos charges pilotables dans l'ordre de priorité que vous choisissez, mettant fin au bras de fer où plusieurs automatisations conscientes du surplus s'allument chacune en voyant de l'injection, dépassent ensemble, puis l'effondrent. Déclarez une charge pilotable (pompe de piscine, chauffe-eau, etc.) sur sa fiche d'équipement (classe, puissance nominale, marche/arrêt minimum, pré-remplis depuis le type et sa propre mesure), activez l'arbitre dans Réglages > Administration > Énergie, et ordonnez vos charges. Énergie > En direct gagne une surface d'arbitrage : une barre d'allocation de là où va la production en ce moment, une frise du jour par charge, et un journal des décisions en langage clair. **Opt-in et désactivé par défaut**, et l'arbitre n'émet aucun ordre lui-même. C'est la fondation contre laquelle les recettes conscientes du surplus réclament de la capacité (`ctx.helpers.energy`) ; les recettes qui l'utilisent arrivent ensuite, donc sur cette version l'arbitre est là pour être activé et observé. Durci par deux passes de revue adversariale indépendantes avant le merge. (#412)
+- Feat (equipments) : **confirmation de livraison d'ordre** (spec 141). Un ordre envoyé avec succès ne prouvait que son arrivée à l'intégration, pas au device : un OFF de pompe de piscine envoyé pendant une fenêtre hors ligne de 104 secondes a un jour laissé la pompe tourner 15,5 h sans que rien ne le signale (issue #398). Les ordres confirmables sont désormais surveillés pour que la valeur commandée apparaisse réellement sous 30 s (verdict immédiat quand tous les devices cibles sont hors ligne) ; sinon, Sowel lève une alarme d'avertissement (transmise en notification push) et renvoie l'ordre une fois quand le device revient dans l'heure. (#404)
+- Feat (core) : **garde-fou données restaurées**. Une base restaurée depuis un autre déploiement porte les brokers MQTT et canaux de ce déploiement ; une instance pleinement armée sur ces données se bat contre l'originale. Une instance restaurée démarre désormais inerte jusqu'à ce que vous confirmiez la reprise, pour que les deux ne se disputent jamais les mêmes devices. (#405)
+- Fix (mqtt) : chaque processus utilise un **client id de publisher MQTT unique** (suffixe aléatoire par connexion) et limite les avertissements de reconnexion, pour qu'une instance de dev sur une copie d'une base de production ne mette plus l'originale dehors en boucle. (#402)
+- Fix (logging) : les fichiers de log quotidiens sont **datés et conservés à travers la recréation du conteneur**, et les fichiers de log au format pré-daté laissés par les anciennes versions sont purgés automatiquement au démarrage. (#403, #408)
+- Fix (ui) : la liste des équipements **regroupe par identité de zone, pas par nom de zone** (deux pièces au même nom ne fusionnent plus), et le badge des plugins communautaires affiche une icône Utilisateurs plutôt qu'un triangle d'avertissement. (#406, #411)
+- Chore (registry) : Zigbee2MQTT passé à 2.4.0 ; pool-pump-schedule à 1.1.0 ; netatmo_weather à 2.1.0. (#397, #409)
+- Docs : les règles de configuration multi-coordinateurs Zigbee sont reportées dans les pages device et prise en main qui couvrent déjà Zigbee ; nouvelle documentation utilisateur et développeur pour l'arbitre de surplus. (#407)
+
+---
+
 ## 1.38.x: Plusieurs coordinateurs Zigbee
 
 ### v1.38.0 — 2026-08-10 { #v1-38-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,21 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.39.x: Energy surplus arbitration
+
+### v1.39.0 — 2026-08-11 { #v1-39-0 }
+
+- Feat (energy): **the energy surplus arbiter** (spec 140). One core referee hands solar surplus to your flexible loads in the priority order you choose, ending the tug-of-war where several surplus-aware automations each switch on when they see export, overshoot together, and collapse it. Declare a pilotable load (pool pump, water heater, ...) on its equipment page (class, nominal power, minimum on/off, pre-filled from the equipment type and its own measurement), enable the arbiter under Settings > Administration > Energy, and order your loads. Energy > Live gains an arbitration surface: an allocation bar of where production is going right now, a day timeline per load, and a plain-language decision journal. **Opt-in and off by default**, and the arbiter issues no orders itself. It is the foundation surplus-aware recipes claim capacity against (`ctx.helpers.energy`); the recipes that use it ship next, so on this release the arbiter is there to enable and observe. Hardened by two independent adversarial review passes before merge. (#412)
+- Feat (equipments): **order delivery confirmation** (spec 141). A dispatched order succeeding only proved it reached the integration, not the device: a pool pump OFF sent into a 104-second offline window once left the pump running 15.5 h unnoticed (issue #398). Confirmable orders are now watched for the ordered value to actually appear within 30 s (immediate verdict when every target device is offline); if it does not, Sowel raises a warning alarm (forwarded as a push) and re-dispatches once when the device comes back within the hour. (#404)
+- Feat (core): **restored-data guardrail**. A database restored from another deployment carries that deployment's MQTT brokers and channels, so a fully armed instance on such data fights the original. A restored instance now starts inert until you confirm takeover, so the two never race for the same devices. (#405)
+- Fix (mqtt): each process uses a **unique MQTT publisher client id** (random per-connection suffix) and throttles reconnect warnings, so a dev instance running on a copy of a production database no longer mutually kicks the original off the broker. (#402)
+- Fix (logging): daily log files are **date-stamped and retained across container recreation**, and pre-date-format log files left by older versions are purged automatically at boot. (#403, #408)
+- Fix (ui): the equipments list **groups by zone identity, not by zone name** (two rooms sharing a name no longer merge), and the community-plugin badge shows a Users icon rather than a warning triangle. (#406, #411)
+- Chore (registry): Zigbee2MQTT bumped to 2.4.0; pool-pump-schedule to 1.1.0; netatmo_weather to 2.1.0. (#397, #409)
+- Docs: the several-Zigbee-coordinators setup rules are carried into the device and getting-started pages that already cover Zigbee; new user and developer documentation for the surplus arbiter. (#407)
+
+---
+
 ## 1.38.x: Several Zigbee coordinators
 
 ### v1.38.0 — 2026-08-10 { #v1-38-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.38.0",
+  "version": "1.39.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Minor release bundling everything merged since v1.38.0 (11 items), headlined by the energy surplus arbiter.

## Included

- **#412 — energy surplus arbiter (spec 140)**: opt-in, off by default, issues no orders; the foundation surplus-aware recipes claim capacity against. Two independent adversarial review passes before merge.
- #404 — order delivery confirmation (spec 141)
- #405 — restored-data guardrail (inert start until takeover confirmed)
- #402 — unique MQTT publisher client id + reconnect warn throttling
- #403, #408 — date-stamped daily logs + cross-container retention; purge pre-date-format logs at boot
- #406, #411 — equipments list grouped by zone identity; community-plugin badge icon
- #397, #409 — registry bumps (zigbee2mqtt 2.4.0, pool-pump-schedule 1.1.0, netatmo_weather 2.1.0)
- #407 — multi-coordinator docs carried into device/getting-started pages

## Release chores

- Version bump to `1.39.0` in `package.json` and `ui/package.json`.
- Release notes added to `docs/release-notes.md` and `docs/release-notes.fr.md` under a new `1.39.x` section with the `{ #v1-39-0 }` anchor (spec 108), covering the full v1.38.0..main range.

No code change beyond the version bump — the features are already on main.