### PR TITLE
chore(registry): bump pool-pump-schedule to 1.2.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "tags": ["pool", "pump", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -340,7 +340,7 @@
     },
     "sowelVersion": ">=1.3.0",
     "owner": "mchacher",
-    "sha256": "7c5130bd06ecd66d0297b2a266fe0ec2e22470b2f6f66a98a76317ce7efd028b"
+    "sha256": "50e17e5ca85ae1bcfe7177b9014258d08047e00cfbea8c170269ee36829fb4ec"
   },
   {
     "id": "freecooling",


### PR DESCRIPTION
Bumps `pool-pump-schedule` 1.2.0 -> **1.2.1** (schema fix: slot 1 can now be cleared in auto mode; it was wrongly `required: true` and blocked the save).

- `sha256` written by `scripts/backfill-registry-sha256.mjs` and independently re-checked with `shasum -a 256` against the published `v1.2.1` release asset — match (`50e17e5c…b4ec`).
- Minimal 2-line diff, JSON valid, compact format preserved.