### PR TITLE
fix(energy): keep the arbiter surplus curve live instead of a mount snapshot (#514)

### DIFF
--- a/ui/src/components/energy/ArbiterTimeline.test.tsx
+++ b/ui/src/components/energy/ArbiterTimeline.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, act } from "../../test-utils";
+import { render, act, screen } from "../../test-utils";
 import { ArbiterTimeline } from "./ArbiterTimeline";
 import { useArbiter } from "../../store/useArbiter";
 import * as api from "../../api";
-import type { ArbiterTimeline as ArbiterTimelineData } from "../../types";
+import type { ArbiterQuarterState, ArbiterTimeline as ArbiterTimelineData } from "../../types";
 
 // Issue #514 — the curve used to fetch once on mount and stay frozen while the
 // live badge moved on. It must now refetch on the live window whenever the
@@ -16,15 +16,30 @@ vi.mock("../../api", async (orig) => ({
 
 const mockTimeline = api.getArbiterTimeline as unknown as ReturnType<typeof vi.fn>;
 
-function timelineData(): ArbiterTimelineData {
+function timelineData(loadName = "Pompe"): ArbiterTimelineData {
   return {
     windowStartIso: "2026-08-15T00:00:00.000Z",
     windowEndIso: "2026-08-15T06:00:00.000Z",
     stepMin: 15,
-    loads: [{ equipmentId: "pump", name: "Pompe", quarters: new Array(24).fill("idle") }],
+    loads: [
+      {
+        equipmentId: "pump",
+        name: loadName,
+        quarters: new Array<ArbiterQuarterState>(24).fill("idle"),
+      },
+    ],
     surplus: [{ atIso: "2026-08-15T05:55:00.000Z", availableW: 500 }],
     journal: [],
   };
+}
+
+/** A promise whose resolution we control, to hold a refetch in flight. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
 }
 
 /** Emulate a debounced arbiter refresh landing (WS burst → one timelineRev bump). */
@@ -102,5 +117,41 @@ describe("ArbiterTimeline live refresh (#514)", () => {
     await act(async () => emitArbiterActivity());
     await tick(30_000);
     expect(mockTimeline).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not clobber a historical page when a live refetch resolves after paging (#514 #1)", async () => {
+    const liveFetch = deferred<ArbiterTimelineData>();
+    let call = 0;
+    mockTimeline.mockReset();
+    mockTimeline.mockImplementation((_h: number, offset: number) => {
+      call += 1;
+      if (offset === 1) return Promise.resolve(timelineData("HISTORY")); // page-back load
+      if (call === 1) return Promise.resolve(timelineData("MOUNT")); // mount
+      return liveFetch.promise; // the live refetch — held in flight
+    });
+
+    const { getAllByRole } = render(<ArbiterTimeline />);
+    await tick(0);
+    expect(screen.getByText("MOUNT")).toBeTruthy();
+
+    // Kick a live refetch and let its timer fire (offset 0, now pending).
+    await act(async () => emitArbiterActivity());
+    await tick(20_000);
+
+    // Page back to history before the live refetch resolves.
+    await act(async () => {
+      getAllByRole("button")[0].click();
+    });
+    await tick(0);
+    expect(screen.getByText("HISTORY")).toBeTruthy();
+
+    // The in-flight live (offset 0) response now resolves — it must be dropped,
+    // not painted over the historical window the user is looking at.
+    await act(async () => {
+      liveFetch.resolve(timelineData("LIVE"));
+      await Promise.resolve();
+    });
+    expect(screen.getByText("HISTORY")).toBeTruthy();
+    expect(screen.queryByText("LIVE")).toBeNull();
   });
 });

--- a/ui/src/components/energy/ArbiterTimeline.test.tsx
+++ b/ui/src/components/energy/ArbiterTimeline.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act } from "../../test-utils";
+import { ArbiterTimeline } from "./ArbiterTimeline";
+import { useArbiter } from "../../store/useArbiter";
+import * as api from "../../api";
+import type { ArbiterTimeline as ArbiterTimelineData } from "../../types";
+
+// Issue #514 — the curve used to fetch once on mount and stay frozen while the
+// live badge moved on. It must now refetch on the live window whenever the
+// arbiter emits activity (useArbiter.timelineRev), throttled, and stay static
+// while paging through history.
+vi.mock("../../api", async (orig) => ({
+  ...(await orig<typeof import("../../api")>()),
+  getArbiterTimeline: vi.fn(),
+}));
+
+const mockTimeline = api.getArbiterTimeline as unknown as ReturnType<typeof vi.fn>;
+
+function timelineData(): ArbiterTimelineData {
+  return {
+    windowStartIso: "2026-08-15T00:00:00.000Z",
+    windowEndIso: "2026-08-15T06:00:00.000Z",
+    stepMin: 15,
+    loads: [{ equipmentId: "pump", name: "Pompe", quarters: new Array(24).fill("idle") }],
+    surplus: [{ atIso: "2026-08-15T05:55:00.000Z", availableW: 500 }],
+    journal: [],
+  };
+}
+
+/** Emulate a debounced arbiter refresh landing (WS burst → one timelineRev bump). */
+function emitArbiterActivity(): void {
+  useArbiter.setState((s) => ({ timelineRev: s.timelineRev + 1 }));
+}
+
+describe("ArbiterTimeline live refresh (#514)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockTimeline.mockReset();
+    mockTimeline.mockResolvedValue(timelineData());
+    useArbiter.setState({ state: null, loading: false, timelineRev: 0 });
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  async function tick(ms: number): Promise<void> {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ms);
+    });
+  }
+
+  it("refetches the live window when the arbiter emits activity, after the throttle window", async () => {
+    render(<ArbiterTimeline />);
+    await tick(0); // flush the mount fetch
+    expect(mockTimeline).toHaveBeenCalledTimes(1);
+
+    await act(async () => emitArbiterActivity());
+
+    // Throttled: no refetch before the window elapses.
+    await tick(19_000);
+    expect(mockTimeline).toHaveBeenCalledTimes(1);
+
+    // After the throttle window, exactly one live refetch on the live page.
+    await tick(2_000);
+    expect(mockTimeline).toHaveBeenCalledTimes(2);
+    expect(mockTimeline).toHaveBeenLastCalledWith(6, 0, 15);
+  });
+
+  it("collapses a burst of arbiter events into a single refetch", async () => {
+    render(<ArbiterTimeline />);
+    await tick(0);
+    expect(mockTimeline).toHaveBeenCalledTimes(1);
+
+    // Five bumps a second apart — all inside one throttle window.
+    for (let i = 0; i < 5; i += 1) {
+      await act(async () => emitArbiterActivity());
+      await tick(1_000);
+    }
+    await tick(20_000);
+
+    // Mount + a single collapsed refetch, not one per event.
+    expect(mockTimeline).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not refetch on arbiter activity while paging through history", async () => {
+    const { getAllByRole } = render(<ArbiterTimeline />);
+    await tick(0);
+    expect(mockTimeline).toHaveBeenCalledTimes(1);
+
+    // Page one window back (ChevronLeft is the first button) → authoritative
+    // refetch at offset 1.
+    await act(async () => {
+      getAllByRole("button")[0].click();
+    });
+    await tick(0);
+    expect(mockTimeline).toHaveBeenCalledTimes(2);
+    expect(mockTimeline).toHaveBeenLastCalledWith(6, 1, 15);
+
+    // Arbiter activity must NOT refresh a historical page.
+    await act(async () => emitArbiterActivity());
+    await tick(30_000);
+    expect(mockTimeline).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/src/components/energy/ArbiterTimeline.tsx
+++ b/ui/src/components/energy/ArbiterTimeline.tsx
@@ -72,6 +72,14 @@ export function ArbiterTimeline() {
   const jscrollRef = useRef<HTMLDivElement>(null);
   const lastFetchAtRef = useRef(0);
   const liveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Latest view params, read from inside the async live refetch to tell whether
+  // the view moved (paged / resized) while a fetch was in flight (issue #514 #1).
+  const pageOffsetRef = useRef(0);
+  const windowHoursRef = useRef(0);
+  // The timelineRev the current view was loaded at: the live effect only reacts
+  // to *later* arbiter activity, so a mount with an already-nonzero global rev
+  // does not schedule a spurious refetch (issue #514 #2).
+  const baselineRevRef = useRef(0);
 
   // Live-refresh signal: bumped once per debounced arbiter burst (issue #514).
   const timelineRev = useArbiter((s) => s.timelineRev);
@@ -85,6 +93,11 @@ export function ArbiterTimeline() {
   useEffect(() => {
     let cancelled = false;
     lastFetchAtRef.current = Date.now();
+    pageOffsetRef.current = pageOffset;
+    windowHoursRef.current = windowHours;
+    // This authoritative load already reflects every arbiter event so far, so
+    // rebase the live signal onto the current rev (no immediate live refetch).
+    baselineRevRef.current = useArbiter.getState().timelineRev;
     getArbiterTimeline(windowHours, pageOffset, 15)
       .then((d) => {
         if (!cancelled) {
@@ -112,14 +125,23 @@ export function ArbiterTimeline() {
   // (offset 0, never while paging history) and throttled to one refetch per
   // LIVE_REFRESH_THROTTLE_MS. The selection is preserved across a live refetch.
   useEffect(() => {
-    if (pageOffset !== 0 || timelineRev === 0) return;
+    // Only react to arbiter activity that landed *after* the current view was
+    // loaded, and only on the live window.
+    if (pageOffset !== 0 || timelineRev === baselineRevRef.current) return;
     if (liveTimerRef.current) return; // a refetch is already queued for this burst
+    const scheduledWindowHours = windowHours;
     const wait = Math.max(0, LIVE_REFRESH_THROTTLE_MS - (Date.now() - lastFetchAtRef.current));
     liveTimerRef.current = setTimeout(() => {
       liveTimerRef.current = null;
       lastFetchAtRef.current = Date.now();
-      getArbiterTimeline(windowHours, 0, 15)
+      getArbiterTimeline(scheduledWindowHours, 0, 15)
         .then((d) => {
+          // The view may have moved (paged to history, breakpoint crossed) while
+          // this refetch was in flight — don't clobber it with live-window data.
+          if (pageOffsetRef.current !== 0 || windowHoursRef.current !== scheduledWindowHours) {
+            return;
+          }
+          baselineRevRef.current = useArbiter.getState().timelineRev;
           setData(d);
           setFailed(false);
         })

--- a/ui/src/components/energy/ArbiterTimeline.tsx
+++ b/ui/src/components/energy/ArbiterTimeline.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { ArbiterQuarterState, ArbiterTimeline as ArbiterTimelineData } from "../../types";
 import { getArbiterTimeline } from "../../api";
+import { useArbiter } from "../../store/useArbiter";
 import { journalDotColor } from "./arbiterColors";
 
 // Spec 148 (Phase B) — the redesigned Energy → arbitrage timeline: a signed
@@ -16,6 +17,13 @@ const WINDOW_HOURS_MOBILE = 6;
 const WINDOW_HOURS_DESKTOP = 12;
 const DEPTH_HOURS = 48;
 const DESKTOP_QUERY = "(min-width: 1024px)";
+
+// Issue #514 — the curve must track the live arbiter state instead of staying
+// frozen on the mount snapshot. On the live window we refetch when the arbiter
+// emits activity (via useArbiter.timelineRev), throttled: a new curve point only
+// lands every ~5 min while status events can fire every few seconds on a
+// jittering surplus, so at most one refetch per this window is worthwhile.
+const LIVE_REFRESH_THROTTLE_MS = 20_000;
 
 /** Live 6h/12h window width from the viewport (SSR- and jsdom-safe, resize-aware). */
 function useWindowHours(): number {
@@ -62,13 +70,21 @@ export function ArbiterTimeline() {
   const [failed, setFailed] = useState(false);
   const [selTime, setSelTime] = useState<number | null>(null);
   const jscrollRef = useRef<HTMLDivElement>(null);
+  const lastFetchAtRef = useRef(0);
+  const liveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Live-refresh signal: bumped once per debounced arbiter burst (issue #514).
+  const timelineRev = useArbiter((s) => s.timelineRev);
 
   // Crossing the breakpoint can shrink maxOffset below the current page —
   // clamp before it reaches the fetch so we never ask past the 48h depth.
   const pageOffset = Math.min(offset, maxOffset);
 
+  // Authoritative load: mount, viewport width change, or paging. Resets the
+  // cell selection (the window moved) and clears any queued live refetch.
   useEffect(() => {
     let cancelled = false;
+    lastFetchAtRef.current = Date.now();
     getArbiterTimeline(windowHours, pageOffset, 15)
       .then((d) => {
         if (!cancelled) {
@@ -84,8 +100,34 @@ export function ArbiterTimeline() {
       });
     return () => {
       cancelled = true;
+      if (liveTimerRef.current) {
+        clearTimeout(liveTimerRef.current);
+        liveTimerRef.current = null;
+      }
     };
   }, [windowHours, pageOffset]);
+
+  // Live refresh (issue #514): when the arbiter emits activity, refetch the
+  // curve + ribbons so they track the badge — but only on the live window
+  // (offset 0, never while paging history) and throttled to one refetch per
+  // LIVE_REFRESH_THROTTLE_MS. The selection is preserved across a live refetch.
+  useEffect(() => {
+    if (pageOffset !== 0 || timelineRev === 0) return;
+    if (liveTimerRef.current) return; // a refetch is already queued for this burst
+    const wait = Math.max(0, LIVE_REFRESH_THROTTLE_MS - (Date.now() - lastFetchAtRef.current));
+    liveTimerRef.current = setTimeout(() => {
+      liveTimerRef.current = null;
+      lastFetchAtRef.current = Date.now();
+      getArbiterTimeline(windowHours, 0, 15)
+        .then((d) => {
+          setData(d);
+          setFailed(false);
+        })
+        .catch(() => {
+          // Transient error: keep the last good curve rather than blanking it.
+        });
+    }, wait);
+  }, [timelineRev, pageOffset, windowHours]);
 
   const geom = useMemo(() => {
     if (!data) return null;

--- a/ui/src/store/useArbiter.ts
+++ b/ui/src/store/useArbiter.ts
@@ -10,6 +10,12 @@ import { getArbiterState } from "../api";
 interface ArbiterStore {
   state: ArbiterPublicState | null;
   loading: boolean;
+  /**
+   * Bumped once per debounced arbiter refresh so live views (the timeline
+   * surplus curve + ribbons) can refetch in step with the badge instead of
+   * staying frozen on their mount snapshot (issue #514).
+   */
+  timelineRev: number;
   fetch: () => Promise<void>;
   /** Patch the live number without a round-trip (status events). */
   patchStatus: (runState: ArbiterRunState, availableSurplusW: number | null) => void;
@@ -22,6 +28,7 @@ let refreshTimer: ReturnType<typeof setTimeout> | null = null;
 export const useArbiter = create<ArbiterStore>((set, get) => ({
   state: null,
   loading: false,
+  timelineRev: 0,
 
   fetch: async () => {
     set({ loading: true });
@@ -44,6 +51,8 @@ export const useArbiter = create<ArbiterStore>((set, get) => ({
     refreshTimer = setTimeout(() => {
       refreshTimer = null;
       void get().fetch();
+      // Signal live timeline views to refetch — once per burst, not per event.
+      set((s) => ({ timelineRev: s.timelineRev + 1 }));
     }, 400);
   },
 }));


### PR DESCRIPTION
## Root cause

The arbitrage timeline's surplus/deficit curve fetched **once on mount** and never refreshed (`ArbiterTimeline.tsx`, deps `[windowHours, pageOffset]`), while the live state **badge** is patched on every `energy.arbiter.status` WS event. So the curve stayed frozen on the page-load snapshot and could read green (surplus) minutes after the home entered deficit, until the user reloaded or changed the window.

Observed on production 2026-08-15: curve samples `11:18 = +530 W` (green) → `11:23 = -794 W` → `11:28 = -1110 W` (red); the data was correct, only the curve display lagged.

## Fix

- `useArbiter`: add a `timelineRev` counter, bumped **once per debounced arbiter refresh** (covers status + grant/revoke/denied/released events).
- `ArbiterTimeline`: refetch when `timelineRev` changes, but **only on the live window** (`pageOffset === 0`, never while paging history) and **throttled to one refetch per 20 s** — a new curve point only lands every ~5 min while status events can fire every few seconds on a jittering surplus. The cell selection is preserved across a live refetch.

The remaining ~5 min latency is the backend sampling cadence (`capacity-arbiter.ts:890`), left as-is for this fix (noted as optional in the issue).

## Tests

`ArbiterTimeline.test.tsx` (new):
- live refetch fires after the throttle window, on the live page;
- a burst of arbiter events collapses into a single refetch;
- no refetch while paging through history.

## Validation

- `cd ui && npx tsc -b --noEmit` clean
- `npx eslint` clean on changed files
- `npx vitest run src/components/energy src/store` → 47 passed

Closes #514