### PR TITLE
fix(devices): scope battery alerts to the equipment zone and show the equipment name (#472)

### DIFF
--- a/src/activity/activity-buffer.test.ts
+++ b/src/activity/activity-buffer.test.ts
@@ -399,6 +399,37 @@ describe("ActivityBuffer", () => {
     });
   });
 
+  describe("system alarms (spec 143/#472)", () => {
+    const isAlarm = (i: { message: { template: string } }) => i.message.template === "alarm.raised";
+
+    it("scopes a zone-tagged alarm to that zone only, not every zone", () => {
+      h.bus.emit({
+        type: "system.alarm.raised",
+        alarmId: "battery-low:dd-1",
+        level: "warning",
+        source: "Détecteur salon",
+        message: "Low battery: 12% (Capteur porte)",
+        zoneId: "zone-A",
+      });
+
+      expect(h.buffer.getItems({ zoneId: "zone-A" }).some(isAlarm)).toBe(true);
+      expect(h.buffer.getItems({ zoneId: "zone-B" }).some(isAlarm)).toBe(false);
+    });
+
+    it("keeps an alarm with no zone global (shown in every zone)", () => {
+      h.bus.emit({
+        type: "system.alarm.raised",
+        alarmId: "poll-fail:z2m",
+        level: "error",
+        source: "Zigbee2MQTT",
+        message: "down",
+      });
+
+      expect(h.buffer.getItems({ zoneId: "zone-A" }).some(isAlarm)).toBe(true);
+      expect(h.buffer.getItems({ zoneId: "zone-B" }).some(isAlarm)).toBe(true);
+    });
+  });
+
   describe("ring buffer cap and emit", () => {
     it("emits activity.added on the bus for every push", () => {
       const onActivity = vi.fn();

--- a/src/activity/activity-buffer.ts
+++ b/src/activity/activity-buffer.ts
@@ -227,8 +227,11 @@ export class ActivityBuffer {
     this.push("sunlight", null, { template, params: {} });
   }
 
-  private onAlarmRaised(event: { source: string; message: string }): void {
-    this.push("alarm", null, {
+  private onAlarmRaised(event: { source: string; message: string; zoneId?: string | null }): void {
+    // A zone-scoped alarm (a battery alert bound to an equipment, spec 143/#472)
+    // lands in that zone; an alarm with no zone (integrations, unbound device)
+    // stays global and shows in every zone, as before.
+    this.push("alarm", event.zoneId ?? null, {
       template: "alarm.raised",
       params: { source: event.source, message: event.message },
     });

--- a/src/devices/battery-monitor.test.ts
+++ b/src/devices/battery-monitor.test.ts
@@ -10,7 +10,8 @@ import {
 } from "./battery-monitor.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
-import type { DeviceWithDetails, EngineEvent, PowerSource } from "../shared/types.js";
+import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import type { DeviceWithDetails, EngineEvent, Equipment, PowerSource } from "../shared/types.js";
 import type { DeviceManager } from "./device-manager.js";
 
 const logger = createLogger("silent").logger;
@@ -59,7 +60,29 @@ function makeDevice(
   };
 }
 
-function createHarness(devices: DeviceWithDetails[] = []) {
+/** Stub EquipmentManager: maps a deviceId to the equipments bound to it. */
+function mkEquipmentManager(byDevice: Record<string, Equipment[]> = {}): EquipmentManager {
+  return {
+    getEquipmentsForDeviceId: (deviceId: string) => byDevice[deviceId] ?? [],
+  } as unknown as EquipmentManager;
+}
+
+function eq(id: string, name: string, zoneId: string): Equipment {
+  return {
+    id,
+    name,
+    zoneId,
+    type: "sensor",
+    enabled: true,
+    createdAt: "2026-08-12T00:00:00Z",
+    updatedAt: "2026-08-12T00:00:00Z",
+  };
+}
+
+function createHarness(
+  devices: DeviceWithDetails[] = [],
+  equipmentsByDevice: Record<string, Equipment[]> = {},
+) {
   const db = createTestDb();
   const eventBus = new EventBus(logger);
   const events: EngineEvent[] = [];
@@ -70,7 +93,13 @@ function createHarness(devices: DeviceWithDetails[] = []) {
     getAllWithData: () => current,
   } as unknown as DeviceManager;
 
-  const monitor = new BatteryMonitor(db, eventBus, deviceManager, logger);
+  const monitor = new BatteryMonitor(
+    db,
+    eventBus,
+    deviceManager,
+    mkEquipmentManager(equipmentsByDevice),
+    logger,
+  );
   return {
     db,
     eventBus,
@@ -205,6 +234,61 @@ describe("BatteryMonitor", () => {
     expect(harness.raised()[0]).toMatchObject({ message: "Low battery" });
   });
 
+  // ─── equipment context (spec 143/#472) ──────────────────────────────────
+
+  it("labels the alarm with the equipment name and scopes it to the equipment's zone", () => {
+    harness = createHarness([makeDevice({ powerSource: "battery" })], {
+      "dev-1": [eq("e1", "Détecteur salon", "zone-salon")],
+    });
+    harness.monitor.init();
+    harness.monitor.sweep();
+
+    expect(harness.raised()[0]).toMatchObject({
+      source: "Détecteur salon", // equipment name headlines the alarm
+      message: "Low battery: 12% (Capteur porte)", // device name stays in the message
+      zoneId: "zone-salon",
+    });
+  });
+
+  it("lists several bound equipments and uses the first one's zone", () => {
+    harness = createHarness([makeDevice({ powerSource: "battery" })], {
+      "dev-1": [eq("e1", "Détecteur salon", "zone-salon"), eq("e2", "Alarme", "zone-hall")],
+    });
+    harness.monitor.init();
+    harness.monitor.sweep();
+
+    expect(harness.raised()[0]).toMatchObject({
+      source: "Détecteur salon, Alarme",
+      zoneId: "zone-salon",
+    });
+  });
+
+  it("falls back to the device name and a global (null) zone when the device is unbound", () => {
+    harness = createHarness([makeDevice({ powerSource: "battery" })]); // no equipment bound
+    harness.monitor.init();
+    harness.monitor.sweep();
+
+    expect(harness.raised()[0]).toMatchObject({
+      source: "Capteur porte",
+      message: "Low battery: 12%",
+      zoneId: null,
+    });
+  });
+
+  it("getActiveAlerts resolves the equipment names and zone live", () => {
+    harness = createHarness([makeDevice({ powerSource: "battery" })], {
+      "dev-1": [eq("e1", "Détecteur salon", "zone-salon")],
+    });
+    harness.monitor.init();
+    harness.monitor.sweep();
+
+    expect(harness.monitor.getActiveAlerts()[0]).toMatchObject({
+      deviceName: "Capteur porte",
+      equipmentNames: ["Détecteur salon"],
+      zoneId: "zone-salon",
+    });
+  });
+
   it("ignores a mains-powered device whatever its battery value", () => {
     harness = createHarness([makeDevice({ powerSource: "mains" })]);
     harness.monitor.init();
@@ -316,6 +400,7 @@ describe("BatteryMonitor", () => {
       {
         getAllWithData: () => [makeDevice({ powerSource: "battery" })],
       } as unknown as DeviceManager,
+      mkEquipmentManager(),
       logger,
     );
     reloaded.init();
@@ -333,6 +418,7 @@ describe("BatteryMonitor", () => {
       {
         getAllWithData: () => [makeDevice({ powerSource: "battery" })],
       } as unknown as DeviceManager,
+      mkEquipmentManager(),
       logger,
     );
     later.init();
@@ -356,6 +442,7 @@ describe("BatteryMonitor", () => {
       {
         getAllWithData: () => [makeDevice({ powerSource: "battery" })],
       } as unknown as DeviceManager,
+      mkEquipmentManager(),
       logger,
     );
     restarted.init();
@@ -385,6 +472,7 @@ describe("BatteryMonitor", () => {
       {
         getAllWithData: () => [makeDevice({ powerSource: "battery", data: [{ value: 95 }] })],
       } as unknown as DeviceManager,
+      mkEquipmentManager(),
       logger,
     );
     restarted.init();

--- a/src/devices/battery-monitor.ts
+++ b/src/devices/battery-monitor.ts
@@ -22,6 +22,7 @@ import type { Logger } from "../core/logger.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { BatteryAlert, DeviceWithDetails } from "../shared/types.js";
 import type { DeviceManager } from "./device-manager.js";
+import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import {
   BATTERY_REMINDER_INTERVAL_MS,
   BATTERY_SWEEP_INTERVAL_MS,
@@ -121,6 +122,7 @@ export class BatteryMonitor {
     private readonly db: Database.Database,
     private readonly eventBus: EventBus,
     private readonly deviceManager: DeviceManager,
+    private readonly equipmentManager: EquipmentManager,
     logger: Logger,
   ) {
     this.logger = logger.child({ module: "battery-monitor" });
@@ -167,7 +169,26 @@ export class BatteryMonitor {
 
   /** Active alerts, newest first. Feeds `GET /devices/battery-alerts`. */
   getActiveAlerts(): BatteryAlert[] {
-    return [...this.alerts.values()].sort((a, b) => b.raisedAt.localeCompare(a.raisedAt));
+    return [...this.alerts.values()]
+      .sort((a, b) => b.raisedAt.localeCompare(a.raisedAt))
+      .map((alert) => ({ ...alert, ...this.resolveEquipmentContext(alert.deviceId) }));
+  }
+
+  /**
+   * Equipment context of a battery device (spec 143/#472): the names of the
+   * equipments it is bound to and the zone of the first one. Resolved live, so
+   * a re-binding is reflected without touching the stored alert. An unbound
+   * device gets an empty list and a null zone, so its alarm stays global.
+   */
+  private resolveEquipmentContext(deviceId: string): {
+    equipmentNames: string[];
+    zoneId: string | null;
+  } {
+    const equipments = this.equipmentManager.getEquipmentsForDeviceId(deviceId);
+    return {
+      equipmentNames: equipments.map((e) => e.name),
+      zoneId: equipments[0]?.zoneId ?? null,
+    };
   }
 
   /**
@@ -244,12 +265,21 @@ export class BatteryMonitor {
   }
 
   private notify(alert: BatteryAlert): void {
+    const { equipmentNames, zoneId } = this.resolveEquipmentContext(alert.deviceId);
+    const bound = equipmentNames.length > 0;
     this.eventBus.emit({
       type: "system.alarm.raised",
       alarmId: `${ALARM_PREFIX}${alert.deviceDataId}`,
       level: "warning",
-      source: alert.deviceName,
-      message: batteryMessage(alert.value),
+      // The equipment name(s) headline the alarm; the device name stays visible
+      // in the message. An unbound device keeps the device name as the source.
+      source: bound ? equipmentNames.join(", ") : alert.deviceName,
+      message: bound
+        ? `${batteryMessage(alert.value)} (${alert.deviceName})`
+        : batteryMessage(alert.value),
+      // Scope the activity to the equipment's zone; null for an unbound device
+      // keeps it global rather than showing it in every zone.
+      zoneId,
     });
   }
 

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -381,6 +381,37 @@ describe("EquipmentManager", () => {
   // DataBinding
   // ============================================================
 
+  describe("getEquipmentsForDeviceId (spec 143/#472)", () => {
+    it("returns every equipment bound to any data of the device, ordered by name", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const eqB = manager.create({ name: "Beta", type: "light_dimmable", zoneId: zone.id });
+      const eqA = manager.create({ name: "Alpha", type: "light_dimmable", zoneId: zone.id });
+      const { dataIds } = seedDevice(db, {
+        deviceId: "dev-x",
+        dataKeys: [
+          { key: "temperature", category: "temperature" },
+          { key: "battery", category: "battery" },
+        ],
+      });
+      // Two equipments each bind a different data of the same device.
+      manager.addDataBinding(eqB.id, dataIds[0], "temperature");
+      manager.addDataBinding(eqA.id, dataIds[1], "battery");
+
+      expect(manager.getEquipmentsForDeviceId("dev-x").map((e) => e.name)).toEqual([
+        "Alpha",
+        "Beta",
+      ]);
+    });
+
+    it("returns an empty array for an unbound device", () => {
+      seedDevice(db, {
+        deviceId: "dev-unbound",
+        dataKeys: [{ key: "battery", category: "battery" }],
+      });
+      expect(manager.getEquipmentsForDeviceId("dev-unbound")).toEqual([]);
+    });
+  });
+
   describe("addDataBinding", () => {
     it("creates a data binding", () => {
       const zone = zoneManager.create({ name: "Salon" });

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -169,6 +169,13 @@ export class EquipmentManager {
          VALUES (@id, @name, @zoneId, @type, @icon, @description, @enabled)`,
       ),
       getEquipmentById: this.db.prepare("SELECT * FROM equipments WHERE id = ?"),
+      // Equipments that bind any data of a given device (reverse lookup, spec 143/#472).
+      equipmentIdsForDevice: this.db.prepare(
+        `SELECT DISTINCT db.equipment_id AS equipmentId
+         FROM data_bindings db
+         JOIN device_data dd ON db.device_data_id = dd.id
+         WHERE dd.device_id = ?`,
+      ),
       getAllEquipments: this.db.prepare("SELECT * FROM equipments ORDER BY name"),
       getEquipmentsByZone: this.db.prepare(
         "SELECT * FROM equipments WHERE zone_id = ? ORDER BY name",
@@ -362,6 +369,18 @@ export class EquipmentManager {
   getById(id: string): Equipment | null {
     const row = this.stmts.getEquipmentById.get(id) as EquipmentRow | undefined;
     return row ? rowToEquipment(row) : null;
+  }
+
+  /**
+   * Every equipment that binds any data of the given device (spec 143/#472).
+   * Ordered by name for a stable label. Empty when the device is unbound.
+   */
+  getEquipmentsForDeviceId(deviceId: string): Equipment[] {
+    const rows = this.stmts.equipmentIdsForDevice.all(deviceId) as { equipmentId: string }[];
+    return rows
+      .map((r) => this.getById(r.equipmentId))
+      .filter((e): e is Equipment => e !== null)
+      .sort((a, b) => a.name.localeCompare(b.name));
   }
 
   getAll(): Equipment[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,7 +286,7 @@ async function main() {
   // battery-powered device drops under the threshold, reminding weekly until
   // the cell is replaced. Not started in shadow mode: a shadow instance must
   // not push notifications to the user's phone.
-  const batteryMonitor = new BatteryMonitor(db, eventBus, deviceManager, logger);
+  const batteryMonitor = new BatteryMonitor(db, eventBus, deviceManager, equipmentManager, logger);
   await runUnlessShadow("batteryMonitor.init()", () => batteryMonitor.init());
 
   // 11. Create InfluxDB client and connect

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -151,6 +151,12 @@ export interface BatteryAlert {
   raisedAt: string;
   /** Drives the weekly reminder — persisted so a restart does not reset it. */
   lastNotifiedAt: string;
+  /** Names of the equipments bound to this device, resolved live for the API
+   *  response (spec 143/#472). Absent on the internal record; empty array when
+   *  the device is unbound. Lets the banner show the equipment. */
+  equipmentNames?: string[];
+  /** Zone of the first bound equipment, null when unbound. Resolved live. */
+  zoneId?: string | null;
 }
 
 export interface DeviceData {
@@ -1025,6 +1031,9 @@ export type EngineEvent =
       level: "warning" | "error";
       source: string;
       message: string;
+      /** Zone the alarm belongs to, so the activity feed can scope it. Absent
+       *  or null = a global alarm shown in every zone (spec 143/#472). */
+      zoneId?: string | null;
     }
   | { type: "system.alarm.resolved"; alarmId: string; source: string; message: string }
   // Self-update events

--- a/ui/src/store/useWebSocket.test.ts
+++ b/ui/src/store/useWebSocket.test.ts
@@ -46,6 +46,11 @@ vi.mock("./useModes", () => ({ useModes: { getState: () => S.modes } }));
 vi.mock("./useActivity", () => ({ useActivity: { getState: () => S.activity } }));
 vi.mock("./useArbiter", () => ({ useArbiter: { getState: () => S.arbiter } }));
 
+// The only ../api call in this store is getBatteryAlerts (banner restore path).
+// Default to an empty list so the health-restore test is unaffected.
+const api = vi.hoisted(() => ({ getBatteryAlerts: vi.fn(async () => [] as unknown[]) }));
+vi.mock("../api", () => api);
+
 // ── Fake WebSocket ──────────────────────────────────────────────────────────
 class FakeWebSocket {
   static CONNECTING = 0;
@@ -203,6 +208,30 @@ describe("connect", () => {
     const s = useWebSocket.getState();
     expect(s.integrationStatuses.panasonic).toBe("error");
     expect(s.alarms.get("poll-fail:panasonic")?.level).toBe("error");
+  });
+
+  it("on open: restores a battery banner headlined by the equipment name (spec 143/#472)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ json: async () => ({}) })));
+    api.getBatteryAlerts.mockResolvedValue([
+      { deviceDataId: "dd-1", deviceName: "Capteur porte", value: "12", equipmentNames: ["Détecteur salon"] },
+      { deviceDataId: "dd-2", deviceName: "Capteur cave", value: "8", equipmentNames: [] },
+    ]);
+
+    const ws = connect();
+    ws.simulateOpen();
+
+    await vi.waitFor(() => {
+      expect(useWebSocket.getState().alarms.get("battery-low:dd-1")).toBeDefined();
+    });
+
+    const bound = useWebSocket.getState().alarms.get("battery-low:dd-1");
+    expect(bound?.source).toBe("Détecteur salon");
+    expect(bound?.message).toBe("Low battery: 12% (Capteur porte)");
+
+    // Unbound device falls back to the device name, no equipment in the message.
+    const unbound = useWebSocket.getState().alarms.get("battery-low:dd-2");
+    expect(unbound?.source).toBe("Capteur cave");
+    expect(unbound?.message).toBe("Low battery: 8%");
   });
 });
 

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -325,11 +325,17 @@ export const useWebSocket = create<WebSocketState>((set) => ({
 
           for (const alert of batteryAlerts) {
             const alarmId = `${BATTERY_ALARM_PREFIX}${alert.deviceDataId}`;
+            // Mirror the engine's live alarm (spec 143/#472): the equipment
+            // name(s) headline the banner, the device name stays in the message.
+            const equipmentNames = alert.equipmentNames ?? [];
+            const bound = equipmentNames.length > 0;
             alarms.set(alarmId, {
               alarmId,
               level: "warning",
-              source: alert.deviceName,
-              message: batteryAlarmMessage(alert.value),
+              source: bound ? equipmentNames.join(", ") : alert.deviceName,
+              message: bound
+                ? `${batteryAlarmMessage(alert.value)} (${alert.deviceName})`
+                : batteryAlarmMessage(alert.value),
             });
           }
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -118,6 +118,11 @@ export interface BatteryAlert {
   value: string;
   raisedAt: string;
   lastNotifiedAt: string;
+  /** Names of the equipments bound to this device (spec 143/#472); empty when
+   *  unbound. Lets the banner show the equipment, not just the device. */
+  equipmentNames?: string[];
+  /** Zone of the first bound equipment, null when unbound. */
+  zoneId?: string | null;
 }
 
 export interface Device {


### PR DESCRIPTION
## Problem (#472)

Low-battery alerts (spec 143) were device-centric:
1. The alarm carried no zone → `ActivityBuffer` pushed it with `zoneId: null`, and `getItems` shows null-zone items in **every** zone's feed. So a faulty sensor appeared in every zone's activity.
2. The banner and activity showed only the **device** name, never the associated equipment.

## Fix

Resolve **device → equipment(s) → zone** on the alert path:

- `EquipmentManager.getEquipmentsForDeviceId(deviceId)` — reverse lookup via `data_bindings` → `device_data` → `device_id`.
- `BatteryMonitor` now takes an `EquipmentManager`. `notify()` headlines the alarm with the **equipment name(s)** (the device name stays in the message) and emits the equipment's **`zoneId`**. `getActiveAlerts()` resolves `equipmentNames` + `zoneId` **live** so the banner restore path (after reconnect) shows the equipment too.
- `system.alarm.raised` gains an optional `zoneId`; `ActivityBuffer.onAlarmRaised` honours it → a bound battery alert lands in **its zone only**.
- UI banner-restore mirrors the engine wording.

### Decided behaviour (from the issue)
- **Unbound device** → keep the device name, activity stays **global** (not per-zone).
- **Several bound equipments** (rare) → list their names, activity uses the **first** equipment's zone.
- Non-battery alarms (no `zoneId`) and genuinely-global activities (modes, sunlight) are **unchanged**.

## Tests
- `battery-monitor.test.ts`: equipment-name headline + zone scoping, multi-equipment list, unbound fallback (device name + null zone), `getActiveAlerts` enrichment.
- `activity-buffer.test.ts`: a zone-tagged alarm is scoped to that zone only; a zone-less alarm stays global.
- `equipment-manager.test.ts`: `getEquipmentsForDeviceId` reverse lookup (bound + unbound).

Full suite green (1526 passed), tsc + eslint clean (backend + UI).

Closes #472