### PR TITLE
fix(deployment): copy src/shared into the Docker ui-build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ RUN npm ci
 # Design system tokens are imported from ui/src/index.css via ../../design-system/
 # (spec 094). The folder lives outside ui/ so copy it explicitly.
 COPY design-system/ /app/design-system/
+# The shared binding-candidates module is imported from ui/src/lib via
+# ../../../src/shared/ (spec 150) — same out-of-ui/ situation as the design
+# system: copy it explicitly so tsc/vite resolve it inside this stage.
+COPY src/shared/ /app/src/shared/
 COPY ui/ ./
 RUN npm run build
 


### PR DESCRIPTION
## Summary

The v1.48.0 release workflow failed in both docker jobs: the ui-build stage copies only `ui/` and `design-system/`, so the spec 150 cross-root import (`ui/src/lib/binding-candidates.ts` → `../../../src/shared/binding-candidates`) did not resolve (TS2307) and `npm run build` exited 2. PR CI did not catch it because the Frontend job builds from the full checkout; only the tag-triggered Docker build is isolated.

## Changes

- `COPY src/shared/ /app/src/shared/` in the ui-build stage, mirroring the existing design-system precedent, with a comment pointing at spec 150.

## Test plan

- [x] `docker build --target ui-build .` passes locally with the fix (failed before, same TS2307 as CI)
- [x] No runtime change: stage 3 (production image) is untouched, src/shared was already compiled into the backend dist

After merge: re-tag v1.48.0 on the new main commit (`git tag -f` + force-push the tag), the documented spec 108 recovery.