### PR TITLE
release: v1.40.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,16 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.40.x: Réglages énergie et résilience de l'Activité
+
+### v1.40.0 — 2026-08-11 { #v1-40-0 }
+
+- Feat (ui) : **les réglages d'énergie ont désormais leur propre onglet**. La grille tarifaire et l'arbitre de surplus quittent Réglages > Administration, où ils voisinaient avec la gestion des utilisateurs, pour un onglet dédié **Réglages > Énergie**, rassemblant tout ce qui touche à l'énergie. Chaque seuil avancé de l'arbitre gagne une bulle d'aide au survol expliquant son rôle et son unité, pour qu'ils ne soient plus des nombres opaques. (#418)
+- Fix (energy) : l'arbitre de surplus **ne prend plus une réémission d'ordre pour une commande manuelle**. Quand l'appareil d'une charge pilotable passait hors ligne puis revenait avec un ordre non confirmé, Sowel réémettait cet ordre (le renvoi de confirmation de livraison de la v1.39.0) et l'arbitre y voyait une prise de main humaine, se suspendant deux heures. Il ignore désormais son propre canal de réémission, donc une charge Zigbee instable n'affiche plus un « Manuel jusqu'à ... » injustifié sur son panneau énergie. (#420)
+- Fix (ui) : le **panneau Activité se remet des échecs de chargement passagers** au lieu de rester bloqué sur « Impossible de charger l'activité » jusqu'à ce qu'on quitte la zone et y revienne. Il réessaie, propose un bouton Réessayer, recharge à la reconnexion WebSocket, et ne laisse plus une requête périmée écraser un résultat plus récent. Les rafales de rechargement WebSocket qui pouvaient épuiser la limite de requêtes (un rechargement complet par événement de recette ou d'équipement) sont regroupées, et les requêtes GET réessaient une fois sur une réponse de dépassement de limite. Contribution d'Adrien Jouve (computingify). (#413)
+
+---
+
 ## 1.39.x: Arbitrage du surplus énergie
 
 ### v1.39.1 — 2026-08-11 { #v1-39-1 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,16 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.40.x: Energy settings and Activity resilience
+
+### v1.40.0 — 2026-08-11 { #v1-40-0 }
+
+- Feat (ui): **energy settings now live in their own tab**. The tariff schedule and the surplus arbiter moved out of Settings > Administration, where they sat next to user management, into a dedicated **Settings > Energy** tab, so everything energy is in one place. Each of the arbiter's advanced thresholds gained a hover tooltip explaining what it does and its unit, so they are no longer opaque numbers. (#418)
+- Fix (energy): the surplus arbiter **no longer mistakes an order re-delivery for a manual override**. When a flexible load's device dropped offline and reconnected with an unconfirmed order, Sowel re-sent that order (the delivery-confirmation retry from v1.39.0) and the arbiter read it as a human taking manual control, suspending itself for two hours. It now ignores its own retry channel, so a flaky Zigbee load no longer shows a spurious "Manual until ..." on its energy panel. (#420)
+- Fix (ui): the **Activity panel recovers from transient load failures** instead of staying stuck on "cannot load activity" until you left the zone and came back. It now retries, offers a Retry button, reloads on WebSocket reconnect, and no longer lets a stale request overwrite a newer result. The WebSocket refetch bursts that could exhaust the request rate limit (a full reload per recipe or equipment event) are coalesced, and GET requests retry once on a rate-limit response. Contributed by Adrien Jouve (computingify). (#413)
+
+---
+
 ## 1.39.x: Energy surplus arbitration
 
 ### v1.39.1 — 2026-08-11 { #v1-39-1 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.39.1",
+  "version": "1.40.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.39.1",
+  "version": "1.40.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release **v1.40.0**. Version bump + release notes only (all code already merged since v1.39.1).

## Included since v1.39.1

- **#418** feat(ui): dedicated Energy settings tab (tariffs + surplus arbiter) with tooltips on the arbiter's advanced thresholds.
- **#420** fix(energy): the arbiter no longer treats a delivery-retry re-dispatch as a manual override.
- **#413** fix(ui): the Activity panel recovers from transient load failures (retry, WS-reconnect reload, request coalescing, 429 retry). Contributed by Adrien Jouve (computingify).

## Release notes

Added the `v1.40.0` block to both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-40-0 }` anchor (spec 108).

## Not included

- **#415** (energy delta accumulation) is intentionally held: it is in "changes requested" pending a fix for a data-integrity race (see the PR review).