### PR TITLE
fix(energy): show submeter energy cumuls at 0 from enrolment (#527)

### DIFF
--- a/src/energy/energy-aggregator.test.ts
+++ b/src/energy/energy-aggregator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { EnergyAggregator } from "./energy-aggregator.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
@@ -37,7 +37,14 @@ describe("EnergyAggregator submeter enrolment (#527)", () => {
   let bus: EventBus;
 
   beforeEach(() => {
+    // scheduleRefresh arms a real 5s setTimeout; fake timers keep it from leaking.
+    vi.useFakeTimers();
     bus = new EventBus(logger);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it("seeds zeroed cumuls for a power-only submeter so its meter UI renders before any consumption", async () => {

--- a/src/energy/energy-aggregator.test.ts
+++ b/src/energy/energy-aggregator.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { EnergyAggregator } from "./energy-aggregator.js";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import type { InfluxClient } from "../core/influx-client.js";
+
+const logger = createLogger("silent").logger;
+
+// InfluxDB disconnected: refreshFromInfluxDB early-returns, so the seeded zero
+// cumuls (#527) survive and we can assert them without a real InfluxDB.
+function offlineInflux(): InfluxClient {
+  return {
+    getClient: vi.fn(() => null),
+    getConfig: vi.fn(() => null),
+  } as unknown as InfluxClient;
+}
+
+const power = [{ alias: "power", category: "power", value: 0 }];
+const energy = [{ alias: "energy", category: "energy", value: 100 }];
+const state = [{ alias: "state", category: "light_state", value: "ON" }];
+
+function managerWith(
+  equipments: Array<{ id: string; type: string; dataBindings: unknown[] }>,
+): EquipmentManager {
+  return {
+    getAllWithDetails: vi.fn(() => equipments),
+    registerComputedDataProvider: vi.fn(),
+    getDataBindingsWithValues: vi.fn((id: string) => {
+      const eq = equipments.find((e) => e.id === id);
+      return eq?.dataBindings ?? [];
+    }),
+  } as unknown as EquipmentManager;
+}
+
+describe("EnergyAggregator submeter enrolment (#527)", () => {
+  let bus: EventBus;
+
+  beforeEach(() => {
+    bus = new EventBus(logger);
+  });
+
+  it("seeds zeroed cumuls for a power-only submeter so its meter UI renders before any consumption", async () => {
+    const mgr = managerWith([
+      { id: "wh", type: "water_heater", dataBindings: power },
+      { id: "meter", type: "energy_meter", dataBindings: [] },
+      { id: "lamp", type: "light_onoff", dataBindings: state },
+    ]);
+    const agg = new EnergyAggregator(mgr, offlineInflux(), bus, logger);
+    await agg.start();
+
+    // Metering water_heater: enrolled, cumuls exposed at 0.
+    const wh = agg.getComputedDataForEquipment("wh");
+    expect(wh.map((e) => e.alias).sort()).toEqual([
+      "energy_day",
+      "energy_hour",
+      "energy_month",
+      "energy_year",
+    ]);
+    expect(wh.every((e) => e.value === 0)).toBe(true);
+
+    // Bare energy_meter still enrolled (declared meter shows 0 until data).
+    expect(agg.getComputedDataForEquipment("meter")).toHaveLength(4);
+
+    // A plain light is not an energy source: no cumuls.
+    expect(agg.getComputedDataForEquipment("lamp")).toEqual([]);
+  });
+
+  it("keeps enrolling energy-binding equipments regardless of type", async () => {
+    const mgr = managerWith([{ id: "solar", type: "solar_panel", dataBindings: energy }]);
+    const agg = new EnergyAggregator(mgr, offlineInflux(), bus, logger);
+    await agg.start();
+    // solar_panel is not a submeter, but its energy binding still enrols it.
+    expect(agg.getComputedDataForEquipment("solar")).toHaveLength(4);
+  });
+
+  it("enrolls a submeter created (and bound) after start, via equipment.updated", async () => {
+    const equipments: Array<{ id: string; type: string; dataBindings: unknown[] }> = [];
+    const mgr = managerWith(equipments);
+    const agg = new EnergyAggregator(mgr, offlineInflux(), bus, logger);
+    await agg.start();
+
+    // Not enrolled yet.
+    expect(agg.getComputedDataForEquipment("wh2")).toEqual([]);
+
+    // User creates a water_heater then binds its power channel → equipment.updated.
+    equipments.push({ id: "wh2", type: "water_heater", dataBindings: power });
+    bus.emit({
+      type: "equipment.updated",
+      equipment: { id: "wh2", type: "water_heater" } as never,
+    });
+
+    const wh = agg.getComputedDataForEquipment("wh2");
+    expect(wh).toHaveLength(4);
+    expect(wh.every((e) => e.value === 0)).toBe(true);
+  });
+
+  it("does not enrol a bare relay (switch with no metering) on update", async () => {
+    const equipments = [{ id: "relay", type: "switch", dataBindings: state }];
+    const mgr = managerWith(equipments);
+    const agg = new EnergyAggregator(mgr, offlineInflux(), bus, logger);
+    await agg.start();
+
+    bus.emit({
+      type: "equipment.updated",
+      equipment: { id: "relay", type: "switch" } as never,
+    });
+    expect(agg.getComputedDataForEquipment("relay")).toEqual([]);
+  });
+});

--- a/src/energy/energy-aggregator.ts
+++ b/src/energy/energy-aggregator.ts
@@ -16,6 +16,7 @@ import type { Logger } from "../core/logger.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { InfluxClient } from "../core/influx-client.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
+import { isSubmeterEquipment } from "../equipments/metering.js";
 import type { ComputedDataEntry } from "../shared/types.js";
 
 /** Minimum interval between two InfluxDB refreshes per equipment (ms). */
@@ -71,30 +72,64 @@ export class EnergyAggregator {
       await this.refreshFromInfluxDB(equipmentId);
     }
 
-    // Subscribe to equipment data changes — used as trigger only
+    // Subscribe to equipment data changes — used as trigger only. Also watch
+    // create/update so a freshly created submeter (or one that just gained a
+    // power binding) is enrolled and shows zeroed cumuls immediately (#527).
     this.eventBus.on((event) => {
-      if (event.type !== "equipment.data.changed") return;
-      if (event.alias !== "energy") return;
-
-      if (!this.energyEquipmentIds.has(event.equipmentId)) {
-        this.energyEquipmentIds.add(event.equipmentId);
+      try {
+        if (event.type === "equipment.data.changed") {
+          if (event.alias !== "energy") return;
+          this.enrol(event.equipmentId);
+          this.scheduleRefresh(event.equipmentId);
+          return;
+        }
+        if (event.type === "equipment.created" || event.type === "equipment.updated") {
+          const id = event.equipment.id;
+          if (this.energyEquipmentIds.has(id)) return;
+          const bindings = this.equipmentManager.getDataBindingsWithValues(id);
+          if (isSubmeterEquipment(event.equipment.type, bindings)) {
+            this.enrol(id);
+            this.scheduleRefresh(id);
+          }
+        }
+      } catch (err) {
+        this.logger.warn({ err }, "Error in energy aggregator event handler");
       }
-
-      this.scheduleRefresh(event.equipmentId);
     });
 
     this.logger.info({ equipmentCount: this.energyEquipmentIds.size }, "Energy aggregator started");
   }
 
-  /** Scan all equipments for energy data bindings. */
+  /**
+   * Enrol an equipment as an energy source. Seeds zeroed cumuls so a submeter's
+   * meter UI renders from creation instead of only after its first consumption
+   * (#527); a later InfluxDB refresh overwrites them with real values.
+   */
+  private enrol(equipmentId: string): void {
+    this.energyEquipmentIds.add(equipmentId);
+    if (!this.cumuls.has(equipmentId)) {
+      this.cumuls.set(equipmentId, {
+        energyHourWh: 0,
+        energyDayWh: 0,
+        energyMonthWh: 0,
+        energyYearWh: 0,
+      });
+    }
+  }
+
+  /**
+   * Scan all equipments for energy sources: an `energy` data binding, or being a
+   * consumption submeter (metering water_heater/switch, energy_meter) whose Wh is
+   * derived from power by the PowerSubmeterIntegrator (#527).
+   */
   private discoverEnergyEquipments(): void {
     const allEquipments = this.equipmentManager.getAllWithDetails();
     for (const eq of allEquipments) {
-      for (const binding of eq.dataBindings) {
-        if (binding.alias === "energy" && binding.category === "energy") {
-          this.energyEquipmentIds.add(eq.id);
-          break;
-        }
+      const hasEnergyBinding = eq.dataBindings.some(
+        (b) => b.alias === "energy" && b.category === "energy",
+      );
+      if (hasEnergyBinding || isSubmeterEquipment(eq.type, eq.dataBindings)) {
+        this.enrol(eq.id);
       }
     }
   }

--- a/src/energy/energy-aggregator.ts
+++ b/src/energy/energy-aggregator.ts
@@ -16,7 +16,7 @@ import type { Logger } from "../core/logger.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { InfluxClient } from "../core/influx-client.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
-import { isSubmeterEquipment } from "../equipments/metering.js";
+import { isSubmeterEquipment, METERING_RELAY_TYPES } from "../equipments/metering.js";
 import type { ComputedDataEntry } from "../shared/types.js";
 
 /** Minimum interval between two InfluxDB refreshes per equipment (ms). */
@@ -84,10 +84,13 @@ export class EnergyAggregator {
           return;
         }
         if (event.type === "equipment.created" || event.type === "equipment.updated") {
-          const id = event.equipment.id;
+          const { id, type } = event.equipment;
           if (this.energyEquipmentIds.has(id)) return;
+          // Only submeter-capable types can qualify; skip lights/sensors/etc.
+          // before touching the DB for their bindings.
+          if (type !== "energy_meter" && !METERING_RELAY_TYPES.has(type)) return;
           const bindings = this.equipmentManager.getDataBindingsWithValues(id);
-          if (isSubmeterEquipment(event.equipment.type, bindings)) {
+          if (isSubmeterEquipment(type, bindings)) {
             this.enrol(id);
             this.scheduleRefresh(id);
           }


### PR DESCRIPTION
## Root cause

A freshly created power-only submeter (a metering `water_heater` that has never run) showed no energy cumuls panel. The `EnergyAggregator` only enrolled equipments with an `energy` data binding; a power-only submeter is enrolled only after the `PowerSubmeterIntegrator` flushes its first non-zero Wh delta. Until then `getComputedDataForEquipment` returned `[]` and `EnergyDataPanel` self-hid, so the equipment looked half-wired (live electrical panel showed, cumuls did not).

## Change

- Enrol any `isSubmeterEquipment` at discovery **and** on `equipment.created` / `equipment.updated`, seeding zeroed cumuls so the meter UI renders from creation. A later InfluxDB refresh overwrites the zeros with real values.
- Adding a data binding emits `equipment.updated`, so the "create the water heater, then bind its power" flow is covered.
- The created/updated handler is wrapped so it never throws (CLAUDE.md) and pre-gates on submeter-capable types before any DB read.

No UI change needed: once `computedData` carries the 4 cumuls (at 0), the existing `EnergyDataPanel` renders and the compact card shows "0 Wh today".

## Tests

New `src/energy/energy-aggregator.test.ts`: a power-only `water_heater` is enrolled with zeroed cumuls at start; a bare `energy_meter` too; a plain light is not; a `solar_panel` with an energy binding still enrols; a submeter created + bound after start (via `equipment.updated`) is enrolled; a bare relay is not. All fail on the pre-fix code.

Independent agent review: correct, no blocking defects; the two nits it raised (type-gate the DB read, fake timers in the test) are applied in a follow-up commit.

Closes #527