### PR TITLE
feat(api): schema-validate auth, button-action, device and user route bodies (#452)

### DIFF
--- a/src/api/routes/auth.test.ts
+++ b/src/api/routes/auth.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+import { createLogger } from "../../core/logger.js";
+import { registerAuthRoutes } from "./auth.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Input-validation characterization (issue #452) for the converted auth routes
+// (login, refresh). setup/logout stay hand-rolled and are not covered here.
+
+function makeDeps() {
+  const tokens = { accessToken: "a", refreshToken: "r" };
+  return {
+    authService: {
+      login: async () => tokens,
+      refresh: async () => tokens,
+      logout: () => undefined,
+    },
+    userManager: {
+      hasUsers: () => true,
+      getByUsername: () => ({ id: "u-1", username: "admin" }),
+      getById: () => null,
+    },
+    auditLogger: { log: () => undefined },
+    logger: createLogger("silent").logger,
+  } as unknown as Parameters<typeof registerAuthRoutes>[1];
+}
+
+function buildApp() {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+  registerAuthRoutes(app, makeDeps());
+  return app;
+}
+
+describe("auth routes — input validation (characterization)", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = buildApp();
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const post = (url: string, body: unknown) => app.inject({ method: "POST", url, payload: body });
+
+  it("POST /auth/login 400 { error } when username or password is missing", async () => {
+    for (const body of [{ password: "pw" }, { username: "admin" }]) {
+      const res = await post("/api/v1/auth/login", body);
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: expect.any(String) });
+    }
+  });
+
+  it("POST /auth/login 200 for a valid body", async () => {
+    const res = await post("/api/v1/auth/login", { username: "admin", password: "pw" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveProperty("accessToken");
+  });
+
+  it("POST /auth/refresh 400 when refreshToken is missing", async () => {
+    const res = await post("/api/v1/auth/refresh", {});
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: expect.any(String) });
+  });
+
+  it("POST /auth/refresh 200 for a valid body", async () => {
+    const res = await post("/api/v1/auth/refresh", { refreshToken: "r" });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -4,6 +4,23 @@ import { AuthError } from "../../auth/auth-service.js";
 import type { UserManager } from "../../auth/user-manager.js";
 import type { Logger } from "../../core/logger.js";
 import type { AuditLogger } from "../../core/audit-logger.js";
+import { nonEmptyString } from "../schemas.js";
+
+// Input schemas (issue #452). login/refresh had bare `!x` guards (no trim), so
+// nonEmptyString matches. /auth/setup and /auth/logout stay hand-rolled: setup
+// returns 403 when a user already exists BEFORE its body check (a body schema
+// would flip that 403 to a 400), and logout has no required field.
+const loginBodySchema = {
+  type: "object",
+  required: ["username", "password"],
+  properties: { username: nonEmptyString, password: nonEmptyString },
+};
+
+const refreshBodySchema = {
+  type: "object",
+  required: ["refreshToken"],
+  properties: { refreshToken: nonEmptyString },
+};
 
 interface AuthDeps {
   authService: AuthService;
@@ -54,12 +71,12 @@ export function registerAuthRoutes(app: FastifyInstance, deps: AuthDeps): void {
     Body: { username: string; password: string };
   }>(
     "/api/v1/auth/login",
-    { config: { rateLimit: { max: 10, timeWindow: "1 minute" } } },
+    {
+      config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
+      schema: { body: loginBodySchema },
+    },
     async (request, reply) => {
-      const { username, password } = request.body ?? {};
-      if (!username || !password) {
-        return reply.code(400).send({ error: "username and password are required" });
-      }
+      const { username, password } = request.body;
 
       try {
         const tokens = await authService.login(username, password);
@@ -93,11 +110,8 @@ export function registerAuthRoutes(app: FastifyInstance, deps: AuthDeps): void {
   // POST /api/v1/auth/refresh
   app.post<{
     Body: { refreshToken: string };
-  }>("/api/v1/auth/refresh", async (request, reply) => {
-    const { refreshToken } = request.body ?? {};
-    if (!refreshToken) {
-      return reply.code(400).send({ error: "refreshToken is required" });
-    }
+  }>("/api/v1/auth/refresh", { schema: { body: refreshBodySchema } }, async (request, reply) => {
+    const { refreshToken } = request.body;
 
     try {
       const tokens = await authService.refresh(refreshToken);

--- a/src/api/routes/button-actions.test.ts
+++ b/src/api/routes/button-actions.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+import { createLogger } from "../../core/logger.js";
+import { registerButtonActionRoutes } from "./button-actions.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Input-validation characterization (issue #452): POST/PUT action-bindings.
+
+function makeDeps() {
+  const binding = { id: "b-1" };
+  return {
+    buttonActionManager: {
+      getBindingsByEquipment: () => [],
+      addBinding: () => binding,
+      updateBinding: () => binding,
+      removeBinding: () => undefined,
+    },
+    logger: createLogger("silent").logger,
+  } as unknown as Parameters<typeof registerButtonActionRoutes>[1];
+}
+
+function buildApp() {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+  registerButtonActionRoutes(app, makeDeps());
+  return app;
+}
+
+describe("button-action routes — input validation (characterization)", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = buildApp();
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const postUrl = "/api/v1/equipments/eq-1/action-bindings";
+  const putUrl = "/api/v1/equipments/eq-1/action-bindings/b-1";
+  const post = (body: unknown) => app.inject({ method: "POST", url: postUrl, payload: body });
+  const put = (body: unknown) => app.inject({ method: "PUT", url: putUrl, payload: body });
+
+  it("POST 400 { error } when actionValue or effectType is missing", async () => {
+    for (const body of [{ effectType: "mode_activate" }, { actionValue: "1" }]) {
+      const res = await post(body);
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: expect.any(String) });
+    }
+  });
+
+  it("POST 400 when effectType is not one of the valid values", async () => {
+    const res = await post({ actionValue: "1", effectType: "bogus" });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("POST 201 for a valid body (config optional)", async () => {
+    const res = await post({ actionValue: "1", effectType: "mode_activate" });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("PUT mirrors POST validation and accepts a valid body", async () => {
+    expect((await put({ actionValue: "1", effectType: "bogus" })).statusCode).toBe(400);
+    expect((await put({ effectType: "zone_order" })).statusCode).toBe(400);
+    expect((await put({ actionValue: "1", effectType: "zone_order" })).statusCode).toBe(200);
+  });
+});

--- a/src/api/routes/button-actions.ts
+++ b/src/api/routes/button-actions.ts
@@ -11,6 +11,20 @@ const VALID_EFFECT_TYPES: ButtonEffectType[] = [
   "zone_order",
 ];
 
+// Input schema (issue #452). Old guards: `!actionValue || !effectType` (bare,
+// no trim) + `!VALID_EFFECT_TYPES.includes(effectType)`. nonEmptyString matches
+// the truthiness check; the enum matches the includes() check. `config` is
+// optional and defaulted to {} in the handler, so it stays unconstrained. POST
+// and PUT share the same body shape.
+const bindingBodySchema = {
+  type: "object",
+  required: ["actionValue", "effectType"],
+  properties: {
+    actionValue: { type: "string", minLength: 1 },
+    effectType: { enum: VALID_EFFECT_TYPES },
+  },
+};
+
 export function registerButtonActionRoutes(
   app: FastifyInstance,
   deps: { buttonActionManager: ButtonActionManager; logger: Logger },
@@ -26,51 +40,41 @@ export function registerButtonActionRoutes(
   app.post<{
     Params: { id: string };
     Body: { actionValue: string; effectType: ButtonEffectType; config: Record<string, unknown> };
-  }>("/api/v1/equipments/:id/action-bindings", async (request, reply) => {
-    const { actionValue, effectType, config } = request.body ?? {};
+  }>(
+    "/api/v1/equipments/:id/action-bindings",
+    { schema: { body: bindingBodySchema } },
+    async (request, reply) => {
+      const { actionValue, effectType, config } = request.body;
 
-    if (!actionValue || !effectType) {
-      return reply.code(400).send({ error: "actionValue and effectType are required" });
-    }
-    if (!VALID_EFFECT_TYPES.includes(effectType)) {
-      return reply
-        .code(400)
-        .send({ error: `Invalid effectType. Must be one of: ${VALID_EFFECT_TYPES.join(", ")}` });
-    }
-
-    const binding = buttonActionManager.addBinding(
-      request.params.id,
-      actionValue,
-      effectType,
-      config ?? {},
-    );
-    return reply.code(201).send(binding);
-  });
+      const binding = buttonActionManager.addBinding(
+        request.params.id,
+        actionValue,
+        effectType,
+        config ?? {},
+      );
+      return reply.code(201).send(binding);
+    },
+  );
 
   // PUT /api/v1/equipments/:id/action-bindings/:bindingId
   app.put<{
     Params: { id: string; bindingId: string };
     Body: { actionValue: string; effectType: ButtonEffectType; config: Record<string, unknown> };
-  }>("/api/v1/equipments/:id/action-bindings/:bindingId", async (request, reply) => {
-    const { actionValue, effectType, config } = request.body ?? {};
+  }>(
+    "/api/v1/equipments/:id/action-bindings/:bindingId",
+    { schema: { body: bindingBodySchema } },
+    async (request, reply) => {
+      const { actionValue, effectType, config } = request.body;
 
-    if (!actionValue || !effectType) {
-      return reply.code(400).send({ error: "actionValue and effectType are required" });
-    }
-    if (!VALID_EFFECT_TYPES.includes(effectType)) {
-      return reply
-        .code(400)
-        .send({ error: `Invalid effectType. Must be one of: ${VALID_EFFECT_TYPES.join(", ")}` });
-    }
-
-    const binding = buttonActionManager.updateBinding(
-      request.params.bindingId,
-      actionValue,
-      effectType,
-      config ?? {},
-    );
-    return reply.send(binding);
-  });
+      const binding = buttonActionManager.updateBinding(
+        request.params.bindingId,
+        actionValue,
+        effectType,
+        config ?? {},
+      );
+      return reply.send(binding);
+    },
+  );
 
   // DELETE /api/v1/equipments/:id/action-bindings/:bindingId
   app.delete<{ Params: { id: string; bindingId: string } }>(

--- a/src/api/routes/devices.test.ts
+++ b/src/api/routes/devices.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+import { createLogger } from "../../core/logger.js";
+import { registerDeviceRoutes } from "./devices.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Input-validation characterization (issue #452): PUT /devices/:id required at
+// least one of name/zoneId (old `name === undefined && zoneId === undefined`),
+// so a body-less/empty/neither-field request stayed a 400.
+
+function makeDeps() {
+  const device = { id: "d-1", name: "x" };
+  return {
+    deviceManager: {
+      getAllWithData: () => [],
+      getByIdWithDetails: () => device,
+      getById: () => device,
+      update: () => device,
+      delete: () => true,
+    },
+    batteryMonitor: undefined,
+    logger: createLogger("silent").logger,
+  } as unknown as Parameters<typeof registerDeviceRoutes>[1];
+}
+
+function buildApp() {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+  registerDeviceRoutes(app, makeDeps());
+  return app;
+}
+
+describe("device routes — input validation (characterization)", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = buildApp();
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const put = (body: unknown) =>
+    app.inject({ method: "PUT", url: "/api/v1/devices/d-1", payload: body });
+
+  it("400 { error } when neither name nor zoneId is provided", async () => {
+    for (const body of [{}, { foo: 1 }]) {
+      const res = await put(body);
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: expect.any(String) });
+    }
+  });
+
+  it("400 for a body-less PUT (old `request.body ?? {}` -> {} -> 400)", async () => {
+    const res = await app.inject({ method: "PUT", url: "/api/v1/devices/d-1" });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("200 when at least one of name/zoneId is present (incl. null zoneId)", async () => {
+    expect((await put({ name: "Renamed" })).statusCode).toBe(200);
+    expect((await put({ zoneId: null })).statusCode).toBe(200);
+    expect((await put({ zoneId: "z-1", extra: 1 })).statusCode).toBe(200);
+  });
+});

--- a/src/api/routes/devices.ts
+++ b/src/api/routes/devices.ts
@@ -3,6 +3,16 @@ import type { DeviceManager } from "../../devices/device-manager.js";
 import type { BatteryMonitor } from "../../devices/battery-monitor.js";
 import type { Logger } from "../../core/logger.js";
 
+// Input schema (issue #452). The old PUT rejected a body with neither `name`
+// nor `zoneId` (`name === undefined && zoneId === undefined`), including a
+// body-less request (`request.body ?? {}` -> {}). `anyOf` on the two fields
+// reproduces that exactly: at least one must be present, and a null/absent body
+// fails `type: object`. Values stay unconstrained (old passed them through).
+const updateDeviceBodySchema = {
+  type: "object",
+  anyOf: [{ required: ["name"] }, { required: ["zoneId"] }],
+};
+
 interface DevicesDeps {
   deviceManager: DeviceManager;
   /** Spec 143 — absent in shadow mode, where the monitor does not run. */
@@ -37,21 +47,19 @@ export function registerDeviceRoutes(app: FastifyInstance, deps: DevicesDeps): v
   app.put<{
     Params: { id: string };
     Body: { name?: string; zoneId?: string | null };
-  }>("/api/v1/devices/:id", async (request, reply) => {
-    const { name, zoneId } = request.body ?? {};
+  }>(
+    "/api/v1/devices/:id",
+    { schema: { body: updateDeviceBodySchema } },
+    async (request, reply) => {
+      const { name, zoneId } = request.body;
 
-    if (name === undefined && zoneId === undefined) {
-      return reply
-        .code(400)
-        .send({ error: "No update fields provided. Use 'name' and/or 'zoneId'." });
-    }
-
-    const device = deviceManager.update(request.params.id, { name, zoneId });
-    if (!device) {
-      return reply.code(404).send({ error: "Device not found" });
-    }
-    return device;
-  });
+      const device = deviceManager.update(request.params.id, { name, zoneId });
+      if (!device) {
+        return reply.code(404).send({ error: "Device not found" });
+      }
+      return device;
+    },
+  );
 
   // DELETE /api/v1/devices/:id — Remove device
   app.delete<{ Params: { id: string } }>("/api/v1/devices/:id", async (request, reply) => {

--- a/src/api/routes/users.test.ts
+++ b/src/api/routes/users.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+import { createLogger } from "../../core/logger.js";
+import { registerUserRoutes } from "./users.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Input-validation characterization (issue #452) for POST /users. These routes
+// are admin-gated by an onRequest hook (runs before schema validation), so the
+// test app injects an admin request.auth first. PUT /users is not converted.
+
+function makeDeps() {
+  const user = { id: "u-1", username: "bob", role: "standard" };
+  return {
+    userManager: {
+      getAll: () => [user],
+      getById: () => user,
+      getByUsername: () => null,
+      createUser: async () => user,
+      updateUser: async () => user,
+    },
+    auditLogger: { log: () => undefined },
+    logger: createLogger("silent").logger,
+  } as unknown as Parameters<typeof registerUserRoutes>[1];
+}
+
+function buildApp() {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+  app.addHook("onRequest", async (request) => {
+    (request as unknown as { auth: unknown }).auth = { userId: "admin", role: "admin" };
+  });
+  registerUserRoutes(app, makeDeps());
+  return app;
+}
+
+describe("POST /api/v1/users — input validation (characterization)", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = buildApp();
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const post = (body: unknown) =>
+    app.inject({ method: "POST", url: "/api/v1/users", payload: body });
+
+  it("400 { error } when username, password or displayName is missing", async () => {
+    for (const body of [
+      { password: "secret1", displayName: "Bob" },
+      { username: "bob", displayName: "Bob" },
+      { username: "bob", password: "secret1" },
+    ]) {
+      const res = await post(body);
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: expect.any(String) });
+    }
+  });
+
+  it("400 when password is shorter than 6 characters", async () => {
+    const res = await post({ username: "bob", password: "12345", displayName: "Bob" });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("400 when role is not admin or standard", async () => {
+    const res = await post({
+      username: "bob",
+      password: "secret1",
+      displayName: "Bob",
+      role: "superuser",
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("201 for a valid body, with or without an explicit role", async () => {
+    expect(
+      (await post({ username: "bob", password: "secret1", displayName: "Bob" })).statusCode,
+    ).toBe(201);
+    expect(
+      (
+        await post({
+          username: "bob",
+          password: "secret1",
+          displayName: "Bob",
+          role: "admin",
+        })
+      ).statusCode,
+    ).toBe(201);
+  });
+});

--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -5,6 +5,26 @@ import type { AuditLogger } from "../../core/audit-logger.js";
 import type { UserRole } from "../../shared/types.js";
 import { requireAdmin } from "../../auth/auth-middleware.js";
 import { buildActor } from "../audit-context.js";
+import { nonEmptyString } from "../schemas.js";
+
+// Input schema (issue #452) for POST /users. Old guards: `!username ||
+// !password || !displayName` (bare, no trim), `password.length < 6`, and an
+// optional-role enum check. nonEmptyString matches the truthiness guards;
+// password gets minLength 6. `role` is optional and enum-checked. The 409
+// unique-username check and admin gating (onRequest hook) stay as-is, both
+// running in the same order as before (403 hook -> body 400 -> 409). PUT /users
+// is left hand-rolled: it returns 404 for an unknown id BEFORE its body check,
+// which a body schema would flip to a 400.
+const createUserBodySchema = {
+  type: "object",
+  required: ["username", "password", "displayName"],
+  properties: {
+    username: nonEmptyString,
+    password: { type: "string", minLength: 6 },
+    displayName: nonEmptyString,
+    role: { enum: ["admin", "standard"] },
+  },
+};
 
 interface UsersDeps {
   userManager: UserManager;
@@ -35,18 +55,8 @@ export function registerUserRoutes(app: FastifyInstance, deps: UsersDeps): void 
       displayName: string;
       role: UserRole;
     };
-  }>("/api/v1/users", async (request, reply) => {
-    const { username, password, displayName, role } = request.body ?? {};
-
-    if (!username || !password || !displayName) {
-      return reply.code(400).send({ error: "username, password, and displayName are required" });
-    }
-    if (password.length < 6) {
-      return reply.code(400).send({ error: "Password must be at least 6 characters" });
-    }
-    if (role && role !== "admin" && role !== "standard") {
-      return reply.code(400).send({ error: "role must be 'admin' or 'standard'" });
-    }
+  }>("/api/v1/users", { schema: { body: createUserBodySchema } }, async (request, reply) => {
+    const { username, password, displayName, role } = request.body;
 
     // Check unique username
     if (userManager.getByUsername(username)) {


### PR DESCRIPTION
## What

Batch 4 of the issue #452 API input-validation hardening. Converts the **precedence-safe** hand-rolled body checks in **auth**, **button-actions**, **devices** and **users** to Fastify JSON schemas.

## No behavioral change for API consumers

Same routes, methods, status codes and `{ error: string }` 400 shape. Only the validation *message wording* changes.

## How

- **auth**: `POST /auth/login` (username, password) and `POST /auth/refresh` (refreshToken) use `nonEmptyString` (old bare `!x`, no trim). The login route keeps its `config.rateLimit`; the schema is merged into the same options object.
- **button-actions**: `POST` and `PUT` action-bindings require `actionValue` (nonEmptyString) and `effectType` (enum of the 5 valid values, matching the old `includes()` check); `config` stays optional.
- **devices**: `PUT /devices/:id` requires at least one of name/zoneId via `anyOf`, reproducing the old `name === undefined && zoneId === undefined` guard — including the **body-less -> 400** behavior (unlike the object-or-null PUTs in earlier batches, this route rejected an empty body).
- **users**: `POST /users` (username, password `minLength 6`, displayName, optional role enum). The 409 unique-username check stays in the handler in the same order as before.

## Intentionally left hand-rolled (precedence)

- **auth `/setup`**: returns `403` (user already exists) *before* its body check — a body schema would flip that to `400`.
- **auth `/logout`**: no required field.
- **users `PUT /:id`**: returns `404` for an unknown id *before* its body check — a schema would flip that to `400`. Its only structural validation is an optional role enum; the rest is business logic (last-admin guard).

## Auth precedence preserved

- **users** is admin-gated by an **onRequest hook**, which runs before schema validation, so `403`-before-`400` holds.
- **auth/button-actions/devices** have no in-handler auth check on the converted routes.

## Tests

- New `auth.test.ts` (4), `button-actions.test.ts` (4), `devices.test.ts` (3), `users.test.ts` (4) characterization tests pin the accept/reject matrix and `{ error }` shape (users injects an admin `request.auth`).
- Full backend + UI suite green: **1596 passed, 2 skipped**; `tsc --noEmit` and eslint clean.

Refs #452