### PR TITLE
feat(ui): show zone paths in every zone dropdown and label (spec 139)

### DIFF
--- a/ui/src/components/dashboard/AddWidgetModal.tsx
+++ b/ui/src/components/dashboard/AddWidgetModal.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { X, Box, Map as MapIcon } from "lucide-react";
 import type { EquipmentWithDetails, ZoneWithChildren, WidgetFamily } from "../../types";
+import { flattenZonesWithPath } from "../../lib/zone-path";
 
 interface AddWidgetModalProps {
   equipments: EquipmentWithDetails[];
@@ -26,18 +27,8 @@ export function AddWidgetModal({
   const [selectedFamily, setSelectedFamily] = useState<WidgetFamily>("lights");
   const [eqZoneId, setEqZoneId] = useState<string>("");
 
-  // Flatten zones for zone picker
-  const flatZones = useMemo(() => {
-    const result: { id: string; name: string; depth: number }[] = [];
-    function walk(zoneList: ZoneWithChildren[], depth: number) {
-      for (const z of zoneList) {
-        result.push({ id: z.id, name: z.name, depth });
-        walk(z.children, depth + 1);
-      }
-    }
-    walk(zones, 0);
-    return result;
-  }, [zones]);
+  // Flatten zones for zone picker, labelled with their disambiguating path (spec 139)
+  const flatZones = useMemo(() => flattenZonesWithPath(zones), [zones]);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
@@ -91,7 +82,7 @@ export function AddWidgetModal({
                   <option value="">{t("dashboard.chooseZone")}</option>
                   {flatZones.map((z) => (
                     <option key={z.id} value={z.id}>
-                      {"  ".repeat(z.depth)}{z.name}
+                      {z.label}
                     </option>
                   ))}
                 </select>
@@ -140,7 +131,7 @@ export function AddWidgetModal({
                   <option value="">{t("dashboard.chooseZone")}</option>
                   {flatZones.map((z) => (
                     <option key={z.id} value={z.id}>
-                      {"  ".repeat(z.depth)}{z.name}
+                      {z.label}
                     </option>
                   ))}
                 </select>

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -398,13 +398,15 @@ function getDescendantZoneIds(zone: ZoneWithChildren): string[] {
 interface ZoneDetailProps {
   widget: DashboardWidget;
   zone: ZoneWithChildren | null;
+  /** Path-aware zone label (spec 139), preferred over the bare zone name. */
+  zoneLabel?: string;
   equipments: EquipmentWithDetails[];
   onClose: () => void;
 }
 
-export function ZoneDetailSheet({ widget, zone, equipments, onClose }: ZoneDetailProps) {
+export function ZoneDetailSheet({ widget, zone, zoneLabel, equipments, onClose }: ZoneDetailProps) {
   const { t } = useTranslation();
-  const label = widget.label || (zone ? `${zone.name}` : "");
+  const label = widget.label || zoneLabel || (zone ? `${zone.name}` : "");
   const family = widget.family;
 
   const zoneIds = useMemo(() => {

--- a/ui/src/components/dashboard/WidgetGrid.tsx
+++ b/ui/src/components/dashboard/WidgetGrid.tsx
@@ -36,6 +36,8 @@ interface WidgetGridProps {
   widgets: DashboardWidget[];
   equipmentMap: Map<string, EquipmentWithDetails>;
   zoneMap: Map<string, ZoneWithChildren>;
+  /** zoneId → path-aware label (spec 139), used wherever a widget shows a zone name. */
+  zoneLabels: Map<string, string>;
   equipments: EquipmentWithDetails[];
   editMode: boolean;
   onExecuteOrder: (equipmentId: string, alias: string, value: unknown) => Promise<void>;
@@ -47,6 +49,7 @@ export function WidgetGrid({
   widgets,
   equipmentMap,
   zoneMap,
+  zoneLabels,
   equipments,
   editMode,
   onExecuteOrder,
@@ -92,6 +95,7 @@ export function WidgetGrid({
               widget={widget}
               equipmentMap={equipmentMap}
               zoneMap={zoneMap}
+              zoneLabels={zoneLabels}
               equipments={equipments}
               onExecuteOrder={onExecuteOrder}
               isMobile={isMobile}
@@ -113,6 +117,7 @@ export function WidgetGrid({
           <ZoneDetailSheet
             widget={detailWidget}
             zone={zoneMap.get(detailWidget.zoneId) ?? null}
+            zoneLabel={zoneLabels.get(detailWidget.zoneId)}
             equipments={equipments}
             onClose={() => setDetailWidgetId(null)}
           />
@@ -131,6 +136,7 @@ export function WidgetGrid({
               widget={widget}
               equipmentMap={equipmentMap}
               zoneMap={zoneMap}
+              zoneLabels={zoneLabels}
               equipments={equipments}
               onExecuteOrder={onExecuteOrder}
               onDelete={onDelete}
@@ -157,6 +163,7 @@ function SortableWidget({
   widget,
   equipmentMap,
   zoneMap,
+  zoneLabels,
   equipments,
   onExecuteOrder,
   onDelete,
@@ -165,6 +172,7 @@ function SortableWidget({
   widget: DashboardWidget;
   equipmentMap: Map<string, EquipmentWithDetails>;
   zoneMap: Map<string, ZoneWithChildren>;
+  zoneLabels: Map<string, string>;
   equipments: EquipmentWithDetails[];
   onExecuteOrder: (equipmentId: string, alias: string, value: unknown) => Promise<void>;
   onDelete: (id: string) => void;
@@ -203,7 +211,7 @@ function SortableWidget({
 
   const currentLabel = widget.label
     || (widget.type === "equipment" && widget.equipmentId ? equipmentMap.get(widget.equipmentId)?.name : undefined)
-    || (widget.type === "zone" && widget.zoneId ? zoneMap.get(widget.zoneId)?.name : undefined)
+    || (widget.type === "zone" && widget.zoneId ? zoneLabels.get(widget.zoneId) : undefined)
     || "";
 
   const handleRenameStart = () => {
@@ -318,6 +326,7 @@ function SortableWidget({
         widget={widget}
         equipmentMap={equipmentMap}
         zoneMap={zoneMap}
+        zoneLabels={zoneLabels}
         equipments={equipments}
         onExecuteOrder={onExecuteOrder}
         isMobile={isMobile}
@@ -331,6 +340,7 @@ function WidgetRenderer({
   widget,
   equipmentMap,
   zoneMap,
+  zoneLabels,
   equipments,
   onExecuteOrder,
   isMobile,
@@ -340,6 +350,7 @@ function WidgetRenderer({
   widget: DashboardWidget;
   equipmentMap: Map<string, EquipmentWithDetails>;
   zoneMap: Map<string, ZoneWithChildren>;
+  zoneLabels: Map<string, string>;
   equipments: EquipmentWithDetails[];
   onExecuteOrder: (equipmentId: string, alias: string, value: unknown) => Promise<void>;
   isMobile?: boolean;
@@ -380,6 +391,7 @@ function WidgetRenderer({
         <MobileZoneCard
           widget={widget}
           zone={zone}
+          zoneLabel={zoneLabels.get(widget.zoneId)}
           equipments={equipments}
           onClick={editMode ? undefined : onOpenDetail}
           editMode={editMode}
@@ -392,6 +404,7 @@ function WidgetRenderer({
       <ZoneWidget
         widget={widget}
         zone={zone}
+        zoneLabel={zoneLabels.get(widget.zoneId)}
         equipments={equipments}
       />
     );
@@ -422,18 +435,20 @@ function getDescendantZoneIds(zone: ZoneWithChildren): string[] {
 function MobileZoneCard({
   widget,
   zone,
+  zoneLabel,
   equipments,
   onClick,
   editMode,
 }: {
   widget: DashboardWidget;
   zone: ZoneWithChildren | null;
+  zoneLabel?: string;
   equipments: EquipmentWithDetails[];
   onClick?: () => void;
   editMode?: boolean;
 }) {
   const { t } = useTranslation();
-  const label = widget.label || zone?.name || t("dashboard.unknownZone");
+  const label = widget.label || zoneLabel || zone?.name || t("dashboard.unknownZone");
   const family = widget.family;
 
   // Filter equipments for this zone + family

--- a/ui/src/components/dashboard/ZoneWidget.tsx
+++ b/ui/src/components/dashboard/ZoneWidget.tsx
@@ -42,6 +42,8 @@ const WIDGET_FAMILY_TYPES: Record<WidgetFamily, string[]> = {
 interface ZoneWidgetProps {
   widget: DashboardWidget;
   zone: ZoneWithChildren | null;
+  /** Path-aware zone label (spec 139), preferred over the bare zone name. */
+  zoneLabel?: string;
   equipments: EquipmentWithDetails[];
 }
 
@@ -53,7 +55,7 @@ function getDescendantZoneIds(zone: ZoneWithChildren): string[] {
   return ids;
 }
 
-export function ZoneWidget({ widget, zone, equipments }: ZoneWidgetProps) {
+export function ZoneWidget({ widget, zone, zoneLabel, equipments }: ZoneWidgetProps) {
   const { t } = useTranslation();
   const [commandLoading, setCommandLoading] = useState<string | null>(null);
 
@@ -71,7 +73,7 @@ export function ZoneWidget({ widget, zone, equipments }: ZoneWidgetProps) {
     );
   }, [equipments, zoneIds, familyTypes]);
 
-  const zoneName = zone?.name ?? t("dashboard.unknownZone");
+  const zoneName = zoneLabel ?? zone?.name ?? t("dashboard.unknownZone");
   const label = widget.label || zoneName;
 
   const handleZoneCommand = useCallback(async (orderKey: string, value?: unknown) => {

--- a/ui/src/components/energy/ArbitrationSurface.tsx
+++ b/ui/src/components/energy/ArbitrationSurface.tsx
@@ -3,8 +3,14 @@ import { useTranslation } from "react-i18next";
 import { Scale } from "lucide-react";
 import { useArbiter } from "../../store/useArbiter";
 import { useEquipments } from "../../store/useEquipments";
+import { useZones } from "../../store/useZones";
 import type { ArbiterDecision, ArbiterPublicState } from "../../types";
 import { buildLanes, isToday, minuteOfDay, type Lane } from "../../lib/arbitration-lanes";
+import {
+  equipmentLabelMap,
+  flattenZonesWithPath,
+  zoneChainMap,
+} from "../../lib/zone-path";
 
 /**
  * Spec 140 / FR-10 — the arbitration surface on Energy → Live. Normative
@@ -212,15 +218,18 @@ export function ArbitrationSurface() {
   const state = useArbiter((s) => s.state);
   const fetch = useArbiter((s) => s.fetch);
   const equipments = useEquipments((s) => s.equipments);
+  const zoneTree = useZones((s) => s.tree);
 
   useEffect(() => {
     void fetch();
   }, [fetch]);
 
-  const profiled = useMemo(
-    () => equipments.filter((e) => e.energyProfile).map((e) => ({ id: e.id, name: e.name })),
-    [equipments],
-  );
+  // Homonym profiled loads get a `name — zone` lane label (spec 139).
+  const profiled = useMemo(() => {
+    const list = equipments.filter((e) => e.energyProfile);
+    const labels = equipmentLabelMap(list, zoneChainMap(flattenZonesWithPath(zoneTree)));
+    return list.map((e) => ({ id: e.id, name: labels.get(e.id) ?? e.name }));
+  }, [equipments, zoneTree]);
 
   const now = new Date();
   const nowMin = now.getHours() * 60 + now.getMinutes();

--- a/ui/src/components/energy/EnergyPage.tsx
+++ b/ui/src/components/energy/EnergyPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useEnergy } from "../../store/useEnergy";
 import { useUiState } from "../../store/useUiState";
+import { useZones } from "../../store/useZones";
 import { PeriodSelector } from "./PeriodSelector";
 import { EnergyBarChart } from "./EnergyBarChart";
 import { EnergyByUsageChart } from "./EnergyByUsageChart";
@@ -10,6 +11,11 @@ import { UnitToggle } from "./UnitToggle";
 import { formatEnergyOrCost, formatKWh } from "./format";
 import { getEnergyByUsage, getEquipments } from "../../api";
 import type { EnergyByUsageResponse } from "../../types";
+import {
+  equipmentLabelMap,
+  flattenZonesWithPath,
+  zoneChainMap,
+} from "../../lib/zone-path";
 
 const AUTOCONSO_COLOR = "#6BCB77";
 
@@ -32,19 +38,25 @@ export function EnergyPage() {
   const [hasSubmeters, setHasSubmeters] = useState(false);
   const [byUsage, setByUsage] = useState<EnergyByUsageResponse | null>(null);
   const [byUsageLoading, setByUsageLoading] = useState(false);
+  const [submeterLookup, setSubmeterLookup] = useState<
+    { id: string; name: string; zoneId: string }[]
+  >([]);
+  const zoneTree = useZones((s) => s.tree);
 
   useEffect(() => {
     fetchHistory();
     checkAvailability();
   }, [fetchHistory, checkAvailability]);
 
-  // Detect whether at least one submeter is configured.
+  // Detect whether at least one submeter is configured, and keep the
+  // id → zone lookup used to disambiguate homonym submeters (spec 139).
   useEffect(() => {
     let cancelled = false;
     getEquipments()
       .then((list) => {
         if (cancelled) return;
         setHasSubmeters(list.some((e) => e.type === "energy_meter" && e.enabled));
+        setSubmeterLookup(list.map((e) => ({ id: e.id, name: e.name, zoneId: e.zoneId })));
       })
       .catch(() => {});
     return () => {
@@ -73,6 +85,25 @@ export function EnergyPage() {
       cancelled = true;
     };
   }, [viewMode, period, date]);
+
+  // Homonym submeters get a `name — zone` series label (spec 139). The series
+  // names come from the backend, so the override is keyed by equipment id and
+  // falls back to the backend name for deleted equipments.
+  const labelledByUsage = useMemo(() => {
+    if (!byUsage) return null;
+    const ids = new Set(byUsage.submeters.map((s) => s.id));
+    const labels = equipmentLabelMap(
+      submeterLookup.filter((e) => ids.has(e.id)),
+      zoneChainMap(flattenZonesWithPath(zoneTree)),
+    );
+    return {
+      ...byUsage,
+      submeters: byUsage.submeters.map((s) => ({
+        ...s,
+        name: labels.get(s.id) ?? s.name,
+      })),
+    };
+  }, [byUsage, submeterLookup, zoneTree]);
 
   const hasHpHc = history ? history.totals.total_hc > 0 : false;
 
@@ -131,9 +162,9 @@ export function EnergyPage() {
                 <div className="flex items-center justify-center h-[350px] text-text-tertiary text-[13px]">
                   {t("common.loading")}
                 </div>
-              ) : byUsage ? (
+              ) : labelledByUsage ? (
                 <EnergyByUsageChart
-                  data={byUsage}
+                  data={labelledByUsage}
                   period={period}
                   date={date}
                   height={350}

--- a/ui/src/components/energy/LiveSubmeterBreakdown.tsx
+++ b/ui/src/components/energy/LiveSubmeterBreakdown.tsx
@@ -10,11 +10,18 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useEquipments } from "../../store/useEquipments";
+import { useZones } from "../../store/useZones";
 import {
   buildSubmeterRows,
   computeOther,
   type SubmeterRow,
 } from "./submeter-helpers";
+import { isSubmeterEquipment } from "../../lib/metering";
+import {
+  equipmentLabelMap,
+  flattenZonesWithPath,
+  zoneChainMap,
+} from "../../lib/zone-path";
 
 const HOUSE_COLOR = "#4F7BE8"; // matches HP_COLOR in LiveEnergyPage
 const OTHER_COLOR = "#A1A1AA"; // var(--n-300), neutral grey
@@ -60,8 +67,17 @@ function formatRelative(iso: string | null): string {
 export function LiveSubmeterBreakdown({ house, hasMainMeter }: Props) {
   const { t } = useTranslation();
   const equipments = useEquipments((s) => s.equipments);
+  const zoneTree = useZones((s) => s.tree);
 
-  const rows = useMemo(() => buildSubmeterRows(equipments), [equipments]);
+  // Homonym submeters get a `name — zone` label (spec 139); the qualifier
+  // only appears when two submeters actually share a name.
+  const rows = useMemo(() => {
+    const labels = equipmentLabelMap(
+      equipments.filter((eq) => isSubmeterEquipment(eq)),
+      zoneChainMap(flattenZonesWithPath(zoneTree)),
+    );
+    return buildSubmeterRows(equipments, labels);
+  }, [equipments, zoneTree]);
   if (rows.length === 0) return null;
 
   const submeterSum = rows.reduce((acc, r) => acc + (r.power ?? 0), 0);

--- a/ui/src/components/energy/submeter-helpers.ts
+++ b/ui/src/components/energy/submeter-helpers.ts
@@ -42,9 +42,13 @@ export function readSubmeterPower(eq: EquipmentWithDetails): number | null {
  *      chart, so a given equipment gets the same color in both views.
  *   3. Re-sort the rows for display: by power descending, then null-power
  *      (offline / no data) last.
+ *
+ * `labels` optionally overrides display names by equipment id (spec 139 —
+ * `name — zone` for homonym submeters); sorting uses the displayed name.
  */
 export function buildSubmeterRows(
   equipments: EquipmentWithDetails[],
+  labels?: Map<string, string>,
 ): SubmeterRow[] {
   const byId = [...equipments]
     .filter((eq) => isSubmeterEquipment(eq))
@@ -52,7 +56,7 @@ export function buildSubmeterRows(
 
   const rows: SubmeterRow[] = byId.map((eq, idx) => ({
     id: eq.id,
-    name: eq.name,
+    name: labels?.get(eq.id) ?? eq.name,
     power: readSubmeterPower(eq),
     status: eq.status,
     offlineSince: eq.statusReason?.offlineSince ?? null,

--- a/ui/src/components/equipments/ButtonActionsSection.tsx
+++ b/ui/src/components/equipments/ButtonActionsSection.tsx
@@ -8,6 +8,7 @@ import { useRecipes } from "../../store/useRecipes";
 import { useZones } from "../../store/useZones";
 import type { ButtonActionBinding, ButtonEffectType, ZoneWithChildren } from "../../types";
 import { allSupportStop } from "../../lib/binding-utils";
+import { flattenZonesWithPath } from "../../lib/zone-path";
 
 const DEFAULT_BUTTON_ACTIONS = ["single", "double", "hold"];
 
@@ -22,18 +23,6 @@ const ZONE_ORDER_OPTIONS: { key: string; group: string; parametric: boolean }[] 
   { key: "allThermostatsPowerOff", group: "heating", parametric: false },
   { key: "allThermostatsSetpoint", group: "heating", parametric: true },
 ];
-
-function flattenZones(tree: ZoneWithChildren[]): { id: string; name: string }[] {
-  const result: { id: string; name: string }[] = [];
-  const walk = (nodes: ZoneWithChildren[]) => {
-    for (const z of nodes) {
-      result.push({ id: z.id, name: z.name });
-      walk(z.children);
-    }
-  };
-  walk(tree);
-  return result;
-}
 
 /** Zone id itself plus every descendant, matching the backend's own
  *  zone-order scope (POST /zones/:id/orders/:orderKey acts on the whole
@@ -70,8 +59,8 @@ export function ButtonActionsSection({ equipmentId }: ButtonActionsSectionProps)
   const fetchModes = useModes((s) => s.fetchModes);
   const equipments = useEquipments((s) => s.equipments);
   const zoneTree = useZones((s) => s.tree);
-  // Flatten zone tree for name lookup
-  const zones = flattenZones(zoneTree);
+  // Flatten zone tree for label lookup (path-aware, spec 139)
+  const zones = useMemo(() => flattenZonesWithPath(zoneTree), [zoneTree]);
   const instances = useRecipes((s) => s.instances);
 
   // Derive action values from the equipment's "action" data binding enum values
@@ -140,7 +129,7 @@ export function ButtonActionsSection({ equipmentId }: ButtonActionsSectionProps)
       }
       case "equipment_order": {
         const eq = equipments.find((e) => e.id === binding.config.equipmentId);
-        const zoneName = eq ? zones.find((z) => z.id === eq.zoneId)?.name : undefined;
+        const zoneName = eq ? zones.find((z) => z.id === eq.zoneId)?.label : undefined;
         const eqName = eq ? (zoneName ? `${zoneName} — ${eq.name}` : eq.name) : String(binding.config.equipmentId);
         const val = binding.config.value;
         const valueStr = val != null && val !== "" ? ` = ${val}` : "";
@@ -156,7 +145,7 @@ export function ButtonActionsSection({ equipmentId }: ButtonActionsSectionProps)
         const orderKey = String(binding.config.orderKey);
         const val = binding.config.value;
         const valueStr = val != null && val !== "" ? ` = ${val}` : "";
-        return `${t("buttonActions.effectType.zone_order")} → ${zone?.name ?? "?"} · ${t(`buttonActions.zoneOrder.${orderKey}`)}${valueStr}`;
+        return `${t("buttonActions.effectType.zone_order")} → ${zone?.label ?? "?"} · ${t(`buttonActions.zoneOrder.${orderKey}`)}${valueStr}`;
       }
       default:
         return binding.effectType;
@@ -266,7 +255,7 @@ function AddEffectForm({
 }: {
   modes: { id: string; name: string; active: boolean }[];
   equipments: { id: string; name: string; type: string; zoneId: string; orderBindings: { alias: string; type?: string; category?: string; enumValues?: string[]; min?: number; max?: number }[] }[];
-  zones: { id: string; name: string }[];
+  zones: { id: string; label: string }[];
   zoneTree: ZoneWithChildren[];
   instances: { id: string; recipeId: string }[];
   actionValues: string[];
@@ -541,7 +530,7 @@ function AddEffectForm({
             >
               <option value="">{t("common.select")}</option>
               {zones.map((z) => (
-                <option key={z.id} value={z.id}>{z.name}</option>
+                <option key={z.id} value={z.id}>{z.label}</option>
               ))}
             </select>
           </div>
@@ -688,7 +677,7 @@ function AddEffectForm({
             >
               <option value="">{t("common.select")}</option>
               {zones.map((z) => (
-                <option key={z.id} value={z.id}>{z.name}</option>
+                <option key={z.id} value={z.id}>{z.label}</option>
               ))}
             </select>
           </div>

--- a/ui/src/components/equipments/EquipmentForm.tsx
+++ b/ui/src/components/equipments/EquipmentForm.tsx
@@ -4,6 +4,7 @@ import { X } from "lucide-react";
 import type { EquipmentType, ZoneWithChildren } from "../../types";
 import { DeviceSelector } from "./DeviceSelector";
 import { getDevices, type DeviceWithData } from "../../api";
+import { flattenZonesWithPath } from "../../lib/zone-path";
 
 const EQUIPMENT_TYPE_KEYS: { value: EquipmentType; labelKey: string }[] = [
   { value: "light_onoff", labelKey: "equipments.type.light_onoff" },
@@ -92,7 +93,7 @@ export function EquipmentForm({ title, initial, defaultZoneId, zones, onSubmit, 
     return { ok: hasPac && hasRelay, hasPac, hasRelay };
   }, [type, allDevices, selectedDeviceIds]);
 
-  const flatZones = flattenZones(zones);
+  const flatZones = useMemo(() => flattenZonesWithPath(zones), [zones]);
   const availableTypes = excludeTypes
     ? EQUIPMENT_TYPE_KEYS.filter((et) => !excludeTypes.has(et.value))
     : EQUIPMENT_TYPE_KEYS;
@@ -286,17 +287,4 @@ export function EquipmentForm({ title, initial, defaultZoneId, zones, onSubmit, 
       </div>
     </div>
   );
-}
-
-function flattenZones(zones: ZoneWithChildren[]): { id: string; name: string; label: string }[] {
-  const result: { id: string; name: string; label: string }[] = [];
-  function walk(list: ZoneWithChildren[], parentLabel?: string) {
-    for (const z of list) {
-      const label = parentLabel ? `${parentLabel} › ${z.name}` : z.name;
-      result.push({ id: z.id, name: z.name, label });
-      if (z.children.length > 0) walk(z.children, label);
-    }
-  }
-  walk(zones);
-  return result;
 }

--- a/ui/src/components/zones/ZoneForm.tsx
+++ b/ui/src/components/zones/ZoneForm.tsx
@@ -2,12 +2,13 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { X } from "lucide-react";
 import type { ZoneWithChildren } from "../../types";
+import { flattenZonesWithPath, type ZoneOption } from "../../lib/zone-path";
 
 interface ZoneFormProps {
   /** If provided, we're editing this zone. Otherwise creating a new one. */
   initial?: { name: string; description?: string; icon?: string };
   /** Available parent zones for the dropdown */
-  parentZones: { id: string; name: string; depth: number }[];
+  parentZones: ZoneOption[];
   /** Pre-selected parent zone ID */
   defaultParentId?: string | null;
   onSubmit: (data: {
@@ -96,7 +97,7 @@ export function ZoneForm({ initial, parentZones, defaultParentId, onSubmit, onCl
               <option value="">{t("zones.form.parentNone")}</option>
               {parentZones.map((z) => (
                 <option key={z.id} value={z.id}>
-                  {"  ".repeat(z.depth)}{z.name}
+                  {z.label}
                 </option>
               ))}
             </select>
@@ -146,18 +147,31 @@ export function ZoneForm({ initial, parentZones, defaultParentId, onSubmit, onCl
   );
 }
 
-/** Flatten zone tree into a list with depth info (for parent dropdown) */
+/** Flatten the zone tree for the parent dropdown, labelling every zone with its
+ *  disambiguating path (spec 139). `excludeId` drops that zone and its whole
+ *  subtree — a zone cannot become its own descendant. Labels are computed on
+ *  the full tree, so they stay stable regardless of the exclusion. */
 // eslint-disable-next-line react-refresh/only-export-components -- utility co-located with ZoneForm
 export function flattenZoneTree(
   zones: ZoneWithChildren[],
-  depth = 0,
   excludeId?: string
-): { id: string; name: string; depth: number }[] {
-  const result: { id: string; name: string; depth: number }[] = [];
-  for (const zone of zones) {
-    if (zone.id === excludeId) continue;
-    result.push({ id: zone.id, name: zone.name, depth });
-    result.push(...flattenZoneTree(zone.children, depth + 1, excludeId));
+): ZoneOption[] {
+  const excluded = new Set<string>();
+  if (excludeId) {
+    const collect = (z: ZoneWithChildren) => {
+      excluded.add(z.id);
+      z.children.forEach(collect);
+    };
+    const find = (nodes: ZoneWithChildren[]): ZoneWithChildren | null => {
+      for (const z of nodes) {
+        if (z.id === excludeId) return z;
+        const found = find(z.children);
+        if (found) return found;
+      }
+      return null;
+    };
+    const node = find(zones);
+    if (node) collect(node);
   }
-  return result;
+  return flattenZonesWithPath(zones).filter((z) => !excluded.has(z.id));
 }

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -9,6 +9,7 @@ import { useWsSubscription } from "../hooks/useWsSubscription";
 import { WidgetGrid } from "../components/dashboard/WidgetGrid";
 import { AddWidgetModal } from "../components/dashboard/AddWidgetModal";
 import type { ZoneWithChildren, WidgetFamily } from "../types";
+import { flattenZonesWithPath } from "../lib/zone-path";
 
 export function DashboardPage() {
   useWsSubscription(["equipments", "zones"]);
@@ -48,6 +49,13 @@ export function DashboardPage() {
     walk(tree);
     return map;
   }, [tree]);
+
+  // Path-aware zone labels (spec 139): a widget on one of two homonym zones
+  // must say which one it watches.
+  const zoneLabels = useMemo(
+    () => new Map(flattenZonesWithPath(tree).map((z) => [z.id, z.label])),
+    [tree],
+  );
 
   // Build equipment map for fast lookup
   const equipmentMap = useMemo(() => {
@@ -177,6 +185,7 @@ export function DashboardPage() {
           widgets={widgets}
           equipmentMap={equipmentMap}
           zoneMap={zoneMap}
+          zoneLabels={zoneLabels}
           equipments={equipments}
           editMode={editMode}
           onExecuteOrder={executeOrder}

--- a/ui/src/pages/DevicesPage.tsx
+++ b/ui/src/pages/DevicesPage.tsx
@@ -5,7 +5,7 @@ import { useDevices } from "../store/useDevices";
 import { useEquipments } from "../store/useEquipments";
 import { useZones } from "../store/useZones";
 import { DeviceList } from "../components/devices/DeviceList";
-import type { ZoneWithChildren } from "../types";
+import { flattenZonesWithPath } from "../lib/zone-path";
 import { Radio, Loader2, Search, X } from "lucide-react";
 import { useWsSubscription } from "../hooks/useWsSubscription";
 import { INTEGRATION_LABELS } from "../constants";
@@ -22,18 +22,11 @@ export function DevicesPage() {
   const equipments = useEquipments((s) => s.equipments);
   const zoneTree = useZones((s) => s.tree);
 
-  // Flatten zone tree into id → name map
-  const zoneNames = useMemo(() => {
-    const map = new Map<string, string>();
-    const walk = (zones: ZoneWithChildren[]) => {
-      for (const z of zones) {
-        map.set(z.id, z.name);
-        if (z.children) walk(z.children);
-      }
-    };
-    walk(zoneTree);
-    return map;
-  }, [zoneTree]);
+  // Flatten zone tree into id → path-aware label map (spec 139)
+  const zoneNames = useMemo(
+    () => new Map(flattenZonesWithPath(zoneTree).map((z) => [z.id, z.label])),
+    [zoneTree],
+  );
 
   // Build map: deviceId → list of equipments that reference it via bindings
   const deviceEquipmentMap = useMemo(() => {

--- a/ui/src/pages/ModeDetailPage.tsx
+++ b/ui/src/pages/ModeDetailPage.tsx
@@ -16,6 +16,7 @@ import { useAuth } from "../store/useAuth";
 import { ModeForm } from "../components/modes/ModeForm";
 import type { ModeWithDetails, EquipmentWithDetails, ZoneModeImpactAction, CalendarSlot, ButtonActionBinding } from "../types";
 import { useWsSubscription } from "../hooks/useWsSubscription";
+import { flattenZonesWithPath } from "../lib/zone-path";
 
 export function ModeDetailPage() {
   useWsSubscription(["modes"]);
@@ -114,18 +115,9 @@ export function ModeDetailPage() {
     );
   }
 
-  // Find zone names for impacts
-  const findZoneName = (zoneId: string): string => {
-    const find = (zones: typeof tree): string | null => {
-      for (const z of zones) {
-        if (z.id === zoneId) return z.name;
-        const found = find(z.children);
-        if (found) return found;
-      }
-      return null;
-    };
-    return find(tree) ?? zoneId;
-  };
+  // Path-aware zone labels for impacts (spec 139)
+  const zoneLabels = new Map(flattenZonesWithPath(tree).map((z) => [z.id, z.label]));
+  const findZoneName = (zoneId: string): string => zoneLabels.get(zoneId) ?? zoneId;
 
   return (
     <div className="p-4 sm:p-6">

--- a/ui/src/pages/MqttPublishersPage.tsx
+++ b/ui/src/pages/MqttPublishersPage.tsx
@@ -40,6 +40,7 @@ import type {
   RecipeInfo,
   MqttBroker,
 } from "../types";
+import { flattenZonesWithPath, type ZoneOption } from "../lib/zone-path";
 
 const ZONE_AGG_KEYS = [
   "temperature",
@@ -542,7 +543,7 @@ function PublisherCard({
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<number | null>(null);
 
-  const flatZones = flattenZones(zones);
+  const flatZones = flattenZonesWithPath(zones);
   const broker = brokers.find((b) => b.id === publisher.brokerId);
 
   if (editing) {
@@ -610,7 +611,7 @@ function PublisherCard({
       return `${label} → ${mapping.sourceKey}`;
     }
     const zone = flatZones.find((z) => z.id === mapping.sourceId);
-    return zone ? `${zone.name} → ${mapping.sourceKey}` : `??? → ${mapping.sourceKey}`;
+    return zone ? `${zone.label} → ${mapping.sourceKey}` : `??? → ${mapping.sourceKey}`;
   };
 
   return (
@@ -759,7 +760,7 @@ function MappingRow({
   mapping: MqttPublisherMapping;
   label: string;
   equipments: EquipmentWithDetails[];
-  zones: FlatZone[];
+  zones: ZoneOption[];
   recipeInstances: RecipeInstance[];
   recipes: RecipeInfo[];
   onRefresh: () => void;
@@ -907,7 +908,7 @@ function MappingRow({
               </option>
               {zones.map((z) => (
                 <option key={z.id} value={z.id}>
-                  {z.name}
+                  {z.label}
                 </option>
               ))}
             </select>
@@ -1052,24 +1053,6 @@ function MappingRow({
 
 // ── Add mapping form ─────────────────────────────────────────
 
-interface FlatZone {
-  id: string;
-  name: string;
-}
-
-function flattenZones(zones: ZoneWithChildren[]): FlatZone[] {
-  const result: FlatZone[] = [];
-  const recurse = (list: ZoneWithChildren[], parentLabel?: string) => {
-    for (const z of list) {
-      const label = parentLabel ? `${parentLabel} › ${z.name}` : z.name;
-      result.push({ id: z.id, name: label });
-      if (z.children.length > 0) recurse(z.children, label);
-    }
-  };
-  recurse(zones, undefined);
-  return result;
-}
-
 function AddMappingForm({
   publisherId,
   equipments,
@@ -1081,7 +1064,7 @@ function AddMappingForm({
 }: {
   publisherId: string;
   equipments: EquipmentWithDetails[];
-  zones: FlatZone[];
+  zones: ZoneOption[];
   recipeInstances: RecipeInstance[];
   recipes: RecipeInfo[];
   onAdded: () => void;
@@ -1205,7 +1188,7 @@ function AddMappingForm({
             </option>
             {zones.map((z) => (
               <option key={z.id} value={z.id}>
-                {z.name}
+                {z.label}
               </option>
             ))}
           </select>

--- a/ui/src/pages/MqttPublishersPage.tsx
+++ b/ui/src/pages/MqttPublishersPage.tsx
@@ -40,7 +40,7 @@ import type {
   RecipeInfo,
   MqttBroker,
 } from "../types";
-import { flattenZonesWithPath, type ZoneOption } from "../lib/zone-path";
+import { equipmentLabelMap, flattenZonesWithPath, zoneChainMap, type ZoneOption } from "../lib/zone-path";
 
 const ZONE_AGG_KEYS = [
   "temperature",
@@ -544,6 +544,8 @@ function PublisherCard({
   const [testResult, setTestResult] = useState<number | null>(null);
 
   const flatZones = flattenZonesWithPath(zones);
+  // Homonym equipments get a "name - zone" label in mapping rows (spec 139).
+  const eqLabels = equipmentLabelMap(equipments, zoneChainMap(flatZones));
   const broker = brokers.find((b) => b.id === publisher.brokerId);
 
   if (editing) {
@@ -602,7 +604,7 @@ function PublisherCard({
   const resolveSourceLabel = (mapping: MqttPublisherMapping): string => {
     if (mapping.sourceType === "equipment") {
       const eq = equipments.find((e) => e.id === mapping.sourceId);
-      return eq ? `${eq.name} → ${mapping.sourceKey}` : `??? → ${mapping.sourceKey}`;
+      return eq ? `${eqLabels.get(eq.id) ?? eq.name} → ${mapping.sourceKey}` : `??? → ${mapping.sourceKey}`;
     }
     if (mapping.sourceType === "recipe") {
       const inst = recipeInstances.find((i) => i.id === mapping.sourceId);
@@ -779,6 +781,10 @@ function MappingRow({
     ? equipments.filter((e) => e.zoneId === filterZoneId)
     : equipments;
 
+  // Homonym equipments get a "name - zone" label (spec 139), qualified only
+  // against the other candidates in this dropdown.
+  const eqLabels = equipmentLabelMap(filteredEquipments, zoneChainMap(zones));
+
   const filteredRecipeInstances = filterZoneId
     ? recipeInstances.filter((i) => i.params.zone === filterZoneId)
     : recipeInstances;
@@ -930,7 +936,7 @@ function MappingRow({
                 <option value="">{t("mqttPublishers.selectSource")}</option>
                 {filteredEquipments.map((eq) => (
                   <option key={eq.id} value={eq.id}>
-                    {eq.name}
+                    {eqLabels.get(eq.id) ?? eq.name}
                   </option>
                 ))}
               </select>
@@ -1084,6 +1090,10 @@ function AddMappingForm({
     ? equipments.filter((e) => e.zoneId === filterZoneId)
     : equipments;
 
+  // Homonym equipments get a "name - zone" label (spec 139), qualified only
+  // against the other candidates in this dropdown.
+  const eqLabels = equipmentLabelMap(filteredEquipments, zoneChainMap(zones));
+
   // Recipe instances filtered by selected zone (zone stored in params.zone)
   const filteredRecipeInstances = filterZoneId
     ? recipeInstances.filter((i) => i.params.zone === filterZoneId)
@@ -1211,7 +1221,7 @@ function AddMappingForm({
               <option value="">{t("mqttPublishers.selectSource")}</option>
               {filteredEquipments.map((eq) => (
                 <option key={eq.id} value={eq.id}>
-                  {eq.name}
+                  {eqLabels.get(eq.id) ?? eq.name}
                 </option>
               ))}
             </select>

--- a/ui/src/pages/NotificationPublishersPage.tsx
+++ b/ui/src/pages/NotificationPublishersPage.tsx
@@ -47,6 +47,7 @@ import {
   repeatFieldsFor,
   type RepeatMode,
 } from "../lib/notif-mapping";
+import { flattenZonesWithPath, type ZoneOption } from "../lib/zone-path";
 
 const ZONE_AGG_KEYS = [
   "temperature",
@@ -403,7 +404,7 @@ function PublisherCard({
   const [testChannelOk, setTestChannelOk] = useState(false);
   const [testResult, setTestResult] = useState<number | null>(null);
 
-  const flatZones = flattenZones(zones);
+  const flatZones = flattenZonesWithPath(zones);
 
   if (editing) {
     return (
@@ -476,7 +477,7 @@ function PublisherCard({
       const eq = equipments.find((e) => e.id === mapping.sourceId);
       if (!eq) return `??? → ${mapping.sourceKey}`;
       const zone = flatZones.find((z) => z.id === eq.zoneId);
-      const zoneName = zone ? zone.name : "";
+      const zoneName = zone ? zone.label : "";
       return zoneName
         ? `${eq.name} (${zoneName}) → ${mapping.sourceKey}`
         : `${eq.name} → ${mapping.sourceKey}`;
@@ -488,11 +489,11 @@ function PublisherCard({
       const zoneId = inst?.params?.zone as string | undefined;
       const zone = zoneId ? flatZones.find((z) => z.id === zoneId) : undefined;
       return zone
-        ? `${label} (${zone.name}) → ${mapping.sourceKey}`
+        ? `${label} (${zone.label}) → ${mapping.sourceKey}`
         : `${label} → ${mapping.sourceKey}`;
     }
     const zone = flatZones.find((z) => z.id === mapping.sourceId);
-    return zone ? `${zone.name} → ${mapping.sourceKey}` : `??? → ${mapping.sourceKey}`;
+    return zone ? `${zone.label} → ${mapping.sourceKey}` : `??? → ${mapping.sourceKey}`;
   };
 
   return (
@@ -702,7 +703,7 @@ function MappingRow({
   mapping: NotificationPublisherMapping;
   label: string;
   equipments: EquipmentWithDetails[];
-  zones: FlatZone[];
+  zones: ZoneOption[];
   recipeInstances: RecipeInstance[];
   recipes: RecipeInfo[];
   onRefresh: () => void;
@@ -859,7 +860,7 @@ function MappingRow({
               </option>
               {zones.map((z) => (
                 <option key={z.id} value={z.id}>
-                  {z.name}
+                  {z.label}
                 </option>
               ))}
             </select>
@@ -1020,24 +1021,6 @@ function MappingRow({
 
 // ── Add mapping form ─────────────────────────────────────────
 
-interface FlatZone {
-  id: string;
-  name: string;
-}
-
-function flattenZones(zones: ZoneWithChildren[]): FlatZone[] {
-  const result: FlatZone[] = [];
-  const recurse = (list: ZoneWithChildren[], parentLabel?: string) => {
-    for (const z of list) {
-      const label = parentLabel ? `${parentLabel} › ${z.name}` : z.name;
-      result.push({ id: z.id, name: label });
-      if (z.children.length > 0) recurse(z.children, label);
-    }
-  };
-  recurse(zones, undefined);
-  return result;
-}
-
 function AddMappingForm({
   publisherId,
   equipments,
@@ -1049,7 +1032,7 @@ function AddMappingForm({
 }: {
   publisherId: string;
   equipments: EquipmentWithDetails[];
-  zones: FlatZone[];
+  zones: ZoneOption[];
   recipeInstances: RecipeInstance[];
   recipes: RecipeInfo[];
   onAdded: () => void;
@@ -1179,7 +1162,7 @@ function AddMappingForm({
             </option>
             {zones.map((z) => (
               <option key={z.id} value={z.id}>
-                {z.name}
+                {z.label}
               </option>
             ))}
           </select>

--- a/ui/src/pages/NotificationPublishersPage.tsx
+++ b/ui/src/pages/NotificationPublishersPage.tsx
@@ -47,7 +47,7 @@ import {
   repeatFieldsFor,
   type RepeatMode,
 } from "../lib/notif-mapping";
-import { flattenZonesWithPath, type ZoneOption } from "../lib/zone-path";
+import { equipmentLabelMap, flattenZonesWithPath, zoneChainMap, type ZoneOption } from "../lib/zone-path";
 
 const ZONE_AGG_KEYS = [
   "temperature",
@@ -730,6 +730,10 @@ function MappingRow({
     ? equipments.filter((e) => e.zoneId === filterZoneId)
     : equipments;
 
+  // Homonym equipments get a "name - zone" label (spec 139), qualified only
+  // against the other candidates in this dropdown.
+  const eqLabels = equipmentLabelMap(filteredEquipments, zoneChainMap(zones));
+
   const filteredRecipeInstances = filterZoneId
     ? recipeInstances.filter((i) => i.params.zone === filterZoneId)
     : recipeInstances;
@@ -882,7 +886,7 @@ function MappingRow({
                 <option value="">{t("notifPublishers.selectSource")}</option>
                 {filteredEquipments.map((eq) => (
                   <option key={eq.id} value={eq.id}>
-                    {eq.name}
+                    {eqLabels.get(eq.id) ?? eq.name}
                   </option>
                 ))}
               </select>
@@ -1055,6 +1059,10 @@ function AddMappingForm({
     ? equipments.filter((e) => e.zoneId === filterZoneId)
     : equipments;
 
+  // Homonym equipments get a "name - zone" label (spec 139), qualified only
+  // against the other candidates in this dropdown.
+  const eqLabels = equipmentLabelMap(filteredEquipments, zoneChainMap(zones));
+
   const filteredRecipeInstances = filterZoneId
     ? recipeInstances.filter((i) => i.params.zone === filterZoneId)
     : recipeInstances;
@@ -1184,7 +1192,7 @@ function AddMappingForm({
               <option value="">{t("notifPublishers.selectSource")}</option>
               {filteredEquipments.map((eq) => (
                 <option key={eq.id} value={eq.id}>
-                  {eq.name}
+                  {eqLabels.get(eq.id) ?? eq.name}
                 </option>
               ))}
             </select>

--- a/ui/src/pages/ZoneDetailPage.tsx
+++ b/ui/src/pages/ZoneDetailPage.tsx
@@ -297,7 +297,7 @@ export function ZoneDetailPage() {
         <ZoneForm
           title={t("zones.editZone")}
           initial={{ name: zone.name, description: zone.description }}
-          parentZones={flattenZoneTree(tree, 0, zone.id)}
+          parentZones={flattenZoneTree(tree, zone.id)}
           defaultParentId={zone.parentId}
           onSubmit={async (data) => {
             await updateZone(zone.id, data);


### PR DESCRIPTION
## Context

Zone-path labelling (spec 139, `flattenZonesWithPath`) was already in place on the equipments page, the analyse view and the zone recipes — but everywhere else a zone still showed its bare name. Two homonym rooms ("Salle de bain" on the ground floor and upstairs) were therefore indistinguishable in most dropdowns.

## Changes

The shared helper is rolled out to every remaining site that renders a zone name flat:

| Screen | Before | After |
|---|---|---|
| Equipment form (create/edit) | local full path | shared disambiguating suffix |
| Button actions (target zone + effect labels) | bare name | disambiguating suffix |
| MQTT & notification publishers (mapping forms + source labels) | local flatten (full path) | shared helper |
| Dashboard add-widget (2 selectors) | indented bare name | disambiguating suffix |
| Parent zone selector (ZoneForm) | indented bare name | disambiguating suffix |
| Mode impacts (ModeDetailPage) | bare name | disambiguating suffix |
| Equipment zone chips (Devices page) | bare name | disambiguating suffix |
| Dashboard zone widget titles (grid, mobile card, bottom sheet, rename default) | bare name | disambiguating suffix via a `zoneLabels` map |

The duplicated local flatteners (EquipmentForm, ButtonActionsSection, MqttPublishersPage, NotificationPublishersPage, AddWidgetModal, DevicesPage, ModeDetailPage) are dropped in favour of `lib/zone-path.ts`. `flattenZoneTree` (ZoneForm) keeps its subtree exclusion but now returns `ZoneOption`s, with the labels computed on the whole tree so they stay stable despite the exclusion.

Net: −39 lines.

## Tests

- `tsc --noEmit` ✅, ESLint ✅ on every file touched
- Full UI vitest suite: 265 tests ✅
- `npm run build` ✅