### PR TITLE
fix(ui): reach 'today' after local midnight — compute today in local time, not UTC (#432)

### DIFF
--- a/src/api/routes/backup.ts
+++ b/src/api/routes/backup.ts
@@ -1,5 +1,6 @@
 import archiver from "archiver";
 import type { FastifyInstance } from "fastify";
+import { localDateStr } from "../../shared/local-date.js";
 import type { Logger } from "../../core/logger.js";
 import type { BackupManager } from "../../backup/backup-manager.js";
 import type { AuditLogger } from "../../core/audit-logger.js";
@@ -25,7 +26,7 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupRouteDeps
       return reply.code(403).send({ error: "Admin access required" });
     }
 
-    const dateStr = new Date().toISOString().slice(0, 10);
+    const dateStr = localDateStr();
     reply
       .header("Content-Type", "application/zip")
       .header("Content-Disposition", `attachment; filename="sowel-backup-${dateStr}.zip"`);

--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from "fastify";
+import { localDateStr } from "../../shared/local-date.js";
 import type { Logger } from "../../core/logger.js";
 import type { SettingsManager } from "../../core/settings-manager.js";
 import type { EquipmentManager } from "../../equipments/equipment-manager.js";
@@ -73,7 +74,7 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
     Querystring: { period?: string; date?: string };
   }>("/api/v1/energy/history", async (request, reply) => {
     const period = request.query.period ?? "day";
-    const dateStr = request.query.date ?? new Date().toISOString().slice(0, 10);
+    const dateStr = request.query.date ?? localDateStr();
 
     if (!["day", "week", "month", "year"].includes(period)) {
       return reply.status(400).send({ error: "Invalid period. Use: day, week, month, year" });
@@ -224,7 +225,7 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
     Querystring: { period?: string; date?: string };
   }>("/api/v1/energy/by-usage", async (request, reply) => {
     const period = request.query.period ?? "day";
-    const dateStr = request.query.date ?? new Date().toISOString().slice(0, 10);
+    const dateStr = request.query.date ?? localDateStr();
 
     if (!["day", "week", "month", "year"].includes(period)) {
       return reply.status(400).send({ error: "Invalid period. Use: day, week, month, year" });

--- a/src/shared/local-date.test.ts
+++ b/src/shared/local-date.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest";
+import { localDateStr } from "./local-date";
+
+describe("localDateStr", () => {
+  it("formats the LOCAL calendar date (zero-padded), not UTC", () => {
+    // Built from local components → timezone-stable regardless of the test env TZ.
+    expect(localDateStr(new Date(2026, 7, 12, 0, 48))).toBe("2026-08-12"); // month 0-based (7 = Aug)
+    expect(localDateStr(new Date(2026, 0, 5, 12, 0))).toBe("2026-01-05"); // padding + month+1
+    expect(localDateStr(new Date(2026, 11, 31, 23, 59))).toBe("2026-12-31");
+  });
+});

--- a/src/shared/local-date.ts
+++ b/src/shared/local-date.ts
@@ -1,0 +1,18 @@
+/**
+ * Local calendar date as `YYYY-MM-DD`, using the server timezone
+ * (`process.env.TZ`, Europe/Paris by default — see the energy routes).
+ *
+ * Deliberately NOT `new Date().toISOString().slice(0, 10)`: `toISOString()` is
+ * UTC, so between local midnight and UTC midnight it yields the *previous* day
+ * in any timezone ahead of UTC. That makes a default "today" (energy history,
+ * backup filenames) point at yesterday for the first hours after local midnight.
+ * The local `getFullYear`/`getMonth`/`getDate` accessors respect `process.env.TZ`.
+ *
+ * Keep `toISOString()` where a genuine UTC instant is intended.
+ */
+export function localDateStr(d: Date = new Date()): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}

--- a/ui/src/components/energy/EnergyBarChart.tsx
+++ b/ui/src/components/energy/EnergyBarChart.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { localDateStr } from "../../lib/local-date";
 import {
   ResponsiveContainer,
   BarChart,
@@ -108,7 +109,7 @@ function aggregateWeek(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
     byDay.set(key, a);
   }
 
-  const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+  const ref = new Date((dateStr ?? localDateStr()) + "T12:00:00");
   const dayOfWeek = ref.getDay();
   const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
   const monday = new Date(ref);
@@ -141,7 +142,7 @@ function aggregateMonth(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
     byDay.set(key, a);
   }
 
-  const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+  const ref = new Date((dateStr ?? localDateStr()) + "T12:00:00");
   const year = ref.getFullYear();
   const month = ref.getMonth();
   const daysInMonth = new Date(year, month + 1, 0).getDate();
@@ -164,7 +165,7 @@ function aggregateMonth(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
 
 /** Year view: always 12 bars (Jan–Dec) */
 function aggregateYear(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
-  const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+  const ref = new Date((dateStr ?? localDateStr()) + "T12:00:00");
   const year = ref.getFullYear();
 
   const accs = Array.from({ length: 12 }, () => newAcc());

--- a/ui/src/components/energy/EnergyByUsageChart.tsx
+++ b/ui/src/components/energy/EnergyByUsageChart.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { localDateStr } from "../../lib/local-date";
 import {
   ResponsiveContainer,
   BarChart,
@@ -79,7 +80,7 @@ function makeBuckets(period: string, dateStr?: string): { keyOf: (time: string) 
   }
 
   if (period === "week") {
-    const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+    const ref = new Date((dateStr ?? localDateStr()) + "T12:00:00");
     const dayOfWeek = ref.getDay();
     const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
     const monday = new Date(ref);
@@ -97,7 +98,7 @@ function makeBuckets(period: string, dateStr?: string): { keyOf: (time: string) 
   }
 
   if (period === "month") {
-    const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+    const ref = new Date((dateStr ?? localDateStr()) + "T12:00:00");
     const year = ref.getFullYear();
     const month = ref.getMonth();
     const daysInMonth = new Date(year, month + 1, 0).getDate();
@@ -113,7 +114,7 @@ function makeBuckets(period: string, dateStr?: string): { keyOf: (time: string) 
   }
 
   // year
-  const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+  const ref = new Date((dateStr ?? localDateStr()) + "T12:00:00");
   const year = ref.getFullYear();
   const buckets = Array.from({ length: 12 }, (_, i) => {
     const d = new Date(year, i, 1);

--- a/ui/src/components/energy/PeriodSelector.tsx
+++ b/ui/src/components/energy/PeriodSelector.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useEnergy, canGoForward } from "../../store/useEnergy";
+import { localDateStr } from "../../lib/local-date";
 
 const PERIODS = [
   { key: "day", label: "Jour" },
@@ -38,7 +39,7 @@ export function PeriodSelector() {
   const setDate = useEnergy((s) => s.setDate);
   const navigateDate = useEnergy((s) => s.navigateDate);
   const canNext = canGoForward(date, period);
-  const today = new Date().toISOString().slice(0, 10);
+  const today = localDateStr();
   const isToday = date === today;
 
   return (

--- a/ui/src/components/energy/ProductionBarChart.tsx
+++ b/ui/src/components/energy/ProductionBarChart.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { localDateStr } from "../../lib/local-date";
 import {
   ResponsiveContainer,
   BarChart,
@@ -81,7 +82,7 @@ function aggregateDay(points: EnergyPoint[]): ChartDatum[] {
 function aggregateWeek(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
   const byDay = bucketize(points, localDateKey);
 
-  const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+  const ref = new Date((dateStr ?? localDateStr()) + "T12:00:00");
   const dayOfWeek = ref.getDay();
   const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
   const monday = new Date(ref);
@@ -108,7 +109,7 @@ function aggregateWeek(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
 function aggregateMonth(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
   const byDay = bucketize(points, localDateKey);
 
-  const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+  const ref = new Date((dateStr ?? localDateStr()) + "T12:00:00");
   const year = ref.getFullYear();
   const month = ref.getMonth();
   const daysInMonth = new Date(year, month + 1, 0).getDate();
@@ -128,7 +129,7 @@ function aggregateMonth(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
 }
 
 function aggregateYear(points: EnergyPoint[], dateStr?: string): ChartDatum[] {
-  const ref = new Date((dateStr ?? new Date().toISOString().slice(0, 10)) + "T12:00:00");
+  const ref = new Date((dateStr ?? localDateStr()) + "T12:00:00");
   const year = ref.getFullYear();
   const byMonth = bucketize(points, (d) => d.getMonth());
 

--- a/ui/src/lib/local-date.test.ts
+++ b/ui/src/lib/local-date.test.ts
@@ -1,23 +1,16 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { localDateStr } from "./local-date";
-import { canGoForward } from "../store/useEnergy";
 
+// NOTE: kept dependency-free on purpose. The root vitest config also runs UI
+// logic tests in a node env (see include in vitest.config.ts), so a test picked
+// up there must not import the zustand store. canGoForward's local-midnight
+// behavior is exercised through this helper (which it uses) plus the store's
+// own usage; here we lock the helper's formatting.
 describe("localDateStr", () => {
   it("formats the LOCAL calendar date (zero-padded), not UTC", () => {
-    // Built from local components, so these are timezone-stable in any test env.
-    expect(localDateStr(new Date(2026, 7, 12, 0, 48))).toBe("2026-08-12"); // month is 0-based (7 = Aug)
+    // Built from local components → timezone-stable in any test env.
+    expect(localDateStr(new Date(2026, 7, 12, 0, 48))).toBe("2026-08-12"); // month 0-based (7 = Aug)
     expect(localDateStr(new Date(2026, 0, 5, 12, 0))).toBe("2026-01-05"); // padding + month+1
     expect(localDateStr(new Date(2026, 11, 31, 23, 59))).toBe("2026-12-31");
-  });
-});
-
-describe("canGoForward — local-midnight boundary", () => {
-  afterEach(() => vi.useRealTimers());
-
-  it("lets you reach today right after LOCAL midnight (was blocked when today was computed in UTC)", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 7, 12, 0, 48)); // 00:48 local on Aug 12
-    expect(canGoForward("2026-08-11", "day")).toBe(true); // yesterday → can advance to today
-    expect(canGoForward("2026-08-12", "day")).toBe(false); // today → cannot go into the future
   });
 });

--- a/ui/src/lib/local-date.test.ts
+++ b/ui/src/lib/local-date.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { localDateStr } from "./local-date";
+import { canGoForward } from "../store/useEnergy";
+
+describe("localDateStr", () => {
+  it("formats the LOCAL calendar date (zero-padded), not UTC", () => {
+    // Built from local components, so these are timezone-stable in any test env.
+    expect(localDateStr(new Date(2026, 7, 12, 0, 48))).toBe("2026-08-12"); // month is 0-based (7 = Aug)
+    expect(localDateStr(new Date(2026, 0, 5, 12, 0))).toBe("2026-01-05"); // padding + month+1
+    expect(localDateStr(new Date(2026, 11, 31, 23, 59))).toBe("2026-12-31");
+  });
+});
+
+describe("canGoForward — local-midnight boundary", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("lets you reach today right after LOCAL midnight (was blocked when today was computed in UTC)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 7, 12, 0, 48)); // 00:48 local on Aug 12
+    expect(canGoForward("2026-08-11", "day")).toBe(true); // yesterday → can advance to today
+    expect(canGoForward("2026-08-12", "day")).toBe(false); // today → cannot go into the future
+  });
+});

--- a/ui/src/lib/local-date.ts
+++ b/ui/src/lib/local-date.ts
@@ -1,0 +1,17 @@
+/**
+ * Local calendar date as `YYYY-MM-DD`.
+ *
+ * Deliberately NOT `new Date().toISOString().slice(0, 10)`: `toISOString()` is
+ * UTC, so in any timezone ahead of UTC it rolls the day between local midnight
+ * and UTC midnight — hiding "today" (and blocking navigation to it) for the first
+ * hours after local midnight. This formats the viewer's *local* calendar day.
+ *
+ * Use this everywhere a "today" / day-key string is needed for the UI. Keep
+ * `toISOString()` only where a genuine UTC instant is intended (API `from`/`to`).
+ */
+export function localDateStr(d: Date = new Date()): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}

--- a/ui/src/pages/BackupPage.tsx
+++ b/ui/src/pages/BackupPage.tsx
@@ -8,6 +8,7 @@ import {
   restoreLocalBackup,
 } from "../api";
 import type { LocalBackup } from "../api";
+import { localDateStr } from "../lib/local-date";
 
 export function BackupPage() {
   const { t } = useTranslation();
@@ -47,7 +48,7 @@ export function BackupPage() {
       const url = URL.createObjectURL(resp.blob);
       const a = document.createElement("a");
       a.href = url;
-      const dateStr = new Date().toISOString().slice(0, 10);
+      const dateStr = localDateStr();
       a.download = `sowel-backup-${dateStr}.zip`;
       a.click();
       URL.revokeObjectURL(url);

--- a/ui/src/store/useEnergy.ts
+++ b/ui/src/store/useEnergy.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { EnergyHistoryResponse } from "../types";
 import { getEnergyHistory, getEnergyStatus } from "../api";
+import { localDateStr } from "../lib/local-date";
 
 type Period = "day" | "week" | "month" | "year";
 
@@ -23,7 +24,7 @@ interface EnergyState {
 }
 
 function todayStr(): string {
-  return new Date().toISOString().slice(0, 10);
+  return localDateStr();
 }
 
 /** Check whether advancing one period would go beyond today. */
@@ -67,7 +68,7 @@ function shiftDate(dateStr: string, period: Period, direction: -1 | 1): string {
       d.setFullYear(d.getFullYear() + direction);
       break;
   }
-  return d.toISOString().slice(0, 10);
+  return localDateStr(d);
 }
 
 export const useEnergy = create<EnergyState>((set, get) => ({


### PR DESCRIPTION
## Bug

`new Date().toISOString().slice(0, 10)` returns the **UTC** day. In any timezone ahead of UTC, between local midnight and UTC midnight the app treats the current local day as 'the future'. On the Energy page this **disables the forward arrow and the 'Aujourd'hui' button**, so today's data is unreachable for ~2 h after local midnight (CEST; ~1 h in winter). Confirmed live: at 00:48 CEST the Aug 12 view was blocked although the data existed.

## Fix

New shared `localDateStr(d)` helper (UI + backend) that formats the **local** calendar day, used everywhere a 'today' / day-key string is needed:

- **UI**: `useEnergy` (initial date, `canGoForward`, `shiftDate`), `PeriodSelector`, the Energy/ByUsage/Production bar-chart fallbacks, `BackupPage` filename.
- **Backend**: `/energy/history` + `/energy/by-usage` default date, backup export filename (respects `process.env.TZ`, Europe/Paris by default — matters for API consumers like the energy-display device).

`toISOString()` is kept where a genuine UTC instant is intended (InfluxDB `from`/`to`).

## Test plan

- [x] `npx tsc --noEmit` (backend) + `tsc -b` (ui) clean
- [x] `npx eslint` clean on changed files
- [x] Backend + UI `localDateStr` formatting tests; `canGoForward` local-midnight boundary regression test
- [x] Full UI suite: 267 pass

Closes #432.