### PR TITLE
chore(registry): bump pool-pump-schedule to 1.4.2

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "tags": ["pool", "pump", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -340,7 +340,7 @@
     },
     "sowelVersion": ">=1.3.0",
     "owner": "mchacher",
-    "sha256": "928f5d8cce15e72eb43a7ae93385b74f91f86aa9d6aeaba0e596ef572c9eece3"
+    "sha256": "c81f2ab285e62e59776afd7886c7eef7fc71c43d6050aa28d462f10b87842f71"
   },
   {
     "id": "freecooling",


### PR DESCRIPTION
Bumps the Pool Pump Schedule recipe to **v1.4.2** in the registry (version + sha256).

v1.4.2 fixes a second ON/OFF chatter, in the **daytime floor** rung this time (prod 2026-08-15 ~20:24). v1.4.1 latched only the night deadline rung; the deferred daytime floor has the identical `deficitH >= hoursUntilSunset` knife-edge near sunset and now latches the same way. See mchacher/sowel-recipe-pool-pump-schedule#10.

- sha256 `c81f2ab2…` verified against the published `v1.4.2` release asset.
- Minimal 2-line diff (version + sha256); registry formatting untouched.