### PR TITLE
chore(registry): bump zigbee2mqtt to 2.5.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -7,11 +7,11 @@
     "icon": "Radio",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-zigbee2mqtt",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "tags": ["zigbee", "mqtt", "z2m", "sensors", "lights", "switches"],
     "sowelVersion": ">=1.38.0",
     "owner": "mchacher",
-    "sha256": "68bfe4ce68607d7d1734f17ac0c902ed3052ed2c120a35b0225e6f0e09b3bdbf"
+    "sha256": "b161bf9d18fd90cbb9597d682c5f88732396ef7b7262e9c0ec43e725b61d2429"
   },
   {
     "id": "lora2mqtt",


### PR DESCRIPTION
Plugin **v2.5.0** is published on `mchacher/sowel-plugin-zigbee2mqtt` (asset `sowel-plugin-zigbee2mqtt-2.5.0.tar.gz`), bundling:
- #11 — mark a network's devices offline when its Z2M bridge dies (was v2.4.1)
- #12 — declare `power_source` and categorise `battery_low` (companion to core spec 143 / #444)

`sha256` regenerated via `scripts/backfill-registry-sha256.mjs` and verified byte-for-byte against the published asset (`b161bf9d…`). `sowelVersion` kept at `>=1.38.0`: the power-source feature degrades gracefully on older cores, and the bridge-offline fix should reach everyone (not gated behind 1.43.0).