### PR TITLE
chore(registry): bump pool-pump-schedule to 1.4.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "tags": ["pool", "pump", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -340,7 +340,7 @@
     },
     "sowelVersion": ">=1.3.0",
     "owner": "mchacher",
-    "sha256": "7a53b347d215be55b9a6a9d579362a66eab523f5b991158ddbd78cbe9879b091"
+    "sha256": "82ae206d0c0271eb890b7914322dc4286e98041ad36e828bb14ce2786f5d25bb"
   },
   {
     "id": "freecooling",


### PR DESCRIPTION
Bumps `pool-pump-schedule` 1.3.0 -> **1.4.0** (publishes `state.summary` for the recipe card status line, paired with #431). sha256 verified against the published `v1.4.0` asset (`82ae206d…d25bb`).