### PR TITLE
release: v1.44.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,14 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.44.x : Validation des entrées API et OpenAPI
+
+### v1.44.0 — 2026-08-13 { #v1-44-0 }
+
+- Fix (devices) : **les alertes de batterie faible nomment désormais l'équipement concerné et restent cantonnées à sa zone**. Un capteur en batterie faible n'apparaissait que par le nom du device et remontait dans le fil d'activité de toutes les zones. Le bandeau d'avertissement et l'activité de zone affichent maintenant le nom de l'équipement associé à côté du device, et l'alerte est rattachée à la zone de l'équipement. Contribué par Adrien Jouve (computingify). (spec 143, #472, #473)
+- Interne (api) : **les corps de requête sont désormais validés par des schémas déclaratifs sur la plupart des routes API**. Les vérifications écrites à la main et dupliquées dans les handlers ont été remplacées par des schémas JSON Fastify, offrant une frontière de validation cohérente et une forme unique `{ error }` pour les réponses 400. Les routes, méthodes et codes de statut sont inchangés ; seul le libellé des messages d'erreur de validation change. Les routes qui contrôlent l'authentification ou l'existence d'une ressource dans le handler conservent leurs vérifications actuelles pour l'instant (suivi dans #482). (#452, #475, #476, #477, #478, #479, #480)
+- Interne (api) : **une description OpenAPI 3 de l'API est maintenant générée à partir de ces schémas**, servie en JSON sur `/api/v1/openapi.json` pour les utilisateurs authentifiés. Aucune interface de documentation interactive n'est montée. (#452, #481)
+
 ## 1.43.x: Alertes batterie faible et contrôles du graphe Analyse
 
 ### v1.43.0 — 2026-08-12 { #v1-43-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,14 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.44.x: API input validation and OpenAPI
+
+### v1.44.0 — 2026-08-13 { #v1-44-0 }
+
+- Fix (devices): **low battery alerts now name the affected equipment and stay scoped to its zone**. A sensor in low battery surfaced by device name only and showed up in every zone's activity feed. The warning banner and the zone activity now show the bound equipment name next to the device, and the alert is attributed to the equipment's own zone. Contributed by Adrien Jouve (computingify). (spec 143, #472, #473)
+- Internal (api): **request bodies are now validated by declarative schemas across most API routes**. The hand-rolled checks duplicated inside route handlers were replaced with Fastify JSON schemas, giving one consistent validation boundary and a single `{ error }` shape for 400 responses. Routes, methods and status codes are unchanged; only the wording of validation error messages changes. Routes that gate on authentication or resource existence inside the handler keep their existing checks for now (tracked in #482). (#452, #475, #476, #477, #478, #479, #480)
+- Internal (api): **an OpenAPI 3 description of the API is now generated from those schemas**, served as JSON at `/api/v1/openapi.json` for authenticated users. No interactive documentation UI is mounted. (#452, #481)
+
 ## 1.43.x: Low battery alerts and Analyse chart controls
 
 ### v1.43.0 — 2026-08-12 { #v1-43-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.43.0",
+  "version": "1.44.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## v1.44.0

Covers everything merged since v1.43.0.

- **API input validation hardening (#452)** — most route bodies now validated by declarative Fastify JSON schemas; one uniform `{ error }`/400 shape. No route/method/status change for consumers, only validation message wording. (#475-#480)
- **OpenAPI spec (#481)** — generated from those schemas, served as JSON at `GET /api/v1/openapi.json` (auth-gated, no UI).
- **Fix (devices) #473** — low battery alerts name the bound equipment and stay scoped to its zone. (#472)

Release notes added to `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-44-0 }` anchor.