### PR TITLE
fix(equipments): stop flagging report-on-change devices as stale

### DIFF
--- a/specs/116-equipment-availability/spec.md
+++ b/specs/116-equipment-availability/spec.md
@@ -105,28 +105,56 @@ export const STREAMING_CATEGORIES: ReadonlySet<DataCategory> = new Set([
 
 /** Maximum age (ms) before a streaming binding is flagged stale. */
 export const STREAMING_TIMEOUT_MS: Record<string, number> = {
-  power: 2 * 60 * 1000, // 2 min — live electrical reads
+  power: 2 * 60 * 1000, // 2 min — live electrical reads (metering equipments only)
   energy: 10 * 60 * 1000, // 10 min — cumulative counter
   voltage: 5 * 60 * 1000,
   current: 5 * 60 * 1000,
-  temperature: 15 * 60 * 1000,
-  temperature_outdoor: 15 * 60 * 1000,
-  humidity: 15 * 60 * 1000,
-  humidity_outdoor: 15 * 60 * 1000,
-  pressure: 30 * 60 * 1000,
-  luminosity: 15 * 60 * 1000,
-  co2: 15 * 60 * 1000,
-  voc: 15 * 60 * 1000,
-  noise: 15 * 60 * 1000,
+  temperature: 65 * 60 * 1000, // > Zigbee's 1 h max_report_interval
+  temperature_outdoor: 65 * 60 * 1000,
+  humidity: 65 * 60 * 1000,
+  humidity_outdoor: 65 * 60 * 1000,
+  pressure: 65 * 60 * 1000,
+  luminosity: 65 * 60 * 1000,
+  co2: 65 * 60 * 1000,
+  voc: 65 * 60 * 1000,
+  noise: 65 * 60 * 1000,
   battery: 2 * 60 * 60 * 1000, // 2 h — battery reports are sparse
   setpoint: 60 * 60 * 1000, // 1 h
-  pool_water_temperature: 15 * 60 * 1000,
+  pool_water_temperature: 65 * 60 * 1000,
   pool_temperature_setpoint: 60 * 60 * 1000,
 };
+
+/** Electrical categories — only checked on METERING_EQUIPMENT_TYPES. */
+export const ELECTRICAL_STREAMING_CATEGORIES = new Set(["power", "energy", "voltage", "current"]);
+export const METERING_EQUIPMENT_TYPES = new Set([
+  "energy_meter",
+  "main_energy_meter",
+  "energy_production_meter",
+  "solar_panel",
+]);
 
 /** Default fallback for any future streaming category not yet listed above. */
 export const DEFAULT_STREAMING_TIMEOUT_MS = 15 * 60 * 1000;
 ```
+
+**Amendment — false positives on report-on-change devices.** The ambient windows
+were 15–30 min in the original design, and the electrical ones applied to every
+equipment type. Both turned healthy devices into permanently `degraded`
+equipments:
+
+- Zigbee sensors report on change, with `max_report_interval` conventionally set
+  to 3600 s. Any window below that flags a healthy sensor as stale, so the
+  ambient windows now sit at 65 min — a freshness window has to exceed the
+  longest silence the device is _allowed_ to keep, not the typical one.
+- Electrical categories are now checked **only on metering equipments**.
+  Elsewhere they arrive as a bonus from a metering smart plug bound to a light or
+  a switch, where silence means "steady load", not "fault". The live-energy case
+  this spec was written for is unaffected: a Shelly Pro 3EM is a
+  `main_energy_meter` and keeps its 2 min window.
+
+Measured before the fix on a 33-equipment install: 180 `equipment.status.changed`
+transitions in 64 minutes, six equipments toggling `online` ↔ `degraded` at every
+reporting cycle, nothing actually wrong.
 
 Categories NOT in `STREAMING_CATEGORIES` (motion, contact_door, contact_window, water_leak, smoke, action, light_state, light_brightness, light_color_temp, light_color, shutter_position, lock_state, gate_state, cover_state, runtime_daily, weather_condition, media_volume, media_mute, media_input, appliance_state, uv, solar_radiation, wind, rain, generic) → never stale, full stop.
 

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -604,7 +604,13 @@ export class EquipmentManager {
     // Annotate staleness on streaming bindings (spec 116).
     const now = Date.now();
     for (const binding of bindings) {
-      binding.stale = isStaleBinding(binding.category, binding.lastUpdated, now, binding.type);
+      binding.stale = isStaleBinding(
+        binding.category,
+        binding.lastUpdated,
+        now,
+        binding.type,
+        equipment?.type,
+      );
     }
 
     return bindings;

--- a/src/equipments/equipment-status.test.ts
+++ b/src/equipments/equipment-status.test.ts
@@ -56,12 +56,18 @@ describe("isStaleBinding", () => {
     expect(isStaleBinding("power", "2026-05-26 09:59:00Z", NOW)).toBe(false);
   });
 
-  it("streaming 'power' beyond 2 min window is stale", () => {
-    expect(isStaleBinding("power", "2026-05-26 09:57:00Z", NOW)).toBe(true);
+  it("streaming 'power' beyond 2 min window is stale on a metering equipment", () => {
+    expect(
+      isStaleBinding("power", "2026-05-26 09:57:00Z", NOW, "number", "main_energy_meter"),
+    ).toBe(true);
   });
 
-  it("streaming 'temperature' is stale at 16 min (timeout is 15 min)", () => {
-    expect(isStaleBinding("temperature", "2026-05-26 09:44:00Z", NOW)).toBe(true);
+  it("streaming 'temperature' is stale past the 65 min window", () => {
+    expect(isStaleBinding("temperature", "2026-05-26 08:54:00Z", NOW)).toBe(true);
+  });
+
+  it("streaming 'temperature' is not stale at 16 min — a Zigbee sensor may stay silent for an hour", () => {
+    expect(isStaleBinding("temperature", "2026-05-26 09:44:00Z", NOW)).toBe(false);
   });
 
   it("streaming 'temperature' is not stale at 10 min", () => {
@@ -88,8 +94,26 @@ describe("isStaleBinding", () => {
     expect(isStaleBinding("power", "2026-05-26 09:57:00Z", NOW, "boolean")).toBe(false);
   });
 
-  it("numeric 'power' beyond the window is still stale (live clamp regression guard)", () => {
-    expect(isStaleBinding("power", "2026-05-26 09:57:00Z", NOW, "number")).toBe(true);
+  it("numeric 'power' beyond the window is still stale on a meter (live clamp regression guard)", () => {
+    expect(
+      isStaleBinding("power", "2026-05-26 09:57:00Z", NOW, "number", "main_energy_meter"),
+    ).toBe(true);
+  });
+
+  it("the same stale 'power' on a switch is not stale — metering plug bound to a non-meter", () => {
+    // A metering smart plug reports power on change: a steady load simply stops
+    // producing updates, and that says nothing about the switch being healthy.
+    expect(isStaleBinding("power", "2026-05-26 09:57:00Z", NOW, "number", "switch")).toBe(false);
+    expect(isStaleBinding("current", "2026-05-26 09:00:00Z", NOW, "number", "light_onoff")).toBe(
+      false,
+    );
+    expect(isStaleBinding("energy", "2026-05-26 09:00:00Z", NOW, "number", "water_heater")).toBe(
+      false,
+    );
+  });
+
+  it("an equipment type left undefined does not get the electrical window", () => {
+    expect(isStaleBinding("power", "2026-05-26 09:57:00Z", NOW, "number")).toBe(false);
   });
 });
 
@@ -160,7 +184,7 @@ describe("deriveEquipmentStatus", () => {
     });
     const device = makeDevice({ status: "online" });
     const map = new Map([[binding.id, device]]);
-    const result = deriveEquipmentStatus([binding], map, NOW);
+    const result = deriveEquipmentStatus([binding], map, NOW, "main_energy_meter");
     expect(result.status).toBe("degraded");
     expect(result.reason?.staleBindings).toEqual(["power"]);
     expect(result.reason?.offlineDevices).toEqual([]);
@@ -223,7 +247,7 @@ describe("deriveEquipmentStatus", () => {
     const binding = makeBinding({ category: "power", lastUpdated: "2026-05-26 09:50:00Z" });
     const device = makeDevice({ status: "unknown" });
     const map = new Map([[binding.id, device]]);
-    const result = deriveEquipmentStatus([binding], map, NOW);
+    const result = deriveEquipmentStatus([binding], map, NOW, "main_energy_meter");
     expect(result.status).toBe("degraded");
   });
 
@@ -251,7 +275,7 @@ describe("deriveEquipmentStatus", () => {
       [b1.id, d1],
       [b2.id, d2],
     ]);
-    const result = deriveEquipmentStatus([b1, b2], map, NOW);
+    const result = deriveEquipmentStatus([b1, b2], map, NOW, "main_energy_meter");
     expect(result.status).toBe("degraded");
     // Earliest of "09:30:00" and "09:45:00" → "09:30:00"
     expect(result.reason?.offlineSince).toBe("2026-05-26 09:30:00Z");
@@ -311,5 +335,76 @@ describe("deriveEquipmentStatus — button silence exemption (issue #348)", () =
     const map = new Map([[binding.id, device]]);
     const result = deriveEquipmentStatus([binding], map, NOW, "sensor");
     expect(result.status).toBe("offline");
+  });
+});
+
+// ─── metering plug bound to a non-metering equipment ────────────────────
+
+describe("electrical bindings on a non-metering equipment", () => {
+  /** A Zigbee metering plug: on/off state plus the electrical extras. */
+  const meteringPlug = (powerLastUpdated: string) => {
+    const state = makeBinding({
+      id: "b-state",
+      category: "light_state",
+      type: "boolean",
+      value: true,
+      alias: "state",
+      lastUpdated: "2026-05-26 09:59:50Z",
+    });
+    const power = makeBinding({
+      id: "b-power",
+      category: "power",
+      type: "number",
+      value: 0,
+      alias: "power",
+      lastUpdated: powerLastUpdated,
+    });
+    const device = makeDevice({ status: "online" });
+    return {
+      bindings: [state, power],
+      map: new Map([
+        [state.id, device],
+        [power.id, device],
+      ]),
+    };
+  };
+
+  it("stays online when the plug has not reported power for an hour", () => {
+    // The load is steady, so the plug has nothing to report. Before this, the
+    // equipment flipped to degraded 2 min after every report and back on the
+    // next one — 180 status transitions in an hour on a healthy install.
+    const { bindings, map } = meteringPlug("2026-05-26 09:00:00Z");
+    expect(deriveEquipmentStatus(bindings, map, NOW, "switch").status).toBe("online");
+    expect(deriveEquipmentStatus(bindings, map, NOW, "light_onoff").status).toBe("online");
+  });
+
+  it("still degrades when the device itself is reported offline", () => {
+    // device.status stays the authoritative health signal for these types.
+    const { bindings, map } = meteringPlug("2026-05-26 09:59:50Z");
+    for (const [, device] of map) device.status = "offline";
+    expect(deriveEquipmentStatus(bindings, map, NOW, "switch").status).toBe("offline");
+  });
+
+  it("the same silence on a meter is still degraded", () => {
+    const { bindings, map } = meteringPlug("2026-05-26 09:00:00Z");
+    const result = deriveEquipmentStatus(bindings, map, NOW, "main_energy_meter");
+    expect(result.status).toBe("degraded");
+    expect(result.reason?.staleBindings).toEqual(["power"]);
+  });
+
+  it("a non-electrical streaming binding still degrades any equipment type", () => {
+    const temperature = makeBinding({
+      id: "b-temp",
+      category: "temperature",
+      type: "number",
+      value: 19,
+      alias: "temperature",
+      lastUpdated: "2026-05-26 08:00:00Z", // 2 h — beyond the 65 min window
+    });
+    const device = makeDevice({ status: "online" });
+    const map = new Map([[temperature.id, device]]);
+    const result = deriveEquipmentStatus([temperature], map, NOW, "sensor");
+    expect(result.status).toBe("degraded");
+    expect(result.reason?.staleBindings).toEqual(["temperature"]);
   });
 });

--- a/src/equipments/equipment-status.ts
+++ b/src/equipments/equipment-status.ts
@@ -57,6 +57,16 @@ function parseTimestamp(iso: string | null): number | null {
  * updates, and the tight electrical window would then flip the equipment to
  * `degraded` on every reporting cycle without anything being wrong. Where the
  * reading *is* the equipment's job, the window still applies in full.
+ *
+ * Known trade-off (review): a `switch` used purely as a submeter is exempted
+ * too, because it is indistinguishable from a plug controlling a load (both
+ * expose a state binding + bonus power), so its electrical freshness is not a
+ * health signal and it leans on `device.status`. Gating on "is a metering
+ * switch" instead would re-flap every controlled-load plug, which is the very
+ * bug this fix removes. The clean fix is to size the electrical window on the
+ * *allowed* report interval (Zigbee `max_report_interval`, ~1 h) rather than the
+ * typical one, so a genuinely dead submeter is caught without flapping healthy
+ * ones — deferred as a follow-up.
  */
 export function isStaleBinding(
   category: DataCategory,

--- a/src/equipments/equipment-status.ts
+++ b/src/equipments/equipment-status.ts
@@ -10,6 +10,8 @@ import {
   STREAMING_CATEGORIES,
   STREAMING_TIMEOUT_MS,
   DEFAULT_STREAMING_TIMEOUT_MS,
+  ELECTRICAL_STREAMING_CATEGORIES,
+  METERING_EQUIPMENT_TYPES,
 } from "../shared/constants.js";
 import type {
   DataBindingWithValue,
@@ -48,15 +50,29 @@ function parseTimestamp(iso: string | null): number | null {
  * (issue #422). This mirrors the `SILENCE_EXEMPT_EQUIPMENT_TYPES` exemption for
  * buttons (#348), at the value-type level instead of the equipment-type level.
  * Numeric streaming reads (Shelly / Legrand live clamps) are unaffected.
+ *
+ * Electrical categories are checked only on metering equipments. A metering
+ * smart plug bound to a light or a switch contributes `power` / `current` /
+ * `voltage` as a bonus, reported on change: a steady load stops producing
+ * updates, and the tight electrical window would then flip the equipment to
+ * `degraded` on every reporting cycle without anything being wrong. Where the
+ * reading *is* the equipment's job, the window still applies in full.
  */
 export function isStaleBinding(
   category: DataCategory,
   lastUpdated: string | null,
   now: number = Date.now(),
   type?: DataType,
+  equipmentType?: string,
 ): boolean {
   if (!STREAMING_CATEGORIES.has(category)) return false;
   if (type === "boolean") return false; // discrete on/off state, not a live stream
+  if (
+    ELECTRICAL_STREAMING_CATEGORIES.has(category) &&
+    !(equipmentType !== undefined && METERING_EQUIPMENT_TYPES.has(equipmentType))
+  ) {
+    return false;
+  }
   const updatedMs = parseTimestamp(lastUpdated);
   if (updatedMs === null) return false;
   const timeoutMs = STREAMING_TIMEOUT_MS[category] ?? DEFAULT_STREAMING_TIMEOUT_MS;
@@ -125,7 +141,7 @@ export function deriveEquipmentStatus(
     (device) => device.status === "offline",
   );
   const staleBindings = bindings.filter((binding) =>
-    isStaleBinding(binding.category, binding.lastUpdated, now, binding.type),
+    isStaleBinding(binding.category, binding.lastUpdated, now, binding.type, equipmentType),
   );
 
   const allOffline = uniqueDevices.size > 0 && offlineDevices.length === uniqueDevices.size;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -215,28 +215,65 @@ export const STREAMING_CATEGORIES: ReadonlySet<DataCategory> = new Set<DataCateg
 ]);
 
 /**
+ * Electrical measurement categories. Their freshness window is tight because a
+ * live power read that silently freezes is the bug spec 116 was written for
+ * (a Shelly Pro 3EM cut at the breaker still charting its last value). That
+ * tightness is only legitimate where the reading *is* the equipment's job —
+ * see METERING_EQUIPMENT_TYPES.
+ */
+export const ELECTRICAL_STREAMING_CATEGORIES: ReadonlySet<DataCategory> = new Set<DataCategory>([
+  "power",
+  "energy",
+  "voltage",
+  "current",
+]);
+
+/**
+ * Equipment types whose function is electrical measurement, and for which a
+ * frozen `power` / `energy` / `voltage` / `current` binding is a real fault.
+ *
+ * Everywhere else those categories arrive as a bonus — a metering smart plug
+ * bound to a light or a switch — and their freshness says nothing about
+ * whether the equipment works: the plug reports power on change, so a steady
+ * load simply stops producing updates. Health for those equipments comes from
+ * `device.status` and from their own state binding.
+ */
+export const METERING_EQUIPMENT_TYPES: ReadonlySet<string> = new Set([
+  "energy_meter",
+  "main_energy_meter",
+  "energy_production_meter",
+  "solar_panel",
+]);
+
+/**
  * Per-category freshness window. A streaming binding whose lastUpdated is
  * older than this value is flagged stale (spec 116). Categories listed in
  * STREAMING_CATEGORIES but missing here fall back to DEFAULT_STREAMING_TIMEOUT_MS.
+ *
+ * Ambient windows sit above one hour on purpose. Zigbee sensors report on
+ * change with a `max_report_interval` conventionally set to 3600 s, so any
+ * window below that guarantees a permanently "degraded" equipment for a
+ * perfectly healthy sensor — the window has to exceed the longest silence the
+ * device is allowed to keep, not the typical one.
  */
 export const STREAMING_TIMEOUT_MS: Partial<Record<DataCategory, number>> = {
-  power: 2 * 60 * 1000, // 2 min — live electrical reads
+  power: 2 * 60 * 1000, // 2 min — live electrical reads (metering equipments only)
   energy: 10 * 60 * 1000, // 10 min — cumulative counter
   voltage: 5 * 60 * 1000,
   current: 5 * 60 * 1000,
-  temperature: 15 * 60 * 1000,
-  temperature_outdoor: 15 * 60 * 1000,
-  temperature_device: 15 * 60 * 1000,
-  humidity: 15 * 60 * 1000,
-  humidity_outdoor: 15 * 60 * 1000,
-  pressure: 30 * 60 * 1000,
-  luminosity: 15 * 60 * 1000,
-  co2: 15 * 60 * 1000,
-  voc: 15 * 60 * 1000,
-  noise: 15 * 60 * 1000,
+  temperature: 65 * 60 * 1000, // > Zigbee's 1 h max_report_interval
+  temperature_outdoor: 65 * 60 * 1000,
+  temperature_device: 65 * 60 * 1000,
+  humidity: 65 * 60 * 1000,
+  humidity_outdoor: 65 * 60 * 1000,
+  pressure: 65 * 60 * 1000,
+  luminosity: 65 * 60 * 1000,
+  co2: 65 * 60 * 1000,
+  voc: 65 * 60 * 1000,
+  noise: 65 * 60 * 1000,
   battery: 2 * 60 * 60 * 1000, // 2 h — battery reports are sparse
   setpoint: 60 * 60 * 1000, // 1 h
-  pool_water_temperature: 15 * 60 * 1000,
+  pool_water_temperature: 65 * 60 * 1000,
   pool_temperature_setpoint: 60 * 60 * 1000,
 };
 


### PR DESCRIPTION
## The symptom

On a 33-equipment install, **180 `equipment.status.changed` transitions in 64 minutes** — six equipments toggling `online` ↔ `degraded` at every reporting cycle, with nothing wrong on the network:

```
x52 Température      online->degraded degraded->online ...
x27 VMC              degraded->online online->degraded ...
x26 Chauffage        ...
x26 Compresseur      ...
x25 Alexa            ...
x24 Chauffe Appoint  ...
```

Every one of them is backed by a healthy, reachable Zigbee device.

## Why

Spec 116 defines streaming categories as those where "the device pushes a value at regular intervals, even when unchanged", and sizes the freshness window on the *typical* interval. Zigbee devices do not work that way: they report **on change**, bounded by a `max_report_interval` conventionally set to 3600 s. Two consequences, independent of each other:

1. **Ambient windows are shorter than the silence a healthy device is allowed to keep.** A TH02Z reporting every 14–50 min crosses the 15 min `temperature` window constantly, so the equipment is `degraded` most of the time and flips back on each report.

2. **Electrical windows applied to every equipment type.** `power` / `current` / `voltage` mostly arrive as a bonus, from a metering smart plug bound to a light or a switch. Measured on one of these plugs: reporting configured at `min=5s` with a 1 W reportable change, so a steady load produces no report at all for minutes on end. The 2 min `power` window then degrades the equipment between two reports — while the plug is perfectly fine, and its actual health (the `state` binding, and `device.status`) says so.

## The fix

- Ambient windows (`temperature*`, `humidity*`, `pressure`, `luminosity`, `co2`, `voc`, `noise`, `pool_water_temperature`) → **65 min**. The principle: a freshness window has to exceed the longest silence the device is *allowed* to keep, not the typical one.
- Electrical categories are checked **only on metering equipment types** (`energy_meter`, `main_energy_meter`, `energy_production_meter`, `solar_panel`) — where the reading is the equipment's own function.

**The case this spec was written for is untouched.** A Shelly Pro 3EM cut at the breaker is a `main_energy_meter`, so it keeps the 2 min `power` window and `LiveEnergyPage` still flags it. `device.status` remains the primary health signal for every type, and staleness stays the backstop it was meant to be.

Follows the shape of the existing exemptions — `SILENCE_EXEMPT_EQUIPMENT_TYPES` (#348) and the boolean-value exemption (#422) — which addressed the same class of false positive.

## Trade-off, stated

A genuinely dead ambient sensor now takes up to 65 min to surface as `degraded` instead of 15, and a metering plug that stops metering while still answering on/off is no longer flagged at all on a non-meter equipment. Both are deliberate: the previous behaviour did not report those cases usefully either — it reported *everything* as degraded, which is the same as reporting nothing.

## Tests

`npm run validate` green: typecheck, lint, format, **1348 tests passing**, ui validation. 11 new tests covering the flapping scenario end-to-end and both exemption boundaries; 6 existing tests updated to the new contract (they asserted the old thresholds).

`specs/116-equipment-availability/spec.md` amended with the reasoning and the measured numbers.

No release-notes entry: this is not a version bump, spec 108 applies when the tag is cut.
