### PR TITLE
release: v1.43.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,14 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.43.x: Alertes batterie faible et contrôles du graphe Analyse
+
+### v1.43.0 — 2026-08-12 { #v1-43-0 }
+
+- Feat (devices): **alertes de batterie faible pour les appareils sur pile**. Un capteur sur pile pouvait tomber à plat en silence : la spec 116 considère le silence radio des équipements à pile événementiels comme normal, donc une pile morte restait affichée en ligne pendant que le pourcentage bas dormait, non lu. Sowel surveille désormais le niveau de batterie de chaque appareil sur pile, lève une alerte système à 20% ou moins (levée à nouveau à 25%), rappelle une fois par semaine tant que le niveau reste bas, et résout l'alerte au remplacement de la pile. La carte d'équipement affiche un indicateur de batterie à côté de ses valeurs. Les appareils sont détectés automatiquement, et précisément dès que le plugin Zigbee2MQTT 2.5.0 déclare la source d'alimentation de chaque appareil. À cette occasion, les alarmes système (batterie, ordres non confirmés, erreurs d'intégration) atteignent maintenant tous les publishers de notification activés au lieu du seul premier Telegram, si bien qu'une installation en web-push seul les reçoit aussi. Contribué par Adrien Jouve (computingify). (spec 143, #444)
+- Feat (ui): **couleurs par série et axes Y ajustés sur le graphe Analyse**. Trois choses échappaient au contrôle sur un graphe Analyse. Les couleurs suivaient l'ordre d'ajout sans rien de sauvegardé, si bien que retirer une série recolorait les autres ; chaque série ouvre désormais un sélecteur de couleur et le choix est sauvegardé. Un axe de mesure était ancré à zéro, donc une température de ballon entre 48 et 55 degrés se lisait comme une ligne plate en haut ; une bascule ajuste maintenant chaque axe de mesure à sa propre plage. Et toutes les mesures partageaient une seule échelle ; un graphe traçant exactement deux quantités obtient désormais un axe chacune, à gauche et à droite, groupées par unité. Les deux réglages sont optionnels, donc un graphe sauvegardé avant ce changement garde l'ordre de la palette et l'axe ancré à zéro, sauf qu'un graphe existant traçant exactement deux quantités d'unités différentes s'ouvrira désormais avec des axes gauche et droite séparés. Contribué par Adrien Jouve (computingify). (spec 145, #446)
+- Interne : couverture de tests automatisés élargie (le UserManager, plusieurs modules backend jusque-là non testés, et les stores UI useAuth et useWebSocket), un nettoyage des gardes de démarrage du mode ombre et du client API UI, plus un nouveau garde-fou CI et des documents de conception complétés pour les dossiers de spec. Aucun changement visible. (#459, #461, #462, #463, #464, #465, #466, #467, #468)
+
 ## 1.42.x: Historique des états et navigation plus claire
 
 ### v1.42.0 — 2026-08-12 { #v1-42-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,14 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.43.x: Low battery alerts and Analyse chart controls
+
+### v1.43.0 — 2026-08-12 { #v1-43-0 }
+
+- Feat (devices): **low battery alerts for battery-powered devices**. A battery-powered sensor could go flat silently: spec 116 treats the radio silence of event-driven battery hardware as normal, so a dead cell still showed as online while the low percentage sat unread. Sowel now watches the battery level of every battery-powered device, raises a system alert at 20% or below (clearing again at 25%), reminds once a week while it stays low, and resolves the alert when the cell is replaced. The equipment card shows a battery marker next to its readings. Devices are detected automatically, and precisely once the Zigbee2MQTT plugin 2.5.0 declares each device's power source. As part of this, system alarms (battery, unconfirmed orders, integration errors) now reach every enabled notification publisher instead of only the first Telegram one, so a web-push-only setup receives them too. Contributed by Adrien Jouve (computingify). (spec 143, #444)
+- Feat (ui): **per-series colours and fitted Y axes on the Analyse chart**. Three things were out of reach on an Analyse chart. Series colours followed insertion order with nothing saved, so removing a series recoloured the rest; each series now opens a colour picker and the choice is saved. A measurement axis was anchored at zero, so a tank temperature living between 48 and 55 degrees read as a flat line at the top; a toggle now fits each measurement axis to its own range. And every measurement shared one scale; a chart plotting exactly two quantities now gets an axis each, left and right, grouped by unit. Both settings are optional, so charts saved before this change keep the palette order and the zero-anchored axis, except that a pre-existing chart plotting exactly two different-unit quantities will now open with split left and right axes. Contributed by Adrien Jouve (computingify). (spec 145, #446)
+- Internal: broader automated test coverage (the UserManager, several previously-untested backend modules, and the useAuth and useWebSocket UI stores), a tidy-up of the shadow-mode boot gates and the UI API client, and a new CI gate plus backfilled design docs for the spec folders. No user-facing change. (#459, #461, #462, #463, #464, #465, #466, #467, #468)
+
 ## 1.42.x: State history and clearer navigation
 
 ### v1.42.0 — 2026-08-12 { #v1-42-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.42.0",
+  "version": "1.43.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## v1.43.0

Two user-facing features (both contributed by Adrien Jouve / computingify) plus internal hardening.

- **Low battery alerts** for battery-powered devices (spec 143, #444). Also broadens system-alarm delivery to every enabled notification publisher. Companion Zigbee2MQTT plugin 2.5.0 (published) declares each device's power source.
- **Per-series colours and fitted Y axes** on the Analyse chart (spec 145, #446). Note: a pre-existing chart plotting exactly two different-unit quantities now opens with split left/right axes.
- **Internal**: broader test coverage (UserManager, several backend modules, useAuth/useWebSocket stores), shadow-mode + UI API-client refactors, a specs-completeness CI gate and backfilled spec docs. (#459, #461-#468)

Release notes added to both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-43-0 }` anchor; version bumped in `package.json` + `ui/package.json`.

On merge: tag `v1.43.0` on the on-main commit and push the tag to trigger the Docker build. Not deploying to prod.