### PR TITLE
feat(ui): recipe status summary line on the recipe card (#431)

### DIFF
--- a/ui/src/components/recipes/ZoneRecipesSection.tsx
+++ b/ui/src/components/recipes/ZoneRecipesSection.tsx
@@ -723,6 +723,16 @@ function RecipeInstanceRow({
             <div className="text-[14px] font-medium text-text truncate">
               {displayName}
             </div>
+            {/* Optional recipe-provided status line (spec: state.summary).
+                A recipe sets it to surface live context (e.g. a pool pump's
+                "Filtration 2,1/9,6 h · heures creuses"). Absent → unchanged. */}
+            {typeof instance.state?.summary === "string" &&
+              instance.state.summary.length > 0 &&
+              instance.enabled && (
+                <div className="text-[11px] text-text-tertiary truncate mt-0.5">
+                  {instance.state.summary}
+                </div>
+              )}
           </button>
           {!!instance.state?.timerExpiresAt && instance.enabled && (
             <CountdownTimer expiresAt={instance.state.timerExpiresAt as string} />


### PR DESCRIPTION
## Motivation

Recipes compute rich runtime state, but the recipe card only rendered a countdown (`timerExpiresAt`) and an override badge — so live context (e.g. the pool pump's daily filtration target and current rung) was only visible by opening the recipe log.

## Change

Render an optional muted subtitle under the recipe name from a conventional **`state.summary`** string, when present and the instance is enabled. Recipes opt in by setting it (e.g. `Filtration 2,1/9,6 h · heures creuses`); recipes that don't set it are visually unchanged. The recipe produces the localized string, so no core i18n is needed.

## Test plan

- [x] `tsc -b` clean; eslint 0 errors on the changed file
- [x] Absent `state.summary` → card unchanged (guarded on `typeof === string && length > 0 && enabled`)

Closes #431. Paired with pool-pump-schedule setting `state.summary` (Phase 3).