### PR TITLE
release: v1.41.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,17 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.41.x: Précision des mesures et alarmes acquittables
+
+### v1.41.0 — 2026-08-12 { #v1-41-0 }
+
+- Feat (ui) : **les alarmes du bandeau peuvent désormais être acquittées**. Une alarme dont la condition persiste (une prise laissée débranchée, un plugin qui reste hors ligne) restait dans la pastille d'alarme de l'en-tête sans aucun moyen de l'effacer. Chaque alarme dispose maintenant d'une action d'acquittement dans la feuille des alarmes ; les alarmes acquittées passent dans une section grisée d'où l'on peut les réafficher, et la pastille de l'en-tête ne compte plus que celles qui ne sont pas acquittées. L'acquittement est mémorisé dans votre navigateur et lié à l'alarme précise, donc la même reste masquée après un rechargement tandis qu'un problème réellement nouveau réapparaît. L'icône de la pastille est désormais un octogone pour les erreurs et un triangle pour les avertissements, cohérente avec la feuille. (#424)
+- Fix (energy) : **l'énergie n'est plus perdue sur les compteurs qui rapportent plusieurs fois par minute**. Un tick d'énergie temps réel porte les wattheures accumulés depuis le précédent, mais la déduplication générique le traitait comme un échantillon et en écartait la plupart, si bien qu'un compteur bavard (le Tuya PJ-1203A publie une trentaine de ticks par minute) voyait sa production plaquée à zéro et laissait le graphe Production vide. Les ticks sont désormais cumulés en un point par minute, la série d'énergie réseau a un écrivain unique pour supprimer une double écriture, et le découpage HP/HC est calculé sur la vraie fenêtre d'une minute au lieu de trente, donc l'énergie n'est plus étalée de part et d'autre d'une bascule tarifaire. L'historique passé n'est pas reconstruit ; les chiffres sont justes à partir de cette version. Contribution d'Adrien Jouve (computingify). (#415)
+- Fix (equipments) : **les équipements reposant sur un état marche/arrêt ne sont plus signalés « dégradés » alors qu'ils sont en ligne**. Un binding power booléen (Panasonic Comfort Cloud, une TV, un lave-linge) se rafraîchit au rythme propre de l'intégration, souvent plus lent que la fenêtre de streaming de deux minutes, si bien qu'un état marche/arrêt stable était lu comme périmé et faisait basculer tout l'équipement en dégradé alors que l'appareil était en ligne et interrogé. Les états booléens sont désormais exemptés de la péremption de streaming ; les lectures numériques temps réel (Shelly, pinces Legrand) continuent de se dégrader sur un vrai silence. (#422)
+- Chore (registry) : pool-pump-schedule passe en 1.2.0 ; smart-cooling en 1.4.0. (#427)
+
+---
+
 ## 1.40.x: Réglages énergie et résilience de l'Activité
 
 ### v1.40.0 — 2026-08-11 { #v1-40-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,17 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.41.x: Metering accuracy and acknowledgeable alarms
+
+### v1.41.0 — 2026-08-12 { #v1-41-0 }
+
+- Feat (ui): **banner alarms can now be acknowledged**. An alarm whose condition persists (a socket left unplugged, a plugin that stays offline) used to sit in the header alarm pill with no way to clear it. Each alarm now has an acknowledge action in the alarms sheet; acknowledged alarms move to a muted section you can restore them from, and the header pill only counts the ones you have not acknowledged. The acknowledgement is remembered in your browser and keyed to the exact alarm, so the same one stays hidden across reloads while a genuinely new problem reappears. The pill icon is now an octagon for errors and a triangle for warnings, matching the sheet. (#424)
+- Fix (energy): **energy is no longer lost on meters that report many times a minute**. A live energy tick carries the watt-hours accumulated since the previous one, but the generic de-duplication treated it as a sample and dropped most of them, so a chatty meter (the Tuya PJ-1203A publishes about thirty ticks a minute) had its production pinned to zero and left the Production chart empty. Ticks are now summed into one point per minute, the grid energy series has a single writer to remove a double-write, and the HP/HC split is computed over the real one-minute window instead of a thirty-minute one, so energy is no longer smeared across a tariff transition. Past data is not backfilled; figures are correct from this release forward. Contributed by Adrien Jouve (computingify). (#415)
+- Fix (equipments): **equipments backed by an on/off state are no longer flagged "degraded" while online**. A boolean power binding (Panasonic Comfort Cloud, a TV, a washing machine) refreshes on the integration's own cadence, often slower than the two-minute streaming window, so a steady on/off value read as stale and tipped the whole equipment to degraded even though the device was online and polling. Boolean states are now exempt from streaming staleness; numeric live reads (Shelly, Legrand clamps) still degrade on genuine silence. (#422)
+- Chore (registry): pool-pump-schedule bumped to 1.2.0; smart-cooling to 1.4.0. (#427)
+
+---
+
 ## 1.40.x: Energy settings and Activity resilience
 
 ### v1.40.0 — 2026-08-11 { #v1-40-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.40.0",
+  "version": "1.41.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release **v1.41.0**. Covers everything on `main` since v1.40.0.

- Feat (ui): banner alarms can be acknowledged; severity icons unified. (#424 / #426)
- Fix (energy): energy no longer lost on chatty meters; single writer for grid energy; HP/HC split over the real one-minute window. (#415)
- Fix (equipments): boolean on/off `power` bindings no longer flag an online equipment as degraded. (#422)
- Chore (registry): pool-pump-schedule 1.2.0, smart-cooling 1.4.0. (#427)

Version bumped in `package.json` + `ui/package.json`; release notes added to `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-41-0 }` anchor (spec 108). Tag is pushed after this merges.