### PR TITLE
fix(energy): do not suspend the arbiter on a delivery-retry re-dispatch (#420)

### DIFF
--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { CapacityArbiter, trimmedMedian } from "./capacity-arbiter.js";
 import { EventBus } from "../core/event-bus.js";
+import { RETRY_CHANNEL } from "../equipments/order-confirmation-tracker.js";
 import type {
   CapacityClaimHandle,
   CapacityClaimRequest,
@@ -144,7 +145,7 @@ function makeHarness(opts?: {
   const order = (
     equipmentId: string,
     value: unknown,
-    source: { kind: string; instanceId?: string },
+    source: { kind: string; instanceId?: string; channel?: string },
   ) =>
     eventBus.emit({
       type: "equipment.order.executed",
@@ -352,6 +353,25 @@ describe("capacity arbiter", () => {
     h.order("pump", true, { kind: "recipe", instanceId: "i1" });
     expect(h.arbiter.getPublicState().suspensions).toHaveLength(0);
     expect(h.revokedEvents()).toHaveLength(0);
+  });
+
+  // #420 — after a device reconnect the confirmation tracker re-dispatches
+  // Sowel's OWN last unconfirmed order (typically a recipe order) as
+  // { kind: "external", channel: "delivery-retry" }. That is not a human
+  // action: it must neither suspend arbitration nor revoke a live grant.
+  it("an external delivery-retry re-dispatch does NOT suspend a granted load", () => {
+    const h = makeHarness();
+    h.claim("i1", { equipmentId: "pump" });
+    h.run(-1000, 150); // pump granted
+    h.order("pump", true, { kind: "external", channel: RETRY_CHANNEL });
+    expect(h.arbiter.getPublicState().suspensions).toHaveLength(0);
+    expect(h.revokedEvents()).toHaveLength(0);
+  });
+
+  it("a non-retry external order still suspends (genuine external control)", () => {
+    const h = makeHarness();
+    h.order("pump", true, { kind: "external", channel: "home-assistant" });
+    expect(h.arbiter.getPublicState().suspensions[0]?.equipmentId).toBe("pump");
   });
 
   it("resume lifts a suspension immediately", () => {

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -18,6 +18,7 @@ import type { Logger } from "../core/logger.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { SettingsManager } from "../core/settings-manager.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import { RETRY_CHANNEL } from "../equipments/order-confirmation-tracker.js";
 import type {
   ArbiterDecision,
   ArbiterPublicState,
@@ -29,6 +30,7 @@ import type {
   CapacitySlack,
   EnergyLoadProfile,
   EngineEvent,
+  OrderSource,
 } from "../shared/types.js";
 
 const SETTING_PREFIX = "energy.arbiter.";
@@ -385,14 +387,24 @@ export class CapacityArbiter {
   private onOrderExecuted(
     equipmentId: string,
     value: unknown,
-    source: { kind: string; instanceId?: string } | undefined,
+    source: OrderSource | undefined,
   ): void {
     if (!this.config.enabled) return;
     const profile = this.profileOf(equipmentId);
     if (!profile) return;
     const now = Date.now();
 
-    if (source?.kind === "manual" || source?.kind === "button" || source?.kind === "external") {
+    // A human (manual/button) or an external system taking control backs the
+    // arbiter off for overrideTtlS so it does not fight them. The delivery-retry
+    // channel is excluded: that is the order-confirmation tracker re-sending
+    // Sowel's OWN last unconfirmed order after a device reconnect (typically a
+    // recipe order), not a person — counting it as a manual override spuriously
+    // suspended flexible loads on flaky links (#420).
+    if (
+      source?.kind === "manual" ||
+      source?.kind === "button" ||
+      (source?.kind === "external" && source.channel !== RETRY_CHANNEL)
+    ) {
       this.suspend(equipmentId, "user-order");
       return;
     }


### PR DESCRIPTION
## Summary

The capacity arbiter (spec 140) backed off from a flexible load for `overrideTtlS` (2h) on any order with `source.kind === "external"`, treating it as a human taking manual control. But the **only** emitter of `external` in the codebase is the order-confirmation tracker's reconnect re-dispatch (`channel: "delivery-retry"`), which re-sends Sowel's **own** last unconfirmed order (typically a recipe order) after a device goes offline then back online.

Consequence: a flexible load on a flaky link (a Zigbee pool pump driven by a recipe) got a spurious "Manual until HH:MM" suspension with no human involved. The confirmation tracker already ignores its own retry (`channel === RETRY_CHANNEL`); the arbiter did not.

Closes #420.

## Root cause

`onOrderExecuted` in `src/energy/capacity-arbiter.ts` suspended on `manual | button | external` without distinguishing the delivery-retry channel from genuine external control.

## Fix

- Exclude `source.kind === "external" && source.channel === RETRY_CHANNEL` from the manual-override trigger.
- Tighten the handler's `source` param from the loose `{ kind: string; instanceId?: string }` to the real `OrderSource` union, so `channel` is type-checked.
- Import the shared `RETRY_CHANNEL` constant (the tracker's imports are all `import type`, so no runtime cycle).

Genuine `manual`/`button` orders and any future real external-control channel still suspend, unchanged.

## Test plan

- [x] `npm run validate` green: backend typecheck, lint, Prettier, **full test suite** (1291 tests), UI lint (0 errors) + typecheck
- [x] New regression tests in `capacity-arbiter.test.ts` (53 pass, was 51):
  - a `{ kind: "external", channel: "delivery-retry" }` order neither suspends nor revokes a live grant
  - a non-retry external order (`channel: "home-assistant"`) still suspends
- [x] Existing manual/button/recipe suspension behavior unchanged

## Notes

- Phase-1 impact is only the confusing banner (no recipe claims capacity yet, so the suspension has no functional effect today). Once consumer recipes claim, a spurious 2h suspension would have actually stopped the arbiter from managing that load, so this is worth fixing before those ship.
