### PR TITLE
release: v1.46.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,19 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.46.x : Finitions de la page Analyse, activité persistante et frise d'arbitrage plus claire
+
+### v1.46.0 — 2026-08-15 { #v1-46-0 }
+
+- Feat (énergie) : **la frise d'arbitrage est redessinée en une courbe signée surplus/déficit, avec un ruban par charge et un journal des décisions**. La vue du surplus disponible se lit désormais comme une seule courbe continue, verte au-dessus de la ligne quand il y a du surplus et rouge en dessous quand la maison puise sur le réseau, avec une voie par charge profilée et un journal des décisions d'accord et de retrait de l'arbitre. La courbe de surplus réutilise le vert de l'auto-consommation pour que la frise garde un seul vert. (#495, #500, #508)
+- Feat (core) : **le fil d'activité et le journal de décisions de l'arbitre survivent maintenant à un redémarrage**. Tous deux étaient gardés en mémoire et effacés à chaque redémarrage de Sowel ; ils sont désormais persistés, si bien que l'historique récent est toujours là après une mise à jour ou un reboot. (#494, #499)
+- Feat (équipements) : **actionner un portail depuis un téléphone demande maintenant un glissement de confirmation**. Un portail est lent et physique : un appui involontaire (téléphone en poche) ne doit pas l'ouvrir ; un glisser-pour-confirmer protège l'action sur mobile. (#320, #497)
+- Feat (ui) : **la page Analyse s'ouvre sur votre premier graphique enregistré, sur aujourd'hui**. Ouvrir Analyse arrivait sur un constructeur de graphique vide ; elle ouvre désormais le premier graphique enregistré à la date du jour, avec le sélecteur zone/équipement replié pour un écran plus clair. Une entrée « Nouveau graphique » (barre latérale et tiroir mobile) permet toujours d'atteindre le constructeur vide. Signalé par Adrien Jouve (computingify). (#498, #505)
+- Correctif (ui) : **l'infobulle de détail d'un point tient à l'écran sur mobile**. Les longs libellés « Zone / Équipement / Mesure » faisaient déborder l'infobulle ; c'est maintenant une carte compacte qui renvoie ses libellés à la ligne et reste dans l'écran. Signalé par Adrien Jouve (computingify). (#498, #506)
+- Correctif (énergie) : **une courbe de relais Marche/Arrêt est désormais tracée sur toute la fenêtre**. Une série d'état n'est échantillonnée qu'au changement : un état qui n'a changé qu'une fois, ou pas du tout, dans la fenêtre était tracé à partir du premier échantillon et s'arrêtait au dernier. La ligne en escalier démarre maintenant au bord gauche dans le bon état précédent et prolonge sa dernière valeur jusqu'au bord droit. Signalé par Adrien Jouve (computingify). (#498, #507)
+- Feat (auth) : **la gestion des tokens API a été déplacée dans Réglages > Compte, et le login QR mobile inutilisé a été retiré**. Les tokens API personnels (utilisés par des intégrations externes comme l'afficheur d'énergie) se trouvent désormais à côté du mot de passe dans l'onglet Compte, et le login QR de l'onglet Système, source de confusion et non documenté, a disparu. (#501)
+- Correctif (ui) : **le bouton d'édition du tableau de bord ne chevauche plus la navigation du bas sur mobile**. Sur les appareils avec un home indicator, le bouton d'édition flottant retombait sur le bouton « Plus » / Réglages ; son décalage tient maintenant compte de la zone de sécurité (safe-area). Signalé par Adrien Jouve (computingify). (#496, #504)
+
 ## 1.45.x : Corrections d'affichage de l'arbitrage et nettoyage de l'UI
 
 ### v1.45.0 — 2026-08-13 { #v1-45-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,19 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.46.x: Analyse page polish, resilient activity, and a clearer arbiter timeline
+
+### v1.46.0 — 2026-08-15 { #v1-46-0 }
+
+- Feat (energy): **the arbiter timeline is redesigned as a signed surplus/deficit curve with per-load ribbons and a decision journal**. The available-surplus view now reads as one continuous curve, green above the line when there is surplus and red below when the house is pulling from the grid, with a lane per profiled load and a running log of the arbiter's grant and revoke decisions. The surplus curve reuses the auto-consumption green so the timeline keeps a single green. (#495, #500, #508)
+- Feat (core): **the activity feed and the arbiter decision journal now survive a restart**. Both were kept in memory and wiped whenever Sowel restarted; they are now persisted, so the recent history is still there after an update or a reboot. (#494, #499)
+- Feat (equipments): **actuating a gate from a phone now asks for a confirming swipe**. A gate is slow and physical, so an accidental tap (a phone in a pocket) should not open it; a slide-to-confirm guards the action on mobile. (#320, #497)
+- Feat (ui): **the Analyse page opens on your first saved chart, on today**. Visiting Analyse used to land on an empty chart builder; it now opens the first saved chart on today's date with the zone and equipment picker collapsed for a cleaner screen. A "New chart" entry (sidebar and mobile drawer) still reaches the empty builder. Reported by Adrien Jouve (computingify). (#498, #505)
+- Fix (ui): **the chart point-detail tooltip fits the screen on mobile**. The long "Zone / Equipment / Metric" labels made the tooltip overflow the viewport; it is now a compact card that wraps its labels and stays on-screen. Reported by Adrien Jouve (computingify). (#498, #506)
+- Fix (energy): **a relay On/Off curve is now drawn across the whole window**. A state series is only sampled when it changes, so a state that changed once, or not at all, inside the window was drawn from the first sample and stopped at the last one. The step line now starts at the window's left edge in the correct prior state and extends its last value to the right edge. Reported by Adrien Jouve (computingify). (#498, #507)
+- Feat (auth): **API token management moved to Settings > Account, and the unused mobile QR login was removed**. Personal API tokens (used by external integrations such as the energy display) now sit next to the password on the Account tab, and the confusing, undocumented QR login on the System tab is gone. (#501)
+- Fix (ui): **the dashboard edit button no longer overlaps the bottom navigation on mobile**. On devices with a home indicator the floating edit button dropped onto the "More" / Settings button; its offset now clears the safe-area inset. Reported by Adrien Jouve (computingify). (#496, #504)
+
 ## 1.45.x: Arbitration display fixes and UI cleanup
 
 ### v1.45.0 — 2026-08-13 { #v1-45-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.45.0",
+  "version": "1.46.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump (1.45.0 → 1.46.0) + release notes (EN/FR) for v1.46.0.

Covers everything merged since v1.45.0:
- Redesigned arbiter surplus/deficit timeline + single-green alignment (#495/#500, #508)
- Activity feed + arbiter journal persist across restarts (#494/#499)
- Gate actuation confirmation on mobile (#320/#497)
- Analyse: open on first saved chart / today / collapsed picker (#498/#505)
- Analyse: responsive mobile tooltip (#498/#506)
- Analyse: state (relay) series span the full window (#498/#507)
- API tokens moved to Account tab, mobile QR login removed (#501)
- Dashboard edit FAB safe-area fix (#496/#504)
- Registry: pool-pump-schedule 1.4.1 (#503, not user-facing)

Release-notes anchor { #v1-46-0 } present in both files (verify-release-notes CI gate).