### PR TITLE
test: cover previously-untested backend modules (#449)

### DIFF
--- a/src/charts/chart-manager.test.ts
+++ b/src/charts/chart-manager.test.ts
@@ -105,6 +105,16 @@ describe("ChartManager", () => {
         expect((e as ChartError).status).toBe(404);
       }
     });
+
+    it("blanks the name on an all-whitespace update (asymmetry with createChart)", () => {
+      // `updates.name?.trim() ?? existing.name`: "   ".trim() is "" which is
+      // NOT nullish, so `??` does not fall back — the name is set to "".
+      // createChart rejects an empty name (400) but updateChart does not; this
+      // test pins the current (asymmetric) behavior so a future fix is deliberate.
+      const chart = manager.createChart("Original", CONFIG);
+      const updated = manager.updateChart(chart.id, { name: "   " });
+      expect(updated.name).toBe("");
+    });
   });
 
   describe("deleteChart", () => {

--- a/src/charts/chart-manager.test.ts
+++ b/src/charts/chart-manager.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type Database from "better-sqlite3";
+import { ChartManager, ChartError } from "./chart-manager.js";
+import { createLogger } from "../core/logger.js";
+import { createMigratedTestDb } from "../test-helpers/migrations.js";
+import type { SavedChartConfig } from "../shared/types.js";
+
+const logger = createLogger("silent").logger;
+
+const CONFIG: SavedChartConfig = {
+  series: [{ equipmentId: "eq-1", alias: "temperature" }],
+  period: "day",
+  date: "2026-08-12",
+};
+
+describe("ChartManager", () => {
+  let db: Database.Database;
+  let manager: ChartManager;
+
+  beforeEach(() => {
+    db = createMigratedTestDb();
+    manager = new ChartManager(db, logger);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe("createChart", () => {
+    it("persists a chart and returns it with the config round-tripped", () => {
+      const chart = manager.createChart("My chart", CONFIG);
+
+      expect(chart.id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(chart.name).toBe("My chart");
+      expect(chart.config).toEqual(CONFIG);
+      expect(chart.createdAt).toBeTruthy();
+      expect(manager.getChart(chart.id)?.config.series[0].alias).toBe("temperature");
+    });
+
+    it("trims the name before storing", () => {
+      const chart = manager.createChart("  spaced  ", CONFIG);
+      expect(chart.name).toBe("spaced");
+    });
+
+    it("rejects an empty or whitespace-only name with a 400 ChartError", () => {
+      expect(() => manager.createChart("", CONFIG)).toThrow(ChartError);
+      expect(() => manager.createChart("   ", CONFIG)).toThrow(ChartError);
+      try {
+        manager.createChart("", CONFIG);
+      } catch (e) {
+        expect((e as ChartError).status).toBe(400);
+      }
+    });
+  });
+
+  describe("listCharts", () => {
+    it("returns an empty array when there are no charts", () => {
+      expect(manager.listCharts()).toEqual([]);
+    });
+
+    it("returns charts ordered by name", () => {
+      manager.createChart("Zeta", CONFIG);
+      manager.createChart("Alpha", CONFIG);
+      manager.createChart("Mike", CONFIG);
+
+      expect(manager.listCharts().map((c) => c.name)).toEqual(["Alpha", "Mike", "Zeta"]);
+    });
+  });
+
+  describe("getChart", () => {
+    it("returns null for an unknown id", () => {
+      expect(manager.getChart("nope")).toBeNull();
+    });
+  });
+
+  describe("updateChart", () => {
+    it("updates the name while keeping the existing config", () => {
+      const chart = manager.createChart("Original", CONFIG);
+      const updated = manager.updateChart(chart.id, { name: "Renamed" });
+
+      expect(updated.name).toBe("Renamed");
+      expect(updated.config).toEqual(CONFIG);
+    });
+
+    it("updates the config while keeping the existing name", () => {
+      const chart = manager.createChart("Keep me", CONFIG);
+      const newConfig: SavedChartConfig = {
+        series: [{ equipmentId: "eq-2", alias: "humidity" }],
+        timeRange: "24h",
+      };
+
+      const updated = manager.updateChart(chart.id, { config: newConfig });
+      expect(updated.name).toBe("Keep me");
+      expect(updated.config).toEqual(newConfig);
+      // Round-trips through the DB, not just the returned object.
+      expect(manager.getChart(chart.id)?.config).toEqual(newConfig);
+    });
+
+    it("throws a 404 ChartError for an unknown id", () => {
+      try {
+        manager.updateChart("missing", { name: "x" });
+        throw new Error("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ChartError);
+        expect((e as ChartError).status).toBe(404);
+      }
+    });
+  });
+
+  describe("deleteChart", () => {
+    it("removes the chart", () => {
+      const chart = manager.createChart("Doomed", CONFIG);
+      manager.deleteChart(chart.id);
+
+      expect(manager.getChart(chart.id)).toBeNull();
+      expect(manager.listCharts()).toEqual([]);
+    });
+
+    it("throws a 404 ChartError for an unknown id", () => {
+      try {
+        manager.deleteChart("missing");
+        throw new Error("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ChartError);
+        expect((e as ChartError).status).toBe(404);
+      }
+    });
+  });
+});

--- a/src/core/version-checker.test.ts
+++ b/src/core/version-checker.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { VersionChecker } from "./version-checker.js";
+import { EventBus } from "./event-bus.js";
+import { createLogger } from "./logger.js";
+import type { UpdateManager } from "./update-manager.js";
+import type { EngineEvent } from "../shared/types.js";
+
+const logger = createLogger("silent").logger;
+
+function ghResponse(tag: string, ok = true, url = "https://github.com/mchacher/sowel/releases/x") {
+  return {
+    ok,
+    status: ok ? 200 : 404,
+    json: async () => ({ tag_name: tag, html_url: url }),
+  } as Response;
+}
+
+function makeChecker(composeManaged = false): {
+  checker: VersionChecker;
+  events: EngineEvent[];
+  current: string;
+} {
+  const eventBus = new EventBus(logger);
+  const events: EngineEvent[] = [];
+  eventBus.on((e) => events.push(e));
+  const updateManager = { isComposeManaged: () => composeManaged } as unknown as UpdateManager;
+  const checker = new VersionChecker(eventBus, updateManager, logger);
+  return { checker, events, current: checker.getVersionInfo().current };
+}
+
+describe("VersionChecker", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reads the current version from package.json in the constructor", () => {
+    const { current } = makeChecker();
+    expect(current).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("emits system.update.available and flags updateAvailable when a newer release exists", async () => {
+    const { checker, events, current } = makeChecker();
+    const [maj, min, patch] = current.split(".").map(Number);
+    const newer = `v${maj}.${min}.${patch + 1}`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ghResponse(newer)),
+    );
+
+    const info = await checker.checkNow();
+
+    expect(info.latest).toBe(newer.replace(/^v/, ""));
+    expect(info.updateAvailable).toBe(true);
+    expect(info.releaseUrl).toBe("https://github.com/mchacher/sowel/releases/x");
+    const update = events.find((e) => e.type === "system.update.available");
+    expect(update).toBeDefined();
+  });
+
+  it("does not flag an update when the latest release equals the current version", async () => {
+    const { checker, events, current } = makeChecker();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ghResponse(`v${current}`)),
+    );
+
+    const info = await checker.checkNow();
+
+    expect(info.latest).toBe(current);
+    expect(info.updateAvailable).toBe(false);
+    expect(events.some((e) => e.type === "system.update.available")).toBe(false);
+  });
+
+  it("does not flag an update when the latest release is older", async () => {
+    const { checker } = makeChecker();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ghResponse("v0.0.1")),
+    );
+
+    const info = await checker.checkNow();
+    expect(info.updateAvailable).toBe(false);
+  });
+
+  it("ignores a non-OK GitHub response without throwing", async () => {
+    const { checker } = makeChecker();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ghResponse("v99.0.0", false)),
+    );
+
+    const info = await checker.checkNow();
+    expect(info.latest).toBeNull();
+    expect(info.updateAvailable).toBe(false);
+  });
+
+  it("swallows a fetch/network error", async () => {
+    const { checker } = makeChecker();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+
+    const info = await checker.checkNow();
+    expect(info.latest).toBeNull();
+  });
+
+  it("reflects the compose-managed flag from the UpdateManager", () => {
+    expect(makeChecker(true).checker.getVersionInfo().composeManaged).toBe(true);
+    expect(makeChecker(false).checker.getVersionInfo().composeManaged).toBe(false);
+  });
+
+  it("stop() is safe to call before start()", () => {
+    const { checker } = makeChecker();
+    expect(() => checker.stop()).not.toThrow();
+  });
+});

--- a/src/core/version-checker.test.ts
+++ b/src/core/version-checker.test.ts
@@ -57,7 +57,27 @@ describe("VersionChecker", () => {
     expect(info.updateAvailable).toBe(true);
     expect(info.releaseUrl).toBe("https://github.com/mchacher/sowel/releases/x");
     const update = events.find((e) => e.type === "system.update.available");
-    expect(update).toBeDefined();
+    expect(update).toMatchObject({
+      type: "system.update.available",
+      current,
+      latest: newer.replace(/^v/, ""),
+      releaseUrl: "https://github.com/mchacher/sowel/releases/x",
+    });
+  });
+
+  it("does not re-emit when a repeated check returns the same latest tag", async () => {
+    const { checker, events, current } = makeChecker();
+    const [maj, min, patch] = current.split(".").map(Number);
+    const newer = `v${maj}.${min}.${patch + 1}`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ghResponse(newer)),
+    );
+
+    await checker.checkNow();
+    await checker.checkNow(); // same tag — cached, no second event
+
+    expect(events.filter((e) => e.type === "system.update.available")).toHaveLength(1);
   });
 
   it("does not flag an update when the latest release equals the current version", async () => {

--- a/src/history/history-query.test.ts
+++ b/src/history/history-query.test.ts
@@ -1,129 +1,301 @@
-import { describe, expect, it } from "vitest";
-import { buildFluxQuery } from "./history-query";
+import { describe, it, expect } from "vitest";
+import {
+  buildFluxQuery,
+  queryHistory,
+  querySparkline,
+  queryZoneSparkline,
+  queryHistorizedAliases,
+} from "./history-query.js";
+import { createLogger } from "../core/logger.js";
+import type { InfluxClient } from "../core/influx-client.js";
 
-const baseParams = {
+const logger = createLogger("silent").logger;
+
+/**
+ * Build a fake InfluxClient. `rows` is the list of row objects each query
+ * iteration should yield; `capture` (optional) records every Flux string run.
+ * Pass `configured: false` to simulate an unconfigured client.
+ */
+function makeInflux(options: {
+  rows?: Record<string, unknown>[];
+  capture?: string[];
+  configured?: boolean;
+  throwOnQuery?: boolean;
+}): InfluxClient {
+  const { rows = [], capture, configured = true, throwOnQuery = false } = options;
+
+  const queryApi = {
+    iterateRows(flux: string) {
+      capture?.push(flux);
+      if (throwOnQuery) throw new Error("influx boom");
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const row of rows) {
+            yield { values: row, tableMeta: { toObject: (v: unknown) => v } };
+          }
+        },
+      };
+    },
+  };
+
+  return {
+    getConfig: () => (configured ? { org: "sowel-org", bucket: "sowel" } : null),
+    getClient: () => (configured ? { getQueryApi: () => queryApi } : null),
+  } as unknown as InfluxClient;
+}
+
+const BASE = {
   bucket: "sowel",
   equipmentId: "eq-1",
-  alias: "sum_rain_24",
-  from: new Date("2026-05-01T00:00:00Z"),
-  to: new Date("2026-06-01T00:00:00Z"),
+  alias: "temperature",
+  from: new Date("2026-08-01T00:00:00Z"),
+  to: new Date("2026-08-02T00:00:00Z"),
 };
 
 describe("buildFluxQuery", () => {
-  describe("raw bucket", () => {
-    it("filters on value_number for raw resolution", () => {
-      const flux = buildFluxQuery({
-        ...baseParams,
-        resolution: "raw",
-      });
-      expect(flux).toContain('_field == "value_number"');
-      expect(flux).not.toContain("aggregateWindow");
-    });
-
-    it("aggregates with sum on raw bucket fallback for cumulative categories", () => {
-      const flux = buildFluxQuery({
-        ...baseParams,
-        bucket: "sowel",
-        resolution: "1d",
-        category: "rain",
-        isDownsampled: false,
-      });
-      expect(flux).toContain('_field == "value_number"');
-      expect(flux).toContain("aggregateWindow(every: 1d, fn: sum");
-    });
-
-    it("aggregates with mean on raw bucket for continuous categories", () => {
-      const flux = buildFluxQuery({
-        ...baseParams,
-        bucket: "sowel",
-        alias: "temperature",
-        resolution: "1d",
-        category: "temperature",
-        isDownsampled: false,
-      });
-      expect(flux).toContain('_field == "value_number"');
-      expect(flux).toContain("aggregateWindow(every: 1d, fn: mean");
-    });
+  it("raw continuous data: value_number filter, no aggregateWindow, limit 2500", () => {
+    const q = buildFluxQuery({ ...BASE, resolution: "raw" });
+    expect(q).toContain('from(bucket: "sowel")');
+    expect(q).toContain('r._field == "value_number"');
+    expect(q).not.toContain("aggregateWindow");
+    expect(q).toContain("limit(n: 2500)");
   });
 
-  describe("downsampled bucket (F8)", () => {
-    // Rain (cumulative, non-energy) reads the hourly-mean bucket and re-sums it
-    // into the target window — the daily bucket only stores the mean, which
-    // collapsed a day's rain total to ~total/24 (0mm on the 30d view).
-    it("re-sums the hourly mean into daily totals for cumulative categories", () => {
-      const flux = buildFluxQuery({
-        ...baseParams,
-        bucket: "sowel-hourly",
-        resolution: "1d",
-        category: "rain",
-        isDownsampled: true,
-      });
-      expect(flux).toContain('_field == "mean"');
-      expect(flux).toContain("aggregateWindow(every: 1d, fn: sum");
-      expect(flux).toContain('timeSrc: "_start"');
-      expect(flux).not.toContain("value_number");
+  it("raw discrete data uses the 2000 limit", () => {
+    const q = buildFluxQuery({ ...BASE, resolution: "raw", isDiscrete: true });
+    expect(q).toContain("limit(n: 2000)");
+  });
+
+  it("raw-bucket aggregated fallback uses mean for continuous categories", () => {
+    const q = buildFluxQuery({ ...BASE, resolution: "1h", category: "temperature" });
+    expect(q).toContain("aggregateWindow(every: 1h, fn: mean");
+    expect(q).toContain("limit(n: 500)");
+  });
+
+  it("raw-bucket aggregated fallback uses sum for cumulative categories", () => {
+    const q = buildFluxQuery({ ...BASE, resolution: "1d", category: "rain" });
+    expect(q).toContain("aggregateWindow(every: 1d, fn: sum");
+  });
+
+  it("downsampled cumulative (rain) re-sums the hourly mean field into the window", () => {
+    const q = buildFluxQuery({
+      ...BASE,
+      bucket: "sowel-hourly",
+      resolution: "1h",
+      category: "rain",
+      isDownsampled: true,
+    });
+    expect(q).toContain('from(bucket: "sowel-hourly")');
+    expect(q).toContain('r._field == "mean"');
+    expect(q).toContain(
+      'aggregateWindow(every: 1h, fn: sum, createEmpty: false, timeSrc: "_start")',
+    );
+  });
+
+  it("downsampled energy reads the mean field directly with no aggregateWindow", () => {
+    const q = buildFluxQuery({
+      ...BASE,
+      bucket: "sowel-energy-hourly",
+      resolution: "1h",
+      category: "energy",
+      isDownsampled: true,
+    });
+    expect(q).toContain('from(bucket: "sowel-energy-hourly")');
+    expect(q).toContain('r._field == "mean"');
+    expect(q).not.toContain("aggregateWindow");
+    expect(q).toContain("limit(n: 500)");
+  });
+
+  it("downsampled continuous data reads the mean field directly", () => {
+    const q = buildFluxQuery({
+      ...BASE,
+      bucket: "sowel-hourly",
+      resolution: "1h",
+      category: "temperature",
+      isDownsampled: true,
+    });
+    expect(q).toContain('r._field == "mean"');
+    expect(q).not.toContain("aggregateWindow");
+  });
+});
+
+describe("queryHistory", () => {
+  it("returns an empty raw result when Influx is not configured", async () => {
+    const res = await queryHistory(
+      makeInflux({ configured: false }),
+      { equipmentId: "eq-1", alias: "temperature", from: "-24h" },
+      logger,
+    );
+    expect(res).toEqual({ points: [], resolution: "raw" });
+  });
+
+  it("maps raw points and drops rows with a missing or non-numeric value", async () => {
+    const influx = makeInflux({
+      rows: [
+        { _time: "2026-08-01T00:00:00Z", _value: 21.5 },
+        { _time: "2026-08-01T00:05:00Z", _value: "NaN-string" }, // dropped
+        { _value: 22 }, // missing time, dropped
+        { _time: "2026-08-01T00:10:00Z", _value: 22.1 },
+      ],
+      capture: [],
     });
 
-    it("re-sums the hourly mean per hour for cumulative categories (hourly)", () => {
-      const flux = buildFluxQuery({
-        ...baseParams,
-        bucket: "sowel-hourly",
-        resolution: "1h",
-        category: "rain",
-        isDownsampled: true,
-      });
-      expect(flux).toContain('_field == "mean"');
-      expect(flux).toContain("aggregateWindow(every: 1h, fn: sum");
-    });
+    const res = await queryHistory(
+      influx,
+      { equipmentId: "eq-1", alias: "temperature", from: "-1h", dataType: "number" },
+      logger,
+    );
 
-    it("reads the mean field directly for continuous categories (no re-aggregation)", () => {
-      const flux = buildFluxQuery({
-        ...baseParams,
-        bucket: "sowel-daily",
-        alias: "temperature",
-        resolution: "1d",
-        category: "temperature",
-        isDownsampled: true,
-      });
-      expect(flux).toContain('_field == "mean"');
-      expect(flux).not.toContain("aggregateWindow");
-    });
+    expect(res.resolution).toBe("raw");
+    expect(res.points).toEqual([
+      { time: "2026-08-01T00:00:00Z", value: 21.5 },
+      { time: "2026-08-01T00:10:00Z", value: 22.1 },
+    ]);
+  });
 
-    it("does not re-sum energy (it uses its own pre-summed buckets)", () => {
-      const flux = buildFluxQuery({
-        ...baseParams,
-        bucket: "sowel-energy-daily",
-        alias: "energy_total",
-        resolution: "1d",
+  it("forces raw resolution for discrete (boolean/enum) data types", async () => {
+    const capture: string[] = [];
+    const influx = makeInflux({ rows: [], capture });
+    const res = await queryHistory(
+      influx,
+      { equipmentId: "eq-1", alias: "state", from: "-30d", dataType: "boolean" },
+      logger,
+    );
+    expect(res.resolution).toBe("raw");
+    expect(capture[0]).toContain("value_number");
+    expect(capture[0]).toContain("limit(n: 2000)"); // discrete raw limit
+  });
+
+  it("aggregated path pivots mean/min/max into points", async () => {
+    const influx = makeInflux({
+      rows: [{ _time: "2026-08-01T00:00:00Z", mean: 20, min: 18, max: 23 }],
+    });
+    const res = await queryHistory(
+      influx,
+      { equipmentId: "eq-1", alias: "temperature", from: "-7d", aggregation: "1h" },
+      logger,
+    );
+    expect(res.resolution).toBe("1h");
+    expect(res.points[0]).toEqual({ time: "2026-08-01T00:00:00Z", value: 20, min: 18, max: 23 });
+  });
+
+  it("energy category routes to the dedicated energy bucket", async () => {
+    const capture: string[] = [];
+    const influx = makeInflux({ rows: [{ _time: "t", _value: 5 }], capture });
+    await queryHistory(
+      influx,
+      {
+        equipmentId: "eq-1",
+        alias: "consumption",
+        from: "-7d",
+        aggregation: "1h",
         category: "energy",
-        isDownsampled: true,
-      });
-      expect(flux).toContain('_field == "mean"');
-      expect(flux).not.toContain("fn: sum");
-    });
+      },
+      logger,
+    );
+    expect(capture[0]).toContain('from(bucket: "sowel-energy-hourly")');
+  });
 
-    it("includes the equipmentId and alias filters", () => {
-      const flux = buildFluxQuery({
-        ...baseParams,
-        bucket: "sowel-hourly",
-        resolution: "1d",
-        category: "rain",
-        isDownsampled: true,
-      });
-      expect(flux).toContain('r.equipmentId == "eq-1"');
-      expect(flux).toContain('r.alias == "sum_rain_24"');
-    });
+  it("cumulative category falls back to the raw bucket when the downsampled one is empty", async () => {
+    const capture: string[] = [];
+    // Downsampled bucket yields nothing on the first query, then the raw
+    // fallback query yields a point. Both share the same fake row set, so we
+    // instead assert two queries ran (downsampled + raw fallback).
+    const influx = makeInflux({ rows: [], capture });
+    const res = await queryHistory(
+      influx,
+      {
+        equipmentId: "eq-1",
+        alias: "consumption",
+        from: "-7d",
+        aggregation: "1h",
+        category: "energy",
+      },
+      logger,
+    );
+    expect(res.points).toEqual([]);
+    expect(capture.length).toBe(2); // downsampled bucket, then raw fallback
+    expect(capture[0]).toContain('from(bucket: "sowel-energy-hourly")');
+    expect(capture[1]).toContain('from(bucket: "sowel")');
+  });
 
-    it("respects the from/to time window", () => {
-      const flux = buildFluxQuery({
-        ...baseParams,
-        bucket: "sowel-hourly",
-        resolution: "1d",
-        category: "rain",
-        isDownsampled: true,
-      });
-      expect(flux).toContain("2026-05-01T00:00:00.000Z");
-      expect(flux).toContain("2026-06-01T00:00:00.000Z");
+  it("aggregated path falls back to the raw bucket when the downsampled one is empty", async () => {
+    const capture: string[] = [];
+    const influx = makeInflux({ rows: [], capture });
+    await queryHistory(
+      influx,
+      { equipmentId: "eq-1", alias: "temperature", from: "-7d", aggregation: "1h" },
+      logger,
+    );
+    expect(capture.length).toBe(2); // downsampled (sowel-hourly), then raw fallback
+    expect(capture[1]).toContain('from(bucket: "sowel")');
+  });
+
+  it("swallows a query error and returns empty points", async () => {
+    const influx = makeInflux({ throwOnQuery: true });
+    const res = await queryHistory(
+      influx,
+      { equipmentId: "eq-1", alias: "temperature", from: "-1h" },
+      logger,
+    );
+    expect(res.points).toEqual([]);
+  });
+});
+
+describe("querySparkline", () => {
+  it("returns [] when Influx is not configured", async () => {
+    const res = await querySparkline(
+      makeInflux({ configured: false }),
+      { equipmentId: "eq-1", alias: "temperature" },
+      logger,
+    );
+    expect(res).toEqual([]);
+  });
+
+  it("collects numeric values over a 24h / 30m window", async () => {
+    const capture: string[] = [];
+    const influx = makeInflux({
+      rows: [{ _value: 1 }, { _value: 2 }, { _value: "skip" }, { _value: 3 }],
+      capture,
     });
+    const res = await querySparkline(influx, { equipmentId: "eq-1", alias: "temperature" }, logger);
+    expect(res).toEqual([1, 2, 3]);
+    expect(capture[0]).toContain("range(start: -24h)");
+    expect(capture[0]).toContain("aggregateWindow(every: 30m");
+  });
+
+  it("returns [] on error", async () => {
+    const influx = makeInflux({ throwOnQuery: true });
+    expect(
+      await querySparkline(influx, { equipmentId: "eq-1", alias: "temperature" }, logger),
+    ).toEqual([]);
+  });
+});
+
+describe("queryZoneSparkline", () => {
+  it("aggregates a zone/category over 24h", async () => {
+    const capture: string[] = [];
+    const influx = makeInflux({ rows: [{ _value: 4 }, { _value: 6 }], capture });
+    const res = await queryZoneSparkline(
+      influx,
+      { zoneId: "zone-1", category: "temperature" },
+      logger,
+    );
+    expect(res).toEqual([4, 6]);
+    expect(capture[0]).toContain('r.zoneId == "zone-1"');
+    expect(capture[0]).toContain('r.category == "temperature"');
+  });
+});
+
+describe("queryHistorizedAliases", () => {
+  it("returns distinct alias strings", async () => {
+    const influx = makeInflux({ rows: [{ _value: "temperature" }, { _value: "humidity" }] });
+    const res = await queryHistorizedAliases(influx, "eq-1", logger);
+    expect(res).toEqual(["temperature", "humidity"]);
+  });
+
+  it("returns [] on error", async () => {
+    const influx = makeInflux({ throwOnQuery: true });
+    expect(await queryHistorizedAliases(influx, "eq-1", logger)).toEqual([]);
   });
 });

--- a/src/history/history-query.test.ts
+++ b/src/history/history-query.test.ts
@@ -1,15 +1,23 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   buildFluxQuery,
   queryHistory,
   querySparkline,
   queryZoneSparkline,
   queryHistorizedAliases,
-} from "./history-query.js";
-import { createLogger } from "../core/logger.js";
-import type { InfluxClient } from "../core/influx-client.js";
+} from "./history-query";
+import { createLogger } from "../core/logger";
+import type { InfluxClient } from "../core/influx-client";
 
 const logger = createLogger("silent").logger;
+
+const baseParams = {
+  bucket: "sowel",
+  equipmentId: "eq-1",
+  alias: "sum_rain_24",
+  from: new Date("2026-05-01T00:00:00Z"),
+  to: new Date("2026-06-01T00:00:00Z"),
+};
 
 /**
  * Build a fake InfluxClient. `rows` is the list of row objects each query
@@ -44,78 +52,134 @@ function makeInflux(options: {
   } as unknown as InfluxClient;
 }
 
-const BASE = {
-  bucket: "sowel",
-  equipmentId: "eq-1",
-  alias: "temperature",
-  from: new Date("2026-08-01T00:00:00Z"),
-  to: new Date("2026-08-02T00:00:00Z"),
-};
-
 describe("buildFluxQuery", () => {
-  it("raw continuous data: value_number filter, no aggregateWindow, limit 2500", () => {
-    const q = buildFluxQuery({ ...BASE, resolution: "raw" });
-    expect(q).toContain('from(bucket: "sowel")');
-    expect(q).toContain('r._field == "value_number"');
-    expect(q).not.toContain("aggregateWindow");
-    expect(q).toContain("limit(n: 2500)");
-  });
-
-  it("raw discrete data uses the 2000 limit", () => {
-    const q = buildFluxQuery({ ...BASE, resolution: "raw", isDiscrete: true });
-    expect(q).toContain("limit(n: 2000)");
-  });
-
-  it("raw-bucket aggregated fallback uses mean for continuous categories", () => {
-    const q = buildFluxQuery({ ...BASE, resolution: "1h", category: "temperature" });
-    expect(q).toContain("aggregateWindow(every: 1h, fn: mean");
-    expect(q).toContain("limit(n: 500)");
-  });
-
-  it("raw-bucket aggregated fallback uses sum for cumulative categories", () => {
-    const q = buildFluxQuery({ ...BASE, resolution: "1d", category: "rain" });
-    expect(q).toContain("aggregateWindow(every: 1d, fn: sum");
-  });
-
-  it("downsampled cumulative (rain) re-sums the hourly mean field into the window", () => {
-    const q = buildFluxQuery({
-      ...BASE,
-      bucket: "sowel-hourly",
-      resolution: "1h",
-      category: "rain",
-      isDownsampled: true,
+  describe("raw bucket", () => {
+    it("filters on value_number for raw resolution", () => {
+      const flux = buildFluxQuery({
+        ...baseParams,
+        resolution: "raw",
+      });
+      expect(flux).toContain('_field == "value_number"');
+      expect(flux).not.toContain("aggregateWindow");
     });
-    expect(q).toContain('from(bucket: "sowel-hourly")');
-    expect(q).toContain('r._field == "mean"');
-    expect(q).toContain(
-      'aggregateWindow(every: 1h, fn: sum, createEmpty: false, timeSrc: "_start")',
-    );
+
+    it("aggregates with sum on raw bucket fallback for cumulative categories", () => {
+      const flux = buildFluxQuery({
+        ...baseParams,
+        bucket: "sowel",
+        resolution: "1d",
+        category: "rain",
+        isDownsampled: false,
+      });
+      expect(flux).toContain('_field == "value_number"');
+      expect(flux).toContain("aggregateWindow(every: 1d, fn: sum");
+    });
+
+    it("aggregates with mean on raw bucket for continuous categories", () => {
+      const flux = buildFluxQuery({
+        ...baseParams,
+        bucket: "sowel",
+        alias: "temperature",
+        resolution: "1d",
+        category: "temperature",
+        isDownsampled: false,
+      });
+      expect(flux).toContain('_field == "value_number"');
+      expect(flux).toContain("aggregateWindow(every: 1d, fn: mean");
+    });
   });
 
-  it("downsampled energy reads the mean field directly with no aggregateWindow", () => {
-    const q = buildFluxQuery({
-      ...BASE,
-      bucket: "sowel-energy-hourly",
-      resolution: "1h",
-      category: "energy",
-      isDownsampled: true,
+  describe("downsampled bucket (F8)", () => {
+    // Rain (cumulative, non-energy) reads the hourly-mean bucket and re-sums it
+    // into the target window — the daily bucket only stores the mean, which
+    // collapsed a day's rain total to ~total/24 (0mm on the 30d view).
+    it("re-sums the hourly mean into daily totals for cumulative categories", () => {
+      const flux = buildFluxQuery({
+        ...baseParams,
+        bucket: "sowel-hourly",
+        resolution: "1d",
+        category: "rain",
+        isDownsampled: true,
+      });
+      expect(flux).toContain('_field == "mean"');
+      expect(flux).toContain("aggregateWindow(every: 1d, fn: sum");
+      expect(flux).toContain('timeSrc: "_start"');
+      expect(flux).not.toContain("value_number");
     });
-    expect(q).toContain('from(bucket: "sowel-energy-hourly")');
-    expect(q).toContain('r._field == "mean"');
-    expect(q).not.toContain("aggregateWindow");
-    expect(q).toContain("limit(n: 500)");
+
+    it("re-sums the hourly mean per hour for cumulative categories (hourly)", () => {
+      const flux = buildFluxQuery({
+        ...baseParams,
+        bucket: "sowel-hourly",
+        resolution: "1h",
+        category: "rain",
+        isDownsampled: true,
+      });
+      expect(flux).toContain('_field == "mean"');
+      expect(flux).toContain("aggregateWindow(every: 1h, fn: sum");
+    });
+
+    it("reads the mean field directly for continuous categories (no re-aggregation)", () => {
+      const flux = buildFluxQuery({
+        ...baseParams,
+        bucket: "sowel-daily",
+        alias: "temperature",
+        resolution: "1d",
+        category: "temperature",
+        isDownsampled: true,
+      });
+      expect(flux).toContain('_field == "mean"');
+      expect(flux).not.toContain("aggregateWindow");
+    });
+
+    it("does not re-sum energy (it uses its own pre-summed buckets)", () => {
+      const flux = buildFluxQuery({
+        ...baseParams,
+        bucket: "sowel-energy-daily",
+        alias: "energy_total",
+        resolution: "1d",
+        category: "energy",
+        isDownsampled: true,
+      });
+      expect(flux).toContain('_field == "mean"');
+      expect(flux).not.toContain("fn: sum");
+    });
+
+    it("includes the equipmentId and alias filters", () => {
+      const flux = buildFluxQuery({
+        ...baseParams,
+        bucket: "sowel-hourly",
+        resolution: "1d",
+        category: "rain",
+        isDownsampled: true,
+      });
+      expect(flux).toContain('r.equipmentId == "eq-1"');
+      expect(flux).toContain('r.alias == "sum_rain_24"');
+    });
+
+    it("respects the from/to time window", () => {
+      const flux = buildFluxQuery({
+        ...baseParams,
+        bucket: "sowel-hourly",
+        resolution: "1d",
+        category: "rain",
+        isDownsampled: true,
+      });
+      expect(flux).toContain("2026-05-01T00:00:00.000Z");
+      expect(flux).toContain("2026-06-01T00:00:00.000Z");
+    });
   });
 
-  it("downsampled continuous data reads the mean field directly", () => {
-    const q = buildFluxQuery({
-      ...BASE,
-      bucket: "sowel-hourly",
-      resolution: "1h",
-      category: "temperature",
-      isDownsampled: true,
+  describe("raw result limits", () => {
+    it("caps continuous raw data at 2500 points", () => {
+      const flux = buildFluxQuery({ ...baseParams, resolution: "raw" });
+      expect(flux).toContain("limit(n: 2500)");
     });
-    expect(q).toContain('r._field == "mean"');
-    expect(q).not.toContain("aggregateWindow");
+
+    it("caps discrete (state) raw data at 2000 points", () => {
+      const flux = buildFluxQuery({ ...baseParams, resolution: "raw", isDiscrete: true });
+      expect(flux).toContain("limit(n: 2000)");
+    });
   });
 });
 
@@ -199,8 +263,8 @@ describe("queryHistory", () => {
   it("cumulative category falls back to the raw bucket when the downsampled one is empty", async () => {
     const capture: string[] = [];
     // Downsampled bucket yields nothing on the first query, then the raw
-    // fallback query yields a point. Both share the same fake row set, so we
-    // instead assert two queries ran (downsampled + raw fallback).
+    // fallback query runs. Both share the same fake row set, so we assert two
+    // queries ran (downsampled + raw fallback).
     const influx = makeInflux({ rows: [], capture });
     const res = await queryHistory(
       influx,

--- a/src/recipes/recipe-loader.test.ts
+++ b/src/recipes/recipe-loader.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { RecipeLoader } from "./recipe-loader.js";
+import { createLogger } from "../core/logger.js";
+import type { PackageManager } from "../packages/package-manager.js";
+import type { RecipeManager } from "./engine/recipe-manager.js";
+
+const logger = createLogger("silent").logger;
+
+/** Minimal PackageManager stub with only the methods RecipeLoader calls. */
+function makePackageManager(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    installFromGitHub: vi.fn(),
+    probePersonalUpdate: vi.fn(async () => undefined),
+    updateFiles: vi.fn(),
+    getInstalledByType: vi.fn(() => []),
+    getPackageDir: vi.fn((id: string) => `/nonexistent/${id}`),
+    downloadMissing: vi.fn(),
+    ...overrides,
+  } as unknown as PackageManager;
+}
+
+function makeRecipeManager() {
+  return {
+    registerExternal: vi.fn(),
+    restartInstancesOfRecipe: vi.fn(() => 2),
+  } as unknown as RecipeManager;
+}
+
+/** Write a temp recipe package exposing dist/index.js with a createRecipe export. */
+function writeRecipePackage(exportName: "named" | "default" | "none"): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "sowel-recipe-"));
+  mkdirSync(resolve(dir, "dist"), { recursive: true });
+  const body =
+    exportName === "named"
+      ? `export function createRecipe() { return { id: "temp-recipe", name: "Temp" }; }`
+      : exportName === "default"
+        ? `export default { createRecipe() { return { id: "temp-recipe", name: "Temp" }; } };`
+        : `export const nothing = true;`;
+  writeFileSync(resolve(dir, "dist/index.js"), body);
+  return dir;
+}
+
+describe("RecipeLoader", () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of tmpDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe("install", () => {
+    it("rejects a package whose manifest type is not 'recipe'", async () => {
+      const pm = makePackageManager({
+        installFromGitHub: vi.fn(async () => ({ id: "pkg", type: "integration" })),
+      });
+      const rm = makeRecipeManager();
+      const loader = new RecipeLoader(pm, rm, logger);
+
+      await expect(loader.install("owner/repo")).rejects.toThrow(/is not a recipe/);
+      expect(rm.registerExternal).not.toHaveBeenCalled();
+    });
+
+    it("loads and registers a valid recipe after install", async () => {
+      const dir = writeRecipePackage("named");
+      tmpDirs.push(dir);
+      const pm = makePackageManager({
+        installFromGitHub: vi.fn(async () => ({ id: "temp-recipe", type: "recipe" })),
+        getPackageDir: vi.fn(() => dir),
+      });
+      const rm = makeRecipeManager();
+      const loader = new RecipeLoader(pm, rm, logger);
+
+      await loader.install("owner/repo");
+      expect(rm.registerExternal).toHaveBeenCalledWith({ id: "temp-recipe", name: "Temp" });
+    });
+  });
+
+  describe("loadNewlyInstalled", () => {
+    it("swallows a load failure (package stays installed, retried at next boot)", async () => {
+      const pm = makePackageManager(); // getPackageDir → /nonexistent → entry missing
+      const rm = makeRecipeManager();
+      const loader = new RecipeLoader(pm, rm, logger);
+
+      await expect(loader.loadNewlyInstalled("ghost")).resolves.toBeUndefined();
+      expect(rm.registerExternal).not.toHaveBeenCalled();
+    });
+
+    it("accepts a package exposing createRecipe via a default export", async () => {
+      const dir = writeRecipePackage("default");
+      tmpDirs.push(dir);
+      const pm = makePackageManager({ getPackageDir: vi.fn(() => dir) });
+      const rm = makeRecipeManager();
+      const loader = new RecipeLoader(pm, rm, logger);
+
+      await loader.loadNewlyInstalled("temp-recipe");
+      expect(rm.registerExternal).toHaveBeenCalledOnce();
+    });
+
+    it("does not register a package missing the createRecipe export", async () => {
+      const dir = writeRecipePackage("none");
+      tmpDirs.push(dir);
+      const pm = makePackageManager({ getPackageDir: vi.fn(() => dir) });
+      const rm = makeRecipeManager();
+      const loader = new RecipeLoader(pm, rm, logger);
+
+      await loader.loadNewlyInstalled("temp-recipe");
+      expect(rm.registerExternal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("update", () => {
+    it("probes, updates files, reloads and restarts running instances", async () => {
+      const dir = writeRecipePackage("named");
+      tmpDirs.push(dir);
+      const pm = makePackageManager({
+        updateFiles: vi.fn(async () => ({ id: "temp-recipe", version: "2.0.0" })),
+        getPackageDir: vi.fn(() => dir),
+      });
+      const rm = makeRecipeManager();
+      const loader = new RecipeLoader(pm, rm, logger);
+
+      await loader.update("temp-recipe");
+
+      expect(pm.probePersonalUpdate).toHaveBeenCalledWith("temp-recipe", {});
+      expect(pm.updateFiles).toHaveBeenCalled();
+      expect(rm.registerExternal).toHaveBeenCalled();
+      expect(rm.restartInstancesOfRecipe).toHaveBeenCalledWith("temp-recipe");
+    });
+
+    it("does not restart instances if the reload fails after updateFiles", async () => {
+      const pm = makePackageManager({
+        updateFiles: vi.fn(async () => ({ id: "ghost", version: "2.0.0" })),
+        // getPackageDir → /nonexistent → reload throws, caught internally
+      });
+      const rm = makeRecipeManager();
+      const loader = new RecipeLoader(pm, rm, logger);
+
+      await expect(loader.update("ghost")).resolves.toBeUndefined();
+      expect(rm.restartInstancesOfRecipe).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("loadAll", () => {
+    it("skips disabled packages", async () => {
+      const pm = makePackageManager({
+        getInstalledByType: vi.fn(() => [{ enabled: false, manifest: { id: "off" } }]),
+      });
+      const rm = makeRecipeManager();
+      const loader = new RecipeLoader(pm, rm, logger);
+
+      await loader.loadAll();
+      expect(rm.registerExternal).not.toHaveBeenCalled();
+    });
+
+    it("loads an enabled package present on disk", async () => {
+      const dir = writeRecipePackage("named");
+      tmpDirs.push(dir);
+      const pm = makePackageManager({
+        getInstalledByType: vi.fn(() => [{ enabled: true, manifest: { id: "temp-recipe" } }]),
+        getPackageDir: vi.fn(() => dir),
+      });
+      const rm = makeRecipeManager();
+      const loader = new RecipeLoader(pm, rm, logger);
+
+      await loader.loadAll();
+      expect(rm.registerExternal).toHaveBeenCalledOnce();
+    });
+
+    it("auto-downloads a package missing on disk when the manifest has a repo", async () => {
+      const pm = makePackageManager({
+        getInstalledByType: vi.fn(() => [
+          { enabled: true, manifest: { id: "gone", repo: "owner/gone" } },
+        ]),
+        getPackageDir: vi.fn(() => "/nonexistent/gone"),
+        downloadMissing: vi.fn(async () => undefined),
+      });
+      const rm = makeRecipeManager();
+      const loader = new RecipeLoader(pm, rm, logger);
+
+      await loader.loadAll();
+      // Download attempted; load still fails (still missing) but no throw.
+      expect(pm.downloadMissing).toHaveBeenCalledWith("owner/gone");
+    });
+
+    it("skips a missing package with no repo in its manifest", async () => {
+      const pm = makePackageManager({
+        getInstalledByType: vi.fn(() => [{ enabled: true, manifest: { id: "orphan" } }]),
+        getPackageDir: vi.fn(() => "/nonexistent/orphan"),
+      });
+      const rm = makeRecipeManager();
+      const loader = new RecipeLoader(pm, rm, logger);
+
+      await loader.loadAll();
+      expect(pm.downloadMissing).not.toHaveBeenCalled();
+      expect(rm.registerExternal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/weather/weather-aggregator.test.ts
+++ b/src/weather/weather-aggregator.test.ts
@@ -2,74 +2,92 @@ import { describe, it, expect, vi } from "vitest";
 import { computeRainCumuls } from "./weather-aggregator.js";
 
 describe("computeRainCumuls", () => {
-  it("uses the native rolling cumulatives as-is when present (never summed)", async () => {
-    const sumIncremental = vi.fn<(w: "-1h" | "-24h") => Promise<number | null>>();
-    const result = await computeRainCumuls(
-      [
-        { alias: "sum_rain_1", value: 1.23 },
-        { alias: "sum_rain_24", value: 8.76 },
-      ],
+  it("uses the native rolling cumulative (sum_rain_24) as-is, never summing samples", async () => {
+    const bindings = [
+      { alias: "rain", value: 0 },
+      { alias: "sum_rain_1", value: 0 },
+      { alias: "sum_rain_24", value: 11.9 },
+    ];
+    // 1392.3 is what the old buggy sum-of-cumuls path produced — must NOT be used.
+    const sumIncremental = vi.fn(async () => 1392.3);
+
+    const { rain1h, rain24h } = await computeRainCumuls(bindings, sumIncremental);
+
+    expect(rain24h).toBe(11.9);
+    expect(rain1h).toBe(0);
+    expect(sumIncremental).not.toHaveBeenCalled();
+  });
+
+  it("rounds the native value to one decimal", async () => {
+    const bindings = [
+      { alias: "sum_rain_24", value: 11.94 },
+      { alias: "sum_rain_1", value: 0.06 },
+    ];
+    const { rain1h, rain24h } = await computeRainCumuls(bindings, async () => null);
+    expect(rain24h).toBe(11.9);
+    expect(rain1h).toBe(0.1);
+  });
+
+  it("falls back to summing the incremental rain when no native cumulative exists", async () => {
+    const bindings = [{ alias: "rain", value: 0.2 }]; // incremental-only station (e.g. z2m)
+    const sumIncremental = vi.fn(async (w: "-1h" | "-24h") => (w === "-24h" ? 3.4 : 0.2));
+
+    const { rain1h, rain24h } = await computeRainCumuls(bindings, sumIncremental);
+
+    expect(rain24h).toBe(3.4);
+    expect(rain1h).toBe(0.2);
+    expect(sumIncremental).toHaveBeenCalledWith("-24h");
+    expect(sumIncremental).toHaveBeenCalledWith("-1h");
+  });
+
+  it("yields null (no fallback) when a native cumulative is present but non-numeric", async () => {
+    const bindings = [
+      { alias: "sum_rain_24", value: null },
+      { alias: "sum_rain_1", value: "x" },
+    ];
+    const sumIncremental = vi.fn(async () => 99);
+
+    const { rain1h, rain24h } = await computeRainCumuls(bindings, sumIncremental);
+
+    expect(rain24h).toBeNull();
+    expect(rain1h).toBeNull();
+    expect(sumIncremental).not.toHaveBeenCalled();
+  });
+
+  // ── Additional cases (spec 449 coverage) ──────────────────────────────
+
+  it("mixes native (present) and incremental fallback (absent) per window", async () => {
+    // sum_rain_1 present → used as-is; sum_rain_24 absent → incremental fallback.
+    const sumIncremental = vi.fn(async () => 3.0);
+    const { rain1h, rain24h } = await computeRainCumuls(
+      [{ alias: "sum_rain_1", value: 2.0 }],
       sumIncremental,
     );
 
-    expect(result).toEqual({ rain1h: 1.2, rain24h: 8.8 }); // rounded to a tenth
-    expect(sumIncremental).not.toHaveBeenCalled(); // native present → no Influx fallback
-  });
-
-  it("falls back to summing the incremental series when a native cumul is absent", async () => {
-    const sumIncremental = vi.fn(async (window: "-1h" | "-24h") =>
-      window === "-1h" ? 0.44 : 5.55,
-    );
-
-    const result = await computeRainCumuls([{ alias: "rain", value: 0.2 }], sumIncremental);
-
-    expect(result).toEqual({ rain1h: 0.4, rain24h: 5.6 });
-    expect(sumIncremental).toHaveBeenCalledWith("-1h");
-    expect(sumIncremental).toHaveBeenCalledWith("-24h");
-  });
-
-  it("mixes native (present) and fallback (absent) per window", async () => {
-    const sumIncremental = vi.fn(async () => 3.0);
-    const result = await computeRainCumuls([{ alias: "sum_rain_1", value: 2.0 }], sumIncremental);
-
-    expect(result.rain1h).toBe(2.0); // native
-    expect(result.rain24h).toBe(3.0); // fallback (sum_rain_24 absent)
+    expect(rain1h).toBe(2.0); // native
+    expect(rain24h).toBe(3.0); // fallback
     expect(sumIncremental).toHaveBeenCalledTimes(1);
     expect(sumIncremental).toHaveBeenCalledWith("-24h");
   });
 
-  it("treats a present-but-empty native binding as null (no fallback)", async () => {
-    const sumIncremental = vi.fn(async () => 9.9);
-    const result = await computeRainCumuls(
-      [
-        { alias: "sum_rain_1", value: null },
-        { alias: "sum_rain_24", value: "" },
-      ],
-      sumIncremental,
-    );
-
-    // Present binding with no numeric value → null, and NOT a fallback trigger.
-    expect(result).toEqual({ rain1h: null, rain24h: null });
-    expect(sumIncremental).not.toHaveBeenCalled();
-  });
-
-  it("coerces string numbers and rejects non-numeric strings to null", async () => {
+  it("coerces a numeric string native value (and only that value is used)", async () => {
     const sumIncremental = vi.fn(async () => null);
-    const result = await computeRainCumuls(
+    const { rain1h, rain24h } = await computeRainCumuls(
       [
-        { alias: "sum_rain_1", value: "1.5" }, // coerced
+        { alias: "sum_rain_1", value: "1.5" }, // coerced to 1.5
         { alias: "sum_rain_24", value: "abc" }, // NaN → null
       ],
       sumIncremental,
     );
 
-    expect(result).toEqual({ rain1h: 1.5, rain24h: null });
+    expect(rain1h).toBe(1.5);
+    expect(rain24h).toBeNull();
     expect(sumIncremental).not.toHaveBeenCalled();
   });
 
-  it("returns null (not 0) when the incremental fallback has no data", async () => {
-    const sumIncremental = vi.fn(async () => null);
-    const result = await computeRainCumuls([], sumIncremental);
-    expect(result).toEqual({ rain1h: null, rain24h: null });
+  it("returns null (not 0) when the incremental fallback itself has no data", async () => {
+    const { rain1h, rain24h } = await computeRainCumuls([], async () => null);
+    expect(rain1h).toBeNull();
+    expect(rain24h).toBeNull();
   });
 });

--- a/src/weather/weather-aggregator.test.ts
+++ b/src/weather/weather-aggregator.test.ts
@@ -2,55 +2,74 @@ import { describe, it, expect, vi } from "vitest";
 import { computeRainCumuls } from "./weather-aggregator.js";
 
 describe("computeRainCumuls", () => {
-  it("uses the native rolling cumulative (sum_rain_24) as-is, never summing samples", async () => {
-    const bindings = [
-      { alias: "rain", value: 0 },
-      { alias: "sum_rain_1", value: 0 },
-      { alias: "sum_rain_24", value: 11.9 },
-    ];
-    // 1392.3 is what the old buggy sum-of-cumuls path produced — must NOT be used.
-    const sumIncremental = vi.fn(async () => 1392.3);
+  it("uses the native rolling cumulatives as-is when present (never summed)", async () => {
+    const sumIncremental = vi.fn<["-1h" | "-24h"], Promise<number | null>>();
+    const result = await computeRainCumuls(
+      [
+        { alias: "sum_rain_1", value: 1.23 },
+        { alias: "sum_rain_24", value: 8.76 },
+      ],
+      sumIncremental,
+    );
 
-    const { rain1h, rain24h } = await computeRainCumuls(bindings, sumIncremental);
-
-    expect(rain24h).toBe(11.9);
-    expect(rain1h).toBe(0);
-    expect(sumIncremental).not.toHaveBeenCalled();
+    expect(result).toEqual({ rain1h: 1.2, rain24h: 8.8 }); // rounded to a tenth
+    expect(sumIncremental).not.toHaveBeenCalled(); // native present → no Influx fallback
   });
 
-  it("rounds the native value to one decimal", async () => {
-    const bindings = [
-      { alias: "sum_rain_24", value: 11.94 },
-      { alias: "sum_rain_1", value: 0.06 },
-    ];
-    const { rain1h, rain24h } = await computeRainCumuls(bindings, async () => null);
-    expect(rain24h).toBe(11.9);
-    expect(rain1h).toBe(0.1);
-  });
+  it("falls back to summing the incremental series when a native cumul is absent", async () => {
+    const sumIncremental = vi.fn(async (window: "-1h" | "-24h") =>
+      window === "-1h" ? 0.44 : 5.55,
+    );
 
-  it("falls back to summing the incremental rain when no native cumulative exists", async () => {
-    const bindings = [{ alias: "rain", value: 0.2 }]; // incremental-only station (e.g. z2m)
-    const sumIncremental = vi.fn(async (w: "-1h" | "-24h") => (w === "-24h" ? 3.4 : 0.2));
+    const result = await computeRainCumuls([{ alias: "rain", value: 0.2 }], sumIncremental);
 
-    const { rain1h, rain24h } = await computeRainCumuls(bindings, sumIncremental);
-
-    expect(rain24h).toBe(3.4);
-    expect(rain1h).toBe(0.2);
-    expect(sumIncremental).toHaveBeenCalledWith("-24h");
+    expect(result).toEqual({ rain1h: 0.4, rain24h: 5.6 });
     expect(sumIncremental).toHaveBeenCalledWith("-1h");
+    expect(sumIncremental).toHaveBeenCalledWith("-24h");
   });
 
-  it("yields null (no fallback) when a native cumulative is present but non-numeric", async () => {
-    const bindings = [
-      { alias: "sum_rain_24", value: null },
-      { alias: "sum_rain_1", value: "x" },
-    ];
-    const sumIncremental = vi.fn(async () => 99);
+  it("mixes native (present) and fallback (absent) per window", async () => {
+    const sumIncremental = vi.fn(async () => 3.0);
+    const result = await computeRainCumuls([{ alias: "sum_rain_1", value: 2.0 }], sumIncremental);
 
-    const { rain1h, rain24h } = await computeRainCumuls(bindings, sumIncremental);
+    expect(result.rain1h).toBe(2.0); // native
+    expect(result.rain24h).toBe(3.0); // fallback (sum_rain_24 absent)
+    expect(sumIncremental).toHaveBeenCalledTimes(1);
+    expect(sumIncremental).toHaveBeenCalledWith("-24h");
+  });
 
-    expect(rain24h).toBeNull();
-    expect(rain1h).toBeNull();
+  it("treats a present-but-empty native binding as null (no fallback)", async () => {
+    const sumIncremental = vi.fn(async () => 9.9);
+    const result = await computeRainCumuls(
+      [
+        { alias: "sum_rain_1", value: null },
+        { alias: "sum_rain_24", value: "" },
+      ],
+      sumIncremental,
+    );
+
+    // Present binding with no numeric value → null, and NOT a fallback trigger.
+    expect(result).toEqual({ rain1h: null, rain24h: null });
     expect(sumIncremental).not.toHaveBeenCalled();
+  });
+
+  it("coerces string numbers and rejects non-numeric strings to null", async () => {
+    const sumIncremental = vi.fn(async () => null);
+    const result = await computeRainCumuls(
+      [
+        { alias: "sum_rain_1", value: "1.5" }, // coerced
+        { alias: "sum_rain_24", value: "abc" }, // NaN → null
+      ],
+      sumIncremental,
+    );
+
+    expect(result).toEqual({ rain1h: 1.5, rain24h: null });
+    expect(sumIncremental).not.toHaveBeenCalled();
+  });
+
+  it("returns null (not 0) when the incremental fallback has no data", async () => {
+    const sumIncremental = vi.fn(async () => null);
+    const result = await computeRainCumuls([], sumIncremental);
+    expect(result).toEqual({ rain1h: null, rain24h: null });
   });
 });

--- a/src/weather/weather-aggregator.test.ts
+++ b/src/weather/weather-aggregator.test.ts
@@ -3,7 +3,7 @@ import { computeRainCumuls } from "./weather-aggregator.js";
 
 describe("computeRainCumuls", () => {
   it("uses the native rolling cumulatives as-is when present (never summed)", async () => {
-    const sumIncremental = vi.fn<["-1h" | "-24h"], Promise<number | null>>();
+    const sumIncremental = vi.fn<(w: "-1h" | "-24h") => Promise<number | null>>();
     const result = await computeRainCumuls(
       [
         { alias: "sum_rain_1", value: 1.23 },

--- a/src/zones/sunlight-manager.test.ts
+++ b/src/zones/sunlight-manager.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type Database from "better-sqlite3";
+import { SunlightManager } from "./sunlight-manager.js";
+import { SettingsManager } from "../core/settings-manager.js";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+import { createMigratedTestDb } from "../test-helpers/migrations.js";
+import type { EngineEvent } from "../shared/types.js";
+
+const logger = createLogger("silent").logger;
+
+// Paris — a location where sunrise/sunset are always well-defined.
+const PARIS = { lat: "48.8566", lon: "2.3522" };
+
+describe("SunlightManager", () => {
+  let db: Database.Database;
+  let settings: SettingsManager;
+  let eventBus: EventBus;
+  let events: EngineEvent[];
+  let manager: SunlightManager;
+
+  beforeEach(() => {
+    db = createMigratedTestDb();
+    settings = new SettingsManager(db);
+    eventBus = new EventBus(logger);
+    events = [];
+    eventBus.on((e) => events.push(e));
+    manager = new SunlightManager(settings, eventBus, logger);
+  });
+
+  afterEach(() => {
+    manager.stop(); // clear the 60s interval
+    db.close();
+  });
+
+  it("leaves data null and emits nothing when no home location is configured", () => {
+    manager.start();
+    expect(manager.getSunlightData()).toEqual({
+      sunrise: null,
+      sunset: null,
+      isDaylight: null,
+    });
+    expect(events.some((e) => e.type === "sunlight.changed")).toBe(false);
+  });
+
+  it("computes formatted sunrise/sunset and a boolean isDaylight from the location", () => {
+    settings.set("home.latitude", PARIS.lat);
+    settings.set("home.longitude", PARIS.lon);
+
+    manager.start();
+    const data = manager.getSunlightData();
+
+    expect(data.sunrise).toMatch(/^\d{2}:\d{2}$/);
+    expect(data.sunset).toMatch(/^\d{2}:\d{2}$/);
+    expect(typeof data.isDaylight).toBe("boolean");
+    // Transitioning from all-null to real values emits a change.
+    expect(events.filter((e) => e.type === "sunlight.changed")).toHaveLength(1);
+  });
+
+  it("treats a non-numeric latitude as no location", () => {
+    settings.set("home.latitude", "not-a-number");
+    settings.set("home.longitude", PARIS.lon);
+
+    manager.start();
+    expect(manager.getSunlightData().sunrise).toBeNull();
+  });
+
+  it("recomputes when a home.* setting changes, and resets to null when the location is cleared", () => {
+    settings.set("home.latitude", PARIS.lat);
+    settings.set("home.longitude", PARIS.lon);
+    manager.start();
+    expect(manager.getSunlightData().sunrise).not.toBeNull();
+    const changesAfterStart = events.filter((e) => e.type === "sunlight.changed").length;
+
+    // Clear the location, then signal a home settings change.
+    db.prepare("DELETE FROM settings WHERE key = ?").run("home.latitude");
+    eventBus.emit({ type: "settings.changed", keys: ["home.latitude"] });
+
+    expect(manager.getSunlightData()).toEqual({
+      sunrise: null,
+      sunset: null,
+      isDaylight: null,
+    });
+    // The reset (non-null → null) emits another sunlight.changed.
+    expect(events.filter((e) => e.type === "sunlight.changed").length).toBe(changesAfterStart + 1);
+  });
+
+  it("ignores settings changes that are not under the home.* namespace", () => {
+    settings.set("home.latitude", PARIS.lat);
+    settings.set("home.longitude", PARIS.lon);
+    manager.start();
+    const before = events.filter((e) => e.type === "sunlight.changed").length;
+
+    eventBus.emit({ type: "settings.changed", keys: ["integration.zigbee2mqtt.mqtt_url"] });
+
+    // No recompute → no additional change event.
+    expect(events.filter((e) => e.type === "sunlight.changed").length).toBe(before);
+  });
+
+  it("stop() is idempotent", () => {
+    manager.start();
+    expect(() => {
+      manager.stop();
+      manager.stop();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

A `v1.42.0` coverage run flagged several backend modules with little or no coverage. This closes those gaps.

## Change

New behavioral suites, all over real in-memory SQLite / real EventBus, with mocks only at genuine external boundaries (InfluxDB query API, GitHub `fetch`, `PackageManager`/`RecipeManager`):

| Module | Before | After | What's covered |
| --- | --- | --- | --- |
| `charts/chart-manager` | 0% | **100%** | CRUD, name validation, 400/404 errors, config round-trip |
| `history/history-query` | 11% | **88%** | `buildFluxQuery` branches (raw / discrete / aggregated / downsampled / cumulative rain vs energy); `queryHistory`/`querySparkline`/`queryZoneSparkline`/`queryHistorizedAliases` mapping, bucket routing, empty-bucket fallback, error swallowing |
| `core/version-checker` | 0% | **85%** | newer / equal / older release, non-OK response, network error, compose-managed flag |
| `zones/sunlight-manager` | 0% | **82%** | compute from location, no-location reset, `home.*` recompute, non-home ignore |
| `recipes/recipe-loader` | 0% | **97%** | install type guard, load via named + default exports, error confinement, update + instance restart, `loadAll` disabled / missing / auto-download paths |
| `weather/weather-aggregator` | 21% | — | `computeRainCumuls` fully covered (native cumul vs incremental fallback, empty/NaN, rounding) |

**No backend module remains at 0% statement coverage.**

## Follow-up (out of scope)

The `WeatherAggregator` *class* internals (Influx-backed refresh loop, debounce/periodic timers, `getComputedDataForEquipment`) still need an Influx+timer harness. Noted for a later PR.

## Verification

- `npx vitest run` — 1405 passed / 2 skipped (66 new)
- `npx tsc --noEmit`, `npx eslint`, prettier all clean

Closes #449