### PR TITLE
fix(ui): responsive Analyse chart tooltip that fits mobile (#498)

### DIFF
--- a/ui/src/components/history/AnalyseView.tsx
+++ b/ui/src/components/history/AnalyseView.tsx
@@ -60,6 +60,7 @@ import { humanBindingLabel, humanBindingLabelFromList } from "./binding-label";
 import { SeriesColorPicker } from "./SeriesColorPicker";
 import { fitYAxis } from "./y-axis";
 import { firstChartTarget } from "./analyse-nav";
+import { ChartTooltip } from "./ChartTooltip";
 
 // ============================================================
 // Types
@@ -123,16 +124,6 @@ function formatTime(iso: string, period: Period): string {
 function formatAxisTick(value: number, unit: string): string {
   const formatted = Number.isInteger(value) ? String(value) : value.toFixed(1);
   return unit ? `${formatted} ${unit}` : formatted;
-}
-
-function formatTooltipTime(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
 }
 
 // ============================================================
@@ -1107,90 +1098,18 @@ export function AnalyseView() {
                     onClick={openColorPickerFromLegend}
                   />
                 );
-                const labelFormatter = (_: unknown, payload?: readonly { payload?: Record<string, unknown> }[]) => {
-                  const ts = payload?.[0]?.payload?.time;
-                  if (typeof ts === "number") {
-                    return formatTooltipTime(new Date(ts).toISOString());
-                  }
-                  return "";
-                };
-                const measurementFormatter = (
-                  value?: number | string,
-                  name?: string,
-                  item?: { payload?: Record<string, number> },
-                ) => {
-                  const num = typeof value === "number" ? value : Number(value);
-                  if (!Number.isFinite(num)) return ["", ""];
-                  // Skip min/max keys — only the mean shows in the tooltip row;
-                  // the band values are appended next to it.
-                  if (name?.endsWith(":min") || name?.endsWith(":max")) return [null, null] as unknown as [string, string];
-                  const s = series.find((ser) => ser.id === name);
-                  const unit = s ? CATEGORY_UNITS[s.category] : "";
-                  const formatted = Number.isInteger(num) ? String(num) : num.toFixed(1);
-                  let valueText = unit ? `${formatted} ${unit}` : formatted;
-                  if (s && item?.payload) {
-                    const min = item.payload[`${s.id}:min`];
-                    const max = item.payload[`${s.id}:max`];
-                    if (typeof min === "number" && typeof max === "number") {
-                      const fmt = (x: number) => (Number.isInteger(x) ? String(x) : x.toFixed(1));
-                      valueText += ` (${fmt(min)} / ${fmt(max)})`;
-                    }
-                  }
-                  const metricLabel = s && s.category
-                    ? humanBindingLabel(
-                        { alias: s.alias, category: s.category, deviceName: s.deviceName, sameCategoryCount: s.sameCategoryCount },
-                        t,
-                      )
-                    : (s?.alias ?? (name ?? ""));
-                  const label = s
-                    ? (s.zoneName ? `${s.zoneName} / ${s.equipmentName} / ${metricLabel}` : `${s.equipmentName} / ${metricLabel}`)
-                    : (name ?? "");
-                  return [valueText, label];
-                };
-                const booleanFormatter = (value?: number | string, name?: string) => {
-                  const s = series.find((ser) => ser.id === name);
-                  if (!s) return [String(value ?? ""), name ?? ""];
-                  const num = typeof value === "number" ? value : Number(value);
-                  const [offKey, onKey] = booleanTickLabels(s.category);
-                  let stateText: string;
-                  if (!Number.isFinite(num)) {
-                    stateText = "";
-                  } else if (num <= 0.05) {
-                    stateText = t(offKey);
-                  } else if (num >= 0.95) {
-                    stateText = t(onKey);
-                  } else {
-                    // Aggregated bucket: mean ∈ (0, 1) → percent of active time.
-                    stateText = `${Math.round(num * 100)}% ${t(onKey)}`;
-                  }
-                  const metricLabel = humanBindingLabel(
-                    { alias: s.alias, category: s.category, deviceName: s.deviceName, sameCategoryCount: s.sameCategoryCount },
-                    t,
-                  );
-                  const label = s.zoneName
-                    ? `${s.zoneName} / ${s.equipmentName} / ${metricLabel}`
-                    : `${s.equipmentName} / ${metricLabel}`;
-                  return [stateText, label];
-                };
-                // Spec 144 — a mixed chart carries both kinds of series, so the
-                // tooltip picks the formatter per series instead of per chart.
-                const mixedFormatter = (
-                  value?: number | string,
-                  name?: string,
-                  item?: { payload?: Record<string, number> },
-                ) => {
-                  const s = series.find((ser) => ser.id === name);
-                  return s && isBooleanCategory(s.category)
-                    ? booleanFormatter(value, name)
-                    : measurementFormatter(value, name, item);
-                };
-                const tooltipStyle = {
-                  backgroundColor: "var(--color-surface)",
-                  border: "1px solid var(--color-border)",
-                  borderRadius: "6px",
-                  fontSize: "12px",
-                  color: "var(--color-text)",
-                };
+                // #498, point 4 — one responsive tooltip for every family. The
+                // custom card caps its width and wraps the long labels so it
+                // never overflows on mobile; per-series value formatting
+                // (measurement unit, boolean state, envelope band) lives in
+                // ChartTooltip / tooltip-format.
+                const tooltip = (
+                  <Tooltip
+                    content={<ChartTooltip series={styledSeries} />}
+                    allowEscapeViewBox={{ x: false, y: false }}
+                    wrapperStyle={{ zIndex: 20 }}
+                  />
+                );
 
                 if (chartFamilies.has("cumulative")) {
                   // F2 — bar chart for rain / energy.
@@ -1205,11 +1124,7 @@ export function AnalyseView() {
                         width={52}
                         tickFormatter={(v: number) => (Number.isInteger(v) ? String(v) : v.toFixed(1))}
                       />
-                      <Tooltip
-                        contentStyle={tooltipStyle}
-                        labelFormatter={labelFormatter}
-                        formatter={measurementFormatter}
-                      />
+                      {tooltip}
                       {commonLegend}
                       {styledSeries.map((s) => (
                         <Bar
@@ -1246,11 +1161,7 @@ export function AnalyseView() {
                         width={68}
                         tickFormatter={(v: number) => (v >= 0.5 ? t(stateOnKey) : t(stateOffKey))}
                       />
-                      <Tooltip
-                        contentStyle={tooltipStyle}
-                        labelFormatter={labelFormatter}
-                        formatter={booleanFormatter}
-                      />
+                      {tooltip}
                       {commonLegend}
                       {styledSeries.map((s) => (
                         <Line
@@ -1323,11 +1234,7 @@ export function AnalyseView() {
                         tickFormatter={(v: number) => (v >= 0.5 ? t(stateOnKey) : t(stateOffKey))}
                       />
                     )}
-                    <Tooltip
-                      contentStyle={tooltipStyle}
-                      labelFormatter={labelFormatter}
-                      formatter={hasStateSeries ? mixedFormatter : measurementFormatter}
-                    />
+                    {tooltip}
                     {commonLegend}
                     {showBand &&
                       styledSeries

--- a/ui/src/components/history/ChartTooltip.test.tsx
+++ b/ui/src/components/history/ChartTooltip.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "../../test-utils";
+import { ChartTooltip } from "./ChartTooltip";
+import type { TooltipSeries } from "./tooltip-format";
+
+// Matches the Recharts-injected payload shape ChartTooltip consumes.
+type Entry = { name?: string; value?: number | string | number[]; payload?: Record<string, number> };
+
+const TS = Date.UTC(2026, 6, 21, 2, 0); // fixed timestamp for the header
+
+const temp: TooltipSeries = {
+  id: "eq1:temp",
+  alias: "temp",
+  category: "temperature",
+  deviceName: "Thermo",
+  sameCategoryCount: 1,
+  equipmentName: "Thermostat",
+  zoneName: "Salon",
+  color: "#123456",
+};
+
+const state: TooltipSeries = {
+  id: "eq2:state",
+  alias: "state",
+  category: "light_state",
+  deviceName: "Relay",
+  sameCategoryCount: 1,
+  equipmentName: "Chauffe-eau",
+  zoneName: "",
+  color: "#abcdef",
+};
+
+// A realistic Recharts payload for a mixed chart with the envelope band on:
+// the mean Line (name = series id), the band Area (name = "id:band", value is a
+// [lo, hi] tuple), and a state Line.
+const payload: Entry[] = [
+  { name: "eq1:temp", value: 20.5, payload: { time: TS, "eq1:temp:min": 19, "eq1:temp:max": 22 } },
+  { name: "eq1:temp:band", value: [19, 22], payload: { time: TS } },
+  { name: "eq2:state", value: 1, payload: { time: TS } },
+];
+
+describe("ChartTooltip (#498, point 4)", () => {
+  it("renders one row per real series and skips the envelope band entry", () => {
+    render(<ChartTooltip active payload={payload} series={[temp, state]} />);
+    // Two data series → exactly two rows; the ":band" tuple entry is dropped.
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    // The band tuple must never surface as text.
+    expect(screen.queryByText(/19\s*,\s*22/)).toBeNull();
+  });
+
+  it("formats the measurement value with unit and band inline", () => {
+    render(<ChartTooltip active payload={payload} series={[temp, state]} />);
+    expect(screen.getByText(/20\.5\s*°C\s*\(19 \/ 22\)/)).toBeTruthy();
+    expect(screen.getByText(/Salon \/ Thermostat/)).toBeTruthy();
+  });
+
+  it("renders nothing when inactive or empty", () => {
+    const { container: c1 } = render(<ChartTooltip active={false} payload={payload} series={[temp]} />);
+    expect(c1.firstChild).toBeNull();
+    const { container: c2 } = render(<ChartTooltip active payload={[]} series={[temp]} />);
+    expect(c2.firstChild).toBeNull();
+  });
+
+  it("drops rows whose value is not finite", () => {
+    const p: Entry[] = [{ name: "eq1:temp", value: undefined, payload: { time: TS } }];
+    const { container } = render(<ChartTooltip active payload={p} series={[temp]} />);
+    // No finite value → no rows → whole card returns null.
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/ui/src/components/history/ChartTooltip.tsx
+++ b/ui/src/components/history/ChartTooltip.tsx
@@ -1,0 +1,77 @@
+import { useTranslation } from "react-i18next";
+import { formatTooltipRow, type TooltipRow, type TooltipSeries } from "./tooltip-format";
+
+interface PayloadEntry {
+  name?: string | number;
+  value?: number | string | number[];
+  payload?: Record<string, number>;
+}
+
+interface ChartTooltipProps {
+  /** Injected by Recharts. */
+  active?: boolean;
+  /** Injected by Recharts — one entry per rendered series at the hovered point. */
+  payload?: PayloadEntry[];
+  /** All plotted series, resolved with their colour. */
+  series: TooltipSeries[];
+}
+
+function formatHeaderTime(ts: number): string {
+  return new Date(ts).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Point-detail tooltip for the Analyse chart (#498, point 4).
+ *
+ * A compact card capped at `min(280px, 88vw)` with wrapping labels, so the long
+ * "Zone / Equipment / Metric" lines never blow past the viewport on mobile
+ * (the previous default Recharts tooltip had no width bound). One row per
+ * series: colour dot, label, formatted value.
+ */
+export function ChartTooltip({ active, payload, series }: ChartTooltipProps) {
+  const { t } = useTranslation();
+  if (!active || !payload || payload.length === 0) return null;
+
+  const ts = payload[0]?.payload?.time;
+  const header = typeof ts === "number" ? formatHeaderTime(ts) : "";
+
+  const byId = new Map(series.map((s) => [s.id, s]));
+  const rows: TooltipRow[] = [];
+  const seen = new Set<string>();
+  for (const p of payload) {
+    const id = typeof p.name === "string" ? p.name : "";
+    // Envelope band / min / max entries carry an "id:band" name that matches no
+    // series id, so they are skipped; the band shows inline on the mean row.
+    const s = byId.get(id);
+    if (!s || seen.has(id)) continue;
+    seen.add(id);
+    const row = formatTooltipRow(s, Array.isArray(p.value) ? undefined : p.value, p.payload, t);
+    if (row) rows.push(row);
+  }
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="max-w-[min(280px,88vw)] rounded-[6px] border border-border bg-surface px-3 py-2 text-[12px] text-text shadow-md">
+      {header && <div className="mb-1.5 font-medium text-text-secondary">{header}</div>}
+      <ul className="space-y-1">
+        {rows.map((r) => (
+          <li key={r.label} className="flex items-start gap-1.5 leading-snug">
+            <span
+              className="mt-1 h-2 w-2 flex-shrink-0 rounded-full"
+              style={{ backgroundColor: r.color }}
+            />
+            <span className="min-w-0 break-words">
+              <span className="text-text-secondary">{r.label}</span>{" "}
+              <span className="font-medium text-text">{r.value}</span>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/ui/src/components/history/tooltip-format.test.ts
+++ b/ui/src/components/history/tooltip-format.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import type { TFunction } from "i18next";
+import { formatTooltipRow, seriesFullLabel, type TooltipSeries } from "./tooltip-format";
+
+// Identity t: returns the i18n key, enough to assert which key is picked.
+const t = ((k: string) => k) as unknown as TFunction;
+
+const measurement: TooltipSeries = {
+  id: "eq1:temp",
+  alias: "temp",
+  category: "temperature",
+  deviceName: "Thermo",
+  sameCategoryCount: 1,
+  equipmentName: "Thermostat",
+  zoneName: "Salon",
+  color: "#123456",
+};
+
+const state: TooltipSeries = {
+  id: "eq2:state",
+  alias: "state",
+  category: "light_state",
+  deviceName: "Relay",
+  sameCategoryCount: 1,
+  equipmentName: "Chauffe-eau",
+  zoneName: "",
+  color: "#abcdef",
+};
+
+describe("formatTooltipRow (#498, point 4)", () => {
+  it("formats a measurement with its unit and carries the colour", () => {
+    const row = formatTooltipRow(measurement, 20.5, undefined, t);
+    expect(row?.value).toBe("20.5 °C");
+    expect(row?.color).toBe("#123456");
+    expect(row?.label.startsWith("Salon / Thermostat /")).toBe(true);
+  });
+
+  it("drops a trailing .0 on integer measurements", () => {
+    expect(formatTooltipRow(measurement, 20, undefined, t)?.value).toBe("20 °C");
+  });
+
+  it("appends the envelope band when the row carries min/max", () => {
+    const row = formatTooltipRow(measurement, 20.5, { "eq1:temp:min": 19, "eq1:temp:max": 22 }, t);
+    expect(row?.value).toBe("20.5 °C (19 / 22)");
+  });
+
+  it("renders a boolean On/Off from the category tick labels", () => {
+    expect(formatTooltipRow(state, 1, undefined, t)?.value).toBe("analyse.bool.power.on");
+    expect(formatTooltipRow(state, 0, undefined, t)?.value).toBe("analyse.bool.power.off");
+  });
+
+  it("renders an aggregated boolean mean as a percentage of active time", () => {
+    expect(formatTooltipRow(state, 0.4, undefined, t)?.value).toBe("40% analyse.bool.power.on");
+  });
+
+  it("omits the zone from the label when unknown", () => {
+    expect(formatTooltipRow(state, 1, undefined, t)?.label.startsWith("Chauffe-eau /")).toBe(true);
+  });
+
+  it("returns null for a non-finite value (nothing to show)", () => {
+    expect(formatTooltipRow(measurement, undefined, undefined, t)).toBeNull();
+    expect(formatTooltipRow(measurement, NaN, undefined, t)).toBeNull();
+  });
+});
+
+describe("seriesFullLabel", () => {
+  it("joins zone / equipment / metric", () => {
+    expect(seriesFullLabel(measurement, t).startsWith("Salon / Thermostat /")).toBe(true);
+  });
+});

--- a/ui/src/components/history/tooltip-format.ts
+++ b/ui/src/components/history/tooltip-format.ts
@@ -1,0 +1,74 @@
+import type { TFunction } from "i18next";
+import { CATEGORY_UNITS, booleanTickLabels, isBooleanCategory } from "./history-utils";
+import { humanBindingLabel } from "./binding-label";
+
+/** The slice of a series the tooltip needs to render one row (#498, point 4). */
+export interface TooltipSeries {
+  id: string;
+  alias: string;
+  category: string;
+  deviceName: string;
+  sameCategoryCount: number;
+  equipmentName: string;
+  zoneName: string;
+  color: string;
+}
+
+export interface TooltipRow {
+  label: string;
+  value: string;
+  color: string;
+}
+
+const fmt = (x: number): string => (Number.isInteger(x) ? String(x) : x.toFixed(1));
+
+/** "Zone / Equipment / Metric" (Zone omitted when unknown) — the same label the
+ *  legend uses. */
+export function seriesFullLabel(s: TooltipSeries, t: TFunction): string {
+  const metric = s.category
+    ? humanBindingLabel(
+        { alias: s.alias, category: s.category, deviceName: s.deviceName, sameCategoryCount: s.sameCategoryCount },
+        t,
+      )
+    : s.alias;
+  return s.zoneName ? `${s.zoneName} / ${s.equipmentName} / ${metric}` : `${s.equipmentName} / ${metric}`;
+}
+
+/**
+ * Format one tooltip row for a series at a data point. Mirrors the previous
+ * inline measurement/boolean formatters:
+ * - boolean/state category → localized On/Off (or "NN% On" for an aggregated
+ *   bucket mean in (0, 1));
+ * - measurement → value with its unit, plus the `(min / max)` envelope band
+ *   when the row carries it.
+ *
+ * Returns `null` when the value is not finite (nothing to show for that row).
+ * `rowData` is the merged chart row, read for the `id:min` / `id:max` band keys.
+ */
+export function formatTooltipRow(
+  s: TooltipSeries,
+  value: number | string | undefined,
+  rowData: Record<string, number> | undefined,
+  t: TFunction,
+): TooltipRow | null {
+  const num = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(num)) return null;
+
+  let valueText: string;
+  if (isBooleanCategory(s.category)) {
+    const [offKey, onKey] = booleanTickLabels(s.category);
+    if (num <= 0.05) valueText = t(offKey);
+    else if (num >= 0.95) valueText = t(onKey);
+    else valueText = `${Math.round(num * 100)}% ${t(onKey)}`;
+  } else {
+    const unit = CATEGORY_UNITS[s.category];
+    valueText = unit ? `${fmt(num)} ${unit}` : fmt(num);
+    const min = rowData?.[`${s.id}:min`];
+    const max = rowData?.[`${s.id}:max`];
+    if (typeof min === "number" && typeof max === "number") {
+      valueText += ` (${fmt(min)} / ${fmt(max)})`;
+    }
+  }
+
+  return { label: seriesFullLabel(s, t), value: valueText, color: s.color };
+}


### PR DESCRIPTION
Part 2 of 3 for the Analyse page improvements reported in #498 (point 4).

## Problem

Tapping/hovering a point showed the default Recharts tooltip, which has no width bound. The chart labels are long ("Zone / Equipment / Metric", e.g. "Maison Principale / Chauffe-eau / Température intérieure"), so on mobile the tooltip box grew past the screen edge (reporter's "grosse box qui dépasse").

## Change

Replace the three per-family Recharts tooltips (cumulative bar / states step / measurements composed) with a single custom `ChartTooltip` card:
- capped at `min(280px, 88vw)` and wraps its labels, so it never runs off-screen;
- one row per series: colour dot, "Zone / Equipment / Metric" label, formatted value;
- `allowEscapeViewBox={{ x: false, y: false }}` keeps it inside the chart.

Per-series value formatting (measurement value + unit, boolean On/Off and the aggregated `NN% On` bucket mean, envelope `(min / max)` band) moves out of the three inline Recharts formatters into a pure `formatTooltipRow` helper. The now-unused `measurement/boolean/mixed` formatters, `labelFormatter`, `formatTooltipTime` and the shared `tooltipStyle` are removed.

## Tests

- New `tooltip-format.test.ts` (8 cases): measurement unit, integer trimming, envelope band, boolean On/Off, aggregated percentage, zone-less label, non-finite → null.
- UI `tsc -b`, `eslint`, `vitest` (399 tests) all green.
- Verified live on a mobile viewport (shadow, prod-seeded data): the tooltip stays within the screen and wraps.

Refs #498 (umbrella; PR 1 merged, PR 3 = full-window state series).
