### PR TITLE
chore(registry): bump pool-pump-schedule to 1.2.2

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "tags": ["pool", "pump", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -340,7 +340,7 @@
     },
     "sowelVersion": ">=1.3.0",
     "owner": "mchacher",
-    "sha256": "50e17e5ca85ae1bcfe7177b9014258d08047e00cfbea8c170269ee36829fb4ec"
+    "sha256": "4bf4d08f508c2bd56666ada75450a16cb13bbed2d2851420b5344056d7bd256d"
   },
   {
     "id": "freecooling",


### PR DESCRIPTION
Bumps `pool-pump-schedule` 1.2.1 -> **1.2.2** (seeds the filtration target immediately on auto-enable instead of showing 0 h until 06:00).

- `sha256` backfilled and independently verified with `shasum -a 256` against the published `v1.2.2` asset — match (`4bf4d08f…256d`).
- Minimal 2-line diff, JSON valid, compact format preserved.