### PR TITLE
fix(energy): enroll metering water_heater as an energy submeter (#521)

### DIFF
--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -6,6 +6,7 @@ import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import type { TariffClassifier } from "../../energy/tariff-classifier.js";
 import type { CapacityArbiter } from "../../energy/capacity-arbiter.js";
 import { blendedRate, computeCost } from "../../energy/cost-calculator.js";
+import { isSubmeterEquipment } from "../../equipments/metering.js";
 import type { InfluxClient } from "../../core/influx-client.js";
 import type {
   EnergyPoint,
@@ -237,7 +238,12 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
       return reply.status(503).send({ error: "InfluxDB not configured" });
     }
 
-    const submeterEquipments = equipmentManager.getAll().filter((eq) => eq.type === "energy_meter");
+    // Dedicated energy_meters + metering relays (switch/water_heater, spec 129/#521).
+    const submeterEquipments = equipmentManager
+      .getAll()
+      .filter((eq) =>
+        isSubmeterEquipment(eq.type, equipmentManager.getDataBindingsWithValues(eq.id)),
+      );
     const mainEquipmentId = findEnergyEquipmentId(equipmentManager);
 
     const { from, to, resolution, bucket } = computeRange(period, dateStr, config.bucket);

--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -6,7 +6,7 @@ import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import type { TariffClassifier } from "../../energy/tariff-classifier.js";
 import type { CapacityArbiter } from "../../energy/capacity-arbiter.js";
 import { blendedRate, computeCost } from "../../energy/cost-calculator.js";
-import { isSubmeterEquipment } from "../../equipments/metering.js";
+import { isSubmeterEquipment, METERING_RELAY_TYPES } from "../../equipments/metering.js";
 import type { InfluxClient } from "../../core/influx-client.js";
 import type {
   EnergyPoint,
@@ -239,11 +239,13 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
     }
 
     // Dedicated energy_meters + metering relays (switch/water_heater, spec 129/#521).
-    const submeterEquipments = equipmentManager
-      .getAll()
-      .filter((eq) =>
-        isSubmeterEquipment(eq.type, equipmentManager.getDataBindingsWithValues(eq.id)),
-      );
+    // energy_meter qualifies on type alone; only metering-relay types need their
+    // bindings inspected, so lights/sensors never trigger a binding fetch.
+    const submeterEquipments = equipmentManager.getAll().filter((eq) => {
+      if (eq.type === "energy_meter") return true;
+      if (!METERING_RELAY_TYPES.has(eq.type)) return false;
+      return isSubmeterEquipment(eq.type, equipmentManager.getDataBindingsWithValues(eq.id));
+    });
     const mainEquipmentId = findEnergyEquipmentId(equipmentManager);
 
     const { from, to, resolution, bucket } = computeRange(period, dateStr, config.bucket);

--- a/src/energy/power-submeter-integrator.test.ts
+++ b/src/energy/power-submeter-integrator.test.ts
@@ -137,6 +137,48 @@ describe("PowerSubmeterIntegrator", () => {
     integ.stop();
   });
 
+  it("integrates a water_heater reporting power but no command (#521)", () => {
+    db.prepare(
+      `INSERT INTO equipments (id, name, zone_id, type, enabled) VALUES (?, ?, ?, ?, 1)`,
+    ).run("eq-cet", "Chauffe-eau", "zone-1", "water_heater");
+    const equipmentManager = {
+      getById: vi.fn((id: string) =>
+        id === "eq-cet"
+          ? { id, name: "Chauffe-eau", zoneId: "zone-1", type: "water_heater", enabled: true }
+          : null,
+      ),
+      getAll: vi.fn(() => [
+        {
+          id: "eq-cet",
+          name: "Chauffe-eau",
+          zoneId: "zone-1",
+          type: "water_heater",
+          enabled: true,
+        },
+      ]),
+      getDataBindingsWithValues: vi.fn(() => [{ alias: "power", category: "power", value: 2000 }]),
+    } as unknown as EquipmentManager;
+    const writePoint = vi.fn();
+    const influxClient = { isConnected: vi.fn(() => true), writePoint } as unknown as InfluxClient;
+
+    let now = 1_700_000_000_000;
+    const integ = new PowerSubmeterIntegrator(db, bus, equipmentManager, influxClient, logger, {
+      now: () => now,
+      flushIntervalMs: 60_000,
+    });
+    integ.init();
+    integ.start();
+    emitPower(bus, "eq-cet", 2000);
+    now += 60_000;
+    emitPower(bus, "eq-cet", 2000);
+    integ.flushAll();
+    expect(writePoint).toHaveBeenCalledOnce();
+    // Surfaced as computed energy so the equipment card sees a growing Wh value.
+    const computed = integ.getComputedDataForEquipment("eq-cet");
+    expect(computed[0]?.alias).toBe("energy");
+    integ.stop();
+  });
+
   it("ignores a bare switch with no power binding (spec 129)", () => {
     db.prepare(
       `INSERT INTO equipments (id, name, zone_id, type, enabled) VALUES (?, ?, ?, ?, 1)`,

--- a/src/energy/power-submeter-integrator.ts
+++ b/src/energy/power-submeter-integrator.ts
@@ -4,7 +4,7 @@ import type { EventBus } from "../core/event-bus.js";
 import type { Logger } from "../core/logger.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { InfluxClient } from "../core/influx-client.js";
-import { isSubmeterEquipment } from "../equipments/metering.js";
+import { isSubmeterEquipment, METERING_RELAY_TYPES } from "../equipments/metering.js";
 
 /**
  * Power-only submeter integration.
@@ -140,11 +140,11 @@ export class PowerSubmeterIntegrator {
    * the energy counter moving when the device only reports on change.
    */
   private catchUpFromBindings(): void {
-    // energy_meter submeters + metering switches (spec 129). Bare switches are
-    // filtered out by isPowerOnlySubmeter (no power binding).
+    // energy_meter submeters + metering relays (switch/water_heater, spec 129/#521).
+    // Bare relays are filtered out by isPowerOnlySubmeter (no power binding).
     const equipments = this.equipmentManager
       .getAll()
-      .filter((e) => e.type === "energy_meter" || e.type === "switch");
+      .filter((e) => e.type === "energy_meter" || METERING_RELAY_TYPES.has(e.type));
     for (const eq of equipments) {
       if (!this.isPowerOnlySubmeter(eq.id)) continue;
       const bindings = this.equipmentManager.getDataBindingsWithValues(eq.id);

--- a/src/equipments/metering.test.ts
+++ b/src/equipments/metering.test.ts
@@ -22,10 +22,18 @@ describe("metering helpers (spec 129)", () => {
     expect(isMeteringSwitch("energy_meter", power)).toBe(false); // not a switch
   });
 
-  it("isSubmeterEquipment: energy_meter OR metering switch", () => {
+  it("isMeteringSwitch: water_heater with power/energy is a metering relay (#521)", () => {
+    expect(isMeteringSwitch("water_heater", power)).toBe(true);
+    expect(isMeteringSwitch("water_heater", energy)).toBe(true);
+    expect(isMeteringSwitch("water_heater", state)).toBe(false); // bare relay, no metering
+  });
+
+  it("isSubmeterEquipment: energy_meter OR metering relay", () => {
     expect(isSubmeterEquipment("energy_meter", [])).toBe(true);
     expect(isSubmeterEquipment("switch", power)).toBe(true);
     expect(isSubmeterEquipment("switch", state)).toBe(false); // bare relay
+    expect(isSubmeterEquipment("water_heater", power)).toBe(true); // #521
+    expect(isSubmeterEquipment("water_heater", state)).toBe(false); // no metering binding
     expect(isSubmeterEquipment("main_energy_meter", power)).toBe(false); // house total, not a submeter
     expect(isSubmeterEquipment("light_onoff", power)).toBe(false);
   });

--- a/src/equipments/metering.ts
+++ b/src/equipments/metering.ts
@@ -19,6 +19,18 @@ export const METERING_CATEGORIES: ReadonlySet<DataCategory> = new Set<DataCatego
   "current",
 ]);
 
+/**
+ * On/off relay equipment types that carry the same candidate shape as a
+ * `switch` (spec 129) and can therefore double as a consumption submeter when
+ * they report power/energy. A `water_heater` (spec 135) is a relay with an
+ * optional metering attach, exactly like a metering plug (#521). Extend this
+ * set to enroll further pilotable loads (`heater`, `pool_pump`, `appliance`).
+ */
+export const METERING_RELAY_TYPES: ReadonlySet<EquipmentType> = new Set<EquipmentType>([
+  "switch",
+  "water_heater",
+]);
+
 interface BindingLike {
   alias?: string | null;
   category?: string | null;
@@ -35,9 +47,9 @@ export function hasMeteringBinding(bindings: readonly BindingLike[]): boolean {
   );
 }
 
-/** A `switch` that also reports power/energy — a metering smart plug. */
+/** A metering relay (`switch`, `water_heater`, ...) that also reports power/energy. */
 export function isMeteringSwitch(type: EquipmentType, bindings: readonly BindingLike[]): boolean {
-  return type === "switch" && hasMeteringBinding(bindings);
+  return METERING_RELAY_TYPES.has(type) && hasMeteringBinding(bindings);
 }
 
 /**

--- a/ui/src/components/energy/EnergyPage.tsx
+++ b/ui/src/components/energy/EnergyPage.tsx
@@ -16,6 +16,7 @@ import {
   flattenZonesWithPath,
   zoneChainMap,
 } from "../../lib/zone-path";
+import { isSubmeterEquipment } from "../../lib/metering";
 
 const AUTOCONSO_COLOR = "#6BCB77";
 
@@ -55,7 +56,8 @@ export function EnergyPage() {
     getEquipments()
       .then((list) => {
         if (cancelled) return;
-        setHasSubmeters(list.some((e) => e.type === "energy_meter" && e.enabled));
+        // Submeters = energy_meter + metering relays (switch/water_heater, #521).
+        setHasSubmeters(list.some((e) => isSubmeterEquipment(e) && e.enabled));
         setSubmeterLookup(list.map((e) => ({ id: e.id, name: e.name, zoneId: e.zoneId })));
       })
       .catch(() => {});

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -126,6 +126,14 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
         return typeof p?.value === "number" ? p.value : null;
       })()
     : null;
+  // Metering water heater (#521): day energy from computedData, shown next to
+  // the live power like an automatic energy meter. Null when not submetered.
+  const waterHeaterDayWh = isWaterHeater
+    ? (() => {
+        const e = equipment.computedData?.find((c) => c.alias === "energy_day");
+        return typeof e?.value === "number" ? e.value : null;
+      })()
+    : null;
   const primaryBinding = !isKnownType
     ? equipment.dataBindings[0] ?? null
     : null;
@@ -248,6 +256,16 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
               {switchPowerW >= 1000
                 ? `${(switchPowerW / 1000).toFixed(2)} kW`
                 : `${Math.round(switchPowerW)} W`}
+            </span>
+          )}
+          {waterHeaterDayWh !== null && (
+            <span className="text-[13px] text-accent tabular-nums font-mono font-semibold">
+              {waterHeaterDayWh >= 1000
+                ? (waterHeaterDayWh / 1000).toFixed(2)
+                : Math.round(waterHeaterDayWh)}
+              <span className="text-[11px] font-normal text-text-tertiary ml-0.5">
+                {waterHeaterDayWh >= 1000 ? "kWh" : "Wh"} {t("energy.today").toLowerCase()}
+              </span>
             </span>
           )}
           <LightControl

--- a/ui/src/lib/metering.test.ts
+++ b/ui/src/lib/metering.test.ts
@@ -42,10 +42,18 @@ describe("metering (UI) — spec 129", () => {
     expect(isMeteringSwitch(eq("light_onoff", [{ alias: "power", category: "power" }]))).toBe(false);
   });
 
-  it("isSubmeterEquipment: energy_meter or metering switch", () => {
+  it("isMeteringSwitch: water_heater with power/energy is a metering relay (#521)", () => {
+    expect(isMeteringSwitch(eq("water_heater", [{ alias: "power", category: "power" }]))).toBe(true);
+    expect(isMeteringSwitch(eq("water_heater", [{ alias: "energy", category: "energy" }]))).toBe(true);
+    expect(isMeteringSwitch(eq("water_heater", [{ alias: "state", category: "light_state" }]))).toBe(false);
+  });
+
+  it("isSubmeterEquipment: energy_meter or metering relay", () => {
     expect(isSubmeterEquipment(eq("energy_meter", []))).toBe(true);
     expect(isSubmeterEquipment(eq("switch", [{ alias: "power", category: "power" }]))).toBe(true);
     expect(isSubmeterEquipment(eq("switch", [{ alias: "state", category: "light_state" }]))).toBe(false);
+    expect(isSubmeterEquipment(eq("water_heater", [{ alias: "power", category: "power" }]))).toBe(true);
+    expect(isSubmeterEquipment(eq("water_heater", [{ alias: "state", category: "light_state" }]))).toBe(false);
     expect(isSubmeterEquipment(eq("main_energy_meter", [{ alias: "power", category: "power" }]))).toBe(false);
   });
 });

--- a/ui/src/lib/metering.ts
+++ b/ui/src/lib/metering.ts
@@ -12,9 +12,16 @@ export const METERING_CATEGORIES: ReadonlySet<string> = new Set([
   "current",
 ]);
 
+/**
+ * On/off relay types that can double as a consumption submeter when they
+ * report power/energy: a metering plug (spec 129) and a water_heater relay
+ * (spec 135 / #521). Mirror of METERING_RELAY_TYPES in src/equipments/metering.ts.
+ */
+export const METERING_RELAY_TYPES: ReadonlySet<string> = new Set(["switch", "water_heater"]);
+
 export function isMeteringSwitch(eq: EquipmentWithDetails): boolean {
   return (
-    eq.type === "switch" &&
+    METERING_RELAY_TYPES.has(eq.type) &&
     eq.dataBindings.some(
       (b) =>
         b.category === "power" ||

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -23,6 +23,7 @@ import { EquipmentStatusBadge } from "../components/equipments/EquipmentStatusBa
 import { DeviceSelector } from "../components/equipments/DeviceSelector";
 import { TYPE_LABELS } from "../components/equipments/EquipmentCard";
 import { useEquipmentState } from "../components/equipments/useEquipmentState";
+import { isSubmeterEquipment } from "../lib/metering";
 import { autoCreateBindings, removeAllBindings } from "../components/equipments/bindingUtils";
 import { GateControl } from "../components/equipments/GateControl";
 import { HeaterControl } from "../components/equipments/HeaterControl";
@@ -403,10 +404,10 @@ export function EquipmentDetailPage() {
         <SensorDataPanel bindings={equipment.dataBindings} equipmentId={equipment.id} />
       ) : null}
 
-      {/* Energy cumuls */}
+      {/* Energy cumuls — meters + metering relays (switch/water_heater, #521) */}
       {(equipment.type === "main_energy_meter" ||
         equipment.type === "energy_production_meter" ||
-        equipment.type === "energy_meter") && equipment.computedData && (
+        isSubmeterEquipment(equipment)) && equipment.computedData && (
         <EnergyDataPanel
           computedData={equipment.computedData}
           status={equipment.status}
@@ -414,10 +415,10 @@ export function EquipmentDetailPage() {
         />
       )}
 
-      {/* Live electrical measures — P/U/I/PF when bound (issue #376) */}
+      {/* Live electrical measures — P/U/I/PF when bound (issue #376, #521) */}
       {(equipment.type === "main_energy_meter" ||
         equipment.type === "energy_production_meter" ||
-        equipment.type === "energy_meter") && (
+        isSubmeterEquipment(equipment)) && (
         <ElectricalMeteringPanel bindings={equipment.dataBindings} />
       )}
 


### PR DESCRIPTION
## Root cause

A `water_heater` (spec 135) is an on/off relay with the same binding candidate shape as a `switch`, so it can carry a `power` measurement. But `isSubmeterEquipment` only recognised `energy_meter` and metering `switch`, so a power-only `water_heater` was never treated as a consumption submeter:

- its power was historised as `category=power` but never integrated into `category=energy` (Wh);
- every energy-balance query reads only `category=energy`, so it contributed nothing;
- the equipment card and detail view never surfaced any energy.

## Change

Define the set of metering-capable relay types once and reuse it everywhere:

- **`METERING_RELAY_TYPES = {switch, water_heater}`** in `src/equipments/metering.ts` (+ UI mirror in `ui/src/lib/metering.ts`), consumed by `isMeteringSwitch` / `isSubmeterEquipment`.
- **Integrator** (`power-submeter-integrator.ts`): the W→Wh catch-up pre-filter now includes metering relays. A power-only `water_heater` gets trapezoidal-integrated and emits `equipment.data.changed(alias=energy)`, which enrols it in the `EnergyAggregator` (hour/day/month/year cumuls) exactly like an `energy_meter`.
- **Balance API** (`api/routes/energy.ts`): the by-usage submeter filter uses `isSubmeterEquipment` instead of a hard-coded `type === "energy_meter"` (energy_meter still qualifies on type alone; only relay types fetch bindings).
- **UI**: the compact card shows the day energy next to live power for a metering `water_heater`; the detail view's `EnergyDataPanel` + `ElectricalMeteringPanel` are gated on `isSubmeterEquipment`; `EnergyPage`'s total/by-usage toggle detection uses the helper too (a home whose only submeter is a metering relay now sees the toggle). `LiveSubmeterBreakdown` already used the helper, so it picks up the water heater automatically. A `water_heater` with no metering binding keeps its current card unchanged.

## Deliberate scope choices

- The set is `{switch, water_heater}`. Extending to `heater` / `pool_pump` / `appliance` is now a one-line addition to the set, left out until validated (pool_pump in particular interacts with the capacity arbiter).
- Switching the balance filter to `isSubmeterEquipment` also admits spec-129 metering `switch` plugs into the by-usage breakdown for the first time. Consistent with spec 129 and desirable.
- Compact card shows `energy_day` for `water_heater` only, not metering `switch` plugs (plug = transient load, water heater = monitored load).

## Tests

- `src/equipments/metering.test.ts`: `water_heater` with power/energy is a metering relay; without metering it is not.
- `src/energy/power-submeter-integrator.test.ts`: regression — a power-only `water_heater` is integrated and exposes a computed `energy` entry.
- `ui/src/lib/metering.test.ts`: UI mirror assertions for `water_heater`.
- Full `npm run validate` passes (backend + UI typecheck, lint, tests). An independent agent review confirmed the fix end-to-end and surfaced the `EnergyPage` toggle gap, now fixed.

Closes #521
