### PR TITLE
test(core): apply full migration set in DB-backed tests via shared helper

### DIFF
--- a/src/api/routes/audit.test.ts
+++ b/src/api/routes/audit.test.ts
@@ -3,6 +3,7 @@ import Fastify from "fastify";
 import { describe, it, expect, afterEach } from "vitest";
 import { AuditLogger } from "../../core/audit-logger.js";
 import { createLogger } from "../../core/logger.js";
+import { applyMigrations } from "../../test-helpers/migrations.js";
 import { registerAuditRoutes } from "./audit.js";
 
 // Spec 113 — Integration test on GET /api/v1/audit via Fastify inject().
@@ -21,20 +22,7 @@ async function buildApp(opts: BuildOpts = {}): Promise<{
   auditLogger: AuditLogger;
 }> {
   const db = new Database(":memory:");
-  db.exec(`
-    CREATE TABLE audit_log (
-      id TEXT PRIMARY KEY,
-      timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      actor_kind TEXT NOT NULL,
-      actor_user_id TEXT,
-      actor_label TEXT NOT NULL,
-      action TEXT NOT NULL,
-      target_type TEXT,
-      target_id TEXT,
-      ip TEXT,
-      meta TEXT
-    );
-  `);
+  applyMigrations(db);
   const auditLogger = new AuditLogger(db, logger);
   if (opts.seed) opts.seed(auditLogger);
 

--- a/src/api/routes/calendar.test.ts
+++ b/src/api/routes/calendar.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Fastify from "fastify";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { CalendarManager } from "../../modes/calendar-manager.js";
+import { applyMigrations } from "../../test-helpers/migrations.js";
 import { ModeManager } from "../../modes/mode-manager.js";
 import { SettingsManager } from "../../core/settings-manager.js";
 import { EventBus } from "../../core/event-bus.js";
@@ -14,20 +13,7 @@ import type { CalendarModeAction } from "../../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-  ]) {
-    const sql = readFileSync(
-      resolve(import.meta.dirname ?? ".", `../../../migrations/${file}`),
-      "utf-8",
-    );
-    db.exec(sql);
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/api/routes/modes.test.ts
+++ b/src/api/routes/modes.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Fastify from "fastify";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { ModeManager } from "../../modes/mode-manager.js";
+import { applyMigrations } from "../../test-helpers/migrations.js";
 import { EventBus } from "../../core/event-bus.js";
 import { createLogger } from "../../core/logger.js";
 import { AuditLogger } from "../../core/audit-logger.js";
@@ -12,21 +11,7 @@ import { registerModeRoutes } from "./modes.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-    "010_audit_log.sql",
-  ]) {
-    const sql = readFileSync(
-      resolve(import.meta.dirname ?? ".", `../../../migrations/${file}`),
-      "utf-8",
-    );
-    db.exec(sql);
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/backup/backup-manager.test.ts
+++ b/src/backup/backup-manager.test.ts
@@ -6,14 +6,13 @@ import { tmpdir } from "node:os";
 import AdmZip from "adm-zip";
 import { BackupManager, BackupSizeCapExceededError } from "./backup-manager.js";
 import { createLogger } from "../core/logger.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import type { InfluxClient } from "../core/influx-client.js";
 
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  db.exec(
-    readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations/001_initial.sql"), "utf-8"),
-  );
+  applyMigrations(db);
   return db;
 }
 

--- a/src/buttons/button-action-manager.test.ts
+++ b/src/buttons/button-action-manager.test.ts
@@ -1,28 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { ButtonActionManager } from "./button-action-manager.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
 
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-  ]) {
-    const sql = readFileSync(
-      resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),
-      "utf-8",
-    );
-    db.exec(sql);
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/core/audit-logger.test.ts
+++ b/src/core/audit-logger.test.ts
@@ -2,9 +2,11 @@ import Database from "better-sqlite3";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { AuditLogger } from "./audit-logger.js";
 import type { Logger } from "./logger.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 
 // Spec 113 — Unit tests on the AuditLogger over an in-memory SQLite
-// database. The schema mirrors migrations/010_audit_log.sql exactly.
+// database seeded with the real migration set (audit_log lives in
+// migrations/010_audit_log.sql).
 
 interface MockLogger {
   error: ReturnType<typeof vi.fn>;
@@ -17,26 +19,6 @@ function makeMockLogger(): MockLogger {
   return self;
 }
 
-function createSchema(db: Database.Database): void {
-  db.exec(`
-    CREATE TABLE audit_log (
-      id TEXT PRIMARY KEY,
-      timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      actor_kind TEXT NOT NULL,
-      actor_user_id TEXT,
-      actor_label TEXT NOT NULL,
-      action TEXT NOT NULL,
-      target_type TEXT,
-      target_id TEXT,
-      ip TEXT,
-      meta TEXT
-    );
-    CREATE INDEX idx_audit_log_timestamp ON audit_log (timestamp DESC);
-    CREATE INDEX idx_audit_log_actor_user_id ON audit_log (actor_user_id);
-    CREATE INDEX idx_audit_log_action ON audit_log (action);
-  `);
-}
-
 describe("AuditLogger", () => {
   let db: Database.Database;
   let logger: MockLogger;
@@ -44,7 +26,7 @@ describe("AuditLogger", () => {
 
   beforeEach(() => {
     db = new Database(":memory:");
-    createSchema(db);
+    applyMigrations(db);
     logger = makeMockLogger();
     auditLogger = new AuditLogger(db, logger as unknown as Logger);
   });

--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { DeviceManager } from "./device-manager.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
 import type { EngineEvent } from "../shared/types.js";
@@ -10,21 +9,7 @@ import type { EngineEvent } from "../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-    "014_device_orders_value_on_off.sql",
-  ]) {
-    const sql = readFileSync(
-      resolve(import.meta.dirname ?? ".", "../../migrations", file),
-      "utf-8",
-    );
-    db.exec(sql);
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/energy/power-submeter-integrator.test.ts
+++ b/src/energy/power-submeter-integrator.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { PowerSubmeterIntegrator } from "./power-submeter-integrator.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
@@ -11,24 +10,7 @@ import type { InfluxClient } from "../core/influx-client.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  const migrations = [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-    "007_pool_water_temp_state.sql",
-    "008_mqtt_publisher_mapping_enabled.sql",
-    "009_submeter_integrator_state.sql",
-  ];
-  for (const file of migrations) {
-    const sql = readFileSync(
-      resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),
-      "utf-8",
-    );
-    db.exec(sql);
-  }
+  applyMigrations(db);
   // Insert minimum zone + equipment rows to satisfy FK on submeter state inserts.
   db.prepare(`INSERT INTO zones (id, name) VALUES (?, ?)`).run("zone-1", "Test");
   db.prepare(

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { EquipmentManager, EquipmentError } from "./equipment-manager.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { DeviceManager } from "../devices/device-manager.js";
 import { ZoneManager } from "../zones/zone-manager.js";
 import { EventBus } from "../core/event-bus.js";
@@ -12,18 +11,7 @@ import type { EngineEvent } from "../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-    "014_device_orders_value_on_off.sql",
-    "016_equipment_energy_profile.sql",
-  ]) {
-    db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/equipments/pool-runtime-tracker.test.ts
+++ b/src/equipments/pool-runtime-tracker.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { EquipmentManager } from "./equipment-manager.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { PoolRuntimeTracker } from "./pool-runtime-tracker.js";
 import { DeviceManager } from "../devices/device-manager.js";
 import { ZoneManager } from "../zones/zone-manager.js";
@@ -12,18 +11,7 @@ import { createLogger } from "../core/logger.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-    "014_device_orders_value_on_off.sql",
-    "016_equipment_energy_profile.sql",
-  ]) {
-    db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/equipments/weather-temp-extremes-tracker.test.ts
+++ b/src/equipments/weather-temp-extremes-tracker.test.ts
@@ -1,23 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Database from "better-sqlite3";
-import { readdirSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import crypto from "node:crypto";
 import { EquipmentManager } from "./equipment-manager.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { WeatherTempExtremesTracker } from "./weather-temp-extremes-tracker.js";
 import { DeviceManager } from "../devices/device-manager.js";
 import { ZoneManager } from "../zones/zone-manager.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
 
-const MIGRATIONS_DIR = resolve(import.meta.dirname ?? ".", "../../migrations");
-
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of readdirSync(MIGRATIONS_DIR).sort()) {
-    if (file.endsWith(".sql")) db.exec(readFileSync(resolve(MIGRATIONS_DIR, file), "utf-8"));
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/modes/calendar-manager.test.ts
+++ b/src/modes/calendar-manager.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { CalendarManager, CalendarError } from "./calendar-manager.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { ModeManager } from "./mode-manager.js";
 import { SettingsManager } from "../core/settings-manager.js";
 import { EventBus } from "../core/event-bus.js";
@@ -12,20 +11,7 @@ import type { CalendarModeAction, EngineEvent } from "../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-  ]) {
-    const sql = readFileSync(
-      resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),
-      "utf-8",
-    );
-    db.exec(sql);
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/modes/mode-manager.test.ts
+++ b/src/modes/mode-manager.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { ModeManager, ModeError } from "./mode-manager.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
 import type { EngineEvent } from "../shared/types.js";
@@ -10,21 +9,7 @@ import type { EngineEvent } from "../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  // Load required migrations
-  for (const file of [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-  ]) {
-    const sql = readFileSync(
-      resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),
-      "utf-8",
-    );
-    db.exec(sql);
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/mqtt-publishers/mqtt-publish-service.test.ts
+++ b/src/mqtt-publishers/mqtt-publish-service.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { MqttBrokerManager } from "./mqtt-broker-manager.js";
 import { MqttPublisherManager } from "./mqtt-publisher-manager.js";
 
@@ -30,23 +29,7 @@ vi.mock("mqtt", () => ({
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  const migrations = [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-    "007_pool_water_temp_state.sql",
-    "008_mqtt_publisher_mapping_enabled.sql",
-  ];
-  for (const file of migrations) {
-    const sql = readFileSync(
-      resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),
-      "utf-8",
-    );
-    db.exec(sql);
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/mqtt-publishers/mqtt-publisher-manager.test.ts
+++ b/src/mqtt-publishers/mqtt-publisher-manager.test.ts
@@ -1,31 +1,14 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { MqttPublisherManager } from "./mqtt-publisher-manager.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
 
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  const migrations = [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-    "007_pool_water_temp_state.sql",
-    "008_mqtt_publisher_mapping_enabled.sql",
-  ];
-  for (const file of migrations) {
-    const sql = readFileSync(
-      resolve(import.meta.dirname ?? ".", `../../migrations/${file}`),
-      "utf-8",
-    );
-    db.exec(sql);
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/notifications/notification-publisher-manager.test.ts
+++ b/src/notifications/notification-publisher-manager.test.ts
@@ -1,24 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { readdirSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import {
   NotificationPublisherManager,
   NotificationPublisherError,
 } from "./notification-publisher-manager.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
-
-const MIGRATIONS_DIR = resolve(import.meta.dirname ?? ".", "../../migrations");
+import { applyMigrations } from "../test-helpers/migrations.js";
 
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of readdirSync(MIGRATIONS_DIR)
-    .filter((f) => f.endsWith(".sql"))
-    .sort()) {
-    db.exec(readFileSync(resolve(MIGRATIONS_DIR, file), "utf-8"));
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/notifications/push-subscription-manager.test.ts
+++ b/src/notifications/push-subscription-manager.test.ts
@@ -1,20 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { readdirSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { PushSubscriptionManager } from "./push-subscription-manager.js";
 import { createLogger } from "../core/logger.js";
-
-const MIGRATIONS_DIR = resolve(import.meta.dirname ?? ".", "../../migrations");
+import { applyMigrations } from "../test-helpers/migrations.js";
 
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of readdirSync(MIGRATIONS_DIR)
-    .filter((f) => f.endsWith(".sql"))
-    .sort()) {
-    db.exec(readFileSync(resolve(MIGRATIONS_DIR, file), "utf-8"));
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/notifications/vapid.test.ts
+++ b/src/notifications/vapid.test.ts
@@ -11,9 +11,8 @@ vi.mock("web-push", () => ({
 }));
 
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { ensureVapidKeys } from "./vapid.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { SettingsManager } from "../core/settings-manager.js";
 import { createLogger } from "../core/logger.js";
 
@@ -21,9 +20,7 @@ const logger = createLogger("silent").logger;
 
 function createSettings(): { settings: SettingsManager; db: Database.Database } {
   const db = new Database(":memory:");
-  db.exec(
-    readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations/001_initial.sql"), "utf-8"),
-  );
+  applyMigrations(db);
   return { settings: new SettingsManager(db), db };
 }
 

--- a/src/packages/package-manager.test.ts
+++ b/src/packages/package-manager.test.ts
@@ -26,6 +26,7 @@ import { createHash } from "node:crypto";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { PackageManager } from "./package-manager.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import {
   ChecksumMismatchError,
   CommunityPluginConfirmationRequiredError,
@@ -44,16 +45,7 @@ const logger = createLogger("silent").logger;
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  db.exec(
-    readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations/001_initial.sql"), "utf-8"),
-  );
-  // Spec 136 — plugin_sources table + plugins.source/pinned_sha256 columns.
-  db.exec(
-    readFileSync(
-      resolve(import.meta.dirname ?? ".", "../../migrations/015_plugin_sources.sql"),
-      "utf-8",
-    ),
-  );
+  applyMigrations(db);
   return db;
 }
 

--- a/src/packages/personal-sources.test.ts
+++ b/src/packages/personal-sources.test.ts
@@ -4,9 +4,8 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { PersonalSourceManager, type PersonalRelease } from "./personal-sources.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { createLogger } from "../core/logger.js";
 
 const logger = createLogger("silent").logger;
@@ -14,15 +13,7 @@ const REPO = "jdupont/sowel-recipe-myrecipe";
 
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
-  db.exec(
-    readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations/001_initial.sql"), "utf-8"),
-  );
-  db.exec(
-    readFileSync(
-      resolve(import.meta.dirname ?? ".", "../../migrations/015_plugin_sources.sql"),
-      "utf-8",
-    ),
-  );
+  applyMigrations(db);
   return db;
 }
 

--- a/src/recipes/engine/recipe-manager.test.ts
+++ b/src/recipes/engine/recipe-manager.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { ZoneManager } from "../../zones/zone-manager.js";
+import { applyMigrations } from "../../test-helpers/migrations.js";
 import { ZoneAggregator } from "../../zones/zone-aggregator.js";
 import { EquipmentManager } from "../../equipments/equipment-manager.js";
 import { DeviceManager } from "../../devices/device-manager.js";
@@ -48,23 +47,7 @@ const tariffClassifier = {
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  const migrations = [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-    "014_device_orders_value_on_off.sql",
-    "016_equipment_energy_profile.sql",
-  ];
-  for (const file of migrations) {
-    const sql = readFileSync(
-      resolve(import.meta.dirname ?? ".", "../../../migrations", file),
-      "utf-8",
-    );
-    db.exec(sql);
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/test-helpers/migrations.ts
+++ b/src/test-helpers/migrations.ts
@@ -1,0 +1,32 @@
+import Database from "better-sqlite3";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Resolve the migrations directory relative to this helper (not the calling
+// test), so the path is stable regardless of the test file's depth in src/.
+const MIGRATIONS_DIR = resolve(import.meta.dirname ?? ".", "../../migrations");
+
+/**
+ * Apply every migration in `migrations/` to the given database, in the same
+ * order as production (`runMigrations` in src/core/database.ts: all `.sql`
+ * files, sorted alphabetically). Tests must not hardcode a subset — that list
+ * silently drifts from the real schema as migrations are added.
+ */
+export function applyMigrations(db: Database.Database): void {
+  for (const file of readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort()) {
+    db.exec(readFileSync(resolve(MIGRATIONS_DIR, file), "utf-8"));
+  }
+}
+
+/**
+ * Create an in-memory SQLite database with foreign keys enabled and the full
+ * migration set applied. The standard starting point for DB-backed tests.
+ */
+export function createMigratedTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  applyMigrations(db);
+  return db;
+}

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { ZoneManager } from "./zone-manager.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { ZoneAggregator } from "./zone-aggregator.js";
 import { EquipmentManager } from "../equipments/equipment-manager.js";
 import { DeviceManager } from "../devices/device-manager.js";
@@ -13,18 +12,7 @@ import type { EngineEvent } from "../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  for (const file of [
-    "001_initial.sql",
-    "002_mqtt_publisher_on_change_only.sql",
-    "003_device_order_category.sql",
-    "004_drop_dispatch_config.sql",
-    "005_device_data_enum_values.sql",
-    "006_pool_runtime_and_category_override.sql",
-    "014_device_orders_value_on_off.sql",
-    "016_equipment_energy_profile.sql",
-  ]) {
-    db.exec(readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations", file), "utf-8"));
-  }
+  applyMigrations(db);
   return db;
 }
 

--- a/src/zones/zone-manager.test.ts
+++ b/src/zones/zone-manager.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { ZoneManager, ZoneError } from "./zone-manager.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
 import type { EngineEvent } from "../shared/types.js";
@@ -10,9 +9,7 @@ import type { EngineEvent } from "../shared/types.js";
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
-  db.exec(
-    readFileSync(resolve(import.meta.dirname ?? ".", "../../migrations/001_initial.sql"), "utf-8"),
-  );
+  applyMigrations(db);
   return db;
 }
 


### PR DESCRIPTION
## Problem

DB-backed tests built their in-memory SQLite schema from a **hardcoded subset** of migration files (e.g. `device-manager.test.ts` listed 7 of the 16 migrations), and `audit-logger.test.ts` kept an inline `CREATE TABLE` copy of `010_audit_log.sql`. As the schema evolves, these lists silently drift from production reality: a test can keep passing against a schema that no longer matches what runs in prod.

This was flagged in the v1.42.0 backend review as the one gap undermining the suite's main strength (real SQLite + real migrations).

## Change

- Add `src/test-helpers/migrations.ts`:
  - `applyMigrations(db)` — globs `migrations/*.sql`, sorts alphabetically, applies all (mirrors `runMigrations()` in `core/database.ts`).
  - `createMigratedTestDb()` — in-memory DB with FKs on + full migration set.
- Point all 22 DB-backed test files at the helper. Three files already globbed correctly (weather-temp-extremes, push-subscription, notification-publisher) and now share the helper too.
- Replace the inline audit-log schema with `applyMigrations`.

Net **-253 lines**. No production code touched.

## Verification

- `npx tsc --noEmit` clean
- `npx eslint src/` clean
- `npx prettier --check` clean
- `npx vitest run` — **1355 passed / 2 skipped** (unchanged)
- No test file references individual migration filenames anymore; adding a new migration now requires zero test changes for the schema to be picked up.

Closes #447