### PR TITLE
feat(core): persist activity feed and arbiter decision journal across restarts (#494)

### DIFF
--- a/migrations/019_activity_arbiter_history.sql
+++ b/migrations/019_activity_arbiter_history.sql
@@ -1,0 +1,30 @@
+-- Spec 147 — persist the activity feed (spec 101) and the arbiter decision
+-- journal (spec 140) across restarts. Both were in-memory ring buffers, lost on
+-- every container restart/update (issue #494). Mirrors the audit_log pattern
+-- (spec 113): bounded, timestamped, append-only, purged at boot (7-day
+-- retention). Live arbiter control state (claims, suspensions, surplus) is NOT
+-- persisted — it is rebuilt from live events by design.
+
+CREATE TABLE IF NOT EXISTS activity_log (
+  id         TEXT PRIMARY KEY,
+  timestamp  INTEGER NOT NULL,      -- epoch ms (ActivityItem.timestamp)
+  category   TEXT NOT NULL,
+  zone_id    TEXT,                  -- nullable (global items)
+  message    TEXT NOT NULL,         -- JSON ActivityMessage {template, params}
+  source     TEXT                   -- JSON OrderSource, nullable
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_log_timestamp ON activity_log (timestamp DESC);
+
+CREATE TABLE IF NOT EXISTS arbiter_decision_log (
+  id             TEXT PRIMARY KEY,
+  at_iso         TEXT NOT NULL,     -- ISO 8601 (ArbiterDecision.atIso)
+  kind           TEXT NOT NULL,
+  equipment_id   TEXT,
+  equipment_name TEXT,
+  watts          REAL,
+  reason         TEXT,
+  note           TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_arbiter_decision_log_at_iso ON arbiter_decision_log (at_iso DESC);

--- a/specs/147-persist-activity-arbiter-history/architecture.md
+++ b/specs/147-persist-activity-arbiter-history/architecture.md
@@ -1,0 +1,154 @@
+# Spec 147 — Architecture
+
+## Overview
+
+Two thin persistence services, each modeled on `AuditLogger` (spec 113): a
+prepared-statement `insert`, a `loadRecent`, and a `purgeOlderThan`, all
+non-throwing. They are injected (optionally) into the two existing owners, which
+keep their in-memory rings as the live read model and gain a persist-on-write +
+load-on-boot behavior.
+
+```
+push()/journal()  ──▶  in-memory ring (unchanged read model)
+        │
+        └──▶ Store.insert(row)   (never throws; pino on failure)
+
+boot:
+  Store.loadRecent(window, cap)  ──▶ seed the in-memory ring
+  Store.purgeOlderThan(7 days)   ──▶ trim the table
+```
+
+No new events, routes, WebSocket topics, or UI. `ActivityBuffer.getItems` and
+`CapacityArbiter.getPublicState` are untouched — they simply return pre-seeded
+data after a restart.
+
+## Data model — migration `019_activity_arbiter_history.sql`
+
+```sql
+-- Spec 147 — persist the activity feed (spec 101) and the arbiter decision
+-- journal (spec 140) across restarts. 7-day retention, purged at boot.
+
+CREATE TABLE IF NOT EXISTS activity_log (
+  id         TEXT PRIMARY KEY,
+  timestamp  INTEGER NOT NULL,      -- epoch ms (ActivityItem.timestamp)
+  category   TEXT NOT NULL,
+  zone_id    TEXT,                  -- nullable (global items)
+  message    TEXT NOT NULL,         -- JSON ActivityMessage {template, params}
+  source     TEXT                   -- JSON OrderSource, nullable
+);
+CREATE INDEX IF NOT EXISTS idx_activity_log_timestamp ON activity_log (timestamp DESC);
+
+CREATE TABLE IF NOT EXISTS arbiter_decision_log (
+  id             TEXT PRIMARY KEY,
+  at_iso         TEXT NOT NULL,     -- ISO 8601 (ArbiterDecision.atIso)
+  kind           TEXT NOT NULL,
+  equipment_id   TEXT,
+  equipment_name TEXT,
+  watts          REAL,
+  reason         TEXT,
+  note           TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_arbiter_decision_log_at_iso ON arbiter_decision_log (at_iso DESC);
+```
+
+Rationale for two tables (not one generic log): the two records have different
+native shapes (activity: category/zone/message/source, epoch-ms; decision:
+kind/equipment/watts/reason, ISO). Two tables keep the mappers trivial and the
+read models unchanged. `activity_log.timestamp` is epoch-ms INTEGER so the purge
+is a numeric compare; `arbiter_decision_log.at_iso` is ISO TEXT so the purge uses
+`datetime('now','-7 days')` like `audit_log`.
+
+## Services
+
+### `src/activity/activity-store.ts` — `ActivityStore`
+
+```ts
+export const ACTIVITY_RETENTION_DAYS = 7;
+
+export class ActivityStore {
+  constructor(db, logger) {
+    /* prepare insert / loadRecent / purge / count */
+  }
+  insert(item: ActivityItem): void; // never throws
+  loadRecent(limit: number): ActivityItem[]; // ORDER BY timestamp DESC LIMIT ?
+  purgeOlderThan(days = ACTIVITY_RETENTION_DAYS): number;
+}
+```
+
+- `insert`: `INSERT INTO activity_log (id, timestamp, category, zone_id, message, source)`
+  with `message = JSON.stringify(item.message)`, `source = item.source ? JSON.stringify(...) : null`.
+- `loadRecent`: `SELECT ... ORDER BY timestamp DESC LIMIT ?`, mapped back to
+  `ActivityItem` (parse JSON columns). Returned newest-first — the same order the
+  in-memory ring holds (`unshift`).
+- `purgeOlderThan`: `DELETE FROM activity_log WHERE timestamp < ?` with cutoff
+  `Date.now() - days * 86_400_000`.
+
+### `src/energy/arbiter-journal-store.ts` — `ArbiterJournalStore`
+
+```ts
+export const ARBITER_JOURNAL_RETENTION_DAYS = 7;
+
+export class ArbiterJournalStore {
+  constructor(db, logger) {
+    /* prepare stmts */
+  }
+  insert(d: ArbiterDecision): void; // never throws
+  loadRecent(limit: number): ArbiterDecision[]; // oldest-first, last `limit`
+  purgeOlderThan(days = ARBITER_JOURNAL_RETENTION_DAYS): number;
+}
+```
+
+- `loadRecent`: select the most recent `limit` rows (`ORDER BY at_iso DESC LIMIT ?`)
+  then reverse to **ascending** so it matches `journalEntries` in-memory order
+  (which appends and reverses only in `getPublicState`).
+- `purgeOlderThan`: `DELETE FROM arbiter_decision_log WHERE at_iso < datetime('now','-'||?||' days')`.
+
+Both services follow `AuditLogger` exactly: constructor prepares statements, every
+public method wraps its DB call in try/catch and logs `{ err }` via a child pino
+logger, and returns a safe default on failure.
+
+## Wiring
+
+### `ActivityBuffer` (`src/activity/activity-buffer.ts`)
+
+- Constructor gains an optional last parameter `store?: ActivityStore`.
+- `push()` (line 104): after updating the ring, `this.store?.insert(item)`.
+- `start()` (line 44): before subscribing, seed the ring from the store:
+  `const recent = this.store?.loadRecent(MAX_ITEMS) ?? []; this.items.push(...recent)`
+  (the store returns newest-first, so a direct push preserves order; guard against
+  double-seeding by only seeding when `items` is empty).
+
+### `CapacityArbiter` (`src/energy/capacity-arbiter.ts`)
+
+- Constructor gains an optional `journalStore?: ArbiterJournalStore` (added after
+  the existing params so `shadowMode`'s default position is preserved, or as a
+  named/options addition — keep call sites explicit).
+- `journal()` (line ~1132): after pushing to `journalEntries`,
+  `this.journalStore?.insert(full)`.
+- `start()`: seed `journalEntries` from
+  `this.journalStore?.loadRecent(JOURNAL_CAP) ?? []` (ascending) when empty.
+
+### Boot (`src/index.ts`)
+
+- Instantiate both stores with the shared `db` and logger, next to the existing
+  `AuditLogger` (around line 406).
+- Pass `activityStore` into `new ActivityBuffer(...)` (line ~381) and
+  `arbiterJournalStore` into `new CapacityArbiter(...)` (line ~325).
+- Call `activityStore.purgeOlderThan()` and `arbiterJournalStore.purgeOlderThan()`
+  at boot, alongside `auditLogger.purgeOlderThan()`.
+
+## Files touched
+
+| File                                          | Change                                             |
+| --------------------------------------------- | -------------------------------------------------- |
+| `migrations/019_activity_arbiter_history.sql` | two new tables + indexes                           |
+| `src/activity/activity-store.ts`              | new `ActivityStore` service                        |
+| `src/energy/arbiter-journal-store.ts`         | new `ArbiterJournalStore` service                  |
+| `src/activity/activity-buffer.ts`             | optional store: persist-on-push + seed-on-start    |
+| `src/energy/capacity-arbiter.ts`              | optional store: persist-on-journal + seed-on-start |
+| `src/index.ts`                                | instantiate stores, inject, boot purge             |
+| `src/activity/activity-store.test.ts`         | round-trip / reload / purge / never-throw          |
+| `src/energy/arbiter-journal-store.test.ts`    | round-trip / reload / purge / never-throw          |
+
+No changes to `src/shared/types.ts` (reuse `ActivityItem` / `ArbiterDecision`),
+no API/WS/UI changes.

--- a/specs/147-persist-activity-arbiter-history/plan.md
+++ b/specs/147-persist-activity-arbiter-history/plan.md
@@ -1,0 +1,72 @@
+# Spec 147 — Implementation plan
+
+Branch: `feat/issue-494-persist-activity-arbiter-history`
+
+## Tasks
+
+### Database
+
+- [x] 1. Migration `019_activity_arbiter_history.sql`: `activity_log` +
+     `arbiter_decision_log` tables and their `timestamp`/`at_iso` indexes.
+
+### Services
+
+- [x] 2. `src/activity/activity-store.ts` — `ActivityStore` (insert / loadRecent /
+     purgeOlderThan, never-throw, `ACTIVITY_RETENTION_DAYS = 7`).
+- [x] 3. `src/energy/arbiter-journal-store.ts` — `ArbiterJournalStore` (insert /
+     loadRecent / purgeOlderThan, never-throw, `ARBITER_JOURNAL_RETENTION_DAYS = 7`).
+
+### Wiring
+
+- [x] 4. `ActivityBuffer`: optional `store?: ActivityStore`; persist in `push()`;
+     seed the ring in `start()` when empty.
+- [x] 5. `CapacityArbiter`: optional `journalStore?: ArbiterJournalStore`; persist
+     in `journal()`; seed `journalEntries` in `start()` when empty.
+- [x] 6. `src/index.ts`: instantiate both stores, inject into `ActivityBuffer` and
+     `CapacityArbiter`, and call `purgeOlderThan()` at boot.
+
+### Tests
+
+- [x] 7. `activity-store.test.ts` — scenarios below.
+- [x] 8. `arbiter-journal-store.test.ts` — scenarios below.
+
+### Docs / release
+
+- [ ] 9. `sowel-docs`: note persistence in the architecture "Activity Buffer" and
+     arbiter sections (they currently say "lost on restart").
+- [ ] 10. Release notes entry (EN + FR) at release time (spec 108).
+
+## Test Plan
+
+### Modules to test
+
+- `ActivityStore` (new persistence + mapping + purge).
+- `ArbiterJournalStore` (new persistence + mapping + purge + ordering).
+
+Both are the pieces with business logic. `ActivityBuffer` / `CapacityArbiter`
+already have tests; the store injection is exercised through the store tests
+(the in-memory rings are unchanged). We do not add React tests (no UI change).
+
+### Scenarios
+
+| Module              | Scenario                       | Expected                                                                  |
+| ------------------- | ------------------------------ | ------------------------------------------------------------------------- |
+| ActivityStore       | insert then loadRecent         | item round-trips (category, zoneId, message JSON, source JSON, timestamp) |
+| ActivityStore       | loadRecent ordering            | newest-first (matches the in-memory ring's `unshift` order)               |
+| ActivityStore       | loadRecent limit               | returns at most `limit` rows                                              |
+| ActivityStore       | null zoneId / undefined source | stored and read back as null/undefined without loss                       |
+| ActivityStore       | purgeOlderThan(7)              | rows older than 7 days deleted, recent kept; returns count removed        |
+| ActivityStore       | insert on a broken db          | does not throw; error logged                                              |
+| ArbiterJournalStore | insert then loadRecent         | decision round-trips (kind, equipmentId/name, watts, reason, note, atIso) |
+| ArbiterJournalStore | loadRecent ordering            | ascending (oldest-first), matching `journalEntries` in-memory order       |
+| ArbiterJournalStore | loadRecent limit = JOURNAL_CAP | returns the most recent `cap` rows, ascending                             |
+| ArbiterJournalStore | purgeOlderThan(7)              | rows older than 7 days deleted, recent kept                               |
+| ArbiterJournalStore | insert on a broken db          | does not throw; error logged                                              |
+
+### Manual verification
+
+- Start the engine, generate a few activities and (with the arbiter enabled) a
+  few decisions, restart the container, confirm the activity feed and the arbiter
+  decision journal are still populated in the UI.
+- Confirm the arbiter's live grants/suspensions are NOT restored (rebuilt from
+  events), i.e. no stale suspension appears right after a restart.

--- a/specs/147-persist-activity-arbiter-history/spec.md
+++ b/specs/147-persist-activity-arbiter-history/spec.md
@@ -1,0 +1,88 @@
+# Spec 147 — Persist the activity feed and the arbiter decision journal
+
+## Context
+
+Two histories are lost on every container restart or update, exactly when you
+most want to look back at what happened:
+
+- **Activity feed** (spec 101) — `ActivityBuffer` keeps a 2000-item / 24h
+  in-memory ring (`src/activity/activity-buffer.ts:28`). Nothing is persisted.
+- **Energy arbiter decision journal** (spec 140) — `CapacityArbiter` keeps a
+  200-entry in-memory ring (`src/energy/capacity-arbiter.ts:125`). Nothing is
+  persisted.
+
+Sowel already has the right pattern for a bounded, timestamped, append-only log
+that survives restarts: the `audit_log` table + `AuditLogger` (spec 113), with a
+boot-time retention purge (`src/core/audit-logger.ts:49`, purged in
+`src/index.ts`). This spec applies that pattern to the two histories.
+
+## Goals
+
+- The **activity feed** and the **arbiter decision journal** survive a restart:
+  recent entries are reloaded on boot into their existing read models.
+- Reuse the `audit_log` approach: one SQLite table per history, persist-on-write,
+  load-recent-on-boot, 7-day retention purged at boot.
+- Zero change to the existing read models, API routes, WebSocket topics, and UI —
+  they simply start pre-populated after a restart.
+
+## Non-goals / explicitly out of scope (v1)
+
+- **Restoring the arbiter's live control state** — current claims/grants, the
+  suspension timers (`overridesUntil`), and the surplus series
+  (`capacity-arbiter.ts:124,136,156`) are NOT persisted or restored. Restoring
+  stale control state after an update is unsafe (a manual-override suspension from
+  before the update may no longer be valid), and the arbiter rebuilds this state
+  from live events within one evaluation cycle by design. Only the **decision
+  journal** (history) is persisted.
+- No new API route, no new WebSocket event, no UI change. The read models
+  (`ActivityBuffer.getItems`, `CapacityArbiter.getPublicState`) are unchanged.
+- No InfluxDB involvement (optional in a Sowel install; wrong shape for discrete
+  templated events).
+- No configurable retention setting in v1 — 7 days is hard-coded like
+  `audit_log`'s 365, and can be lifted to a setting later.
+
+## Requirements
+
+1. A new SQLite table persists each activity item as it is pushed, and each
+   arbiter decision as it is journaled.
+2. On boot, `ActivityBuffer` and `CapacityArbiter` load their recent persisted
+   entries (within the retention window, capped to their existing in-memory ring
+   sizes) so the read models are populated before the first client connects.
+3. At boot, entries older than **7 days** are purged from both tables.
+4. Persistence must **never throw** into the engine: a DB write failure is logged
+   via pino and the in-memory ring continues to work (degraded to pre-147
+   behavior).
+5. The in-memory ring caps (`MAX_ITEMS = 2000`, `JOURNAL_CAP = 200`) still bound
+   live memory; persistence is additive.
+
+## Acceptance criteria
+
+- [x] A migration (`019`) creates an `activity_log` table and an
+      `arbiter_decision_log` table, mirroring the `audit_log` shape.
+- [x] Every activity item pushed by `ActivityBuffer` is persisted; every decision
+      journaled by `CapacityArbiter` is persisted.
+- [x] On boot, the activity feed reloads the last 7 days (up to `MAX_ITEMS`) and
+      the arbiter journal reloads the last 7 days (up to `JOURNAL_CAP`), newest
+      entries first in the read model, matching pre-restart ordering.
+- [x] Boot-time purge deletes entries older than 7 days from both tables.
+- [x] A DB failure on write or load is swallowed (logged, not thrown); the engine
+      runs with the in-memory ring only.
+- [x] The arbiter's live control state (claims, suspensions, surplus) is NOT
+      persisted or restored — unchanged behavior.
+- [x] No change to REST routes, WebSocket topics, or the UI.
+- [x] Tests: persistence round-trip, boot reload, retention purge, and
+      never-throw on a failing store, for both histories.
+
+## Edge cases
+
+- Empty tables on first boot after the migration → read models start empty
+  (current behavior).
+- Store injection absent (unit tests, or a future opt-out) → in-memory only, no
+  persistence, no crash.
+- Shadow mode: activities still persist to the shadow's own DB copy (harmless);
+  the arbiter does not arbitrate in shadow so it journals nothing new.
+- Clock/timestamp: activity items use epoch-ms (`ActivityItem.timestamp`);
+  arbiter decisions use ISO (`ArbiterDecision.atIso`). Each table stores its
+  native form and the retention purge matches it.
+- A very large backlog within 7 days → boot load is capped to the ring size, so
+  memory stays bounded regardless of table size.

--- a/src/activity/activity-buffer.test.ts
+++ b/src/activity/activity-buffer.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ActivityBuffer } from "./activity-buffer.js";
+import type { ActivityStore } from "./activity-store.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
-import type { Equipment } from "../shared/types.js";
+import type { ActivityItem, Equipment } from "../shared/types.js";
 
 const logger = createLogger("silent").logger;
 
@@ -445,5 +446,58 @@ describe("ActivityBuffer", () => {
       }
       expect(h.buffer.size()).toBe(2000);
     });
+  });
+});
+
+// Spec 147 — persistence wiring (store injected).
+describe("ActivityBuffer persistence", () => {
+  function mkItem(id: string, timestamp: number): ActivityItem {
+    return {
+      id,
+      timestamp,
+      category: "mode",
+      zoneId: null,
+      message: { template: "mode.activated", params: { modeName: id } },
+    };
+  }
+
+  function buildWithStore(store: Partial<ActivityStore>) {
+    const bus = new EventBus(logger);
+    const noop = {
+      getById: () => null,
+      getDataBindingsWithValues: () => [],
+    } as unknown as Parameters<typeof ActivityBuffer.prototype.constructor>[1];
+    const zoneManager = {
+      getDescendantIds: (z: string) => [z],
+    } as unknown as Parameters<typeof ActivityBuffer.prototype.constructor>[3];
+    const sunlightManager = {
+      getSunlightData: () => ({ sunrise: null, sunset: null, isDaylight: false }),
+    } as unknown as Parameters<typeof ActivityBuffer.prototype.constructor>[4];
+    const buffer = new ActivityBuffer(
+      bus,
+      noop,
+      noop,
+      zoneManager,
+      sunlightManager,
+      logger,
+      store as ActivityStore,
+    );
+    return { bus, buffer };
+  }
+
+  it("seeds the ring from the store on start (newest-first, as returned)", () => {
+    const seed = [mkItem("newer", 200), mkItem("older", 100)]; // store returns DESC
+    const { buffer } = buildWithStore({ loadRecent: () => seed, insert: vi.fn() });
+    buffer.start();
+    expect(buffer.getItems({ limit: 10 }).map((i) => i.id)).toEqual(["newer", "older"]);
+  });
+
+  it("persists each pushed item to the store", () => {
+    const insert = vi.fn();
+    const { bus, buffer } = buildWithStore({ loadRecent: () => [], insert });
+    buffer.start();
+    bus.emit({ type: "mode.activated", modeId: "m1", modeName: "Night" });
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(insert.mock.calls[0][0]).toMatchObject({ category: "mode" });
   });
 });

--- a/src/activity/activity-buffer.ts
+++ b/src/activity/activity-buffer.ts
@@ -5,6 +5,7 @@ import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { RecipeManager } from "../recipes/engine/recipe-manager.js";
 import type { ZoneManager } from "../zones/zone-manager.js";
 import type { SunlightManager } from "../zones/sunlight-manager.js";
+import { ACTIVITY_RETENTION_DAYS, type ActivityStore } from "./activity-store.js";
 import type { ActivityItem, ActivityCategory, ActivityMessage } from "../shared/types.js";
 
 interface GetItemsOptions {
@@ -14,15 +15,19 @@ interface GetItemsOptions {
 }
 
 const MAX_ITEMS = 2000;
-const TTL_MS = 24 * 60 * 60 * 1000;
+// Spec 147 — keep the live ring aligned with the persisted retention so a
+// restart restores the same window it will then maintain (bounded by MAX_ITEMS).
+const TTL_MS = ACTIVITY_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 
 /**
  * Ring buffer of activity items fed by the engine event bus (spec 101).
  *
- * - In-memory only (lost on container restart, like the logs ring buffer).
- * - Cap of 200 items, 1h TTL purged on every push.
+ * - Cap of 2000 items, 7-day TTL purged on every push (matches persistence).
  * - Filters and enriches engine events before storage, then re-emits
  *   `activity.added` on the bus so the WebSocket layer can broadcast.
+ * - Spec 147: when an `ActivityStore` is injected, every item is persisted to
+ *   SQLite and the recent history is reloaded on boot, so the feed survives a
+ *   restart. Without a store it stays in-memory only (pre-147 behaviour).
  */
 export class ActivityBuffer {
   private readonly items: ActivityItem[] = [];
@@ -36,12 +41,22 @@ export class ActivityBuffer {
     private readonly zoneManager: ZoneManager,
     private readonly sunlightManager: SunlightManager,
     logger: Logger,
+    private readonly store?: ActivityStore,
   ) {
     this.logger = logger.child({ module: "activity-buffer" });
     this.prevIsDaylight = this.sunlightManager.getSunlightData().isDaylight;
   }
 
   start(): void {
+    // Spec 147 — seed from persisted history (newest-first, matching the ring)
+    // before subscribing, so the feed is populated right after a restart.
+    if (this.store && this.items.length === 0) {
+      const recent = this.store.loadRecent(MAX_ITEMS);
+      this.items.push(...recent);
+      if (recent.length > 0) {
+        this.logger.info({ count: recent.length }, "Activity feed restored from store");
+      }
+    }
     this.bus.onType("equipment.order.executed", (e) => this.onOrderExecuted(e));
     this.bus.onType("equipment.data.changed", (e) => this.onDataChanged(e));
     this.bus.onType("recipe.instance.started", (e) => this.onRecipeStarted(e));
@@ -112,6 +127,9 @@ export class ActivityBuffer {
     while (this.items.length > 0 && this.items[this.items.length - 1].timestamp < cutoff) {
       this.items.pop();
     }
+
+    // Spec 147 — persist so the feed survives a restart (never throws).
+    this.store?.insert(item);
 
     this.bus.emit({ type: "activity.added", item });
   }

--- a/src/activity/activity-store.test.ts
+++ b/src/activity/activity-store.test.ts
@@ -1,0 +1,100 @@
+import Database from "better-sqlite3";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ActivityStore } from "./activity-store.js";
+import type { Logger } from "../core/logger.js";
+import type { ActivityItem } from "../shared/types.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
+
+// Spec 147 — ActivityStore over an in-memory SQLite db seeded with the real
+// migration set (activity_log lives in migrations/019).
+
+interface MockLogger {
+  error: ReturnType<typeof vi.fn>;
+  child: () => MockLogger;
+}
+
+function makeMockLogger(): MockLogger {
+  const error = vi.fn();
+  const self: MockLogger = { error, child: () => self };
+  return self;
+}
+
+let seq = 0;
+function item(over: Partial<ActivityItem> = {}): ActivityItem {
+  seq += 1;
+  return {
+    id: `a${seq}`,
+    timestamp: 1_000_000 + seq,
+    category: "order",
+    zoneId: "z1",
+    message: {
+      template: "order.executed",
+      params: { equipmentName: "Lamp", alias: "state", value: "ON" },
+    },
+    source: { kind: "manual", userId: "u1" },
+    ...over,
+  };
+}
+
+describe("ActivityStore", () => {
+  let db: Database.Database;
+  let logger: MockLogger;
+  let store: ActivityStore;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    applyMigrations(db);
+    logger = makeMockLogger();
+    store = new ActivityStore(db, logger as unknown as Logger);
+  });
+
+  afterEach(() => db.close());
+
+  it("round-trips an item through insert + loadRecent", () => {
+    const it = item({ id: "x1", timestamp: 5_000 });
+    store.insert(it);
+    const rows = store.loadRecent(10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual(it);
+  });
+
+  it("loadRecent returns newest-first (matches the in-memory ring)", () => {
+    const older = item({ id: "old", timestamp: 100 });
+    const newer = item({ id: "new", timestamp: 200 });
+    store.insert(older);
+    store.insert(newer);
+    expect(store.loadRecent(10).map((r) => r.id)).toEqual(["new", "old"]);
+  });
+
+  it("loadRecent honours the limit", () => {
+    store.insert(item({ timestamp: 1 }));
+    store.insert(item({ timestamp: 2 }));
+    store.insert(item({ timestamp: 3 }));
+    expect(store.loadRecent(2)).toHaveLength(2);
+  });
+
+  it("preserves a null zoneId and an undefined source", () => {
+    store.insert(item({ id: "g", zoneId: null, source: undefined }));
+    const [row] = store.loadRecent(10);
+    expect(row.zoneId).toBeNull();
+    expect(row.source).toBeUndefined();
+  });
+
+  it("purgeOlderThan deletes items older than the window and keeps recent ones", () => {
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    const now = Date.now();
+    store.insert(item({ id: "stale", timestamp: eightDaysAgo }));
+    store.insert(item({ id: "fresh", timestamp: now }));
+    const removed = store.purgeOlderThan(7);
+    expect(removed).toBe(1);
+    expect(store.loadRecent(10).map((r) => r.id)).toEqual(["fresh"]);
+  });
+
+  it("never throws when the underlying table is gone (logs instead)", () => {
+    db.exec("DROP TABLE activity_log");
+    expect(() => store.insert(item())).not.toThrow();
+    expect(store.loadRecent(10)).toEqual([]);
+    expect(store.purgeOlderThan(7)).toBe(0);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/src/activity/activity-store.ts
+++ b/src/activity/activity-store.ts
@@ -1,0 +1,99 @@
+import type Database from "better-sqlite3";
+import type { Logger } from "../core/logger.js";
+import type {
+  ActivityItem,
+  ActivityCategory,
+  ActivityMessage,
+  OrderSource,
+} from "../shared/types.js";
+
+// Spec 147 — persistence for the activity feed (spec 101).
+//
+// Mirrors AuditLogger (spec 113): persist-on-write, load-recent-on-boot,
+// retention purged at boot. NEVER throws into the engine — a DB failure is
+// logged via pino and the in-memory ring keeps working (pre-147 behaviour).
+
+export const ACTIVITY_RETENTION_DAYS = 7;
+
+interface ActivityRow {
+  id: string;
+  timestamp: number;
+  category: string;
+  zone_id: string | null;
+  message: string;
+  source: string | null;
+}
+
+export class ActivityStore {
+  private logger: Logger;
+  private insertStmt: Database.Statement;
+  private loadRecentStmt: Database.Statement;
+  private purgeStmt: Database.Statement;
+  private countStmt: Database.Statement;
+
+  constructor(db: Database.Database, logger: Logger) {
+    this.logger = logger.child({ module: "activity-store" });
+    this.insertStmt = db.prepare(
+      `INSERT INTO activity_log (id, timestamp, category, zone_id, message, source)
+       VALUES (@id, @timestamp, @category, @zoneId, @message, @source)`,
+    );
+    this.loadRecentStmt = db.prepare(
+      "SELECT id, timestamp, category, zone_id, message, source FROM activity_log" +
+        // rowid (insertion order) is a stable tiebreak for same-ms timestamps.
+        " ORDER BY timestamp DESC, rowid DESC LIMIT ?",
+    );
+    this.purgeStmt = db.prepare("DELETE FROM activity_log WHERE timestamp < ?");
+    this.countStmt = db.prepare("SELECT COUNT(*) AS n FROM activity_log");
+  }
+
+  /** Persist one activity item. NEVER throws. */
+  insert(item: ActivityItem): void {
+    try {
+      this.insertStmt.run({
+        id: item.id,
+        timestamp: item.timestamp,
+        category: item.category,
+        zoneId: item.zoneId,
+        message: JSON.stringify(item.message),
+        source: item.source ? JSON.stringify(item.source) : null,
+      });
+    } catch (err) {
+      this.logger.error({ err, category: item.category }, "Failed to persist activity item");
+    }
+  }
+
+  /**
+   * Load the most recent items (newest first), matching the in-memory ring's
+   * order. NEVER throws — returns [] on failure so boot continues.
+   */
+  loadRecent(limit: number): ActivityItem[] {
+    try {
+      const rows = this.loadRecentStmt.all(limit) as ActivityRow[];
+      return rows.map((r) => ({
+        id: r.id,
+        timestamp: r.timestamp,
+        category: r.category as ActivityCategory,
+        zoneId: r.zone_id,
+        message: JSON.parse(r.message) as ActivityMessage,
+        source: r.source ? (JSON.parse(r.source) as OrderSource) : undefined,
+      }));
+    } catch (err) {
+      this.logger.error({ err }, "Failed to load recent activity items");
+      return [];
+    }
+  }
+
+  /** Delete items older than `days`. Returns the number of rows removed. */
+  purgeOlderThan(days: number = ACTIVITY_RETENTION_DAYS): number {
+    try {
+      const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+      const before = (this.countStmt.get() as { n: number }).n;
+      this.purgeStmt.run(cutoff);
+      const after = (this.countStmt.get() as { n: number }).n;
+      return before - after;
+    } catch (err) {
+      this.logger.error({ err }, "Failed to purge activity log");
+      return 0;
+    }
+  }
+}

--- a/src/energy/arbiter-journal-store.test.ts
+++ b/src/energy/arbiter-journal-store.test.ts
@@ -1,0 +1,104 @@
+import Database from "better-sqlite3";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ArbiterJournalStore } from "./arbiter-journal-store.js";
+import type { Logger } from "../core/logger.js";
+import type { ArbiterDecision } from "../shared/types.js";
+import { applyMigrations } from "../test-helpers/migrations.js";
+
+// Spec 147 — ArbiterJournalStore over an in-memory SQLite db seeded with the
+// real migration set (arbiter_decision_log lives in migrations/019).
+
+interface MockLogger {
+  error: ReturnType<typeof vi.fn>;
+  child: () => MockLogger;
+}
+
+function makeMockLogger(): MockLogger {
+  const error = vi.fn();
+  const self: MockLogger = { error, child: () => self };
+  return self;
+}
+
+function decision(over: Partial<ArbiterDecision> = {}): ArbiterDecision {
+  return {
+    atIso: "2026-08-14T10:00:00.000Z",
+    kind: "granted",
+    equipmentId: "e1",
+    equipmentName: "Pool pump",
+    watts: 600,
+    reason: "surplus available",
+    note: undefined,
+    ...over,
+  };
+}
+
+describe("ArbiterJournalStore", () => {
+  let db: Database.Database;
+  let logger: MockLogger;
+  let store: ArbiterJournalStore;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    applyMigrations(db);
+    logger = makeMockLogger();
+    store = new ArbiterJournalStore(db, logger as unknown as Logger);
+  });
+
+  afterEach(() => db.close());
+
+  it("round-trips a decision through insert + loadRecent", () => {
+    const d = decision({ atIso: "2026-08-14T09:00:00.000Z" });
+    store.insert(d);
+    const rows = store.loadRecent(10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual(d);
+  });
+
+  it("maps optional fields to undefined when absent", () => {
+    store.insert(
+      decision({
+        atIso: "2026-08-14T09:00:00.000Z",
+        kind: "released",
+        equipmentId: undefined,
+        equipmentName: undefined,
+        watts: undefined,
+        reason: undefined,
+      }),
+    );
+    const [row] = store.loadRecent(10);
+    expect(row.equipmentId).toBeUndefined();
+    expect(row.watts).toBeUndefined();
+    expect(row.reason).toBeUndefined();
+  });
+
+  it("loadRecent returns ascending (oldest-first), matching the ring order", () => {
+    store.insert(decision({ atIso: "2026-08-14T08:00:00.000Z", reason: "older" }));
+    store.insert(decision({ atIso: "2026-08-14T09:00:00.000Z", reason: "newer" }));
+    expect(store.loadRecent(10).map((r) => r.reason)).toEqual(["older", "newer"]);
+  });
+
+  it("loadRecent(cap) returns the most recent `cap` rows, ascending", () => {
+    store.insert(decision({ atIso: "2026-08-14T07:00:00.000Z", reason: "a" }));
+    store.insert(decision({ atIso: "2026-08-14T08:00:00.000Z", reason: "b" }));
+    store.insert(decision({ atIso: "2026-08-14T09:00:00.000Z", reason: "c" }));
+    expect(store.loadRecent(2).map((r) => r.reason)).toEqual(["b", "c"]);
+  });
+
+  it("purgeOlderThan deletes decisions older than the window", () => {
+    const stale = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const fresh = new Date().toISOString();
+    store.insert(decision({ atIso: stale, reason: "stale" }));
+    store.insert(decision({ atIso: fresh, reason: "fresh" }));
+    const removed = store.purgeOlderThan(7);
+    expect(removed).toBe(1);
+    expect(store.loadRecent(10).map((r) => r.reason)).toEqual(["fresh"]);
+  });
+
+  it("never throws when the underlying table is gone (logs instead)", () => {
+    db.exec("DROP TABLE arbiter_decision_log");
+    expect(() => store.insert(decision())).not.toThrow();
+    expect(store.loadRecent(10)).toEqual([]);
+    expect(store.purgeOlderThan(7)).toBe(0);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/src/energy/arbiter-journal-store.ts
+++ b/src/energy/arbiter-journal-store.ts
@@ -1,0 +1,105 @@
+import type Database from "better-sqlite3";
+import { randomUUID } from "node:crypto";
+import type { Logger } from "../core/logger.js";
+import type { ArbiterDecision, ArbiterDecisionKind } from "../shared/types.js";
+
+// Spec 147 — persistence for the energy arbiter decision journal (spec 140).
+//
+// Mirrors AuditLogger (spec 113): persist-on-write, load-recent-on-boot,
+// retention purged at boot. NEVER throws into the arbiter — a DB failure is
+// logged via pino and the in-memory journal ring keeps working. Only the
+// decision journal is persisted, never the live control state (claims,
+// suspensions, surplus), which the arbiter rebuilds from live events.
+
+export const ARBITER_JOURNAL_RETENTION_DAYS = 7;
+
+interface ArbiterDecisionRow {
+  at_iso: string;
+  kind: string;
+  equipment_id: string | null;
+  equipment_name: string | null;
+  watts: number | null;
+  reason: string | null;
+  note: string | null;
+}
+
+export class ArbiterJournalStore {
+  private logger: Logger;
+  private insertStmt: Database.Statement;
+  private loadRecentStmt: Database.Statement;
+  private purgeStmt: Database.Statement;
+  private countStmt: Database.Statement;
+
+  constructor(db: Database.Database, logger: Logger) {
+    this.logger = logger.child({ module: "arbiter-journal-store" });
+    this.insertStmt = db.prepare(
+      `INSERT INTO arbiter_decision_log
+        (id, at_iso, kind, equipment_id, equipment_name, watts, reason, note)
+       VALUES (@id, @atIso, @kind, @equipmentId, @equipmentName, @watts, @reason, @note)`,
+    );
+    this.loadRecentStmt = db.prepare(
+      "SELECT at_iso, kind, equipment_id, equipment_name, watts, reason, note" +
+        // rowid (insertion order) is a stable tiebreak for same-ms timestamps.
+        " FROM arbiter_decision_log ORDER BY at_iso DESC, rowid DESC LIMIT ?",
+    );
+    this.purgeStmt = db.prepare(
+      "DELETE FROM arbiter_decision_log WHERE at_iso < datetime('now', '-' || ? || ' days')",
+    );
+    this.countStmt = db.prepare("SELECT COUNT(*) AS n FROM arbiter_decision_log");
+  }
+
+  /** Persist one arbiter decision. NEVER throws. */
+  insert(d: ArbiterDecision): void {
+    try {
+      this.insertStmt.run({
+        id: randomUUID(),
+        atIso: d.atIso,
+        kind: d.kind,
+        equipmentId: d.equipmentId ?? null,
+        equipmentName: d.equipmentName ?? null,
+        watts: d.watts ?? null,
+        reason: d.reason ?? null,
+        note: d.note ?? null,
+      });
+    } catch (err) {
+      this.logger.error({ err, kind: d.kind }, "Failed to persist arbiter decision");
+    }
+  }
+
+  /**
+   * Load the most recent decisions in ASCENDING (oldest-first) order, matching
+   * the in-memory `journalEntries` ring (which appends and only reverses in
+   * getPublicState). NEVER throws — returns [] on failure so boot continues.
+   */
+  loadRecent(limit: number): ArbiterDecision[] {
+    try {
+      const rows = this.loadRecentStmt.all(limit) as ArbiterDecisionRow[];
+      // Query is DESC (most recent `limit`); reverse to ascending for the ring.
+      return rows.reverse().map((r) => ({
+        atIso: r.at_iso,
+        kind: r.kind as ArbiterDecisionKind,
+        equipmentId: r.equipment_id ?? undefined,
+        equipmentName: r.equipment_name ?? undefined,
+        watts: r.watts ?? undefined,
+        reason: r.reason ?? undefined,
+        note: r.note ?? undefined,
+      }));
+    } catch (err) {
+      this.logger.error({ err }, "Failed to load recent arbiter decisions");
+      return [];
+    }
+  }
+
+  /** Delete decisions older than `days`. Returns the number of rows removed. */
+  purgeOlderThan(days: number = ARBITER_JOURNAL_RETENTION_DAYS): number {
+    try {
+      const before = (this.countStmt.get() as { n: number }).n;
+      this.purgeStmt.run(days);
+      const after = (this.countStmt.get() as { n: number }).n;
+      return before - after;
+    } catch (err) {
+      this.logger.error({ err }, "Failed to purge arbiter decision log");
+      return 0;
+    }
+  }
+}

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -18,6 +18,7 @@ import type { Logger } from "../core/logger.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { SettingsManager } from "../core/settings-manager.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import type { ArbiterJournalStore } from "./arbiter-journal-store.js";
 import { RETRY_CHANNEL } from "../equipments/order-confirmation-tracker.js";
 import type {
   ArbiterDecision,
@@ -123,6 +124,9 @@ export class CapacityArbiter {
   private config: ArbiterConfig;
   private claims = new Map<string, ClaimRecord>(); // by claim id
   private journalEntries: ArbiterDecision[] = [];
+  /** Spec 147 — optional persistence for the decision journal (history only,
+   *  never the live control state). Undefined = in-memory only (pre-147). */
+  private journalStore?: ArbiterJournalStore;
 
   // Meter
   private meterId: string | null = null;
@@ -167,18 +171,30 @@ export class CapacityArbiter {
     equipments: EquipmentManager,
     logger: Logger,
     shadowMode = false, // spec 124 — a shadow instance never arbitrates
+    journalStore?: ArbiterJournalStore, // spec 147 — persist the decision journal
   ) {
     this.eventBus = eventBus;
     this.settings = settings;
     this.equipments = equipments;
     this.logger = logger.child({ module: "capacity-arbiter" });
     this.shadowMode = shadowMode;
+    this.journalStore = journalStore;
     this.config = this.readConfig();
   }
 
   // ── Lifecycle ───────────────────────────────────────────────
 
   start(): void {
+    // Spec 147 — restore the decision journal from persisted history (oldest
+    // first, matching the ring) so it survives a restart. History only: live
+    // control state (claims, suspensions, surplus) is still rebuilt from events.
+    if (this.journalStore && this.journalEntries.length === 0) {
+      const recent = this.journalStore.loadRecent(JOURNAL_CAP);
+      this.journalEntries.push(...recent);
+      if (recent.length > 0) {
+        this.logger.info({ count: recent.length }, "Arbiter decision journal restored from store");
+      }
+    }
     this.resolveMeter();
     this.unsubscribes.push(
       this.eventBus.onType("equipment.data.changed", (e) => {
@@ -1138,6 +1154,8 @@ export class CapacityArbiter {
     };
     this.journalEntries.push(full);
     if (this.journalEntries.length > JOURNAL_CAP) this.journalEntries.shift();
+    // Spec 147 — persist so the journal survives a restart (never throws).
+    this.journalStore?.insert(full);
     const { kind, ...ctx } = full;
     this.logger.info({ decision: kind, ...ctx }, `Arbiter decision: ${kind}`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,9 @@ import { ZoneAggregator } from "./zones/zone-aggregator.js";
 import { SunlightManager } from "./zones/sunlight-manager.js";
 import { RecipeManager } from "./recipes/engine/recipe-manager.js";
 import { CapacityArbiter } from "./energy/capacity-arbiter.js";
+import { ArbiterJournalStore } from "./energy/arbiter-journal-store.js";
 import { ActivityBuffer } from "./activity/activity-buffer.js";
+import { ActivityStore } from "./activity/activity-store.js";
 import { RecipeLoader } from "./recipes/recipe-loader.js";
 import { VersionChecker } from "./core/version-checker.js";
 import { UpdateManager } from "./core/update-manager.js";
@@ -322,12 +324,17 @@ async function main() {
   // 11d. Create Capacity Arbiter (spec 140) — single meter reader arbitrating
   // solar surplus between declared flexible loads. Default off; zero behavior
   // until `energy.arbiter.enabled` is set.
+  // Spec 147 — persist the arbiter decision journal so it survives a restart.
+  // Purge BEFORE start() so the journal seeds only from within the retention window.
+  const arbiterJournalStore = new ArbiterJournalStore(db, logger);
+  const purgedArbiterRows = arbiterJournalStore.purgeOlderThan();
   const capacityArbiter = new CapacityArbiter(
     eventBus,
     settingsManager,
     equipmentManager,
     logger,
     config.shadowMode, // spec 124 — a shadow instance never arbitrates
+    arbiterJournalStore, // spec 147 — history persistence (journal only)
   );
   capacityArbiter.start();
 
@@ -378,6 +385,8 @@ async function main() {
   const calendarManager = new CalendarManager(db, eventBus, settingsManager, modeManager, logger);
 
   // 13b. Create Activity Buffer (spec 101) — depends on equipment / recipe / zone / sunlight managers
+  // Spec 147 — persist the feed so it survives a restart.
+  const activityStore = new ActivityStore(db, logger);
   const activityBuffer = new ActivityBuffer(
     eventBus,
     equipmentManager,
@@ -385,6 +394,7 @@ async function main() {
     zoneManager,
     sunlightManager,
     logger,
+    activityStore, // spec 147 — history persistence
   );
 
   // 12b. Create Button Action Manager
@@ -407,6 +417,17 @@ async function main() {
   const purgedAuditRows = auditLogger.purgeOlderThan();
   if (purgedAuditRows > 0) {
     logger.info({ purged: purgedAuditRows }, "Audit log retention purge complete");
+  }
+
+  // Spec 147 — retention purge for the persisted activity feed (7 days), same
+  // boot-time pattern as the audit log. The arbiter journal was already purged
+  // above (before its start() so it seeds only within the retention window).
+  const purgedActivityRows = activityStore.purgeOlderThan();
+  if (purgedActivityRows > 0 || purgedArbiterRows > 0) {
+    logger.info(
+      { activity: purgedActivityRows, arbiter: purgedArbiterRows },
+      "History retention purge complete",
+    );
   }
 
   // 14. Create Package Manager + warm registry cache (await remote fetch before loading plugins)


### PR DESCRIPTION
## Summary

Spec 147 — resolves #494. The activity feed (spec 101) and the energy arbiter's decision journal (spec 140) were in-memory ring buffers, wiped on every container restart or update — exactly when you want to look back at what happened. This persists both **histories** to SQLite, mirroring the `audit_log` pattern (spec 113): persist-on-write, load-recent-on-boot, 7-day retention purged at boot. On restart, the feed and the decision journal come back populated.

## Design

- **Two new SQLite tables** (migration `019`): `activity_log` (epoch-ms) and `arbiter_decision_log` (ISO), each mirroring `audit_log`.
- **Two never-throw services** — `ActivityStore`, `ArbiterJournalStore` — with `insert` / `loadRecent` / `purgeOlderThan`. A DB failure is logged via pino and the in-memory ring keeps working (pre-147 behaviour).
- **Injected optionally** into `ActivityBuffer` and `CapacityArbiter`: persist on write, seed the ring on `start()` when empty. Absent store (unit tests) → in-memory only.
- **Boot purge** in `index.ts` (arbiter journal purged before it seeds, so it only restores within the window).
- Activity ring TTL aligned to the 7-day retention; `rowid` tiebreak for same-millisecond timestamps.

**Explicitly out of scope**: restoring the arbiter's **live control state** (claims, suspension timers, surplus series). It is rebuilt from live events by design, and restoring stale control state after an update would be unsafe. Only the decision journal (history) is persisted.

**No API / WebSocket / UI change** — the read models (`getItems`, `getPublicState`) are untouched, just pre-populated after a restart.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors (no UI change)
- [x] `npx vitest run` — 1293 pass (12 new store tests + 2 buffer seed-on-start tests)
- [x] `eslint` on changed files — 0 errors
- [x] Pre-PR agent code review — nothing blocking; 3 findings applied (7-day feed window, purge-before-seed, rowid tiebreak) + seed-on-start tests added
- [ ] Manual: generate activities + arbiter decisions, restart the container, confirm both histories are still populated and no stale arbiter suspension is restored

Docs (`sowel-docs`, the architecture "lost on restart" notes) and release notes follow at release time (spec 108).

Closes #494
