### PR TITLE
fix(deployment): cap container log size in compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,6 +20,11 @@ services:
       - sowel-plugins:/app/plugins
     depends_on:
       - influxdb
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   influxdb:
     image: influxdb:2.7
@@ -36,6 +41,11 @@ services:
       - DOCKER_INFLUXDB_INIT_ORG=sowel
       - DOCKER_INFLUXDB_INIT_BUCKET=sowel
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=sowel-dev-token
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   sowel-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,14 @@ services:
       - "host.docker.internal:host-gateway"
     depends_on:
       - influxdb
+    logging:
+      # Docker's json-file driver is unbounded by default: a chatty container
+      # fills the host disk with no warning. Cap it per service so a Sowel
+      # install cannot take its own host down.
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   influxdb:
     image: influxdb:2.7
@@ -52,6 +60,11 @@ services:
       - DOCKER_INFLUXDB_INIT_ORG=sowel
       - DOCKER_INFLUXDB_INIT_BUCKET=sowel
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=sowel-auto-token
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   sowel-data:

--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -240,8 +240,42 @@ Voir la section "Backup et restauration" dans [architecture.md](architecture.md)
 | Source                                              | Rétention                                       | Cas d'usage                                                                               |
 | --------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | **Ring buffer** (mémoire)                           | Perdu au redémarrage                            | Tail live via UI Admin → Logs                                                             |
-| **stdout Docker**                                   | Par conteneur (perdu à la recréation)           | `docker logs sowel`                                                                       |
+| **stdout Docker**                                   | Plafonné à 3 × 10 Mo par conteneur              | `docker logs sowel`                                                                       |
 | **Fichiers `pino-roll`** sur le volume `sowel-data` | 14 fichiers journaliers, survit à la recréation | **Investigation post-incident**, la seule source qui survit aux recréations d'auto-update |
+
+### Taille des logs Docker
+
+`docker-compose.yml` plafonne le stdout de chaque conteneur à `max-size: 10m` /
+`max-file: 3`. Sans ce plafond, le driver `json-file` de Docker est **illimité** :
+un conteneur bavard grossit en silence jusqu'à saturer le disque de l'hôte, ce qui
+met à terre tous les services de la machine, Sowel compris. Compose applique le
+plafond à la **création** du conteneur : sur une install existante, il prendra
+donc effet au prochain `docker compose up -d` (ou au prochain auto-update, qui
+recrée le conteneur).
+
+Pour récupérer l'espace déjà perdu sur un hôte en marche, et repérer les autres
+coupables :
+
+```bash
+# Taille de chaque log de conteneur, le plus gros en dernier
+for c in $(docker ps -aq); do
+  printf '%s\t%s\n' \
+    "$(sudo du -h "$(docker inspect --format '{{.LogPath}}' $c)" | cut -f1)" \
+    "$(docker inspect --format '{{.Name}}' $c)"
+done | sort -h
+
+# Vider un log en place, sans redémarrage
+sudo truncate -s 0 "$(docker inspect --format '{{.LogPath}}' <conteneur>)"
+```
+
+Les conteneurs que Sowel ne gère pas (un Zigbee2MQTT installé à côté, par exemple)
+gardent leurs propres réglages. Un défaut valable pour tout l'hôte se pose dans
+`/etc/docker/daemon.json`, mais il ne s'applique qu'aux conteneurs créés après un
+redémarrage du démon :
+
+```json
+{ "log-driver": "json-file", "log-opts": { "max-size": "10m", "max-file": "3" } }
+```
 
 ### Accéder aux logs fichiers
 

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -246,8 +246,40 @@ See the "Backup & Restore" section in [architecture.md](architecture.md) for the
 | Source                                       | Retention                           | Use case                                                                              |
 | -------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------- |
 | **Ring buffer** (memory)                     | Lost on restart                     | Live tail via UI Admin → Logs                                                         |
-| **Docker stdout**                            | Per-container (lost on recreate)    | `docker logs sowel`                                                                   |
+| **Docker stdout**                            | Capped at 3 × 10 MB per container   | `docker logs sowel`                                                                   |
 | **`pino-roll` files** on `sowel-data` volume | 14 daily files, survives recreation | **Post-incident investigation** — the only source that survives self-update recreates |
+
+### Docker log size
+
+`docker-compose.yml` caps each container's stdout at `max-size: 10m` /
+`max-file: 3`. Without it, Docker's `json-file` driver is **unbounded**: a chatty
+container quietly grows until the host disk is full, which takes down every
+service on the machine — Sowel included. Compose applies the cap when a container
+is **created**, so on an existing install it takes effect at the next
+`docker compose up -d` (or the next self-update, which recreates the container).
+
+To reclaim space already lost on a running host, and check for other offenders:
+
+```bash
+# Size of every container log, largest last
+for c in $(docker ps -aq); do
+  printf '%s\t%s\n' \
+    "$(sudo du -h "$(docker inspect --format '{{.LogPath}}' $c)" | cut -f1)" \
+    "$(docker inspect --format '{{.Name}}' $c)"
+done | sort -h
+
+# Truncate one in place — no restart needed
+sudo truncate -s 0 "$(docker inspect --format '{{.LogPath}}' <container>)"
+```
+
+Containers Sowel does not manage (a Zigbee2MQTT running alongside it, for
+instance) keep their own settings. A host-wide default can be set in
+`/etc/docker/daemon.json`, but it only applies to containers created after a
+daemon restart:
+
+```json
+{ "log-driver": "json-file", "log-opts": { "max-size": "10m", "max-file": "3" } }
+```
 
 ### Accessing the file logs
 


### PR DESCRIPTION
## The problem

Neither `docker-compose.yml` nor `docker-compose.dev.yml` sets a `logging:` section, so every Sowel install inherits Docker's `json-file` default — which is **unbounded**. Container stdout grows until the host disk is full, silently.

Measured on a live install this morning, 15 GB disk at 93%:

| container | stdout log |
| --- | --- |
| `zigbee2mqtt` | **182 MB** |
| `sowel-influxdb` | **130 MB** |
| `sowel` | 2.7 MB |

That same disk filling completely had already taken the whole stack down for 2h20 earlier in the month: SQLite returning `disk I/O error`, the `sowel` container in a restart loop, and InfluxDB staying *up* while rejecting every write with `no space left on device`. A logging default is a poor reason to lose a home automation system.

## What this changes

- `logging: driver: json-file` with `max-size: 10m` / `max-file: 3` on both services, in the production and the dev compose file. 30 MB per container is a ceiling, not a target — it is far more than `docker logs` is ever used for, and the `pino-roll` files on the `sowel-data` volume remain the real post-incident source.
- `docs/technical/deployment.md` and its French counterpart: the log-sources table now states the cap instead of "per-container", and a new **Docker log size** section explains why the default is dangerous, how to find and truncate an oversized log on a running host, and gives the `/etc/docker/daemon.json` equivalent for containers Sowel does not manage (a side-by-side Zigbee2MQTT, typically — which was the biggest offender here).

Compose applies the cap when a container is **created**, so existing installs pick it up at their next `docker compose up -d` or self-update recreate. That is called out in the docs, since it is the part that surprises people.

## Verification

`docker compose config` parses both files and resolves the `logging` block on all four services. `npm run validate` green (typecheck, lint, format, 1348 tests, ui validation).
