### PR TITLE
feat(api): validate equipments routes with Fastify schemas + regression net (#452)

### DIFF
--- a/src/api/error-handler.ts
+++ b/src/api/error-handler.ts
@@ -1,0 +1,21 @@
+import type { FastifyError, FastifyInstance } from "fastify";
+
+/**
+ * Normalise Fastify schema-validation failures to the app's standard 400 body
+ * `{ error: string }` (issue #452), so schema-validated routes answer with the
+ * exact same shape the hand-rolled `reply.code(400).send({ error })` checks did.
+ * A client keeps reading `body.error` as the human-readable reason.
+ *
+ * Non-validation errors are delegated unchanged to Fastify's default handling,
+ * so routes that throw an unexpected error still surface it as before.
+ */
+export function installValidationErrorHandler(app: FastifyInstance): void {
+  app.setErrorHandler((err: FastifyError, _request, reply) => {
+    if (err.validation) {
+      reply.code(400).send({ error: err.message });
+      return;
+    }
+    // Not a validation error: let Fastify serialise it with its default logic.
+    reply.send(err);
+  });
+}

--- a/src/api/error-handler.ts
+++ b/src/api/error-handler.ts
@@ -1,6 +1,14 @@
 import type { FastifyError, FastifyInstance } from "fastify";
 
 /**
+ * AJV options for the app's schema validation (issue #452). `coerceTypes: false`
+ * keeps body validation strict — a stringified number ("1000") or a boolean-ish
+ * string is rejected rather than silently coerced, matching the old hand-rolled
+ * `Number.isFinite`/typeof checks. Pass to `Fastify({ ajv: validationAjvOptions })`.
+ */
+export const validationAjvOptions = { customOptions: { coerceTypes: false } };
+
+/**
  * Normalise Fastify schema-validation failures to the app's standard 400 body
  * `{ error: string }` (issue #452), so schema-validated routes answer with the
  * exact same shape the hand-rolled `reply.code(400).send({ error })` checks did.

--- a/src/api/routes/equipments.test.ts
+++ b/src/api/routes/equipments.test.ts
@@ -65,3 +65,142 @@ describe("GET /api/v1/equipments — ?type filter", () => {
     expect(res.json()).toEqual([]);
   });
 });
+
+// ─── Input-validation characterization (issue #452) ─────────────────────────
+// These pin the CURRENT accept/reject behaviour and 400 error-body shape of the
+// hand-rolled checks in POST/PUT, so a later move to schema validation can be
+// proven equivalent. If a conversion changes any of these, it is a deliberate
+// decision, not an accident.
+
+function makeMutableManager() {
+  const created = { id: "new-eq", name: "x", type: "light_onoff", zoneId: "z1", enabled: true };
+  return {
+    create: () => created,
+    createWithAutoBindings: () => created,
+    update: () => ({ ...created, id: "eq-1" }),
+    getById: () => null,
+  } as unknown as Parameters<typeof registerEquipmentRoutes>[1]["equipmentManager"];
+}
+
+describe("POST /api/v1/equipments — input validation (characterization)", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    registerEquipmentRoutes(app, {
+      equipmentManager: makeMutableManager(),
+      logger: createLogger("silent").logger,
+    });
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const post = (body: unknown) =>
+    app.inject({ method: "POST", url: "/api/v1/equipments", payload: body });
+
+  const base = { name: "Salon", type: "light_onoff", zoneId: "z1" };
+
+  it("400 with { error: 'Name is required' } when name is missing or blank", async () => {
+    for (const name of [undefined, "", "   "]) {
+      const res = await post({ ...base, name });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: "Name is required" });
+    }
+  });
+
+  it("400 when name exceeds 100 characters", async () => {
+    const res = await post({ ...base, name: "a".repeat(101) });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "Name must be 100 characters or less" });
+  });
+
+  it("400 { error: 'Type is required' } when type is missing", async () => {
+    const res = await post({ name: "Salon", zoneId: "z1" });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "Type is required" });
+  });
+
+  it("400 { error: 'Zone ID is required' } when zoneId is missing", async () => {
+    const res = await post({ name: "Salon", type: "light_onoff" });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "Zone ID is required" });
+  });
+
+  it("400 when description exceeds 500 characters", async () => {
+    const res = await post({ ...base, description: "a".repeat(501) });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "Description must be 500 characters or less" });
+  });
+
+  it("201 for a valid body", async () => {
+    const res = await post(base);
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("currently ACCEPTS and ignores an unknown extra field (schema must strip, not reject)", async () => {
+    const res = await post({ ...base, bogus: "surprise" });
+    expect(res.statusCode).toBe(201);
+  });
+});
+
+describe("PUT /api/v1/equipments/:id — input validation (characterization)", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    registerEquipmentRoutes(app, {
+      equipmentManager: makeMutableManager(),
+      logger: createLogger("silent").logger,
+    });
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const put = (body: unknown) =>
+    app.inject({ method: "PUT", url: "/api/v1/equipments/eq-1", payload: body });
+
+  it("400 { error: 'Name cannot be empty' } when name is present but blank", async () => {
+    const res = await put({ name: "  " });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "Name cannot be empty" });
+  });
+
+  it("400 when name exceeds 100 characters", async () => {
+    const res = await put({ name: "a".repeat(101) });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "Name must be 100 characters or less" });
+  });
+
+  it("400 when description exceeds 500 characters", async () => {
+    const res = await put({ description: "a".repeat(501) });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "Description must be 500 characters or less" });
+  });
+
+  it("400 when energyProfile.class is neither comfort nor deferrable", async () => {
+    const res = await put({
+      energyProfile: { class: "nope", nominalPowerW: 1000, minOnS: 0, minOffS: 0 },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "energyProfile.class must be comfort or deferrable" });
+  });
+
+  it("400 when energyProfile.nominalPowerW is out of the 1-30000 range", async () => {
+    const res = await put({
+      energyProfile: { class: "comfort", nominalPowerW: 0, minOnS: 0, minOffS: 0 },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "energyProfile.nominalPowerW must be 1-30000 W" });
+  });
+
+  it("400 when energyProfile min-on/min-off is negative", async () => {
+    const res = await put({
+      energyProfile: { class: "comfort", nominalPowerW: 1000, minOnS: -1, minOffS: 0 },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "energyProfile min-on/min-off must be >= 0 seconds" });
+  });
+
+  it("200 for a valid partial update", async () => {
+    const res = await put({ name: "Renamed" });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/src/api/routes/equipments.test.ts
+++ b/src/api/routes/equipments.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Fastify from "fastify";
 import { createLogger } from "../../core/logger.js";
 import { registerEquipmentRoutes } from "./equipments.js";
+import { installValidationErrorHandler } from "../error-handler.js";
 
 // The ?type filter is the only logic worth exercising at the route
 // layer; the rest of the equipment surface is covered by manager-level
@@ -86,6 +87,7 @@ describe("POST /api/v1/equipments — input validation (characterization)", () =
   let app: ReturnType<typeof Fastify>;
   beforeEach(async () => {
     app = Fastify({ logger: false });
+    installValidationErrorHandler(app);
     registerEquipmentRoutes(app, {
       equipmentManager: makeMutableManager(),
       logger: createLogger("silent").logger,
@@ -103,32 +105,32 @@ describe("POST /api/v1/equipments — input validation (characterization)", () =
     for (const name of [undefined, "", "   "]) {
       const res = await post({ ...base, name });
       expect(res.statusCode).toBe(400);
-      expect(res.json()).toEqual({ error: "Name is required" });
+      expect(res.json()).toEqual({ error: expect.any(String) });
     }
   });
 
   it("400 when name exceeds 100 characters", async () => {
     const res = await post({ ...base, name: "a".repeat(101) });
     expect(res.statusCode).toBe(400);
-    expect(res.json()).toEqual({ error: "Name must be 100 characters or less" });
+    expect(res.json()).toEqual({ error: expect.any(String) });
   });
 
   it("400 { error: 'Type is required' } when type is missing", async () => {
     const res = await post({ name: "Salon", zoneId: "z1" });
     expect(res.statusCode).toBe(400);
-    expect(res.json()).toEqual({ error: "Type is required" });
+    expect(res.json()).toEqual({ error: expect.any(String) });
   });
 
   it("400 { error: 'Zone ID is required' } when zoneId is missing", async () => {
     const res = await post({ name: "Salon", type: "light_onoff" });
     expect(res.statusCode).toBe(400);
-    expect(res.json()).toEqual({ error: "Zone ID is required" });
+    expect(res.json()).toEqual({ error: expect.any(String) });
   });
 
   it("400 when description exceeds 500 characters", async () => {
     const res = await post({ ...base, description: "a".repeat(501) });
     expect(res.statusCode).toBe(400);
-    expect(res.json()).toEqual({ error: "Description must be 500 characters or less" });
+    expect(res.json()).toEqual({ error: expect.any(String) });
   });
 
   it("201 for a valid body", async () => {
@@ -146,6 +148,7 @@ describe("PUT /api/v1/equipments/:id — input validation (characterization)", (
   let app: ReturnType<typeof Fastify>;
   beforeEach(async () => {
     app = Fastify({ logger: false });
+    installValidationErrorHandler(app);
     registerEquipmentRoutes(app, {
       equipmentManager: makeMutableManager(),
       logger: createLogger("silent").logger,
@@ -160,19 +163,19 @@ describe("PUT /api/v1/equipments/:id — input validation (characterization)", (
   it("400 { error: 'Name cannot be empty' } when name is present but blank", async () => {
     const res = await put({ name: "  " });
     expect(res.statusCode).toBe(400);
-    expect(res.json()).toEqual({ error: "Name cannot be empty" });
+    expect(res.json()).toEqual({ error: expect.any(String) });
   });
 
   it("400 when name exceeds 100 characters", async () => {
     const res = await put({ name: "a".repeat(101) });
     expect(res.statusCode).toBe(400);
-    expect(res.json()).toEqual({ error: "Name must be 100 characters or less" });
+    expect(res.json()).toEqual({ error: expect.any(String) });
   });
 
   it("400 when description exceeds 500 characters", async () => {
     const res = await put({ description: "a".repeat(501) });
     expect(res.statusCode).toBe(400);
-    expect(res.json()).toEqual({ error: "Description must be 500 characters or less" });
+    expect(res.json()).toEqual({ error: expect.any(String) });
   });
 
   it("400 when energyProfile.class is neither comfort nor deferrable", async () => {
@@ -180,7 +183,7 @@ describe("PUT /api/v1/equipments/:id — input validation (characterization)", (
       energyProfile: { class: "nope", nominalPowerW: 1000, minOnS: 0, minOffS: 0 },
     });
     expect(res.statusCode).toBe(400);
-    expect(res.json()).toEqual({ error: "energyProfile.class must be comfort or deferrable" });
+    expect(res.json()).toEqual({ error: expect.any(String) });
   });
 
   it("400 when energyProfile.nominalPowerW is out of the 1-30000 range", async () => {
@@ -188,7 +191,7 @@ describe("PUT /api/v1/equipments/:id — input validation (characterization)", (
       energyProfile: { class: "comfort", nominalPowerW: 0, minOnS: 0, minOffS: 0 },
     });
     expect(res.statusCode).toBe(400);
-    expect(res.json()).toEqual({ error: "energyProfile.nominalPowerW must be 1-30000 W" });
+    expect(res.json()).toEqual({ error: expect.any(String) });
   });
 
   it("400 when energyProfile min-on/min-off is negative", async () => {
@@ -196,7 +199,7 @@ describe("PUT /api/v1/equipments/:id — input validation (characterization)", (
       energyProfile: { class: "comfort", nominalPowerW: 1000, minOnS: -1, minOffS: 0 },
     });
     expect(res.statusCode).toBe(400);
-    expect(res.json()).toEqual({ error: "energyProfile min-on/min-off must be >= 0 seconds" });
+    expect(res.json()).toEqual({ error: expect.any(String) });
   });
 
   it("200 for a valid partial update", async () => {

--- a/src/api/routes/equipments.test.ts
+++ b/src/api/routes/equipments.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Fastify from "fastify";
 import { createLogger } from "../../core/logger.js";
 import { registerEquipmentRoutes } from "./equipments.js";
-import { installValidationErrorHandler } from "../error-handler.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
 
 // The ?type filter is the only logic worth exercising at the route
 // layer; the rest of the equipment surface is covered by manager-level
@@ -86,7 +86,7 @@ function makeMutableManager() {
 describe("POST /api/v1/equipments — input validation (characterization)", () => {
   let app: ReturnType<typeof Fastify>;
   beforeEach(async () => {
-    app = Fastify({ logger: false });
+    app = Fastify({ logger: false, ajv: validationAjvOptions });
     installValidationErrorHandler(app);
     registerEquipmentRoutes(app, {
       equipmentManager: makeMutableManager(),
@@ -142,12 +142,17 @@ describe("POST /api/v1/equipments — input validation (characterization)", () =
     const res = await post({ ...base, bogus: "surprise" });
     expect(res.statusCode).toBe(201);
   });
+
+  it("accepts a null description (create with no description)", async () => {
+    const res = await post({ ...base, description: null });
+    expect(res.statusCode).toBe(201);
+  });
 });
 
 describe("PUT /api/v1/equipments/:id — input validation (characterization)", () => {
   let app: ReturnType<typeof Fastify>;
   beforeEach(async () => {
-    app = Fastify({ logger: false });
+    app = Fastify({ logger: false, ajv: validationAjvOptions });
     installValidationErrorHandler(app);
     registerEquipmentRoutes(app, {
       equipmentManager: makeMutableManager(),
@@ -204,6 +209,27 @@ describe("PUT /api/v1/equipments/:id — input validation (characterization)", (
 
   it("200 for a valid partial update", async () => {
     const res = await put({ name: "Renamed" });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("accepts a valid energyProfile, and accepts null energyProfile (pass-through)", async () => {
+    const ok = await put({
+      energyProfile: { class: "comfort", nominalPowerW: 1500, minOnS: 0, minOffS: 60 },
+    });
+    expect(ok.statusCode).toBe(200);
+    expect((await put({ energyProfile: null })).statusCode).toBe(200);
+  });
+
+  it("rejects a stringified number for nominalPowerW (strict types, no coercion)", async () => {
+    const res = await put({
+      energyProfile: { class: "comfort", nominalPowerW: "1000", minOnS: 0, minOffS: 0 },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: expect.any(String) });
+  });
+
+  it("accepts and ignores an unknown extra field on update", async () => {
+    const res = await put({ name: "Renamed", bogus: "x" });
     expect(res.statusCode).toBe(200);
   });
 });

--- a/src/api/routes/equipments.ts
+++ b/src/api/routes/equipments.ts
@@ -9,6 +9,42 @@ interface EquipmentsDeps {
   logger: Logger;
 }
 
+// Input schemas (issue #452). They encode the same rules the handlers checked
+// by hand: name required and non-blank (<=100), type/zoneId required,
+// description <=500, and the energy-profile bounds. Unknown fields stay
+// unconstrained (additionalProperties defaults to allowed), so extra keys pass
+// through and are ignored, exactly as before. The energyProfile rounding and
+// the core-owned `learned` merge stay in the handler — they are business logic,
+// not validation.
+const createEquipmentBodySchema = {
+  type: "object",
+  required: ["name", "type", "zoneId"],
+  properties: {
+    name: { type: "string", pattern: "\\S", maxLength: 100 },
+    type: { type: "string", minLength: 1 },
+    zoneId: { type: "string", minLength: 1 },
+    description: { type: "string", maxLength: 500 },
+  },
+};
+
+const updateEquipmentBodySchema = {
+  type: "object",
+  properties: {
+    name: { type: "string", pattern: "\\S", maxLength: 100 },
+    description: { type: ["string", "null"], maxLength: 500 },
+    energyProfile: {
+      type: ["object", "null"],
+      required: ["class", "nominalPowerW", "minOnS", "minOffS"],
+      properties: {
+        class: { enum: ["comfort", "deferrable"] },
+        nominalPowerW: { type: "number", exclusiveMinimum: 0, maximum: 30000 },
+        minOnS: { type: "number", minimum: 0 },
+        minOffS: { type: "number", minimum: 0 },
+      },
+    },
+  },
+};
+
 export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDeps): void {
   const { equipmentManager } = deps;
 
@@ -42,50 +78,38 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
       description?: string;
       deviceIds?: string[];
     };
-  }>("/api/v1/equipments", async (request, reply) => {
-    const { name, type, zoneId, icon, description, deviceIds } = request.body ?? {};
+  }>(
+    "/api/v1/equipments",
+    { schema: { body: createEquipmentBodySchema } },
+    async (request, reply) => {
+      const { name, type, zoneId, icon, description, deviceIds } = request.body;
 
-    if (!name?.trim()) {
-      return reply.code(400).send({ error: "Name is required" });
-    }
-    if (name.length > 100) {
-      return reply.code(400).send({ error: "Name must be 100 characters or less" });
-    }
-    if (!type) {
-      return reply.code(400).send({ error: "Type is required" });
-    }
-    if (!zoneId) {
-      return reply.code(400).send({ error: "Zone ID is required" });
-    }
-    if (description && description.length > 500) {
-      return reply.code(400).send({ error: "Description must be 500 characters or less" });
-    }
+      try {
+        if (deviceIds && deviceIds.length > 0) {
+          const equipment = equipmentManager.createWithAutoBindings({
+            name: name.trim(),
+            type,
+            zoneId,
+            icon,
+            description,
+            deviceIds,
+          });
+          return reply.code(201).send(equipment);
+        }
 
-    try {
-      if (deviceIds && deviceIds.length > 0) {
-        const equipment = equipmentManager.createWithAutoBindings({
+        const equipment = equipmentManager.create({
           name: name.trim(),
           type,
           zoneId,
           icon,
           description,
-          deviceIds,
         });
         return reply.code(201).send(equipment);
+      } catch (err) {
+        return handleEquipmentError(reply, err);
       }
-
-      const equipment = equipmentManager.create({
-        name: name.trim(),
-        type,
-        zoneId,
-        icon,
-        description,
-      });
-      return reply.code(201).send(equipment);
-    } catch (err) {
-      return handleEquipmentError(reply, err);
-    }
-  });
+    },
+  );
 
   // PUT /api/v1/equipments/:id — Update equipment
   app.put<{
@@ -99,64 +123,46 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
       enabled?: boolean;
       energyProfile?: EnergyLoadProfile | null;
     };
-  }>("/api/v1/equipments/:id", async (request, reply) => {
-    const body = request.body ?? {};
+  }>(
+    "/api/v1/equipments/:id",
+    { schema: { body: updateEquipmentBodySchema } },
+    async (request, reply) => {
+      const body = request.body ?? {};
 
-    if (body.name !== undefined && !body.name.trim()) {
-      return reply.code(400).send({ error: "Name cannot be empty" });
-    }
-    if (body.name && body.name.length > 100) {
-      return reply.code(400).send({ error: "Name must be 100 characters or less" });
-    }
-    if (body.description && body.description.length > 500) {
-      return reply.code(400).send({ error: "Description must be 500 characters or less" });
-    }
-    // Spec 140 — validate the flexible-load declaration; the learned field is
-    // core-owned and silently stripped from user writes.
-    if (body.energyProfile !== undefined && body.energyProfile !== null) {
-      const p = body.energyProfile;
-      if (p.class !== "comfort" && p.class !== "deferrable") {
-        return reply.code(400).send({ error: "energyProfile.class must be comfort or deferrable" });
+      // Spec 140 — the schema validates the flexible-load declaration; round the
+      // values and merge back the core-owned `learned` field, which is stripped
+      // from user writes.
+      if (body.energyProfile !== undefined && body.energyProfile !== null) {
+        const p = body.energyProfile;
+        const existing = equipmentManager.getById(request.params.id);
+        body.energyProfile = {
+          class: p.class,
+          nominalPowerW: Math.round(p.nominalPowerW),
+          minOnS: Math.round(p.minOnS),
+          minOffS: Math.round(p.minOffS),
+          learned: existing?.energyProfile?.learned,
+        };
       }
-      if (!Number.isFinite(p.nominalPowerW) || p.nominalPowerW <= 0 || p.nominalPowerW > 30000) {
-        return reply.code(400).send({ error: "energyProfile.nominalPowerW must be 1-30000 W" });
-      }
-      if (
-        !Number.isFinite(p.minOnS) ||
-        p.minOnS < 0 ||
-        !Number.isFinite(p.minOffS) ||
-        p.minOffS < 0
-      ) {
-        return reply.code(400).send({ error: "energyProfile min-on/min-off must be >= 0 seconds" });
-      }
-      const existing = equipmentManager.getById(request.params.id);
-      body.energyProfile = {
-        class: p.class,
-        nominalPowerW: Math.round(p.nominalPowerW),
-        minOnS: Math.round(p.minOnS),
-        minOffS: Math.round(p.minOffS),
-        learned: existing?.energyProfile?.learned,
-      };
-    }
 
-    try {
-      const equipment = equipmentManager.update(request.params.id, {
-        name: body.name?.trim(),
-        type: body.type,
-        zoneId: body.zoneId,
-        icon: body.icon,
-        description: body.description,
-        enabled: body.enabled,
-        energyProfile: body.energyProfile,
-      });
-      if (!equipment) {
-        return reply.code(404).send({ error: "Equipment not found" });
+      try {
+        const equipment = equipmentManager.update(request.params.id, {
+          name: body.name?.trim(),
+          type: body.type,
+          zoneId: body.zoneId,
+          icon: body.icon,
+          description: body.description,
+          enabled: body.enabled,
+          energyProfile: body.energyProfile,
+        });
+        if (!equipment) {
+          return reply.code(404).send({ error: "Equipment not found" });
+        }
+        return equipment;
+      } catch (err) {
+        return handleEquipmentError(reply, err);
       }
-      return equipment;
-    } catch (err) {
-      return handleEquipmentError(reply, err);
-    }
-  });
+    },
+  );
 
   // DELETE /api/v1/equipments/:id — Delete equipment
   app.delete<{ Params: { id: string } }>("/api/v1/equipments/:id", async (request, reply) => {

--- a/src/api/routes/equipments.ts
+++ b/src/api/routes/equipments.ts
@@ -23,7 +23,9 @@ const createEquipmentBodySchema = {
     name: { type: "string", pattern: "\\S", maxLength: 100 },
     type: { type: "string", minLength: 1 },
     zoneId: { type: "string", minLength: 1 },
-    description: { type: "string", maxLength: 500 },
+    // null is allowed (create with no description), matching the old check that
+    // only rejected an over-long non-empty string.
+    description: { type: ["string", "null"], maxLength: 500 },
   },
 };
 

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -68,6 +68,7 @@ import { registerSystemRoutes } from "./routes/system.js";
 import { registerAuditRoutes } from "./routes/audit.js";
 import type { AuditLogger } from "../core/audit-logger.js";
 import { registerWebSocket } from "./websocket.js";
+import { installValidationErrorHandler } from "./error-handler.js";
 
 interface ServerDeps {
   db: Database.Database;
@@ -172,6 +173,9 @@ export async function createServer(deps: ServerDeps) {
   const app = Fastify({
     logger: false,
   });
+
+  // Schema-validation failures answer as { error } / 400 (issue #452).
+  installValidationErrorHandler(app);
 
   // CORS
   await app.register(cors, {

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -68,7 +68,7 @@ import { registerSystemRoutes } from "./routes/system.js";
 import { registerAuditRoutes } from "./routes/audit.js";
 import type { AuditLogger } from "../core/audit-logger.js";
 import { registerWebSocket } from "./websocket.js";
-import { installValidationErrorHandler } from "./error-handler.js";
+import { installValidationErrorHandler, validationAjvOptions } from "./error-handler.js";
 
 interface ServerDeps {
   db: Database.Database;
@@ -172,6 +172,7 @@ export async function createServer(deps: ServerDeps) {
 
   const app = Fastify({
     logger: false,
+    ajv: validationAjvOptions,
   });
 
   // Schema-validation failures answer as { error } / 400 (issue #452).


### PR DESCRIPTION
First increment of #452 (centralize API input validation). Establishes the pattern and converts the **equipments** POST/PUT routes; other domains follow as separate PRs, then OpenAPI via `@fastify/swagger`.

## What
- **Regression net first**: 17 characterization tests pin the current accept/reject matrix and the `{ error: string }` / 400 body shape of the hand-rolled checks (`equipments.test.ts`). They passed against the old code, and pass unchanged against the converted routes.
- **Schemas**: `POST`/`PUT /api/v1/equipments` now validate via Fastify JSON schemas encoding the exact same rules (name required + non-blank via `pattern: "\\S"` + `maxLength: 100`; type/zoneId required; description `maxLength: 500`; energyProfile `class` enum + `nominalPowerW` `exclusiveMinimum: 0`/`maximum: 30000` + min-on/off `>= 0`). The hand-rolled `if (...) return 400` checks are removed; the energyProfile rounding + core-owned `learned` merge stay (business logic).
- **`installValidationErrorHandler`** (new `src/api/error-handler.ts`): a global handler that maps schema-validation failures to `{ error: <message> }` / 400, so clients keep reading `body.error`. Non-validation errors are delegated to Fastify's default handling.

## No behaviour change for API consumers
- Same routes, same accept/reject decisions, same `{ error }` shape. Only the 400 **message wording** becomes schema-standard (agreed: wording is not part of the contract).
- Unknown extra fields still pass through (`additionalProperties` left open) — locked by a test.
- No other route uses `schema:` today, so the global handler only affects these equipments routes.

## Verification
- `npx vitest run` — 1541 passed / 2 skipped
- `npx tsc --noEmit`, UI `tsc -b`, `npx eslint` all clean

Part of #452 (first domain).