### PR TITLE
feat(api): schema-validate zones, modes and calendar route bodies (#452)

### DIFF
--- a/src/api/routes/calendar.test.ts
+++ b/src/api/routes/calendar.test.ts
@@ -8,6 +8,7 @@ import { SettingsManager } from "../../core/settings-manager.js";
 import { EventBus } from "../../core/event-bus.js";
 import { createLogger } from "../../core/logger.js";
 import { registerCalendarRoutes } from "./calendar.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
 import type { CalendarModeAction } from "../../shared/types.js";
 
 function createTestDb(): Database.Database {
@@ -54,7 +55,8 @@ describe("Calendar API routes", () => {
     );
     calendarManager = new CalendarManager(db, eventBus, settingsManager, modeManager, logger);
 
-    app = Fastify({ logger: false });
+    app = Fastify({ logger: false, ajv: validationAjvOptions });
+    installValidationErrorHandler(app);
     registerCalendarRoutes(app, { calendarManager, logger });
     await app.ready();
   });

--- a/src/api/routes/calendar.ts
+++ b/src/api/routes/calendar.ts
@@ -3,6 +3,26 @@ import type { CalendarManager } from "../../modes/calendar-manager.js";
 import { CalendarError } from "../../modes/calendar-manager.js";
 import type { Logger } from "../../core/logger.js";
 import type { CalendarModeAction } from "../../shared/types.js";
+import { nonEmptyString } from "../schemas.js";
+
+// Input schemas (issue #452): active profile needs a non-empty profileId (old
+// `!profileId`); a slot needs a days array, a non-empty time and a modeActions
+// array (old `!Array.isArray(days) || !time || !Array.isArray(modeActions)`).
+const setActiveProfileBodySchema = {
+  type: "object",
+  required: ["profileId"],
+  properties: { profileId: nonEmptyString },
+};
+
+const addSlotBodySchema = {
+  type: "object",
+  required: ["days", "time", "modeActions"],
+  properties: {
+    days: { type: "array" },
+    time: nonEmptyString,
+    modeActions: { type: "array" },
+  },
+};
 
 interface CalendarDeps {
   calendarManager: CalendarManager;
@@ -27,20 +47,24 @@ export function registerCalendarRoutes(app: FastifyInstance, deps: CalendarDeps)
   // PUT /api/v1/calendar/active
   app.put<{
     Body: { profileId: string };
-  }>("/api/v1/calendar/active", async (request, reply) => {
-    const { profileId } = request.body ?? {};
-    if (!profileId) return reply.code(400).send({ error: "profileId is required" });
+  }>(
+    "/api/v1/calendar/active",
+    { schema: { body: setActiveProfileBodySchema } },
+    async (request, reply) => {
+      const { profileId } = request.body;
 
-    try {
-      calendarManager.setActiveProfile(profileId);
-      const profile = calendarManager.getActiveProfile();
-      const slots = calendarManager.listSlots(profile.id);
-      return { profile, slots };
-    } catch (err) {
-      if (err instanceof CalendarError) return reply.code(err.status).send({ error: err.message });
-      throw err;
-    }
-  });
+      try {
+        calendarManager.setActiveProfile(profileId);
+        const profile = calendarManager.getActiveProfile();
+        const slots = calendarManager.listSlots(profile.id);
+        return { profile, slots };
+      } catch (err) {
+        if (err instanceof CalendarError)
+          return reply.code(err.status).send({ error: err.message });
+        throw err;
+      }
+    },
+  );
 
   // GET /api/v1/calendar/profiles/:id/slots
   app.get<{ Params: { id: string } }>("/api/v1/calendar/profiles/:id/slots", async (request) => {
@@ -51,20 +75,22 @@ export function registerCalendarRoutes(app: FastifyInstance, deps: CalendarDeps)
   app.post<{
     Params: { id: string };
     Body: { days: number[]; time: string; modeActions: CalendarModeAction[] };
-  }>("/api/v1/calendar/profiles/:id/slots", async (request, reply) => {
-    const { days, time, modeActions } = request.body ?? {};
-    if (!Array.isArray(days) || !time || !Array.isArray(modeActions)) {
-      return reply.code(400).send({ error: "days, time, and modeActions are required" });
-    }
+  }>(
+    "/api/v1/calendar/profiles/:id/slots",
+    { schema: { body: addSlotBodySchema } },
+    async (request, reply) => {
+      const { days, time, modeActions } = request.body;
 
-    try {
-      const slot = calendarManager.addSlot(request.params.id, days, time, modeActions);
-      return reply.code(201).send(slot);
-    } catch (err) {
-      if (err instanceof CalendarError) return reply.code(err.status).send({ error: err.message });
-      throw err;
-    }
-  });
+      try {
+        const slot = calendarManager.addSlot(request.params.id, days, time, modeActions);
+        return reply.code(201).send(slot);
+      } catch (err) {
+        if (err instanceof CalendarError)
+          return reply.code(err.status).send({ error: err.message });
+        throw err;
+      }
+    },
+  );
 
   // PUT /api/v1/calendar/slots/:slotId
   app.put<{

--- a/src/api/routes/modes.test.ts
+++ b/src/api/routes/modes.test.ts
@@ -121,6 +121,27 @@ describe("Mode API routes", () => {
         payload: { description: "No name" },
       });
       expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: expect.any(String) });
+    });
+
+    it("returns 400 when name is an empty string", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/modes",
+        payload: { name: "" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("accepts a whitespace-only name (old `!name` did not trim)", async () => {
+      // Characterization: nonEmptyString (minLength 1), NOT nameField — a bare
+      // `!name` guard accepted "   ". Swapping to a \\S pattern would regress.
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/modes",
+        payload: { name: "   " },
+      });
+      expect(res.statusCode).toBe(201);
     });
   });
 

--- a/src/api/routes/modes.test.ts
+++ b/src/api/routes/modes.test.ts
@@ -7,6 +7,7 @@ import { EventBus } from "../../core/event-bus.js";
 import { createLogger } from "../../core/logger.js";
 import { AuditLogger } from "../../core/audit-logger.js";
 import { registerModeRoutes } from "./modes.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
 
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
@@ -45,7 +46,8 @@ describe("Mode API routes", () => {
       logger,
     );
 
-    app = Fastify({ logger: false });
+    app = Fastify({ logger: false, ajv: validationAjvOptions });
+    installValidationErrorHandler(app);
     const auditLogger = new AuditLogger(db, logger);
     const userManager = {
       getById: () => null,

--- a/src/api/routes/modes.ts
+++ b/src/api/routes/modes.ts
@@ -7,6 +7,22 @@ import type { AuditLogger } from "../../core/audit-logger.js";
 import type { UserManager } from "../../auth/user-manager.js";
 import type { ZoneModeImpactAction } from "../../shared/types.js";
 import { buildActor } from "../audit-context.js";
+import { nonEmptyString } from "../schemas.js";
+
+// Input schemas (issue #452): POST requires a non-empty name (old `!name`, no
+// trim, so "   " is accepted); the impacts PUT requires an `actions` array
+// (old `!Array.isArray(actions)`). Other fields pass through unconstrained.
+const createModeBodySchema = {
+  type: "object",
+  required: ["name"],
+  properties: { name: nonEmptyString },
+};
+
+const setZoneImpactBodySchema = {
+  type: "object",
+  required: ["actions"],
+  properties: { actions: { type: "array" } },
+};
 
 interface ModesDeps {
   modeManager: ModeManager;
@@ -36,9 +52,8 @@ export function registerModeRoutes(app: FastifyInstance, deps: ModesDeps): void 
   // POST /api/v1/modes
   app.post<{
     Body: { name: string; icon?: string; description?: string };
-  }>("/api/v1/modes", async (request, reply) => {
-    const { name, icon, description } = request.body ?? {};
-    if (!name) return reply.code(400).send({ error: "name is required" });
+  }>("/api/v1/modes", { schema: { body: createModeBodySchema } }, async (request, reply) => {
+    const { name, icon, description } = request.body;
 
     try {
       const mode = modeManager.createMode(name, icon, description);
@@ -141,20 +156,21 @@ export function registerModeRoutes(app: FastifyInstance, deps: ModesDeps): void 
   app.put<{
     Params: { id: string; zoneId: string };
     Body: { actions: ZoneModeImpactAction[] };
-  }>("/api/v1/modes/:id/impacts/:zoneId", async (request, reply) => {
-    const { actions } = request.body ?? {};
-    if (!Array.isArray(actions)) {
-      return reply.code(400).send({ error: "actions array is required" });
-    }
+  }>(
+    "/api/v1/modes/:id/impacts/:zoneId",
+    { schema: { body: setZoneImpactBodySchema } },
+    async (request, reply) => {
+      const { actions } = request.body;
 
-    try {
-      const impact = modeManager.setZoneImpact(request.params.id, request.params.zoneId, actions);
-      return impact;
-    } catch (err) {
-      if (err instanceof ModeError) return reply.code(err.status).send({ error: err.message });
-      throw err;
-    }
-  });
+      try {
+        const impact = modeManager.setZoneImpact(request.params.id, request.params.zoneId, actions);
+        return impact;
+      } catch (err) {
+        if (err instanceof ModeError) return reply.code(err.status).send({ error: err.message });
+        throw err;
+      }
+    },
+  );
 
   // DELETE /api/v1/modes/:id/impacts/:zoneId
   app.delete<{ Params: { id: string; zoneId: string } }>(

--- a/src/api/routes/zones.test.ts
+++ b/src/api/routes/zones.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+import { createLogger } from "../../core/logger.js";
+import { registerZoneRoutes } from "./zones.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Input-validation characterization (issue #452): pin the accept/reject matrix
+// and { error } 400 shape of the POST/PUT /zones checks so the schema move is
+// provably regression-free.
+
+function makeDeps() {
+  const zone = { id: "z-new", name: "x", parentId: null };
+  return {
+    zoneManager: {
+      create: () => zone,
+      update: () => ({ ...zone, id: "z-1" }),
+    },
+    zoneAggregator: {},
+    equipmentManager: {},
+  } as unknown as Parameters<typeof registerZoneRoutes>[1];
+}
+
+function buildApp() {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+  registerZoneRoutes(app, { ...makeDeps(), logger: createLogger("silent").logger });
+  return app;
+}
+
+describe("POST /api/v1/zones — input validation (characterization)", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = buildApp();
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const post = (body: unknown) =>
+    app.inject({ method: "POST", url: "/api/v1/zones", payload: body });
+
+  it("400 { error } when name is missing or blank", async () => {
+    for (const name of [undefined, "", "   "]) {
+      const res = await post({ name });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: expect.any(String) });
+    }
+  });
+
+  it("400 when name exceeds 100 characters", async () => {
+    const res = await post({ name: "a".repeat(101) });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: expect.any(String) });
+  });
+
+  it("400 when description exceeds 500 characters", async () => {
+    const res = await post({ name: "Salon", description: "a".repeat(501) });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: expect.any(String) });
+  });
+
+  it("201 for a valid body, and accepts null description + extra fields", async () => {
+    expect((await post({ name: "Salon" })).statusCode).toBe(201);
+    expect((await post({ name: "Salon", description: null })).statusCode).toBe(201);
+    expect((await post({ name: "Salon", parentId: "p", icon: "Home", bogus: 1 })).statusCode).toBe(
+      201,
+    );
+  });
+});
+
+describe("PUT /api/v1/zones/:id — input validation (characterization)", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = buildApp();
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const put = (body: unknown) =>
+    app.inject({ method: "PUT", url: "/api/v1/zones/z-1", payload: body });
+
+  it("400 when name is present but blank", async () => {
+    const res = await put({ name: "  " });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: expect.any(String) });
+  });
+
+  it("400 when name exceeds 100 / description exceeds 500", async () => {
+    expect((await put({ name: "a".repeat(101) })).statusCode).toBe(400);
+    expect((await put({ description: "a".repeat(501) })).statusCode).toBe(400);
+  });
+
+  it("200 for a valid partial update, null description, and extra fields", async () => {
+    expect((await put({ name: "Renamed" })).statusCode).toBe(200);
+    expect((await put({ description: null })).statusCode).toBe(200);
+    expect((await put({ parentId: null, bogus: 1 })).statusCode).toBe(200);
+  });
+});

--- a/src/api/routes/zones.test.ts
+++ b/src/api/routes/zones.test.ts
@@ -94,4 +94,9 @@ describe("PUT /api/v1/zones/:id — input validation (characterization)", () => 
     expect((await put({ description: null })).statusCode).toBe(200);
     expect((await put({ parentId: null, bogus: 1 })).statusCode).toBe(200);
   });
+
+  it("200 for a body-less PUT (old `request.body ?? {}` no-op update)", async () => {
+    const res = await app.inject({ method: "PUT", url: "/api/v1/zones/z-1" });
+    expect(res.statusCode).toBe(200);
+  });
 });

--- a/src/api/routes/zones.ts
+++ b/src/api/routes/zones.ts
@@ -15,8 +15,10 @@ const createZoneBodySchema = {
   properties: { name: nameField, description: descriptionField },
 };
 
+// Allow a null/absent body: the old handler did `request.body ?? {}`, so a
+// body-less PUT was a 200 no-op. `type: ["object", "null"]` keeps that.
 const updateZoneBodySchema = {
-  type: "object",
+  type: ["object", "null"],
   properties: { name: nameField, description: descriptionField },
 };
 

--- a/src/api/routes/zones.ts
+++ b/src/api/routes/zones.ts
@@ -4,6 +4,21 @@ import type { ZoneAggregator } from "../../zones/zone-aggregator.js";
 import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import type { Logger } from "../../core/logger.js";
 import { ROOT_ZONE_ID } from "../../shared/constants.js";
+import { nameField, descriptionField } from "../schemas.js";
+
+// Input schemas (issue #452) — same rules the handlers checked by hand:
+// name required + non-blank + <=100, description <=500. Other fields
+// (parentId, icon, displayOrder) stay unconstrained and pass through.
+const createZoneBodySchema = {
+  type: "object",
+  required: ["name"],
+  properties: { name: nameField, description: descriptionField },
+};
+
+const updateZoneBodySchema = {
+  type: "object",
+  properties: { name: nameField, description: descriptionField },
+};
 
 interface ZonesDeps {
   zoneManager: ZoneManager;
@@ -43,18 +58,8 @@ export function registerZoneRoutes(app: FastifyInstance, deps: ZonesDeps): void 
       description?: string;
       displayOrder?: number;
     };
-  }>("/api/v1/zones", async (request, reply) => {
-    const { name, parentId, icon, description, displayOrder } = request.body ?? {};
-
-    if (!name || typeof name !== "string" || name.trim().length === 0) {
-      return reply.code(400).send({ error: "Name is required" });
-    }
-    if (name.length > 100) {
-      return reply.code(400).send({ error: "Name must be 100 characters or less" });
-    }
-    if (description && description.length > 500) {
-      return reply.code(400).send({ error: "Description must be 500 characters or less" });
-    }
+  }>("/api/v1/zones", { schema: { body: createZoneBodySchema } }, async (request, reply) => {
+    const { name, parentId, icon, description, displayOrder } = request.body;
 
     try {
       const zone = zoneManager.create({
@@ -80,25 +85,11 @@ export function registerZoneRoutes(app: FastifyInstance, deps: ZonesDeps): void 
       description?: string | null;
       displayOrder?: number;
     };
-  }>("/api/v1/zones/:id", async (request, reply) => {
+  }>("/api/v1/zones/:id", { schema: { body: updateZoneBodySchema } }, async (request, reply) => {
     const body = request.body ?? {};
 
-    if (body.name !== undefined) {
-      if (typeof body.name !== "string" || body.name.trim().length === 0) {
-        return reply.code(400).send({ error: "Name cannot be empty" });
-      }
-      if (body.name.length > 100) {
-        return reply.code(400).send({ error: "Name must be 100 characters or less" });
-      }
-      body.name = body.name.trim();
-    }
-    if (
-      body.description !== undefined &&
-      body.description !== null &&
-      body.description.length > 500
-    ) {
-      return reply.code(400).send({ error: "Description must be 500 characters or less" });
-    }
+    // Schema validates name/description; keep the trim (business behaviour).
+    if (body.name !== undefined) body.name = body.name.trim();
 
     try {
       const zone = zoneManager.update(request.params.id, body);

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -1,0 +1,16 @@
+// Shared JSON-schema fragments for route input validation (issue #452).
+// These encode the recurring hand-rolled rules so each route stays a thin
+// declaration and the rules cannot drift between routes.
+
+/** A non-blank string of at most 100 chars (old `!v?.trim()` + length <= 100). */
+export const nameField = { type: "string", pattern: "\\S", maxLength: 100 };
+
+/** An optional description: string or null, at most 500 chars (old `v && v.length > 500`). */
+export const descriptionField = { type: ["string", "null"], maxLength: 500 };
+
+/**
+ * A non-empty string (old `!v` guard: rejects undefined and ""), but WITHOUT a
+ * whitespace check — "   " passes, matching a bare `!v`. Use this instead of
+ * `nameField` where the old code did not `.trim()`.
+ */
+export const nonEmptyString = { type: "string", minLength: 1 };


### PR DESCRIPTION
## What

First rollout batch of the issue #452 API input-validation hardening. Converts the hand-rolled body checks in the **zones**, **modes** and **calendar** routes to declarative Fastify JSON schemas, building on the shared error-handler + `coerceTypes:false` infra landed in #475.

## No behavioral change for API consumers

- Same routes, same methods, same status codes.
- Same `{ error: string }` 400 body shape.
- Only the error *message wording* changes (now emitted by the AJV validator) — explicitly in scope per the issue.

## How

- New `src/api/schemas.ts` holds shared fragments. Critical distinction preserved per route:
  - `nameField` — non-blank, `<=100` chars — replicates the old `!v?.trim()` (rejects whitespace-only). Used by zones.
  - `nonEmptyString` — `minLength: 1` — replicates a bare `!v` that *accepted* `"   "`. Used by modes (`!name`) and calendar (`!profileId`, `!time`).
- `zones.ts`: POST/PUT bodies (`createZoneBodySchema` / `updateZoneBodySchema`), trim on PUT kept in handler.
- `modes.ts`: POST `/modes` name-required; PUT impacts `actions`-array-required.
- `calendar.ts`: PUT `/calendar/active` profileId-required; POST slots days/time/modeActions-required.

## Tests

- New characterization tests (`zones.test.ts`) pin the accept/reject matrix and `{ error }` shape.
- Existing `modes.test.ts` / `calendar.test.ts` now install `installValidationErrorHandler` + `validationAjvOptions` so schema 400s surface (a self-built test app otherwise returns 500 on validation errors).
- Full backend + UI suite green: **1552 passed, 2 skipped**, `tsc --noEmit` and eslint clean.

Refs #452