### PR TITLE
fix(ui): render energy-meter on mobile and media-player on desktop (#323, #324)

### DIFF
--- a/ui/src/components/dashboard/EquipmentWidget.test.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.test.tsx
@@ -137,4 +137,70 @@ describe("EquipmentWidget", () => {
     );
     expect(screen.getByText("Living room temp")).toBeTruthy();
   });
+
+  // Issue #324 — a media_player used to fall through to the generic widget on
+  // desktop. It now renders the source and a power toggle.
+  it("renders a media_player with its source and fires the power toggle", async () => {
+    const onExecuteOrder = vi.fn().mockResolvedValue(undefined);
+    const tv = makeEquipment({
+      id: "tv-1",
+      name: "TV",
+      type: "media_player",
+      dataBindings: [
+        {
+          id: "db-p",
+          equipmentId: "tv-1",
+          deviceDataId: "dd-p",
+          alias: "power",
+          deviceId: "dev-tv",
+          deviceName: "TV",
+          key: "power",
+          type: "boolean",
+          category: "light_state",
+          value: true,
+          lastUpdated: "2026-01-01T00:00:00Z",
+          lastChanged: "2026-01-01T00:00:00Z",
+          stale: false,
+        },
+        {
+          id: "db-s",
+          equipmentId: "tv-1",
+          deviceDataId: "dd-s",
+          alias: "input_source",
+          deviceId: "dev-tv",
+          deviceName: "TV",
+          key: "input_source",
+          type: "string",
+          category: "generic",
+          value: "HDMI1",
+          lastUpdated: "2026-01-01T00:00:00Z",
+          lastChanged: "2026-01-01T00:00:00Z",
+          stale: false,
+        },
+      ] as EquipmentWithDetails["dataBindings"],
+      orderBindings: [
+        {
+          id: "ob-p",
+          equipmentId: "tv-1",
+          deviceOrderId: "do-p",
+          alias: "power",
+          deviceId: "dev-tv",
+          deviceName: "TV",
+          key: "power",
+          type: "boolean",
+        },
+      ] as EquipmentWithDetails["orderBindings"],
+    });
+    render(
+      <EquipmentWidget
+        widget={makeWidget({ equipmentId: "tv-1" })}
+        equipment={tv}
+        onExecuteOrder={onExecuteOrder}
+      />,
+    );
+
+    expect(screen.getByText("HDMI1")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button"));
+    expect(onExecuteOrder).toHaveBeenCalledWith("tv-1", "power", false);
+  });
 });

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -15,6 +15,7 @@ import {
   WashingMachine,
   Timer,
   Camera,
+  Tv,
 } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
 import type { DashboardWidget } from "../../types";
@@ -49,7 +50,6 @@ import { WeatherForecastWidget } from "./WeatherForecastWidget";
 import { WidgetCard } from "./WidgetCard";
 import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
 
-
 /** Render the widget's custom icon (widget.icon -> CUSTOM_ICON_REGISTRY) when set,
  *  otherwise the equipment-type default. Mirrors the mobile card so a custom icon
  *  shows the same on phone and desktop (issue #318). */
@@ -66,7 +66,12 @@ interface EquipmentWidgetProps {
   onOpenDetail?: () => void;
 }
 
-export function EquipmentWidget({ widget, equipment, onExecuteOrder, onOpenDetail }: EquipmentWidgetProps) {
+export function EquipmentWidget({
+  widget,
+  equipment,
+  onExecuteOrder,
+  onOpenDetail,
+}: EquipmentWidgetProps) {
   const {
     isLight,
     isShutterFamily,
@@ -81,31 +86,132 @@ export function EquipmentWidget({ widget, equipment, onExecuteOrder, onOpenDetai
     isPoolPump,
     isPoolCover,
     isPoolHeatPump,
+    isMediaPlayer,
   } = useEquipmentState(equipment);
 
   const label = widget.label || equipment.name;
   const execOrder = (alias: string, value: unknown) => onExecuteOrder(equipment.id, alias, value);
 
-  if (isLight) return <LightEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
+  if (isLight)
+    return (
+      <LightEquipmentWidget
+        label={label}
+        equipment={equipment}
+        onExecuteOrder={execOrder}
+        iconKey={widget.icon}
+      />
+    );
   // Awnings share the shutter widget shape (icon + position + 3-button row).
   // ShutterEquipmentWidget swaps the icon (AwningWidgetIcon) and the vocabulary
   // (deployed/retracted, extend/retract) when type === "awning".
-  if (isShutterFamily) return <ShutterEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
-  if (isThermostat || isPoolHeatPump) return <ThermostatEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
-  if (isGate) return <GateEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
-  if (isHeater) return <HeaterEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
+  if (isShutterFamily)
+    return (
+      <ShutterEquipmentWidget
+        label={label}
+        equipment={equipment}
+        onExecuteOrder={execOrder}
+        iconKey={widget.icon}
+      />
+    );
+  if (isThermostat || isPoolHeatPump)
+    return (
+      <ThermostatEquipmentWidget
+        label={label}
+        equipment={equipment}
+        onExecuteOrder={execOrder}
+        iconKey={widget.icon}
+      />
+    );
+  if (isGate)
+    return (
+      <GateEquipmentWidget
+        label={label}
+        equipment={equipment}
+        onExecuteOrder={execOrder}
+        iconKey={widget.icon}
+      />
+    );
+  if (isHeater)
+    return (
+      <HeaterEquipmentWidget
+        label={label}
+        equipment={equipment}
+        onExecuteOrder={execOrder}
+        iconKey={widget.icon}
+      />
+    );
   if (isEnergyMeter) return <EnergyMeterEquipmentWidget label={label} equipment={equipment} />;
-  if (equipment.type === "solar_panel") return <SolarPanelEquipmentWidget label={label} equipment={equipment} />;
-  if (equipment.type === "switch") return <SwitchEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
-  if (equipment.type === "water_heater") return <WaterHeaterEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
+  if (equipment.type === "solar_panel")
+    return <SolarPanelEquipmentWidget label={label} equipment={equipment} />;
+  if (equipment.type === "switch")
+    return (
+      <SwitchEquipmentWidget
+        label={label}
+        equipment={equipment}
+        onExecuteOrder={execOrder}
+        iconKey={widget.icon}
+      />
+    );
+  if (equipment.type === "water_heater")
+    return (
+      <WaterHeaterEquipmentWidget
+        label={label}
+        equipment={equipment}
+        onExecuteOrder={execOrder}
+        iconKey={widget.icon}
+      />
+    );
   if (isWeatherForecast) return <WeatherForecastWidget label={label} equipment={equipment} />;
-  if (equipment.type === "weather") return <WeatherStationWidget label={label} equipment={equipment} onOpenDetail={onOpenDetail} />;
+  if (equipment.type === "weather")
+    return <WeatherStationWidget label={label} equipment={equipment} onOpenDetail={onOpenDetail} />;
   if (isAppliance) return <ApplianceEquipmentWidget label={label} equipment={equipment} />;
-  if (isWaterValve) return <WaterValveEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
-  if (isPoolPump) return <PoolPumpEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
-  if (isPoolCover) return <PoolCoverEquipmentWidget label={label} equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />;
-  if (isSensor) return <SensorEquipmentWidget label={label} equipment={equipment} iconKey={widget.icon} visibleBindings={widget.config?.visibleBindings} />;
-  if (equipment.type === "camera") return <CameraEquipmentWidget label={label} equipment={equipment} />;
+  if (isWaterValve)
+    return (
+      <WaterValveEquipmentWidget
+        label={label}
+        equipment={equipment}
+        onExecuteOrder={execOrder}
+        iconKey={widget.icon}
+      />
+    );
+  if (isPoolPump)
+    return (
+      <PoolPumpEquipmentWidget
+        label={label}
+        equipment={equipment}
+        onExecuteOrder={execOrder}
+        iconKey={widget.icon}
+      />
+    );
+  if (isPoolCover)
+    return (
+      <PoolCoverEquipmentWidget
+        label={label}
+        equipment={equipment}
+        onExecuteOrder={execOrder}
+        iconKey={widget.icon}
+      />
+    );
+  if (isSensor)
+    return (
+      <SensorEquipmentWidget
+        label={label}
+        equipment={equipment}
+        iconKey={widget.icon}
+        visibleBindings={widget.config?.visibleBindings}
+      />
+    );
+  if (equipment.type === "camera")
+    return <CameraEquipmentWidget label={label} equipment={equipment} />;
+  if (isMediaPlayer)
+    return (
+      <MediaPlayerEquipmentWidget
+        label={label}
+        equipment={equipment}
+        onExecuteOrder={execOrder}
+        iconKey={widget.icon}
+      />
+    );
 
   return <GenericEquipmentWidget label={label} equipment={equipment} />;
 }
@@ -141,9 +247,10 @@ function LightEquipmentWidget({
   const brightnessBinding = equipment.dataBindings.find(
     (db) => db.alias === "brightness" || db.category === "light_brightness",
   );
-  const deviceBrightness = brightnessBinding && typeof brightnessBinding.value === "number"
-    ? brightnessBinding.value
-    : null;
+  const deviceBrightness =
+    brightnessBinding && typeof brightnessBinding.value === "number"
+      ? brightnessBinding.value
+      : null;
   const brightness = slider.displayValue(deviceBrightness);
   const brightnessPct = brightness !== null ? Math.round((brightness / 254) * 100) : null;
 
@@ -159,19 +266,17 @@ function LightEquipmentWidget({
     setExecuting(true);
     try {
       const alias = toggleBinding.alias;
-      const onVal = toggleBinding.enumValues?.find(v => /^on$/i.test(v)) ?? "ON";
-      const offVal = toggleBinding.enumValues?.find(v => /^off$/i.test(v)) ?? "OFF";
-      const value = toggleBinding.type === "boolean" && alias !== "state"
-        ? !isOn
-        : (isOn ? offVal : onVal);
+      const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
+      const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
+      const value =
+        toggleBinding.type === "boolean" && alias !== "state" ? !isOn : isOn ? offVal : onVal;
       await onExecuteOrder(alias, value);
     } finally {
       setExecuting(false);
     }
   };
 
-  const handleBrightnessCommit = () =>
-    slider.onCommit((v) => onExecuteOrder("brightness", v));
+  const handleBrightnessCommit = () => slider.onCommit((v) => onExecuteOrder("brightness", v));
 
   return (
     <WidgetCard label={label}>
@@ -224,7 +329,11 @@ function LightEquipmentWidget({
             }`}
             title={isOn ? t("controls.turnOff") : t("controls.turnOn")}
           >
-            {executing ? <Loader2 size={16} className="animate-spin" /> : <Power size={16} strokeWidth={1.5} />}
+            {executing ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Power size={16} strokeWidth={1.5} />
+            )}
           </button>
         </div>
       )}
@@ -308,7 +417,11 @@ function SwitchEquipmentWidget({
             }`}
             title={isOn ? t("controls.turnOff") : t("controls.turnOn")}
           >
-            {executing ? <Loader2 size={16} className="animate-spin" /> : <Power size={16} strokeWidth={1.5} />}
+            {executing ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Power size={16} strokeWidth={1.5} />
+            )}
           </button>
         </div>
       )}
@@ -406,7 +519,11 @@ function WaterHeaterEquipmentWidget({
             }`}
             title={isOn ? t("controls.turnOff") : t("controls.turnOn")}
           >
-            {executing ? <Loader2 size={16} className="animate-spin" /> : <Power size={16} strokeWidth={1.5} />}
+            {executing ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Power size={16} strokeWidth={1.5} />
+            )}
           </button>
         </div>
       )}
@@ -435,12 +552,9 @@ function ShutterEquipmentWidget({
 
   const isAwning = equipment.type === "awning";
 
-  const positionBinding = equipment.dataBindings.find(
-    (db) => db.category === "shutter_position",
-  );
-  const devicePosition = positionBinding && typeof positionBinding.value === "number"
-    ? positionBinding.value
-    : null;
+  const positionBinding = equipment.dataBindings.find((db) => db.category === "shutter_position");
+  const devicePosition =
+    positionBinding && typeof positionBinding.value === "number" ? positionBinding.value : null;
   const position = slider.displayValue(devicePosition);
 
   // Category-first resolver — mirrors the detail variant below (spec 110).
@@ -458,7 +572,8 @@ function ShutterEquipmentWidget({
   // control — confirmed live: a stop command only makes the motor pause
   // briefly before it continues to its original target). The integration
   // signals this by omitting "STOP" from the move order's enumValues.
-  const hasStop = !moveBinding?.enumValues || moveBinding.enumValues.some((v) => v.toUpperCase() === "STOP");
+  const hasStop =
+    !moveBinding?.enumValues || moveBinding.enumValues.some((v) => v.toUpperCase() === "STOP");
   const level = position !== null ? shutterLevel(position) : null;
 
   // Awning vocabulary swap (mirrors ShutterControl):
@@ -497,12 +612,18 @@ function ShutterEquipmentWidget({
           {position === null ? (
             <span className="text-[16px] text-text-tertiary">{"\u2014"}</span>
           ) : position === 100 ? (
-            <span className="text-[13px] font-medium text-success px-2 py-0.5 rounded bg-success/10">{pillAtHundred}</span>
+            <span className="text-[13px] font-medium text-success px-2 py-0.5 rounded bg-success/10">
+              {pillAtHundred}
+            </span>
           ) : position === 0 ? (
-            <span className="text-[13px] font-medium text-text-secondary px-2 py-0.5 rounded bg-border-light">{pillAtZero}</span>
+            <span className="text-[13px] font-medium text-text-secondary px-2 py-0.5 rounded bg-border-light">
+              {pillAtZero}
+            </span>
           ) : (
             <div className="flex items-baseline gap-0.5">
-              <span className="text-[16px] font-semibold text-text tabular-nums leading-none">{position}</span>
+              <span className="text-[16px] font-semibold text-text tabular-nums leading-none">
+                {position}
+              </span>
               <span className="text-[12px] font-medium text-text-tertiary">%</span>
             </div>
           )}
@@ -518,7 +639,11 @@ function ShutterEquipmentWidget({
             className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
             title={openTitle}
           >
-            {executing ? <Loader2 size={16} className="animate-spin" /> : <ChevronUp size={16} strokeWidth={2} />}
+            {executing ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <ChevronUp size={16} strokeWidth={2} />
+            )}
           </button>
           {hasStop && (
             <button
@@ -583,7 +708,8 @@ function ThermostatEquipmentWidget({
     : typeof insideTempBinding?.value === "number"
       ? insideTempBinding.value
       : null;
-  const deviceSetpoint = typeof targetTempBinding?.value === "number" ? targetTempBinding.value : null;
+  const deviceSetpoint =
+    typeof targetTempBinding?.value === "number" ? targetTempBinding.value : null;
   const displaySetpoint = setpointOverride.displayValue(deviceSetpoint);
 
   const hasPowerOrder = !isPoolHeatPump && equipment.orderBindings.some((o) => o.alias === "power");
@@ -592,9 +718,8 @@ function ThermostatEquipmentWidget({
   const targetMax = targetTempOrder?.max ?? 30;
   const STEP = 0.5;
 
-  const thermometerLevel = displaySetpoint !== null
-    ? (displaySetpoint - targetMin) / (targetMax - targetMin)
-    : undefined;
+  const thermometerLevel =
+    displaySetpoint !== null ? (displaySetpoint - targetMin) / (targetMax - targetMin) : undefined;
 
   const handleSetpoint = (newValue: number) => {
     setpointOverride.onStart();
@@ -640,7 +765,11 @@ function ThermostatEquipmentWidget({
               }`}
               title={isOn ? t("controls.turnOff") : t("controls.turnOn")}
             >
-              {executing === "power" ? <Loader2 size={14} className="animate-spin" /> : <Power size={14} strokeWidth={1.5} />}
+              {executing === "power" ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Power size={14} strokeWidth={1.5} />
+              )}
             </button>
           )}
         </div>
@@ -696,9 +825,7 @@ function GateEquipmentWidget({
   const { t } = useTranslation();
   const [executing, setExecuting] = useState(false);
 
-  const stateBinding = equipment.dataBindings.find(
-    (db) => db.category === "gate_state",
-  );
+  const stateBinding = equipment.dataBindings.find((db) => db.category === "gate_state");
   const gateState = (stateBinding?.value as string) ?? "unknown";
   const isOpen = gateState === "open";
 
@@ -811,9 +938,7 @@ function HeaterEquipmentWidget({
         <div className="pl-2">
           <span
             className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
-              isComfort
-                ? "bg-error/10 text-error"
-                : "bg-primary/10 text-primary"
+              isComfort ? "bg-error/10 text-error" : "bg-primary/10 text-primary"
             }`}
           >
             {isComfort ? t("controls.heater.comfort") : t("controls.heater.eco")}
@@ -834,12 +959,13 @@ function HeaterEquipmentWidget({
             }`}
             title={isComfort ? t("controls.heater.switchEco") : t("controls.heater.switchComfort")}
           >
-            {executing
-              ? <Loader2 size={16} className="animate-spin" />
-              : isComfort
-                ? <Snowflake size={16} strokeWidth={1.5} />
-                : <Flame size={16} strokeWidth={1.5} />
-            }
+            {executing ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : isComfort ? (
+              <Snowflake size={16} strokeWidth={1.5} />
+            ) : (
+              <Flame size={16} strokeWidth={1.5} />
+            )}
           </button>
         </div>
       )}
@@ -865,14 +991,19 @@ function SensorEquipmentWidget({
   const { sensorBindings, batteryBindings, batteryAlert } = useEquipmentState(equipment);
 
   const customEntry = iconKey ? CUSTOM_ICON_REGISTRY[iconKey] : undefined;
-  const sensorIcon = customEntry
-    ? createElement(customEntry.component, customEntry.previewProps)
-    : <MultiSensorIcon />;
+  const sensorIcon = customEntry ? (
+    createElement(customEntry.component, customEntry.previewProps)
+  ) : (
+    <MultiSensorIcon />
+  );
 
   // Filter and order bindings according to visibleBindings config
-  const filteredBindings = visibleBindings && visibleBindings.length > 0
-    ? visibleBindings.map((alias) => sensorBindings.find((b) => b.alias === alias)).filter((b): b is typeof sensorBindings[number] => !!b)
-    : sensorBindings;
+  const filteredBindings =
+    visibleBindings && visibleBindings.length > 0
+      ? visibleBindings
+          .map((alias) => sensorBindings.find((b) => b.alias === alias))
+          .filter((b): b is (typeof sensorBindings)[number] => !!b)
+      : sensorBindings;
 
   return (
     <WidgetCard label={label}>
@@ -913,8 +1044,7 @@ function WeatherStationWidget({
   const outdoorExtremes = findTempExtremes(equipment, "temperature_outdoor");
   const indoorExtremes = findTempExtremes(equipment, "temperature");
 
-  const fmt = (b: typeof outdoor) =>
-    b && typeof b.value === "number" ? b.value.toFixed(1) : "—";
+  const fmt = (b: typeof outdoor) => (b && typeof b.value === "number" ? b.value.toFixed(1) : "—");
 
   const clickClass = onOpenDetail
     ? "cursor-pointer transition-colors hover:bg-primary-light/30"
@@ -930,14 +1060,30 @@ function WeatherStationWidget({
       <div className="flex items-stretch justify-center flex-1 min-h-0">
         {both ? (
           <div className="flex items-stretch gap-4 sm:gap-6">
-            <WeatherTempColumn label={t("weather.outdoor")} value={fmt(outdoor)} extremes={outdoorExtremes} />
+            <WeatherTempColumn
+              label={t("weather.outdoor")}
+              value={fmt(outdoor)}
+              extremes={outdoorExtremes}
+            />
             <div className="w-px bg-border self-stretch" />
-            <WeatherTempColumn label={t("weather.indoor")} value={fmt(indoor)} extremes={indoorExtremes} />
+            <WeatherTempColumn
+              label={t("weather.indoor")}
+              value={fmt(indoor)}
+              extremes={indoorExtremes}
+            />
           </div>
         ) : outdoor ? (
-          <WeatherTempColumn label={t("weather.outdoor")} value={fmt(outdoor)} extremes={outdoorExtremes} />
+          <WeatherTempColumn
+            label={t("weather.outdoor")}
+            value={fmt(outdoor)}
+            extremes={outdoorExtremes}
+          />
         ) : indoor ? (
-          <WeatherTempColumn label={t("weather.indoor")} value={fmt(indoor)} extremes={indoorExtremes} />
+          <WeatherTempColumn
+            label={t("weather.indoor")}
+            value={fmt(indoor)}
+            extremes={indoorExtremes}
+          />
         ) : (
           <WeatherTempColumn label={null} value="—" />
         )}
@@ -966,7 +1112,9 @@ function WeatherTempColumn({
         <span className="font-mono font-bold text-[32px] sm:text-[36px] text-text tabular-nums leading-none">
           {value}
         </span>
-        <span className="text-text-tertiary font-medium text-[14px] sm:text-[16px] leading-none ml-1">°C</span>
+        <span className="text-text-tertiary font-medium text-[14px] sm:text-[16px] leading-none ml-1">
+          °C
+        </span>
       </div>
       {extremes && <TempExtremes min={extremes.min} max={extremes.max} />}
     </div>
@@ -1019,7 +1167,9 @@ function EnergyMeterEquipmentWidget({
         <div className="flex flex-col items-start gap-1.5 pl-2">
           {/* Today's consumption — primary value (green for production meters) */}
           <div className="flex items-baseline gap-0.5">
-            <span className={`text-[20px] font-semibold ${primaryColor} tabular-nums leading-none font-mono`}>
+            <span
+              className={`text-[20px] font-semibold ${primaryColor} tabular-nums leading-none font-mono`}
+            >
               {formatWh(energyDay?.value)}
             </span>
             <span className="text-[11px] font-medium text-text-tertiary">
@@ -1111,12 +1261,15 @@ function ApplianceEquipmentWidget({
 
   const powerBinding = equipment.dataBindings.find((b) => b.alias === "power");
   const stateBinding = equipment.dataBindings.find((b) => b.alias === "state");
-  const remainingTimeStrBinding = equipment.dataBindings.find((b) => b.alias === "remaining_time_str");
+  const remainingTimeStrBinding = equipment.dataBindings.find(
+    (b) => b.alias === "remaining_time_str",
+  );
   const progressBinding = equipment.dataBindings.find((b) => b.alias === "progress");
 
   const isOn = powerBinding?.value === true;
   const state = typeof stateBinding?.value === "string" ? stateBinding.value : "off";
-  const remainingStr = typeof remainingTimeStrBinding?.value === "string" ? remainingTimeStrBinding.value : null;
+  const remainingStr =
+    typeof remainingTimeStrBinding?.value === "string" ? remainingTimeStrBinding.value : null;
   const progress = typeof progressBinding?.value === "number" ? progressBinding.value : 0;
 
   const isRunning = state === "running";
@@ -1128,7 +1281,13 @@ function ApplianceEquipmentWidget({
         <WashingMachine
           size={120}
           strokeWidth={0.8}
-          className={isRunning ? "text-accent animate-pulse" : isOn ? "text-text-secondary" : "text-text-tertiary"}
+          className={
+            isRunning
+              ? "text-accent animate-pulse"
+              : isOn
+                ? "text-text-secondary"
+                : "text-text-tertiary"
+          }
         />
 
         {!isOn || state === "off" ? (
@@ -1194,9 +1353,7 @@ function WaterValveEquipmentWidget({
     try {
       const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
       const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
-      const value = toggleBinding.type === "boolean"
-        ? !isOpen
-        : isOpen ? offVal : onVal;
+      const value = toggleBinding.type === "boolean" ? !isOpen : isOpen ? offVal : onVal;
       await onExecuteOrder(toggleBinding.alias, value);
     } finally {
       setExecuting(false);
@@ -1229,7 +1386,11 @@ function WaterValveEquipmentWidget({
             }`}
             title={isOpen ? t("controls.turnOff") : t("controls.turnOn")}
           >
-            {executing ? <Loader2 size={16} className="animate-spin" /> : <Power size={16} strokeWidth={1.5} />}
+            {executing ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Power size={16} strokeWidth={1.5} />
+            )}
           </button>
         </div>
       )}
@@ -1293,9 +1454,7 @@ function PoolPumpEquipmentWidget({
     try {
       const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
       const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
-      const value = toggleBinding.type === "boolean"
-        ? !isOn
-        : isOn ? offVal : onVal;
+      const value = toggleBinding.type === "boolean" ? !isOn : isOn ? offVal : onVal;
       await onExecuteOrder(toggleBinding.alias, value);
     } finally {
       setExecuting(false);
@@ -1331,7 +1490,11 @@ function PoolPumpEquipmentWidget({
             }`}
             title={isOn ? t("controls.turnOff") : t("controls.turnOn")}
           >
-            {executing ? <Loader2 size={16} className="animate-spin" /> : <Power size={16} strokeWidth={1.5} />}
+            {executing ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Power size={16} strokeWidth={1.5} />
+            )}
           </button>
         </div>
       )}
@@ -1368,9 +1531,7 @@ function PoolCoverEquipmentWidget({
       db.alias === "position",
   );
   const devicePosition =
-    positionBinding && typeof positionBinding.value === "number"
-      ? positionBinding.value
-      : null;
+    positionBinding && typeof positionBinding.value === "number" ? positionBinding.value : null;
   const position = slider.displayValue(devicePosition);
 
   // Find the move-style order binding by, in order:
@@ -1379,17 +1540,16 @@ function PoolCoverEquipmentWidget({
   //   3. enum values that look like OPEN/CLOSE/STOP
   // This covers freshly auto-bound pool covers as well as bindings created
   // before the category-aware aliasing landed.
-  const moveBinding = equipment.orderBindings.find(
-    (ob) => ob.category === "pool_cover_move" || ob.category === "shutter_move",
-  )
-    ?? equipment.orderBindings.find(
+  const moveBinding =
+    equipment.orderBindings.find(
+      (ob) => ob.category === "pool_cover_move" || ob.category === "shutter_move",
+    ) ??
+    equipment.orderBindings.find(
       (ob) => ob.alias === "state" || /shutter\d*_state/.test(ob.alias),
-    )
-    ?? equipment.orderBindings.find((ob) => {
+    ) ??
+    equipment.orderBindings.find((ob) => {
       if (ob.type !== "enum" || !ob.enumValues) return false;
-      const upper = ob.enumValues.map((v) =>
-        typeof v === "string" ? v.toUpperCase() : "",
-      );
+      const upper = ob.enumValues.map((v) => (typeof v === "string" ? v.toUpperCase() : ""));
       return upper.includes("OPEN") && upper.includes("CLOSE");
     });
 
@@ -1411,7 +1571,8 @@ function PoolCoverEquipmentWidget({
   // makes the motor pause briefly before it continues to its original
   // target). The integration signals this by omitting "STOP" from the
   // move order's enumValues.
-  const hasStop = !moveBinding?.enumValues || moveBinding.enumValues.some((v) => v.toUpperCase() === "STOP");
+  const hasStop =
+    !moveBinding?.enumValues || moveBinding.enumValues.some((v) => v.toUpperCase() === "STOP");
 
   return (
     <WidgetCard label={label}>
@@ -1453,7 +1614,11 @@ function PoolCoverEquipmentWidget({
             className="w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
             title={t("controls.open")}
           >
-            {executing ? <Loader2 size={16} className="animate-spin" /> : <ChevronLeft size={16} strokeWidth={2} />}
+            {executing ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <ChevronLeft size={16} strokeWidth={2} />
+            )}
           </button>
           {hasStop && (
             <button
@@ -1515,8 +1680,87 @@ function CameraEquipmentWidget({
               : "bg-border-light text-text-tertiary"
           }`}
         >
-          {monitoringBinding.value === true ? t("cameras.monitoring.on") : t("cameras.monitoring.off")}
+          {monitoringBinding.value === true
+            ? t("cameras.monitoring.on")
+            : t("cameras.monitoring.off")}
         </span>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ============================================================
+// Media player widget (issue #324) — mirrors the mobile card: Tv icon,
+// input source line, and a power toggle when an orders binding exposes it.
+// Without this branch a media_player fell through to the generic widget.
+// ============================================================
+
+function MediaPlayerEquipmentWidget({
+  label,
+  equipment,
+  onExecuteOrder,
+  iconKey,
+}: {
+  label: string;
+  equipment: EquipmentWithDetails;
+  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+  iconKey?: string;
+}) {
+  const [executing, setExecuting] = useState(false);
+
+  const powerBinding = equipment.dataBindings.find((b) => b.alias === "power");
+  const sourceBinding = equipment.dataBindings.find((b) => b.alias === "input_source");
+  const tvOn = powerBinding?.value === true;
+  const source = typeof sourceBinding?.value === "string" ? sourceBinding.value : null;
+
+  const toggleBinding = equipment.orderBindings.find((ob) => ob.alias === "power");
+  const hasToggle = !!toggleBinding;
+
+  const handleToggle = async () => {
+    if (executing || !toggleBinding) return;
+    setExecuting(true);
+    try {
+      await onExecuteOrder(toggleBinding.alias, !tvOn);
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  return (
+    <WidgetCard label={label}>
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
+        <div />
+        {resolveWidgetIcon(
+          iconKey,
+          <Tv size={64} strokeWidth={1} className={tvOn ? "text-primary" : "text-text-tertiary"} />,
+        )}
+        <div className="flex items-center gap-2 pl-2">
+          <span
+            className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
+              tvOn ? "bg-active/10 text-active" : "bg-border-light text-text-tertiary"
+            }`}
+          >
+            {tvOn ? (source ?? "ON") : "OFF"}
+          </span>
+        </div>
+      </div>
+
+      {hasToggle && equipment.enabled && (
+        <div className="flex justify-center gap-3 mt-auto pt-1">
+          <button
+            onClick={handleToggle}
+            disabled={executing}
+            className={`w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed ${
+              tvOn ? "!border-active/40 !text-active !bg-active/5" : ""
+            }`}
+          >
+            {executing ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Power size={16} strokeWidth={1.5} />
+            )}
+          </button>
+        </div>
       )}
     </WidgetCard>
   );
@@ -1549,7 +1793,9 @@ function GenericEquipmentWidget({
             </span>
           )}
           {stateBinding && (
-            <span className={`text-[11px] font-medium px-2 py-0.5 rounded-full ${isOn ? "bg-success/10 text-success" : "bg-border-light text-text-tertiary"}`}>
+            <span
+              className={`text-[11px] font-medium px-2 py-0.5 rounded-full ${isOn ? "bg-success/10 text-success" : "bg-border-light text-text-tertiary"}`}
+            >
               {isOn ? t("common.on") : t("common.off")}
             </span>
           )}

--- a/ui/src/components/dashboard/MobileWidgetCard.test.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "../../test-utils";
+import { MobileWidgetCard } from "./MobileWidgetCard";
+import type { DashboardWidget, EquipmentWithDetails } from "../../types";
+
+// Issue #323 — an energy_meter used to render a blank mobile card (label only)
+// because useMobileState had no isEnergyMeter branch. It now shows today's
+// consumption and the current power.
+
+function makeEnergyMeter(): EquipmentWithDetails {
+  return {
+    id: "em-1",
+    name: "Main meter",
+    zoneId: "z-1",
+    type: "energy_meter",
+    enabled: true,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    status: "online",
+    dataBindings: [
+      {
+        id: "db-d",
+        equipmentId: "em-1",
+        deviceDataId: "dd-d",
+        alias: "demand_5min",
+        deviceId: "dev-1",
+        deviceName: "Meter",
+        key: "demand_5min",
+        type: "number",
+        category: "power",
+        value: 800,
+        lastUpdated: "2026-01-01T00:00:00Z",
+        lastChanged: "2026-01-01T00:00:00Z",
+        stale: false,
+      },
+    ] as EquipmentWithDetails["dataBindings"],
+    orderBindings: [],
+    computedData: [{ alias: "energy_day", value: 1500, lastUpdated: "2026-01-01T00:00:00Z" }],
+  };
+}
+
+const widget: DashboardWidget = {
+  id: "w-1",
+  type: "equipment",
+  equipmentId: "em-1",
+  displayOrder: 0,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+describe("MobileWidgetCard", () => {
+  it("renders an energy_meter's today value and current power (issue #323)", () => {
+    render(<MobileWidgetCard widget={widget} equipment={makeEnergyMeter()} />);
+    // energy_day 1500 Wh -> 1.5 kWh, demand_5min 800 -> 800 W, joined by " · ".
+    expect(screen.getByText(/1\.5 kWh/)).toBeTruthy();
+    expect(screen.getByText(/800 W/)).toBeTruthy();
+  });
+
+  it("still shows the equipment label", () => {
+    render(<MobileWidgetCard widget={widget} equipment={makeEnergyMeter()} />);
+    expect(screen.getByText("Main meter")).toBeTruthy();
+  });
+});

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -3,7 +3,11 @@ import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import type { DashboardWidget, EquipmentWithDetails } from "../../types";
 import { useEquipmentState } from "../equipments/useEquipmentState";
-import { getSensorBindings, formatSensorValue, formatBooleanSensor } from "../equipments/sensorUtils";
+import {
+  getSensorBindings,
+  formatSensorValue,
+  formatBooleanSensor,
+} from "../equipments/sensorUtils";
 import {
   LightBulbIcon,
   ShutterWidgetIcon,
@@ -19,11 +23,16 @@ import {
   PoolPumpIcon,
   PoolCoverIcon,
   WaterValveWidgetIcon,
+  EnergyMeterIcon,
 } from "./WidgetIcons";
 import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
 import { SolarPanelIcon } from "../icons/SolarPanelIcon";
 import { solarWidgetState } from "./solarWidget";
-import { parseForecastDays, CONDITION_ICONS, CONDITION_COLORS } from "../equipments/weatherForecastUtils";
+import {
+  parseForecastDays,
+  CONDITION_ICONS,
+  CONDITION_COLORS,
+} from "../equipments/weatherForecastUtils";
 import { findTempExtremes, findTempIndoor, findTempOutdoor } from "../equipments/weather-utils";
 import { TempExtremes } from "../TempExtremes";
 import { Cloud, WashingMachine, Tv, Camera } from "lucide-react";
@@ -48,9 +57,11 @@ export function MobileWidgetCard({ widget, equipment, onClick, editMode }: Mobil
       } transition-transform`}
     >
       {/* Label */}
-      <span className={`text-[12px] font-semibold text-text truncate w-full text-center ${
-        editMode ? "pl-5 pr-8" : ""
-      }`}>
+      <span
+        className={`text-[12px] font-semibold text-text truncate w-full text-center ${
+          editMode ? "pl-5 pr-8" : ""
+        }`}
+      >
         {label}
       </span>
 
@@ -84,6 +95,7 @@ function useMobileState(
     isSensor,
     isWeatherForecast,
     isMediaPlayer,
+    isEnergyMeter,
     isAppliance,
     isWaterValve,
     isPoolPump,
@@ -99,15 +111,18 @@ function useMobileState(
     const brightness = equipment.dataBindings.find(
       (b) => b.alias === "brightness" || b.category === "light_brightness",
     );
-    const pct = brightness && typeof brightness.value === "number"
-      ? Math.round((brightness.value / 254) * 100)
-      : null;
+    const pct =
+      brightness && typeof brightness.value === "number"
+        ? Math.round((brightness.value / 254) * 100)
+        : null;
     const isDimmable = equipment.type === "light_dimmable" || equipment.type === "light_color";
     return {
-      icon: customEntry
-        ? createElement(customEntry.component, customEntry.previewProps)
-        : <LightBulbIcon on={isOn} />,
-      stateLines: [isDimmable && pct !== null ? `${pct}%` : (isOn ? "ON" : "OFF")],
+      icon: customEntry ? (
+        createElement(customEntry.component, customEntry.previewProps)
+      ) : (
+        <LightBulbIcon on={isOn} />
+      ),
+      stateLines: [isDimmable && pct !== null ? `${pct}%` : isOn ? "ON" : "OFF"],
     };
   }
 
@@ -115,17 +130,20 @@ function useMobileState(
     const pos = equipment.dataBindings.find((b) => b.category === "shutter_position");
     const position = pos && typeof pos.value === "number" ? pos.value : null;
     const level = position !== null ? shutterLevel(position) : null;
-    const text = position === 100
-      ? t("controls.opened")
-      : position === 0
-        ? t("controls.closed")
-        : position !== null
-          ? `${position}%`
-          : null;
+    const text =
+      position === 100
+        ? t("controls.opened")
+        : position === 0
+          ? t("controls.closed")
+          : position !== null
+            ? `${position}%`
+            : null;
     return {
-      icon: customEntry
-        ? createElement(customEntry.component, customEntry.previewProps)
-        : <ShutterWidgetIcon level={level} />,
+      icon: customEntry ? (
+        createElement(customEntry.component, customEntry.previewProps)
+      ) : (
+        <ShutterWidgetIcon level={level} />
+      ),
       stateLines: text ? [text] : [],
     };
   }
@@ -133,17 +151,20 @@ function useMobileState(
   if (isAwning) {
     const pos = equipment.dataBindings.find((b) => b.category === "shutter_position");
     const position = pos && typeof pos.value === "number" ? pos.value : null;
-    const text = position === 100
-      ? t("controls.deployed")
-      : position === 0
-        ? t("controls.retracted")
-        : position !== null
-          ? `${position}%`
-          : null;
+    const text =
+      position === 100
+        ? t("controls.deployed")
+        : position === 0
+          ? t("controls.retracted")
+          : position !== null
+            ? `${position}%`
+            : null;
     return {
-      icon: customEntry
-        ? createElement(customEntry.component, customEntry.previewProps)
-        : <AwningWidgetIcon deployed={position !== null && position > 0} />,
+      icon: customEntry ? (
+        createElement(customEntry.component, customEntry.previewProps)
+      ) : (
+        <AwningWidgetIcon deployed={position !== null && position > 0} />
+      ),
       stateLines: text ? [text] : [],
     };
   }
@@ -154,18 +175,21 @@ function useMobileState(
       ? equipment.computedData?.find((c) => c.alias === "effective_water_temperature")
       : null;
     const setpoint = equipment.dataBindings.find((b) => b.alias === "setpoint");
-    const tempVal = isPoolHeatPump && typeof computedTemp?.value === "number"
-      ? computedTemp.value
-      : typeof temp?.value === "number"
-        ? temp.value
-        : null;
+    const tempVal =
+      isPoolHeatPump && typeof computedTemp?.value === "number"
+        ? computedTemp.value
+        : typeof temp?.value === "number"
+          ? temp.value
+          : null;
     const spVal = typeof setpoint?.value === "number" ? setpoint.value : null;
     const minBound = isPoolHeatPump ? 10 : 16;
     const level = spVal !== null ? (spVal - minBound) / (30 - minBound) : undefined;
     return {
-      icon: customEntry
-        ? createElement(customEntry.component, customEntry.previewProps)
-        : <ThermometerIcon warm={isOn} level={level} />,
+      icon: customEntry ? (
+        createElement(customEntry.component, customEntry.previewProps)
+      ) : (
+        <ThermometerIcon warm={isOn} level={level} />
+      ),
       stateLines: tempVal !== null ? [`${tempVal.toFixed(1)}°C`] : [],
     };
   }
@@ -177,9 +201,12 @@ function useMobileState(
     const gateState = (stateBinding?.value as string) ?? "unknown";
     const isOpen = gateState === "open";
     const iconKey = widget.icon;
-    const GateIcon = iconKey === "sliding_gate" ? SlidingGateIcon
-      : iconKey === "garage_door" ? GarageDoorIcon
-      : GateWidgetIcon;
+    const GateIcon =
+      iconKey === "sliding_gate"
+        ? SlidingGateIcon
+        : iconKey === "garage_door"
+          ? GarageDoorIcon
+          : GateWidgetIcon;
     return {
       icon: <GateIcon open={isOpen} />,
       stateLines: [t(`controls.gate.${gateState}`)],
@@ -195,9 +222,11 @@ function useMobileState(
       : false;
     const isComfort = !relayOn;
     return {
-      icon: customEntry
-        ? createElement(customEntry.component, customEntry.previewProps)
-        : <HeaterWidgetIcon comfort={isComfort} />,
+      icon: customEntry ? (
+        createElement(customEntry.component, customEntry.previewProps)
+      ) : (
+        <HeaterWidgetIcon comfort={isComfort} />
+      ),
       stateLines: [isComfort ? t("controls.heater.comfort") : t("controls.heater.eco")],
     };
   }
@@ -271,14 +300,19 @@ function useMobileState(
   }
 
   if (isSensor) {
-    const sensorIcon = customEntry
-      ? createElement(customEntry.component, customEntry.previewProps)
-      : <MultiSensorIcon />;
+    const sensorIcon = customEntry ? (
+      createElement(customEntry.component, customEntry.previewProps)
+    ) : (
+      <MultiSensorIcon />
+    );
     const allSensorBindings = getSensorBindings(equipment.dataBindings);
     const visibleBindings = widget.config?.visibleBindings;
-    const sensorBindings = visibleBindings && visibleBindings.length > 0
-      ? visibleBindings.map((alias) => allSensorBindings.find((b) => b.alias === alias)).filter((b): b is typeof allSensorBindings[number] => !!b)
-      : allSensorBindings;
+    const sensorBindings =
+      visibleBindings && visibleBindings.length > 0
+        ? visibleBindings
+            .map((alias) => allSensorBindings.find((b) => b.alias === alias))
+            .filter((b): b is (typeof allSensorBindings)[number] => !!b)
+        : allSensorBindings;
     const lines: string[] = [];
     for (const b of sensorBindings.slice(0, 2)) {
       if (b.value !== null && b.value !== undefined) {
@@ -300,7 +334,7 @@ function useMobileState(
     const tomorrow = days[0];
     if (tomorrow) {
       const ConditionIcon = tomorrow.condition
-        ? CONDITION_ICONS[tomorrow.condition] ?? Cloud
+        ? (CONDITION_ICONS[tomorrow.condition] ?? Cloud)
         : Cloud;
       const conditionColor = tomorrow.condition
         ? (CONDITION_COLORS[tomorrow.condition] ?? "text-text-tertiary")
@@ -319,7 +353,10 @@ function useMobileState(
         stateLines: lines,
       };
     }
-    return { icon: <Cloud size={96} strokeWidth={1.2} className="text-text-tertiary" />, stateLines: [] };
+    return {
+      icon: <Cloud size={96} strokeWidth={1.2} className="text-text-tertiary" />,
+      stateLines: [],
+    };
   }
 
   if (isAppliance) {
@@ -328,7 +365,8 @@ function useMobileState(
     const remainingBinding = equipment.dataBindings.find((b) => b.alias === "remaining_time_str");
     const applianceOn = powerBinding?.value === true;
     const state = typeof stateBinding?.value === "string" ? stateBinding.value : "off";
-    const remainingStr = typeof remainingBinding?.value === "string" ? remainingBinding.value : null;
+    const remainingStr =
+      typeof remainingBinding?.value === "string" ? remainingBinding.value : null;
     const isRunning = state === "running";
 
     const lines: string[] = [];
@@ -340,7 +378,13 @@ function useMobileState(
       lines.push(state === "paused" ? t("common.paused") : state === "ready" ? "Ready" : state);
     }
     return {
-      icon: <WashingMachine size={96} strokeWidth={1} className={isRunning ? "text-accent" : "text-text-tertiary"} />,
+      icon: (
+        <WashingMachine
+          size={96}
+          strokeWidth={1}
+          className={isRunning ? "text-accent" : "text-text-tertiary"}
+        />
+      ),
       stateLines: lines,
     };
   }
@@ -351,7 +395,9 @@ function useMobileState(
     const tvOn = powerBinding?.value === true;
     const source = typeof sourceBinding?.value === "string" ? sourceBinding.value : null;
     return {
-      icon: <Tv size={96} strokeWidth={1} className={tvOn ? "text-primary" : "text-text-tertiary"} />,
+      icon: (
+        <Tv size={96} strokeWidth={1} className={tvOn ? "text-primary" : "text-text-tertiary"} />
+      ),
       stateLines: tvOn && source ? [source] : ["OFF"],
     };
   }
@@ -373,9 +419,11 @@ function useMobileState(
   // Switch / generic
   if (equipment.type === "switch") {
     return {
-      icon: customEntry
-        ? createElement(customEntry.component, customEntry.previewProps)
-        : <PlugWidgetIcon on={isOn} />,
+      icon: customEntry ? (
+        createElement(customEntry.component, customEntry.previewProps)
+      ) : (
+        <PlugWidgetIcon on={isOn} />
+      ),
       stateLines: [isOn ? "ON" : "OFF"],
     };
   }
@@ -384,9 +432,11 @@ function useMobileState(
     const waterTemp = equipment.dataBindings.find((db) => db.alias === "water_temperature");
     const tempValue = typeof waterTemp?.value === "number" ? waterTemp.value : null;
     return {
-      icon: customEntry
-        ? createElement(customEntry.component, customEntry.previewProps)
-        : <WaterHeaterIcon on={isOn} />,
+      icon: customEntry ? (
+        createElement(customEntry.component, customEntry.previewProps)
+      ) : (
+        <WaterHeaterIcon on={isOn} />
+      ),
       stateLines: [
         isOn ? "ON" : "OFF",
         ...(tempValue !== null ? [`${tempValue.toFixed(1)}°C`] : []),
@@ -396,18 +446,22 @@ function useMobileState(
 
   if (isWaterValve) {
     return {
-      icon: customEntry
-        ? createElement(customEntry.component, customEntry.previewProps)
-        : <WaterValveWidgetIcon open={isOn} />,
+      icon: customEntry ? (
+        createElement(customEntry.component, customEntry.previewProps)
+      ) : (
+        <WaterValveWidgetIcon open={isOn} />
+      ),
       stateLines: [isOn ? t("water.open") : t("water.closed")],
     };
   }
 
   if (isPoolPump) {
     return {
-      icon: customEntry
-        ? createElement(customEntry.component, customEntry.previewProps)
-        : <PoolPumpIcon on={isOn} />,
+      icon: customEntry ? (
+        createElement(customEntry.component, customEntry.previewProps)
+      ) : (
+        <PoolPumpIcon on={isOn} />
+      ),
       stateLines: [isOn ? "ON" : "OFF"],
     };
   }
@@ -417,17 +471,20 @@ function useMobileState(
       (b) => b.category === "shutter_position" || b.alias === "position",
     );
     const position = pos && typeof pos.value === "number" ? pos.value : null;
-    const text = position === 100
-      ? t("controls.opened")
-      : position === 0
-        ? t("controls.closed")
-        : position !== null
-          ? `${position}%`
-          : null;
+    const text =
+      position === 100
+        ? t("controls.opened")
+        : position === 0
+          ? t("controls.closed")
+          : position !== null
+            ? `${position}%`
+            : null;
     return {
-      icon: customEntry
-        ? createElement(customEntry.component, customEntry.previewProps)
-        : <PoolCoverIcon position={position} />,
+      icon: customEntry ? (
+        createElement(customEntry.component, customEntry.previewProps)
+      ) : (
+        <PoolCoverIcon position={position} />
+      ),
       stateLines: text ? [text] : [],
     };
   }
@@ -441,6 +498,29 @@ function useMobileState(
           ? [monitoring.value === true ? t("cameras.monitoring.on") : t("cameras.monitoring.off")]
           : [],
     };
+  }
+
+  // Energy meter — mirrors the desktop EnergyMeterEquipmentWidget (issue #323):
+  // today's consumption from computedData `energy_day`, plus current power
+  // (`demand_5min`) when present. Without this branch the card rendered blank.
+  if (isEnergyMeter) {
+    const computed = equipment.computedData ?? [];
+    const energyDay = computed.find((c) => c.alias === "energy_day");
+    const demandBinding = equipment.dataBindings.find((b) => b.alias === "demand_5min");
+    const demandW = typeof demandBinding?.value === "number" ? demandBinding.value : null;
+    const fmtWh = (wh: unknown): string =>
+      typeof wh !== "number"
+        ? "—"
+        : wh >= 1000
+          ? `${(wh / 1000).toFixed(1)} kWh`
+          : `${Math.round(wh)} Wh`;
+    const lines = [fmtWh(energyDay?.value)];
+    if (demandW !== null) {
+      lines.push(
+        demandW >= 1000 ? `${(demandW / 1000).toFixed(1)} kW` : `${Math.round(demandW)} W`,
+      );
+    }
+    return { icon: <EnergyMeterIcon />, stateLines: lines };
   }
 
   return { icon: null, stateLines: [] };


### PR DESCRIPTION
## What

Two symptoms of the dashboard mobile ↔ desktop render-path drift (the shared origin tracked in #325):

- **#323** — an `energy_meter` / `energy_production_meter` showed a **blank mobile card** (label only). `useMobileState` had no `isEnergyMeter` branch, so it fell through to `{ icon: null, stateLines: [] }`. Added a branch mirroring the desktop `EnergyMeterEquipmentWidget`: `EnergyMeterIcon`, today's consumption (`computedData.energy_day`, formatted Wh/kWh), and current power (`demand_5min`) when present.
- **#324** — a `media_player` rendered the **generic widget on desktop**. `EquipmentWidget` had no media-player branch. Added `MediaPlayerEquipmentWidget` mirroring the mobile card: Tv icon, `input_source` line, and a power toggle when an order binding exposes `power`.

Both `is*` flags were already exposed by `useEquipmentState`; only the consuming branch was missing on one render path — a minimal, behavior-mirroring fix, not a refactor.

## Tests (issue #458 tier)

- `EquipmentWidget.test.tsx`: the desktop `media_player` renders its source (`HDMI1`) and its toggle fires `onExecuteOrder("tv-1", "power", false)`.
- `MobileWidgetCard.test.tsx` (new): the mobile `energy_meter` shows `1.5 kWh` and `800 W` (was blank).

UI suite: **337 tests** (was 334). `tsc -b`, eslint clean.

## Note

This does not fix the *root cause* (three independent render paths that keep drifting) — that is the resolver consolidation in #325, which I'll bring as a separate design proposal. These two are the concrete user-visible regressions, fixed directly.

Closes #323
Closes #324