### PR TITLE
refactor(ui): make notification channels descriptor-driven (#457 step 2)

### DIFF
--- a/ui/src/components/publishers/ChannelConfigFields.tsx
+++ b/ui/src/components/publishers/ChannelConfigFields.tsx
@@ -1,0 +1,41 @@
+import { useTranslation } from "react-i18next";
+import type { NotificationChannelSpec } from "./notification-channels";
+
+// The field renderer for the generic notification-channel descriptors (issue
+// #457 step 2). Kept in its own .tsx so notification-channels.ts stays a pure
+// logic/registry module. Renders the selected channel's config fields (or its
+// hint) from the descriptor.
+export function ChannelConfigFields({
+  spec,
+  values,
+  onChange,
+}: {
+  spec: NotificationChannelSpec;
+  values: Record<string, string>;
+  onChange: (key: string, value: string) => void;
+}) {
+  const { t } = useTranslation();
+  if (spec.fields.length === 0) {
+    return spec.hintKey ? (
+      <p className="text-[11px] text-text-tertiary">{t(spec.hintKey)}</p>
+    ) : null;
+  }
+  return (
+    <>
+      {spec.fields.map((field) => (
+        <div key={field.key}>
+          <label className="block text-[12px] text-text-secondary mb-1">{t(field.labelKey)}</label>
+          <input
+            type={field.inputType}
+            value={values[field.key] ?? ""}
+            onChange={(e) => onChange(field.key, e.target.value)}
+            placeholder={field.placeholder}
+            className={`w-full px-3 py-1.5 text-[13px] bg-bg border border-border rounded-[6px] text-text placeholder:text-text-tertiary${
+              field.mono ? " font-mono" : ""
+            }`}
+          />
+        </div>
+      ))}
+    </>
+  );
+}

--- a/ui/src/components/publishers/notification-channels.test.tsx
+++ b/ui/src/components/publishers/notification-channels.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "../../test-utils";
+import { NOTIFICATION_CHANNELS, channelSpec, channelConfigComplete } from "./notification-channels";
+import { ChannelConfigFields } from "./ChannelConfigFields";
+
+// Generic notification-channel descriptors (issue #457 step 2): adding a channel
+// is a descriptor entry, and the form renders/validates from it.
+
+describe("notification channel descriptors", () => {
+  it("round-trips telegram config through fromConfig/toConfig", () => {
+    const tg = channelSpec("telegram");
+    const values = tg.fromConfig({ botToken: "abc", chatId: "-100" });
+    expect(values).toEqual({ botToken: "abc", chatId: "-100" });
+    expect(tg.toConfig(values)).toEqual({ botToken: "abc", chatId: "-100" });
+    // trims on save
+    expect(tg.toConfig({ botToken: " a ", chatId: " b " })).toEqual({ botToken: "a", chatId: "b" });
+  });
+
+  it("web-push has no config and an empty object config", () => {
+    const wp = channelSpec("web-push");
+    expect(wp.fields).toHaveLength(0);
+    expect(wp.toConfig({})).toEqual({});
+    expect(wp.fromConfig(undefined)).toEqual({});
+  });
+
+  it("channelConfigComplete requires telegram's required fields, web-push always complete", () => {
+    const tg = channelSpec("telegram");
+    expect(channelConfigComplete(tg, { botToken: "", chatId: "" })).toBe(false);
+    expect(channelConfigComplete(tg, { botToken: "x", chatId: "" })).toBe(false);
+    expect(channelConfigComplete(tg, { botToken: "x", chatId: "y" })).toBe(true);
+    expect(channelConfigComplete(channelSpec("web-push"), {})).toBe(true);
+  });
+
+  it("registry lists web-push and telegram", () => {
+    expect(NOTIFICATION_CHANNELS.map((c) => c.type)).toEqual(["web-push", "telegram"]);
+  });
+});
+
+describe("ChannelConfigFields", () => {
+  it("renders the telegram fields and fires onChange", () => {
+    const onChange = vi.fn();
+    render(
+      <ChannelConfigFields
+        spec={channelSpec("telegram")}
+        values={{ botToken: "", chatId: "" }}
+        onChange={onChange}
+      />,
+    );
+    const inputs = screen.getAllByRole("textbox");
+    // chatId is a text field (botToken is type=password, not a textbox role)
+    expect(inputs.length).toBeGreaterThanOrEqual(1);
+    fireEvent.change(inputs[0], { target: { value: "-100" } });
+    expect(onChange).toHaveBeenCalledWith("chatId", "-100");
+  });
+
+  it("renders only a hint for web-push (no config fields)", () => {
+    render(<ChannelConfigFields spec={channelSpec("web-push")} values={{}} onChange={vi.fn()} />);
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+});

--- a/ui/src/components/publishers/notification-channels.ts
+++ b/ui/src/components/publishers/notification-channels.ts
@@ -1,0 +1,103 @@
+import { useTranslation } from "react-i18next";
+import type {
+  NotificationChannelType,
+  NotificationChannelConfig,
+  TelegramChannelConfig,
+  WebPushChannelConfig,
+} from "../../types";
+
+// Generic notification-channel descriptors (issue #457 step 2). A notification
+// publisher rests on common concepts — a name, a channel, and mappings — and
+// only the channel's *config* differs (Telegram needs a bot token + chat id,
+// Web Push needs nothing). Each channel is described once here; the form renders
+// its config fields from the descriptor, so adding a channel (ntfy, a webhook,
+// ...) is a new entry, not new form code. The field renderer lives in
+// notification-channels.tsx (ChannelConfigFields).
+
+export interface ChannelFieldSpec {
+  /** Key inside the flat config record and the channelConfig object. */
+  key: string;
+  labelKey: string;
+  inputType: "text" | "password";
+  placeholder?: string;
+  mono?: boolean;
+  required?: boolean;
+}
+
+export interface NotificationChannelSpec {
+  type: NotificationChannelType;
+  /** Literal label, or an i18n key resolved with t(). Exactly one is set. */
+  label?: string;
+  labelKey?: string;
+  /** Config fields, empty for channels that need no config (Web Push). */
+  fields: ChannelFieldSpec[];
+  /** Optional hint shown when there are no fields. */
+  hintKey?: string;
+  /** Build the persisted channelConfig from the flat field record. */
+  toConfig: (values: Record<string, string>) => NotificationChannelConfig;
+  /** Read the flat field record from an existing channelConfig. */
+  fromConfig: (config: NotificationChannelConfig | undefined) => Record<string, string>;
+}
+
+export const NOTIFICATION_CHANNELS: NotificationChannelSpec[] = [
+  {
+    type: "web-push",
+    labelKey: "notifPublishers.webPush",
+    fields: [],
+    hintKey: "notifPublishers.webPushHint",
+    toConfig: () => ({}) as WebPushChannelConfig,
+    fromConfig: () => ({}),
+  },
+  {
+    type: "telegram",
+    label: "Telegram",
+    fields: [
+      {
+        key: "botToken",
+        labelKey: "notifPublishers.botToken",
+        inputType: "password",
+        placeholder: "123456:ABC-DEF...",
+        mono: true,
+        required: true,
+      },
+      {
+        key: "chatId",
+        labelKey: "notifPublishers.chatId",
+        inputType: "text",
+        placeholder: "-1001234567890",
+        mono: true,
+        required: true,
+      },
+    ],
+    toConfig: (v) =>
+      ({
+        botToken: (v.botToken ?? "").trim(),
+        chatId: (v.chatId ?? "").trim(),
+      }) as TelegramChannelConfig,
+    fromConfig: (config) => {
+      const tg = config as TelegramChannelConfig | undefined;
+      return { botToken: tg?.botToken ?? "", chatId: tg?.chatId ?? "" };
+    },
+  },
+];
+
+export function channelSpec(type: NotificationChannelType): NotificationChannelSpec {
+  return NOTIFICATION_CHANNELS.find((c) => c.type === type) ?? NOTIFICATION_CHANNELS[0];
+}
+
+/** Are all required fields of the channel filled? */
+export function channelConfigComplete(
+  spec: NotificationChannelSpec,
+  values: Record<string, string>,
+): boolean {
+  return spec.fields.every((f) => !f.required || !!(values[f.key] ?? "").trim());
+}
+
+/** The channel's display label (literal or translated). */
+export function useChannelLabel(): (type: NotificationChannelType) => string {
+  const { t } = useTranslation();
+  return (type) => {
+    const spec = channelSpec(type);
+    return spec.label ?? (spec.labelKey ? t(spec.labelKey) : type);
+  };
+}

--- a/ui/src/components/publishers/notification-channels.ts
+++ b/ui/src/components/publishers/notification-channels.ts
@@ -26,9 +26,12 @@ export interface ChannelFieldSpec {
 
 export interface NotificationChannelSpec {
   type: NotificationChannelType;
-  /** Literal label, or an i18n key resolved with t(). Exactly one is set. */
-  label?: string;
-  labelKey?: string;
+  /** Short label for the publisher card badge (literal, matches the pre-refactor
+   *  hard-coded badge). */
+  label: string;
+  /** Optional longer i18n label for the channel picker option (e.g. "Web Push
+   *  (this app)"); falls back to `label` when absent. */
+  optionLabelKey?: string;
   /** Config fields, empty for channels that need no config (Web Push). */
   fields: ChannelFieldSpec[];
   /** Optional hint shown when there are no fields. */
@@ -42,7 +45,8 @@ export interface NotificationChannelSpec {
 export const NOTIFICATION_CHANNELS: NotificationChannelSpec[] = [
   {
     type: "web-push",
-    labelKey: "notifPublishers.webPush",
+    label: "Web Push",
+    optionLabelKey: "notifPublishers.webPush",
     fields: [],
     hintKey: "notifPublishers.webPushHint",
     toConfig: () => ({}) as WebPushChannelConfig,
@@ -93,11 +97,19 @@ export function channelConfigComplete(
   return spec.fields.every((f) => !f.required || !!(values[f.key] ?? "").trim());
 }
 
-/** The channel's display label (literal or translated). */
+/** The channel's short badge label (matches the pre-refactor card badge). */
+export function channelLabel(type: NotificationChannelType): string {
+  return channelSpec(type).label;
+}
+
+/** Hook form for components that render the badge inside JSX. */
 export function useChannelLabel(): (type: NotificationChannelType) => string {
+  return channelLabel;
+}
+
+/** The channel picker option label: the longer i18n form when set, else the
+ *  short badge label (matches the pre-refactor `<select>` options). */
+export function useChannelOptionLabel(): (spec: NotificationChannelSpec) => string {
   const { t } = useTranslation();
-  return (type) => {
-    const spec = channelSpec(type);
-    return spec.label ?? (spec.labelKey ? t(spec.labelKey) : type);
-  };
+  return (spec) => (spec.optionLabelKey ? t(spec.optionLabelKey) : spec.label);
 }

--- a/ui/src/pages/NotificationPublishersPage.tsx
+++ b/ui/src/pages/NotificationPublishersPage.tsx
@@ -52,6 +52,7 @@ import {
   channelSpec,
   channelConfigComplete,
   useChannelLabel,
+  useChannelOptionLabel,
 } from "../components/publishers/notification-channels";
 import { ChannelConfigFields } from "../components/publishers/ChannelConfigFields";
 
@@ -230,7 +231,7 @@ function PublisherForm({
   onCancel: () => void;
 }) {
   const { t } = useTranslation();
-  const channelLabel = useChannelLabel();
+  const channelOptionLabel = useChannelOptionLabel();
   const [name, setName] = useState(publisher?.name ?? "");
   const [channelType, setChannelType] = useState<NotificationChannelType>(
     publisher?.channelType ?? "web-push",
@@ -305,7 +306,7 @@ function PublisherForm({
           >
             {NOTIFICATION_CHANNELS.map((c) => (
               <option key={c.type} value={c.type}>
-                {channelLabel(c.type)}
+                {channelOptionLabel(c)}
               </option>
             ))}
           </select>

--- a/ui/src/pages/NotificationPublishersPage.tsx
+++ b/ui/src/pages/NotificationPublishersPage.tsx
@@ -30,10 +30,8 @@ import {
 import type {
   NotificationPublisherWithMappings,
   NotificationPublisherMapping,
-  TelegramChannelConfig,
   NotificationChannelType,
   NotificationChannelConfig,
-  WebPushChannelConfig,
   EquipmentWithDetails,
   ZoneWithChildren,
   RecipeInstance,
@@ -49,6 +47,13 @@ import {
 } from "../lib/notif-mapping";
 import { flattenZonesWithPath, type ZoneOption } from "../lib/zone-path";
 import { MappingSourceFields } from "../components/publishers/MappingSourceFields";
+import {
+  NOTIFICATION_CHANNELS,
+  channelSpec,
+  channelConfigComplete,
+  useChannelLabel,
+} from "../components/publishers/notification-channels";
+import { ChannelConfigFields } from "../components/publishers/ChannelConfigFields";
 
 const DEFAULT_THROTTLE_MS = 300_000; // 5 min
 
@@ -225,21 +230,26 @@ function PublisherForm({
   onCancel: () => void;
 }) {
   const { t } = useTranslation();
+  const channelLabel = useChannelLabel();
   const [name, setName] = useState(publisher?.name ?? "");
   const [channelType, setChannelType] = useState<NotificationChannelType>(
     publisher?.channelType ?? "web-push",
   );
-  const tg =
-    publisher?.channelType === "telegram"
-      ? (publisher.channelConfig as TelegramChannelConfig)
-      : undefined;
-  const [botToken, setBotToken] = useState(tg?.botToken ?? "");
-  const [chatId, setChatId] = useState(tg?.chatId ?? "");
+  // Flat config record driven by the channel descriptor (issue #457 step 2).
+  const [config, setConfig] = useState<Record<string, string>>(() =>
+    channelSpec(publisher?.channelType ?? "web-push").fromConfig(publisher?.channelConfig),
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
-  const telegramReady = channelType !== "telegram" || (!!botToken.trim() && !!chatId.trim());
-  const canSubmit = !!name.trim() && telegramReady;
+  const spec = channelSpec(channelType);
+  const canSubmit = !!name.trim() && channelConfigComplete(spec, config);
+
+  const handleChannelChange = (type: NotificationChannelType) => {
+    setChannelType(type);
+    // Reset the config to the new channel's shape (keeps overlapping keys).
+    setConfig((prev) => ({ ...channelSpec(type).fromConfig(undefined), ...prev }));
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -247,10 +257,7 @@ function PublisherForm({
     setSaving(true);
     setError("");
     try {
-      const channelConfig: NotificationChannelConfig =
-        channelType === "telegram"
-          ? { botToken: botToken.trim(), chatId: chatId.trim() }
-          : ({} as WebPushChannelConfig);
+      const channelConfig: NotificationChannelConfig = spec.toConfig(config);
       if (publisher) {
         await updateNotificationPublisher(publisher.id, {
           name: name.trim(),
@@ -293,43 +300,21 @@ function PublisherForm({
           </label>
           <select
             value={channelType}
-            onChange={(e) => setChannelType(e.target.value as NotificationChannelType)}
+            onChange={(e) => handleChannelChange(e.target.value as NotificationChannelType)}
             className="w-full px-3 py-1.5 text-[13px] bg-bg border border-border rounded-[6px] text-text"
           >
-            <option value="web-push">{t("notifPublishers.webPush")}</option>
-            <option value="telegram">Telegram</option>
+            {NOTIFICATION_CHANNELS.map((c) => (
+              <option key={c.type} value={c.type}>
+                {channelLabel(c.type)}
+              </option>
+            ))}
           </select>
         </div>
-        {channelType === "telegram" ? (
-          <>
-            <div>
-              <label className="block text-[12px] text-text-secondary mb-1">
-                {t("notifPublishers.botToken")}
-              </label>
-              <input
-                type="password"
-                value={botToken}
-                onChange={(e) => setBotToken(e.target.value)}
-                placeholder="123456:ABC-DEF..."
-                className="w-full px-3 py-1.5 text-[13px] bg-bg border border-border rounded-[6px] text-text font-mono placeholder:text-text-tertiary"
-              />
-            </div>
-            <div>
-              <label className="block text-[12px] text-text-secondary mb-1">
-                {t("notifPublishers.chatId")}
-              </label>
-              <input
-                type="text"
-                value={chatId}
-                onChange={(e) => setChatId(e.target.value)}
-                placeholder="-1001234567890"
-                className="w-full px-3 py-1.5 text-[13px] bg-bg border border-border rounded-[6px] text-text font-mono placeholder:text-text-tertiary"
-              />
-            </div>
-          </>
-        ) : (
-          <p className="text-[11px] text-text-tertiary">{t("notifPublishers.webPushHint")}</p>
-        )}
+        <ChannelConfigFields
+          spec={spec}
+          values={config}
+          onChange={(key, value) => setConfig((prev) => ({ ...prev, [key]: value }))}
+        />
         {error && <div className="text-[11px] text-red-500">{error}</div>}
         <div className="flex items-center gap-2">
           <button
@@ -376,6 +361,7 @@ function PublisherCard({
   onRefresh: () => void;
 }) {
   const { t } = useTranslation();
+  const channelLabel = useChannelLabel();
   const [showAddMapping, setShowAddMapping] = useState(false);
   const [editing, setEditing] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -489,7 +475,7 @@ function PublisherCard({
           <div className="min-w-0">
             <h3 className="text-[14px] font-medium text-text truncate">{publisher.name}</h3>
             <span className="text-[12px] text-text-tertiary">
-              {publisher.channelType === "web-push" ? "Web Push" : "Telegram"}
+              {channelLabel(publisher.channelType)}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## What

Step 2 of the generic publisher architecture. A notification publisher rests on common concepts (name, channel, mappings); only the **channel's config** differs. This turns each channel into a **descriptor** instead of hard-coding the Telegram-vs-Web-Push branch in `PublisherForm`.

## How

- `notification-channels.ts` — `NOTIFICATION_CHANNELS` registry. Each channel declares its config fields (Telegram: `botToken` + `chatId`; Web Push: none + a hint), plus `toConfig`/`fromConfig` and required-field validation. Also `channelSpec`, `channelConfigComplete`, and a `useChannelLabel` hook.
- `ChannelConfigFields.tsx` — renders the selected channel's fields (or its hint) from the descriptor.
- `NotificationPublishersPage` `PublisherForm` now holds a flat `config` record and drives the channel picker options, the config fields, validation (`channelConfigComplete`) and the saved `channelConfig` (`spec.toConfig`) entirely from the registry. The publisher card badge uses the descriptor label too.

**Adding a channel (ntfy, a webhook, ...) is now a registry entry, not new form code.** This is the "push and telegram rest on common concepts, the UI reflects that" architecture. Telegram/Web Push behaviour is unchanged.

## Verification

- New `notification-channels.test.tsx` (6): descriptor round-trips (`fromConfig`/`toConfig`, trims on save), `channelConfigComplete` validation, `ChannelConfigFields` renders Telegram fields / Web Push hint.
- Full UI suite: **347 tests**; `tsc -b`, eslint clean.
- **Playwright QA on the local shadow** (seeded with prod data, inert): the create form shows Web Push's hint and no config; switching the Canal to Telegram renders Bot Token + Chat ID from the descriptor; the channel picker and card badges come from the registry. Screenshot: `qa-457b-telegram-descriptor-form.png`.

## Next

MQTT as a third transport is a larger cross-backend unification (separate brokers/topics model) — a further step; this PR delivers the notification-channel descriptors that match the push/telegram common-concepts ask.

Refs #457