### PR TITLE
refactor(ui): consolidate the duplicate local-date helper

### DIFF
--- a/ui/src/components/history/history-utils.ts
+++ b/ui/src/components/history/history-utils.ts
@@ -1,3 +1,5 @@
+import { localDateStr } from "../../lib/local-date";
+
 export type TimeRange = "6h" | "24h" | "7d" | "30d";
 
 // ============================================================
@@ -150,19 +152,8 @@ export function rangeToDurationMs(range: TimeRange): number {
 
 export type Period = "day" | "week" | "month" | "year";
 
-/** YYYY-MM-DD in the **local** timezone — NOT UTC. `.toISOString().slice(0,10)`
- *  is unsafe here because midnight local sits in the previous UTC day for
- *  any positive timezone offset, causing date-string arithmetic to silently
- *  fall back to "the previous local day" (no forward motion). */
-function toLocalDateStr(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
 function todayStr(): string {
-  return toLocalDateStr(new Date());
+  return localDateStr();
 }
 
 /** Returns the start of the period that contains `dateStr`, in local time. */
@@ -263,7 +254,7 @@ export function shiftPeriod(dateStr: string, period: Period, delta: number): str
       d.setFullYear(d.getFullYear() + delta);
       break;
   }
-  return toLocalDateStr(d);
+  return localDateStr(d);
 }
 
 export const periodTodayStr = todayStr;


### PR DESCRIPTION
Follow-up from the batch review: `ui/src/components/history/history-utils.ts` had its own byte-identical `toLocalDateStr`. Consolidate onto the shared `ui/src/lib/local-date` helper (from #432) so there's a single source of truth for the local 'today' string. No behavior change; tsc + eslint clean, 55 history tests pass.