### PR TITLE
fix(api): return metering relays from the submeter equipments query (#526)

### DIFF
--- a/src/api/routes/equipments.test.ts
+++ b/src/api/routes/equipments.test.ts
@@ -4,10 +4,15 @@ import { createLogger } from "../../core/logger.js";
 import { registerEquipmentRoutes } from "./equipments.js";
 import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
 
-// The ?type filter is the only logic worth exercising at the route
+// The ?type / ?role filter is the only logic worth exercising at the route
 // layer; the rest of the equipment surface is covered by manager-level
 // tests. A mocked EquipmentManager keeps this test fast and isolated.
-function makeManager(fixture: Array<{ id: string; type: string }>) {
+interface FixtureEq {
+  id: string;
+  type: string;
+  dataBindings?: Array<{ alias?: string; category?: string }>;
+}
+function makeManager(fixture: FixtureEq[]) {
   return {
     getAllWithDetails: () => fixture,
     getByIdWithDetails: () => null,
@@ -17,14 +22,19 @@ function makeManager(fixture: Array<{ id: string; type: string }>) {
   } as unknown as Parameters<typeof registerEquipmentRoutes>[1]["equipmentManager"];
 }
 
-describe("GET /api/v1/equipments — ?type filter", () => {
+describe("GET /api/v1/equipments — ?type / ?role filter", () => {
   let app: ReturnType<typeof Fastify>;
 
-  const fixture = [
-    { id: "1", type: "light_onoff" },
-    { id: "2", type: "energy_meter" },
-    { id: "3", type: "energy_meter" },
-    { id: "4", type: "main_energy_meter" },
+  const power = [{ alias: "power", category: "power" }];
+  const state = [{ alias: "state", category: "light_state" }];
+  const fixture: FixtureEq[] = [
+    { id: "1", type: "light_onoff", dataBindings: [] },
+    { id: "2", type: "energy_meter", dataBindings: [] },
+    { id: "3", type: "energy_meter", dataBindings: [] },
+    { id: "4", type: "main_energy_meter", dataBindings: power }, // house total, never a submeter
+    { id: "5", type: "water_heater", dataBindings: power }, // metering relay (#521) → submeter
+    { id: "6", type: "switch", dataBindings: power }, // metering plug (spec 129) → submeter
+    { id: "7", type: "switch", dataBindings: state }, // bare relay → not a submeter
   ];
 
   beforeEach(async () => {
@@ -43,18 +53,30 @@ describe("GET /api/v1/equipments — ?type filter", () => {
   it("returns all equipments when ?type is omitted", async () => {
     const res = await app.inject({ method: "GET", url: "/api/v1/equipments" });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toHaveLength(4);
+    expect(res.json()).toHaveLength(7);
   });
 
-  it("narrows the result set to a single type when ?type is set", async () => {
-    const res = await app.inject({
-      method: "GET",
-      url: "/api/v1/equipments?type=energy_meter",
-    });
+  it("narrows the result set to a single type for a non-meter ?type", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/equipments?type=light_onoff" });
     expect(res.statusCode).toBe(200);
-    const body = res.json() as Array<{ id: string; type: string }>;
-    expect(body).toHaveLength(2);
-    expect(body.every((eq) => eq.type === "energy_meter")).toBe(true);
+    const body = res.json() as FixtureEq[];
+    expect(body.map((e) => e.id)).toEqual(["1"]);
+  });
+
+  it("?role=submeter returns energy_meters + metering relays, never the house total or bare relays (#526)", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/equipments?role=submeter" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as FixtureEq[];
+    // energy_meter x2 + metering water_heater + metering switch; NOT main_energy_meter, NOT bare switch, NOT light
+    expect(body.map((e) => e.id).sort()).toEqual(["2", "3", "5", "6"]);
+  });
+
+  it("?type=energy_meter is honoured as the submeter role for the legacy display client (#224/#526)", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/equipments?type=energy_meter" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as FixtureEq[];
+    // Includes the metering water_heater so the unflashed energy display sees it.
+    expect(body.map((e) => e.id).sort()).toEqual(["2", "3", "5", "6"]);
   });
 
   it("returns an empty list for an unknown type (pass-through, no 400)", async () => {

--- a/src/api/routes/equipments.ts
+++ b/src/api/routes/equipments.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import { EquipmentError } from "../../equipments/equipment-manager.js";
+import { isSubmeterEquipment } from "../../equipments/metering.js";
 import type { EnergyLoadProfile, EquipmentType } from "../../shared/types.js";
 import type { Logger } from "../../core/logger.js";
 
@@ -69,15 +70,30 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
   const { equipmentManager } = deps;
 
   // GET /api/v1/equipments — List all equipments with bindings and current data.
-  // Optional ?type=<EquipmentType> narrows the response to a single type
-  // (e.g. ?type=energy_meter for clients that only render submeter clamps).
-  // Unknown values yield an empty list rather than 400 so callers can
+  // Optional ?type=<EquipmentType> narrows the response to a single type.
+  // Optional ?role=submeter returns the consumption submeter set — dedicated
+  // energy_meters plus metering relays (water_heater, switch...), i.e. every
+  // equipment isSubmeterEquipment considers a per-usage meter (#526).
+  //
+  // The energy display (#224) has long queried ?type=energy_meter to get "the
+  // submeter clamps". Since metering relays became submeters (#521) that literal
+  // type filter dropped them, so ?type=energy_meter is honoured as the submeter
+  // role too — the unflashed display picks up a metering water_heater without a
+  // reflash. New clients should use ?role=submeter.
+  //
+  // Unknown ?type values yield an empty list rather than 400 so callers can
   // safely pass-through user input without their own validation.
-  app.get<{ Querystring: { type?: string } }>("/api/v1/equipments", async (request) => {
-    const all = equipmentManager.getAllWithDetails();
-    const typeFilter = request.query.type;
-    return typeFilter ? all.filter((eq) => eq.type === typeFilter) : all;
-  });
+  app.get<{ Querystring: { type?: string; role?: string } }>(
+    "/api/v1/equipments",
+    async (request) => {
+      const all = equipmentManager.getAllWithDetails();
+      const { type, role } = request.query;
+      if (role === "submeter" || type === "energy_meter") {
+        return all.filter((eq) => isSubmeterEquipment(eq.type, eq.dataBindings));
+      }
+      return type ? all.filter((eq) => eq.type === type) : all;
+    },
+  );
 
   // GET /api/v1/equipments/:id — Get equipment with bindings and current data
   app.get<{ Params: { id: string } }>("/api/v1/equipments/:id", async (request, reply) => {


### PR DESCRIPTION
## Root cause

The `sowel-energy-display` firmware fetches its breakdown submeters via `GET /api/v1/equipments?type=energy_meter` (added by #224 for this client). Since metering relays became consumption submeters (#521), that literal `eq.type === "energy_meter"` filter dropped a metering `water_heater` / `switch`, so the display never showed them.

## Change

- Add `?role=submeter` backed by `isSubmeterEquipment` (energy_meter + metering relays, never the house total, production meters, or bare relays).
- Honour the legacy `?type=energy_meter` value as the same submeter role, so the **unflashed** energy display picks up a metering `water_heater` with no reflash.
- Other `?type=<X>` values stay strictly literal.

The Sowel UI never calls `?type=energy_meter` (it fetches unfiltered and filters client-side via `isSubmeterEquipment`), so nothing else is affected. Verified by the review agent (no other caller in the tree relies on strict `type=energy_meter`).

## Tests

`src/api/routes/equipments.test.ts`: `?role=submeter` and `?type=energy_meter` both return `energy_meter + metering water_heater + metering switch`, excluding `main_energy_meter` and bare relays; non-meter `?type` stays literal; unknown type still returns `[]`. Both new assertions fail on the pre-fix code.

Independent agent review: correct, well-tested, no defects.

Closes #526