### PR TITLE
release: v1.48.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,17 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.48.x : Valeurs typées et portails sur tout relais
+
+### v1.48.0 — 2026-08-15 { #v1-48-0 }
+
+- Feat (devices) : **les valeurs des devices sont désormais normalisées une seule fois à l'ingestion, ce qui clôt la famille de bugs "ça marche dans Zigbee2MQTT, pas dans Sowel"**. Une donnée booléenne porte toujours un vrai booléen quelle que soit la forme envoyée par le device ("ON", "true", 1...), les nombres reçus en texte deviennent des nombres, et les valeurs d'énumération retrouvent leur casse déclarée : tous les consommateurs (dashboard, zones, historique, recettes, confirmation d'ordres) voient un type stable. Une valeur impossible à convertir sûrement est conservée telle quelle et signalée une fois dans le log ; les vocabulaires ambigus comme OPEN/CLOSED ne sont jamais devinés. Une déclaration dont le type contredit sa catégorie (un capteur de contact déclaré en texte, par exemple) est signalée au discovery. Aucune mise à jour de plugin nécessaire : tous les protocoles en bénéficient. (spec 150, #530)
+- Feat (equipments) : **un portail peut désormais être piloté par n'importe quel relais on/off, y compris les modules contact sec Zigbee comme le SONOFF MINI-ZBD**. Jusqu'ici seuls les canaux de relais LoRa et les télécommandes Somfy RTS étaient proposés comme actionneurs de portail ; le sélecteur de devices propose maintenant tout relais on/off comme commande du portail (action impulsionnelle ; configurez l'impulsion/inching sur le module lui-même), les capteurs d'ouverture restent associables au même équipement pour l'état ouvert/fermé, et le bouton de commande actionne désormais les relais booléens (il n'envoyait silencieusement rien sur ceux-ci auparavant). (spec 150, #530)
+- Fix (ui) : **les lumières variateur et couleur se lient à nouveau automatiquement à la création d'équipement**. La logique de liaison du sélecteur de devices avait divergé de celle du backend et ne proposait aucun candidat pour ces deux types ; les deux côtés partagent maintenant une implémentation unique. (spec 150, #530)
+- Fix (energy) : **un sous-compteur en puissance seule affiche ses cumuls d'énergie à 0 dès sa création**. Un chauffe-eau mesuré qui n'avait jamais fonctionné montrait son panneau de puissance en direct mais aucun cumul ; il est désormais enrôlé avec des compteurs à zéro à la création, les vraies valeurs prenant le relais dès les premières mesures. (#527, #529)
+- Fix (api) : **la requête des sous-compteurs de l'afficheur d'énergie renvoie maintenant les relais mesureurs**. Le firmware sowel-energy-display récupère sa ventilation via `?type=energy_meter` ; depuis que les relais mesureurs sont devenus des sous-compteurs, ce filtre littéral les excluait. Un filtre `?role=submeter` a été ajouté et la valeur historique continue de renvoyer le même ensemble, si bien qu'un afficheur non reflashé voit un chauffe-eau mesureur sans mise à jour. (#526, #528)
+- Note (equipments) : les valeurs de reed LoRa arrivant en texte ("0") dérivaient auparavant un état de portail fermé ; la normalisation dérive maintenant ouvert correctement (correction de polarité).
+
 ## 1.47.x : Sous-comptage des chauffe-eau et finitions de l'arbitrage
 
 ### v1.47.0 — 2026-08-15 { #v1-47-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,17 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.48.x: Typed device values and universal gate relays
+
+### v1.48.0 — 2026-08-15 { #v1-48-0 }
+
+- Feat (devices): **device values are now normalized once at ingestion, closing the "works in Zigbee2MQTT, fails in Sowel" family of bugs**. A boolean data point always carries a real boolean whatever the device sent ("ON", "true", 1...), numeric strings become numbers, and enum values are recased to their declared form, so every consumer (dashboard, zones, history, recipes, order confirmation) sees one stable type. A value that cannot be safely coerced is kept raw and logged once; polarity-ambiguous vocabularies like OPEN/CLOSED are never guessed. A declaration whose type contradicts its category (a contact sensor declared as text, for instance) is flagged in the log at discovery. No plugin update required: every protocol benefits. (spec 150, #530)
+- Feat (equipments): **a gate can now be driven by any on/off relay, including Zigbee dry-contact modules such as the SONOFF MINI-ZBD**. Until now only LoRa relay channels and Somfy RTS remotes were offered as gate actuators; the device picker now proposes any on/off relay as the gate command (momentary action; configure the pulse/inching on the module itself), contact sensors remain bindable on the same equipment for the open/closed state, and the command button now actuates boolean relays (it silently dispatched nothing on them before). (spec 150, #530)
+- Fix (ui): **dimmable and colour lights auto-bind again from the equipment creation flow**. The device selector's binding logic had drifted from the backend's and offered zero candidates for these two types; both sides now share a single implementation. (spec 150, #530)
+- Fix (energy): **a freshly created power-only submeter shows its energy cumuls at 0 from creation**. A metering water heater that had never run showed its live power panel but no cumuls; it is now enrolled with zeroed counters at creation, and real values take over from the first measurements. (#527, #529)
+- Fix (api): **the energy display's submeter query now returns metering relays**. The sowel-energy-display firmware fetches its breakdown via `?type=energy_meter`; since metering relays became consumption submeters that literal filter dropped them. A `?role=submeter` filter was added and the legacy value keeps returning the same submeter set, so an unflashed display picks up a metering water heater with no reflash. (#526, #528)
+- Note (equipments): LoRa reed values arriving as strings ("0") previously derived a gate state of closed; normalization now derives open correctly (polarity fix).
+
 ## 1.47.x: Water-heater submetering and arbiter UI polish
 
 ### v1.47.0 — 2026-08-15 { #v1-47-0 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sowel",
-  "version": "1.43.0",
+  "version": "1.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sowel",
-      "version": "1.43.0",
+      "version": "1.48.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cors": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.47.0",
+  "version": "1.48.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "1.45.0",
+  "version": "1.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "1.45.0",
+      "version": "1.48.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.47.0",
+  "version": "1.48.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Release v1.48.0. Covers everything merged since v1.47.0:

- #530 — feat(devices): typed value normalization at ingestion + unified binding candidates + gate on any on/off relay (spec 150)
- #529 — fix(energy): power-only submeters show energy cumuls at 0 from enrolment
- #528 — fix(api): submeter equipments query returns metering relays (`?role=submeter` + legacy `?type=energy_meter` compat)

## Changes

- Version bump 1.47.0 → 1.48.0 (root + ui)
- Release notes EN + FR with the `{ #v1-48-0 }` anchor (spec 108)

After merge: tag `v1.48.0` on the squash commit and push the tag to trigger the release workflow.