### PR TITLE
chore(analyse): integration-review cleanups (#442 follow-up)

### DIFF
--- a/ui/src/components/history/history-utils.test.ts
+++ b/ui/src/components/history/history-utils.test.ts
@@ -79,9 +79,15 @@ describe("familiesCompatible", () => {
     expect(familiesCompatible("cumulative", "cumulative")).toBe(true);
   });
 
-  it("accepts unclassified categories anywhere", () => {
-    expect(familiesCompatible(null, "cumulative")).toBe(true);
-    expect(familiesCompatible("cumulative", null)).toBe(true);
+  it("mixes an unclassified (null) category with measurements/states but NOT cumulative", () => {
+    // A null-family series charts as a measurement line, so it joins those — but
+    // cumulative owns the plot as bars and must stay alone (a cover index on an
+    // energy bar chart would be nonsense).
+    expect(familiesCompatible(null, "measurements")).toBe(true);
+    expect(familiesCompatible(null, "states")).toBe(true);
+    expect(familiesCompatible(null, null)).toBe(true);
+    expect(familiesCompatible(null, "cumulative")).toBe(false);
+    expect(familiesCompatible("cumulative", null)).toBe(false);
   });
 });
 

--- a/ui/src/components/history/history-utils.ts
+++ b/ui/src/components/history/history-utils.ts
@@ -26,6 +26,9 @@ export const BOOLEAN_CATEGORIES = new Set<string>([
   // third value (a cover's OPEN/CLOSED/STOP), which HistoryWriter encodes by
   // declared index (#434), so forcing them onto a two-label [0,1] axis would
   // clip and mislabel them. They chart as a plain numeric series instead.
+  // appliance_state is likewise ASSUMED strictly binary here; a plugin that
+  // declares it as a >2-value enum would clip the same way — the robust fix is
+  // to classify by enum cardinality rather than category name (deferred).
   "light_state",
   "appliance_state",
 ]);
@@ -83,8 +86,9 @@ export function familyOf(category: string): ChartFamily | null {
  * anywhere, which is the pre-144 behaviour.
  */
 export function familiesCompatible(a: ChartFamily | null, b: ChartFamily | null): boolean {
-  if (a === null || b === null) return true;
-  if (a === b) return true;
+  if (a === b) return true; // same family (including both unclassified) always mixes
+  // cumulative owns the plot as bars and never mixes — including with a null
+  // (unclassified) family, which otherwise charts as a measurement line.
   return a !== "cumulative" && b !== "cumulative";
 }
 

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -838,8 +838,6 @@
   "analyse.bool.generic.on": "On",
   "analyse.bool.power.off": "Off",
   "analyse.bool.power.on": "On",
-  "analyse.bool.lock.unlocked": "Unlocked",
-  "analyse.bool.lock.locked": "Locked",
   "mqttPublishers.title": "MQTT Publishers",
   "mqttPublishers.subtitle": "Publish equipment, zone and recipe data to MQTT topics",
   "mqttPublishers.newPublisher": "New Publisher",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -838,8 +838,6 @@
   "analyse.bool.generic.on": "Actif",
   "analyse.bool.power.off": "Arrêt",
   "analyse.bool.power.on": "Marche",
-  "analyse.bool.lock.unlocked": "Déverrouillé",
-  "analyse.bool.lock.locked": "Verrouillé",
   "mqttPublishers.title": "Publications MQTT",
   "mqttPublishers.subtitle": "Publier les données d'équipements, zones et recettes vers des topics MQTT",
   "mqttPublishers.newPublisher": "Nouveau publisher",


### PR DESCRIPTION
Low-severity cleanups from the batch integration review:

- **familiesCompatible**: a `null` (unclassified) family no longer mixes with `cumulative` (it would render a numeric index as bars on an energy chart). Still mixes with measurements/states. Test updated.
- **orphaned i18n**: remove `analyse.bool.lock.*` (both locales) unused after cover/gate/lock were dropped from the boolean set in #442's pre-merge fix.
- **doc**: note that `appliance_state` is assumed strictly binary on the 0/1 axis.

tsc + eslint clean, 62 history tests pass.