### PR TITLE
fix(energy): shrink the arbiter state sticker + colour it by surplus/deficit

### DIFF
--- a/ui/src/components/energy/ArbitrationSurface.tsx
+++ b/ui/src/components/energy/ArbitrationSurface.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Scale, Zap, Clock } from "lucide-react";
 import { ArbiterTimeline } from "./ArbiterTimeline";
+import { surplusStickerColor } from "./arbiterColors";
 import { useArbiter } from "../../store/useArbiter";
 
 /**
@@ -47,6 +48,7 @@ export function ArbitrationSurface() {
   if (!state || !state.enabled) return null;
 
   const available = state.availableSurplusW;
+  const stickerColor = surplusStickerColor(available);
 
   return (
     <div className="bg-surface border border-border rounded-[10px] p-4 mt-4">
@@ -57,11 +59,11 @@ export function ArbitrationSurface() {
           <p className="text-[12px] text-text-secondary">{t("arbiter.surfaceHint")}</p>
         </div>
         <span
-          className={`ml-auto flex items-center gap-1.5 text-[12px] font-semibold px-2.5 py-0.5 rounded-full border ${
-            state.state === "active"
-              ? "text-success border-success/40"
-              : "text-warning border-warning/40"
-          }`}
+          className="ml-auto flex items-center gap-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-full whitespace-nowrap"
+          style={{
+            color: stickerColor,
+            background: `color-mix(in srgb, ${stickerColor} 12%, transparent)`,
+          }}
           title={state.state === "degraded" ? t("arbiter.degradedReason") : undefined}
         >
           {t(`arbiter.state.${state.state}`)}

--- a/ui/src/components/energy/arbiterColors.test.ts
+++ b/ui/src/components/energy/arbiterColors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { journalDotColor } from "./arbiterColors";
+import { journalDotColor, surplusStickerColor } from "./arbiterColors";
 
 describe("journalDotColor (spec 148)", () => {
   it("maps granted/resumed to the auto-consumption green token", () => {
@@ -21,5 +21,21 @@ describe("journalDotColor (spec 148)", () => {
   it("falls back to a neutral token for other kinds", () => {
     expect(journalDotColor("unclaimed-run-ended")).toBe("var(--color-text-tertiary)");
     expect(journalDotColor("denied")).toBe("var(--color-text-tertiary)");
+  });
+});
+
+describe("surplusStickerColor", () => {
+  it("uses the surplus green when there is surplus to give", () => {
+    expect(surplusStickerColor(300)).toBe("var(--color-solar-auto)");
+    expect(surplusStickerColor(1)).toBe("var(--color-solar-auto)");
+  });
+
+  it("uses red on a deficit (zero or negative surplus)", () => {
+    expect(surplusStickerColor(0)).toBe("var(--color-error)");
+    expect(surplusStickerColor(-1091)).toBe("var(--color-error)");
+  });
+
+  it("uses a neutral tint while degraded/stale (null)", () => {
+    expect(surplusStickerColor(null)).toBe("var(--color-text-tertiary)");
   });
 });

--- a/ui/src/components/energy/arbiterColors.ts
+++ b/ui/src/components/energy/arbiterColors.ts
@@ -24,3 +24,13 @@ export function journalDotColor(kind: ArbiterDecision["kind"]): string {
       return "var(--color-text-tertiary)";
   }
 }
+
+/**
+ * Colour token for the arbiter state sticker, matching the timeline curve:
+ * the surplus green when there is surplus to give, red on a deficit, and a
+ * neutral tint while the reading is degraded/stale (`availableSurplusW` null).
+ */
+export function surplusStickerColor(availableSurplusW: number | null): string {
+  if (availableSurplusW === null) return "var(--color-text-tertiary)";
+  return availableSurplusW > 0 ? "var(--color-solar-auto)" : "var(--color-error)";
+}


### PR DESCRIPTION
The arbiter state badge ("Actif 0.3 kW") in the arbitration surface header was a chunky 12px bordered pill coloured by active/degraded, bulky on mobile and unrelated to the timeline's surplus/deficit reading.

Now a small 10px tinted pill, coloured like the timeline curve:
- surplus available (availableSurplusW > 0) → surplus green `--color-solar-auto` (#6BCB77)
- deficit (availableSurplusW is signed; 0 or negative) → red `--color-error`
- degraded/stale (null) → neutral tint

Size: text-[12px] px-2.5 border → text-[10px] px-1.5, borderless with a faint `color-mix` background (same pattern as LiveEnergyPage's status pill).

The colour mapping is a unit-tested `surplusStickerColor()` helper in arbiterColors (surplus/deficit/degraded cases, incl. the signed -1091 deficit from the existing test fixture).

Verified: UI tsc + eslint + energy tests (44) green. Colours only render on a live instance with meter data; the inert shadow reads degraded (neutral), so no live green/red screenshot.

Closes #511