### PR TITLE
fix(history): span discrete state series across the full chart window (#498)

### DIFF
--- a/src/history/history-query.test.ts
+++ b/src/history/history-query.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   buildFluxQuery,
+  buildLastBeforeQuery,
+  applyDiscreteBoundaries,
   queryHistory,
   querySparkline,
   queryZoneSparkline,
   queryHistorizedAliases,
 } from "./history-query";
+import type { HistoryPoint } from "../shared/types";
 import { createLogger } from "../core/logger";
 import type { InfluxClient } from "../core/influx-client";
 
@@ -26,19 +29,24 @@ const baseParams = {
  */
 function makeInflux(options: {
   rows?: Record<string, unknown>[];
+  /** Rows returned specifically for the discrete carry-in `last()` query, so a
+   *  test can prove the anchor value comes from *before* the window rather than
+   *  leaking the in-window rows. Falls back to `rows` when omitted. */
+  lastRows?: Record<string, unknown>[];
   capture?: string[];
   configured?: boolean;
   throwOnQuery?: boolean;
 }): InfluxClient {
-  const { rows = [], capture, configured = true, throwOnQuery = false } = options;
+  const { rows = [], lastRows, capture, configured = true, throwOnQuery = false } = options;
 
   const queryApi = {
     iterateRows(flux: string) {
       capture?.push(flux);
       if (throwOnQuery) throw new Error("influx boom");
+      const out = lastRows && flux.includes("|> last()") ? lastRows : rows;
       return {
         async *[Symbol.asyncIterator]() {
-          for (const row of rows) {
+          for (const row of out) {
             yield { values: row, tableMeta: { toObject: (v: unknown) => v } };
           }
         },
@@ -361,5 +369,111 @@ describe("queryHistorizedAliases", () => {
   it("returns [] on error", async () => {
     const influx = makeInflux({ throwOnQuery: true });
     expect(await queryHistorizedAliases(influx, "eq-1", logger)).toEqual([]);
+  });
+});
+
+// ============================================================
+// #498 — discrete (state) series span the whole window
+// ============================================================
+
+const p = (time: string, value: number): HistoryPoint => ({ time, value });
+
+describe("buildLastBeforeQuery (#498 carry-in)", () => {
+  it("looks for the last value strictly before the window start", () => {
+    const flux = buildLastBeforeQuery({
+      bucket: "sowel",
+      equipmentId: "eq-1",
+      alias: "state",
+      from: new Date("2026-05-01T00:00:00Z"),
+      lookbackMs: 30 * 86_400_000,
+    });
+    expect(flux).toContain(
+      "range(start: 2026-04-01T00:00:00.000Z, stop: 2026-05-01T00:00:00.000Z)",
+    );
+    expect(flux).toContain('r.equipmentId == "eq-1"');
+    expect(flux).toContain('r.alias == "state"');
+    expect(flux).toContain('r._field == "value_number"');
+    expect(flux).toContain("|> last()");
+  });
+});
+
+describe("applyDiscreteBoundaries (#498)", () => {
+  const from = "2026-05-01T00:00:00.000Z";
+  const to = "2026-05-01T23:59:59.000Z";
+
+  it("anchors the line at the window start with the prior state", () => {
+    const out = applyDiscreteBoundaries([p("2026-05-01T12:00:00Z", 1)], from, to, 0);
+    expect(out[0]).toEqual(p(from, 0)); // carry-in: was Off before the window
+    expect(out[out.length - 1]).toEqual(p(to, 1)); // extend the last state On to the end
+  });
+
+  it("does not prepend when a sample already sits at the window start", () => {
+    const out = applyDiscreteBoundaries([p(from, 1), p("2026-05-01T10:00:00Z", 0)], from, to, 1);
+    expect(out.filter((x) => x.time === from)).toHaveLength(1);
+    expect(out[0]).toEqual(p(from, 1));
+  });
+
+  it("draws a flat line across the window when the state never changed inside it", () => {
+    const out = applyDiscreteBoundaries([], from, to, 0);
+    expect(out).toEqual([p(from, 0), p(to, 0)]);
+  });
+
+  it("returns nothing when there is no in-window data and no prior state", () => {
+    expect(applyDiscreteBoundaries([], from, to, null)).toEqual([]);
+  });
+
+  it("does not extend when the last sample is already at the window end", () => {
+    const out = applyDiscreteBoundaries([p("2026-05-01T08:00:00Z", 1), p(to, 0)], from, to, 1);
+    expect(out.filter((x) => x.time === to)).toHaveLength(1);
+  });
+});
+
+describe("queryHistory — discrete boundaries (#498)", () => {
+  it("anchors a discrete series with the state from before the window, then extends it", async () => {
+    const capture: string[] = [];
+    // In-window: a single On (1) at noon. Before the window: Off (0). The
+    // carry-in must anchor at Off, proving the value comes from the
+    // strictly-before `last()` query, not the in-window sample.
+    const influx = makeInflux({
+      rows: [{ _time: "2026-05-01T12:00:00Z", _value: 1 }],
+      lastRows: [{ _time: "2026-04-30T20:00:00Z", _value: 0 }],
+      capture,
+    });
+    const result = await queryHistory(
+      influx,
+      {
+        equipmentId: "eq-1",
+        alias: "state",
+        from: "2026-05-01T00:00:00Z",
+        to: "2026-05-01T23:59:59Z",
+        aggregation: "raw",
+        dataType: "boolean",
+      },
+      logger,
+    );
+    expect(capture.some((q) => q.includes("|> last()"))).toBe(true);
+    expect(result.points).toEqual([
+      { time: "2026-05-01T00:00:00.000Z", value: 0 }, // carry-in: Off, from before the window
+      { time: "2026-05-01T12:00:00Z", value: 1 }, // in-window change to On
+      { time: "2026-05-01T23:59:59.000Z", value: 1 }, // extend the last state to the window end
+    ]);
+  });
+
+  it("does not issue a carry-in query for a continuous series", async () => {
+    const capture: string[] = [];
+    const influx = makeInflux({ rows: [{ _time: "2026-05-01T02:00:00Z", _value: 20 }], capture });
+    await queryHistory(
+      influx,
+      {
+        equipmentId: "eq-1",
+        alias: "temp",
+        from: "2026-05-01T00:00:00Z",
+        to: "2026-05-01T06:00:00Z",
+        aggregation: "raw",
+        dataType: "number",
+      },
+      logger,
+    );
+    expect(capture.some((q) => q.includes("|> last()"))).toBe(false);
   });
 });

--- a/src/history/history-query.ts
+++ b/src/history/history-query.ts
@@ -150,6 +150,75 @@ export function buildFluxQuery(params: {
   return query;
 }
 
+/** How far before the window start we look for a discrete series' prior state
+ *  (#498 carry-in). Bounded so the query stays cheap; the raw bucket only
+ *  retains ~7 days anyway. */
+export const DISCRETE_CARRY_IN_LOOKBACK_MS = 30 * 86_400_000;
+
+/**
+ * Flux for the last recorded value strictly before `from` — the state a
+ * discrete series was in when the window opened (#498 carry-in). `range` stop
+ * is exclusive, so a sample exactly at `from` is not returned here (the main
+ * query already has it).
+ */
+export function buildLastBeforeQuery(params: {
+  bucket: string;
+  equipmentId: string;
+  alias: string;
+  from: Date;
+  lookbackMs: number;
+}): string {
+  const { bucket, equipmentId, alias, from, lookbackMs } = params;
+  const start = new Date(from.getTime() - lookbackMs).toISOString();
+  const stop = from.toISOString();
+  return `from(bucket: "${bucket}")
+  |> range(start: ${start}, stop: ${stop})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => r.alias == "${alias}")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> last()`;
+}
+
+/**
+ * Extend a discrete (boolean/enum) series across the whole chart window so its
+ * step line is continuous (#498). InfluxDB only returns points inside
+ * `[from, to]`, so without this a state that changed once — or not at all —
+ * inside the window is drawn from the first in-window sample and stops at the
+ * last one, leaving the head and tail of the graph blank.
+ *
+ * - Carry-in: when the first point is after `fromIso`, prepend the last known
+ *   state before the window (`priorValue`) stamped at `fromIso`.
+ * - Extend: repeat the last known value at `toIso` so the line reaches the
+ *   window end.
+ *
+ * `points` must be sorted ascending by time. Times are compared numerically to
+ * be robust to RFC3339 vs `toISOString()` formatting differences. Pure — no I/O.
+ */
+export function applyDiscreteBoundaries(
+  points: HistoryPoint[],
+  fromIso: string,
+  toIso: string,
+  priorValue: number | null,
+): HistoryPoint[] {
+  const result = points.slice();
+  const fromMs = Date.parse(fromIso);
+  const toMs = Date.parse(toIso);
+
+  if (priorValue !== null && (result.length === 0 || Date.parse(result[0].time) > fromMs)) {
+    result.unshift({ time: fromIso, value: priorValue });
+  }
+
+  if (result.length > 0) {
+    const last = result[result.length - 1];
+    if (Date.parse(last.time) < toMs) {
+      result.push({ time: toIso, value: last.value });
+    }
+  }
+
+  return result;
+}
+
 /**
  * Build a Flux query that returns min/max alongside mean for aggregated data.
  * When querying a downsampled bucket (hourly/daily), reads pre-computed mean/min/max fields.
@@ -264,6 +333,43 @@ export async function queryHistory(
         if (time && typeof value === "number") {
           points.push({ time, value });
         }
+      }
+
+      // #498 — a discrete (boolean/enum) state series is only sampled on change,
+      // so the window can open and close between two changes. Anchor the step
+      // line at the window start with the last state before it, and extend the
+      // last known value to the window end (or now, whichever is earlier — never
+      // draw a state into the future) so the line spans the whole graph.
+      if (isDiscrete) {
+        let priorValue: number | null = null;
+        try {
+          const carryFlux = buildLastBeforeQuery({
+            bucket: config.bucket,
+            equipmentId: params.equipmentId,
+            alias: params.alias,
+            from: fromDate,
+            lookbackMs: DISCRETE_CARRY_IN_LOOKBACK_MS,
+          });
+          for await (const { values, tableMeta } of queryApi.iterateRows(carryFlux)) {
+            const o = tableMeta.toObject(values);
+            const v = o._value as number | undefined;
+            if (typeof v === "number") priorValue = v;
+          }
+        } catch (err) {
+          logger.debug(
+            { err, equipmentId: params.equipmentId, alias: params.alias },
+            "Discrete carry-in query failed",
+          );
+        }
+        const extendTo = new Date(Math.min(toDate.getTime(), Date.now()));
+        const bounded = applyDiscreteBoundaries(
+          points,
+          fromDate.toISOString(),
+          extendTo.toISOString(),
+          priorValue,
+        );
+        points.length = 0;
+        points.push(...bounded);
       }
     } else if (CUMULATIVE_CATEGORIES.has(params.category ?? "")) {
       // Cumulative categories (energy, rain): read the pre-aggregated mean field directly


### PR DESCRIPTION
Part 3 of 3 for the Analyse page improvements reported in #498 (point 5).

## Problem

A boolean/enum state series (e.g. a relay "On/Off") is only sampled when it changes, and InfluxDB returns only points inside `[from, to]`. So when the state changed once — or not at all — inside the window, the step line was drawn from the first in-window sample and stopped at the last one: the "On" did not start at the graph's left edge, and a trailing "Off" segment never appeared (the reporter's screenshot).

## Fix (backend only)

For discrete raw queries in `queryHistory`, anchor the step line at both edges:
- **Carry-in**: a bounded `last()` query (`buildLastBeforeQuery`) fetches the state just before `from` and stamps it at the window start, so the line starts at the left edge in the correct state.
- **Extend**: the last known value is repeated at the window end, clamped to `now` so a state is never drawn into the future.

The point synthesis is a pure `applyDiscreteBoundaries(points, fromIso, toIso, priorValue)` helper (numeric time comparison, robust to RFC3339 vs `toISOString()` formatting). Only discrete (`dataType` boolean/enum) series are touched; continuous series are unchanged.

The frontend needs no change: it already merges series by timestamp, so the two boundary points extend the `stepAfter` line across the window, and measurement series (which use `connectNulls`) bridge the timestamps where they have no sample.

## Scope note

Discrete series always query the raw bucket (mean is meaningless for a state), and the raw bucket retains ~7 days — so this is most relevant on the day/week views, which is where state series are actually read.

## Tests

- `applyDiscreteBoundaries`: carry-in prepend, no prepend when a sample sits at `from`, flat line across the window when the state never changed, empty when there's no data and no prior state, no double-extend when the last sample is already at `to`.
- `buildLastBeforeQuery`: bounded lookback range, filters, `last()`.
- `queryHistory` integration: a discrete series issues the carry-in `last()` query and the result reaches both window edges; a continuous series issues no carry-in.
- Full `npm run validate` (backend tsc + eslint + 33 history tests + UI suite) green.

## Verification note

Not exercised end-to-end on the shadow instance: the shadow's raw bucket (7-day retention, inert since the seed) holds no recent raw state samples to drive a live chart. Correctness is pinned by the unit + integration tests above (carry-in query issuance and boundary synthesis), and the change is backend-only.

Refs #498 (umbrella; PR 1 and PR 2 merged).
