### PR TITLE
refactor(ui): dashboard presentation resolver — migrate switch, media_player, pool_pump (#325)

### DIFF
--- a/specs/149-dashboard-presentation-resolver/architecture.md
+++ b/specs/149-dashboard-presentation-resolver/architecture.md
@@ -1,0 +1,147 @@
+# Spec 149 — Architecture
+
+## Overview
+
+A new `presentation/` layer under `ui/src/components/dashboard/` owns the per-type derivation of icon, state and controls. Surfaces (desktop widget, mobile card, mobile tap action, and later the detail sheet) render the descriptor instead of re-deriving it.
+
+```
+resolveWidgetPresentation(widget, equipment, t)
+        │  (pure — no hooks, no JSX for controls)
+        ▼
+WidgetPresentation ── consumed by ──┬─ EquipmentWidget (desktop)  → PresentationWidget shell
+                                    ├─ useMobileState (mobile card) → { icon, stateLines }
+                                    └─ getMobileClickAction (tap)   → direct toggle from `toggle` control
+```
+
+`null` return = type not migrated → caller falls back to its legacy per-type path. The resolver and legacy paths coexist until the last type is migrated (final phase deletes the legacy derivations).
+
+## New files
+
+```
+ui/src/components/dashboard/presentation/
+├── types.ts                        # WidgetPresentation, WidgetControl, IconCtx
+├── resolveWidgetPresentation.ts    # dispatcher + per-type resolvers (switch, media_player, pool_pump)
+├── resolve-helpers.ts              # shared binding lookups (findToggleBinding, isOnFromBinding, …)
+├── resolveWidgetPresentation.test.ts
+└── PresentationWidget.tsx          # desktop renderer for a descriptor (WidgetCard shell + controls)
+```
+
+## Descriptor types
+
+```ts
+export interface IconCtx {
+  /** Surface hint: mobile icons are ~96px pre-scale, desktop ~64. */
+  surface: "desktop" | "mobile-card" | "detail";
+}
+
+export type WidgetControl =
+  | {
+      kind: "toggle";
+      alias: string; // order binding alias to execute
+      on: boolean; // current state (drives button tint)
+      onValue: unknown; // value to send to turn ON  (enum match or boolean true)
+      offValue: unknown; // value to send to turn OFF
+    }
+  | {
+      kind: "buttons";
+      buttons: Array<{ label: string; alias: string; value: unknown }>;
+    };
+// "slider" kind reserved for later phases (light brightness, shutter position,
+// thermostat setpoint) — designed here so the union is stable, added when the
+// first consumer type migrates.
+
+export interface WidgetPresentation {
+  icon: (ctx: IconCtx) => ReactNode; // ctx-dependent size/stroke; respects widget.icon custom override
+  isActive: boolean; // drives active tint on state pill / icon
+  state: { primary: string; secondary?: string[] }; // "ON", "1.5 kWh"; secondary = extra lines
+  controls: WidgetControl[];
+  accent?: "success" | "warning" | null;
+}
+```
+
+Design notes:
+
+- **Controls are declarative.** The resolver owns _which_ control exists and the exact order alias/values (killing the 7-copy toggle-resolution drift); each surface owns only pixels (desktop 40px button, mobile direct tap, sheet full-width button later).
+- **`onValue`/`offValue` are precomputed** in the resolver: category-first binding lookup (`findOrderByCategory(["light_toggle", "pool_pump_toggle", "toggle_power"], ["state"])` with plain-`find` fallback), enum values matched case-insensitively with `"ON"`/`"OFF"` fallback, boolean orders map to `true`/`false`. The surface just sends `on ? offValue : onValue`.
+- **Pure function, not a hook.** `useEquipmentState` reaches into `useWebSocket` (battery alerts) so it cannot be called from a pure resolver. The three phase-1 types don't need store state. When the sensor type migrates, store-derived context will be passed in as an explicit argument (e.g. `resolveWidgetPresentation(widget, equipment, t, ctx)`), keeping the function pure.
+- **`state.primary` is pre-localized** (the resolver receives `t`). Surfaces never re-translate.
+- **Custom icons**: the resolver applies the `widget.icon → CUSTOM_ICON_REGISTRY` override internally, so no surface can forget it (#318).
+
+## Per-type resolvers (phase 1)
+
+| Type           | icon                 | isActive         | state.primary               | state.secondary                               | controls                                             |
+| -------------- | -------------------- | ---------------- | --------------------------- | --------------------------------------------- | ---------------------------------------------------- |
+| `switch`       | `PlugWidgetIcon(on)` | `light_state` ON | `"ON"/"OFF"`                | —                                             | `[toggle]`                                           |
+| `media_player` | `Tv` tinted          | `power === true` | source name or `"ON"/"OFF"` | —                                             | `[toggle on power alias]` (boolean)                  |
+| `pool_pump`    | `PoolPumpIcon(on)`   | `light_state` ON | `"ON"/"OFF"`                | `[formatRuntime(runtime_daily)]` when present | `[toggle]` (category-first incl. `pool_pump_toggle`) |
+
+`formatRuntime` moves from `EquipmentWidget.tsx` into `resolve-helpers.ts` (shared).
+
+## Surface changes
+
+### Desktop — `EquipmentWidget.tsx`
+
+At the top of the dispatcher:
+
+```ts
+const presentation = resolveWidgetPresentation(widget, equipment, t);
+if (presentation) return <PresentationWidget label sublabel equipment presentation onExecuteOrder />;
+// …legacy per-type branches unchanged for unmigrated types
+```
+
+`PresentationWidget` reproduces the existing switch-family layout exactly: `WidgetCard` shell → centered icon grid + state pill (+ secondary lines) → bottom control row (toggle button with `Power` icon + `Loader2` while executing, gated on `equipment.enabled`). `SwitchEquipmentWidget`, `MediaPlayerEquipmentWidget`, `PoolPumpEquipmentWidget` are **deleted**.
+
+### Mobile card — `MobileWidgetCard.tsx`
+
+At the top of `useMobileState`:
+
+```ts
+const presentation = resolveWidgetPresentation(widget, equipment, t);
+if (presentation)
+  return {
+    icon: presentation.icon({ surface: "mobile-card" }),
+    stateLines: [presentation.state.primary, ...(presentation.state.secondary ?? [])],
+  };
+// …legacy branches for unmigrated types
+```
+
+The `switch`, `media_player`, `pool_pump` branches are **deleted**.
+
+### Mobile tap — `getMobileClickAction` (extracted to `mobile-click-action.ts`)
+
+The function moves out of `WidgetGrid.tsx` into its own module (react-refresh
+forbids non-component exports from component files, and it is now unit-tested).
+For migrated types, the direct-tap toggle comes from the descriptor:
+
+```ts
+const presentation = resolveWidgetPresentation(widget, equipment, t);
+const toggle = presentation?.controls.find((c) => c.kind === "toggle");
+if (presentation && toggle)
+  return () => {
+    onExecuteOrder(equipment.id, toggle.alias, toggle.on ? toggle.offValue : toggle.onValue);
+  };
+if (presentation) return undefined; // migrated, no toggle → no tap action
+```
+
+Requires threading `widget` + `t` into `getMobileClickAction` (call site already has both). `switch` and `pool_pump` leave the legacy hand-rolled list; `light_onoff`, `water_heater`, `water_valve` stay on it until migrated.
+
+### Point fix — desktop gate multi-action (`EquipmentWidget.tsx`)
+
+`GateEquipmentWidget`: when `enumValues.length > 1`, render one bottom-row button per enum value (same `handleCommand(val)` semantics as `GateDetailContent`), and drop the card-level single-tap. Single-action gates unchanged. This is a legacy-path fix; the gate type migrates to the resolver in a later phase (its confirm-guard logic — spec 146 — makes it a poor first candidate).
+
+### Point fix — string-boolean sensor normalization (`MobileWidgetCard.tsx`)
+
+No new helper: the desktop `SensorValues` (#315's fix) routes by **category**, not by runtime type — `isBooleanSensorCategory(b.category)` → `formatBooleanSensor(category, value, t)`, which already understands string `"ON"`/`"OFF"` itself. The mobile sensor branch converges on the exact same predicate: a boolean-category value goes through the category-aware formatter whatever its runtime type, others keep `formatSensorValue`. Both surfaces now share one normalization authority.
+
+## Data model / API / events
+
+None. UI-only refactor; no backend, DB, or WebSocket change.
+
+## Retro-compatibility contract
+
+- Existing component tests (`EquipmentWidget.test.tsx` — 6 tests incl. switch toggle semantics, `MobileWidgetCard.test.tsx` — energy meter) must pass **unchanged**: they pin the visual/behavior contract across the migration.
+- Enum toggle value semantics preserved exactly: enum match case-insensitive, fallback literal `"ON"`/`"OFF"`; boolean orders send `true`/`false` — except a boolean order aliased `state`, which keeps the historical ON/OFF string contract (from the legacy switch/light/water-heater handlers). Deliberate unifications, all converging on one semantic instead of per-type drift:
+  - the desktop switch's toggle lookup becomes category-first (`light_toggle`/`toggle_power` before generic boolean), aligning it with the mobile tap path;
+  - a **boolean pool-pump toggle aliased `state`** now sends `"ON"`/`"OFF"` strings like every other relay (the deleted desktop handler sent raw booleans for that one case, while the mobile tap already sent strings — the backend `resolveWireValue` coerces where the device declares wire values, and the pool-pump auto-binding path is enum-typed anyway);
+  - the mobile tap on a **disabled** migrated equipment is now inert (previously it fired and the backend rejected with 400);
+  - a **media_player that is ON without a source** shows `"ON"` on mobile (the legacy card showed `"OFF"` — a bug), and the custom widget icon override now applies on mobile too (#318 contract).

--- a/specs/149-dashboard-presentation-resolver/plan.md
+++ b/specs/149-dashboard-presentation-resolver/plan.md
@@ -1,0 +1,71 @@
+# Spec 149 — Implementation plan
+
+## Tasks
+
+1. [x] `presentation/types.ts` — `WidgetPresentation`, `WidgetControl`, `IconCtx`.
+2. [x] `presentation/resolve-helpers.ts` — `findToggleBinding` (category-first + fallback), `toggleValues` (onValue/offValue from enum/boolean), `isOnFromStateBinding`, `formatRuntime` (moved from `EquipmentWidget.tsx`).
+3. [x] `presentation/resolveWidgetPresentation.ts` — dispatcher + `switch`, `media_player`, `pool_pump` resolvers (custom-icon override included).
+4. [x] `presentation/resolveWidgetPresentation.test.ts` — unit tests (see test plan).
+5. [x] `presentation/PresentationWidget.tsx` — desktop descriptor renderer (WidgetCard shell, state pill + secondary lines, toggle button row).
+6. [x] `EquipmentWidget.tsx` — resolver short-circuit at top of dispatcher; delete `SwitchEquipmentWidget`, `MediaPlayerEquipmentWidget`, `PoolPumpEquipmentWidget`; gate multi-action point fix in `GateEquipmentWidget`.
+7. [x] `MobileWidgetCard.tsx` — resolver short-circuit at top of `useMobileState`; delete the three legacy branches; string-boolean sensor normalization via `coerceBooleanString`.
+8. [x] ~~`sensorUtils.ts` — add `coerceBooleanString`~~ — not needed: converged on the existing `isBooleanSensorCategory` + `formatBooleanSensor` (the desktop authority).
+9. [x] `getMobileClickAction` (extracted to `mobile-click-action.ts`) consumes the descriptor toggle for migrated types (thread `widget` + `t`).
+10. [x] Component tests updated/added (existing tests untouched — retro-compat pin).
+11. [x] Full validation: `npx tsc --noEmit`, `cd ui && npx tsc -b --noEmit`, `npx vitest run`, eslint backend + UI.
+12. [x] Playwright visual QA — done against the Vite dev build proxied onto the local shadow (prod data): desktop 1440px (switch ON pill + toggle, TV OFF + power, pool pump OFF + runtime) and mobile 390px (pool pump "OFF · 0s", switch "ON", TV "OFF") all match the legacy rendering. No multi-action gate in the dataset (both prod gates are single-action) — covered by the component test instead.
+
+## Test plan
+
+### Modules to test
+
+- `presentation/resolveWidgetPresentation.ts` (new — pure logic, prime unit-test target)
+- `presentation/resolve-helpers.ts` (via the resolver tests)
+- `EquipmentWidget.tsx` (component tier, #458 pattern)
+- `MobileWidgetCard.tsx` (component tier)
+- `WidgetGrid.tsx` `getMobileClickAction` (via component test or extracted unit)
+- `sensorUtils.coerceBooleanString` (unit)
+
+### Scenarios
+
+| Module               | Scenario                                                                                        | Expected                                                                                        |
+| -------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| resolver             | switch OFF, enum order `["ON","OFF"]`                                                           | `isActive=false`, `state.primary="OFF"`, toggle `{alias:"state", onValue:"ON", offValue:"OFF"}` |
+| resolver             | switch ON with lowercase enum `["on","off"]`                                                    | toggle values `"on"`/`"off"` (case-insensitive match preserved)                                 |
+| resolver             | switch with boolean order binding                                                               | toggle `{onValue:true, offValue:false}`                                                         |
+| resolver             | switch with **no** order binding                                                                | `controls: []`                                                                                  |
+| resolver             | media_player ON with `input_source="HDMI 1"`                                                    | `state.primary="HDMI 1"`, `isActive=true`                                                       |
+| resolver             | media_player OFF / no source                                                                    | `state.primary="OFF"` / `"ON"` fallback                                                         |
+| resolver             | pool_pump with `runtime_daily=5400`                                                             | `state.secondary=["1h 30m"]`                                                                    |
+| resolver             | pool_pump without `runtime_daily`                                                               | no secondary line                                                                               |
+| resolver             | pool_pump toggle prefers `pool_pump_toggle` category over unrelated boolean order (`auto_mode`) | toggle alias = the category-bound order                                                         |
+| resolver             | unmigrated type (e.g. `light_onoff`)                                                            | returns `null`                                                                                  |
+| resolver             | custom `widget.icon` set                                                                        | `icon(ctx)` renders the registry component, not the type default                                |
+| EquipmentWidget      | **existing 6 tests** (switch ON/OFF + toggle fire, disabled, other category)                    | pass unchanged                                                                                  |
+| EquipmentWidget      | media_player renders Tv + source pill, toggle fires `power` with `!on`                          | new test                                                                                        |
+| EquipmentWidget      | pool_pump renders runtime line                                                                  | new test                                                                                        |
+| EquipmentWidget      | gate with `enumValues=["OPEN","CLOSE","PEDESTRIAN"]`                                            | renders 3 action buttons, each firing its enum value; no card-level tap                         |
+| EquipmentWidget      | gate with single/no enum value                                                                  | keeps tap-the-card single-action behavior                                                       |
+| MobileWidgetCard     | **existing tests** (energy meter, label)                                                        | pass unchanged                                                                                  |
+| MobileWidgetCard     | switch shows ON/OFF from descriptor                                                             | new test                                                                                        |
+| MobileWidgetCard     | pool_pump shows ON + runtime line (divergence 1 regression test)                                | new test                                                                                        |
+| MobileWidgetCard     | sensor with string `"OPEN"` contact value                                                       | localized open/closed text, not raw `"OPEN"`                                                    |
+| getMobileClickAction | switch tap fires descriptor toggle (alias + value)                                              | same order as before migration                                                                  |
+| getMobileClickAction | migrated type without toggle                                                                    | no tap action                                                                                   |
+
+### Retro-compat
+
+- The pre-existing component tests are the contract: **do not modify them**; if one fails, the migration broke behavior — fix the code, not the test.
+- Desktop visual parity checked by Playwright pass (task 12) against the shadow instance.
+
+## Verification
+
+- `npm run validate` equivalent: backend tsc + eslint (untouched, must stay green), UI tsc + eslint, full vitest.
+- Playwright QA notes: shadow instance disables recipes but dashboard widgets render fine; remember the PWA service-worker stale-bundle gotcha (unregister SW + hard reload before screenshots).
+
+## Later phases (tracked in #325, not this spec)
+
+- Migrate light family (needs `slider` control), water_heater, water_valve (near-clones of switch).
+- Migrate shutter/awning/pool_cover (buttons row + slider + stop-capability flag).
+- Migrate thermostat/pool_heat_pump, heater, gate (confirm-guard), sensor (needs store ctx for battery), weather, energy meter, appliance, camera, solar.
+- Delete `useMobileState` legacy branches, `needsDetailSheet`, and the remaining per-type sub-widgets; detail sheet reads descriptors.

--- a/specs/149-dashboard-presentation-resolver/spec.md
+++ b/specs/149-dashboard-presentation-resolver/spec.md
@@ -1,0 +1,76 @@
+# Spec 149 — Dashboard presentation resolver (phase 1)
+
+**Issue**: [#325](https://github.com/mchacher/sowel/issues/325)
+**Status**: draft
+**Scope**: UI only (no backend change)
+
+## Problem
+
+Each equipment type derives its dashboard **icon + state text + controls** independently in four places:
+
+| Path                | File                                                                  | Shape produced                                    |
+| ------------------- | --------------------------------------------------------------------- | ------------------------------------------------- |
+| Desktop widget      | `ui/src/components/dashboard/EquipmentWidget.tsx` (~1860 l.)          | per-type sub-widget rendering a full `WidgetCard` |
+| Mobile card         | `ui/src/components/dashboard/MobileWidgetCard.tsx` → `useMobileState` | `{ icon, stateLines[] }`                          |
+| Mobile detail sheet | `ui/src/components/dashboard/WidgetDetailSheet.tsx` (~1500 l.)        | per-type layout + controls                        |
+| Mobile tap action   | `ui/src/components/dashboard/WidgetGrid.tsx` → `getMobileClickAction` | re-resolves the toggle order binding a 4th time   |
+
+Adding or changing a type means touching all of them, in sync, by hand. This drift is the shared root cause of #315, #318, #323, #324, and the still-open divergences below.
+
+## Confirmed divergences (verified against current code)
+
+1. **Pool pump daily runtime**: desktop shows `runtime_daily` (`PoolPumpEquipmentWidget`); the mobile card shows only ON/OFF.
+2. **Gate multi-action on desktop**: the mobile detail sheet renders one button per enum action (`GateDetailContent`), but the desktop `GateEquipmentWidget` only supports the single-action tap — with >1 enum values the desktop card exposes **no way to trigger any action**.
+3. **String-valued boolean sensors**: the mobile card formats `typeof value === "boolean"` via `formatBooleanSensor`, but a sensor emitting the string `"ON"`/`"OPEN"` falls through to `formatSensorValue` and renders raw (residual of #315).
+4. **Sensor value count**: the mobile card caps at 2 values (`slice(0, 2)`); desktop shows all in a scrollable column. **Resolution: keep the mobile cap** — it is a real surface constraint (120 px card), not drift. The descriptor carries the full list; each surface decides how many to show. Documented here so it stops being re-reported.
+5. **Toggle-binding resolution drift**: the "find the ON/OFF order binding" logic exists in at least 7 copies with subtle differences — `SwitchEquipmentWidget` (plain `find`, NOT category-first), `LightEquipmentWidget`, `WaterHeaterEquipmentWidget`, `WaterValveEquipmentWidget` (plain), `PoolPumpEquipmentWidget` (category-first), `LightDetailContent` (category-first), `getMobileClickAction` (category-first). A switch bound with a non-conventional alias behaves differently on desktop vs mobile tap.
+
+## Goal
+
+Introduce a single **presentation resolver**: one pure function per equipment type returning a layout-agnostic descriptor consumed by every surface. A widget type is described once; the surfaces only own pixels.
+
+This spec is **phase 1 of an incremental, type-by-type migration** (per the migration plan in #325): land the resolver scaffold, migrate three switch-like types end-to-end, point-fix the two remaining confirmed divergences on unmigrated types, then evaluate ergonomics before committing to the full ~15-type sweep.
+
+## In scope (phase 1)
+
+- `resolveWidgetPresentation(widget, equipment, t): WidgetPresentation | null` — pure function, no hooks. Returns `null` for types not yet migrated (callers fall back to the legacy path). This is the coexistence mechanism.
+- Descriptor types (`WidgetPresentation`, `WidgetControl`) — controls are **declarative** (`toggle`, `buttons`; `slider` reserved for later phases), not JSX.
+- Migrate **`switch`**, **`media_player`**, **`pool_pump`** across all their surfaces:
+  - desktop `EquipmentWidget` renders the descriptor through a shared `PresentationWidget` shell;
+  - mobile `useMobileState` returns icon/stateLines from the descriptor;
+  - `getMobileClickAction` derives the direct-tap toggle from the descriptor's `toggle` control (single source for alias/on-off values);
+  - none of the three types has a mobile detail sheet. `switch` and `pool_pump` keep their direct-tap toggle unchanged. **`media_player` gains it** (deliberate): its mobile tap used to be inert — there was no way at all to control a TV from the mobile dashboard — and the descriptor toggle aligns it with the desktop power button and the other simple on/off types.
+  - Migrating `pool_pump` folds in divergence 1 (runtime line appears on mobile via `state.secondary`).
+- Point fixes on unmigrated types (full migration comes in later phases):
+  - divergence 2: desktop gate widget renders the per-enum action buttons when `enumValues.length > 1` (same actions as `GateDetailContent`);
+  - divergence 3: the mobile sensor card normalizes string booleans (`"ON"`, `"OFF"`, `"OPEN"`, `"CLOSED"`, …) through the same category-aware formatter as real booleans.
+
+## Out of scope (later phases)
+
+- Migrating the other ~12 types (light, shutter/awning, thermostat, heater, gate, sensor, weather, energy meter, appliance, water valve, water heater, pool cover, camera, solar).
+- Any change to the mobile detail sheet layout or `BottomSheet`.
+- The `slider` control kind (needed by light/shutter/thermostat migration — designed now, wired later).
+- Zone widgets (`ZoneWidget`, `MobileZoneCard`, `ZoneDetailSheet`).
+- Visual redesign of any card: phase 1 is behavior-preserving for migrated types (except the two point fixes, which add missing behavior).
+
+## Acceptance criteria
+
+- [x] `resolveWidgetPresentation` exists, is a pure function (no hooks), and returns `null` for unmigrated types.
+- [x] `switch`, `media_player`, `pool_pump` render identical desktop visuals as before (same state pill, same toggle button, same layout shell).
+- [x] Mobile card for the three types shows the same icon and state as before, plus the pool pump daily runtime (new, divergence 1).
+- [x] Mobile tap on the three types still fires the direct toggle with the same alias/value semantics, now derived from the descriptor.
+- [x] Toggle-binding resolution for the three migrated types is category-first everywhere (fixes divergence 5 for these types).
+- [x] Desktop gate widget with >1 enum actions renders one button per action; single-action gates keep the tap-the-card behavior (divergence 2).
+- [x] A sensor emitting string `"ON"`/`"OPEN"` renders the same localized text as a boolean `true` on the mobile card (divergence 3).
+- [x] All existing component tests pass unchanged (they pin the retro-compat contract).
+- [x] New unit tests cover the resolver and the two point fixes (see plan.md).
+
+## Edge cases
+
+- Equipment with **no toggle order binding** → descriptor has `controls: []`; desktop shows no button, mobile tap does nothing (matches current behavior).
+- Equipment **disabled** (`enabled: false`) → controls are surfaced in the descriptor but every surface suppresses interactive rendering (current `equipment.enabled` gate preserved — the surface owns this, the resolver stays state-pure).
+- **Boolean-typed** toggle order vs **enum-typed** (`ON`/`OFF`, arbitrary case) → descriptor precomputes `onValue`/`offValue` (`enumValues` matched case-insensitively, fallback `"ON"`/`"OFF"`; boolean orders use `true`/`false`).
+- `media_player` with no `input_source` binding → primary state falls back to `"ON"`/`"OFF"`.
+- `pool_pump` with no `runtime_daily` computed → no secondary line (not `0s`).
+- Gate with **zero** command binding → no buttons, no tap action (current behavior).
+- Custom widget icon (`widget.icon` → `CUSTOM_ICON_REGISTRY`) keeps overriding the type icon on every surface (#318 contract).

--- a/ui/src/components/dashboard/EquipmentWidget.test.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.test.tsx
@@ -229,4 +229,134 @@ describe("EquipmentWidget", () => {
     await userEvent.click(screen.getByRole("button"));
     expect(onExecuteOrder).toHaveBeenCalledWith("tv-1", "power", false);
   });
+
+  // Spec 149 — the pool pump descriptor exposes the daily runtime as a
+  // secondary state line (was desktop-only before the resolver migration).
+  it("renders a pool_pump with its ON state and daily runtime", () => {
+    const pump = makeEquipment({
+      id: "pp-1",
+      name: "Pool pump",
+      type: "pool_pump",
+      computedData: [
+        { alias: "runtime_daily", value: 5400, lastUpdated: "2026-01-01T00:00:00Z" },
+      ],
+    });
+    pump.dataBindings[0].value = true;
+    render(
+      <EquipmentWidget
+        widget={makeWidget({ equipmentId: "pp-1" })}
+        equipment={pump}
+        onExecuteOrder={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("ON")).toBeTruthy();
+    expect(screen.getByText("1h 30m")).toBeTruthy();
+  });
+
+  // Issue #325 — a multi-action gate exposed NO way to act on desktop (the
+  // mobile detail sheet had one button per enum action, the desktop card none).
+  it("renders one button per action on a multi-action gate and fires the enum value", async () => {
+    const onExecuteOrder = vi.fn().mockResolvedValue(undefined);
+    const gate = makeEquipment({
+      id: "g-1",
+      name: "Portail",
+      type: "gate",
+      dataBindings: [
+        {
+          id: "db-g",
+          equipmentId: "g-1",
+          deviceDataId: "dd-g",
+          alias: "state",
+          deviceId: "dev-g",
+          deviceName: "Gate",
+          key: "state",
+          type: "enum",
+          category: "gate_state",
+          value: "closed",
+          lastUpdated: "2026-01-01T00:00:00Z",
+          lastChanged: "2026-01-01T00:00:00Z",
+          stale: false,
+        },
+      ] as EquipmentWithDetails["dataBindings"],
+      orderBindings: [
+        {
+          id: "ob-g",
+          equipmentId: "g-1",
+          deviceOrderId: "do-g",
+          alias: "command",
+          deviceId: "dev-g",
+          deviceName: "Gate",
+          key: "command",
+          type: "enum",
+          category: "gate_trigger",
+          enumValues: ["OPEN", "CLOSE", "PEDESTRIAN"],
+        },
+      ] as EquipmentWithDetails["orderBindings"],
+    });
+    render(
+      <EquipmentWidget
+        widget={makeWidget({ equipmentId: "g-1" })}
+        equipment={gate}
+        onExecuteOrder={onExecuteOrder}
+      />,
+    );
+
+    expect(screen.getByText("OPEN")).toBeTruthy();
+    expect(screen.getByText("CLOSE")).toBeTruthy();
+    await userEvent.click(screen.getByText("PEDESTRIAN"));
+    expect(onExecuteOrder).toHaveBeenCalledWith("g-1", "command", "PEDESTRIAN");
+  });
+
+  it("keeps the single-action gate as a tap-the-card action (no button row)", async () => {
+    const onExecuteOrder = vi.fn().mockResolvedValue(undefined);
+    const gate = makeEquipment({
+      id: "g-2",
+      name: "Garage",
+      type: "gate",
+      dataBindings: [
+        {
+          id: "db-g2",
+          equipmentId: "g-2",
+          deviceDataId: "dd-g2",
+          alias: "state",
+          deviceId: "dev-g2",
+          deviceName: "Gate",
+          key: "state",
+          type: "enum",
+          category: "gate_state",
+          value: "closed",
+          lastUpdated: "2026-01-01T00:00:00Z",
+          lastChanged: "2026-01-01T00:00:00Z",
+          stale: false,
+        },
+      ] as EquipmentWithDetails["dataBindings"],
+      orderBindings: [
+        {
+          id: "ob-g2",
+          equipmentId: "g-2",
+          deviceOrderId: "do-g2",
+          alias: "command",
+          deviceId: "dev-g2",
+          deviceName: "Gate",
+          key: "command",
+          type: "enum",
+          category: "gate_trigger",
+          enumValues: ["TRIGGER"],
+        },
+      ] as EquipmentWithDetails["orderBindings"],
+    });
+    render(
+      <EquipmentWidget
+        widget={makeWidget({ equipmentId: "g-2" })}
+        equipment={gate}
+        onExecuteOrder={onExecuteOrder}
+      />,
+    );
+
+    // No per-enum button row for a single action…
+    expect(screen.queryByText("TRIGGER")).toBeNull();
+    // …the whole card is the action.
+    await userEvent.click(screen.getByText("Garage"));
+    expect(onExecuteOrder).toHaveBeenCalledWith("g-2", "command", null);
+  });
 });

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -15,7 +15,6 @@ import {
   WashingMachine,
   Timer,
   Camera,
-  Tv,
 } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
 import type { DashboardWidget } from "../../types";
@@ -31,7 +30,6 @@ import { solarWidgetState } from "./solarWidget";
 import { createElement, type ReactNode } from "react";
 import {
   LightBulbIcon,
-  PlugWidgetIcon,
   ShutterWidgetIcon,
   AwningWidgetIcon,
   ThermometerIcon,
@@ -42,13 +40,14 @@ import {
   SlidingGateIcon,
   GarageDoorIcon,
   EnergyMeterIcon,
-  PoolPumpIcon,
   PoolCoverIcon,
   WaterValveWidgetIcon,
 } from "./WidgetIcons";
 import { WeatherForecastWidget } from "./WeatherForecastWidget";
 import { WidgetCard } from "./WidgetCard";
 import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
+import { resolveWidgetPresentation } from "./presentation/resolveWidgetPresentation";
+import { PresentationWidget } from "./presentation/PresentationWidget";
 
 /** Render the widget's custom icon (widget.icon -> CUSTOM_ICON_REGISTRY) when set,
  *  otherwise the equipment-type default. Mirrors the mobile card so a custom icon
@@ -75,6 +74,7 @@ export function EquipmentWidget({
   onExecuteOrder,
   onOpenDetail,
 }: EquipmentWidgetProps) {
+  const { t } = useTranslation();
   const {
     isLight,
     isShutterFamily,
@@ -86,10 +86,8 @@ export function EquipmentWidget({
     isGate,
     isAppliance,
     isWaterValve,
-    isPoolPump,
     isPoolCover,
     isPoolHeatPump,
-    isMediaPlayer,
   } = useEquipmentState(equipment);
 
   // A hand-picked label replaces the whole thing, zone line included: the user
@@ -97,6 +95,20 @@ export function EquipmentWidget({
   const label = widget.label || equipment.name;
   const sublabel = widget.label ? undefined : equipmentZone;
   const execOrder = (alias: string, value: unknown) => onExecuteOrder(equipment.id, alias, value);
+
+  // Spec 149 — migrated types render their presentation descriptor through the
+  // shared shell; a null descriptor falls through to the legacy per-type path.
+  const presentation = resolveWidgetPresentation(widget, equipment, t);
+  if (presentation)
+    return (
+      <PresentationWidget
+        label={label}
+        sublabel={sublabel}
+        equipment={equipment}
+        presentation={presentation}
+        onExecuteOrder={execOrder}
+      />
+    );
 
   if (isLight)
     return (
@@ -154,16 +166,6 @@ export function EquipmentWidget({
   if (isEnergyMeter) return <EnergyMeterEquipmentWidget label={label} sublabel={sublabel} equipment={equipment} />;
   if (equipment.type === "solar_panel")
     return <SolarPanelEquipmentWidget label={label} sublabel={sublabel} equipment={equipment} />;
-  if (equipment.type === "switch")
-    return (
-      <SwitchEquipmentWidget
-        label={label}
-        sublabel={sublabel}
-        equipment={equipment}
-        onExecuteOrder={execOrder}
-        iconKey={widget.icon}
-      />
-    );
   if (equipment.type === "water_heater")
     return (
       <WaterHeaterEquipmentWidget
@@ -181,16 +183,6 @@ export function EquipmentWidget({
   if (isWaterValve)
     return (
       <WaterValveEquipmentWidget
-        label={label}
-        sublabel={sublabel}
-        equipment={equipment}
-        onExecuteOrder={execOrder}
-        iconKey={widget.icon}
-      />
-    );
-  if (isPoolPump)
-    return (
-      <PoolPumpEquipmentWidget
         label={label}
         sublabel={sublabel}
         equipment={equipment}
@@ -220,16 +212,6 @@ export function EquipmentWidget({
     );
   if (equipment.type === "camera")
     return <CameraEquipmentWidget label={label} sublabel={sublabel} equipment={equipment} />;
-  if (isMediaPlayer)
-    return (
-      <MediaPlayerEquipmentWidget
-        label={label}
-        sublabel={sublabel}
-        equipment={equipment}
-        onExecuteOrder={execOrder}
-        iconKey={widget.icon}
-      />
-    );
 
   return <GenericEquipmentWidget label={label} sublabel={sublabel} equipment={equipment} />;
 }
@@ -362,95 +344,8 @@ function LightEquipmentWidget({
 }
 
 // ============================================================
-// Switch (smart plug) widget — plug picto + ON/OFF state + toggle.
-// Mirrors LightEquipmentWidget without the brightness slider. The plug's
-// on/off command is a `light_toggle` order (enum ON/OFF or boolean state),
-// and the state indicator reads the `light_state` data binding.
-// ============================================================
-
-function SwitchEquipmentWidget({
-  label,
-  sublabel,
-  equipment,
-  onExecuteOrder,
-  iconKey,
-}: {
-  label: string;
-  sublabel?: string;
-  equipment: EquipmentWithDetails;
-  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
-  iconKey?: string;
-}) {
-  const { t } = useTranslation();
-  const [executing, setExecuting] = useState(false);
-
-  const stateBinding = equipment.dataBindings.find(
-    (db) => db.alias === "state" || db.category === "light_state",
-  );
-  const isOn = stateBinding
-    ? stateBinding.value === true || String(stateBinding.value).toUpperCase() === "ON"
-    : false;
-
-  const toggleBinding = equipment.orderBindings.find(
-    (ob) => ob.type === "boolean" || (ob.alias === "state" && ob.type === "enum"),
-  );
-  const hasToggle = !!toggleBinding;
-
-  const handleToggle = async () => {
-    if (executing || !toggleBinding) return;
-    setExecuting(true);
-    try {
-      const alias = toggleBinding.alias;
-      const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
-      const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
-      const value =
-        toggleBinding.type === "boolean" && alias !== "state" ? !isOn : isOn ? offVal : onVal;
-      await onExecuteOrder(alias, value);
-    } finally {
-      setExecuting(false);
-    }
-  };
-
-  return (
-    <WidgetCard label={label} sublabel={sublabel}>
-      {/* Zone 2: Picto + état */}
-      <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
-        <div />
-        {resolveWidgetIcon(iconKey, <PlugWidgetIcon on={isOn} />)}
-        <div className="flex items-center gap-2 pl-2">
-          <span
-            className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
-              isOn ? "bg-active/10 text-active" : "bg-border-light text-text-tertiary"
-            }`}
-          >
-            {isOn ? "ON" : "OFF"}
-          </span>
-        </div>
-      </div>
-
-      {/* Zone 3: Bouton — toggle */}
-      {hasToggle && equipment.enabled && (
-        <div className="flex justify-center gap-3 mt-auto pt-1">
-          <button
-            onClick={handleToggle}
-            disabled={executing}
-            className={`w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed ${
-              isOn ? "!border-active/40 !text-active !bg-active/5" : ""
-            }`}
-            title={isOn ? t("controls.turnOff") : t("controls.turnOn")}
-          >
-            {executing ? (
-              <Loader2 size={16} className="animate-spin" />
-            ) : (
-              <Power size={16} strokeWidth={1.5} />
-            )}
-          </button>
-        </div>
-      )}
-    </WidgetCard>
-  );
-}
-
+// Switch / media player / pool pump widgets migrated to the presentation
+// resolver (spec 149) — see presentation/resolveWidgetPresentation.tsx.
 // ============================================================
 // Water heater equipment widget (spec 135)
 // ============================================================
@@ -853,7 +748,7 @@ function GateEquipmentWidget({
   iconKey?: string;
 }) {
   const { t } = useTranslation();
-  const [executing, setExecuting] = useState(false);
+  const [executing, setExecuting] = useState<string | null>(null);
 
   const stateBinding = equipment.dataBindings.find((db) => db.category === "gate_state");
   const gateState = (stateBinding?.value as string) ?? "unknown";
@@ -869,14 +764,17 @@ function GateEquipmentWidget({
   const hasCommand = !!commandBinding;
   const enumValues = commandBinding?.enumValues ?? [];
   const hasSingleAction = hasCommand && enumValues.length <= 1;
+  // Issue #325 — multi-action gates used to expose NO way to act on desktop
+  // (the mobile detail sheet had one button per enum action, the card none).
+  const hasMultiAction = hasCommand && enumValues.length > 1 && equipment.enabled;
 
-  const handleCommand = async () => {
-    if (executing || !commandBinding || !hasSingleAction) return;
-    setExecuting(true);
+  const handleCommand = async (value: string | null) => {
+    if (executing || !commandBinding) return;
+    setExecuting(value ?? "command");
     try {
-      await onExecuteOrder(commandBinding.alias, null);
+      await onExecuteOrder(commandBinding.alias, value);
     } finally {
-      setExecuting(false);
+      setExecuting(null);
     }
   };
 
@@ -886,7 +784,7 @@ function GateEquipmentWidget({
     <WidgetCard
       label={label}
       sublabel={sublabel}
-      onClick={hasSingleAction ? handleCommand : undefined}
+      onClick={hasSingleAction ? () => handleCommand(null) : undefined}
       className={hasSingleAction ? "cursor-pointer active:scale-[0.98] transition-transform" : ""}
     >
       {/* Icon centered */}
@@ -912,6 +810,22 @@ function GateEquipmentWidget({
           {t(`controls.gate.${gateState}`)}
         </span>
       </div>
+
+      {/* Multi-action buttons — same actions as the mobile GateDetailContent */}
+      {hasMultiAction && (
+        <div className="flex justify-center flex-wrap gap-2 mt-1 pt-1">
+          {enumValues.map((val) => (
+            <button
+              key={val}
+              onClick={() => handleCommand(val)}
+              disabled={executing !== null}
+              className="h-8 px-2.5 flex items-center justify-center rounded-[6px] text-[11px] font-medium transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {val}
+            </button>
+          ))}
+        </div>
+      )}
     </WidgetCard>
   );
 }
@@ -1444,112 +1358,6 @@ function WaterValveEquipmentWidget({
 }
 
 // ============================================================
-// Pool pump equipment widget — ON/OFF toggle + daily runtime
-// ============================================================
-
-function formatRuntime(seconds: number): string {
-  if (seconds < 60) return `${seconds}s`;
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  return `${h}h ${String(m).padStart(2, "0")}m`;
-}
-
-function PoolPumpEquipmentWidget({
-  label,
-  sublabel,
-  equipment,
-  onExecuteOrder,
-  iconKey,
-}: {
-  label: string;
-  sublabel?: string;
-  equipment: EquipmentWithDetails;
-  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
-  iconKey?: string;
-}) {
-  const { t } = useTranslation();
-  const [executing, setExecuting] = useState(false);
-
-  const stateBinding = equipment.dataBindings.find(
-    (db) => db.alias === "state" || db.category === "light_state",
-  );
-  const isOn = stateBinding
-    ? stateBinding.value === true || String(stateBinding.value).toUpperCase() === "ON"
-    : false;
-
-  const runtime = equipment.computedData?.find((c) => c.alias === "runtime_daily");
-  const runtimeSeconds = typeof runtime?.value === "number" ? runtime.value : 0;
-
-  // Category-first resolver (spec 110). Putting category last in a hybrid
-  // chain would let an unrelated boolean order on multi-relay pool pumps
-  // (e.g. `auto_mode`) win over the real toggle.
-  const toggleBinding =
-    findOrderByCategory(
-      equipment.orderBindings,
-      ["pool_pump_toggle", "light_toggle", "toggle_power"],
-      ["state"],
-    ) ??
-    equipment.orderBindings.find(
-      (ob) => ob.type === "boolean" || (ob.alias === "state" && ob.type === "enum"),
-    );
-  const hasToggle = !!toggleBinding;
-
-  const handleToggle = async () => {
-    if (executing || !toggleBinding) return;
-    setExecuting(true);
-    try {
-      const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
-      const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
-      const value = toggleBinding.type === "boolean" ? !isOn : isOn ? offVal : onVal;
-      await onExecuteOrder(toggleBinding.alias, value);
-    } finally {
-      setExecuting(false);
-    }
-  };
-
-  return (
-    <WidgetCard label={label} sublabel={sublabel}>
-      <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
-        <div />
-        {resolveWidgetIcon(iconKey, <PoolPumpIcon on={isOn} />)}
-        <div className="flex flex-col items-start gap-1 pl-2">
-          <span
-            className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
-              isOn ? "bg-active/10 text-active" : "bg-border-light text-text-tertiary"
-            }`}
-          >
-            {isOn ? "ON" : "OFF"}
-          </span>
-          <span className="text-[11px] text-text-tertiary tabular-nums font-mono">
-            {formatRuntime(runtimeSeconds)}
-          </span>
-        </div>
-      </div>
-
-      {hasToggle && equipment.enabled && (
-        <div className="flex justify-center gap-3 mt-auto pt-1">
-          <button
-            onClick={handleToggle}
-            disabled={executing}
-            className={`w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed ${
-              isOn ? "!border-active/40 !text-active !bg-active/5" : ""
-            }`}
-            title={isOn ? t("controls.turnOff") : t("controls.turnOn")}
-          >
-            {executing ? (
-              <Loader2 size={16} className="animate-spin" />
-            ) : (
-              <Power size={16} strokeWidth={1.5} />
-            )}
-          </button>
-        </div>
-      )}
-    </WidgetCard>
-  );
-}
-
-// ============================================================
 // Pool cover equipment widget — Open/Stop/Close + position
 // ============================================================
 
@@ -1735,85 +1543,6 @@ function CameraEquipmentWidget({
             ? t("cameras.monitoring.on")
             : t("cameras.monitoring.off")}
         </span>
-      )}
-    </WidgetCard>
-  );
-}
-
-// ============================================================
-// Media player widget (issue #324) — mirrors the mobile card: Tv icon,
-// input source line, and a power toggle when an orders binding exposes it.
-// Without this branch a media_player fell through to the generic widget.
-// ============================================================
-
-function MediaPlayerEquipmentWidget({
-  label,
-  sublabel,
-  equipment,
-  onExecuteOrder,
-  iconKey,
-}: {
-  label: string;
-  sublabel?: string;
-  equipment: EquipmentWithDetails;
-  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
-  iconKey?: string;
-}) {
-  const [executing, setExecuting] = useState(false);
-
-  const powerBinding = equipment.dataBindings.find((b) => b.alias === "power");
-  const sourceBinding = equipment.dataBindings.find((b) => b.alias === "input_source");
-  const tvOn = powerBinding?.value === true;
-  const source = typeof sourceBinding?.value === "string" ? sourceBinding.value : null;
-
-  const toggleBinding = equipment.orderBindings.find((ob) => ob.alias === "power");
-  const hasToggle = !!toggleBinding;
-
-  const handleToggle = async () => {
-    if (executing || !toggleBinding) return;
-    setExecuting(true);
-    try {
-      await onExecuteOrder(toggleBinding.alias, !tvOn);
-    } finally {
-      setExecuting(false);
-    }
-  };
-
-  return (
-    <WidgetCard label={label} sublabel={sublabel}>
-      <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
-        <div />
-        {resolveWidgetIcon(
-          iconKey,
-          <Tv size={64} strokeWidth={1} className={tvOn ? "text-primary" : "text-text-tertiary"} />,
-        )}
-        <div className="flex items-center gap-2 pl-2">
-          <span
-            className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
-              tvOn ? "bg-active/10 text-active" : "bg-border-light text-text-tertiary"
-            }`}
-          >
-            {tvOn ? (source ?? "ON") : "OFF"}
-          </span>
-        </div>
-      </div>
-
-      {hasToggle && equipment.enabled && (
-        <div className="flex justify-center gap-3 mt-auto pt-1">
-          <button
-            onClick={handleToggle}
-            disabled={executing}
-            className={`w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed ${
-              tvOn ? "!border-active/40 !text-active !bg-active/5" : ""
-            }`}
-          >
-            {executing ? (
-              <Loader2 size={16} className="animate-spin" />
-            ) : (
-              <Power size={16} strokeWidth={1.5} />
-            )}
-          </button>
-        </div>
       )}
     </WidgetCard>
   );

--- a/ui/src/components/dashboard/MobileWidgetCard.test.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "../../test-utils";
+import i18n from "../../i18n";
 import { MobileWidgetCard } from "./MobileWidgetCard";
 import type { DashboardWidget, EquipmentWithDetails } from "../../types";
 
@@ -59,4 +60,141 @@ describe("MobileWidgetCard", () => {
     render(<MobileWidgetCard widget={widget} equipment={makeEnergyMeter()} />);
     expect(screen.getByText("Main meter")).toBeTruthy();
   });
+
+  // Spec 149 — switch/pool_pump/media_player state comes from the shared
+  // presentation descriptor, the same source the desktop widget renders.
+  it("renders a switch ON state from the presentation descriptor", () => {
+    const plug = makeEquipment({
+      id: "sw-1",
+      name: "Plug",
+      type: "switch",
+      dataBindings: [
+        stateDataBinding({ equipmentId: "sw-1", value: true }),
+      ] as EquipmentWithDetails["dataBindings"],
+    });
+    render(
+      <MobileWidgetCard widget={{ ...widget, equipmentId: "sw-1" }} equipment={plug} />,
+    );
+    expect(screen.getByText("ON")).toBeTruthy();
+  });
+
+  // Issue #325 divergence 1 — the daily runtime was desktop-only; the mobile
+  // card now shows it as a secondary line.
+  it("renders a pool_pump's runtime line next to its ON/OFF state", () => {
+    const pump = makeEquipment({
+      id: "pp-1",
+      name: "Pool pump",
+      type: "pool_pump",
+      dataBindings: [
+        stateDataBinding({ equipmentId: "pp-1", value: true }),
+      ] as EquipmentWithDetails["dataBindings"],
+      computedData: [
+        { alias: "runtime_daily", value: 5400, lastUpdated: "2026-01-01T00:00:00Z" },
+      ],
+    });
+    render(
+      <MobileWidgetCard widget={{ ...widget, equipmentId: "pp-1" }} equipment={pump} />,
+    );
+    expect(screen.getByText(/ON/)).toBeTruthy();
+    expect(screen.getByText(/1h 30m/)).toBeTruthy();
+  });
+
+  // Issue #325 divergence 3 — a boolean-category sensor emitting a string
+  // ("OFF" contact) must render the same localized label as a real boolean,
+  // not the raw string (same rule as the desktop SensorValues, #315).
+  it("normalizes a string-valued contact sensor through the boolean formatter", () => {
+    const door = makeEquipment({
+      id: "se-1",
+      name: "Door",
+      type: "sensor",
+      dataBindings: [
+        {
+          id: "db-c",
+          equipmentId: "se-1",
+          deviceDataId: "dd-c",
+          alias: "contact",
+          deviceId: "dev-c",
+          deviceName: "Door sensor",
+          key: "contact",
+          type: "enum",
+          category: "contact_door",
+          value: "OFF",
+          lastUpdated: "2026-01-01T00:00:00Z",
+          lastChanged: "2026-01-01T00:00:00Z",
+          stale: false,
+        },
+      ] as EquipmentWithDetails["dataBindings"],
+    });
+    render(
+      <MobileWidgetCard widget={{ ...widget, equipmentId: "se-1" }} equipment={door} />,
+    );
+    // "OFF" on a contact means open — the localized label, never the raw string.
+    expect(screen.getByText(i18n.t("controls.opened") as string)).toBeTruthy();
+    expect(screen.queryByText("OFF")).toBeNull();
+  });
+
+  it("understands an explicit OPEN string on a contact sensor", () => {
+    const door = makeEquipment({
+      id: "se-2",
+      name: "Gate door",
+      type: "sensor",
+      dataBindings: [
+        {
+          id: "db-c2",
+          equipmentId: "se-2",
+          deviceDataId: "dd-c2",
+          alias: "contact",
+          deviceId: "dev-c2",
+          deviceName: "Door sensor",
+          key: "contact",
+          type: "enum",
+          category: "contact_door",
+          value: "OPEN",
+          lastUpdated: "2026-01-01T00:00:00Z",
+          lastChanged: "2026-01-01T00:00:00Z",
+          stale: false,
+        },
+      ] as EquipmentWithDetails["dataBindings"],
+    });
+    render(
+      <MobileWidgetCard widget={{ ...widget, equipmentId: "se-2" }} equipment={door} />,
+    );
+    expect(screen.getByText(i18n.t("controls.opened") as string)).toBeTruthy();
+    expect(screen.queryByText("OPEN")).toBeNull();
+  });
 });
+
+function makeEquipment(over: Partial<EquipmentWithDetails>): EquipmentWithDetails {
+  return {
+    id: "eq-1",
+    name: "Equipment",
+    zoneId: "z-1",
+    type: "switch",
+    enabled: true,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    status: "online",
+    dataBindings: [],
+    orderBindings: [],
+    ...over,
+  } as EquipmentWithDetails;
+}
+
+function stateDataBinding(over: Record<string, unknown>) {
+  return {
+    id: "db-s",
+    equipmentId: "eq-1",
+    deviceDataId: "dd-s",
+    alias: "state",
+    deviceId: "dev-1",
+    deviceName: "Device",
+    key: "state",
+    type: "boolean",
+    category: "light_state",
+    value: false,
+    lastUpdated: "2026-01-01T00:00:00Z",
+    lastChanged: "2026-01-01T00:00:00Z",
+    stale: false,
+    ...over,
+  };
+}

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -7,6 +7,7 @@ import {
   getSensorBindings,
   formatSensorValue,
   formatBooleanSensor,
+  isBooleanSensorCategory,
 } from "../equipments/sensorUtils";
 import {
   LightBulbIcon,
@@ -19,12 +20,11 @@ import {
   WaterHeaterIcon,
   SlidingGateIcon,
   GarageDoorIcon,
-  PlugWidgetIcon,
-  PoolPumpIcon,
   PoolCoverIcon,
   WaterValveWidgetIcon,
   EnergyMeterIcon,
 } from "./WidgetIcons";
+import { resolveWidgetPresentation } from "./presentation/resolveWidgetPresentation";
 import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
 import { SolarPanelIcon } from "../icons/SolarPanelIcon";
 import { solarWidgetState } from "./solarWidget";
@@ -35,7 +35,7 @@ import {
 } from "../equipments/weatherForecastUtils";
 import { findTempExtremes, findTempIndoor, findTempOutdoor } from "../equipments/weather-utils";
 import { TempExtremes } from "../TempExtremes";
-import { Cloud, WashingMachine, Tv, Camera, ShieldCheck } from "lucide-react";
+import { Cloud, WashingMachine, Camera, ShieldCheck } from "lucide-react";
 import { gateNeedsConfirm } from "./gate-confirm";
 
 interface MobileWidgetCardProps {
@@ -122,15 +122,23 @@ function useMobileState(
     isHeater,
     isSensor,
     isWeatherForecast,
-    isMediaPlayer,
     isEnergyMeter,
     isAppliance,
     isWaterValve,
-    isPoolPump,
     isPoolCover,
     isPoolHeatPump,
     isOn,
   } = useEquipmentState(equipment);
+
+  // Spec 149 — migrated types read the presentation descriptor; a null
+  // descriptor falls through to the legacy per-type branches below.
+  const presentation = resolveWidgetPresentation(widget, equipment, t);
+  if (presentation) {
+    return {
+      icon: presentation.icon({ surface: "mobile-card" }),
+      stateLines: [presentation.state.primary, ...(presentation.state.secondary ?? [])],
+    };
+  }
 
   // Custom icon from registry
   const customEntry = widget.icon ? CUSTOM_ICON_REGISTRY[widget.icon] : undefined;
@@ -344,11 +352,12 @@ function useMobileState(
     const lines: string[] = [];
     for (const b of sensorBindings.slice(0, 2)) {
       if (b.value !== null && b.value !== undefined) {
-        // Category-aware for booleans (contact_door -> Ouvert/Fermé, motion ->
-        // Détecté/…) like the desktop card; the generic formatter would render
-        // any boolean as a bare Oui/Non.
+        // Category-driven like the desktop SensorValues (#315, #325): a
+        // boolean-category value goes through the category-aware formatter
+        // whatever its runtime type, so a string "ON"/"OFF" contact renders
+        // the same localized label as a real boolean instead of raw text.
         lines.push(
-          typeof b.value === "boolean"
+          isBooleanSensorCategory(b.category)
             ? formatBooleanSensor(b.category, b.value, t)
             : formatSensorValue(b.value, b.unit ?? undefined, t),
         );
@@ -417,19 +426,6 @@ function useMobileState(
     };
   }
 
-  if (isMediaPlayer) {
-    const powerBinding = equipment.dataBindings.find((b) => b.alias === "power");
-    const sourceBinding = equipment.dataBindings.find((b) => b.alias === "input_source");
-    const tvOn = powerBinding?.value === true;
-    const source = typeof sourceBinding?.value === "string" ? sourceBinding.value : null;
-    return {
-      icon: (
-        <Tv size={96} strokeWidth={1} className={tvOn ? "text-primary" : "text-text-tertiary"} />
-      ),
-      stateLines: tvOn && source ? [source] : ["OFF"],
-    };
-  }
-
   if (equipment.type === "solar_panel") {
     const { producing, lines } = solarWidgetState(equipment, t);
     return {
@@ -441,18 +437,6 @@ function useMobileState(
         />
       ),
       stateLines: lines,
-    };
-  }
-
-  // Switch / generic
-  if (equipment.type === "switch") {
-    return {
-      icon: customEntry ? (
-        createElement(customEntry.component, customEntry.previewProps)
-      ) : (
-        <PlugWidgetIcon on={isOn} />
-      ),
-      stateLines: [isOn ? "ON" : "OFF"],
     };
   }
 
@@ -480,17 +464,6 @@ function useMobileState(
         <WaterValveWidgetIcon open={isOn} />
       ),
       stateLines: [isOn ? t("water.open") : t("water.closed")],
-    };
-  }
-
-  if (isPoolPump) {
-    return {
-      icon: customEntry ? (
-        createElement(customEntry.component, customEntry.previewProps)
-      ) : (
-        <PoolPumpIcon on={isOn} />
-      ),
-      stateLines: [isOn ? "ON" : "OFF"],
     };
   }
 

--- a/ui/src/components/dashboard/WidgetGrid.tsx
+++ b/ui/src/components/dashboard/WidgetGrid.tsx
@@ -28,8 +28,7 @@ import { LightBulbIcon, ShutterWidgetIcon, AwningWidgetIcon, ThermometerIcon, Mu
 import { shutterLevel } from "./widget-icons";
 import { EquipmentDetailSheet, ZoneDetailSheet } from "./WidgetDetailSheet";
 import { ConfirmActionSheet } from "./ConfirmActionSheet";
-import { gateNeedsConfirm } from "./gate-confirm";
-import { needsDetailSheet } from "./widget-utils";
+import { getMobileClickAction } from "./mobile-click-action";
 import { useDashboard } from "../../store/useDashboard";
 import { useIsMobile } from "../../hooks/useIsMobile";
 import { getSensorBindings } from "../equipments/sensorUtils";
@@ -412,6 +411,7 @@ function WidgetRenderer({
   onConfirmAction?: () => void;
   editMode?: boolean;
 }) {
+  const { t } = useTranslation();
   if (widget.type === "equipment" && widget.equipmentId) {
     const equipment = equipmentMap.get(widget.equipmentId);
     if (!equipment) return null;
@@ -419,7 +419,7 @@ function WidgetRenderer({
 
     // On mobile: ALL equipment widgets use compact MobileWidgetCard
     if (isMobile) {
-      const mobileClick = editMode ? undefined : getMobileClickAction(equipment, onExecuteOrder, onOpenDetail, onConfirmAction);
+      const mobileClick = editMode ? undefined : getMobileClickAction(widget, equipment, t, onExecuteOrder, onOpenDetail, onConfirmAction);
       return (
         <MobileWidgetCard
           widget={widget}
@@ -610,70 +610,4 @@ function MobileZoneCard({
   );
 }
 
-// Determine the click action for a mobile equipment widget card
-function getMobileClickAction(
-  equipment: EquipmentWithDetails,
-  onExecuteOrder: (equipmentId: string, alias: string, value: unknown) => Promise<void>,
-  onOpenDetail?: () => void,
-  onConfirmAction?: () => void,
-): (() => void) | undefined {
-  const type = equipment.type;
-
-  // Complex widgets → open detail sheet
-  if (needsDetailSheet(type)) return onOpenDetail;
-
-  // Gate: single action = direct toggle, multiple = detail sheet
-  if (type === "gate") {
-    const commandBinding = findOrderByCategory(
-      equipment.orderBindings,
-      ["gate_trigger"],
-      ["command"],
-    );
-    const enumValues = commandBinding?.enumValues ?? [];
-    if (commandBinding && enumValues.length <= 1) {
-      // Spec 146 — guarded gate: open the slide-to-confirm sheet instead of
-      // actuating on a single tap (issue #320).
-      if (gateNeedsConfirm(equipment) && onConfirmAction) return onConfirmAction;
-      return () => { onExecuteOrder(equipment.id, commandBinding.alias, null); };
-    }
-    return onOpenDetail;
-  }
-
-  // Simple on/off (light_onoff, switch, water_heater, pool_pump, water_valve) → direct toggle
-  if (
-    type === "light_onoff" ||
-    type === "switch" ||
-    type === "water_heater" ||
-    type === "pool_pump" ||
-    type === "water_valve"
-  ) {
-    const stateBindingRaw = findOrderByCategory(
-      equipment.orderBindings,
-      ["light_toggle", "pool_pump_toggle", "valve_toggle", "toggle_power"],
-      ["state"],
-    );
-    const stateBinding =
-      stateBindingRaw &&
-      (stateBindingRaw.type === "enum" || stateBindingRaw.type === "boolean")
-        ? stateBindingRaw
-        : undefined;
-    if (stateBinding) {
-      const dataBinding = equipment.dataBindings.find((db) => db.category === "light_state");
-      const isOn = dataBinding
-        ? dataBinding.value === true || dataBinding.value === "ON" || dataBinding.value === 1
-        : false;
-      return () => {
-        const onVal = stateBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
-        const offVal = stateBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
-        onExecuteOrder(equipment.id, stateBinding.alias, isOn ? offVal : onVal);
-      };
-    }
-  }
-
-  // Sensor / weather → open detail sheet to see all data
-  if (type === "sensor" || type === "weather") {
-    return onOpenDetail;
-  }
-
-  return undefined;
-}
+// The mobile tap-action derivation lives in mobile-click-action.ts (spec 149).

--- a/ui/src/components/dashboard/getMobileClickAction.test.tsx
+++ b/ui/src/components/dashboard/getMobileClickAction.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+import "../../test-utils";
+import i18n from "../../i18n";
+import { getMobileClickAction } from "./mobile-click-action";
+import type { DashboardWidget, EquipmentWithDetails } from "../../types";
+
+// Spec 149 — for migrated types the mobile direct-tap toggle is derived from
+// the presentation descriptor (same source as the desktop button), so the
+// alias/value semantics cannot drift between the two surfaces anymore.
+
+const t = i18n.t.bind(i18n);
+
+function makeSwitch(over: Partial<EquipmentWithDetails> = {}): EquipmentWithDetails {
+  return {
+    id: "sw-1",
+    name: "Plug",
+    zoneId: "z-1",
+    type: "switch",
+    enabled: true,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    status: "online",
+    dataBindings: [
+      {
+        id: "db-1",
+        equipmentId: "sw-1",
+        deviceDataId: "dd-1",
+        alias: "state",
+        deviceId: "dev-1",
+        deviceName: "Plug",
+        key: "state",
+        type: "boolean",
+        category: "light_state",
+        value: false,
+        lastUpdated: "2026-01-01T00:00:00Z",
+        lastChanged: "2026-01-01T00:00:00Z",
+        stale: false,
+      },
+    ] as EquipmentWithDetails["dataBindings"],
+    orderBindings: [
+      {
+        id: "ob-1",
+        equipmentId: "sw-1",
+        deviceOrderId: "do-1",
+        alias: "state",
+        deviceId: "dev-1",
+        deviceName: "Plug",
+        key: "state",
+        type: "enum",
+        enumValues: ["ON", "OFF"],
+      },
+    ] as EquipmentWithDetails["orderBindings"],
+    ...over,
+  } as EquipmentWithDetails;
+}
+
+const widget: DashboardWidget = {
+  id: "w-1",
+  type: "equipment",
+  equipmentId: "sw-1",
+  displayOrder: 0,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+describe("getMobileClickAction", () => {
+  it("fires the descriptor toggle for an OFF switch (sends ON)", () => {
+    const onExecuteOrder = vi.fn().mockResolvedValue(undefined);
+    const action = getMobileClickAction(widget, makeSwitch(), t, onExecuteOrder);
+    expect(action).toBeTypeOf("function");
+    action!();
+    expect(onExecuteOrder).toHaveBeenCalledWith("sw-1", "state", "ON");
+  });
+
+  it("sends OFF when the switch is ON", () => {
+    const onExecuteOrder = vi.fn().mockResolvedValue(undefined);
+    const eq = makeSwitch();
+    eq.dataBindings[0].value = true;
+    getMobileClickAction(widget, eq, t, onExecuteOrder)!();
+    expect(onExecuteOrder).toHaveBeenCalledWith("sw-1", "state", "OFF");
+  });
+
+  it("returns no action for a migrated type without a toggle", () => {
+    const eq = makeSwitch({ orderBindings: [] });
+    expect(getMobileClickAction(widget, eq, t, vi.fn())).toBeUndefined();
+  });
+
+  it("returns no action when the equipment is disabled", () => {
+    const eq = makeSwitch({ enabled: false });
+    expect(getMobileClickAction(widget, eq, t, vi.fn())).toBeUndefined();
+  });
+
+  it("still opens the detail sheet for complex (unmigrated) types", () => {
+    const onOpenDetail = vi.fn();
+    const eq = makeSwitch({ type: "thermostat" });
+    const action = getMobileClickAction(widget, eq, t, vi.fn(), onOpenDetail);
+    expect(action).toBe(onOpenDetail);
+  });
+});

--- a/ui/src/components/dashboard/mobile-click-action.ts
+++ b/ui/src/components/dashboard/mobile-click-action.ts
@@ -1,0 +1,90 @@
+import type { TFunction } from "i18next";
+import type { DashboardWidget, EquipmentWithDetails } from "../../types";
+import { findOrderByCategory } from "../equipments/bindingUtils";
+import { gateNeedsConfirm } from "./gate-confirm";
+import { needsDetailSheet } from "./widget-utils";
+import { resolveWidgetPresentation } from "./presentation/resolveWidgetPresentation";
+
+/**
+ * Determine the click action for a mobile equipment widget card:
+ * detail sheet for complex types, direct toggle for simple on/off ones,
+ * confirm sheet for guarded gates (spec 146), nothing otherwise.
+ */
+export function getMobileClickAction(
+  widget: DashboardWidget,
+  equipment: EquipmentWithDetails,
+  t: TFunction,
+  onExecuteOrder: (equipmentId: string, alias: string, value: unknown) => Promise<void>,
+  onOpenDetail?: () => void,
+  onConfirmAction?: () => void,
+): (() => void) | undefined {
+  const type = equipment.type;
+
+  // Complex widgets → open detail sheet
+  if (needsDetailSheet(type)) return onOpenDetail;
+
+  // Spec 149 — migrated types: the direct-tap toggle comes from the
+  // presentation descriptor, the same source the desktop button uses, so the
+  // alias/value semantics can no longer drift between the two surfaces.
+  const presentation = resolveWidgetPresentation(widget, equipment, t);
+  if (presentation) {
+    const toggle = presentation.controls.find((c) => c.kind === "toggle");
+    if (!toggle || !equipment.enabled) return undefined;
+    return () => {
+      void onExecuteOrder(equipment.id, toggle.alias, toggle.on ? toggle.offValue : toggle.onValue);
+    };
+  }
+
+  // Gate: single action = direct toggle, multiple = detail sheet
+  if (type === "gate") {
+    const commandBinding = findOrderByCategory(
+      equipment.orderBindings,
+      ["gate_trigger"],
+      ["command"],
+    );
+    const enumValues = commandBinding?.enumValues ?? [];
+    if (commandBinding && enumValues.length <= 1) {
+      // Spec 146 — guarded gate: open the slide-to-confirm sheet instead of
+      // actuating on a single tap (issue #320).
+      if (gateNeedsConfirm(equipment) && onConfirmAction) return onConfirmAction;
+      return () => { void onExecuteOrder(equipment.id, commandBinding.alias, null); };
+    }
+    return onOpenDetail;
+  }
+
+  // Simple on/off (light_onoff, water_heater, water_valve) → direct toggle
+  if (
+    type === "light_onoff" ||
+    type === "water_heater" ||
+    type === "water_valve"
+  ) {
+    const stateBindingRaw = findOrderByCategory(
+      equipment.orderBindings,
+      ["light_toggle", "pool_pump_toggle", "valve_toggle", "toggle_power"],
+      ["state"],
+    );
+    const stateBinding =
+      stateBindingRaw &&
+      (stateBindingRaw.type === "enum" || stateBindingRaw.type === "boolean")
+        ? stateBindingRaw
+        : undefined;
+    if (stateBinding) {
+      const dataBinding = equipment.dataBindings.find((db) => db.category === "light_state");
+      const isOn = dataBinding
+        ? dataBinding.value === true || dataBinding.value === "ON" || dataBinding.value === 1
+        : false;
+      return () => {
+        const onVal = stateBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
+        const offVal = stateBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
+        void onExecuteOrder(equipment.id, stateBinding.alias, isOn ? offVal : onVal);
+      };
+    }
+  }
+
+  // Sensor / weather → open detail sheet to see all data
+  if (type === "sensor" || type === "weather") {
+    return onOpenDetail;
+  }
+
+  return undefined;
+}

--- a/ui/src/components/dashboard/presentation/PresentationWidget.tsx
+++ b/ui/src/components/dashboard/presentation/PresentationWidget.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Loader2, Power } from "lucide-react";
+import type { EquipmentWithDetails } from "../../../types";
+import { WidgetCard } from "../WidgetCard";
+import type { WidgetPresentation } from "./types";
+
+// Spec 149 — desktop renderer for a presentation descriptor. Reproduces the
+// switch-family layout exactly: WidgetCard shell → centered icon + state pill
+// (+ secondary lines) → bottom toggle row. The per-type derivation lives in
+// resolveWidgetPresentation; this component owns only the desktop pixels.
+
+interface PresentationWidgetProps {
+  label: string;
+  sublabel?: string;
+  equipment: EquipmentWithDetails;
+  presentation: WidgetPresentation;
+  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+}
+
+export function PresentationWidget({
+  label,
+  sublabel,
+  equipment,
+  presentation,
+  onExecuteOrder,
+}: PresentationWidgetProps) {
+  const { t } = useTranslation();
+  const [executing, setExecuting] = useState(false);
+
+  const { isActive, state } = presentation;
+  const toggle = presentation.controls.find((c) => c.kind === "toggle");
+
+  const handleToggle = async () => {
+    if (executing || !toggle) return;
+    setExecuting(true);
+    try {
+      await onExecuteOrder(toggle.alias, toggle.on ? toggle.offValue : toggle.onValue);
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  return (
+    <WidgetCard label={label} sublabel={sublabel}>
+      {/* Zone 2: icon + state */}
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
+        <div />
+        {presentation.icon({ surface: "desktop" })}
+        <div className="flex flex-col items-start gap-1 pl-2">
+          <span
+            className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
+              isActive ? "bg-active/10 text-active" : "bg-border-light text-text-tertiary"
+            }`}
+          >
+            {state.primary}
+          </span>
+          {state.secondary?.map((line) => (
+            <span key={line} className="text-[11px] text-text-tertiary tabular-nums font-mono">
+              {line}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Zone 3: toggle button */}
+      {toggle && equipment.enabled && (
+        <div className="flex justify-center gap-3 mt-auto pt-1">
+          <button
+            onClick={handleToggle}
+            disabled={executing}
+            className={`w-10 h-10 flex items-center justify-center rounded-[6px] transition-all duration-150 cursor-pointer border border-border bg-surface text-text-secondary hover:border-primary/40 hover:text-primary hover:bg-primary/5 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed ${
+              toggle.on ? "!border-active/40 !text-active !bg-active/5" : ""
+            }`}
+            title={toggle.on ? t("controls.turnOff") : t("controls.turnOn")}
+          >
+            {executing ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Power size={16} strokeWidth={1.5} />
+            )}
+          </button>
+        </div>
+      )}
+    </WidgetCard>
+  );
+}

--- a/ui/src/components/dashboard/presentation/resolve-helpers.ts
+++ b/ui/src/components/dashboard/presentation/resolve-helpers.ts
@@ -1,0 +1,64 @@
+import type { EquipmentWithDetails, OrderBindingWithDetails, OrderCategory } from "../../../types";
+import { findDataByCategory, findOrderByCategory } from "../../equipments/bindingUtils";
+
+// Spec 149 — shared binding lookups for the presentation resolvers.
+// These unify the 7 hand-rolled copies that had drifted across the desktop
+// sub-widgets, the mobile card and the mobile tap action (issue #325).
+
+/**
+ * Find the ON/OFF toggle order binding, category-first (spec 110) with the
+ * legacy alias/shape fallback, and reject non-togglable types.
+ */
+export function findToggleBinding(
+  bindings: readonly OrderBindingWithDetails[],
+  categories: readonly OrderCategory[],
+): OrderBindingWithDetails | undefined {
+  const binding =
+    findOrderByCategory(bindings, categories, ["state"]) ??
+    bindings.find((ob) => ob.type === "boolean" || (ob.alias === "state" && ob.type === "enum"));
+  if (!binding) return undefined;
+  return binding.type === "enum" || binding.type === "boolean" ? binding : undefined;
+}
+
+/**
+ * Values a toggle control sends. Enum values are matched case-insensitively
+ * with a literal ON/OFF fallback; boolean orders send true/false — except a
+ * boolean binding aliased `state`, which keeps the historical ON/OFF strings
+ * (legacy relay contract preserved from the pre-resolver sub-widgets).
+ */
+export function toggleValues(binding: OrderBindingWithDetails): {
+  onValue: unknown;
+  offValue: unknown;
+} {
+  if (binding.type === "boolean" && binding.alias !== "state") {
+    return { onValue: true, offValue: false };
+  }
+  return {
+    onValue: binding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON",
+    offValue: binding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF",
+  };
+}
+
+/**
+ * Relay-style ON state from the canonical `light_state` data binding
+ * (category-first, `state` alias fallback — spec 110). Accepts the value
+ * shapes seen across integrations: boolean, "ON"/"on", numeric 1.
+ */
+export function isOnFromStateBinding(equipment: EquipmentWithDetails): boolean {
+  const binding = findDataByCategory(equipment.dataBindings, ["light_state"], ["state"]);
+  if (!binding) return false;
+  return (
+    binding.value === true ||
+    binding.value === 1 ||
+    (typeof binding.value === "string" && binding.value.toUpperCase() === "ON")
+  );
+}
+
+/** Format a daily runtime in seconds as a compact string (45s, 12m, 1h 05m). */
+export function formatRuntime(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${h}h ${String(m).padStart(2, "0")}m`;
+}

--- a/ui/src/components/dashboard/presentation/resolveWidgetPresentation.test.tsx
+++ b/ui/src/components/dashboard/presentation/resolveWidgetPresentation.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect } from "vitest";
+import i18n from "../../../i18n";
+import { resolveWidgetPresentation } from "./resolveWidgetPresentation";
+import { formatRuntime } from "./resolve-helpers";
+import { CUSTOM_ICON_REGISTRY } from "../widget-icons";
+import type {
+  DashboardWidget,
+  DataBindingWithValue,
+  EquipmentWithDetails,
+  OrderBindingWithDetails,
+} from "../../../types";
+
+// Spec 149 (issue #325) — the resolver is the single source of truth for a
+// migrated type's icon/state/controls. These tests pin the descriptor
+// contract every surface (desktop, mobile card, mobile tap) renders from.
+
+const t = i18n.t.bind(i18n);
+
+function dataBinding(over: Partial<DataBindingWithValue>): DataBindingWithValue {
+  return {
+    id: "db-1",
+    equipmentId: "eq-1",
+    deviceDataId: "dd-1",
+    alias: "state",
+    deviceId: "dev-1",
+    deviceName: "Device",
+    key: "state",
+    type: "boolean",
+    category: "light_state",
+    value: false,
+    lastUpdated: "2026-01-01T00:00:00Z",
+    lastChanged: "2026-01-01T00:00:00Z",
+    stale: false,
+    ...over,
+  } as DataBindingWithValue;
+}
+
+function orderBinding(over: Partial<OrderBindingWithDetails>): OrderBindingWithDetails {
+  return {
+    id: "ob-1",
+    equipmentId: "eq-1",
+    deviceOrderId: "do-1",
+    alias: "state",
+    deviceId: "dev-1",
+    deviceName: "Device",
+    key: "state",
+    type: "enum",
+    enumValues: ["ON", "OFF"],
+    ...over,
+  } as OrderBindingWithDetails;
+}
+
+function makeEquipment(over: Partial<EquipmentWithDetails> = {}): EquipmentWithDetails {
+  return {
+    id: "eq-1",
+    name: "Plug",
+    zoneId: "z-1",
+    type: "switch",
+    enabled: true,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    status: "online",
+    dataBindings: [dataBinding({})],
+    orderBindings: [orderBinding({})],
+    ...over,
+  } as EquipmentWithDetails;
+}
+
+function makeWidget(over: Partial<DashboardWidget> = {}): DashboardWidget {
+  return {
+    id: "w-1",
+    type: "equipment",
+    equipmentId: "eq-1",
+    displayOrder: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    ...over,
+  };
+}
+
+function toggleOf(p: ReturnType<typeof resolveWidgetPresentation>) {
+  const control = p?.controls.find((c) => c.kind === "toggle");
+  if (!control || control.kind !== "toggle") throw new Error("no toggle control");
+  return control;
+}
+
+describe("resolveWidgetPresentation", () => {
+  it("returns null for a type that has not been migrated", () => {
+    const eq = makeEquipment({ type: "light_onoff" });
+    expect(resolveWidgetPresentation(makeWidget(), eq, t)).toBeNull();
+  });
+
+  describe("switch", () => {
+    it("resolves OFF state and an ON/OFF enum toggle", () => {
+      const p = resolveWidgetPresentation(makeWidget(), makeEquipment(), t);
+      expect(p).not.toBeNull();
+      expect(p!.isActive).toBe(false);
+      expect(p!.state.primary).toBe("OFF");
+      expect(toggleOf(p)).toMatchObject({
+        alias: "state",
+        on: false,
+        onValue: "ON",
+        offValue: "OFF",
+      });
+    });
+
+    it("resolves ON state (string 'ON' value) and preserves lowercase enum values", () => {
+      const eq = makeEquipment({
+        dataBindings: [dataBinding({ value: "ON", type: "enum" })],
+        orderBindings: [orderBinding({ enumValues: ["on", "off"] })],
+      });
+      const p = resolveWidgetPresentation(makeWidget(), eq, t);
+      expect(p!.isActive).toBe(true);
+      expect(p!.state.primary).toBe("ON");
+      expect(toggleOf(p)).toMatchObject({ on: true, onValue: "on", offValue: "off" });
+    });
+
+    it("keeps the ON/OFF string contract for a boolean order aliased 'state' (legacy relay)", () => {
+      const eq = makeEquipment({
+        orderBindings: [orderBinding({ type: "boolean", enumValues: undefined })],
+      });
+      expect(toggleOf(resolveWidgetPresentation(makeWidget(), eq, t))).toMatchObject({
+        alias: "state",
+        onValue: "ON",
+        offValue: "OFF",
+      });
+    });
+
+    it("maps a boolean order binding (non-state alias) to true/false values", () => {
+      const eq = makeEquipment({
+        orderBindings: [
+          orderBinding({ alias: "power_switch", key: "power_switch", type: "boolean", enumValues: undefined }),
+        ],
+      });
+      expect(toggleOf(resolveWidgetPresentation(makeWidget(), eq, t))).toMatchObject({
+        alias: "power_switch",
+        onValue: true,
+        offValue: false,
+      });
+    });
+
+    it("has no control when the equipment exposes no togglable order", () => {
+      const eq = makeEquipment({ orderBindings: [] });
+      expect(resolveWidgetPresentation(makeWidget(), eq, t)!.controls).toEqual([]);
+    });
+
+    it("prefers the category-bound toggle (light_toggle) over an earlier generic boolean order", () => {
+      const eq = makeEquipment({
+        orderBindings: [
+          orderBinding({ id: "ob-x", alias: "child_lock", key: "child_lock", type: "boolean", enumValues: undefined }),
+          orderBinding({ id: "ob-y", alias: "relay", key: "relay", category: "light_toggle" }),
+        ],
+      });
+      expect(toggleOf(resolveWidgetPresentation(makeWidget(), eq, t)).alias).toBe("relay");
+    });
+  });
+
+  describe("media_player", () => {
+    function makeTv(over: Partial<EquipmentWithDetails> = {}): EquipmentWithDetails {
+      return makeEquipment({
+        type: "media_player",
+        dataBindings: [
+          dataBinding({ id: "db-p", alias: "power", key: "power", value: true }),
+          dataBinding({
+            id: "db-s",
+            alias: "input_source",
+            key: "input_source",
+            type: "enum",
+            category: "generic",
+            value: "HDMI 1",
+          }),
+        ],
+        orderBindings: [
+          orderBinding({ alias: "power", key: "power", type: "boolean", enumValues: undefined }),
+        ],
+        ...over,
+      });
+    }
+
+    it("shows the input source when ON and toggles power with booleans", () => {
+      const p = resolveWidgetPresentation(makeWidget(), makeTv(), t);
+      expect(p!.isActive).toBe(true);
+      expect(p!.state.primary).toBe("HDMI 1");
+      expect(toggleOf(p)).toMatchObject({ alias: "power", on: true, onValue: true, offValue: false });
+    });
+
+    it("falls back to ON when powered without a source, OFF otherwise", () => {
+      const noSource = makeTv();
+      noSource.dataBindings = noSource.dataBindings.filter((b) => b.alias !== "input_source");
+      expect(resolveWidgetPresentation(makeWidget(), noSource, t)!.state.primary).toBe("ON");
+
+      const off = makeTv();
+      off.dataBindings[0].value = false;
+      expect(resolveWidgetPresentation(makeWidget(), off, t)!.state.primary).toBe("OFF");
+    });
+  });
+
+  describe("pool_pump", () => {
+    it("adds the daily runtime as a secondary state line", () => {
+      const eq = makeEquipment({
+        type: "pool_pump",
+        computedData: [{ alias: "runtime_daily", value: 5400, lastUpdated: "2026-01-01T00:00:00Z" }],
+      });
+      const p = resolveWidgetPresentation(makeWidget(), eq, t);
+      expect(p!.state.secondary).toEqual(["1h 30m"]);
+    });
+
+    it("omits the runtime line when runtime_daily is absent", () => {
+      const eq = makeEquipment({ type: "pool_pump" });
+      expect(resolveWidgetPresentation(makeWidget(), eq, t)!.state.secondary).toBeUndefined();
+    });
+
+    it("prefers the pool_pump_toggle category over an unrelated boolean order (auto_mode)", () => {
+      const eq = makeEquipment({
+        type: "pool_pump",
+        orderBindings: [
+          orderBinding({ id: "ob-a", alias: "auto_mode", key: "auto_mode", type: "boolean", enumValues: undefined }),
+          orderBinding({ id: "ob-t", alias: "relay", key: "relay", category: "pool_pump_toggle" }),
+        ],
+      });
+      expect(toggleOf(resolveWidgetPresentation(makeWidget(), eq, t)).alias).toBe("relay");
+    });
+  });
+
+  it("renders the custom widget icon override instead of the type default (#318)", () => {
+    const p = resolveWidgetPresentation(makeWidget({ icon: "light_bulb" }), makeEquipment(), t);
+    const node = p!.icon({ surface: "desktop" }) as { type: unknown };
+    expect(node.type).toBe(CUSTOM_ICON_REGISTRY.light_bulb.component);
+  });
+});
+
+describe("formatRuntime", () => {
+  it("formats seconds, minutes and hours compactly", () => {
+    expect(formatRuntime(45)).toBe("45s");
+    expect(formatRuntime(720)).toBe("12m");
+    expect(formatRuntime(5400)).toBe("1h 30m");
+  });
+});

--- a/ui/src/components/dashboard/presentation/resolveWidgetPresentation.tsx
+++ b/ui/src/components/dashboard/presentation/resolveWidgetPresentation.tsx
@@ -1,0 +1,130 @@
+import { createElement, type ReactNode } from "react";
+import { Tv } from "lucide-react";
+import type { TFunction } from "i18next";
+import type { DashboardWidget, EquipmentWithDetails } from "../../../types";
+import { CUSTOM_ICON_REGISTRY } from "../widget-icons";
+import { PlugWidgetIcon, PoolPumpIcon } from "../WidgetIcons";
+import type { IconCtx, WidgetControl, WidgetPresentation } from "./types";
+import {
+  findToggleBinding,
+  formatRuntime,
+  isOnFromStateBinding,
+  toggleValues,
+} from "./resolve-helpers";
+
+// Spec 149 (issue #325) — single source of truth for a widget type's
+// icon/state/controls. Returns null for types not yet migrated: callers fall
+// back to their legacy per-type path. The resolver and the legacy paths
+// coexist until the last type is migrated.
+//
+// Pure function on purpose (no hooks): it can be exercised by plain unit
+// tests and called from non-component code (the mobile tap action). Types
+// that need store-derived context (e.g. sensor battery alerts) will receive
+// it as an explicit argument when they migrate.
+
+/** Custom widget icon (#318) wins over the type default on every surface. */
+function iconWithOverride(
+  widget: DashboardWidget,
+  typeIcon: (ctx: IconCtx) => ReactNode,
+): (ctx: IconCtx) => ReactNode {
+  const custom = widget.icon ? CUSTOM_ICON_REGISTRY[widget.icon] : undefined;
+  if (!custom) return typeIcon;
+  return () => createElement(custom.component, custom.previewProps);
+}
+
+/** Build the single toggle control, or none when no togglable order exists. */
+function toggleControlOf(
+  equipment: EquipmentWithDetails,
+  on: boolean,
+  categories: Parameters<typeof findToggleBinding>[1],
+): WidgetControl[] {
+  const binding = findToggleBinding(equipment.orderBindings, categories);
+  if (!binding) return [];
+  return [{ kind: "toggle", alias: binding.alias, on, ...toggleValues(binding) }];
+}
+
+function resolveSwitch(
+  widget: DashboardWidget,
+  equipment: EquipmentWithDetails,
+): WidgetPresentation {
+  const on = isOnFromStateBinding(equipment);
+  return {
+    icon: iconWithOverride(widget, () => <PlugWidgetIcon on={on} />),
+    isActive: on,
+    state: { primary: on ? "ON" : "OFF" },
+    controls: toggleControlOf(equipment, on, ["light_toggle", "toggle_power"]),
+  };
+}
+
+function resolveMediaPlayer(
+  widget: DashboardWidget,
+  equipment: EquipmentWithDetails,
+): WidgetPresentation {
+  const powerBinding = equipment.dataBindings.find((b) => b.alias === "power");
+  const sourceBinding = equipment.dataBindings.find((b) => b.alias === "input_source");
+  const on = powerBinding?.value === true;
+  const source = typeof sourceBinding?.value === "string" ? sourceBinding.value : null;
+  const toggle = equipment.orderBindings.find((ob) => ob.alias === "power");
+  return {
+    icon: iconWithOverride(widget, (ctx) => (
+      <Tv
+        size={ctx.surface === "mobile-card" ? 96 : 64}
+        strokeWidth={1}
+        className={on ? "text-primary" : "text-text-tertiary"}
+      />
+    )),
+    isActive: on,
+    state: { primary: on ? (source ?? "ON") : "OFF" },
+    controls: toggle
+      ? [{ kind: "toggle", alias: toggle.alias, on, onValue: true, offValue: false }]
+      : [],
+  };
+}
+
+function resolvePoolPump(
+  widget: DashboardWidget,
+  equipment: EquipmentWithDetails,
+): WidgetPresentation {
+  const on = isOnFromStateBinding(equipment);
+  const runtime = equipment.computedData?.find((c) => c.alias === "runtime_daily");
+  const secondary =
+    typeof runtime?.value === "number" ? [formatRuntime(runtime.value)] : undefined;
+  return {
+    icon: iconWithOverride(widget, () => <PoolPumpIcon on={on} />),
+    isActive: on,
+    state: { primary: on ? "ON" : "OFF", secondary },
+    // Category-first incl. pool_pump_toggle so an unrelated boolean order on
+    // multi-relay pumps (e.g. auto_mode) can't win over the real toggle.
+    controls: toggleControlOf(equipment, on, [
+      "pool_pump_toggle",
+      "light_toggle",
+      "toggle_power",
+    ]),
+  };
+}
+
+/**
+ * Resolve the presentation descriptor for a dashboard equipment widget.
+ * Returns null when the equipment type has not been migrated yet — the
+ * caller must then use its legacy per-type rendering path.
+ */
+export function resolveWidgetPresentation(
+  widget: DashboardWidget,
+  equipment: EquipmentWithDetails,
+  // Localizer for descriptor state text. The phase-1 types only emit
+  // locale-neutral strings (ON/OFF, source names, runtimes) but the signature
+  // takes it now so migrating a localized type never changes the call sites.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _t: TFunction,
+): WidgetPresentation | null {
+  switch (equipment.type) {
+    case "switch":
+      return resolveSwitch(widget, equipment);
+    case "media_player":
+      return resolveMediaPlayer(widget, equipment);
+    case "pool_pump":
+      return resolvePoolPump(widget, equipment);
+    default:
+      return null;
+  }
+}

--- a/ui/src/components/dashboard/presentation/types.ts
+++ b/ui/src/components/dashboard/presentation/types.ts
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+
+// Spec 149 (issue #325) — layout-agnostic widget presentation descriptor.
+// One resolver per equipment type produces this shape; every surface
+// (desktop widget, mobile card, mobile tap action, detail sheet) renders it
+// instead of re-deriving icon/state/controls on its own.
+
+/** Rendering context passed to the descriptor's icon factory. */
+export interface IconCtx {
+  /**
+   * Which surface is asking. Mobile cards render icons ~96px before their
+   * 50% container scale; desktop slots are ~64px. The factory picks
+   * size/stroke from this instead of each surface hardcoding its own.
+   */
+  surface: "desktop" | "mobile-card" | "detail";
+}
+
+/**
+ * Declarative control — the resolver owns WHICH control exists and the exact
+ * order alias/values (single source of truth); each surface owns only the
+ * pixels (desktop 40px button, mobile direct tap, sheet full-width button).
+ *
+ * A "slider" kind (brightness/position/setpoint) is reserved for the phases
+ * that migrate the light/shutter/thermostat families.
+ */
+export type WidgetControl =
+  | {
+      kind: "toggle";
+      /** Order binding alias to execute. */
+      alias: string;
+      /** Current state — drives the button tint and picks the value to send. */
+      on: boolean;
+      /** Value that turns the equipment ON (enum match or boolean true). */
+      onValue: unknown;
+      /** Value that turns the equipment OFF. */
+      offValue: unknown;
+    }
+  | {
+      kind: "buttons";
+      buttons: Array<{ label: string; alias: string; value: unknown }>;
+    };
+
+/** Everything a surface needs to render an equipment widget. */
+export interface WidgetPresentation {
+  /** Icon factory — respects the widget.icon custom override internally (#318). */
+  icon: (ctx: IconCtx) => ReactNode;
+  /** Drives the active tint on the state pill / icon. */
+  isActive: boolean;
+  /** Pre-localized state text. Surfaces never re-translate. */
+  state: { primary: string; secondary?: string[] };
+  controls: WidgetControl[];
+  accent?: "success" | "warning" | null;
+}

--- a/ui/src/components/equipments/sensorUtils.test.ts
+++ b/ui/src/components/equipments/sensorUtils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import i18n from "../../i18n";
+import { formatBooleanSensor, isBooleanActive } from "./sensorUtils";
+
+// Issue #325 — boolean-category sensor values arrive from integrations as
+// booleans, ON/OFF strings (any case), 1/0, or OPEN/CLOSED for contacts.
+// These pin the shared normalization authority used by both the desktop
+// SensorValues and the mobile widget card.
+
+const t = i18n.t.bind(i18n);
+
+describe("isBooleanActive", () => {
+  it("recognizes the boolean-ish active shapes on a motion sensor", () => {
+    for (const v of [true, "ON", "on", 1, "1", "TRUE"]) {
+      expect(isBooleanActive("motion", v), String(v)).toBe(true);
+    }
+    for (const v of [false, "OFF", "off", 0, "FALSE", "garbage", null, undefined]) {
+      expect(isBooleanActive("motion", v), String(v)).toBe(false);
+    }
+  });
+
+  it("applies the contact polarity (false/OFF/OPEN = open = active)", () => {
+    for (const v of [false, "OFF", "off", 0, "OPEN", "open"]) {
+      expect(isBooleanActive("contact_door", v), String(v)).toBe(true);
+    }
+    for (const v of [true, "ON", "CLOSED", "closed", 1, "garbage"]) {
+      expect(isBooleanActive("contact_door", v), String(v)).toBe(false);
+    }
+  });
+});
+
+describe("formatBooleanSensor", () => {
+  it("labels motion whatever the wire shape", () => {
+    const detected = t("category.value.motion.detected") as string;
+    const clear = t("category.value.motion.clear") as string;
+    expect(formatBooleanSensor("motion", true, t)).toBe(detected);
+    expect(formatBooleanSensor("motion", "on", t)).toBe(detected);
+    expect(formatBooleanSensor("motion", 1, t)).toBe(detected);
+    expect(formatBooleanSensor("motion", "OFF", t)).toBe(clear);
+  });
+
+  it("labels contacts with the open/closed polarity, incl. explicit OPEN/CLOSED strings", () => {
+    const opened = t("controls.opened") as string;
+    const closed = t("controls.closed") as string;
+    expect(formatBooleanSensor("contact_door", false, t)).toBe(opened);
+    expect(formatBooleanSensor("contact_door", "OPEN", t)).toBe(opened);
+    expect(formatBooleanSensor("contact_door", "off", t)).toBe(opened);
+    expect(formatBooleanSensor("contact_door", true, t)).toBe(closed);
+    expect(formatBooleanSensor("contact_door", "CLOSED", t)).toBe(closed);
+    // Unrecognized values keep the historical "closed" fallback — an odd
+    // string must never invert the label.
+    expect(formatBooleanSensor("contact_door", "weird", t)).toBe(closed);
+  });
+});

--- a/ui/src/components/equipments/sensorUtils.tsx
+++ b/ui/src/components/equipments/sensorUtils.tsx
@@ -157,11 +157,35 @@ export function getSensorCategoryLabel(category: DataCategory, t?: TFunction): s
 }
 
 /** Check if a boolean sensor value is in the "active" state (e.g. motion detected, contact open). */
-export function isBooleanActive(category: string, value: unknown): boolean {
+/**
+ * Normalize the boolean-ish wire values integrations emit (true/false,
+ * ON/OFF/TRUE/FALSE in any case, 1/0, and OPEN/CLOSED for contacts) to the
+ * raw boolean convention of the category. For contacts the z2m convention is
+ * `false = open`, so the explicit "OPEN"/"CLOSED" strings map to that
+ * polarity. Returns null when the value is not recognizably boolean.
+ * Issue #325 — single authority shared by the desktop SensorValues and the
+ * mobile card, so a string-emitting sensor renders the same on both.
+ */
+function coerceBooleanish(category: string, value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (value === 1 || value === 0) return value === 1;
+  if (typeof value !== "string") return null;
+  const v = value.trim().toUpperCase();
   if (category === "contact_door" || category === "contact_window") {
-    return value === false || value === "OFF"; // contact=false means open
+    if (v === "OPEN") return false; // contact=false means open
+    if (v === "CLOSED") return true;
   }
-  return value === true || value === "ON";
+  if (v === "ON" || v === "TRUE" || v === "1") return true;
+  if (v === "OFF" || v === "FALSE" || v === "0") return false;
+  return null;
+}
+
+export function isBooleanActive(category: string, value: unknown): boolean {
+  const raw = coerceBooleanish(category, value);
+  if (category === "contact_door" || category === "contact_window") {
+    return raw === false; // contact=false means open
+  }
+  return raw === true;
 }
 
 /** Check if a category represents a boolean sensor (motion, contact, water_leak, smoke). */
@@ -216,14 +240,18 @@ export function formatSensorValue(value: unknown, unit?: string, t?: TFunction):
 
 /** Format a boolean sensor value as a translated label. */
 export function formatBooleanSensor(category: DataCategory, value: unknown, t?: TFunction): string {
-  const isActive = value === true || value === "ON";
+  const raw = coerceBooleanish(category, value);
+  const isActive = raw === true;
+  // Contact convention: raw false = open. An unrecognized value keeps the
+  // historical "closed" fallback so odd strings never invert the label.
+  const contactOpen = raw === false;
   if (t) {
     switch (category) {
       case "motion":
         return isActive ? t("category.value.motion.detected") : t("category.value.motion.clear");
       case "contact_door":
       case "contact_window":
-        return value === false || value === "OFF" ? t("controls.opened") : t("controls.closed");
+        return contactOpen ? t("controls.opened") : t("controls.closed");
       case "water_leak":
         return isActive ? t("category.value.water_leak.active") : t("category.value.water_leak.ok");
       case "smoke":
@@ -238,7 +266,7 @@ export function formatBooleanSensor(category: DataCategory, value: unknown, t?: 
       return isActive ? "Detected" : "Clear";
     case "contact_door":
     case "contact_window":
-      return value === false || value === "OFF" ? "Open" : "Closed";
+      return contactOpen ? "Open" : "Closed";
     case "water_leak":
       return isActive ? "Leak!" : "OK";
     case "smoke":


### PR DESCRIPTION
## Summary

Phase 1 of #325 (spec **149**): introduce a single **presentation resolver** so a dashboard widget type is described once and every surface renders the same descriptor — killing the mobile/desktop drift class behind #315, #318, #323, #324.

`resolveWidgetPresentation(widget, equipment, t)` is a pure function returning `{icon, isActive, state, controls}`; `null` = type not migrated → the caller falls back to its legacy per-type path. Controls are **declarative** (`toggle` with precomputed on/off values from a category-first binding lookup), so the 7 drifted copies of the toggle resolution converge on one source of truth.

## Changes

- **New `presentation/` layer**: descriptor types, resolver (+ `switch`, `media_player`, `pool_pump`), shared binding helpers, `PresentationWidget` desktop shell.
- **3 surfaces wired**: desktop dispatcher short-circuit (3 sub-widgets deleted), `useMobileState` short-circuit (3 branches deleted), mobile tap action (extracted to `mobile-click-action.ts`, unit-tested) reads the descriptor toggle.
- **Divergence fixes**:
  - pool pump daily runtime now shows on the mobile card;
  - multi-action gates render one button per enum action on **desktop** (previously there was no way to act on them there); single-action tap unchanged;
  - boolean-category sensors normalize string/number wire values (`on`/`1`/`OPEN`/`CLOSED`) through the shared `formatBooleanSensor` authority on both surfaces.
- **Deliberate behavior notes** (called out in `specs/149-*/architecture.md`): `media_player` gains the mobile direct-tap power toggle (was inert — no way to control a TV from mobile); a mobile tap on a *disabled* migrated equipment is now inert instead of firing a 400; media_player ON-without-source shows `ON` (was `OFF`, a bug); custom widget icons now apply on mobile for the migrated types (#318 contract).

Sensor 2-value mobile cap is **kept** and documented as a surface constraint (120px card), not drift.

## Test plan

- [x] `npx tsc --noEmit` + `cd ui && npx tsc -b --noEmit` — zero errors
- [x] `npx eslint src/ --ext .ts` + `cd ui && npx eslint .` — zero errors
- [x] `npx vitest run` — backend 1315 passed; UI 436 passed (45 dashboard/equipments tests, incl. 15 new resolver units, 4 sensorUtils units, gate multi/single-action, mobile switch/pool-pump/string-contact)
- [x] The 8 pre-existing component tests pass **unchanged** — they pin the retro-compat contract
- [x] Playwright visual QA on the local shadow (prod data), desktop 1440px + mobile 390px: switch, TV, pool pump match the legacy rendering; pool pump mobile shows `OFF · 0s`

Branch passed the Phase 5 agent review (2 major findings fixed: media_player tap declared + spec'd, `formatBooleanSensor` extended at the shared authority; boolean-`state`-alias contract pinned by test).

## Follow-up (tracked in #325)

Next phases migrate the remaining ~12 types (lights need the `slider` control kind), then the detail sheet reads descriptors and the legacy branches are deleted.

Closes nothing yet — #325 stays open as the migration tracker.