### PR TITLE
feat(api): schema-validate mqtt broker/publisher and notification route bodies (#452)

### DIFF
--- a/src/api/routes/mqtt-brokers.test.ts
+++ b/src/api/routes/mqtt-brokers.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+import { registerMqttBrokerRoutes } from "./mqtt-brokers.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Input-validation characterization (issue #452). These routes are admin-gated
+// by an onRequest hook that runs BEFORE schema validation, so the test app
+// registers its own onRequest hook first to populate an admin `request.auth`;
+// that keeps requireAdmin happy and lets the schema layer be exercised.
+
+function makeDeps() {
+  const broker = { id: "b-1", name: "x", url: "mqtt://h" };
+  return {
+    mqttBrokerManager: {
+      getAll: () => [],
+      create: () => broker,
+      update: () => broker,
+      delete: () => undefined,
+    },
+  } as unknown as Parameters<typeof registerMqttBrokerRoutes>[1];
+}
+
+function buildApp() {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+  app.addHook("onRequest", async (request) => {
+    (request as unknown as { auth: unknown }).auth = { userId: "u", role: "admin" };
+  });
+  registerMqttBrokerRoutes(app, makeDeps());
+  return app;
+}
+
+describe("mqtt-broker routes — input validation (characterization)", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = buildApp();
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const post = (body: unknown) =>
+    app.inject({ method: "POST", url: "/api/v1/mqtt-brokers", payload: body });
+
+  it("400 { error } when name or url is missing (old `!name` / `!url`)", async () => {
+    for (const body of [{ url: "mqtt://h" }, { name: "Broker" }]) {
+      const res = await post(body);
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: expect.any(String) });
+    }
+  });
+
+  it("accepts whitespace-only name/url (bare `!x` did not trim)", async () => {
+    const res = await post({ name: "   ", url: "   " });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("201 for a valid body with extra fields", async () => {
+    const res = await post({ name: "Broker", url: "mqtt://h", username: "u", bogus: 1 });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("200 for a body-less PUT (old `request.body ?? {}` no-op)", async () => {
+    const res = await app.inject({ method: "PUT", url: "/api/v1/mqtt-brokers/b-1" });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/src/api/routes/mqtt-brokers.ts
+++ b/src/api/routes/mqtt-brokers.ts
@@ -2,6 +2,20 @@ import type { FastifyInstance } from "fastify";
 import type { MqttBrokerManager } from "../../mqtt-publishers/mqtt-broker-manager.js";
 import { MqttBrokerError } from "../../mqtt-publishers/mqtt-broker-manager.js";
 import { requireAdmin } from "../../auth/auth-middleware.js";
+import { nonEmptyString } from "../schemas.js";
+
+// Input schemas (issue #452). Old guards were bare `!name` / `!url` (no trim),
+// so nonEmptyString matches. Admin gating is an onRequest hook, which runs
+// before schema validation, so the 403-before-400 precedence is preserved.
+// PUT had no validation and did `request.body ?? {}`, so its schema stays
+// permissive (object-or-null) to keep the body-less 200 no-op.
+const createBrokerBodySchema = {
+  type: "object",
+  required: ["name", "url"],
+  properties: { name: nonEmptyString, url: nonEmptyString },
+};
+
+const updateBrokerBodySchema = { type: ["object", "null"] };
 
 interface MqttBrokersDeps {
   mqttBrokerManager: MqttBrokerManager;
@@ -24,35 +38,41 @@ export function registerMqttBrokerRoutes(app: FastifyInstance, deps: MqttBrokers
   // POST /api/v1/mqtt-brokers
   app.post<{
     Body: { name: string; url: string; username?: string; password?: string };
-  }>("/api/v1/mqtt-brokers", async (request, reply) => {
-    const { name, url, username, password } = request.body ?? {};
-    if (!name) return reply.code(400).send({ error: "name is required" });
-    if (!url) return reply.code(400).send({ error: "url is required" });
+  }>(
+    "/api/v1/mqtt-brokers",
+    { schema: { body: createBrokerBodySchema } },
+    async (request, reply) => {
+      const { name, url, username, password } = request.body;
 
-    try {
-      const broker = mqttBrokerManager.create({ name, url, username, password });
-      return reply.code(201).send(broker);
-    } catch (err) {
-      if (err instanceof MqttBrokerError)
-        return reply.code(err.status).send({ error: err.message });
-      throw err;
-    }
-  });
+      try {
+        const broker = mqttBrokerManager.create({ name, url, username, password });
+        return reply.code(201).send(broker);
+      } catch (err) {
+        if (err instanceof MqttBrokerError)
+          return reply.code(err.status).send({ error: err.message });
+        throw err;
+      }
+    },
+  );
 
   // PUT /api/v1/mqtt-brokers/:id
   app.put<{
     Params: { id: string };
     Body: { name?: string; url?: string; username?: string; password?: string };
-  }>("/api/v1/mqtt-brokers/:id", async (request, reply) => {
-    try {
-      const broker = mqttBrokerManager.update(request.params.id, request.body ?? {});
-      return broker;
-    } catch (err) {
-      if (err instanceof MqttBrokerError)
-        return reply.code(err.status).send({ error: err.message });
-      throw err;
-    }
-  });
+  }>(
+    "/api/v1/mqtt-brokers/:id",
+    { schema: { body: updateBrokerBodySchema } },
+    async (request, reply) => {
+      try {
+        const broker = mqttBrokerManager.update(request.params.id, request.body ?? {});
+        return broker;
+      } catch (err) {
+        if (err instanceof MqttBrokerError)
+          return reply.code(err.status).send({ error: err.message });
+        throw err;
+      }
+    },
+  );
 
   // DELETE /api/v1/mqtt-brokers/:id
   app.delete<{ Params: { id: string } }>("/api/v1/mqtt-brokers/:id", async (request, reply) => {

--- a/src/api/routes/mqtt-publishers.test.ts
+++ b/src/api/routes/mqtt-publishers.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+import { registerMqttPublisherRoutes } from "./mqtt-publishers.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Input-validation characterization (issue #452). Admin-gated by an onRequest
+// hook (runs before schema validation), so the test app injects an admin
+// request.auth first.
+
+function makeDeps() {
+  const publisher = { id: "p-1", name: "x", brokerId: "b-1", topic: "t" };
+  const mapping = { id: "m-1" };
+  return {
+    mqttPublisherManager: {
+      getAllWithMappings: () => [],
+      getByIdWithMappings: () => publisher,
+      getById: () => publisher,
+      create: () => publisher,
+      update: () => publisher,
+      delete: () => undefined,
+      addMapping: () => mapping,
+      updateMapping: () => mapping,
+      removeMapping: () => undefined,
+    },
+    mqttPublishService: { publishSnapshotForPublisher: () => 0 },
+  } as unknown as Parameters<typeof registerMqttPublisherRoutes>[1];
+}
+
+function buildApp() {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+  app.addHook("onRequest", async (request) => {
+    (request as unknown as { auth: unknown }).auth = { userId: "u", role: "admin" };
+  });
+  registerMqttPublisherRoutes(app, makeDeps());
+  return app;
+}
+
+describe("mqtt-publisher routes — input validation (characterization)", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = buildApp();
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const post = (url: string, body: unknown) => app.inject({ method: "POST", url, payload: body });
+
+  it("POST /mqtt-publishers 400 when name, brokerId or topic is missing", async () => {
+    for (const body of [
+      { brokerId: "b-1", topic: "t" },
+      { name: "P", topic: "t" },
+      { name: "P", brokerId: "b-1" },
+    ]) {
+      const res = await post("/api/v1/mqtt-publishers", body);
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: expect.any(String) });
+    }
+  });
+
+  it("POST /mqtt-publishers 201 for a valid body", async () => {
+    const res = await post("/api/v1/mqtt-publishers", { name: "P", brokerId: "b-1", topic: "t" });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("POST mappings 400 when a required source field is missing", async () => {
+    for (const body of [
+      { sourceType: "equipment", sourceId: "e-1", sourceKey: "k" },
+      { publishKey: "pk", sourceId: "e-1", sourceKey: "k" },
+      { publishKey: "pk", sourceType: "equipment", sourceKey: "k" },
+      { publishKey: "pk", sourceType: "equipment", sourceId: "e-1" },
+    ]) {
+      const res = await post("/api/v1/mqtt-publishers/p-1/mappings", body);
+      expect(res.statusCode).toBe(400);
+    }
+  });
+
+  it("POST mappings 201 for a valid body", async () => {
+    const res = await post("/api/v1/mqtt-publishers/p-1/mappings", {
+      publishKey: "pk",
+      sourceType: "equipment",
+      sourceId: "e-1",
+      sourceKey: "k",
+    });
+    expect(res.statusCode).toBe(201);
+  });
+});

--- a/src/api/routes/mqtt-publishers.ts
+++ b/src/api/routes/mqtt-publishers.ts
@@ -3,6 +3,30 @@ import type { MqttPublisherManager } from "../../mqtt-publishers/mqtt-publisher-
 import type { MqttPublishService } from "../../mqtt-publishers/mqtt-publish-service.js";
 import { MqttPublisherError } from "../../mqtt-publishers/mqtt-publisher-manager.js";
 import { requireAdmin } from "../../auth/auth-middleware.js";
+import { nonEmptyString } from "../schemas.js";
+
+// Input schemas (issue #452). Old guards were bare `!x` (no trim), so
+// nonEmptyString matches. Admin gating is an onRequest hook (runs before schema
+// validation), so the 403-before-400 precedence holds. PUT had no validation
+// (`request.body ?? {}`), so its schema stays permissive (object-or-null).
+const createPublisherBodySchema = {
+  type: "object",
+  required: ["name", "brokerId", "topic"],
+  properties: { name: nonEmptyString, brokerId: nonEmptyString, topic: nonEmptyString },
+};
+
+const updatePublisherBodySchema = { type: ["object", "null"] };
+
+const addMappingBodySchema = {
+  type: "object",
+  required: ["publishKey", "sourceType", "sourceId", "sourceKey"],
+  properties: {
+    publishKey: nonEmptyString,
+    sourceType: nonEmptyString,
+    sourceId: nonEmptyString,
+    sourceKey: nonEmptyString,
+  },
+};
 
 interface MqttPublishersDeps {
   mqttPublisherManager: MqttPublisherManager;
@@ -38,27 +62,28 @@ export function registerMqttPublisherRoutes(app: FastifyInstance, deps: MqttPubl
       enabled?: boolean;
       onChangeOnly?: boolean;
     };
-  }>("/api/v1/mqtt-publishers", async (request, reply) => {
-    const { name, brokerId, topic, enabled, onChangeOnly } = request.body ?? {};
-    if (!name) return reply.code(400).send({ error: "name is required" });
-    if (!brokerId) return reply.code(400).send({ error: "brokerId is required" });
-    if (!topic) return reply.code(400).send({ error: "topic is required" });
+  }>(
+    "/api/v1/mqtt-publishers",
+    { schema: { body: createPublisherBodySchema } },
+    async (request, reply) => {
+      const { name, brokerId, topic, enabled, onChangeOnly } = request.body;
 
-    try {
-      const publisher = mqttPublisherManager.create({
-        name,
-        brokerId,
-        topic,
-        enabled,
-        onChangeOnly,
-      });
-      return reply.code(201).send(publisher);
-    } catch (err) {
-      if (err instanceof MqttPublisherError)
-        return reply.code(err.status).send({ error: err.message });
-      throw err;
-    }
-  });
+      try {
+        const publisher = mqttPublisherManager.create({
+          name,
+          brokerId,
+          topic,
+          enabled,
+          onChangeOnly,
+        });
+        return reply.code(201).send(publisher);
+      } catch (err) {
+        if (err instanceof MqttPublisherError)
+          return reply.code(err.status).send({ error: err.message });
+        throw err;
+      }
+    },
+  );
 
   // PUT /api/v1/mqtt-publishers/:id
   app.put<{
@@ -70,16 +95,20 @@ export function registerMqttPublisherRoutes(app: FastifyInstance, deps: MqttPubl
       enabled?: boolean;
       onChangeOnly?: boolean;
     };
-  }>("/api/v1/mqtt-publishers/:id", async (request, reply) => {
-    try {
-      const publisher = mqttPublisherManager.update(request.params.id, request.body ?? {});
-      return publisher;
-    } catch (err) {
-      if (err instanceof MqttPublisherError)
-        return reply.code(err.status).send({ error: err.message });
-      throw err;
-    }
-  });
+  }>(
+    "/api/v1/mqtt-publishers/:id",
+    { schema: { body: updatePublisherBodySchema } },
+    async (request, reply) => {
+      try {
+        const publisher = mqttPublisherManager.update(request.params.id, request.body ?? {});
+        return publisher;
+      } catch (err) {
+        if (err instanceof MqttPublisherError)
+          return reply.code(err.status).send({ error: err.message });
+        throw err;
+      }
+    },
+  );
 
   // DELETE /api/v1/mqtt-publishers/:id
   app.delete<{ Params: { id: string } }>("/api/v1/mqtt-publishers/:id", async (request, reply) => {
@@ -115,28 +144,28 @@ export function registerMqttPublisherRoutes(app: FastifyInstance, deps: MqttPubl
       sourceKey: string;
       enabled?: boolean;
     };
-  }>("/api/v1/mqtt-publishers/:id/mappings", async (request, reply) => {
-    const { publishKey, sourceType, sourceId, sourceKey, enabled } = request.body ?? {};
-    if (!publishKey) return reply.code(400).send({ error: "publishKey is required" });
-    if (!sourceType) return reply.code(400).send({ error: "sourceType is required" });
-    if (!sourceId) return reply.code(400).send({ error: "sourceId is required" });
-    if (!sourceKey) return reply.code(400).send({ error: "sourceKey is required" });
+  }>(
+    "/api/v1/mqtt-publishers/:id/mappings",
+    { schema: { body: addMappingBodySchema } },
+    async (request, reply) => {
+      const { publishKey, sourceType, sourceId, sourceKey, enabled } = request.body;
 
-    try {
-      const mapping = mqttPublisherManager.addMapping(request.params.id, {
-        publishKey,
-        sourceType,
-        sourceId,
-        sourceKey,
-        enabled,
-      });
-      return reply.code(201).send(mapping);
-    } catch (err) {
-      if (err instanceof MqttPublisherError)
-        return reply.code(err.status).send({ error: err.message });
-      throw err;
-    }
-  });
+      try {
+        const mapping = mqttPublisherManager.addMapping(request.params.id, {
+          publishKey,
+          sourceType,
+          sourceId,
+          sourceKey,
+          enabled,
+        });
+        return reply.code(201).send(mapping);
+      } catch (err) {
+        if (err instanceof MqttPublisherError)
+          return reply.code(err.status).send({ error: err.message });
+        throw err;
+      }
+    },
+  );
 
   // PUT /api/v1/mqtt-publishers/:id/mappings/:mappingId
   app.put<{

--- a/src/api/routes/notification-publishers.test.ts
+++ b/src/api/routes/notification-publishers.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+import { registerNotificationPublisherRoutes } from "./notification-publishers.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Input-validation characterization (issue #452). Admin-gated by an onRequest
+// hook (runs before schema validation), so the test app injects an admin
+// request.auth first.
+
+function makeDeps() {
+  const publisher = { id: "np-1", name: "x" };
+  const mapping = { id: "m-1" };
+  return {
+    notificationPublisherManager: {
+      getAllWithMappings: () => [],
+      getByIdWithMappings: () => publisher,
+      create: () => publisher,
+      update: () => publisher,
+      delete: () => undefined,
+      addMapping: () => mapping,
+      updateMapping: () => mapping,
+      removeMapping: () => undefined,
+    },
+    notificationPublishService: {
+      testChannel: async () => undefined,
+      testPublisher: async () => true,
+    },
+  } as unknown as Parameters<typeof registerNotificationPublisherRoutes>[1];
+}
+
+function buildApp() {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+  app.addHook("onRequest", async (request) => {
+    (request as unknown as { auth: unknown }).auth = { userId: "u", role: "admin" };
+  });
+  registerNotificationPublisherRoutes(app, makeDeps());
+  return app;
+}
+
+describe("notification-publisher routes — input validation (characterization)", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = buildApp();
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const post = (url: string, body: unknown) => app.inject({ method: "POST", url, payload: body });
+
+  it("POST publisher 400 { error } when name is missing (old `!name`)", async () => {
+    const res = await post("/api/v1/notification-publishers", { channelType: "telegram" });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: expect.any(String) });
+  });
+
+  it("POST publisher 201 with only a name (channelType/channelConfig defaulted)", async () => {
+    const res = await post("/api/v1/notification-publishers", { name: "Notif" });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("POST mappings 400 when a required field is missing", async () => {
+    for (const body of [
+      { sourceType: "equipment", sourceId: "e-1", sourceKey: "k" },
+      { message: "hi", sourceId: "e-1", sourceKey: "k" },
+      { message: "hi", sourceType: "equipment", sourceKey: "k" },
+      { message: "hi", sourceType: "equipment", sourceId: "e-1" },
+    ]) {
+      const res = await post("/api/v1/notification-publishers/np-1/mappings", body);
+      expect(res.statusCode).toBe(400);
+    }
+  });
+
+  it("POST mappings 201 for a valid body", async () => {
+    const res = await post("/api/v1/notification-publishers/np-1/mappings", {
+      message: "hi",
+      sourceType: "equipment",
+      sourceId: "e-1",
+      sourceKey: "k",
+    });
+    expect(res.statusCode).toBe(201);
+  });
+});

--- a/src/api/routes/notification-publishers.ts
+++ b/src/api/routes/notification-publishers.ts
@@ -4,6 +4,31 @@ import type { NotificationPublishService } from "../../notifications/notificatio
 import { NotificationPublisherError } from "../../notifications/notification-publisher-manager.js";
 import type { NotificationChannelType, NotificationChannelConfig } from "../../shared/types.js";
 import { requireAdmin } from "../../auth/auth-middleware.js";
+import { nonEmptyString } from "../schemas.js";
+
+// Input schemas (issue #452). Old guards were bare `!x` (no trim), so
+// nonEmptyString matches. Admin gating is an onRequest hook (runs before schema
+// validation), preserving 403-before-400. The POST publisher only checked
+// `!name` (channelType/channelConfig are defaulted in the handler), so only
+// `name` is constrained. PUT had no validation, so its schema stays permissive.
+const createPublisherBodySchema = {
+  type: "object",
+  required: ["name"],
+  properties: { name: nonEmptyString },
+};
+
+const updatePublisherBodySchema = { type: ["object", "null"] };
+
+const addMappingBodySchema = {
+  type: "object",
+  required: ["message", "sourceType", "sourceId", "sourceKey"],
+  properties: {
+    message: nonEmptyString,
+    sourceType: nonEmptyString,
+    sourceId: nonEmptyString,
+    sourceKey: nonEmptyString,
+  },
+};
 
 interface NotificationPublishersDeps {
   notificationPublisherManager: NotificationPublisherManager;
@@ -45,24 +70,27 @@ export function registerNotificationPublisherRoutes(
       channelConfig: NotificationChannelConfig;
       enabled?: boolean;
     };
-  }>("/api/v1/notification-publishers", async (request, reply) => {
-    const { name, channelType, channelConfig, enabled } = request.body ?? {};
-    if (!name) return reply.code(400).send({ error: "name is required" });
+  }>(
+    "/api/v1/notification-publishers",
+    { schema: { body: createPublisherBodySchema } },
+    async (request, reply) => {
+      const { name, channelType, channelConfig, enabled } = request.body;
 
-    try {
-      const publisher = notificationPublisherManager.create({
-        name,
-        channelType: channelType ?? "telegram",
-        channelConfig: channelConfig ?? ({} as NotificationChannelConfig),
-        enabled,
-      });
-      return reply.code(201).send(publisher);
-    } catch (err) {
-      if (err instanceof NotificationPublisherError)
-        return reply.code(err.status).send({ error: err.message });
-      throw err;
-    }
-  });
+      try {
+        const publisher = notificationPublisherManager.create({
+          name,
+          channelType: channelType ?? "telegram",
+          channelConfig: channelConfig ?? ({} as NotificationChannelConfig),
+          enabled,
+        });
+        return reply.code(201).send(publisher);
+      } catch (err) {
+        if (err instanceof NotificationPublisherError)
+          return reply.code(err.status).send({ error: err.message });
+        throw err;
+      }
+    },
+  );
 
   // PUT /api/v1/notification-publishers/:id
   app.put<{
@@ -73,16 +101,23 @@ export function registerNotificationPublisherRoutes(
       channelConfig?: NotificationChannelConfig;
       enabled?: boolean;
     };
-  }>("/api/v1/notification-publishers/:id", async (request, reply) => {
-    try {
-      const publisher = notificationPublisherManager.update(request.params.id, request.body ?? {});
-      return publisher;
-    } catch (err) {
-      if (err instanceof NotificationPublisherError)
-        return reply.code(err.status).send({ error: err.message });
-      throw err;
-    }
-  });
+  }>(
+    "/api/v1/notification-publishers/:id",
+    { schema: { body: updatePublisherBodySchema } },
+    async (request, reply) => {
+      try {
+        const publisher = notificationPublisherManager.update(
+          request.params.id,
+          request.body ?? {},
+        );
+        return publisher;
+      } catch (err) {
+        if (err instanceof NotificationPublisherError)
+          return reply.code(err.status).send({ error: err.message });
+        throw err;
+      }
+    },
+  );
 
   // DELETE /api/v1/notification-publishers/:id
   app.delete<{ Params: { id: string } }>(
@@ -141,31 +176,31 @@ export function registerNotificationPublisherRoutes(
       repeatMs?: number | null;
       repeatMax?: number | null;
     };
-  }>("/api/v1/notification-publishers/:id/mappings", async (request, reply) => {
-    const { message, sourceType, sourceId, sourceKey, throttleMs, repeatMs, repeatMax } =
-      request.body ?? {};
-    if (!message) return reply.code(400).send({ error: "message is required" });
-    if (!sourceType) return reply.code(400).send({ error: "sourceType is required" });
-    if (!sourceId) return reply.code(400).send({ error: "sourceId is required" });
-    if (!sourceKey) return reply.code(400).send({ error: "sourceKey is required" });
+  }>(
+    "/api/v1/notification-publishers/:id/mappings",
+    { schema: { body: addMappingBodySchema } },
+    async (request, reply) => {
+      const { message, sourceType, sourceId, sourceKey, throttleMs, repeatMs, repeatMax } =
+        request.body;
 
-    try {
-      const mapping = notificationPublisherManager.addMapping(request.params.id, {
-        message,
-        sourceType,
-        sourceId,
-        sourceKey,
-        throttleMs,
-        repeatMs,
-        repeatMax,
-      });
-      return reply.code(201).send(mapping);
-    } catch (err) {
-      if (err instanceof NotificationPublisherError)
-        return reply.code(err.status).send({ error: err.message });
-      throw err;
-    }
-  });
+      try {
+        const mapping = notificationPublisherManager.addMapping(request.params.id, {
+          message,
+          sourceType,
+          sourceId,
+          sourceKey,
+          throttleMs,
+          repeatMs,
+          repeatMax,
+        });
+        return reply.code(201).send(mapping);
+      } catch (err) {
+        if (err instanceof NotificationPublisherError)
+          return reply.code(err.status).send({ error: err.message });
+        throw err;
+      }
+    },
+  );
 
   // PUT /api/v1/notification-publishers/:id/mappings/:mappingId
   app.put<{


### PR DESCRIPTION
## What

Batch 3 of the issue #452 API input-validation hardening. Converts the hand-rolled body checks in **mqtt-brokers**, **mqtt-publishers** and **notification-publishers** to Fastify JSON schemas.

## No behavioral change for API consumers

Same routes, methods, status codes and `{ error: string }` 400 shape. Only the validation *message wording* changes.

## How

All old guards were bare `!x` truthiness with no trim, so `nonEmptyString` is used throughout (whitespace still passes, matching the old behavior). Required arrays mirror the old mandatory fields exactly:

- **mqtt-brokers** `POST` — name, url
- **mqtt-publishers** `POST` — name, brokerId, topic; `POST /:id/mappings` — publishKey, sourceType, sourceId, sourceKey
- **notification-publishers** `POST` — name only (channelType/channelConfig are defaulted in the handler, so only name was ever checked); `POST /:id/mappings` — message, sourceType, sourceId, sourceKey

`PUT` routes had no hand-rolled validation, so their schemas stay **permissive** (`object-or-null`) to preserve the body-less 200 no-op.

## Auth precedence preserved

Admin gating on these three route groups is an **onRequest hook**, which runs *before* schema validation, so a non-admin still gets `403` regardless of body (the 403-before-400 order is unchanged).

**push.ts is intentionally left hand-rolled**: it checks `request.auth` *inside* the handler (`401` before `400`), which a body schema would invert (a body schema validates before the handler, flipping an unauthenticated caller's `401` to `400`).

## Tests

- New `mqtt-brokers.test.ts`, `mqtt-publishers.test.ts`, `notification-publishers.test.ts` characterization tests inject an admin `request.auth` (onRequest hook registered before the routes) and pin the accept/reject matrix, `{ error }` shape and whitespace-accepted contract.
- Full backend + UI suite green: **1581 passed, 2 skipped**; `tsc --noEmit` and eslint clean.

Refs #452