### PR TITLE
fix(equipments): exempt boolean bindings from streaming staleness (#422)

### DIFF
--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -604,7 +604,7 @@ export class EquipmentManager {
     // Annotate staleness on streaming bindings (spec 116).
     const now = Date.now();
     for (const binding of bindings) {
-      binding.stale = isStaleBinding(binding.category, binding.lastUpdated, now);
+      binding.stale = isStaleBinding(binding.category, binding.lastUpdated, now, binding.type);
     }
 
     return bindings;

--- a/src/equipments/equipment-status.test.ts
+++ b/src/equipments/equipment-status.test.ts
@@ -80,6 +80,17 @@ describe("isStaleBinding", () => {
   it("unparseable timestamp is treated as no value — not stale", () => {
     expect(isStaleBinding("power", "not-a-date", NOW)).toBe(false);
   });
+
+  it("boolean 'power' (on/off state) is never stale, even far beyond the window (#422)", () => {
+    // PAC / TV pattern: a discrete on/off state that legitimately does not
+    // change between polls. Would be stale as a numeric read (2 min window).
+    expect(isStaleBinding("power", "2026-04-19 00:00:00Z", NOW, "boolean")).toBe(false);
+    expect(isStaleBinding("power", "2026-05-26 09:57:00Z", NOW, "boolean")).toBe(false);
+  });
+
+  it("numeric 'power' beyond the window is still stale (live clamp regression guard)", () => {
+    expect(isStaleBinding("power", "2026-05-26 09:57:00Z", NOW, "number")).toBe(true);
+  });
 });
 
 // ─── deriveEquipmentStatus ──────────────────────────────────────────────
@@ -153,6 +164,51 @@ describe("deriveEquipmentStatus", () => {
     expect(result.status).toBe("degraded");
     expect(result.reason?.staleBindings).toEqual(["power"]);
     expect(result.reason?.offlineDevices).toEqual([]);
+  });
+
+  it("boolean 'power' stale by time on an online device stays 'online', not degraded (#422)", () => {
+    // PAC / TV: the on/off state has not changed for a long time, but the
+    // device is online and polling. A steady discrete state must not degrade.
+    const binding = makeBinding({
+      category: "power",
+      type: "boolean",
+      value: true,
+      lastUpdated: "2026-04-19 00:00:00Z", // weeks old
+      alias: "power",
+    });
+    const device = makeDevice({ status: "online" });
+    const map = new Map([[binding.id, device]]);
+    const result = deriveEquipmentStatus([binding], map, NOW);
+    expect(result.status).toBe("online");
+    expect(result.reason).toBeNull();
+  });
+
+  it("stale boolean 'power' alongside fresh bindings on an online device stays 'online' (#422)", () => {
+    // PAC evidence: boolean power (stale) + temperature/setpoint fresh at the
+    // same online device. The stale boolean must not tip the equipment.
+    const power = makeBinding({
+      id: "b-power",
+      category: "power",
+      type: "boolean",
+      value: false,
+      lastUpdated: "2026-04-19 00:00:00Z",
+      alias: "power",
+    });
+    const temperature = makeBinding({
+      id: "b-temp",
+      category: "temperature",
+      type: "number",
+      value: 21,
+      lastUpdated: "2026-05-26 09:59:00Z",
+      alias: "temperature",
+    });
+    const device = makeDevice({ status: "online" });
+    const map = new Map([
+      [power.id, device],
+      [temperature.id, device],
+    ]);
+    const result = deriveEquipmentStatus([power, temperature], map, NOW);
+    expect(result.status).toBe("online");
   });
 
   it("device 'unknown' is treated as online — no degradation alone", () => {

--- a/src/equipments/equipment-status.ts
+++ b/src/equipments/equipment-status.ts
@@ -14,6 +14,7 @@ import {
 import type {
   DataBindingWithValue,
   DataCategory,
+  DataType,
   Device,
   EquipmentStatus,
   EquipmentStatusReason,
@@ -38,13 +39,24 @@ function parseTimestamp(iso: string | null): number | null {
  * is older than the per-category threshold. Bindings that have never received
  * a value (lastUpdated === null) are NOT stale — we never had any value to
  * begin with, so silence is expected.
+ *
+ * A **boolean** value on a streaming category is a discrete on/off state, not a
+ * live stream: a steady state legitimately does not change, and poll-driven or
+ * state-only integrations refresh it on a cadence longer than the streaming
+ * window (e.g. Panasonic Comfort Cloud `power`). Its health comes from
+ * `device.status`, not from a freshness window, so it is exempt from staleness
+ * (issue #422). This mirrors the `SILENCE_EXEMPT_EQUIPMENT_TYPES` exemption for
+ * buttons (#348), at the value-type level instead of the equipment-type level.
+ * Numeric streaming reads (Shelly / Legrand live clamps) are unaffected.
  */
 export function isStaleBinding(
   category: DataCategory,
   lastUpdated: string | null,
   now: number = Date.now(),
+  type?: DataType,
 ): boolean {
   if (!STREAMING_CATEGORIES.has(category)) return false;
+  if (type === "boolean") return false; // discrete on/off state, not a live stream
   const updatedMs = parseTimestamp(lastUpdated);
   if (updatedMs === null) return false;
   const timeoutMs = STREAMING_TIMEOUT_MS[category] ?? DEFAULT_STREAMING_TIMEOUT_MS;
@@ -113,7 +125,7 @@ export function deriveEquipmentStatus(
     (device) => device.status === "offline",
   );
   const staleBindings = bindings.filter((binding) =>
-    isStaleBinding(binding.category, binding.lastUpdated, now),
+    isStaleBinding(binding.category, binding.lastUpdated, now, binding.type),
   );
 
   const allOffline = uniqueDevices.size > 0 && offlineDevices.length === uniqueDevices.size;


### PR DESCRIPTION
## Root cause

`isStaleBinding` keyed the freshness window on the binding **category only**, ignoring the value `type`. `STREAMING_TIMEOUT_MS.power = 2 min` is calibrated for live analog electrical reads (Shelly / Legrand clamps at ~1 Hz), but it was applied identically to a **boolean `power`** on/off state that a polling integration refreshes on its own cadence — often longer than 2 min. A steady on/off value legitimately does not change, so between two polls the binding exceeded the window, went `stale`, and one stale streaming binding tips the whole equipment to `degraded`.

Result: false-positive `degraded` for any equipment whose health signal is a discrete on/off state from a poll-driven or state-only device. Observed on prod (2026-08-11) for **PAC** (Panasonic Comfort Cloud), **TV** (Samsung), **Lave-linge**, all with `device.status === online`.

## Fix

Exempt `type === "boolean"` from staleness in `isStaleBinding` and pass `binding.type` at both call sites (`deriveEquipmentStatus` and `EquipmentManager` binding annotation). A boolean on a streaming category is a discrete state whose health comes from `device.status` (already handled via `offlineDevices`), not from a freshness window. This mirrors the `SILENCE_EXEMPT_EQUIPMENT_TYPES` exemption for buttons (#348), at the value-type level instead of the equipment-type level.

Numeric streaming reads (Shelly / Legrand live clamps) are unaffected: they still degrade on real silence.

## Tests

`src/equipments/equipment-status.test.ts`:
- `isStaleBinding`: a boolean `power` binding is never stale, even weeks old; a numeric `power` binding beyond the window is still stale (regression guard).
- `deriveEquipmentStatus`: a stale boolean `power` on an online device stays `online` (PAC/TV pattern); the same alongside fresh temperature bindings stays `online`; the existing numeric-`power`-stale → `degraded` case is preserved.

Full backend suite green (1325 passing), typecheck + lint clean.

## Out of scope

The **`energy` (numeric)** binding on Lave-linge going stale while the appliance is idle (cumulative counter does not increment) is a separate concern on the numeric side — tracked separately, not addressed here.

Closes #422