### PR TITLE
release: v1.42.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,18 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.42.x: Historique des états et navigation plus claire
+
+### v1.42.0 — 2026-08-12 { #v1-42-0 }
+
+- Feat (ui): **les états des équipements apparaissent enfin dans l'historique, à côté des mesures**. Le retour d'état marche/arrêt d'un actionneur (un relais, une pompe, un interrupteur) était enregistré mais jamais tracé, car seules les séries numériques l'étaient. Les valeurs d'état sont désormais stockées aussi sous forme numérique : la page Analyse peut tracer une courbe de température et le relais qui la pilote sur un même graphe, le relais sur son propre axe 0/1 à droite. Les volets, portails et serrures à plus de deux valeurs se tracent en série numérique simple. L'historisation des états est côté cœur ; l'axe mixte d'Analyse a été contribué par Adrien Jouve (computingify). (spec 144, #434, #442)
+- Feat (ui): **les recettes peuvent afficher une ligne de statut en direct sur leur carte**. Une recette peut résumer en une ligne ce qu'elle fait, par exemple une pompe de piscine affichant « Filtration 2,1/9,6 h, heures creuses » au lieu que ce contexte vive uniquement dans le journal de la recette. (#431)
+- Feat (ui): **les chemins de zone sont affichés dans tous les menus et libellés de zone**. Deux pièces de même nom (une « Salle de bain » à chaque étage) étaient indiscernables dans la plupart des sélecteurs ; chaque zone porte désormais son chemin de désambiguïsation partout. Contribué par Adrien Jouve (computingify). (spec 139, #433)
+- Fix (ui): **la vue énergie est atteignable juste après minuit local**. « Aujourd'hui » était calculé en UTC, donc pendant les premières heures après minuit (jusqu'à 02:00 l'été) le jour courant était traité comme futur et ses données inaccessibles. Le jour calendaire local est désormais utilisé. (#432)
+- Fix (equipments): **les appareils qui reportent à la variation ne clignotent plus entre online et degraded**. Une prise avec mesure ne remonte sa puissance qu'au changement : une charge stable cesse de mettre à jour et la fenêtre de fraîcheur serrée basculait l'équipement en degraded à chaque cycle (180 changements de statut en une heure sur une installation). La puissance, le courant et la tension qui arrivent en bonus sur un équipement non-compteur sont désormais exemptés de cette fenêtre ; les vrais compteurs restent dégradés en cas de silence réel. Contribué par Adrien Jouve (computingify). (spec 116, #440)
+
+---
+
 ## 1.41.x: Précision des mesures et alarmes acquittables
 
 ### v1.41.0 — 2026-08-12 { #v1-41-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,18 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.42.x: State history and clearer navigation
+
+### v1.42.0 — 2026-08-12 { #v1-42-0 }
+
+- Feat (ui): **equipment states now appear in history, next to measurements**. On/off actuator feedback (a relay, a pump, a switch) was recorded but never drawn, because only numeric series were charted. State values are now stored numerically as well, so the Analyse page can plot a temperature curve and the relay driving it on a single chart, with the relay on its own 0/1 axis on the right. Covers, gates and locks that carry more than two values chart as a plain numeric series. The state historization is core; the Analyse mixed-axis was contributed by Adrien Jouve (computingify). (spec 144, #434, #442)
+- Feat (ui): **recipes can show a live status line on their card**. A recipe can now surface a one-line summary of what it is doing, for example a pool pump showing "Filtration 2.1/9.6 h, off-peak" instead of that context living only in the recipe log. (#431)
+- Feat (ui): **zone paths are shown in every zone dropdown and label**. Two rooms sharing a name (a "Bathroom" on each floor) were indistinguishable in most pickers; every zone now carries its disambiguating path everywhere. Contributed by Adrien Jouve (computingify). (spec 139, #433)
+- Fix (ui): **the energy view is reachable right after local midnight**. "Today" was computed in UTC, so for the first hours after local midnight (until 02:00 in summer) the current day was treated as the future and its data was unreachable. It now uses the local calendar day. (#432)
+- Fix (equipments): **report-on-change devices no longer flap between online and degraded**. A metering plug reports power only when it changes, so a steady load stopped updating and the tight freshness window tipped the equipment to degraded on every reporting cycle (180 status changes in an hour on one install). Power, current and voltage that arrive as a bonus on a non-metering equipment are now exempt from that window; dedicated meters still degrade on genuine silence. Contributed by Adrien Jouve (computingify). (spec 116, #440)
+
+---
+
 ## 1.41.x: Metering accuracy and acknowledgeable alarms
 
 ### v1.41.0 — 2026-08-12 { #v1-41-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.41.0",
+  "version": "1.42.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## v1.42.0

Cuts the release for the batch already on `main` (all merged, integrated main green: 1355 tests + tsc clean, integration-reviewed SAFE).

**User-facing (release notes added to both locales, anchor `{ #v1-42-0 }`):**
- Equipment states now chart, and read next to measurements on Analyse (spec 144, #434 + #442)
- Recipe status line on the card (#431)
- Zone paths in every dropdown/label (spec 139, #433)
- Energy view reachable right after local midnight (#432)
- Report-on-change devices no longer flap online/degraded (spec 116, #440)

**Internal:** local-date helper consolidation (#441), Analyse review cleanups (#443).

**Contributors:** #442 (Analyse axis), #433, #440 by Adrien Jouve (computingify).

- [x] version bumped 1.41.0 -> 1.42.0 (package.json + ui/package.json)
- [x] release notes in `docs/release-notes.md` + `docs/release-notes.fr.md` with `{ #v1-42-0 }`

After merge: tag `v1.42.0` on the merged commit + push (triggers the Docker build). **No deploy** the running instance is updated separately when you choose.