### PR TITLE
ci(release): install ui deps before the release-workflow test step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,9 @@ jobs:
           cache: npm
 
       - run: npm ci
+      # The root vitest run (Tests step) includes ui/src store tests that import
+      # zustand, so ui/node_modules must be present before it runs.
+      - run: cd ui && npm ci
 
       - name: TypeScript check
         run: npx tsc --noEmit


### PR DESCRIPTION
The v1.43.0 release build failed: release.yml's `ci` job runs `npx vitest run` (which includes the ui/src store tests importing zustand) **before** installing ui deps (the `cd ui && npm ci` lived in a later "UI checks" step). Result: `Failed to load url zustand`, and the docker + release jobs were skipped, so no image and no GitHub release were produced.

Same gap as the ci.yml fix shipped earlier; release.yml has its own `ci` job that was missed. Add `cd ui && npm ci` before the Tests step.

After merge: re-tag `v1.43.0` on the fixed main (`git tag -f v1.43.0 && git push --force origin v1.43.0`) to re-run the release.