### PR TITLE
fix(history): chart enum states (write value_number, not just value_string) (#434)

### DIFF
--- a/src/history/history-writer.test.ts
+++ b/src/history/history-writer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type Database from "better-sqlite3";
-import { HistoryWriter } from "./history-writer.js";
+import { HistoryWriter, enumToNumber } from "./history-writer.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
 import type { Point } from "../core/influx-client.js";
@@ -8,6 +8,37 @@ import type { InfluxClient } from "../core/influx-client.js";
 import type { SettingsManager } from "../core/settings-manager.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { DataCategory } from "../shared/types.js";
+
+describe("enumToNumber (#434 — enum states charted)", () => {
+  it("maps binary on/off-like states intuitively (1 = on, 0 = off)", () => {
+    expect(enumToNumber("ON", ["ON", "OFF"])).toBe(1); // token wins over index (index would be 0)
+    expect(enumToNumber("OFF", ["ON", "OFF"])).toBe(0); // token wins over index (index would be 1)
+    expect(enumToNumber("OFF", ["OFF", "ON"])).toBe(0); // OFF token → 0 regardless of declared order
+    expect(enumToNumber("OPEN", ["OPEN", "CLOSED"])).toBe(1);
+    expect(enumToNumber("CLOSED", ["OPEN", "CLOSED"])).toBe(0);
+    expect(enumToNumber("true", null)).toBe(1); // no list needed for a known token
+    expect(enumToNumber("false", null)).toBe(0);
+  });
+
+  it("uses the declared-value index for multi-value enums (no token collision)", () => {
+    expect(enumToNumber("IDLE", ["IDLE", "HEAT", "COOL"])).toBe(0);
+    expect(enumToNumber("HEAT", ["IDLE", "HEAT", "COOL"])).toBe(1);
+    expect(enumToNumber("COOL", ["IDLE", "HEAT", "COOL"])).toBe(2);
+    // A 3-value enum containing an on/off token: index wins, NOT the token.
+    expect(enumToNumber("OFF", ["LOW", "OFF", "HIGH"])).toBe(1);
+  });
+
+  it("falls back to the index for a 2-value enum without on/off tokens", () => {
+    expect(enumToNumber("LOW", ["LOW", "HIGH"])).toBe(0);
+    expect(enumToNumber("HIGH", ["LOW", "HIGH"])).toBe(1);
+  });
+
+  it("returns null when the value cannot be encoded (label kept in value_string)", () => {
+    expect(enumToNumber("WHATEVER", null)).toBeNull();
+    expect(enumToNumber("WHATEVER", [])).toBeNull();
+    expect(enumToNumber("MISSING", ["A", "B", "C"])).toBeNull(); // not in the declared list
+  });
+});
 
 describe("HistoryWriter.resolveHistorize", () => {
   // ============================================================
@@ -377,5 +408,63 @@ describe("HistoryWriter — grid energy ownership", () => {
 
     const energy = influx.written.filter((p) => p.alias === "energy");
     expect(energy).toEqual([{ alias: "energy", value: 40, timestamp: T0_MS / 1000 }]);
+  });
+});
+
+describe("HistoryWriter — enum state charting (#434)", () => {
+  const logger = createLogger("silent").logger;
+  let bus: EventBus;
+  let influx: StubInfluxClient;
+  let writer: HistoryWriter;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0_MS);
+    bus = new EventBus(logger);
+    influx = new StubInfluxClient();
+    const equipmentManager = {
+      getAll: () => [{ id: EQUIPMENT_ID, enabled: true, zoneId: ZONE_ID }],
+      getDataBindingsWithValues: () => [
+        {
+          id: "pump-state",
+          alias: "state",
+          category: "light_state",
+          type: "enum",
+          enumValues: ["ON", "OFF"],
+          historize: 1,
+        },
+      ],
+    } as unknown as EquipmentManager;
+    writer = new HistoryWriter(
+      {} as Database.Database,
+      bus,
+      { get: () => undefined } as unknown as SettingsManager,
+      equipmentManager,
+      influx as unknown as InfluxClient,
+      logger,
+    );
+    writer.init();
+  });
+
+  afterEach(() => {
+    writer.destroy();
+    vi.useRealTimers();
+  });
+
+  function emitState(value: string, previous: unknown): void {
+    bus.emit({
+      type: "equipment.data.changed",
+      equipmentId: EQUIPMENT_ID,
+      alias: "state",
+      value,
+      previous,
+    } as never);
+  }
+
+  it("writes value_number for an enum ON/OFF state (previously value_string only → empty chart)", () => {
+    emitState("ON", "OFF");
+    emitState("OFF", "ON");
+    const states = influx.written.filter((p) => p.alias === "state");
+    expect(states.map((p) => p.value)).toEqual([1, 0]); // ON=1, OFF=0 → chartable step
   });
 });

--- a/src/history/history-writer.ts
+++ b/src/history/history-writer.ts
@@ -308,6 +308,7 @@ export class HistoryWriter {
           type: b.type,
           equipmentId: eq.id,
           zoneId: eq.zoneId,
+          enumValues: b.enumValues ?? null,
         });
       }
     }
@@ -396,6 +397,13 @@ export class HistoryWriter {
       const boolVal = value === true || value === "ON" || value === "true";
       point.stringField("value_string", String(boolVal));
       point.floatField("value_number", boolVal ? 1 : 0);
+    } else if (meta.type === "enum") {
+      // Enum states keep their label in value_string; ALSO emit a numeric
+      // encoding so the (numeric-only) history chart can render them as steps.
+      // Without this the state is stored but never charts (#434).
+      point.stringField("value_string", String(value));
+      const n = enumToNumber(value, meta.enumValues);
+      if (n !== null) point.floatField("value_number", n);
     } else {
       point.stringField("value_string", String(value));
     }
@@ -616,10 +624,38 @@ export class HistoryWriter {
   }
 }
 
+const ENUM_ON_TOKENS = new Set(["ON", "OPEN", "OPENED", "TRUE", "ACTIVE", "YES", "1"]);
+const ENUM_OFF_TOKENS = new Set(["OFF", "CLOSED", "CLOSE", "FALSE", "INACTIVE", "NO", "0"]);
+
+/**
+ * Numeric encoding for an enum state so it can be charted (#434). Binary states
+ * map to intuitive on/off (ON/OPEN/... -> 1, OFF/CLOSED/... -> 0); enums with
+ * more than two declared values use the value's index in that declared list
+ * (tokens are ignored there to avoid index/token collisions). Returns null when
+ * the value cannot be encoded (unknown value, no declared list) — the label is
+ * still kept in value_string.
+ */
+export function enumToNumber(value: unknown, enumValues?: string[] | null): number | null {
+  const s = String(value).trim();
+  if (enumValues && enumValues.length > 2) {
+    const i = enumValues.indexOf(s);
+    return i >= 0 ? i : null;
+  }
+  const up = s.toUpperCase();
+  if (ENUM_ON_TOKENS.has(up)) return 1;
+  if (ENUM_OFF_TOKENS.has(up)) return 0;
+  if (enumValues && enumValues.length) {
+    const i = enumValues.indexOf(s);
+    if (i >= 0) return i;
+  }
+  return null;
+}
+
 interface BindingMeta {
   alias: string;
   category: DataCategory;
   type: string;
   equipmentId: string;
   zoneId: string;
+  enumValues?: string[] | null;
 }


### PR DESCRIPTION
## Bug

An `enum` state binding (a pump `state` ON/OFF, or any ON/OFF/OPEN/CLOSED) was historized to `value_string` **only**, but the history query filters `value_number` — so the state was recorded yet never charted (empty graph). `boolean` bindings already wrote a numeric 1/0. Confirmed on the pool pump: its state is typed `enum` (`enumValues: ["ON","OFF"]`) while other ON/OFF lights are `boolean`.

## Fix

Thread `enumValues` into `BindingMeta`; for `type === "enum"` also emit `value_number` via `enumToNumber()`:
- binary on/off-like → intuitive **1/0** (ON/OPEN/TRUE → 1, OFF/CLOSED/FALSE → 0),
- enums with **>2** declared values → the value's **index** (tokens ignored to avoid collisions),
- unknown value / no list → `value_string` only (no misleading number).

No query change — the discrete query already reads `value_number`. Historic text-only data is not backfilled; charts fill from deploy onward.

## Test plan

- [x] `tsc` + `eslint` clean, full suite 1341 pass
- [x] `enumToNumber` unit tests (binary tokens, multi-value index, collision case, null)
- [x] Integration: an enum ON/OFF binding now writes `value_number` 1/0

Closes #434.