### PR TITLE
release: v1.45.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,17 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.45.x : Corrections d'affichage de l'arbitrage et nettoyage de l'UI
+
+### v1.45.0 — 2026-08-13 { #v1-45-0 }
+
+- Correctif (énergie) : **une charge qui tourne réellement n'est plus affichée « en attente de surplus »**. Quand une recette fait tourner une charge pilotable en repli « marche obligatoire » alors que sa demande de surplus solaire reste en attente (journée chaude, aucun surplus à accorder), la surface d'arbitrage l'indiquait « en attente de surplus » alors qu'elle consommait plusieurs kW. Une telle demande affiche désormais « en marche (hors surplus) » avec son propre marqueur ; une demande réellement à l'arrêt est inchangée. (#491, #492)
+- Correctif (énergie) : **une demande d'arbitrage en attente indique le surplus qu'elle attend, pas sa propre consommation**. Une demande qui tolère d'acheter un peu de réseau démarre bien en dessous de sa puissance nominale ; afficher la puissance nominale laissait croire « ça ne démarrera jamais ». La ligne montre maintenant le surplus réellement testé par l'arbitre, avec la puissance de l'appareil et l'import réseau toléré en contexte, et la frise du surplus a gagné des segments par run pour les charges tournant hors arbitrage. Contribution d'Adrien Jouve (computingify). (#474)
+- Correctif (ui) : **les tuiles d'équipements portant le même nom sont distinguées par leur zone**. Deux capteurs de même nom dans des pièces différentes étaient indiscernables sur le tableau de bord ; chacun affiche désormais sa zone distinctive sur une deuxième ligne, en réutilisant l'étiquetage par plus court suffixe déjà employé ailleurs dans l'application. Contribution d'Adrien Jouve (computingify). (#488)
+- Correctif (ui) : **les nœuds au repos du schéma énergétique en direct restent opaques**. Un nœud à l'arrêt s'estompait assez pour laisser transparaître les flux à travers son icône ; la boîte garde maintenant une opacité pleine et seul son contenu s'estompe. Contribution d'Adrien Jouve (computingify). (#487)
+- Correctif (ui) : **la tuile compteur d'énergie s'affiche désormais sur mobile et la tuile lecteur multimédia sur ordinateur**. Chacune des deux catégories de tuiles ne s'affichait que sur un seul format d'écran. (#323, #324, #485)
+- Interne (ui) : grande passe de maintenabilité sur l'UI des recettes et des publishers, sans changement visible. Le fichier `ZoneRecipesSection` de 2200 lignes a été découpé en modules par composant avec un hook partagé d'options de zone, les pages de publishers de notifications et MQTT ont été unifiées sur un éditeur descriptif et une couche de source de mapping partagés, et un niveau de tests de composants jsdom + Testing Library a été introduit. (#456, #387, #457, #458, #484, #486, #489, #490)
+
 ## 1.44.x : Validation des entrées API et OpenAPI
 
 ### v1.44.0 — 2026-08-13 { #v1-44-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,17 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.45.x: Arbitration display fixes and UI cleanup
+
+### v1.45.0 — 2026-08-13 { #v1-45-0 }
+
+- Fix (energy): **a load that is actually running is no longer shown as "waiting for surplus"**. When a recipe runs a flexible load as a must-run fallback while its solar-surplus claim stays pending (a hot day with no surplus to grant), the arbitration surface listed it as waiting for surplus even though it was drawing several kW. Such a claim now reads "running (no surplus)" with its own marker; a genuinely idle claim is unchanged. (#491, #492)
+- Fix (energy): **a pending arbiter claim shows the surplus it is waiting for, not its own draw**. A claim that tolerates buying a little grid engages well below its own rating, so quoting the full rating read as "it will never start". The row now shows the surplus the arbiter actually tests against, with the appliance rating and the tolerated grid import given as context, and the surplus timeline gained per-run spans for loads running outside arbitration. Contributed by Adrien Jouve (computingify). (#474)
+- Fix (ui): **equipment widgets that share a name are told apart by their zone**. Two identically named sensors in different rooms were indistinguishable on the dashboard; each now shows its disambiguating zone on a second line, reusing the shortest-suffix labelling already used elsewhere in the app. Contributed by Adrien Jouve (computingify). (#488)
+- Fix (ui): **idle nodes in the live energy diagram stay opaque**. A node at rest dimmed enough for the flow paths to bleed through its icon; the box now keeps full opacity while only its content dims. Contributed by Adrien Jouve (computingify). (#487)
+- Fix (ui): **the energy-meter widget now renders on mobile and the media-player widget on desktop**. Each of the two dashboard widget categories rendered on only one breakpoint. (#323, #324, #485)
+- Internal (ui): a large maintainability pass on the recipe and publisher UI, with no user-facing change. The 2200-line `ZoneRecipesSection` was split into focused per-component modules with a shared zone-options hook, the notification and MQTT publisher pages were unified onto a shared descriptor-driven editor and mapping-source layer, and a jsdom + Testing Library component-test tier was introduced. (#456, #387, #457, #458, #484, #486, #489, #490)
+
 ## 1.44.x: API input validation and OpenAPI
 
 ### v1.44.0 — 2026-08-13 { #v1-44-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.44.0",
+  "version": "1.45.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump + release notes for v1.45.0.

Covers everything merged since v1.44.0:
- Fix (energy): running must-run load shown as running, not waiting for surplus (#491, #492)
- Fix (energy): pending claim shows the surplus it waits for, not its own draw (#474, computingify)
- Fix (ui): homonym equipment widgets disambiguated by zone (#488, computingify)
- Fix (ui): idle live-diagram nodes stay opaque (#487, computingify)
- Fix (ui): energy-meter on mobile, media-player on desktop (#323, #324, #485)
- Internal (ui): recipe/publisher UI maintainability pass + component-test tier (#456, #387, #457, #458, #484, #486, #489, #490)

Release notes added to docs/release-notes.md and docs/release-notes.fr.md with the { #v1-45-0 } anchor.