### PR TITLE
chore(deployment): quiet InfluxDB stdout with INFLUXD_LOG_LEVEL (#516)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,6 +41,8 @@ services:
       - DOCKER_INFLUXDB_INIT_ORG=sowel
       - DOCKER_INFLUXDB_INIT_BUCKET=sowel
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=sowel-dev-token
+      # Quiet the per-request `info` firehose (see docker-compose.yml).
+      - INFLUXD_LOG_LEVEL=warn
     logging:
       driver: json-file
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,12 @@ services:
       - DOCKER_INFLUXDB_INIT_ORG=sowel
       - DOCKER_INFLUXDB_INIT_BUCKET=sowel
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=sowel-auto-token
+      # InfluxDB logs every HTTP request at the default `info` level (writes +
+      # chart/history queries + the downsampling task runs Sowel creates on
+      # startup), which is what fills the container log. `warn` keeps warnings
+      # and errors but drops that per-request firehose at the source, so the
+      # json-file cap below rotates far less.
+      - INFLUXD_LOG_LEVEL=warn
     logging:
       driver: json-file
       options:

--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -253,6 +253,13 @@ plafond à la **création** du conteneur : sur une install existante, il prendra
 donc effet au prochain `docker compose up -d` (ou au prochain auto-update, qui
 recrée le conteneur).
 
+InfluxDB est le service le plus bavard : il journalise chaque requête HTTP au
+niveau `info` par défaut (écritures, requêtes charts/history, exécutions des
+tâches de downsampling), ce qui remplit son log. `docker-compose.yml` lui fixe
+donc `INFLUXD_LOG_LEVEL=warn`, ce qui réduit le volume à la source tandis que le
+plafond de taille ci-dessus reste le garde-fou. Passe à `error` pour un InfluxDB
+encore plus silencieux.
+
 Pour récupérer l'espace déjà perdu sur un hôte en marche, et repérer les autres
 coupables :
 

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -258,6 +258,12 @@ service on the machine — Sowel included. Compose applies the cap when a contai
 is **created**, so on an existing install it takes effect at the next
 `docker compose up -d` (or the next self-update, which recreates the container).
 
+InfluxDB is the chattiest service: it logs every HTTP request at the default
+`info` level (writes, chart/history queries, downsampling task runs), which is
+what fills its log. `docker-compose.yml` therefore sets `INFLUXD_LOG_LEVEL=warn`
+on it, cutting the volume at the source while the size cap above stays as the
+ceiling. Use `error` for an even quieter InfluxDB.
+
 To reclaim space already lost on a running host, and check for other offenders:
 
 ```bash

--- a/src/deployment-logging.test.ts
+++ b/src/deployment-logging.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+// Guard for the deployment logging safety net. These are compose-only settings
+// (no Sowel runtime path exercises them), yet a missing json-file cap or a
+// re-verbose InfluxDB is a disk-exhaustion outage path — the exact failure that
+// took the stack down for 2h20 (see docs/technical/deployment.md "Docker log
+// size"). Lock the config here so it cannot silently regress.
+//
+//   #512 — cap every container's json-file log at max-size 10m / max-file 3.
+//   #516 — quiet InfluxDB stdout at the source with INFLUXD_LOG_LEVEL.
+
+const COMPOSE_FILES = ["docker-compose.yml", "docker-compose.dev.yml"];
+
+function read(file: string): string {
+  return readFileSync(resolve(process.cwd(), file), "utf8");
+}
+
+/** The `influxdb:` service block (influxdb is the last service, before `volumes:`). */
+function influxBlock(text: string): string {
+  const start = text.indexOf("\n  influxdb:");
+  expect(start, "influxdb service present").toBeGreaterThanOrEqual(0);
+  const rest = text.slice(start);
+  const end = rest.indexOf("\nvolumes:");
+  return end >= 0 ? rest.slice(0, end) : rest;
+}
+
+describe("deployment compose logging safety net", () => {
+  for (const file of COMPOSE_FILES) {
+    describe(file, () => {
+      const text = read(file);
+
+      it("caps each container's json-file log (10m x 3, #512)", () => {
+        // Both services (sowel + influxdb) declare the cap → two logging blocks.
+        expect(text.match(/driver:\s*json-file/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+        expect(text.match(/max-size:\s*"10m"/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+        expect(text.match(/max-file:\s*"3"/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+      });
+
+      it("quiets InfluxDB stdout at the source (INFLUXD_LOG_LEVEL, #516)", () => {
+        expect(influxBlock(text)).toMatch(/INFLUXD_LOG_LEVEL=warn/);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Why

Follow-up to #512. InfluxDB logs **every HTTP request** at the default `info` level (writes, chart/history queries, the downsampling task runs Sowel creates on startup), which is what filled its container log to ~130 MB on a live install. #512 capped the log **size** (json-file `10m` x `3`), but that *rotates* the volume rather than stopping it from being written. The cap bounds disk usage; the log level bounds disk writes.

## Change

- `INFLUXD_LOG_LEVEL=warn` on the `influxdb` service in `docker-compose.yml` and `docker-compose.dev.yml` — cuts the per-request firehose at the source while the size cap stays as the ceiling. (`warn` keeps warnings and errors; `error` is noted in the docs for an even quieter influx.)
- Docs (`deployment.md` + `.fr.md`): the "Docker log size" section now explains the influx log level alongside the size cap.

Applies at the next container recreate (`docker compose up -d` / self-update), same as #512.

## Tests

`src/deployment-logging.test.ts` (new) — a guard that locks the whole deployment logging safety net (the #512 caps + this log level) against silent regression. It parses both compose files and fails if a json-file cap or the influx log level is removed. Verified it fails without the `INFLUXD_LOG_LEVEL` line.

## Validation

- `docker compose config -q` resolves both files
- `npx tsc --noEmit`, `npx eslint`, guard test green

Closes #516