### PR TITLE
fix(energy): show a running must-run load as running, not waiting for surplus (#491)

### DIFF
--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -255,6 +255,28 @@ describe("capacity arbiter", () => {
     expect(pending?.needW).toBe(300); // 600 + 100 margin - 400 tolerated
   });
 
+  it("flags a pending claim as running when its load runs as a recipe must-run fallback (#491)", () => {
+    // A recipe keeps a surplus claim but runs the load anyway (hot day). With
+    // no surplus the claim stays pending, yet the load draws power — it must
+    // read as running-without-surplus, not "waiting for surplus".
+    const h = makeHarness();
+    h.claim("i1", { equipmentId: "pump" });
+    h.feedMeter(-500);
+    h.run(-500, 300);
+    // The claim is pending and idle so far.
+    expect(h.arbiter.getPublicState().pending[0]?.running).toBe(false);
+
+    // The recipe turns the load on outside a grant (must-run fallback).
+    h.order("pump", "ON", { kind: "recipe", instanceId: "i1" });
+    const [pending] = h.arbiter.getPublicState().pending;
+    expect(pending?.equipmentId).toBe("pump");
+    expect(pending?.running).toBe(true);
+
+    // When the recipe switches it back off, it reads as waiting again.
+    h.order("pump", "OFF", { kind: "recipe", instanceId: "i1" });
+    expect(h.arbiter.getPublicState().pending[0]?.running).toBe(false);
+  });
+
   it("does NOT revoke when its own grant collapses the export (reservation accounting)", () => {
     const h = makeHarness();
     h.claim("i1", { equipmentId: "pump" });

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -597,6 +597,10 @@ export class CapacityArbiter {
         needW: Math.round(this.engageNeedW(c)),
         toleratedImportW: c.toleratedImportW,
         reasonWaiting: this.pendingReason(c, accounting.headroomW),
+        // A pending claim whose load a recipe is already running as a must-run
+        // fallback (tracked in unclaimedRunning) is drawing power, not idle —
+        // the UI relabels it "running (no surplus)" instead of "waiting" (#491).
+        running: this.unclaimedRunning.has(c.equipmentId),
       }));
     const suspensions = [...this.overridesUntil.entries()]
       .filter(([, until]) => until > now)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -728,6 +728,13 @@ export interface ArbiterPendingInfo {
    */
   toleratedImportW: number;
   reasonWaiting: string;
+  /**
+   * The claim is pending (no surplus granted) yet its equipment is actually
+   * running — a recipe drives it as a must-run fallback outside arbitration
+   * (`unclaimedRunning`). The load is drawing power, not idle, so the UI must
+   * show it as "running (no surplus)" rather than "waiting for surplus" (#491).
+   */
+  running: boolean;
 }
 
 export interface ArbiterSuspensionInfo {

--- a/ui/src/components/energy/ArbitrationSurface.test.tsx
+++ b/ui/src/components/energy/ArbitrationSurface.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "../../test-utils";
+import { ArbitrationSurface } from "./ArbitrationSurface";
+import { useArbiter } from "../../store/useArbiter";
+import { useEquipments } from "../../store/useEquipments";
+import { useZones } from "../../store/useZones";
+import type { ArbiterPublicState } from "../../types";
+
+// The mounted surface calls the arbiter store's fetch() on mount; stub the
+// network call so the state we seed via setState is what renders.
+vi.mock("../../api", async (orig) => ({
+  ...(await orig<typeof import("../../api")>()),
+  getArbiterState: vi.fn().mockRejectedValue(new Error("no network in test")),
+}));
+
+// #491: a pending claim whose load a recipe runs as a must-run fallback
+// (running: true) must read as "running (no surplus)", never "waiting for
+// surplus" — while a genuinely idle pending claim (running: false) still shows
+// the waiting reason.
+function pendingEntry(over: Partial<ArbiterPublicState["pending"][number]> = {}): ArbiterPublicState["pending"][number] {
+  return {
+    equipmentId: "pump",
+    equipmentName: "Pompe Piscine",
+    instanceId: "i-pump",
+    watts: 600,
+    needW: 300,
+    toleratedImportW: 0,
+    reasonWaiting: "insufficient-surplus:0",
+    running: false,
+    ...over,
+  };
+}
+
+function seedState(pending: ArbiterPublicState["pending"]): void {
+  const state: ArbiterPublicState = {
+    enabled: true,
+    state: "active",
+    availableSurplusW: -1091,
+    productionDetected: true,
+    grants: [],
+    pending,
+    suspensions: [],
+    journal: [],
+    surplusSeries: [],
+  };
+  useArbiter.setState({ state, loading: false });
+  useEquipments.setState({ equipments: [] });
+  useZones.setState({ tree: [] });
+}
+
+describe("ArbitrationSurface pending rows (#491)", () => {
+  beforeEach(() => {
+    useArbiter.setState({ state: null, loading: false });
+  });
+
+  it("shows a running must-run fallback as 'running (no surplus)', not 'waiting'", () => {
+    seedState([pendingEntry({ equipmentId: "pac", equipmentName: "PAC", watts: 2000, needW: 2000, running: true })]);
+    render(<ArbitrationSurface />);
+
+    expect(screen.getByText("running (no surplus)")).toBeTruthy();
+    expect(screen.getByText("running on grid; will switch to surplus when available")).toBeTruthy();
+    // It must NOT be presented as waiting for surplus.
+    expect(screen.queryByText(/waiting for surplus/)).toBeNull();
+  });
+
+  it("keeps an idle pending claim showing the waiting reason", () => {
+    seedState([pendingEntry({ running: false })]);
+    render(<ArbitrationSurface />);
+
+    expect(screen.getByText(/waiting for surplus \(needs 300 W\)/)).toBeTruthy();
+    expect(screen.queryByText("running (no surplus)")).toBeNull();
+  });
+
+  it("renders each pending load with its own label when both states coexist", () => {
+    seedState([
+      pendingEntry({ equipmentId: "pac", equipmentName: "PAC", watts: 2000, needW: 2000, running: true }),
+      pendingEntry({ running: false }),
+    ]);
+    render(<ArbitrationSurface />);
+
+    expect(screen.getByText("running (no surplus)")).toBeTruthy();
+    expect(screen.getByText(/waiting for surplus \(needs 300 W\)/)).toBeTruthy();
+  });
+});

--- a/ui/src/components/energy/ArbitrationSurface.tsx
+++ b/ui/src/components/energy/ArbitrationSurface.tsx
@@ -380,14 +380,20 @@ export function ArbitrationSurface() {
           key={p.equipmentId}
           className="flex items-center gap-2 mb-1 px-3 py-1.5 rounded-md bg-background border border-border-light text-[12.5px] text-text-secondary"
         >
-          <span>⏳</span>
+          {/* A pending claim whose load a recipe is already running as a
+              must-run fallback is drawing power, not idle — show it as running
+              on grid, never "waiting for surplus" (#491). */}
+          <span>{p.running ? "⚡" : "⏳"}</span>
           <span>
-            <b className="text-text">{p.equipmentName}</b> {waitingReason(p.reasonWaiting, p.needW, t)}
+            <b className="text-text">{p.equipmentName}</b>{" "}
+            {p.running ? t("arbiter.runningNoSurplus") : waitingReason(p.reasonWaiting, p.needW, t)}
             {/* The trigger alone leaves "why is it not 2200 W?" unanswered —
                 the appliance rating and the grid it accepts to buy are what
                 make the lower figure make sense. Secondary on purpose. */}
             <span className="block text-[11.5px] text-text-tertiary">
-              {t("arbiter.waitContext", { watts: p.watts, tolerated: p.toleratedImportW })}
+              {p.running
+                ? t("arbiter.runningNoSurplusHint")
+                : t("arbiter.waitContext", { watts: p.watts, tolerated: p.toleratedImportW })}
             </span>
           </span>
         </div>

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1228,6 +1228,8 @@
   "arbiter.waitReason.override-active": "paused (manual override active)",
   "arbiter.waitReason.min-off-cooldown": "waiting out the minimum-off delay",
   "arbiter.waitReason.unresponsive": "did not respond to the last revoke",
+  "arbiter.runningNoSurplus": "running (no surplus)",
+  "arbiter.runningNoSurplusHint": "running on grid; will switch to surplus when available",
   "arbiter.revokeReason.surplus-deficit": "production dropped",
   "arbiter.revokeReason.priority-preempted": "yielded to a higher-priority load",
   "arbiter.revokeReason.manual-override": "you took manual control",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1228,6 +1228,8 @@
   "arbiter.waitReason.override-active": "en pause (pilotage manuel actif)",
   "arbiter.waitReason.min-off-cooldown": "attente du délai d'arrêt minimum",
   "arbiter.waitReason.unresponsive": "n'a pas répondu à la dernière révocation",
+  "arbiter.runningNoSurplus": "en marche (hors surplus)",
+  "arbiter.runningNoSurplusHint": "tourne sur le réseau, passera sur le surplus dès qu'il y en aura",
   "arbiter.revokeReason.surplus-deficit": "la production a baissé",
   "arbiter.revokeReason.priority-preempted": "cédé à une charge plus prioritaire",
   "arbiter.revokeReason.manual-override": "vous avez pris le pilotage manuel",

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -335,6 +335,9 @@ export interface ArbiterPublicState {
     /** Grid the claim accepts to buy; explains the gap between the two above. */
     toleratedImportW: number;
     reasonWaiting: string;
+    /** Pending but its load is already running as a recipe must-run fallback
+     *  (no surplus granted) — shown as "running (no surplus)", not "waiting" (#491). */
+    running: boolean;
   }>;
   suspensions: Array<{ equipmentId: string; equipmentName: string; untilIso: string }>;
   journal: ArbiterDecision[];


### PR DESCRIPTION
## Root cause

When a recipe (e.g. `smart-cooling`) holds a solar-surplus capacity claim but runs the load anyway as a must-run/comfort fallback (hot day, no surplus), the claim legitimately stays **pending** while the equipment draws power. The arbiter already tracks this in `unclaimedRunning` (it journals `unclaimed-run`), but `buildPublicState` published the claim in `pending` with **no cross-check against `unclaimedRunning`**, and never exposed that set. The UI therefore rendered a load pulling several kW as *"en attente de surplus (besoin de 2000 W)"*.

Confirmed live on prod 2026-08-13 18:08Z: surplus **−1091 W**, PAC energy meter **835 W** (running), PAC in `pending` (2000 W); arbiter journal logged `unclaimed-run PAC` at 07:35 and 16:00. The PAC ran continuously 08:00→18:00 (peak **3.9 kW** at 14:00).

Distinct from #474, which only changed *which number* a pending row shows.

## Fix

Reconcile the read model with the running state — no change to grant/revoke logic or the `unclaimed-run` guard (which is correct):

- `ArbiterPendingInfo` gains a `running: boolean`, set from `this.unclaimedRunning.has(c.equipmentId)` in `buildPublicState` ([capacity-arbiter.ts](../blob/main/src/energy/capacity-arbiter.ts)).
- `ArbitrationSurface` renders a running pending claim as **"running (no surplus)"** with a distinct icon (⚡ vs ⏳) and a matching hint; a genuinely idle pending claim (e.g. pool pump OFF) is unchanged and still shows the waiting reason.
- New i18n keys `arbiter.runningNoSurplus` / `arbiter.runningNoSurplusHint` (fr + en).

## Tests

- **Backend** (`capacity-arbiter.test.ts`): a pending claim flips `running` false→true when the recipe turns the load on outside a grant, and back to false on OFF.
- **UI** (`ArbitrationSurface.test.tsx`): a running pending claim renders "running (no surplus)" and never "waiting for surplus"; an idle one keeps the waiting reason; both coexist correctly.

## Verification

- `npx tsc --noEmit` (backend) + `tsc -b` (ui): green
- `eslint`: clean; `vitest`: backend 1276 pass, ui 366 pass; `vite build`: green

Note: prod runs an older core, so this ships in the next release; no prod deploy in this PR.

Closes #491