### PR TITLE
fix(ui): make mobile dashboard edit FAB safe-area aware (#496)

### DIFF
--- a/ui/src/lib/mobile-fab.test.ts
+++ b/ui/src/lib/mobile-fab.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { MOBILE_FAB_BOTTOM } from "./mobile-fab";
+
+/**
+ * Regression guard for issue #496: the mobile dashboard edit FAB overlapped the
+ * bottom nav "Plus"/Settings button on devices with a bottom safe-area inset
+ * because its offset was a hardcoded pixel value. The offset must stay
+ * safe-area aware so the clearance above the nav is constant on every device.
+ */
+describe("MOBILE_FAB_BOTTOM (#496)", () => {
+  it("is the exact safe-area-aware offset (spaces around + keep the calc valid CSS)", () => {
+    expect(MOBILE_FAB_BOTTOM).toBe("calc(72px + env(safe-area-inset-bottom, 0px))");
+  });
+
+  it("is a calc() expression", () => {
+    expect(MOBILE_FAB_BOTTOM).toMatch(/^calc\(.*\)$/);
+  });
+
+  it("accounts for the bottom safe-area inset", () => {
+    expect(MOBILE_FAB_BOTTOM).toContain("env(safe-area-inset-bottom");
+  });
+
+  it("keeps the base 72px clearance above the nav", () => {
+    expect(MOBILE_FAB_BOTTOM).toContain("72px");
+  });
+
+  it("is not a bare hardcoded pixel offset", () => {
+    expect(MOBILE_FAB_BOTTOM).not.toMatch(/^\d+px$/);
+  });
+});

--- a/ui/src/lib/mobile-fab.ts
+++ b/ui/src/lib/mobile-fab.ts
@@ -1,0 +1,12 @@
+/**
+ * Bottom offset (from the viewport bottom) for the mobile dashboard edit FAB.
+ *
+ * The FAB must clear the bottom navigation bar, which is `min-h-[56px]` plus a
+ * device safe-area spacer (`env(safe-area-inset-bottom)`). A hardcoded pixel
+ * offset ignores that inset, so on notched devices (iOS/Android PWA with a home
+ * indicator) the FAB dropped onto the rightmost "Plus"/Settings nav button.
+ *
+ * Adding the inset keeps a constant ~16px clearance above the nav on every
+ * device. See issue #496.
+ */
+export const MOBILE_FAB_BOTTOM = "calc(72px + env(safe-area-inset-bottom, 0px))";

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ import { WidgetGrid } from "../components/dashboard/WidgetGrid";
 import { AddWidgetModal } from "../components/dashboard/AddWidgetModal";
 import type { EquipmentWithDetails, ZoneWithChildren, WidgetFamily } from "../types";
 import { equipmentZoneQualifiers, flattenZonesWithPath, zoneChainMap } from "../lib/zone-path";
+import { MOBILE_FAB_BOTTOM } from "../lib/mobile-fab";
 
 export function DashboardPage() {
   useWsSubscription(["equipments", "zones"]);
@@ -174,9 +175,12 @@ export function DashboardPage() {
           )}
         </div>
 
-        {/* Mobile FAB — bottom right, above bottom nav */}
+        {/* Mobile FAB — bottom right, above bottom nav (safe-area aware, #496) */}
         {isAdmin && (
-          <div className="sm:hidden fixed bottom-[72px] right-4 z-30 flex flex-col items-end gap-2">
+          <div
+            className="sm:hidden fixed right-4 z-30 flex flex-col items-end gap-2"
+            style={{ bottom: MOBILE_FAB_BOTTOM }}
+          >
             {editMode && (
               <button
                 onClick={() => setShowAddModal(true)}


### PR DESCRIPTION
## What

The admin **edit FAB** (pencil) on the mobile dashboard used a hardcoded `bottom-[72px]` offset. It ignores `env(safe-area-inset-bottom)`, while the bottom nav bar is `min-h-[56px]` **plus** a safe-area spacer. On devices with a home indicator (iOS/Android PWA, inset ~34px), the nav grows but the FAB stays put, so the FAB dropped onto the rightmost **"Plus"/Settings** nav button.

Fix: offset the FAB by `calc(72px + env(safe-area-inset-bottom, 0px))` so the clearance above the nav is constant (~16px) on every device. The value lives in a small `MOBILE_FAB_BOTTOM` constant.

## Root cause

`bottom-[72px]` is measured from the viewport bottom and does not grow with the safe-area inset. Overlap appears whenever `safe-area-inset-bottom > ~15px` (all notched iPhones ~34px, many Android). It does **not** reproduce in a desktop browser at mobile width because the inset is 0 there.

## Verification

Driven on a 390x844 mobile viewport with a simulated 34px inset (typical iPhone):

| | FAB bottom | Nav top | Overlap | On "Plus"? |
|---|---|---|---|---|
| Before (`bottom:72px`) | 772 | 753 | 19px | yes |
| After (`calc(72px+env)`) | 738 | 753 | 0px (clearance +15px) | no |

At inset 0 (desktop / non-notched) the FAB still sits ~15px above the nav — no regression.

## Tests

- New `ui/src/lib/mobile-fab.test.ts` guards `MOBILE_FAB_BOTTOM`: it must be a `calc()` that includes `env(safe-area-inset-bottom` and the base `72px`, and must not be a bare hardcoded pixel offset.
- UI `tsc -b`, `eslint`, `vitest` (385 tests) all green.

## Note

Not auto-closing the issue: leaving #496 open so the reporter (@computingify) can confirm the fix on a real device after it ships. Refs #496.
