### PR TITLE
fix(energy): align the arbiter surplus curve with the auto-conso green

### DIFF
--- a/ui/src/components/energy/ArbiterTimeline.tsx
+++ b/ui/src/components/energy/ArbiterTimeline.tsx
@@ -253,7 +253,7 @@ export function ArbiterTimeline() {
               <>
                 <polygon
                   points={area}
-                  fill="var(--color-solar-injection)"
+                  fill="var(--color-solar-auto)"
                   opacity="0.16"
                   clipPath={`url(#up-${uid})`}
                 />
@@ -266,7 +266,7 @@ export function ArbiterTimeline() {
                 <polyline
                   points={pts}
                   fill="none"
-                  stroke="var(--color-solar-injection)"
+                  stroke="var(--color-solar-auto)"
                   strokeWidth="1.5"
                   strokeLinejoin="round"
                   strokeLinecap="round"


### PR DESCRIPTION
The redesigned arbiter timeline (spec 148, #500) drew the available-surplus curve in the darker `--color-solar-injection` (#2D8F3E light / #3DA855 dark) — a second green alongside `--color-solar-auto` (#6BCB77) already used for granted lanes, journal dots and the legend on the same chart. The darker, full-opacity stroke also read harder than the softer surplus curve shipped in v1.45.0.

Point the surplus area + stroke at `--color-solar-auto` so the curve shares the auto-consumption green: fewer colors on the timeline, closer to the v1.45.0 look. Deficit stays red (`--color-error`); the production bar chart keeps its own injection green (a meaningful split there).

Color before/after (surplus curve): #2D8F3E/#3DA855 → #6BCB77/#74C77F (light/dark).

Verified: UI tsc + eslint + energy tests green. Static token swap, no logic; the inert test instance has no today's surplus data to render the curve, so no live screenshot.