### PR TITLE
docs(specs): backfill architecture/plan for specs 138, 141, 144

### DIFF
--- a/specs/138-recipe-tariff-helper/architecture.md
+++ b/specs/138-recipe-tariff-helper/architecture.md
@@ -1,0 +1,138 @@
+# Spec 138 — Architecture
+
+## Component
+
+No new module. The feature adds one read-only helper to the recipe runtime and
+factors the schedule-interpretation logic out of `TariffClassifier`. The
+instance already owns the HP/HC schedule (Settings → Administration → Energy
+tariff, stored in settings under `energy.tariff`); spec 138 hands recipes a copy
+of it, on the same pattern as `getSunlight()` (spec 126).
+
+```
+Settings (energy.tariff, owned by the admin page)
+  → TariffClassifier.getConfig()  (cached parse, by reference)
+    → RecipeManager.buildTariffSnapshot()  (copies out by value, drops prices)
+      → ctx.helpers.getTariff() : RecipeTariff  (fresh object per call)
+```
+
+`slotRanges()` / `isWithinSlot()` are exported from `tariff-classifier.ts` and
+used by both `classify()` (energy split at write time) and
+`buildTariffSnapshot()` (recipe-facing `isOffPeakNow`), so the two schedule
+conventions have one definition instead of being re-derived per caller.
+
+## Data model
+
+### Types (`src/shared/types.ts`)
+
+```ts
+export interface RecipeTariff {
+  configured: boolean;
+  offPeakToday: TariffSlot[]; // { start, end, tariff: "hc" }
+  isOffPeakNow: boolean | null;
+}
+```
+
+`getTariff(): RecipeTariff` is added to `RecipeHelpers`, next to `getSunlight`.
+
+The existing tariff types are reused unchanged: `TariffSlot` (`start`, `end` as
+`"HH:MM"`, `tariff: "hp" | "hc"`), `DaySchedule` (`days: number[]` with
+`0=Sunday..6=Saturday`, `slots`), and `TariffConfig` (`schedules`, `prices`).
+`TariffPrices` exists on `TariffConfig` but is deliberately never read into the
+snapshot (see Security).
+
+`offPeakToday` holds only the `hc` slots of the schedule covering the current
+local day-of-week. A slot whose `end` is not after its `start` wraps past
+midnight (`22:00 → 06:00`), and an `end` of `"00:00"` reads as `24:00`, the same
+conventions energy classification applies.
+
+## Flow
+
+### Schedule interpretation, extracted (`src/energy/tariff-classifier.ts`)
+
+Two pure functions, exported so both callers share them:
+
+```ts
+export function slotRanges(slot: TariffSlot): Array<[number, number]>;
+export function isWithinSlot(minuteOfDay: number, slot: TariffSlot): boolean;
+```
+
+`slotRanges` expands a slot into concrete `[startMinute, endMinute)` ranges,
+applying the two conventions: an `end` of `"00:00"` becomes `1440` (24:00), and a
+slot whose `end` is not after its `start` yields two ranges (`[start, 1440]` and
+`[0, end]`). `isWithinSlot` tests a minute-of-day against those ranges (start
+inclusive, end exclusive). `classify()` now iterates `slotRanges(slot)` instead
+of inlining the wrap arithmetic; behaviour is unchanged, which the new
+`tariff-classifier.test.ts` pins.
+
+### Snapshot build (`src/recipes/engine/recipe-manager.ts`)
+
+`RecipeManager` gains a `tariffClassifier: TariffClassifier | null` constructor
+dependency, wired in `src/index.ts` from
+`historyWriter.getTariffClassifier()` (a new accessor on `HistoryWriter`, which
+already owns the single classifier instance). Null is a valid value: when the
+energy stack is unavailable, recipes see `configured: false`.
+
+`buildTariffSnapshot()` runs on every `getTariff()` call:
+
+1. Read `tariffClassifier?.getConfig()` inside a try/catch. A missing classifier,
+   a `null` config (nothing configured, or unparseable settings JSON where the
+   classifier already logged and returned `null`), or a throw all return the
+   empty snapshot `{ configured: false, offPeakToday: [], isOffPeakNow: null }`.
+2. Find the `DaySchedule` covering `now.getDay()`. Keep only its `hc` slots and
+   copy each out by value (`{ start, end, tariff }`).
+3. Compute `isOffPeakNow` as `offPeakToday.some((s) => isWithinSlot(minuteOfDay, s))`
+   where `minuteOfDay = now.getHours() * 60 + now.getMinutes()`.
+
+`getTariff` is registered lazily as an arrow (`() => this.buildTariffSnapshot()`)
+on the shared helpers object, so the classifier is read at recipe runtime, not at
+construction.
+
+## Key decisions
+
+- **Read-only, no event.** The tariff is owned by the settings page; there is no
+  setter and no write path. No `tariff.changed` event is emitted: a recipe
+  re-reads the snapshot on its own cadence. An event can follow later if a recipe
+  needs to re-arm timers the instant the schedule changes.
+- **Today only.** `offPeakToday` covers the current day-of-week, which is what a
+  same-night load placement needs. Tomorrow's schedule is out of scope.
+- **One schedule interpretation.** `slotRanges` / `isWithinSlot` are the single
+  source of truth for the `"00:00" = 24:00` and midnight-wrap conventions, shared
+  by energy classification and the recipe snapshot.
+- **Never breaks a recipe.** Every failure mode (no classifier, no config,
+  unparseable JSON, classifier throw, a day with no schedule) collapses to the
+  same empty snapshot, so a recipe can always fall back to its own parameters.
+
+## Security
+
+A recipe package is third-party code running in-process that can republish
+anything it is handed (instance state goes out over the WebSocket; MQTT and
+notification publishers reach further still). Two properties are deliberate:
+
+1. **No mutation path.** `TariffClassifier.getConfig()` returns its cached object
+   by reference; handing that straight to a package would let it rewrite the
+   schedule energy billing runs on. `buildTariffSnapshot()` copies every field
+   out by value and builds a fresh object per call, so mutating the returned
+   snapshot cannot corrupt the stored config, and there is no setter.
+2. **Prices are withheld.** Knowing _when_ energy is cheap is enough to schedule a
+   load; what it costs is commercial data with no bearing on the decision.
+   `config.prices` is never copied into `RecipeTariff` and never leaves the
+   manager.
+
+Recorded for context (unchanged by this spec): `GET
+/api/v1/settings/energy/tariff` requires authentication but not the admin role
+at the time of this spec. Aligning that with `GET /api/v1/settings` (which does
+check admin) was a separate follow-up.
+
+## Files changed
+
+| File                                        | Change                                                                   |
+| ------------------------------------------- | ------------------------------------------------------------------------ |
+| `src/shared/types.ts`                       | `RecipeTariff` type, `getTariff()` on `RecipeHelpers`                    |
+| `src/energy/tariff-classifier.ts`           | export `slotRanges` / `isWithinSlot`, route `classify` through them      |
+| `src/energy/tariff-classifier.test.ts`      | new tests for the extracted functions and `classify`                     |
+| `src/recipes/engine/recipe-manager.ts`      | `tariffClassifier` dependency, `buildTariffSnapshot`, `getTariff` helper |
+| `src/recipes/engine/recipe-manager.test.ts` | `getTariff` snapshot tests                                               |
+| `src/index.ts`                              | pass `historyWriter.getTariffClassifier()` to `RecipeManager`            |
+| `src/history/history-writer.ts`             | `getTariffClassifier()` accessor                                         |
+| `docs/technical/recipe-development.md`      | document `getTariff()`                                                   |
+| `docs/specs-index.md`                       | spec 138 row                                                             |

--- a/specs/138-recipe-tariff-helper/plan.md
+++ b/specs/138-recipe-tariff-helper/plan.md
@@ -1,0 +1,66 @@
+# Spec 138 — Implementation plan
+
+Branch: `feat/recipe-tariff-helper`
+
+## Steps
+
+1. **Extract schedule interpretation** — in `src/energy/tariff-classifier.ts`,
+   pull the slot-to-range logic out of `classify()` into exported pure functions
+   `slotRanges(slot)` and `isWithinSlot(minuteOfDay, slot)`, carrying the two
+   conventions (`"00:00"` end means 24:00; an end not after its start wraps past
+   midnight). Route `classify()` through `slotRanges` so its behaviour is
+   unchanged.
+2. **Types** — add `RecipeTariff` (`configured`, `offPeakToday: TariffSlot[]`,
+   `isOffPeakNow: boolean | null`) to `src/shared/types.ts` and `getTariff():
+RecipeTariff` to `RecipeHelpers`, next to `getSunlight`.
+3. **Accessor** — add `getTariffClassifier()` on `HistoryWriter`, which already
+   owns the single `TariffClassifier` instance.
+4. **RecipeManager** — accept `tariffClassifier: TariffClassifier | null` in the
+   constructor; add `buildTariffSnapshot()` (read config, filter today's `hc`
+   slots, copy out by value, compute `isOffPeakNow` via `isWithinSlot`, collapse
+   every failure to the empty snapshot); register `getTariff: () =>
+this.buildTariffSnapshot()` on the shared helpers object.
+5. **Wiring** — in `src/index.ts`, pass `historyWriter.getTariffClassifier()`
+   to `RecipeManager`.
+6. **Tests** — `tariff-classifier.test.ts` (new) and additions to
+   `recipe-manager.test.ts` (see test plan below).
+7. **Docs** — `docs/technical/recipe-development.md` documents `getTariff()`;
+   `docs/specs-index.md` gets the spec 138 row.
+
+## Test Plan
+
+### Modules to test
+
+- `src/energy/tariff-classifier.ts` — the extracted `slotRanges` / `isWithinSlot`
+  functions and that `classify()` is behaviour-preserving after the refactor.
+- `src/recipes/engine/recipe-manager.ts` — the `getTariff()` snapshot handed to a
+  running instance.
+
+### Scenarios
+
+| Module            | Scenario                                             | Expected                                                      |
+| ----------------- | ---------------------------------------------------- | ------------------------------------------------------------- |
+| tariff-classifier | ordinary slot                                        | one `[start, end)` range                                      |
+| tariff-classifier | slot ending at `"00:00"`                             | range ends at 1440, not empty                                 |
+| tariff-classifier | slot wrapping past midnight                          | two ranges (`[start,1440]`, `[0,end]`)                        |
+| tariff-classifier | zero-length slot                                     | wraps the whole day                                           |
+| tariff-classifier | `isWithinSlot` at start and end                      | start included, end excluded                                  |
+| tariff-classifier | `isWithinSlot` across the midnight wrap              | true on both sides                                            |
+| tariff-classifier | no tariff configured                                 | `classify` bills everything as HP                             |
+| tariff-classifier | unparseable settings value                           | bills everything as HP (classifier logs, returns null)        |
+| tariff-classifier | window fully inside the off-peak wrap                | attributed fully to HC                                        |
+| tariff-classifier | daytime window                                       | attributed fully to HP                                        |
+| tariff-classifier | window straddling a transition                       | prorata split                                                 |
+| tariff-classifier | non-default window duration                          | honoured, not assumed 30 min                                  |
+| tariff-classifier | day with no schedule / slots covering none of window | falls back to HP                                              |
+| recipe-manager    | no schedule set (or classifier null)                 | `{ configured: false, offPeakToday: [], isOffPeakNow: null }` |
+| recipe-manager    | schedule configured for today                        | only today's `hc` slots returned; prices absent               |
+| recipe-manager    | current time inside a midnight-wrapping slot         | `isOffPeakNow: true`                                          |
+| recipe-manager    | mutate the returned snapshot, call again             | stored config intact, next call returns the real schedule     |
+
+### Acceptance criteria mapping
+
+AC1 `getTariff()` callable from a recipe; AC2 unconfigured yields the empty
+snapshot; AC3 only today's `hc` slots leak in; AC4 `isOffPeakNow` correct across
+a midnight wrap; AC5 mutating the snapshot leaves the config intact; AC6 no price
+reachable; AC7 `classify()` unchanged by the `slotRanges` extraction.

--- a/specs/141-order-delivery-confirmation/plan.md
+++ b/specs/141-order-delivery-confirmation/plan.md
@@ -1,0 +1,81 @@
+# Spec 141 — Implementation plan
+
+Branch: `feat/spec-141-order-delivery-confirmation`
+
+## Steps
+
+1. **Event bus addition** — one new `equipment.order.unconfirmed` member in the
+   `EngineEvent` union in `src/shared/types.ts` (`equipmentId`, `orderAlias`,
+   `value`, `reason: "timeout" | "device_offline"`, optional `source`). No other
+   consumer is required; alarms carry the user-facing path.
+2. **Value helpers** — `normalizeValue`, exported `valuesMatch(ordered, actual)`
+   and `isConfirmableValue(ordered, enumValues?)` in
+   `src/equipments/order-confirmation-tracker.ts`. Boolean-like strings map to
+   booleans, numeric strings to numbers, other strings compare lowercased.
+   Confirmability additionally requires the ordered value to be boolean-like,
+   numeric, or a member of the mirror binding's `enumValues`, which exempts
+   cross-vocabulary enums (cover `CLOSE` order vs `CLOSED` state).
+3. **Tracker skeleton** — `OrderConfirmationTracker` class taking the
+   `EventBus`, `EquipmentManager`, `DeviceManager`, `IntegrationRegistry` and a
+   logger. In-memory `pending` map keyed `equipmentId:alias`, `init()` that
+   subscribes to the three events, `destroy()` that clears timers and
+   unsubscribes. Constants `CONFIRMATION_TIMEOUT_MS = 30_000`,
+   `REDISPATCH_TTL_MS = 3_600_000`, exported `RETRY_CHANNEL = "delivery-retry"`.
+4. **Watchdog on `equipment.order.executed`** — resolve the mirror data binding
+   for the alias; exempt orders with no mirror binding or a non-confirmable
+   value. Supersede any pending entry on the same key (resolving its alarm).
+   Confirm immediately when the mirror already holds the ordered value. Mark
+   `device_offline` at once when every target device is offline, otherwise arm
+   the timer.
+5. **Poll-aware timeout** — `confirmationTimeoutFor(deviceIds)` stretches the
+   delay to `max(30 s, 2 x poll interval)` by reading `getPollingInfo()` from
+   the integration behind each device, so polling integrations (Panasonic, MCZ)
+   do not false-alarm before their next poll.
+6. **Unconfirmed marking** — `markUnconfirmed(entry, reason)` clears the timer,
+   emits `equipment.order.unconfirmed`, and raises `system.alarm.raised` once
+   with `alarmId order-unconfirmed:<equipmentId>:<alias>`, level `warning`,
+   source `order-confirmation`, and a message naming the equipment, ordered
+   value, and reason.
+7. **Confirmation on `equipment.data.changed`** — when the mirror value matches
+   the pending order, clear the timer, resolve the alarm if raised, and drop the
+   entry.
+8. **Reconnect re-dispatch on `device.status_changed`** — for each unconfirmed,
+   not-yet-retried entry bound to the now-online device and younger than the
+   TTL, re-dispatch once via `equipmentManager.executeOrder(..., { kind:
+"external", channel: RETRY_CHANNEL })` and mark `retried`. The retry's own
+   `equipment.order.executed` echo re-arms the existing entry instead of
+   creating a new one, so exactly one retry can ever happen.
+9. **Tests** — `src/equipments/order-confirmation-tracker.test.ts` (see test
+   plan below).
+10. **Wiring** — instantiate the tracker in `src/index.ts` next to the other
+    equipment trackers, `init()` unless shadow mode, `destroy()` on shutdown.
+
+## Test Plan
+
+### Modules to test
+
+- `src/equipments/order-confirmation-tracker.ts` — value helpers,
+  confirmability, watchdog lifecycle, offline fast path, reconnect re-dispatch,
+  supersession, poll-aware timeout.
+
+### Scenarios
+
+| Scenario                                                    | Expected                                                           |
+| ----------------------------------------------------------- | ------------------------------------------------------------------ |
+| `valuesMatch` across boolean-like, numeric, string forms    | equivalent wire representations match, mismatches do not           |
+| `isConfirmableValue` boolean-like and numeric               | confirmable                                                        |
+| `isConfirmableValue` enum member vs cross-vocabulary enum   | member confirmable, `CLOSE`/`STOP` vs `OPEN`/`CLOSED` exempt       |
+| state reports the ordered value in time                     | confirmed silently, no unconfirmed event, no alarm                 |
+| state already holds the ordered value at order time         | confirmed immediately, no watchdog, no alarm                       |
+| no state change before timeout                              | `equipment.order.unconfirmed` (`timeout`) plus one `warning` alarm |
+| late `equipment.data.changed` after a raised alarm          | `system.alarm.resolved`                                            |
+| every target device offline at order time                   | `unconfirmed` (`device_offline`) and alarm raised immediately      |
+| device back online, unconfirmed order younger than the TTL  | re-dispatched exactly once, later confirmation resolves the alarm  |
+| second reconnect after the retry                            | no second re-dispatch                                              |
+| retry's own `order.executed` echo (RETRY_CHANNEL)           | re-arms the existing entry, still a single alarm                   |
+| newer order on the same key while one is pending            | old alarm resolved, new order gets its own watchdog                |
+| order with no mirror data binding                           | exempt, no alarm                                                   |
+| cross-vocabulary enum order (`CLOSE` vs `OPEN`/`CLOSED`)    | exempt, no alarm                                                   |
+| unconfirmed order older than the 1h TTL, device back online | no re-dispatch                                                     |
+| polling integration, 60 s interval                          | no alarm before 2 x interval (120 s), alarm fires past it          |
+| numeric order confirmed against a numeric-string state      | confirmed, no alarm                                                |

--- a/specs/144-analyse-mixed-state-axis/architecture.md
+++ b/specs/144-analyse-mixed-state-axis/architecture.md
@@ -3,14 +3,21 @@
 UI-only. No type, route, event, table or migration changes; `SavedChartConfig`
 is untouched, so saved charts survive as-is.
 
+> Shipped-scope note: `BOOLEAN_CATEGORIES` gained only `light_state` and
+> `appliance_state`, not five categories; `booleanTickLabels` gained only the
+> power pair; and only `analyse.family.mixed` + `analyse.bool.power.{off,on}`
+> were added to i18n. `cover_state` / `gate_state` / `lock_state` are excluded
+> on purpose (index-encoded per spec 434). The table below reflects the original
+> five-category design; plan.md reflects what shipped.
+
 ## Files
 
-| File | Change |
-| ---- | ------ |
-| `ui/src/components/history/history-utils.ts` | `BOOLEAN_CATEGORIES` gains the five actuator state categories; new `familiesCompatible(a, b)`; `booleanTickLabels` gains power / lock / gate-cover cases. |
-| `ui/src/components/history/AnalyseView.tsx` | `lockedFamily` → `chartFamilies` + `hasStateSeries` / `hasMeasurementSeries`; picker gate, family pill, envelope toggle and the render branches follow. |
-| `ui/src/components/history/history-utils.test.ts` | Cases for the new classification, `familiesCompatible` and the new label pairs. |
-| `ui/src/i18n/locales/{en,fr}.json` | `analyse.family.mixed`, `analyse.bool.power.{off,on}`, `analyse.bool.lock.{unlocked,locked}`. |
+| File                                              | Change                                                                                                                                                    |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ui/src/components/history/history-utils.ts`      | `BOOLEAN_CATEGORIES` gains the five actuator state categories; new `familiesCompatible(a, b)`; `booleanTickLabels` gains power / lock / gate-cover cases. |
+| `ui/src/components/history/AnalyseView.tsx`       | `lockedFamily` → `chartFamilies` + `hasStateSeries` / `hasMeasurementSeries`; picker gate, family pill, envelope toggle and the render branches follow.   |
+| `ui/src/components/history/history-utils.test.ts` | Cases for the new classification, `familiesCompatible` and the new label pairs.                                                                           |
+| `ui/src/i18n/locales/{en,fr}.json`                | `analyse.family.mixed`, `analyse.bool.power.{off,on}`, `analyse.bool.lock.{unlocked,locked}`.                                                             |
 
 ## Family model
 
@@ -18,9 +25,9 @@ is untouched, so saved charts survive as-is.
 chart is no longer described by one family:
 
 ```ts
-const chartFamilies: Set<ChartFamily>   // families actually present
-const hasStateSeries: boolean           // ≥1 series in `states`
-const hasMeasurementSeries: boolean     // ≥1 series in `measurements` or unclassified
+const chartFamilies: Set<ChartFamily>; // families actually present
+const hasStateSeries: boolean; // ≥1 series in `states`
+const hasMeasurementSeries: boolean; // ≥1 series in `measurements` or unclassified
 ```
 
 `familiesCompatible(a, b)` states the only remaining exclusion — `cumulative`
@@ -40,7 +47,7 @@ Three branches, selected in this order:
 
 1. `chartFamilies.has("cumulative")` → `BarChart`, unchanged.
 2. `hasStateSeries && !hasMeasurementSeries` → the states `LineChart`,
-   unchanged except that its tick labels now come from the first *state*
+   unchanged except that its tick labels now come from the first _state_
    series instead of the first series.
 3. otherwise → the measurements `ComposedChart`, which grows the secondary
    axis.

--- a/specs/144-analyse-mixed-state-axis/plan.md
+++ b/specs/144-analyse-mixed-state-axis/plan.md
@@ -1,0 +1,88 @@
+# Spec 144 — Implementation plan
+
+Branch: `feat/analyse-mixed-state-axis`
+
+UI-only. No type, route, event, table or migration change; `SavedChartConfig`
+is untouched, so saved charts survive as-is.
+
+## Steps
+
+1. **Classify the actuator categories** — add `light_state`, `appliance_state`,
+   `lock_state`, `gate_state` and `cover_state` to `BOOLEAN_CATEGORIES` in
+   `ui/src/components/history/history-utils.ts`. `familyOf` and
+   `isBooleanCategory` then report them as `states` with no further change.
+2. **Family compatibility** — add `familiesCompatible(a, b)` to
+   `history-utils.ts`: everything mixes except `cumulative`, which stays alone;
+   `null` (unclassified) is compatible with anything. Keeping it in the utils
+   file rather than inline in the picker is what lets the test file pin it down;
+   `AnalyseView` has no test harness.
+3. **Tick labels** — extend `booleanTickLabels` with three cases:
+   `light_state` / `appliance_state` map to the new power pair (`Arrêt` /
+   `Marche`) rather than the generic `Inactif` / `Actif`; `lock_state` maps to
+   unlocked / locked; `gate_state` / `cover_state` reuse the contact pair
+   (`Fermé` / `Ouvert`).
+4. **Chart family model** — in `AnalyseView.tsx`, replace the single
+   `lockedFamily` with `chartFamilies: Set<ChartFamily>`, `hasStateSeries` and
+   `hasMeasurementSeries` derived from the plotted series.
+5. **Picker gate** — swap the strict first-series lock for
+   `[...chartFamilies].some((f) => !familiesCompatible(f, bindingFamily))`, so a
+   state binding is accepted next to a measurement and vice versa, while
+   `cumulative` still refuses any other family.
+6. **Render branches** — keep the three-branch order: `cumulative` →
+   `BarChart` (unchanged); `hasStateSeries && !hasMeasurementSeries` → the
+   states `LineChart` (unchanged, but tick labels now come from the first
+   _state_ series); otherwise the measurements `ComposedChart`. In the third
+   branch add `yAxisId="left"` to the existing axis, band and lines, and render
+   a second `YAxis yAxisId="state" orientation="right"` with a fixed `[0, 1]`
+   domain, `ticks={[0, 1]}` and semantic labels only when `hasStateSeries`.
+   Each line picks `yAxisId` and `type` (`stepAfter` vs `monotone`) from whether
+   its series is a state.
+7. **Tooltip** — add a `mixedFormatter` that dispatches per series id between
+   the existing measurement and state formatters, used only on the mixed chart;
+   charts with no state series keep passing `measurementFormatter` directly.
+8. **Family pill and envelope toggle** — pill reads `Mesures + états` on a mixed
+   chart; the envelope toggle stays gated on measurement series only.
+9. **i18n** — add `analyse.family.mixed`, `analyse.bool.power.{off,on}` and
+   `analyse.bool.lock.{unlocked,locked}` to
+   `ui/src/i18n/locales/{en,fr}.json`.
+10. **Tests** — extend `ui/src/components/history/history-utils.test.ts` (see
+    test plan below).
+11. **Docs** — add the spec to `docs/specs-index.md`.
+
+## Test Plan
+
+### Module to test
+
+- `ui/src/components/history/history-utils.ts` — classification,
+  `familiesCompatible` and the new label pairs. `AnalyseView.tsx` has no React
+  test harness in this project and is covered by manual verification.
+
+### Scenarios (`history-utils.test.ts`)
+
+| Function             | Scenario                                                                    | Expected                          |
+| -------------------- | --------------------------------------------------------------------------- | --------------------------------- |
+| `familyOf`           | `light_state`, `appliance_state`, `lock_state`, `gate_state`, `cover_state` | `states`                          |
+| `familyOf`           | `setpoint`, unknown category                                                | `null` (unchanged)                |
+| `familiesCompatible` | `measurements` with `states` (either order)                                 | `true`                            |
+| `familiesCompatible` | `cumulative` with `measurements` or `states`                                | `false`                           |
+| `familiesCompatible` | `cumulative` with `cumulative`                                              | `true`                            |
+| `familiesCompatible` | `null` with any family (either order)                                       | `true`                            |
+| `isBooleanCategory`  | `light_state`, `appliance_state`                                            | `true`                            |
+| `isBooleanCategory`  | `temperature`, `rain`                                                       | `false` (unchanged)               |
+| `booleanTickLabels`  | `light_state` / `appliance_state`                                           | power pair (`Arrêt` / `Marche`)   |
+| `booleanTickLabels`  | `lock_state`                                                                | unlocked / locked pair            |
+| `booleanTickLabels`  | `gate_state` / `cover_state`                                                | contact pair (`Fermé` / `Ouvert`) |
+
+### Manual verification
+
+- On a local dev instance, add a temperature measurement and a `light_state`
+  relay (historization enabled) to one Analyse chart: measurements draw on the
+  left axis, the relay draws as `stepAfter` steps on a right-hand `[0, 1]` axis
+  with `Marche` / `Arrêt` ticks, and the tooltip shows `24.8 °C` on one row and
+  `Marche` on the next.
+- A chart holding only states is unchanged: single `[0, 1]` axis, step lines,
+  semantic ticks.
+- A chart holding `rain` or `energy` is unchanged and still refuses any other
+  family.
+- The family pill reads `Mesures + états` on a mixed chart.
+- Reload a chart saved before this change: the same series come back.

--- a/specs/144-analyse-mixed-state-axis/plan.md
+++ b/specs/144-analyse-mixed-state-axis/plan.md
@@ -5,22 +5,28 @@ Branch: `feat/analyse-mixed-state-axis`
 UI-only. No type, route, event, table or migration change; `SavedChartConfig`
 is untouched, so saved charts survive as-is.
 
+> Note: the spec was originally drafted for five actuator categories. The
+> shipped code narrowed this to the two strictly-binary ones (`light_state`,
+> `appliance_state`); `cover_state` / `gate_state` / `lock_state` are excluded
+> on purpose because they can carry a third value, which `HistoryWriter`
+> encodes by declared index (spec 434). This plan describes what shipped.
+
 ## Steps
 
-1. **Classify the actuator categories** — add `light_state`, `appliance_state`,
-   `lock_state`, `gate_state` and `cover_state` to `BOOLEAN_CATEGORIES` in
-   `ui/src/components/history/history-utils.ts`. `familyOf` and
-   `isBooleanCategory` then report them as `states` with no further change.
+1. **Classify the binary actuator categories** — add `light_state` and
+   `appliance_state` to `BOOLEAN_CATEGORIES` in
+   `ui/src/components/history/history-utils.ts`, so `familyOf` and
+   `isBooleanCategory` report them as `states`. `cover_state` / `gate_state` /
+   `lock_state` are deliberately left out (a three-value cover would clip on a
+   two-label `[0, 1]` axis); they keep charting as a plain numeric series.
 2. **Family compatibility** — add `familiesCompatible(a, b)` to
    `history-utils.ts`: everything mixes except `cumulative`, which stays alone;
    `null` (unclassified) is compatible with anything. Keeping it in the utils
    file rather than inline in the picker is what lets the test file pin it down;
    `AnalyseView` has no test harness.
-3. **Tick labels** — extend `booleanTickLabels` with three cases:
-   `light_state` / `appliance_state` map to the new power pair (`Arrêt` /
-   `Marche`) rather than the generic `Inactif` / `Actif`; `lock_state` maps to
-   unlocked / locked; `gate_state` / `cover_state` reuse the contact pair
-   (`Fermé` / `Ouvert`).
+3. **Tick labels** — extend `booleanTickLabels` with one case: `light_state` /
+   `appliance_state` map to the new power pair (`Arrêt` / `Marche`) rather than
+   the generic `Inactif` / `Actif`.
 4. **Chart family model** — in `AnalyseView.tsx`, replace the single
    `lockedFamily` with `chartFamilies: Set<ChartFamily>`, `hasStateSeries` and
    `hasMeasurementSeries` derived from the plotted series.
@@ -42,8 +48,7 @@ is untouched, so saved charts survive as-is.
    charts with no state series keep passing `measurementFormatter` directly.
 8. **Family pill and envelope toggle** — pill reads `Mesures + états` on a mixed
    chart; the envelope toggle stays gated on measurement series only.
-9. **i18n** — add `analyse.family.mixed`, `analyse.bool.power.{off,on}` and
-   `analyse.bool.lock.{unlocked,locked}` to
+9. **i18n** — add `analyse.family.mixed` and `analyse.bool.power.{off,on}` to
    `ui/src/i18n/locales/{en,fr}.json`.
 10. **Tests** — extend `ui/src/components/history/history-utils.test.ts` (see
     test plan below).
@@ -54,24 +59,23 @@ is untouched, so saved charts survive as-is.
 ### Module to test
 
 - `ui/src/components/history/history-utils.ts` — classification,
-  `familiesCompatible` and the new label pairs. `AnalyseView.tsx` has no React
+  `familiesCompatible` and the new label pair. `AnalyseView.tsx` has no React
   test harness in this project and is covered by manual verification.
 
 ### Scenarios (`history-utils.test.ts`)
 
-| Function             | Scenario                                                                    | Expected                          |
-| -------------------- | --------------------------------------------------------------------------- | --------------------------------- |
-| `familyOf`           | `light_state`, `appliance_state`, `lock_state`, `gate_state`, `cover_state` | `states`                          |
-| `familyOf`           | `setpoint`, unknown category                                                | `null` (unchanged)                |
-| `familiesCompatible` | `measurements` with `states` (either order)                                 | `true`                            |
-| `familiesCompatible` | `cumulative` with `measurements` or `states`                                | `false`                           |
-| `familiesCompatible` | `cumulative` with `cumulative`                                              | `true`                            |
-| `familiesCompatible` | `null` with any family (either order)                                       | `true`                            |
-| `isBooleanCategory`  | `light_state`, `appliance_state`                                            | `true`                            |
-| `isBooleanCategory`  | `temperature`, `rain`                                                       | `false` (unchanged)               |
-| `booleanTickLabels`  | `light_state` / `appliance_state`                                           | power pair (`Arrêt` / `Marche`)   |
-| `booleanTickLabels`  | `lock_state`                                                                | unlocked / locked pair            |
-| `booleanTickLabels`  | `gate_state` / `cover_state`                                                | contact pair (`Fermé` / `Ouvert`) |
+| Function             | Scenario                                     | Expected                        |
+| -------------------- | -------------------------------------------- | ------------------------------- |
+| `familyOf`           | `light_state`, `appliance_state`             | `states`                        |
+| `familyOf`           | `cover_state`, `gate_state`, `lock_state`    | `null` (not forced onto 0/1)    |
+| `familyOf`           | `setpoint`, unknown category                 | `null` (unchanged)              |
+| `familiesCompatible` | `measurements` with `states` (either order)  | `true`                          |
+| `familiesCompatible` | `cumulative` with `measurements` or `states` | `false`                         |
+| `familiesCompatible` | `cumulative` with `cumulative`               | `true`                          |
+| `familiesCompatible` | `null` with any family (either order)        | `true`                          |
+| `isBooleanCategory`  | `light_state`, `appliance_state`             | `true`                          |
+| `isBooleanCategory`  | `temperature`, `rain`                        | `false` (unchanged)             |
+| `booleanTickLabels`  | `light_state` / `appliance_state`            | power pair (`Arrêt` / `Marche`) |
 
 ### Manual verification
 

--- a/specs/144-analyse-mixed-state-axis/spec.md
+++ b/specs/144-analyse-mixed-state-axis/spec.md
@@ -1,10 +1,18 @@
 # Spec 144 — States and measurements on one Analyse chart
 
+> Shipped-scope note: this spec was drafted for five actuator categories, but
+> the shipped code classifies only the two strictly-binary ones (`light_state`,
+> `appliance_state`) as `states`. `cover_state` / `gate_state` / `lock_state`
+> are excluded on purpose (they can carry a third value, which `HistoryWriter`
+> encodes by declared index, spec 434), so AC1's five-category list and the
+> lock/gate/cover tick labels below describe the original design, not what
+> ships. See plan.md for the shipped behaviour.
+
 ## Context
 
 Following a water heater means reading two series together: the tank
-temperature and the relay that heats it. The temperature answers *how hot*, the
-relay answers *why* — a rise with no relay activity is solar gain or a wrong
+temperature and the relay that heats it. The temperature answers _how hot_, the
+relay answers _why_ — a rise with no relay activity is solar gain or a wrong
 sensor, a relay run with no rise is a dead element. Separately, neither series
 says much; overlaid, they are a diagnosis.
 


### PR DESCRIPTION
## What

Three recently-shipped features shipped without the complete spec doc set. Backfill the missing documents retrospectively, describing the merged implementation and matching the existing house style (mirrors spec 143's docs):

| Spec | Added |
| --- | --- |
| 138 recipe-tariff-helper | `architecture.md` + `plan.md` |
| 141 order-delivery-confirmation | `plan.md` |
| 144 analyse-mixed-state-axis | `plan.md` |

Docs-only. Each folder now has `spec.md` + `architecture.md` + `plan.md`.

Companion to the specs-completeness CI gate (#467).