### PR TITLE
release: v1.47.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,18 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.47.x : Sous-comptage des chauffe-eau et finitions de l'arbitrage
+
+### v1.47.0 — 2026-08-15 { #v1-47-0 }
+
+- Feat (énergie) : **un chauffe-eau qui ne mesure que la puissance est désormais compté dans le bilan énergie**. Un équipement water_heater relié à une mesure de puissance, sans commande Marche/Arrêt nécessaire, est maintenant traité comme un sous-compteur de consommation, comme un compteur d'énergie dédié : ses watts sont intégrés en énergie, il apparaît dans la répartition par usage, et son énergie du jour s'affiche sur sa carte et sa vue détail. L'énergie se cumule à partir du moment où la mesure est reliée, sans rattrapage rétroactif. Les prises connectées avec mesure (spec 129) entrent elles aussi pour la première fois dans la répartition par usage. (#521, #522)
+- Correctif (énergie) : **la courbe de surplus de l'arbitre reste vivante au lieu de se figer sur un instantané pris à l'ouverture de la page**. (#514, #515)
+- Correctif (énergie) : **la pastille d'état de l'arbitre est plus petite et colorée selon le surplus ou le déficit**. (#511)
+- Correctif (ui) : **les motifs du journal de décisions de l'arbitre suivent la langue de l'application**. Les motifs d'accord et de retrait n'étaient affichés qu'en anglais ; ils sont désormais localisés (FR/EN). (#518, #519)
+- Correctif (déploiement) : **les journaux des conteneurs sont plafonnés et la sortie standard d'InfluxDB est réduite au silence**. Compose borne désormais la taille du fichier de log de chaque conteneur et fixe INFLUXD_LOG_LEVEL pour qu'InfluxDB cesse d'inonder la sortie standard, ce qui limite l'usage disque et le bruit des logs sur une instance qui tourne longtemps. (#512, #516, #517)
+- Interne (ui) : la présentation des widgets du tableau de bord passe maintenant par un résolveur partagé (switch, media_player et pool_pump migrés), sans changement visible. (#325, #513)
+- Interne (outillage) : la skill de gestion des issues Sowel a gagné une phase de revue par agent avant l'ouverture de la PR. (#520)
+
 ## 1.46.x : Finitions de la page Analyse, activité persistante et frise d'arbitrage plus claire
 
 ### v1.46.0 — 2026-08-15 { #v1-46-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,18 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.47.x: Water-heater submetering and arbiter UI polish
+
+### v1.47.0 — 2026-08-15 { #v1-47-0 }
+
+- Feat (energy): **a water heater that only measures power is now counted in the energy balance**. A water_heater equipment bound to a power measurement, with no on/off command required, is now treated as a consumption submeter like a dedicated energy meter: its watts are integrated into energy, it appears in the by-usage breakdown, and its day energy shows on its card and detail view. Energy accrues forward from the moment the measurement is bound, with no retroactive backfill. Metering smart plugs (spec 129) also enter the by-usage breakdown for the first time. (#521, #522)
+- Fix (energy): **the arbiter surplus curve stays live instead of freezing on a snapshot taken when the page opened**. (#514, #515)
+- Fix (energy): **the arbiter state sticker is smaller and coloured by surplus or deficit**. (#511)
+- Fix (ui): **the arbiter decision journal reasons follow the app language**. The grant and revoke reasons were shown in English only; they are now localised (FR/EN). (#518, #519)
+- Fix (deployment): **container logs are capped and InfluxDB stdout is quieted**. Compose now bounds each container's log file size and sets INFLUXD_LOG_LEVEL so InfluxDB stops flooding stdout, keeping disk use and log noise down on a long-running instance. (#512, #516, #517)
+- Internal (ui): the dashboard widget presentation now flows through a shared resolver, with switch, media_player and pool_pump migrated; no user-facing change. (#325, #513)
+- Internal (tooling): the Sowel issue skill gained an agent-review phase before the PR is opened. (#520)
+
 ## 1.46.x: Analyse page polish, resilient activity, and a clearer arbiter timeline
 
 ### v1.46.0 — 2026-08-15 { #v1-46-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.46.0",
+  "version": "1.47.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump + release notes for v1.47.0.

Covers all merged PRs since v1.46.0:

- **Feat (energy)**: water_heater with a power measurement is now an energy submeter (#521, #522)
- **Fix (energy)**: arbiter surplus curve stays live (#514, #515); state sticker resized + coloured (#511)
- **Fix (ui)**: arbiter decision journal reasons localised FR/EN (#518, #519)
- **Fix (deployment)**: container log size cap (#512) + quieter InfluxDB stdout (#516, #517)
- **Internal (ui)**: dashboard presentation resolver migration (#325, #513)
- **Internal (tooling)**: sowel-issue skill agent-review phase (#520)

Release notes added to both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-47-0 }` anchor (spec 108).