### PR TITLE
feat(ui): Analyse opens on the first saved chart, on today (#498)

### DIFF
--- a/ui/src/components/history/AnalyseMobileNav.tsx
+++ b/ui/src/components/history/AnalyseMobileNav.tsx
@@ -34,6 +34,10 @@ export function AnalyseMobileNav() {
 
   const isNewActive = location.pathname === "/analyse";
 
+  // `?new` reaches the empty builder without being bounced to the first saved
+  // chart by AnalyseView's default-landing redirect (#498, point 1).
+  const NEW_CHART_PATH = "/analyse?new";
+
   return (
     <div className="fixed inset-0 z-50 lg:hidden">
       <div className="absolute inset-0 bg-black/40" onClick={close} />
@@ -49,7 +53,7 @@ export function AnalyseMobileNav() {
           {/* New chart */}
           <button
             type="button"
-            onClick={() => goto("/analyse")}
+            onClick={() => goto(NEW_CHART_PATH)}
             className={`flex items-center gap-3 w-full px-3 py-3 rounded-[10px] transition-colors duration-150 text-left ${
               isNewActive ? "bg-primary-light text-primary" : "text-text hover:bg-border-light"
             }`}

--- a/ui/src/components/history/AnalyseView.tsx
+++ b/ui/src/components/history/AnalyseView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef, type MouseEvent } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   Loader2,
@@ -59,6 +59,7 @@ import {
 import { humanBindingLabel, humanBindingLabelFromList } from "./binding-label";
 import { SeriesColorPicker } from "./SeriesColorPicker";
 import { fitYAxis } from "./y-axis";
+import { firstChartTarget } from "./analyse-nav";
 
 // ============================================================
 // Types
@@ -142,10 +143,17 @@ export function AnalyseView() {
   const { t } = useTranslation();
   const { chartId } = useParams();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  // `?new` = the user explicitly asked for the empty "build a new chart"
+  // workspace (sidebar / mobile-drawer "New chart"). Without it, the bare
+  // /analyse route redirects to the first saved chart (#498, point 1).
+  const isNewWorkspace = searchParams.has("new");
   const createChart = useCharts((s) => s.createChart);
   const updateChartStore = useCharts((s) => s.updateChart);
   const deleteChartStore = useCharts((s) => s.deleteChart);
   const fetchCharts = useCharts((s) => s.fetchCharts);
+  const savedCharts = useCharts((s) => s.charts);
+  const chartsLoading = useCharts((s) => s.loading);
   // Saving/deleting charts is a config mutation (rejected server-side for
   // standard users); hide those controls. Building and viewing a chart stays
   // available to everyone (series add/remove are local until saved).
@@ -191,9 +199,13 @@ export function AnalyseView() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   // --- Add series form ---
-  // Open by default on the empty workspace (`/analyse` with no chartId) so
-  // the user immediately sees the zone / equipment / metric pickers instead
-  // of an inscrutable empty chart placeholder.
+  // Open on the empty workspace (`/analyse` / `/analyse?new`, no chartId) so
+  // the user immediately sees the zone / equipment / metric pickers; collapsed
+  // when viewing a saved chart for a cleaner screen (#498, point 3). Synced to
+  // `chartId` below — `/analyse` and `/analyse/:id` share one AnalysePage
+  // element (no route key), so the default-landing redirect (#498, point 1)
+  // changes chartId without remounting, and an init-only value would stay
+  // stale (add panel left open on the first chart).
   const [showAddForm, setShowAddForm] = useState(() => !chartId);
   const [selectedZoneId, setSelectedZoneId] = useState<string>("");
   const [selectedEquipmentId, setSelectedEquipmentId] = useState<string>("");
@@ -248,19 +260,16 @@ export function AnalyseView() {
         const chart = await getChart(chartId);
         setCurrentChart(chart);
         loadedChartIdRef.current = chartId;
-        // New format (period + date) takes precedence. Legacy charts saved
-        // with `timeRange` are mapped to the closest period on today, so the
-        // user can pick the date back to whatever they had in mind.
-        if (chart.config.period && chart.config.date) {
+        // Keep the saved period (day/week/month/year) but always open on
+        // today rather than the date the chart was saved on (#498, point 2) —
+        // a saved chart is a view template, users want the latest data.
+        if (chart.config.period) {
           setPeriod(chart.config.period);
-          setDate(chart.config.date);
         } else {
           const legacy = chart.config.timeRange;
-          const mapped: Period =
-            legacy === "30d" ? "month" : legacy === "7d" ? "week" : "day";
-          setPeriod(mapped);
-          setDate(periodTodayStr());
+          setPeriod(legacy === "30d" ? "month" : legacy === "7d" ? "week" : "day");
         }
+        setDate(periodTodayStr());
         // Spec 145 — absent on pre-145 charts, which then keep the
         // zero-anchored axis they were saved with.
         setYAxisFit(chart.config.yAxisFit ?? false);
@@ -517,6 +526,27 @@ export function AnalyseView() {
   useEffect(() => {
     fetchCharts();
   }, [fetchCharts]);
+
+  // #498, point 1 — the bare /analyse workspace opens on the first saved chart
+  // instead of the empty builder. `?new` (sidebar / mobile "New chart") opts
+  // out; with no saved charts the empty workspace stays.
+  useEffect(() => {
+    if (chartId) return;
+    const target = firstChartTarget({
+      isNew: isNewWorkspace,
+      loading: chartsLoading,
+      charts: savedCharts,
+    });
+    if (target) navigate(target, { replace: true });
+  }, [chartId, isNewWorkspace, chartsLoading, savedCharts, navigate]);
+
+  // Keep the add panel collapsed on a saved chart and open on the empty
+  // builder as chartId changes (the redirect above mutates it without a
+  // remount). Runs only on chartId transitions, so it never fights the
+  // user's manual toggle while they stay on one view.
+  useEffect(() => {
+    setShowAddForm(!chartId);
+  }, [chartId]);
 
   // --- Merge all series into a unified chart dataset ---
   // The X axis is a continuous time-scale (epoch milliseconds), not a

--- a/ui/src/components/history/analyse-nav.test.ts
+++ b/ui/src/components/history/analyse-nav.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { firstChartTarget } from "./analyse-nav";
+
+describe("firstChartTarget (#498, point 1)", () => {
+  it("redirects the bare workspace to the first saved chart", () => {
+    expect(
+      firstChartTarget({ isNew: false, loading: false, charts: [{ id: "a" }, { id: "b" }] }),
+    ).toBe("/analyse/a");
+  });
+
+  it("stays put while the charts are still loading", () => {
+    expect(
+      firstChartTarget({ isNew: false, loading: true, charts: [{ id: "a" }] }),
+    ).toBeNull();
+  });
+
+  it("stays put when the user asked for the new-chart workspace", () => {
+    expect(
+      firstChartTarget({ isNew: true, loading: false, charts: [{ id: "a" }] }),
+    ).toBeNull();
+  });
+
+  it("stays on the empty workspace when there are no saved charts", () => {
+    expect(
+      firstChartTarget({ isNew: false, loading: false, charts: [] }),
+    ).toBeNull();
+  });
+
+  it("prefers ?new over an available chart (explicit intent wins)", () => {
+    expect(
+      firstChartTarget({ isNew: true, loading: false, charts: [{ id: "a" }] }),
+    ).toBeNull();
+  });
+});

--- a/ui/src/components/history/analyse-nav.ts
+++ b/ui/src/components/history/analyse-nav.ts
@@ -1,0 +1,25 @@
+/**
+ * Analyse landing decision (#498, point 1).
+ *
+ * Visiting the bare `/analyse` workspace should redirect to the first saved
+ * chart so the page opens on real content by default. The empty
+ * "build a new chart" workspace stays reachable through an explicit
+ * `/analyse?new` entry (sidebar + mobile drawer "New chart" buttons), which
+ * sets `isNew` and suppresses the redirect.
+ *
+ * Returns the path to redirect to, or `null` to stay on the current view.
+ */
+export function firstChartTarget(params: {
+  /** True when the route carries `?new` — the user explicitly wants the
+   * empty workspace. */
+  isNew: boolean;
+  /** True while the saved-charts list is still being fetched — wait rather
+   * than deciding on a transiently-empty list. */
+  loading: boolean;
+  /** The user's saved charts, in display order. */
+  charts: { id: string }[];
+}): string | null {
+  if (params.isNew || params.loading) return null;
+  const first = params.charts[0];
+  return first ? `/analyse/${first.id}` : null;
+}

--- a/ui/src/components/layout/SidebarChartList.tsx
+++ b/ui/src/components/layout/SidebarChartList.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { NavLink, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { LineChart } from "lucide-react";
+import { LineChart, Plus } from "lucide-react";
 import { useCharts } from "../../store/useCharts";
 
 export function SidebarChartList({ collapsed }: { collapsed: boolean }) {
@@ -16,10 +16,33 @@ export function SidebarChartList({ collapsed }: { collapsed: boolean }) {
 
   if (collapsed) return null;
 
+  // `?new` reaches the empty builder without AnalyseView's default-landing
+  // redirect bouncing back to the first saved chart (#498, point 1).
+  const newChartLink = (
+    <NavLink
+      to="/analyse?new"
+      end
+      className={({ isActive }) => `
+        flex items-center gap-2 px-3 py-1.5 rounded-[6px] min-w-0
+        text-[13px] transition-colors duration-150 ease-out
+        ${isActive
+          ? "bg-primary-light text-primary font-medium"
+          : "text-text-secondary hover:bg-border-light hover:text-text"
+        }
+      `}
+    >
+      <span className="flex-shrink-0">
+        <Plus size={15} strokeWidth={1.5} />
+      </span>
+      <span className="truncate">{t("analyse.new")}</span>
+    </NavLink>
+  );
+
   if (charts.length === 0) {
     return (
-      <div className="pl-2 px-3 py-2">
-        <p className="text-[11px] text-text-tertiary leading-tight">
+      <div className="space-y-0.5 pl-2">
+        {newChartLink}
+        <p className="px-3 py-1.5 text-[11px] text-text-tertiary leading-tight">
           {t("analyse.noSavedCharts")}
         </p>
       </div>
@@ -28,6 +51,7 @@ export function SidebarChartList({ collapsed }: { collapsed: boolean }) {
 
   return (
     <div className="space-y-0.5 pl-2">
+      {newChartLink}
       {charts.map((chart) => {
         const isActive = activeId === chart.id;
         return (


### PR DESCRIPTION
Part 1 of 3 for the Analyse page improvements reported in #498 (points 1, 2, 3).

## Changes

**Default landing (point 1).** The bare `/analyse` workspace redirected to the empty chart builder. It now redirects to the **first saved chart**, so the page opens on real content. The empty "build a new chart" workspace stays reachable through an explicit `/analyse?new` entry:
- Desktop: a "New chart" link at the top of the sidebar chart list.
- Mobile: the drawer "New chart" button now targets `/analyse?new`.

With no saved charts, `/analyse` keeps showing the empty workspace. The decision is a pure `firstChartTarget()` helper (`analyse-nav.ts`) with unit tests; `AnalyseView` runs it in a redirect effect gated on `?new` and the charts-loading flag.

**Today on open (point 2).** Loading a saved chart kept the date it was saved on. It now keeps the saved **period** (day/week/month/year) but always opens on **today** — a saved chart is a view template, users want the latest data.

**Cleaner screen (point 3).** Satisfied by the redirect: viewing a chart keeps the zone/equipment add panel collapsed (`showAddForm = !chartId`); it only opens when building a new chart (`?new` / no saved charts).

## Why a `?new` escape hatch

The desktop sidebar and mobile drawer both used `/analyse` as the "new chart" entry. Redirecting `/analyse` to the first chart would make the builder unreachable, so the new-chart affordances now carry `?new`, which `AnalyseView` detects to suppress the redirect.

## Tests

- New `analyse-nav.test.ts` covers `firstChartTarget`: redirect to first chart, no redirect while loading, `?new` opt-out, empty-list stays put.
- UI `tsc -b`, `eslint`, `vitest` (391 tests) all green.

Refs #498 (umbrella; PR 2 = mobile tooltip, PR 3 = full-window state series).
