### PR TITLE
feat(api): expose OpenAPI spec via @fastify/swagger (#452 follow-up)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sowel",
-  "version": "1.33.0",
+  "version": "1.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sowel",
-      "version": "1.33.0",
+      "version": "1.43.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cors": "^10.0.2",
@@ -14,6 +14,7 @@
         "@fastify/multipart": "^9.4.0",
         "@fastify/rate-limit": "^10.3.0",
         "@fastify/static": "^9.0.0",
+        "@fastify/swagger": "^9.8.1",
         "@fastify/websocket": "^11.0.1",
         "@influxdata/influxdb-client": "^1.35.0",
         "@types/archiver": "^7.0.0",
@@ -995,6 +996,45 @@
         "fastq": "^1.17.1",
         "glob": "^13.0.0"
       }
+    },
+    "node_modules/@fastify/swagger": {
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/@fastify/swagger/-/swagger-9.8.1.tgz",
+      "integrity": "sha512-VpHMnqZTY8iBZYJE8WWkbKPrXIYWy2rDfIf5qLr6DzZSpQYZ+KxQVcJFiq/AMlvNwI4gCBd66++iUlxXXGT0IQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^6.0.0",
+        "json-schema-resolver": "^3.0.0",
+        "openapi-types": "^12.1.3",
+        "rfdc": "^1.3.1",
+        "yaml": "^2.4.2"
+      }
+    },
+    "node_modules/@fastify/swagger/node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/websocket": {
       "version": "11.2.0",
@@ -4571,6 +4611,23 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/json-schema-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-resolver/-/json-schema-resolver-3.0.0.tgz",
+      "integrity": "sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fast-uri": "^3.0.5",
+        "rfdc": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/Eomm/json-schema-resolver?sponsor=1"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -5245,6 +5302,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -7549,7 +7612,6 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@fastify/multipart": "^9.4.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",
+    "@fastify/swagger": "^9.8.1",
     "@fastify/websocket": "^11.0.1",
     "@influxdata/influxdb-client": "^1.35.0",
     "@types/archiver": "^7.0.0",

--- a/src/api/openapi.test.ts
+++ b/src/api/openapi.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import Fastify from "fastify";
+import swagger from "@fastify/swagger";
+import { createLogger } from "../core/logger.js";
+import { registerZoneRoutes } from "./routes/zones.js";
+import { installValidationErrorHandler, validationAjvOptions } from "./error-handler.js";
+
+// Verifies the issue #452 OpenAPI follow-up: @fastify/swagger builds an OpenAPI
+// 3 document from the route body schemas added during the validation rollout,
+// and the GET /api/v1/openapi.json endpoint serves it. Mirrors the server wiring
+// (swagger registered before routes) on a single converted domain.
+
+function zonesDeps() {
+  const zone = { id: "z-1", name: "x", parentId: null };
+  return {
+    zoneManager: { create: () => zone, update: () => zone },
+    zoneAggregator: {},
+    equipmentManager: {},
+    logger: createLogger("silent").logger,
+  } as unknown as Parameters<typeof registerZoneRoutes>[1];
+}
+
+async function buildApp() {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+  await app.register(swagger, {
+    openapi: { info: { title: "Sowel API", version: "0.0.0-test" } },
+  });
+  registerZoneRoutes(app, zonesDeps());
+  app.get("/api/v1/openapi.json", async () => app.swagger());
+  await app.ready();
+  return app;
+}
+
+describe("OpenAPI spec generation (issue #452 follow-up)", () => {
+  it("builds an OpenAPI 3 document that includes a converted route's body schema", async () => {
+    const app = await buildApp();
+    const spec = app.swagger() as {
+      openapi: string;
+      info: { title: string };
+      paths: Record<string, Record<string, { requestBody?: unknown }>>;
+    };
+    expect(spec.openapi).toMatch(/^3\./);
+    expect(spec.info.title).toBe("Sowel API");
+    // POST /api/v1/zones carries createZoneBodySchema -> a requestBody is emitted.
+    expect(spec.paths["/api/v1/zones"]?.post?.requestBody).toBeDefined();
+    await app.close();
+  });
+
+  it("serves the spec as JSON at GET /api/v1/openapi.json", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/v1/openapi.json" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { openapi: string; paths: Record<string, unknown> };
+    expect(body.openapi).toMatch(/^3\./);
+    expect(Object.keys(body.paths).length).toBeGreaterThan(0);
+    await app.close();
+  });
+});

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import Fastify from "fastify";
@@ -8,6 +8,7 @@ import multipart from "@fastify/multipart";
 import rateLimit from "@fastify/rate-limit";
 import fastifyStatic from "@fastify/static";
 import websocket from "@fastify/websocket";
+import swagger from "@fastify/swagger";
 import type { Logger } from "../core/logger.js";
 import type { LogRingBuffer } from "../core/log-buffer.js";
 import type { ActivityBuffer } from "../activity/activity-buffer.js";
@@ -178,6 +179,23 @@ export async function createServer(deps: ServerDeps) {
   // Schema-validation failures answer as { error } / 400 (issue #452).
   installValidationErrorHandler(app);
 
+  // OpenAPI spec generation (issue #452 follow-up). @fastify/swagger reads the
+  // JSON schemas declared on routes (added by the #452 rollout) and builds an
+  // OpenAPI 3 document, served as JSON at GET /api/v1/openapi.json below. Must be
+  // registered before the routes so it captures their schemas. No Swagger UI is
+  // mounted — this exposes the machine-readable spec only.
+  const pkgVersion = (
+    JSON.parse(
+      readFileSync(resolve(import.meta.dirname ?? ".", "../../package.json"), "utf-8"),
+    ) as { version: string }
+  ).version;
+  await app.register(swagger, {
+    openapi: {
+      info: { title: "Sowel API", version: pkgVersion },
+      servers: [{ url: "/" }],
+    },
+  });
+
   // CORS
   await app.register(cors, {
     origin: corsOrigins,
@@ -281,6 +299,12 @@ export async function createServer(deps: ServerDeps) {
 
   // Auth middleware (must be registered before routes)
   registerAuthMiddleware(app, { authService, userManager, logger });
+
+  // OpenAPI spec (issue #452 follow-up). Machine-readable document built by
+  // @fastify/swagger from the route schemas. Not in PUBLIC_ROUTES, so it sits
+  // behind the auth middleware like any other /api route — authenticated users
+  // can fetch it; add it to PUBLIC_ROUTES to expose it anonymously.
+  app.get("/api/v1/openapi.json", async () => app.swagger());
 
   // Register routes
   registerHealthRoutes(app, { deviceManager, integrationRegistry, logger });


### PR DESCRIPTION
## Draft — awaiting your decision on endpoint exposure

The #452 follow-up you flagged as interesting. Now that routes carry JSON body schemas, this registers `@fastify/swagger` to build an OpenAPI 3 document and serve it as JSON at **`GET /api/v1/openapi.json`**.

I left this as a **draft** rather than auto-merging because it adds a **new outward-facing endpoint** and a runtime dependency — that exposure choice is yours. Everything is implemented, tested and green; just say the word (and pick an option below) and I'll finalize + merge.

## What it does

- Registers `@fastify/swagger@^9.8.1` (compatible with Fastify 5.7.4) **before** the routes so it captures their schemas.
- Serves the machine-readable spec at `GET /api/v1/openapi.json`.
- **No Swagger UI** is mounted — spec only, minimal surface.

## Exposure (the decision)

The endpoint is **not** in `PUBLIC_ROUTES`, so today it sits behind the auth middleware like any other `/api` route: **an authenticated user can fetch it, anonymous cannot**. Options:

1. **Keep it auth-gated** (current) — safest, authenticated users only.
2. **Make it public** — add `/api/v1/openapi.json` to `PUBLIC_ROUTES` (one line). Standard for public API docs.
3. **Add Swagger UI** — mount `@fastify/swagger-ui` at e.g. `/api/docs` for an interactive browser (another dependency).

Default in this PR is option 1.

## Scope note

Only the routes converted in #452 carry body schemas, so the spec documents request bodies for those; routes still using hand-rolled validation (the auth-in-handler set documented on #452) appear without a request-body schema. That is expected and improves as those routes are migrated.

## Tests

- `src/api/openapi.test.ts`: asserts the generated document is OpenAPI 3, includes a converted route's `requestBody` schema, and is served at the endpoint.
- Full backend + UI suite green: **1602 passed, 2 skipped**; `npm run build`, `tsc`, eslint clean.

Refs #452