### PR TITLE
ci: gate PRs that add a spec folder without the three required docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,13 @@ jobs:
       - run: cd ui && npm ci
       - run: cd ui && npm run lint
       - run: cd ui && npm run build
+
+  specs:
+    name: Specs completeness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need main's history for the merge-base diff
+      - name: Every new spec folder has spec.md + architecture.md + plan.md
+        run: bash scripts/check-specs-complete.sh

--- a/scripts/check-specs-complete.sh
+++ b/scripts/check-specs-complete.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Specs completeness gate (see the sowel-feature skill).
+#
+# Every spec folder MUST carry the three documents the workflow produces:
+#   spec.md · architecture.md · plan.md
+#
+# This check fails a PR that ADDS any file under specs/<NNN-name>/ while that
+# folder is still missing one of the three. It only looks at folders the PR
+# touches with a *new* file, so it enforces completeness going forward without
+# retro-failing the historical specs that predate this rule.
+#
+# Runs in CI (pull_request) and locally: `bash scripts/check-specs-complete.sh`.
+# Portable to bash 3.2 (macOS) — no mapfile / associative arrays.
+
+set -eu
+
+BASE_REF="${1:-origin/main}"
+
+# Make sure the base ref is available (CI shallow clones).
+if ! git rev-parse --verify --quiet "${BASE_REF}" >/dev/null; then
+  git fetch --quiet origin main
+  BASE_REF="origin/main"
+fi
+
+BASE="$(git merge-base "${BASE_REF}" HEAD)"
+
+# Folders under specs/ that this PR adds at least one new file to.
+touched="$(
+  git diff --name-only --diff-filter=A "${BASE}" HEAD -- 'specs/*/*' \
+    | sed -E 's#(specs/[^/]+)/.*#\1#' \
+    | sort -u
+)"
+
+if [ -z "${touched}" ]; then
+  echo "No new spec files in this PR — specs completeness check skipped."
+  exit 0
+fi
+
+failed=0
+while IFS= read -r dir; do
+  [ -n "${dir}" ] || continue
+  missing=""
+  for f in spec.md architecture.md plan.md; do
+    [ -f "${dir}/${f}" ] || missing="${missing} ${f}"
+  done
+  if [ -n "${missing}" ]; then
+    echo "❌ ${dir} is missing:${missing}"
+    failed=1
+  else
+    echo "✓ ${dir}"
+  fi
+done <<EOF
+${touched}
+EOF
+
+if [ "${failed}" -ne 0 ]; then
+  echo
+  echo "Every spec folder must contain spec.md, architecture.md and plan.md."
+  echo "Use the sowel-feature workflow so all three are produced together."
+  exit 1
+fi
+
+echo "All touched spec folders are complete."

--- a/scripts/check-specs-complete.sh
+++ b/scripts/check-specs-complete.sh
@@ -2,18 +2,19 @@
 #
 # Specs completeness gate (see the sowel-feature skill).
 #
-# Every spec folder MUST carry the three documents the workflow produces:
+# A NEW spec folder marks a new feature, and a feature's folder must carry the
+# three documents the workflow produces:
 #   spec.md · architecture.md · plan.md
 #
-# This check fails a PR that ADDS any file under specs/<NNN-name>/ while that
-# folder is still missing one of the three. It only looks at folders the PR
-# touches with a *new* file, so it enforces completeness going forward without
-# retro-failing the historical specs that predate this rule.
+# This check fails a PR only when it CREATES a new specs/<NNN-name>/ folder that
+# is missing one of the three. It deliberately ignores PRs that merely add files
+# to an existing spec folder (issue fixes, follow-up notes, review screenshots),
+# and never retro-fails the historical specs that predate this rule.
 #
 # Runs in CI (pull_request) and locally: `bash scripts/check-specs-complete.sh`.
 # Portable to bash 3.2 (macOS) — no mapfile / associative arrays.
 
-set -eu
+set -euo pipefail
 
 BASE_REF="${1:-origin/main}"
 
@@ -25,40 +26,43 @@ fi
 
 BASE="$(git merge-base "${BASE_REF}" HEAD)"
 
-# Folders under specs/ that this PR adds at least one new file to.
-touched="$(
-  git diff --name-only --diff-filter=A "${BASE}" HEAD -- 'specs/*/*' \
-    | sed -E 's#(specs/[^/]+)/.*#\1#' \
-    | sort -u
-)"
+# Spec folders that exist now but did NOT exist at the merge base = folders this
+# PR creates. Robust to how the files were added (plain add or rename).
+base_dirs="$(git ls-tree -d --name-only "${BASE}" -- specs/ 2>/dev/null || true)"
 
-if [ -z "${touched}" ]; then
-  echo "No new spec files in this PR — specs completeness check skipped."
+new_dirs=""
+for dir in $(git ls-tree -d --name-only HEAD -- specs/); do
+  if printf '%s\n' "${base_dirs}" | grep -qxF "${dir}"; then
+    continue # folder already existed — not a new feature spec
+  fi
+  new_dirs="${new_dirs} ${dir}"
+done
+
+if [ -z "${new_dirs}" ]; then
+  echo "No new spec folder in this PR — specs completeness check skipped."
   exit 0
 fi
 
 failed=0
-while IFS= read -r dir; do
-  [ -n "${dir}" ] || continue
+for dir in ${new_dirs}; do
   missing=""
   for f in spec.md architecture.md plan.md; do
     [ -f "${dir}/${f}" ] || missing="${missing} ${f}"
   done
   if [ -n "${missing}" ]; then
-    echo "❌ ${dir} is missing:${missing}"
+    echo "❌ new spec ${dir} is missing:${missing}"
     failed=1
   else
     echo "✓ ${dir}"
   fi
-done <<EOF
-${touched}
-EOF
+done
 
 if [ "${failed}" -ne 0 ]; then
   echo
-  echo "Every spec folder must contain spec.md, architecture.md and plan.md."
+  echo "A new spec folder must contain spec.md, architecture.md and plan.md."
   echo "Use the sowel-feature workflow so all three are produced together."
+  echo "(Issue fixes and follow-ups that touch an existing spec are not gated.)"
   exit 1
 fi
 
-echo "All touched spec folders are complete."
+echo "All new spec folders are complete."


### PR DESCRIPTION
## Why

A **new** spec folder marks a new feature, and by the sowel-feature workflow a feature's folder should carry `spec.md` + `architecture.md` + `plan.md`. Nothing enforced it, so recent features shipped incomplete.

## What

- `scripts/check-specs-complete.sh` — fails a PR **only when it creates a new `specs/<NNN-name>/` folder** that is missing one of the three docs. It detects newly-created folders (absent at the merge base), so:
  - a **fix or follow-up** that adds a file to an existing spec folder (a note, a review screenshot) is **not** gated;
  - the ~34 historical incomplete specs are **never** retro-failed;
  - only genuine new feature specs must be complete.
- A `Specs completeness` job in `.github/workflows/ci.yml` (`fetch-depth: 0` for the merge-base diff).
- Portable to bash 3.2; `set -euo pipefail` so a broken base ref fails loud.

## Verified locally

| Scenario | Result |
| --- | --- |
| No new spec folder | skipped ✓ |
| New folder missing architecture/plan | ❌ exit 1 |
| Add a file to an existing incomplete spec (030) | skipped ✓ (the key relaxation) |
| New folder with all 3 docs | pass ✓ |

Scoped to features only, per review feedback. Companion backfill of the incomplete recent specs (138, 141, 144) is #468.