### PR TITLE
feat(api): schema-validate equipment data/order-binding route bodies (#452)

### DIFF
--- a/src/api/routes/equipments.test.ts
+++ b/src/api/routes/equipments.test.ts
@@ -233,3 +233,60 @@ describe("PUT /api/v1/equipments/:id — input validation (characterization)", (
     expect(res.statusCode).toBe(200);
   });
 });
+
+describe("POST /api/v1/equipments/:id/(data|order)-bindings — validation", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = Fastify({ logger: false, ajv: validationAjvOptions });
+    installValidationErrorHandler(app);
+    const manager = {
+      getAllWithDetails: () => [],
+      addDataBinding: () => ({ id: "db-1" }),
+      addOrderBinding: () => ({ id: "ob-1" }),
+    } as unknown as Parameters<typeof registerEquipmentRoutes>[1]["equipmentManager"];
+    registerEquipmentRoutes(app, {
+      equipmentManager: manager,
+      logger: createLogger("silent").logger,
+    });
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const dataUrl = "/api/v1/equipments/eq-1/data-bindings";
+  const orderUrl = "/api/v1/equipments/eq-1/order-bindings";
+  const post = (url: string, body: unknown) => app.inject({ method: "POST", url, payload: body });
+
+  it("data-bindings: 400 { error } when deviceDataId or alias is missing/blank", async () => {
+    // old: `!deviceDataId` (bare) + `!alias?.trim()` (rejects whitespace)
+    for (const body of [
+      { alias: "temp" },
+      { deviceDataId: "d-1" },
+      { deviceDataId: "d-1", alias: "   " },
+    ]) {
+      const res = await post(dataUrl, body);
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: expect.any(String) });
+    }
+  });
+
+  it("data-bindings: 201 for a valid body", async () => {
+    const res = await post(dataUrl, { deviceDataId: "d-1", alias: "temp" });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("order-bindings: 400 when deviceOrderId or alias is missing/blank", async () => {
+    for (const body of [
+      { alias: "on" },
+      { deviceOrderId: "o-1" },
+      { deviceOrderId: "o-1", alias: "  " },
+    ]) {
+      const res = await post(orderUrl, body);
+      expect(res.statusCode).toBe(400);
+    }
+  });
+
+  it("order-bindings: 201 for a valid body", async () => {
+    const res = await post(orderUrl, { deviceOrderId: "o-1", alias: "on" });
+    expect(res.statusCode).toBe(201);
+  });
+});

--- a/src/api/routes/equipments.ts
+++ b/src/api/routes/equipments.ts
@@ -47,6 +47,23 @@ const updateEquipmentBodySchema = {
   },
 };
 
+// Binding bodies (issue #452). Old guards: `!deviceDataId` / `!deviceOrderId`
+// (bare truthiness, so minLength 1) and `!alias?.trim()` (rejects a blank or
+// whitespace-only alias). The alias uses a `\S` pattern (a non-blank char) but,
+// unlike name, NO maxLength — the old check never capped its length. The handler
+// keeps `alias.trim()` normalization.
+const nonBlankAlias = { type: "string", pattern: "\\S" };
+const addDataBindingBodySchema = {
+  type: "object",
+  required: ["deviceDataId", "alias"],
+  properties: { deviceDataId: { type: "string", minLength: 1 }, alias: nonBlankAlias },
+};
+const addOrderBindingBodySchema = {
+  type: "object",
+  required: ["deviceOrderId", "alias"],
+  properties: { deviceOrderId: { type: "string", minLength: 1 }, alias: nonBlankAlias },
+};
+
 export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDeps): void {
   const { equipmentManager } = deps;
 
@@ -208,27 +225,24 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
   app.post<{
     Params: { id: string };
     Body: { deviceDataId: string; alias: string };
-  }>("/api/v1/equipments/:id/data-bindings", async (request, reply) => {
-    const { deviceDataId, alias } = request.body ?? {};
+  }>(
+    "/api/v1/equipments/:id/data-bindings",
+    { schema: { body: addDataBindingBodySchema } },
+    async (request, reply) => {
+      const { deviceDataId, alias } = request.body;
 
-    if (!deviceDataId) {
-      return reply.code(400).send({ error: "deviceDataId is required" });
-    }
-    if (!alias?.trim()) {
-      return reply.code(400).send({ error: "alias is required" });
-    }
-
-    try {
-      const binding = equipmentManager.addDataBinding(
-        request.params.id,
-        deviceDataId,
-        alias.trim(),
-      );
-      return reply.code(201).send(binding);
-    } catch (err) {
-      return handleEquipmentError(reply, err);
-    }
-  });
+      try {
+        const binding = equipmentManager.addDataBinding(
+          request.params.id,
+          deviceDataId,
+          alias.trim(),
+        );
+        return reply.code(201).send(binding);
+      } catch (err) {
+        return handleEquipmentError(reply, err);
+      }
+    },
+  );
 
   // DELETE /api/v1/equipments/:id/data-bindings/:bindingId — Remove a DataBinding
   app.delete<{
@@ -250,27 +264,24 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
   app.post<{
     Params: { id: string };
     Body: { deviceOrderId: string; alias: string };
-  }>("/api/v1/equipments/:id/order-bindings", async (request, reply) => {
-    const { deviceOrderId, alias } = request.body ?? {};
+  }>(
+    "/api/v1/equipments/:id/order-bindings",
+    { schema: { body: addOrderBindingBodySchema } },
+    async (request, reply) => {
+      const { deviceOrderId, alias } = request.body;
 
-    if (!deviceOrderId) {
-      return reply.code(400).send({ error: "deviceOrderId is required" });
-    }
-    if (!alias?.trim()) {
-      return reply.code(400).send({ error: "alias is required" });
-    }
-
-    try {
-      const binding = equipmentManager.addOrderBinding(
-        request.params.id,
-        deviceOrderId,
-        alias.trim(),
-      );
-      return reply.code(201).send(binding);
-    } catch (err) {
-      return handleEquipmentError(reply, err);
-    }
-  });
+      try {
+        const binding = equipmentManager.addOrderBinding(
+          request.params.id,
+          deviceOrderId,
+          alias.trim(),
+        );
+        return reply.code(201).send(binding);
+      } catch (err) {
+        return handleEquipmentError(reply, err);
+      }
+    },
+  );
 
   // DELETE /api/v1/equipments/:id/order-bindings/:bindingId — Remove an OrderBinding
   app.delete<{


### PR DESCRIPTION
## What

Batch 6 (final conversion batch) of the issue #452 API input-validation hardening. Converts the last two hand-rolled body checks in **equipments.ts** — `POST /:id/data-bindings` and `POST /:id/order-bindings` — to Fastify JSON schemas, matching the POST/PUT equipment routes already converted in #475.

## No behavioral change for API consumers

Same routes, methods, status codes and `{ error: string }` 400 shape. Only the validation *message wording* changes.

## How

Old guards:
- `deviceDataId` / `deviceOrderId` via bare truthiness -> `{ type: "string", minLength: 1 }`.
- `alias` via `!alias?.trim()` (rejects blank/whitespace) -> `{ type: "string", pattern: "\\S" }`.

The alias schema uses a `\S` pattern (a non-blank character) but **no** `maxLength`, because the old check never capped alias length (unlike equipment `name`, which is capped at 100). The handler keeps its `alias.trim()` normalization.

## Tests

- `equipments.test.ts` extended with characterization tests pinning the accept/reject matrix (missing deviceDataId/deviceOrderId, missing/whitespace alias) and the `{ error }` shape for both binding routes.
- Full backend + UI suite green: **1600 passed, 2 skipped**; `tsc --noEmit` and eslint clean.

Refs #452