### PR TITLE
chore(registry): bump pool-pump-schedule to 1.4.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "tags": ["pool", "pump", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -340,7 +340,7 @@
     },
     "sowelVersion": ">=1.3.0",
     "owner": "mchacher",
-    "sha256": "82ae206d0c0271eb890b7914322dc4286e98041ad36e828bb14ce2786f5d25bb"
+    "sha256": "928f5d8cce15e72eb43a7ae93385b74f91f86aa9d6aeaba0e596ef572c9eece3"
   },
   {
     "id": "freecooling",


### PR DESCRIPTION
Bumps the Pool Pump Schedule recipe to **v1.4.1** in the registry (version + sha256).

v1.4.1 fixes the night deadline catch-up ON/OFF chatter observed on prod (2026-08-14): the rung now latches ON once engaged instead of flipping on a bare `remainingH >= hoursUntilBoundary` threshold at the crossing. See mchacher/sowel-recipe-pool-pump-schedule#9.

- sha256 `928f5d8c…eece3` verified against the published `v1.4.1` release asset.
- Diff is the minimal 2 lines (version + sha256); registry formatting untouched.