### PR TITLE
refactor(ui): share the universal publisher mapping-source layer (#457)

### DIFF
--- a/ui/src/components/publishers/MappingSourceFields.test.tsx
+++ b/ui/src/components/publishers/MappingSourceFields.test.tsx
@@ -57,6 +57,20 @@ describe("MappingSourceFields", () => {
     expect(screen.getByRole("option", { name: "motion" })).toBeTruthy();
   });
 
+  it("uses recipeOptionLabel for recipe options when provided (notif page)", () => {
+    const inst = { id: "ri-1", recipeId: "r-1", params: {}, state: {} } as Parameters<
+      typeof MappingSourceFields
+    >[0]["recipeInstances"][number];
+    renderFields({
+      sourceType: "recipe",
+      sourceId: "",
+      recipeInstances: [inst],
+      recipes: [{ id: "r-1", name: "State Watch" } as never],
+      recipeOptionLabel: (i) => `${i.recipeId} (Washer)`,
+    });
+    expect(screen.getByRole("option", { name: "r-1 (Washer)" })).toBeTruthy();
+  });
+
   it("resets the downstream selections when the source type changes", () => {
     const props = renderFields();
     const sourceTypeSelect = screen.getAllByRole("combobox")[0];

--- a/ui/src/components/publishers/MappingSourceFields.test.tsx
+++ b/ui/src/components/publishers/MappingSourceFields.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "../../test-utils";
+import { MappingSourceFields } from "./MappingSourceFields";
+import type { EquipmentWithDetails } from "../../types";
+
+// The shared publisher mapping-source selector (issue #457). These pin the
+// universal behaviour both the MQTT and notification pages now rely on: the key
+// options follow the selected source, and switching source type resets the
+// downstream selections.
+
+function equipmentWithKeys(id: string, aliases: string[]): EquipmentWithDetails {
+  return {
+    id,
+    name: id,
+    zoneId: "z-1",
+    type: "sensor",
+    enabled: true,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    status: "online",
+    dataBindings: aliases.map((alias) => ({ alias })) as EquipmentWithDetails["dataBindings"],
+    orderBindings: [],
+  };
+}
+
+function renderFields(over: Partial<Parameters<typeof MappingSourceFields>[0]> = {}) {
+  const props = {
+    keyPrefix: "mqttPublishers",
+    sourceType: "equipment" as const,
+    setSourceType: vi.fn(),
+    sourceId: "eq-1",
+    setSourceId: vi.fn(),
+    sourceKey: "",
+    setSourceKey: vi.fn(),
+    filterZoneId: "",
+    setFilterZoneId: vi.fn(),
+    equipments: [equipmentWithKeys("eq-1", ["temperature", "humidity"])],
+    zones: [{ id: "z-1", label: "Salon" }] as Parameters<typeof MappingSourceFields>[0]["zones"],
+    recipeInstances: [],
+    recipes: [],
+    ...over,
+  };
+  render(<MappingSourceFields {...props} />);
+  return props;
+}
+
+describe("MappingSourceFields", () => {
+  it("lists the selected equipment's binding aliases as key options", () => {
+    renderFields();
+    expect(screen.getByRole("option", { name: "temperature" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "humidity" })).toBeTruthy();
+  });
+
+  it("lists the zone aggregate keys when the source is a zone", () => {
+    renderFields({ sourceType: "zone", sourceId: "z-1" });
+    // motion is a zone-aggregate key, never an equipment binding alias here.
+    expect(screen.getByRole("option", { name: "motion" })).toBeTruthy();
+  });
+
+  it("resets the downstream selections when the source type changes", () => {
+    const props = renderFields();
+    const sourceTypeSelect = screen.getAllByRole("combobox")[0];
+    fireEvent.change(sourceTypeSelect, { target: { value: "zone" } });
+    expect(props.setSourceType).toHaveBeenCalledWith("zone");
+    expect(props.setFilterZoneId).toHaveBeenCalledWith("");
+    expect(props.setSourceId).toHaveBeenCalledWith("");
+    expect(props.setSourceKey).toHaveBeenCalledWith("");
+  });
+});

--- a/ui/src/components/publishers/MappingSourceFields.tsx
+++ b/ui/src/components/publishers/MappingSourceFields.tsx
@@ -24,6 +24,13 @@ interface MappingSourceFieldsProps {
   zones: ZoneOption[];
   recipeInstances: RecipeInstance[];
   recipes: RecipeInfo[];
+  /**
+   * How a recipe instance is labelled in the dropdown. Defaults to the recipe
+   * name (the MQTT page behaviour); the notification page passes a richer label
+   * that appends the target equipment names so identical recipes are
+   * distinguishable.
+   */
+  recipeOptionLabel?: (inst: RecipeInstance) => string;
 }
 
 export function MappingSourceFields({
@@ -40,6 +47,7 @@ export function MappingSourceFields({
   zones,
   recipeInstances,
   recipes,
+  recipeOptionLabel,
 }: MappingSourceFieldsProps) {
   const { t } = useTranslation();
   const k = (suffix: string) => t(`${keyPrefix}.${suffix}`);
@@ -142,14 +150,13 @@ export function MappingSourceFields({
             className={selectClass}
           >
             <option value="">{k("selectSource")}</option>
-            {filteredRecipeInstances.map((inst) => {
-              const recipe = recipes.find((r) => r.id === inst.recipeId);
-              return (
-                <option key={inst.id} value={inst.id}>
-                  {recipe?.name ?? inst.recipeId}
-                </option>
-              );
-            })}
+            {filteredRecipeInstances.map((inst) => (
+              <option key={inst.id} value={inst.id}>
+                {recipeOptionLabel
+                  ? recipeOptionLabel(inst)
+                  : (recipes.find((r) => r.id === inst.recipeId)?.name ?? inst.recipeId)}
+              </option>
+            ))}
           </select>
         </div>
       )}

--- a/ui/src/components/publishers/MappingSourceFields.tsx
+++ b/ui/src/components/publishers/MappingSourceFields.tsx
@@ -1,0 +1,175 @@
+import { useTranslation } from "react-i18next";
+import type { EquipmentWithDetails, RecipeInstance, RecipeInfo } from "../../types";
+import { type ZoneOption, zoneChainMap, equipmentLabelMap } from "../../lib/zone-path";
+import { mappingSourceKeys, type MappingSourceType } from "./mapping-source";
+
+// The universal "publisher mapping source" selector (issue #457): pick a source
+// (equipment / zone / recipe), optionally filter equipments and recipes by
+// zone, then pick one of the source's keys. Identical across every publisher
+// transport (MQTT, Telegram, Web Push, ...), so it lives once here. Callers own
+// the surrounding grid, the transport-specific payload field (a publish key, a
+// message, ...) and the submit buttons. The i18n keys differ only by prefix, so
+// callers pass `keyPrefix` ("mqttPublishers" | "notifPublishers").
+interface MappingSourceFieldsProps {
+  keyPrefix: string;
+  sourceType: MappingSourceType;
+  setSourceType: (v: MappingSourceType) => void;
+  sourceId: string;
+  setSourceId: (v: string) => void;
+  sourceKey: string;
+  setSourceKey: (v: string) => void;
+  filterZoneId: string;
+  setFilterZoneId: (v: string) => void;
+  equipments: EquipmentWithDetails[];
+  zones: ZoneOption[];
+  recipeInstances: RecipeInstance[];
+  recipes: RecipeInfo[];
+}
+
+export function MappingSourceFields({
+  keyPrefix,
+  sourceType,
+  setSourceType,
+  sourceId,
+  setSourceId,
+  sourceKey,
+  setSourceKey,
+  filterZoneId,
+  setFilterZoneId,
+  equipments,
+  zones,
+  recipeInstances,
+  recipes,
+}: MappingSourceFieldsProps) {
+  const { t } = useTranslation();
+  const k = (suffix: string) => t(`${keyPrefix}.${suffix}`);
+
+  const filteredEquipments = filterZoneId
+    ? equipments.filter((e) => e.zoneId === filterZoneId)
+    : equipments;
+
+  // Homonym equipments get a "name - zone" label (spec 139), qualified only
+  // against the other candidates in this dropdown.
+  const eqLabels = equipmentLabelMap(filteredEquipments, zoneChainMap(zones));
+
+  const filteredRecipeInstances = filterZoneId
+    ? recipeInstances.filter((i) => i.params.zone === filterZoneId)
+    : recipeInstances;
+
+  const availableKeys = mappingSourceKeys(sourceType, sourceId, { equipments, recipeInstances });
+
+  const handleSourceTypeChange = (val: MappingSourceType) => {
+    setSourceType(val);
+    setFilterZoneId("");
+    setSourceId("");
+    setSourceKey("");
+  };
+
+  const selectClass =
+    "w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text";
+  const labelClass = "block text-[11px] text-text-secondary mb-1";
+
+  return (
+    <>
+      <div>
+        <label className={labelClass}>{k("sourceType")}</label>
+        <select
+          value={sourceType}
+          onChange={(e) => handleSourceTypeChange(e.target.value as MappingSourceType)}
+          className={selectClass}
+        >
+          <option value="equipment">{k("equipment")}</option>
+          <option value="zone">{k("zone")}</option>
+          <option value="recipe">{k("recipe")}</option>
+        </select>
+      </div>
+
+      <div>
+        <label className={labelClass}>{k("zone")}</label>
+        <select
+          value={sourceType === "zone" ? sourceId : filterZoneId}
+          onChange={(e) => {
+            if (sourceType === "zone") {
+              setSourceId(e.target.value);
+              setSourceKey("");
+            } else {
+              setFilterZoneId(e.target.value);
+              setSourceId("");
+              setSourceKey("");
+            }
+          }}
+          className={selectClass}
+        >
+          <option value="">{sourceType === "zone" ? k("selectSource") : k("allZones")}</option>
+          {zones.map((z) => (
+            <option key={z.id} value={z.id}>
+              {z.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {sourceType === "equipment" && (
+        <div>
+          <label className={labelClass}>{k("equipment")}</label>
+          <select
+            value={sourceId}
+            onChange={(e) => {
+              setSourceId(e.target.value);
+              setSourceKey("");
+            }}
+            className={selectClass}
+          >
+            <option value="">{k("selectSource")}</option>
+            {filteredEquipments.map((eq) => (
+              <option key={eq.id} value={eq.id}>
+                {eqLabels.get(eq.id) ?? eq.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {sourceType === "recipe" && (
+        <div>
+          <label className={labelClass}>{k("recipeInstance")}</label>
+          <select
+            value={sourceId}
+            onChange={(e) => {
+              setSourceId(e.target.value);
+              setSourceKey("");
+            }}
+            className={selectClass}
+          >
+            <option value="">{k("selectSource")}</option>
+            {filteredRecipeInstances.map((inst) => {
+              const recipe = recipes.find((r) => r.id === inst.recipeId);
+              return (
+                <option key={inst.id} value={inst.id}>
+                  {recipe?.name ?? inst.recipeId}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+      )}
+
+      <div>
+        <label className={labelClass}>{k("sourceKey")}</label>
+        <select
+          value={sourceKey}
+          onChange={(e) => setSourceKey(e.target.value)}
+          className={selectClass}
+          disabled={!sourceId}
+        >
+          <option value="">{k("selectKey")}</option>
+          {availableKeys.map((key) => (
+            <option key={key} value={key}>
+              {key}
+            </option>
+          ))}
+        </select>
+      </div>
+    </>
+  );
+}

--- a/ui/src/components/publishers/mapping-source.ts
+++ b/ui/src/components/publishers/mapping-source.ts
@@ -1,0 +1,58 @@
+import type { EquipmentWithDetails, RecipeInstance } from "../../types";
+
+// Universal "publisher mapping source" concepts (issue #457). Every publisher —
+// MQTT, Telegram, Web Push, and any future transport — maps the same source
+// space (an equipment / a zone / a recipe instance and one of its keys) onto a
+// transport-specific payload. Only the source selection is shared here; the
+// payload (a topic value, a message, ...) is owned by each transport.
+
+export type MappingSourceType = "equipment" | "zone" | "recipe";
+
+/** Aggregated keys a zone exposes, shared by every publisher's source picker. */
+export const ZONE_AGG_KEYS = [
+  "temperature",
+  "humidity",
+  "luminosity",
+  "motion",
+  "motionSensors",
+  "openDoors",
+  "openWindows",
+  "waterLeak",
+  "smoke",
+  "lightsOn",
+  "lightsTotal",
+  "shuttersOpen",
+  "shuttersTotal",
+  "averageShutterPosition",
+  "awningsDeployed",
+  "awningsTotal",
+  "isDaylight",
+];
+
+export interface MappingSourceContext {
+  equipments: EquipmentWithDetails[];
+  recipeInstances: RecipeInstance[];
+}
+
+/**
+ * The keys selectable for a given source, identical across all publishers:
+ * - zone: the aggregated ZONE_AGG_KEYS
+ * - equipment: its data-binding aliases
+ * - recipe: the keys of the running instance's state
+ */
+export function mappingSourceKeys(
+  sourceType: MappingSourceType,
+  sourceId: string,
+  { equipments, recipeInstances }: MappingSourceContext,
+): string[] {
+  if (sourceType === "zone") return ZONE_AGG_KEYS;
+  if (sourceType === "equipment" && sourceId) {
+    const eq = equipments.find((e) => e.id === sourceId);
+    if (eq) return eq.dataBindings.map((b) => b.alias);
+  }
+  if (sourceType === "recipe" && sourceId) {
+    const inst = recipeInstances.find((i) => i.id === sourceId);
+    if (inst?.state) return Object.keys(inst.state);
+  }
+  return [];
+}

--- a/ui/src/pages/MqttPublishersPage.tsx
+++ b/ui/src/pages/MqttPublishersPage.tsx
@@ -40,27 +40,13 @@ import type {
   RecipeInfo,
   MqttBroker,
 } from "../types";
-import { equipmentLabelMap, flattenZonesWithPath, zoneChainMap, type ZoneOption } from "../lib/zone-path";
-
-const ZONE_AGG_KEYS = [
-  "temperature",
-  "humidity",
-  "luminosity",
-  "motion",
-  "motionSensors",
-  "openDoors",
-  "openWindows",
-  "waterLeak",
-  "smoke",
-  "lightsOn",
-  "lightsTotal",
-  "shuttersOpen",
-  "shuttersTotal",
-  "averageShutterPosition",
-  "awningsDeployed",
-  "awningsTotal",
-  "isDaylight",
-];
+import {
+  equipmentLabelMap,
+  flattenZonesWithPath,
+  zoneChainMap,
+  type ZoneOption,
+} from "../lib/zone-path";
+import { MappingSourceFields } from "../components/publishers/MappingSourceFields";
 
 export function MqttPublishersPage() {
   const { t } = useTranslation();
@@ -114,13 +100,9 @@ export function MqttPublishersPage() {
       <div className="mb-6">
         <div className="flex items-center gap-2.5 mb-1">
           <Send size={22} strokeWidth={1.5} className="text-text-secondary" />
-          <h1>
-            {t("mqttPublishers.title")}
-          </h1>
+          <h1>{t("mqttPublishers.title")}</h1>
         </div>
-        <p className="text-[13px] text-text-secondary mt-1">
-          {t("mqttPublishers.subtitle")}
-        </p>
+        <p className="text-[13px] text-text-secondary mt-1">{t("mqttPublishers.subtitle")}</p>
       </div>
 
       {/* Brokers section */}
@@ -133,9 +115,7 @@ export function MqttPublishersPage() {
           {t("mqttPublishers.brokers")} ({brokers.length})
           {showBrokers ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
         </button>
-        {showBrokers && (
-          <BrokersSection brokers={brokers} onRefresh={load} />
-        )}
+        {showBrokers && <BrokersSection brokers={brokers} onRefresh={load} />}
       </div>
 
       {/* Actions */}
@@ -190,13 +170,7 @@ export function MqttPublishersPage() {
 
 // ── Brokers section ───────────────────────────────────────────
 
-function BrokersSection({
-  brokers,
-  onRefresh,
-}: {
-  brokers: MqttBroker[];
-  onRefresh: () => void;
-}) {
+function BrokersSection({ brokers, onRefresh }: { brokers: MqttBroker[]; onRefresh: () => void }) {
   const { t } = useTranslation();
   const [showAdd, setShowAdd] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -233,7 +207,9 @@ function BrokersSection({
               <div className="text-[13px] font-medium text-text">{broker.name}</div>
               <div className="text-[12px] text-text-tertiary font-mono">{broker.url}</div>
               {broker.username && (
-                <div className="text-[11px] text-text-tertiary">{t("mqttPublishers.brokerUsername")}: {broker.username}</div>
+                <div className="text-[11px] text-text-tertiary">
+                  {t("mqttPublishers.brokerUsername")}: {broker.username}
+                </div>
               )}
             </div>
             <div className="flex items-center gap-1">
@@ -323,7 +299,10 @@ function BrokerForm({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="p-4 bg-surface rounded-[10px] border border-border max-w-lg">
+    <form
+      onSubmit={handleSubmit}
+      className="p-4 bg-surface rounded-[10px] border border-border max-w-lg"
+    >
       <div className="space-y-3">
         <div>
           <label className="block text-[12px] text-text-secondary mb-1">
@@ -379,7 +358,13 @@ function BrokerForm({
             disabled={saving || !name.trim() || !url.trim()}
             className="px-4 py-1.5 bg-primary text-white text-[13px] rounded-[6px] hover:bg-primary-hover disabled:opacity-50"
           >
-            {saving ? <Loader2 size={14} className="animate-spin" /> : broker ? t("common.save") : t("common.create")}
+            {saving ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : broker ? (
+              t("common.save")
+            ) : (
+              t("common.create")
+            )}
           </button>
           <button
             type="button"
@@ -429,7 +414,12 @@ function PublisherForm({
           onChangeOnly,
         });
       } else {
-        await createMqttPublisher({ name: name.trim(), brokerId, topic: topic.trim(), onChangeOnly });
+        await createMqttPublisher({
+          name: name.trim(),
+          brokerId,
+          topic: topic.trim(),
+          onChangeOnly,
+        });
       }
       onSaved();
     } catch {
@@ -440,7 +430,10 @@ function PublisherForm({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="mb-4 p-4 bg-surface rounded-[10px] border border-border max-w-lg">
+    <form
+      onSubmit={handleSubmit}
+      className="mb-4 p-4 bg-surface rounded-[10px] border border-border max-w-lg"
+    >
       <div className="space-y-3">
         <div>
           <label className="block text-[12px] text-text-secondary mb-1">
@@ -501,7 +494,13 @@ function PublisherForm({
             disabled={saving || !name.trim() || !brokerId || !topic.trim()}
             className="px-4 py-1.5 bg-primary text-white text-[13px] rounded-[6px] hover:bg-primary-hover disabled:opacity-50"
           >
-            {saving ? <Loader2 size={14} className="animate-spin" /> : publisher ? t("common.save") : t("common.create")}
+            {saving ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : publisher ? (
+              t("common.save")
+            ) : (
+              t("common.create")
+            )}
           </button>
           <button
             type="button"
@@ -604,7 +603,9 @@ function PublisherCard({
   const resolveSourceLabel = (mapping: MqttPublisherMapping): string => {
     if (mapping.sourceType === "equipment") {
       const eq = equipments.find((e) => e.id === mapping.sourceId);
-      return eq ? `${eqLabels.get(eq.id) ?? eq.name} → ${mapping.sourceKey}` : `??? → ${mapping.sourceKey}`;
+      return eq
+        ? `${eqLabels.get(eq.id) ?? eq.name} → ${mapping.sourceKey}`
+        : `??? → ${mapping.sourceKey}`;
     }
     if (mapping.sourceType === "recipe") {
       const inst = recipeInstances.find((i) => i.id === mapping.sourceId);
@@ -617,7 +618,9 @@ function PublisherCard({
   };
 
   return (
-    <div className={`p-4 bg-surface rounded-[10px] border ${publisher.enabled ? "border-border" : "border-border opacity-60"}`}>
+    <div
+      className={`p-4 bg-surface rounded-[10px] border ${publisher.enabled ? "border-border" : "border-border opacity-60"}`}
+    >
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-3">
@@ -625,11 +628,7 @@ function PublisherCard({
           <div>
             <h3 className="text-[14px] font-medium text-text">{publisher.name}</h3>
             <span className="text-[12px] text-text-tertiary font-mono">{publisher.topic}</span>
-            {broker && (
-              <span className="ml-2 text-[11px] text-text-tertiary">
-                → {broker.name}
-              </span>
-            )}
+            {broker && <span className="ml-2 text-[11px] text-text-tertiary">→ {broker.name}</span>}
             {publisher.onChangeOnly && (
               <span className="ml-2 text-[11px] text-primary bg-primary/10 px-1.5 py-0.5 rounded">
                 {t("mqttPublishers.onChangeOnlyBadge")}
@@ -649,11 +648,7 @@ function PublisherCard({
             className="flex items-center gap-1 px-2 py-1 text-[11px] rounded-[6px] hover:bg-bg transition-colors text-text-secondary hover:text-accent disabled:opacity-40"
             title={t("mqttPublishers.testPublish")}
           >
-            {testing ? (
-              <Loader2 size={13} className="animate-spin" />
-            ) : (
-              <Zap size={13} />
-            )}
+            {testing ? <Loader2 size={13} className="animate-spin" /> : <Zap size={13} />}
             {t("mqttPublishers.test")}
           </button>
           {testResult !== null && (
@@ -777,38 +772,6 @@ function MappingRow({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
-  const filteredEquipments = filterZoneId
-    ? equipments.filter((e) => e.zoneId === filterZoneId)
-    : equipments;
-
-  // Homonym equipments get a "name - zone" label (spec 139), qualified only
-  // against the other candidates in this dropdown.
-  const eqLabels = equipmentLabelMap(filteredEquipments, zoneChainMap(zones));
-
-  const filteredRecipeInstances = filterZoneId
-    ? recipeInstances.filter((i) => i.params.zone === filterZoneId)
-    : recipeInstances;
-
-  const availableKeys: string[] = (() => {
-    if (sourceType === "zone") return ZONE_AGG_KEYS;
-    if (sourceType === "equipment" && sourceId) {
-      const eq = equipments.find((e) => e.id === sourceId);
-      if (eq) return eq.dataBindings.map((b) => b.alias);
-    }
-    if (sourceType === "recipe" && sourceId) {
-      const inst = recipeInstances.find((i) => i.id === sourceId);
-      if (inst?.state) return Object.keys(inst.state);
-    }
-    return [];
-  })();
-
-  const handleSourceTypeChange = (val: "equipment" | "zone" | "recipe") => {
-    setSourceType(val);
-    setFilterZoneId("");
-    setSourceId("");
-    setSourceKey("");
-  };
-
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!publishKey.trim() || !sourceId || !sourceKey) return;
@@ -874,123 +837,23 @@ function MappingRow({
               autoFocus
             />
           </div>
-          <div>
-            <label className="block text-[11px] text-text-secondary mb-1">
-              {t("mqttPublishers.sourceType")}
-            </label>
-            <select
-              value={sourceType}
-              onChange={(e) => handleSourceTypeChange(e.target.value as "equipment" | "zone" | "recipe")}
-              className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-            >
-              <option value="equipment">{t("mqttPublishers.equipment")}</option>
-              <option value="zone">{t("mqttPublishers.zone")}</option>
-              <option value="recipe">{t("mqttPublishers.recipe")}</option>
-            </select>
-          </div>
-
-          <div>
-            <label className="block text-[11px] text-text-secondary mb-1">
-              {t("mqttPublishers.zone")}
-            </label>
-            <select
-              value={sourceType === "zone" ? sourceId : filterZoneId}
-              onChange={(e) => {
-                if (sourceType === "zone") {
-                  setSourceId(e.target.value);
-                  setSourceKey("");
-                } else {
-                  setFilterZoneId(e.target.value);
-                  setSourceId("");
-                  setSourceKey("");
-                }
-              }}
-              className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-            >
-              <option value="">
-                {sourceType === "zone"
-                  ? t("mqttPublishers.selectSource")
-                  : t("mqttPublishers.allZones")}
-              </option>
-              {zones.map((z) => (
-                <option key={z.id} value={z.id}>
-                  {z.label}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {sourceType === "equipment" && (
-            <div>
-              <label className="block text-[11px] text-text-secondary mb-1">
-                {t("mqttPublishers.equipment")}
-              </label>
-              <select
-                value={sourceId}
-                onChange={(e) => {
-                  setSourceId(e.target.value);
-                  setSourceKey("");
-                }}
-                className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-              >
-                <option value="">{t("mqttPublishers.selectSource")}</option>
-                {filteredEquipments.map((eq) => (
-                  <option key={eq.id} value={eq.id}>
-                    {eqLabels.get(eq.id) ?? eq.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          {sourceType === "recipe" && (
-            <div>
-              <label className="block text-[11px] text-text-secondary mb-1">
-                {t("mqttPublishers.recipeInstance")}
-              </label>
-              <select
-                value={sourceId}
-                onChange={(e) => {
-                  setSourceId(e.target.value);
-                  setSourceKey("");
-                }}
-                className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-              >
-                <option value="">{t("mqttPublishers.selectSource")}</option>
-                {filteredRecipeInstances.map((inst) => {
-                  const recipe = recipes.find((r) => r.id === inst.recipeId);
-                  return (
-                    <option key={inst.id} value={inst.id}>
-                      {recipe?.name ?? inst.recipeId}
-                    </option>
-                  );
-                })}
-              </select>
-            </div>
-          )}
-
-          <div>
-            <label className="block text-[11px] text-text-secondary mb-1">
-              {t("mqttPublishers.sourceKey")}
-            </label>
-            <select
-              value={sourceKey}
-              onChange={(e) => setSourceKey(e.target.value)}
-              className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-              disabled={!sourceId}
-            >
-              <option value="">{t("mqttPublishers.selectKey")}</option>
-              {availableKeys.map((k) => (
-                <option key={k} value={k}>
-                  {k}
-                </option>
-              ))}
-            </select>
-          </div>
+          <MappingSourceFields
+            keyPrefix="mqttPublishers"
+            sourceType={sourceType}
+            setSourceType={setSourceType}
+            sourceId={sourceId}
+            setSourceId={setSourceId}
+            sourceKey={sourceKey}
+            setSourceKey={setSourceKey}
+            filterZoneId={filterZoneId}
+            setFilterZoneId={setFilterZoneId}
+            equipments={equipments}
+            zones={zones}
+            recipeInstances={recipeInstances}
+            recipes={recipes}
+          />
         </div>
-        {error && (
-          <div className="mt-2 text-[11px] text-red-500">{error}</div>
-        )}
+        {error && <div className="mt-2 text-[11px] text-red-500">{error}</div>}
         <div className="flex items-center gap-2 mt-3">
           <button
             type="submit"
@@ -1038,9 +901,7 @@ function MappingRow({
           onClick={handleToggleEnabled}
           className="p-1 rounded hover:bg-surface transition-colors text-text-tertiary hover:text-text"
           title={
-            mapping.enabled
-              ? t("mqttPublishers.mappingDisable")
-              : t("mqttPublishers.mappingEnable")
+            mapping.enabled ? t("mqttPublishers.mappingDisable") : t("mqttPublishers.mappingEnable")
           }
         >
           {mapping.enabled ? <Power size={12} /> : <PowerOff size={12} />}
@@ -1085,42 +946,6 @@ function AddMappingForm({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
-  // Equipments filtered by selected zone
-  const filteredEquipments = filterZoneId
-    ? equipments.filter((e) => e.zoneId === filterZoneId)
-    : equipments;
-
-  // Homonym equipments get a "name - zone" label (spec 139), qualified only
-  // against the other candidates in this dropdown.
-  const eqLabels = equipmentLabelMap(filteredEquipments, zoneChainMap(zones));
-
-  // Recipe instances filtered by selected zone (zone stored in params.zone)
-  const filteredRecipeInstances = filterZoneId
-    ? recipeInstances.filter((i) => i.params.zone === filterZoneId)
-    : recipeInstances;
-
-  // Available keys depend on source type and selected source
-  const availableKeys: string[] = (() => {
-    if (sourceType === "zone") return ZONE_AGG_KEYS;
-    if (sourceType === "equipment" && sourceId) {
-      const eq = equipments.find((e) => e.id === sourceId);
-      if (eq) return eq.dataBindings.map((b) => b.alias);
-    }
-    if (sourceType === "recipe" && sourceId) {
-      const inst = recipeInstances.find((i) => i.id === sourceId);
-      if (inst?.state) return Object.keys(inst.state);
-    }
-    return [];
-  })();
-
-  // Reset downstream selections when sourceType changes
-  const handleSourceTypeChange = (val: "equipment" | "zone" | "recipe") => {
-    setSourceType(val);
-    setFilterZoneId("");
-    setSourceId("");
-    setSourceKey("");
-  };
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!publishKey.trim() || !sourceId || !sourceKey) return;
@@ -1157,126 +982,23 @@ function AddMappingForm({
             autoFocus
           />
         </div>
-        <div>
-          <label className="block text-[11px] text-text-secondary mb-1">
-            {t("mqttPublishers.sourceType")}
-          </label>
-          <select
-            value={sourceType}
-            onChange={(e) => handleSourceTypeChange(e.target.value as "equipment" | "zone" | "recipe")}
-            className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-          >
-            <option value="equipment">{t("mqttPublishers.equipment")}</option>
-            <option value="zone">{t("mqttPublishers.zone")}</option>
-            <option value="recipe">{t("mqttPublishers.recipe")}</option>
-          </select>
-        </div>
-
-        {/* Zone selector — filter for equipment/recipe, direct source for zone */}
-        <div>
-          <label className="block text-[11px] text-text-secondary mb-1">
-            {t("mqttPublishers.zone")}
-          </label>
-          <select
-            value={sourceType === "zone" ? sourceId : filterZoneId}
-            onChange={(e) => {
-              if (sourceType === "zone") {
-                setSourceId(e.target.value);
-                setSourceKey("");
-              } else {
-                setFilterZoneId(e.target.value);
-                setSourceId("");
-                setSourceKey("");
-              }
-            }}
-            className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-          >
-            <option value="">
-              {sourceType === "zone"
-                ? t("mqttPublishers.selectSource")
-                : t("mqttPublishers.allZones")}
-            </option>
-            {zones.map((z) => (
-              <option key={z.id} value={z.id}>
-                {z.label}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {/* Equipment selector — only when sourceType is equipment */}
-        {sourceType === "equipment" && (
-          <div>
-            <label className="block text-[11px] text-text-secondary mb-1">
-              {t("mqttPublishers.equipment")}
-            </label>
-            <select
-              value={sourceId}
-              onChange={(e) => {
-                setSourceId(e.target.value);
-                setSourceKey("");
-              }}
-              className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-            >
-              <option value="">{t("mqttPublishers.selectSource")}</option>
-              {filteredEquipments.map((eq) => (
-                <option key={eq.id} value={eq.id}>
-                  {eqLabels.get(eq.id) ?? eq.name}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
-
-        {/* Recipe instance selector — only when sourceType is recipe */}
-        {sourceType === "recipe" && (
-          <div>
-            <label className="block text-[11px] text-text-secondary mb-1">
-              {t("mqttPublishers.recipeInstance")}
-            </label>
-            <select
-              value={sourceId}
-              onChange={(e) => {
-                setSourceId(e.target.value);
-                setSourceKey("");
-              }}
-              className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-            >
-              <option value="">{t("mqttPublishers.selectSource")}</option>
-              {filteredRecipeInstances.map((inst) => {
-                const recipe = recipes.find((r) => r.id === inst.recipeId);
-                return (
-                  <option key={inst.id} value={inst.id}>
-                    {recipe?.name ?? inst.recipeId}
-                  </option>
-                );
-              })}
-            </select>
-          </div>
-        )}
-
-        <div>
-          <label className="block text-[11px] text-text-secondary mb-1">
-            {t("mqttPublishers.sourceKey")}
-          </label>
-          <select
-            value={sourceKey}
-            onChange={(e) => setSourceKey(e.target.value)}
-            className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-            disabled={!sourceId}
-          >
-            <option value="">{t("mqttPublishers.selectKey")}</option>
-            {availableKeys.map((k) => (
-              <option key={k} value={k}>
-                {k}
-              </option>
-            ))}
-          </select>
-        </div>
+        <MappingSourceFields
+          keyPrefix="mqttPublishers"
+          sourceType={sourceType}
+          setSourceType={setSourceType}
+          sourceId={sourceId}
+          setSourceId={setSourceId}
+          sourceKey={sourceKey}
+          setSourceKey={setSourceKey}
+          filterZoneId={filterZoneId}
+          setFilterZoneId={setFilterZoneId}
+          equipments={equipments}
+          zones={zones}
+          recipeInstances={recipeInstances}
+          recipes={recipes}
+        />
       </div>
-      {error && (
-        <div className="mt-2 text-[11px] text-red-500">{error}</div>
-      )}
+      {error && <div className="mt-2 text-[11px] text-red-500">{error}</div>}
       <div className="flex items-center gap-2 mt-3">
         <button
           type="submit"

--- a/ui/src/pages/NotificationPublishersPage.tsx
+++ b/ui/src/pages/NotificationPublishersPage.tsx
@@ -42,6 +42,7 @@ import type {
 import { usePushSubscription } from "../hooks/usePushSubscription";
 import {
   deriveSourceZoneFilter,
+  recipeInstanceLabel,
   repeatModeOf,
   repeatFieldsFor,
   type RepeatMode,
@@ -784,6 +785,7 @@ function MappingRow({
             zones={zones}
             recipeInstances={recipeInstances}
             recipes={recipes}
+            recipeOptionLabel={(inst) => recipeInstanceLabel(inst, recipes, equipments)}
           />
 
           <div>
@@ -960,6 +962,7 @@ function AddMappingForm({
           zones={zones}
           recipeInstances={recipeInstances}
           recipes={recipes}
+          recipeOptionLabel={(inst) => recipeInstanceLabel(inst, recipes, equipments)}
         />
 
         <div>

--- a/ui/src/pages/NotificationPublishersPage.tsx
+++ b/ui/src/pages/NotificationPublishersPage.tsx
@@ -42,32 +42,12 @@ import type {
 import { usePushSubscription } from "../hooks/usePushSubscription";
 import {
   deriveSourceZoneFilter,
-  recipeInstanceLabel,
   repeatModeOf,
   repeatFieldsFor,
   type RepeatMode,
 } from "../lib/notif-mapping";
-import { equipmentLabelMap, flattenZonesWithPath, zoneChainMap, type ZoneOption } from "../lib/zone-path";
-
-const ZONE_AGG_KEYS = [
-  "temperature",
-  "humidity",
-  "luminosity",
-  "motion",
-  "motionSensors",
-  "openDoors",
-  "openWindows",
-  "waterLeak",
-  "smoke",
-  "lightsOn",
-  "lightsTotal",
-  "shuttersOpen",
-  "shuttersTotal",
-  "averageShutterPosition",
-  "awningsDeployed",
-  "awningsTotal",
-  "isDaylight",
-];
+import { flattenZonesWithPath, type ZoneOption } from "../lib/zone-path";
+import { MappingSourceFields } from "../components/publishers/MappingSourceFields";
 
 const DEFAULT_THROTTLE_MS = 300_000; // 5 min
 
@@ -726,38 +706,6 @@ function MappingRow({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
-  const filteredEquipments = filterZoneId
-    ? equipments.filter((e) => e.zoneId === filterZoneId)
-    : equipments;
-
-  // Homonym equipments get a "name - zone" label (spec 139), qualified only
-  // against the other candidates in this dropdown.
-  const eqLabels = equipmentLabelMap(filteredEquipments, zoneChainMap(zones));
-
-  const filteredRecipeInstances = filterZoneId
-    ? recipeInstances.filter((i) => i.params.zone === filterZoneId)
-    : recipeInstances;
-
-  const availableKeys: string[] = (() => {
-    if (sourceType === "zone") return ZONE_AGG_KEYS;
-    if (sourceType === "equipment" && sourceId) {
-      const eq = equipments.find((e) => e.id === sourceId);
-      if (eq) return eq.dataBindings.map((b) => b.alias);
-    }
-    if (sourceType === "recipe" && sourceId) {
-      const inst = recipeInstances.find((i) => i.id === sourceId);
-      if (inst?.state) return Object.keys(inst.state);
-    }
-    return [];
-  })();
-
-  const handleSourceTypeChange = (val: "equipment" | "zone" | "recipe") => {
-    setSourceType(val);
-    setFilterZoneId("");
-    setSourceId("");
-    setSourceKey("");
-  };
-
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!message.trim() || !sourceId || !sourceKey) return;
@@ -822,118 +770,21 @@ function MappingRow({
               autoFocus
             />
           </div>
-          <div>
-            <label className="block text-[11px] text-text-secondary mb-1">
-              {t("notifPublishers.sourceType")}
-            </label>
-            <select
-              value={sourceType}
-              onChange={(e) =>
-                handleSourceTypeChange(e.target.value as "equipment" | "zone" | "recipe")
-              }
-              className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-            >
-              <option value="equipment">{t("notifPublishers.equipment")}</option>
-              <option value="zone">{t("notifPublishers.zone")}</option>
-              <option value="recipe">{t("notifPublishers.recipe")}</option>
-            </select>
-          </div>
-
-          <div>
-            <label className="block text-[11px] text-text-secondary mb-1">
-              {t("notifPublishers.zone")}
-            </label>
-            <select
-              value={sourceType === "zone" ? sourceId : filterZoneId}
-              onChange={(e) => {
-                if (sourceType === "zone") {
-                  setSourceId(e.target.value);
-                  setSourceKey("");
-                } else {
-                  setFilterZoneId(e.target.value);
-                  setSourceId("");
-                  setSourceKey("");
-                }
-              }}
-              className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-            >
-              <option value="">
-                {sourceType === "zone"
-                  ? t("notifPublishers.selectSource")
-                  : t("notifPublishers.allZones")}
-              </option>
-              {zones.map((z) => (
-                <option key={z.id} value={z.id}>
-                  {z.label}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {sourceType === "equipment" && (
-            <div>
-              <label className="block text-[11px] text-text-secondary mb-1">
-                {t("notifPublishers.equipment")}
-              </label>
-              <select
-                value={sourceId}
-                onChange={(e) => {
-                  setSourceId(e.target.value);
-                  setSourceKey("");
-                }}
-                className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-              >
-                <option value="">{t("notifPublishers.selectSource")}</option>
-                {filteredEquipments.map((eq) => (
-                  <option key={eq.id} value={eq.id}>
-                    {eqLabels.get(eq.id) ?? eq.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          {sourceType === "recipe" && (
-            <div>
-              <label className="block text-[11px] text-text-secondary mb-1">
-                {t("notifPublishers.recipeInstance")}
-              </label>
-              <select
-                value={sourceId}
-                onChange={(e) => {
-                  setSourceId(e.target.value);
-                  setSourceKey("");
-                }}
-                className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-              >
-                <option value="">{t("notifPublishers.selectSource")}</option>
-                {filteredRecipeInstances.map((inst) => (
-                  <option key={inst.id} value={inst.id}>
-                    {recipeInstanceLabel(inst, recipes, equipments)}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          <div>
-            <label className="block text-[11px] text-text-secondary mb-1">
-              {t("notifPublishers.sourceKey")}
-            </label>
-            <select
-              value={sourceKey}
-              onChange={(e) => setSourceKey(e.target.value)}
-              className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-              disabled={!sourceId}
-            >
-              <option value="">{t("notifPublishers.selectKey")}</option>
-              {availableKeys.map((k) => (
-                <option key={k} value={k}>
-                  {k}
-                </option>
-              ))}
-            </select>
-          </div>
+          <MappingSourceFields
+            keyPrefix="notifPublishers"
+            sourceType={sourceType}
+            setSourceType={setSourceType}
+            sourceId={sourceId}
+            setSourceId={setSourceId}
+            sourceKey={sourceKey}
+            setSourceKey={setSourceKey}
+            filterZoneId={filterZoneId}
+            setFilterZoneId={setFilterZoneId}
+            equipments={equipments}
+            zones={zones}
+            recipeInstances={recipeInstances}
+            recipes={recipes}
+          />
 
           <div>
             <label className="block text-[11px] text-text-secondary mb-1">
@@ -1055,38 +906,6 @@ function AddMappingForm({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
-  const filteredEquipments = filterZoneId
-    ? equipments.filter((e) => e.zoneId === filterZoneId)
-    : equipments;
-
-  // Homonym equipments get a "name - zone" label (spec 139), qualified only
-  // against the other candidates in this dropdown.
-  const eqLabels = equipmentLabelMap(filteredEquipments, zoneChainMap(zones));
-
-  const filteredRecipeInstances = filterZoneId
-    ? recipeInstances.filter((i) => i.params.zone === filterZoneId)
-    : recipeInstances;
-
-  const availableKeys: string[] = (() => {
-    if (sourceType === "zone") return ZONE_AGG_KEYS;
-    if (sourceType === "equipment" && sourceId) {
-      const eq = equipments.find((e) => e.id === sourceId);
-      if (eq) return eq.dataBindings.map((b) => b.alias);
-    }
-    if (sourceType === "recipe" && sourceId) {
-      const inst = recipeInstances.find((i) => i.id === sourceId);
-      if (inst?.state) return Object.keys(inst.state);
-    }
-    return [];
-  })();
-
-  const handleSourceTypeChange = (val: "equipment" | "zone" | "recipe") => {
-    setSourceType(val);
-    setFilterZoneId("");
-    setSourceId("");
-    setSourceKey("");
-  };
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!message.trim() || !sourceId || !sourceKey) return;
@@ -1127,119 +946,21 @@ function AddMappingForm({
             autoFocus
           />
         </div>
-        <div>
-          <label className="block text-[11px] text-text-secondary mb-1">
-            {t("notifPublishers.sourceType")}
-          </label>
-          <select
-            value={sourceType}
-            onChange={(e) =>
-              handleSourceTypeChange(e.target.value as "equipment" | "zone" | "recipe")
-            }
-            className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-          >
-            <option value="equipment">{t("notifPublishers.equipment")}</option>
-            <option value="zone">{t("notifPublishers.zone")}</option>
-            <option value="recipe">{t("notifPublishers.recipe")}</option>
-          </select>
-        </div>
-
-        {/* Zone selector */}
-        <div>
-          <label className="block text-[11px] text-text-secondary mb-1">
-            {t("notifPublishers.zone")}
-          </label>
-          <select
-            value={sourceType === "zone" ? sourceId : filterZoneId}
-            onChange={(e) => {
-              if (sourceType === "zone") {
-                setSourceId(e.target.value);
-                setSourceKey("");
-              } else {
-                setFilterZoneId(e.target.value);
-                setSourceId("");
-                setSourceKey("");
-              }
-            }}
-            className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-          >
-            <option value="">
-              {sourceType === "zone"
-                ? t("notifPublishers.selectSource")
-                : t("notifPublishers.allZones")}
-            </option>
-            {zones.map((z) => (
-              <option key={z.id} value={z.id}>
-                {z.label}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {sourceType === "equipment" && (
-          <div>
-            <label className="block text-[11px] text-text-secondary mb-1">
-              {t("notifPublishers.equipment")}
-            </label>
-            <select
-              value={sourceId}
-              onChange={(e) => {
-                setSourceId(e.target.value);
-                setSourceKey("");
-              }}
-              className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-            >
-              <option value="">{t("notifPublishers.selectSource")}</option>
-              {filteredEquipments.map((eq) => (
-                <option key={eq.id} value={eq.id}>
-                  {eqLabels.get(eq.id) ?? eq.name}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
-
-        {sourceType === "recipe" && (
-          <div>
-            <label className="block text-[11px] text-text-secondary mb-1">
-              {t("notifPublishers.recipeInstance")}
-            </label>
-            <select
-              value={sourceId}
-              onChange={(e) => {
-                setSourceId(e.target.value);
-                setSourceKey("");
-              }}
-              className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-            >
-              <option value="">{t("notifPublishers.selectSource")}</option>
-              {filteredRecipeInstances.map((inst) => (
-                <option key={inst.id} value={inst.id}>
-                  {recipeInstanceLabel(inst, recipes, equipments)}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
-
-        <div>
-          <label className="block text-[11px] text-text-secondary mb-1">
-            {t("notifPublishers.sourceKey")}
-          </label>
-          <select
-            value={sourceKey}
-            onChange={(e) => setSourceKey(e.target.value)}
-            className="w-full px-2 py-1 text-[12px] bg-surface border border-border rounded-[4px] text-text"
-            disabled={!sourceId}
-          >
-            <option value="">{t("notifPublishers.selectKey")}</option>
-            {availableKeys.map((k) => (
-              <option key={k} value={k}>
-                {k}
-              </option>
-            ))}
-          </select>
-        </div>
+        <MappingSourceFields
+          keyPrefix="notifPublishers"
+          sourceType={sourceType}
+          setSourceType={setSourceType}
+          sourceId={sourceId}
+          setSourceId={setSourceId}
+          sourceKey={sourceKey}
+          setSourceKey={setSourceKey}
+          filterZoneId={filterZoneId}
+          setFilterZoneId={setFilterZoneId}
+          equipments={equipments}
+          zones={zones}
+          recipeInstances={recipeInstances}
+          recipes={recipes}
+        />
 
         <div>
           <label className="block text-[11px] text-text-secondary mb-1">


### PR DESCRIPTION
## What

First step of the generic publisher architecture. Every publisher — MQTT, Telegram, Web Push, and any future transport — maps the same **source space** (an equipment / zone / recipe and one of its keys) onto a transport-specific payload. That universal layer was copy-pasted across `MqttPublishersPage` and `NotificationPublishersPage` (an identical `ZONE_AGG_KEYS`, the `availableKeys` derivation, and the whole source-selector UI in **both** the row editor and the add form) and had started to drift.

## How

New `ui/src/components/publishers/`:
- `mapping-source.ts` — `ZONE_AGG_KEYS` + `mappingSourceKeys(sourceType, sourceId, ctx)` (the universal model).
- `MappingSourceFields.tsx` — the shared source selector (source type, zone filter, equipment/recipe pick, source key), parametrised by a `keyPrefix` so each page keeps its own i18n namespace (`mqttPublishers.*` / `notifPublishers.*`).

Callers still own their **transport-specific** parts — the payload field (a publish key vs a message) and the throttle/repeat policy — which is exactly the divergence that must NOT be merged away. Both pages' `MappingRow` and `AddMappingForm` now render `<MappingSourceFields/>`: **~557 net lines removed**.

This delivers the shared mapping concept; the **transport descriptor** (per-transport config + payload fields, so a page becomes descriptor-driven) is the natural next PR.

## Verification

- New `MappingSourceFields.test.tsx` (issue #458 tier): key options track the selected source (equipment aliases vs zone-aggregate keys); switching source type resets the downstream selections.
- Full UI suite green: **340 tests** (337 + 3). `tsc -b`, eslint clean.
- **Note**: the demo instance was unreachable at review time, so there is no Playwright visual pass. Confidence rests on this being a behaviour-preserving extraction (the shared component reproduces the exact JSX + logic), the type-checker, and the component test. A visual pass on both pages is recommended before/after merge.

Refs #457