### PR TITLE
fix(energy): stop painting OFF loads as unmanaged on the arbiter timeline (#535)

### DIFF
--- a/migrations/021_arbiter_decision_running.sql
+++ b/migrations/021_arbiter_decision_running.sql
@@ -1,0 +1,5 @@
+-- Issue #535 — the timeline painted "on outside arbitration" for loads that
+-- were OFF: a `suspended` entry said nothing about the load's actual on/off
+-- state at suspension time. Record it (0/1) so the timeline can map an
+-- OFF-triggered suspension to idle. NULL = unknown (legacy rows).
+ALTER TABLE arbiter_decision_log ADD COLUMN running INTEGER;

--- a/src/energy/arbiter-journal-store.test.ts
+++ b/src/energy/arbiter-journal-store.test.ts
@@ -71,6 +71,18 @@ describe("ArbiterJournalStore", () => {
     expect(row.reason).toBeUndefined();
   });
 
+  it("round-trips the running flag (#535): true, false, and unknown", () => {
+    store.insert(decision({ atIso: "2026-08-14T09:00:00.000Z", kind: "suspended", running: true }));
+    store.insert(
+      decision({ atIso: "2026-08-14T09:01:00.000Z", kind: "suspended", running: false }),
+    );
+    store.insert(decision({ atIso: "2026-08-14T09:02:00.000Z", kind: "resumed" }));
+    const rows = store.loadRecent(10);
+    expect(rows.map((r) => r.running)).toEqual([true, false, undefined]);
+    const ranged = store.range("2026-08-14T09:00:00.000Z", "2026-08-14T09:02:00.000Z");
+    expect(ranged.map((r) => r.running)).toEqual([true, false, undefined]);
+  });
+
   it("loadRecent returns ascending (oldest-first), matching the ring order", () => {
     store.insert(decision({ atIso: "2026-08-14T08:00:00.000Z", reason: "older" }));
     store.insert(decision({ atIso: "2026-08-14T09:00:00.000Z", reason: "newer" }));

--- a/src/energy/arbiter-journal-store.ts
+++ b/src/energy/arbiter-journal-store.ts
@@ -21,6 +21,7 @@ interface ArbiterDecisionRow {
   watts: number | null;
   reason: string | null;
   note: string | null;
+  running: number | null; // 0/1, NULL = unknown (#535, legacy rows)
 }
 
 export class ArbiterJournalStore {
@@ -35,11 +36,11 @@ export class ArbiterJournalStore {
     this.logger = logger.child({ module: "arbiter-journal-store" });
     this.insertStmt = db.prepare(
       `INSERT INTO arbiter_decision_log
-        (id, at_iso, kind, equipment_id, equipment_name, watts, reason, note)
-       VALUES (@id, @atIso, @kind, @equipmentId, @equipmentName, @watts, @reason, @note)`,
+        (id, at_iso, kind, equipment_id, equipment_name, watts, reason, note, running)
+       VALUES (@id, @atIso, @kind, @equipmentId, @equipmentName, @watts, @reason, @note, @running)`,
     );
     this.loadRecentStmt = db.prepare(
-      "SELECT at_iso, kind, equipment_id, equipment_name, watts, reason, note" +
+      "SELECT at_iso, kind, equipment_id, equipment_name, watts, reason, note, running" +
         // rowid (insertion order) is a stable tiebreak for same-ms timestamps.
         " FROM arbiter_decision_log ORDER BY at_iso DESC, rowid DESC LIMIT ?",
     );
@@ -47,7 +48,7 @@ export class ArbiterJournalStore {
       "DELETE FROM arbiter_decision_log WHERE at_iso < datetime('now', '-' || ? || ' days')",
     );
     this.rangeStmt = db.prepare(
-      "SELECT at_iso, kind, equipment_id, equipment_name, watts, reason, note" +
+      "SELECT at_iso, kind, equipment_id, equipment_name, watts, reason, note, running" +
         " FROM arbiter_decision_log WHERE at_iso >= ? AND at_iso <= ?" +
         " ORDER BY at_iso ASC, rowid ASC",
     );
@@ -66,6 +67,7 @@ export class ArbiterJournalStore {
         watts: d.watts ?? null,
         reason: d.reason ?? null,
         note: d.note ?? null,
+        running: d.running === undefined ? null : d.running ? 1 : 0,
       });
     } catch (err) {
       this.logger.error({ err, kind: d.kind }, "Failed to persist arbiter decision");
@@ -89,6 +91,7 @@ export class ArbiterJournalStore {
         watts: r.watts ?? undefined,
         reason: r.reason ?? undefined,
         note: r.note ?? undefined,
+        running: r.running === null ? undefined : r.running === 1,
       }));
     } catch (err) {
       this.logger.error({ err }, "Failed to load recent arbiter decisions");
@@ -108,6 +111,7 @@ export class ArbiterJournalStore {
         watts: r.watts ?? undefined,
         reason: r.reason ?? undefined,
         note: r.note ?? undefined,
+        running: r.running === null ? undefined : r.running === 1,
       }));
     } catch (err) {
       this.logger.error({ err }, "Failed to read arbiter decision range");

--- a/src/energy/arbiter-timeline.test.ts
+++ b/src/energy/arbiter-timeline.test.ts
@@ -8,8 +8,13 @@ const START = Date.parse("2026-08-14T12:00:00.000Z");
 const END = Date.parse("2026-08-14T13:00:00.000Z");
 const iso = (min: number) => new Date(START + min * 60_000).toISOString();
 
-function dec(min: number, kind: ArbiterDecision["kind"], equipmentId = "pac"): ArbiterDecision {
-  return { atIso: iso(min), kind, equipmentId, equipmentName: "PAC" };
+function dec(
+  min: number,
+  kind: ArbiterDecision["kind"],
+  equipmentId = "pac",
+  running?: boolean,
+): ArbiterDecision {
+  return { atIso: iso(min), kind, equipmentId, equipmentName: "PAC", running };
 }
 const LOADS = [{ equipmentId: "pac", name: "PAC" }];
 
@@ -79,6 +84,44 @@ describe("buildLoadTimelines (spec 148)", () => {
 
   it("returns idle everywhere for a load with no decisions, and ignores other equipments", () => {
     const [load] = buildLoadTimelines([dec(20, "granted", "pompe")], LOADS, START, END);
+    expect(load.quarters).toEqual(["idle", "idle", "idle", "idle"]);
+  });
+});
+
+describe("buildLoadTimelines (issue #535) — an OFF load must not read 'unmanaged'", () => {
+  it("maps a suspension that switched the load off (running=false) to idle", () => {
+    // A manual OFF order suspends arbitration — but the load is stopped, so
+    // the lane must not paint "on outside arbitration" for the whole TTL.
+    const [load] = buildLoadTimelines([dec(5, "suspended", "pac", false)], LOADS, START, END);
+    expect(load.quarters).toEqual(["idle", "idle", "idle", "idle"]);
+  });
+
+  it("keeps a suspension that left the load on (running=true) as unmanaged", () => {
+    const [load] = buildLoadTimelines([dec(5, "suspended", "pac", true)], LOADS, START, END);
+    expect(load.quarters).toEqual(["unmanaged", "unmanaged", "unmanaged", "unmanaged"]);
+  });
+
+  it("maps resumed on an OFF load to idle, not granted", () => {
+    // Suspension left the load on, then the TTL expires while it is off:
+    // control returns to the arbiter, nothing is granted yet.
+    const [load] = buildLoadTimelines(
+      [dec(-10, "suspended", "pac", true), dec(20, "resumed", "pac", false)],
+      LOADS,
+      START,
+      END,
+    );
+    expect(load.quarters).toEqual(["unmanaged", "idle", "idle", "idle"]);
+  });
+
+  it("maps resumed on a still-running load to unmanaged (no grant yet)", () => {
+    const [load] = buildLoadTimelines([dec(5, "resumed", "pac", true)], LOADS, START, END);
+    expect(load.quarters).toEqual(["unmanaged", "unmanaged", "unmanaged", "unmanaged"]);
+  });
+
+  it("maps a legacy resumed entry (no running field) to idle", () => {
+    // Pre-#535 rows have no `running`; the preceding suspend revoked any
+    // grant, so idle is the only defensible reading (was: granted).
+    const [load] = buildLoadTimelines([dec(5, "resumed")], LOADS, START, END);
     expect(load.quarters).toEqual(["idle", "idle", "idle", "idle"]);
   });
 });

--- a/src/energy/arbiter-timeline.ts
+++ b/src/energy/arbiter-timeline.ts
@@ -23,18 +23,28 @@ export interface TimelineLoad {
 }
 
 /** The sustained state a decision transitions a load into. */
-function sustainedAfter(kind: ArbiterDecision["kind"]): QuarterState | null {
+function sustainedAfter(kind: ArbiterDecision["kind"], running?: boolean): QuarterState | null {
   switch (kind) {
     case "granted":
-    case "resumed":
       return "granted";
+    // A resume (manual or TTL expiry) hands control back to the arbiter but
+    // grants nothing by itself — a re-grant journals its own `granted`. The
+    // load is either still running outside arbitration or simply off (#535).
+    // Legacy entries (no `running`) default to idle: the suspend that preceded
+    // them revoked any grant, so idle is the only defensible fallback.
+    case "resumed":
+      return running === true ? "unmanaged" : "idle";
     case "revoked":
     case "revoke-not-honored":
     case "released":
     case "denied":
     case "unclaimed-run-ended":
       return "idle";
+    // A suspension caused by an OFF order (manual OFF, wall-switch-off) leaves
+    // the load stopped — painting it "on outside arbitration" was issue #535.
+    // Legacy entries (no `running`) keep the historical "unmanaged" reading.
     case "suspended":
+      return running === false ? "idle" : "unmanaged";
     case "unclaimed-run":
       return "unmanaged";
     // Audit-only events emitted *while another state already holds* — NOT
@@ -70,14 +80,17 @@ export function buildLoadTimelines(
   const nQuarters = Math.max(0, Math.round((windowEnd - windowStart) / stepMs));
 
   // Decisions per equipment, chronological.
-  const byEq = new Map<string, { at: number; kind: ArbiterDecision["kind"] }[]>();
+  const byEq = new Map<
+    string,
+    { at: number; kind: ArbiterDecision["kind"]; running?: boolean }[]
+  >();
   for (const d of decisions) {
     if (!d.equipmentId) continue;
     const at = Date.parse(d.atIso);
     if (Number.isNaN(at)) continue;
     let list = byEq.get(d.equipmentId);
     if (!list) byEq.set(d.equipmentId, (list = []));
-    list.push({ at, kind: d.kind });
+    list.push({ at, kind: d.kind, running: d.running });
   }
   for (const list of byEq.values()) list.sort((a, b) => a.at - b.at);
 
@@ -89,7 +102,7 @@ export function buildLoadTimelines(
 
     // Establish the state entering the window (events strictly before it).
     while (idx < events.length && events[idx].at < windowStart) {
-      const s = sustainedAfter(events[idx].kind);
+      const s = sustainedAfter(events[idx].kind, events[idx].running);
       if (s) sustained = s;
       idx += 1;
     }
@@ -99,7 +112,7 @@ export function buildLoadTimelines(
       let revokeHere = false;
       while (idx < events.length && events[idx].at < qEnd) {
         if (isRevoke(events[idx].kind)) revokeHere = true;
-        const s = sustainedAfter(events[idx].kind);
+        const s = sustainedAfter(events[idx].kind, events[idx].running);
         if (s) sustained = s;
         idx += 1;
       }

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -34,6 +34,7 @@ function makeHarness(opts?: {
   priority?: string[];
   settings?: Record<string, string>;
   profiles?: Record<string, EnergyLoadProfile | undefined>;
+  bindings?: Record<string, Array<{ alias: string; category: string; value?: unknown }>>;
   shadow?: boolean;
 }) {
   const settingsMap = new Map<string, string>(
@@ -84,7 +85,7 @@ function makeHarness(opts?: {
   // Loads expose their power measurement plus a conventional "state" binding
   // (plugs/switches categorise state as generic) — isStateAlias resolves the
   // latter, so feedState() drives the arbiter's on/off observation (#535).
-  const bindings = new Map<string, Array<{ alias: string; category: string }>>([
+  const bindings = new Map<string, Array<{ alias: string; category: string; value?: unknown }>>([
     ["grid", [{ alias: "power", category: "power" }]],
     [
       "pac",
@@ -108,6 +109,7 @@ function makeHarness(opts?: {
       ],
     ],
   ]);
+  for (const [id, list] of Object.entries(opts?.bindings ?? {})) bindings.set(id, list);
 
   const learnedCalls: Array<{ id: string; watts: number; runs: number }> = [];
   const equipmentManager = {
@@ -701,6 +703,30 @@ describe("capacity arbiter", () => {
     h.feedState("pac", true); // on by itself, no grant, no recipe order
     h.run(-100, 80); // > divergenceConfirmS
     expect(h.arbiter.getPublicState().suspensions).toHaveLength(0);
+  });
+
+  it("a boolean-valued 'power' alias is the state binding when no 'state' alias exists (prod PAC shape)", () => {
+    // The Panasonic PAC exposes its on/off switch as alias "power" (category
+    // "power", boolean value) with no "state" alias at all — a wattmeter
+    // would read numeric there, so the boolean value disambiguates.
+    const h = makeHarness({
+      bindings: {
+        pac: [
+          { alias: "power", category: "power", value: true },
+          { alias: "nanoe", category: "generic", value: "on" },
+        ],
+      },
+    });
+    h.feedMeter(-100);
+    h.order("pac", true, { kind: "recipe", instanceId: "i1" }); // unclaimed run
+    h.eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: "pac",
+      alias: "power",
+      value: false, // the PAC reached temperature and reports its switch off
+      previous: null,
+    });
+    expect(h.arbiter.getPublicState().journal.map((j) => j.kind)).toContain("unclaimed-run-ended");
   });
 
   it("a boolean value on a non-state alias is not read as the run state", () => {

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -663,6 +663,25 @@ describe("capacity arbiter", () => {
     expect(resumed?.running).toBe(true);
   });
 
+  it("a comfort load (PAC) reported OFF closes its unclaimed run — the prod #535 scenario", () => {
+    // Smart Cooling starts the PAC as a raw-export fallback (no grant), the
+    // PAC reaches temperature and stops itself: a state report, never an
+    // order. The state observation must not be gated on the deferrable class.
+    const h = makeHarness();
+    h.feedMeter(-100);
+    h.order("pac", true, { kind: "recipe", instanceId: "i1" }); // unclaimed run
+    h.feedState("pac", false);
+    expect(h.arbiter.getPublicState().journal.map((j) => j.kind)).toContain("unclaimed-run-ended");
+  });
+
+  it("a comfort load's reported state never triggers a wall-switch suspension (FR-6 stays deferrable-only)", () => {
+    const h = makeHarness();
+    h.feedMeter(-100);
+    h.feedState("pac", true); // on by itself, no grant, no recipe order
+    h.run(-100, 80); // > divergenceConfirmS
+    expect(h.arbiter.getPublicState().suspensions).toHaveLength(0);
+  });
+
   // ── Tolerated import & slack (FR-3) ───────────────────────
 
   it("toleratedImportW widens engage and narrows release by exactly that amount", () => {

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -81,11 +81,32 @@ function makeHarness(opts?: {
     ["lamp", base("lamp", "Lampe", "light_onoff")],
   ]);
 
+  // Loads expose their power measurement plus a conventional "state" binding
+  // (plugs/switches categorise state as generic) — isStateAlias resolves the
+  // latter, so feedState() drives the arbiter's on/off observation (#535).
   const bindings = new Map<string, Array<{ alias: string; category: string }>>([
     ["grid", [{ alias: "power", category: "power" }]],
-    ["pac", [{ alias: "power", category: "power" }]],
-    ["pump", [{ alias: "power", category: "power" }]],
-    ["heater", [{ alias: "power", category: "power" }]],
+    [
+      "pac",
+      [
+        { alias: "power", category: "power" },
+        { alias: "state", category: "generic" },
+      ],
+    ],
+    [
+      "pump",
+      [
+        { alias: "power", category: "power" },
+        { alias: "state", category: "generic" },
+      ],
+    ],
+    [
+      "heater",
+      [
+        { alias: "power", category: "power" },
+        { alias: "state", category: "generic" },
+      ],
+    ],
   ]);
 
   const learnedCalls: Array<{ id: string; watts: number; runs: number }> = [];
@@ -680,6 +701,24 @@ describe("capacity arbiter", () => {
     h.feedState("pac", true); // on by itself, no grant, no recipe order
     h.run(-100, 80); // > divergenceConfirmS
     expect(h.arbiter.getPublicState().suspensions).toHaveLength(0);
+  });
+
+  it("a boolean value on a non-state alias is not read as the run state", () => {
+    // A load can expose other boolean aliases (window detection, child lock…);
+    // only the state binding may close a run or feed the running flag.
+    const h = makeHarness();
+    h.feedMeter(-100);
+    h.order("pac", true, { kind: "recipe", instanceId: "i1" }); // unclaimed run
+    h.eventBus.emit({
+      type: "equipment.data.changed",
+      equipmentId: "pac",
+      alias: "window_detection",
+      value: "OFF",
+      previous: null,
+    });
+    expect(h.arbiter.getPublicState().journal.map((j) => j.kind)).not.toContain(
+      "unclaimed-run-ended",
+    );
   });
 
   // ── Tolerated import & slack (FR-3) ───────────────────────

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -599,6 +599,70 @@ describe("capacity arbiter", () => {
     expect(kinds).not.toContain("unclaimed-run-ended");
   });
 
+  // ── Issue #535 — OFF loads must not stay "on outside arbitration" ──
+
+  it("a manual OFF order closes an unclaimed run and journals suspended with running=false", () => {
+    const h = makeHarness();
+    h.feedMeter(-100);
+    h.order("pump", true, { kind: "recipe", instanceId: "i1" }); // unclaimed run starts
+    h.order("pump", false, { kind: "manual" }); // human switches it off
+    const journal = h.arbiter.getPublicState().journal;
+    // The run is closed even though the OFF came from a manual order, and the
+    // suspension records that the load is stopped — both feed the timeline.
+    expect(journal.map((j) => j.kind)).toContain("unclaimed-run-ended");
+    expect(journal.find((j) => j.kind === "suspended")?.running).toBe(false);
+  });
+
+  it("a manual ON order journals suspended with running=true", () => {
+    const h = makeHarness();
+    h.order("pump", true, { kind: "manual" });
+    expect(h.arbiter.getPublicState().journal.find((j) => j.kind === "suspended")?.running).toBe(
+      true,
+    );
+  });
+
+  it("a reported OFF state closes an unclaimed run (load stopping on its own)", () => {
+    const h = makeHarness();
+    h.feedMeter(-100);
+    h.order("pump", true, { kind: "recipe", instanceId: "i1" });
+    h.feedState("pump", false); // the load's own regulation stopped it — no order
+    expect(h.arbiter.getPublicState().journal.map((j) => j.kind)).toContain("unclaimed-run-ended");
+  });
+
+  it("a wall-switch-off suspension journals running=false", () => {
+    const h = makeHarness();
+    h.claim("i1", { equipmentId: "pump" });
+    h.run(-1000, 150);
+    h.order("pump", true, { kind: "recipe", instanceId: "i1" });
+    h.feedState("pump", false); // flipped off at the box
+    h.run(-400, 80); // > divergenceConfirmS
+    const suspended = h.arbiter.getPublicState().journal.find((j) => j.kind === "suspended");
+    expect(suspended?.reason).toBe("wall-switch-off");
+    expect(suspended?.running).toBe(false);
+  });
+
+  it("suspension TTL expiry journals a resumed hand-back with the load state", () => {
+    const h = makeHarness({ settings: { "energy.arbiter.overrideTtlS": "60" } });
+    h.feedState("pump", false);
+    h.order("pump", false, { kind: "manual" }); // suspends for 60 s
+    h.run(-100, 80); // ticks past the TTL
+    const resumed = h.arbiter.getPublicState().journal.find((j) => j.kind === "resumed");
+    // A silent lapse left the timeline painting the pre-expiry state forever.
+    expect(resumed?.reason).toBe("override-expired");
+    expect(resumed?.running).toBe(false);
+    expect(h.arbiter.getPublicState().suspensions).toHaveLength(0);
+  });
+
+  it("an explicit resume journals the observed load state", () => {
+    const h = makeHarness();
+    h.feedState("pump", true);
+    h.order("pump", true, { kind: "manual" });
+    h.arbiter.resumeEquipment("pump");
+    const resumed = h.arbiter.getPublicState().journal.find((j) => j.kind === "resumed");
+    expect(resumed?.reason).toBe("resume control");
+    expect(resumed?.running).toBe(true);
+  });
+
   // ── Tolerated import & slack (FR-3) ───────────────────────
 
   it("toleratedImportW widens engage and narrows release by exactly that amount", () => {

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -403,7 +403,12 @@ export class CapacityArbiter {
     // wall-switch OFF. `isBooleanState` accepts boolean / "on"|"off" strings
     // and rejects numbers precisely to exclude those measurements.
     if (profile.class === "deferrable" && isBooleanState(value)) {
-      this.reportedOnOff.set(equipmentId, isOnLike(value));
+      const on = isOnLike(value);
+      this.reportedOnOff.set(equipmentId, on);
+      // A load that stops on its own regulation (the PAC reaching temperature)
+      // emits no order at all — the reported OFF is the only signal that the
+      // unclaimed run is over (#535).
+      if (!on) this.endUnclaimedRun(equipmentId);
     }
   }
 
@@ -423,12 +428,25 @@ export class CapacityArbiter {
     // Sowel's OWN last unconfirmed order after a device reconnect (typically a
     // recipe order), not a person — counting it as a manual override spuriously
     // suspended flexible loads on flaky links (#420).
+    // An unclaimed run ends on ANY observed OFF order, whatever its source:
+    // only the recipe branch used to close it, so a manual OFF (which returns
+    // through the suspend path below) left the load painted "on outside
+    // arbitration" on the timeline indefinitely (#535).
+    if (isOffLike(value)) this.endUnclaimedRun(equipmentId);
+
     if (
       source?.kind === "manual" ||
       source?.kind === "button" ||
       (source?.kind === "external" && source.channel !== RETRY_CHANNEL)
     ) {
-      this.suspend(equipmentId, "user-order");
+      // The order value tells the resulting on/off state; an order that is
+      // neither (e.g. a setpoint) falls back to the last observed state.
+      const running = isOnLike(value)
+        ? true
+        : isOffLike(value)
+          ? false
+          : this.observedRunning(equipmentId);
+      this.suspend(equipmentId, "user-order", running);
       return;
     }
 
@@ -465,19 +483,38 @@ export class CapacityArbiter {
           });
         }
       }
-      if (isOffLike(value) && this.unclaimedRunning.has(equipmentId)) {
-        this.unclaimedRunning.delete(equipmentId);
-        // Journaled so the run reads as a span on the timeline. Without an end
-        // the lane could only ever show where it started, which says nothing
-        // about how long the load held power outside arbitration.
-        this.journal({
-          kind: "unclaimed-run-ended",
-          equipmentId,
-          reason: "run outside arbitration finished",
-        });
-        this.finishLearnerRun(equipmentId);
-      }
+      // The unclaimed-run END is handled above for orders of every source, not
+      // just recipes (#535).
     }
+  }
+
+  /**
+   * Close an unclaimed run (#535): journaled so the run reads as a span on the
+   * timeline — without an end the lane could only ever show where it started,
+   * which says nothing about how long the load held power outside arbitration.
+   * Called on any observed OFF: an order from any source, or a reported OFF
+   * state (a load stopping on its own regulation never emits an order).
+   */
+  private endUnclaimedRun(equipmentId: string): void {
+    if (!this.unclaimedRunning.has(equipmentId)) return;
+    this.unclaimedRunning.delete(equipmentId);
+    this.journal({
+      kind: "unclaimed-run-ended",
+      equipmentId,
+      reason: "run outside arbitration finished",
+    });
+    this.finishLearnerRun(equipmentId);
+  }
+
+  /**
+   * Best-effort on/off state of a load as the arbiter knows it (#535): a
+   * granted claim or an unclaimed run means ON; otherwise the last reported
+   * boolean state (only tracked on deferrable loads — undefined if never seen).
+   */
+  private observedRunning(equipmentId: string): boolean | undefined {
+    if (this.grantedClaimFor(equipmentId) !== undefined) return true;
+    if (this.unclaimedRunning.has(equipmentId)) return true;
+    return this.reportedOnOff.get(equipmentId);
   }
 
   private onEquipmentRemoved(equipmentId: string): void {
@@ -580,7 +617,12 @@ export class CapacityArbiter {
     // Also drop any half-armed divergence timer, so a resume never re-suspends
     // on a contradiction that started before the manual override was lifted.
     this.divergenceSince.delete(equipmentId);
-    this.journal({ kind: "resumed", equipmentId, reason: "resume control" });
+    this.journal({
+      kind: "resumed",
+      equipmentId,
+      reason: "resume control",
+      running: this.observedRunning(equipmentId),
+    });
     this.forceStatusEmit(); // let the UI drop the "Manual until…" chip live
     this.evaluate();
     return true;
@@ -751,9 +793,19 @@ export class CapacityArbiter {
     if (!this.config.enabled) return;
     const now = Date.now();
 
-    // Expire suspensions silently (the explicit resume path journals).
+    // Expire suspensions. Journaled (#535): a silent lapse left the timeline
+    // painting the pre-expiry state indefinitely — the hand-back must be an
+    // event the timeline can key on, exactly like an explicit resume.
     for (const [eq, until] of this.overridesUntil) {
-      if (until <= now) this.overridesUntil.delete(eq);
+      if (until <= now) {
+        this.overridesUntil.delete(eq);
+        this.journal({
+          kind: "resumed",
+          equipmentId: eq,
+          reason: "override-expired",
+          running: this.observedRunning(eq),
+        });
+      }
     }
     for (const [eq, until] of this.unresponsiveUntil) {
       if (until <= now) this.unresponsiveUntil.delete(eq);
@@ -1020,12 +1072,14 @@ export class CapacityArbiter {
     for (const claim of this.grantedClaims()) this.revoke(claim, reason);
   }
 
-  private suspend(equipmentId: string, why: string): void {
+  private suspend(equipmentId: string, why: string, running?: boolean): void {
     const until = Date.now() + this.config.overrideTtlS * 1000;
     this.overridesUntil.set(equipmentId, until);
     const granted = this.grantedClaimFor(equipmentId);
     if (granted) this.revoke(granted, "manual-override");
-    this.journal({ kind: "suspended", equipmentId, reason: why });
+    // `running` reaches the journal so the timeline can tell an OFF-triggered
+    // suspension (load stopped → idle) from a takeover that left it on (#535).
+    this.journal({ kind: "suspended", equipmentId, reason: why, running });
     this.logger.info({ equipmentId, why }, "Arbitration suspended (manual override)");
     // Force a status event: suspending an IDLE (ungranted) load revokes
     // nothing, so without this the UI (which refreshes on energy.* events)
@@ -1088,7 +1142,8 @@ export class CapacityArbiter {
       if (now - since < confirmMs) continue;
       this.divergenceSince.delete(equipmentId);
       // Stable codes (not free text) so the UI journal can translate them.
-      this.suspend(equipmentId, wallOff ? "wall-switch-off" : "wall-switch-on");
+      // wallOn ⇔ the load is on: exactly one of wallOff/wallOn holds here.
+      this.suspend(equipmentId, wallOff ? "wall-switch-off" : "wall-switch-on", wallOn);
     }
   }
 

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -396,18 +396,23 @@ export class CapacityArbiter {
       return;
     }
 
-    // Reported on/off state → wall-switch divergence tracking (FR-6), on
-    // deferrable loads only. Only a genuine on/off STATE value is tracked:
-    // measurement bindings a load exposes (current, voltage, power) report
-    // numeric 0 when a thermostat opens mid-run, which must NOT read as a
-    // wall-switch OFF. `isBooleanState` accepts boolean / "on"|"off" strings
-    // and rejects numbers precisely to exclude those measurements.
-    if (profile.class === "deferrable" && isBooleanState(value)) {
+    // Reported on/off state, tracked for EVERY profiled load (#535 review):
+    // comfort loads (the PAC) stop on their own regulation too, and that state
+    // report is the only signal the arbiter gets — no order is emitted. The
+    // wall-switch divergence REACTION (FR-6) stays deferrable-only in
+    // checkStateDivergence; only the observation is class-wide. A genuine
+    // on/off STATE value only: measurement bindings a load exposes (current,
+    // voltage, power) report numeric 0 when a thermostat opens mid-run, which
+    // must NOT read as a wall-switch OFF. `isBooleanState` accepts boolean /
+    // "on"|"off" strings and rejects numbers precisely to exclude those.
+    if (isBooleanState(value)) {
       const on = isOnLike(value);
       this.reportedOnOff.set(equipmentId, on);
-      // A load that stops on its own regulation (the PAC reaching temperature)
-      // emits no order at all — the reported OFF is the only signal that the
-      // unclaimed run is over (#535).
+      // Closed on the FIRST OFF report, no confirm window (decision): a
+      // boolean state report is authoritative, unlike a power reading — and
+      // keeping the span open was exactly issue #535. A stale retained OFF
+      // replayed on reconnect closes the span early; the next recipe ON
+      // order simply opens a fresh unclaimed run.
       if (!on) this.endUnclaimedRun(equipmentId);
     }
   }
@@ -1120,6 +1125,11 @@ export class CapacityArbiter {
   private checkStateDivergence(now: number): void {
     const confirmMs = this.config.divergenceConfirmS * 1000;
     for (const [equipmentId, reportedOn] of this.reportedOnOff) {
+      // FR-6 reacts on deferrable loads only: a comfort load (thermostat-led)
+      // legitimately switches itself on and off, so a mismatch with the
+      // arbiter's book is regulation, not a human at a wall switch. Its state
+      // is still OBSERVED above for #535 (unclaimed-run end, `running`).
+      if (this.profileOf(equipmentId)?.class !== "deferrable") continue;
       if (this.isSuspended(equipmentId)) {
         this.divergenceSince.delete(equipmentId);
         continue;

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -147,9 +147,10 @@ export class CapacityArbiter {
   private runSamples = new Map<string, number[]>();
   private unclaimedRunning = new Set<string>();
   private recipeWantsOn = new Map<string, boolean>();
-  /** Last reported on/off STATE per profiled deferrable load. The confirm
-   *  timing lives in `divergenceSince`, not here — this is only the current
-   *  state to compare the grant expectation against. */
+  /** Last reported on/off STATE per profiled load, every class (#535). The
+   *  confirm timing lives in `divergenceSince`, not here — this is only the
+   *  current state to compare the grant expectation against, and the source
+   *  of the `running` flag journaled on suspended/resumed. */
   private reportedOnOff = new Map<string, boolean>();
   /** When the current (grant-expectation vs reported-state) contradiction
    *  began — the confirm window is measured from here, NOT from the last
@@ -400,12 +401,14 @@ export class CapacityArbiter {
     // comfort loads (the PAC) stop on their own regulation too, and that state
     // report is the only signal the arbiter gets — no order is emitted. The
     // wall-switch divergence REACTION (FR-6) stays deferrable-only in
-    // checkStateDivergence; only the observation is class-wide. A genuine
-    // on/off STATE value only: measurement bindings a load exposes (current,
-    // voltage, power) report numeric 0 when a thermostat opens mid-run, which
-    // must NOT read as a wall-switch OFF. `isBooleanState` accepts boolean /
-    // "on"|"off" strings and rejects numbers precisely to exclude those.
-    if (isBooleanState(value)) {
+    // checkStateDivergence; only the observation is class-wide. Two gates keep
+    // the observation honest: `isBooleanState` accepts boolean / "on"|"off"
+    // strings and rejects numbers (measurement bindings report numeric 0 when
+    // a thermostat opens mid-run, which must NOT read as a wall-switch OFF),
+    // and `isStateAlias` pins the equipment's actual state binding (a load can
+    // expose other boolean aliases — window detection, child lock — that must
+    // not be read as its run state).
+    if (isBooleanState(value) && this.isStateAlias(equipmentId, alias)) {
       const on = isOnLike(value);
       this.reportedOnOff.set(equipmentId, on);
       // Closed on the FIRST OFF report, no confirm window (decision): a
@@ -514,7 +517,7 @@ export class CapacityArbiter {
   /**
    * Best-effort on/off state of a load as the arbiter knows it (#535): a
    * granted claim or an unclaimed run means ON; otherwise the last reported
-   * boolean state (only tracked on deferrable loads — undefined if never seen).
+   * boolean state (undefined if never seen).
    */
   private observedRunning(equipmentId: string): boolean | undefined {
     if (this.grantedClaimFor(equipmentId) !== undefined) return true;
@@ -1189,6 +1192,19 @@ export class CapacityArbiter {
     const powerBinding =
       bindings.find((b) => b.category === "power") ?? bindings.find((b) => b.alias === "power");
     return powerBinding?.alias === alias;
+  }
+
+  /**
+   * Whether `alias` is the equipment's on/off STATE binding (#535 review):
+   * mirrors isPowerAlias — prefer a state-categorised binding, fall back to
+   * the conventional "state" alias (plugs/switches categorise as generic).
+   */
+  private isStateAlias(equipmentId: string, alias: string): boolean {
+    const bindings = this.equipments.getDataBindingsWithValues(equipmentId);
+    const stateBinding =
+      bindings.find((b) => b.category === "appliance_state" || b.category === "light_state") ??
+      bindings.find((b) => b.alias === "state");
+    return stateBinding?.alias === alias;
   }
 
   private grantedClaims(): ClaimRecord[] {

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -1197,13 +1197,17 @@ export class CapacityArbiter {
   /**
    * Whether `alias` is the equipment's on/off STATE binding (#535 review):
    * mirrors isPowerAlias — prefer a state-categorised binding, fall back to
-   * the conventional "state" alias (plugs/switches categorise as generic).
+   * the conventional "state" alias (plugs/switches categorise as generic),
+   * then to a BOOLEAN-valued "power" alias: cloud-API loads (the Panasonic
+   * PAC) expose their on/off switch under "power" — a wattmeter binding reads
+   * numeric there and never matches `isBooleanState`.
    */
   private isStateAlias(equipmentId: string, alias: string): boolean {
     const bindings = this.equipments.getDataBindingsWithValues(equipmentId);
     const stateBinding =
       bindings.find((b) => b.category === "appliance_state" || b.category === "light_state") ??
-      bindings.find((b) => b.alias === "state");
+      bindings.find((b) => b.alias === "state") ??
+      bindings.find((b) => b.alias === "power" && isBooleanState(b.value));
     return stateBinding?.alias === alias;
   }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -700,6 +700,12 @@ export interface ArbiterDecision {
   watts?: number;
   reason?: string;
   note?: string;
+  /**
+   * Whether the load was ON at the time of the decision, when known (#535).
+   * Set on `suspended`/`resumed`: a suspension triggered by an OFF order must
+   * not paint the timeline "on outside arbitration". Absent on legacy entries.
+   */
+  running?: boolean;
 }
 
 export interface ArbiterGrantInfo {

--- a/ui/src/components/energy/arbiterReason.ts
+++ b/ui/src/components/energy/arbiterReason.ts
@@ -27,6 +27,8 @@ export const REASON_SLUG: Record<string, string> = {
   "user-order": "user-order",
   "wall-switch-off": "wall-switch-off",
   "wall-switch-on": "wall-switch-on",
+  // resumed — automatic hand-back when the suspension TTL lapses (#535)
+  "override-expired": "override-expired",
   // informative free-text
   "export did not recover (a cloud can mask this)": "export-not-recovered",
 };

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1240,6 +1240,7 @@
   "arbiter.reason.user-order": "user command",
   "arbiter.reason.wall-switch-off": "wall switch off",
   "arbiter.reason.wall-switch-on": "wall switch on",
+  "arbiter.reason.override-expired": "suspension expired, control resumed",
   "arbiter.reason.export-not-recovered": "export did not recover (a cloud can mask this)",
   "arbiter.reason.watts-divergence": "declared {{watts}} W",
   "arbiter.waitReason.insufficient": "waiting for surplus (needs {{watts}} W)",

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1240,7 +1240,7 @@
   "arbiter.reason.user-order": "user command",
   "arbiter.reason.wall-switch-off": "wall switch off",
   "arbiter.reason.wall-switch-on": "wall switch on",
-  "arbiter.reason.override-expired": "suspension expired, control resumed",
+  "arbiter.reason.override-expired": "suspension expired",
   "arbiter.reason.export-not-recovered": "export did not recover (a cloud can mask this)",
   "arbiter.reason.watts-divergence": "declared {{watts}} W",
   "arbiter.waitReason.insufficient": "waiting for surplus (needs {{watts}} W)",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1240,6 +1240,7 @@
   "arbiter.reason.user-order": "commande utilisateur",
   "arbiter.reason.wall-switch-off": "interrupteur mural (arrêt)",
   "arbiter.reason.wall-switch-on": "interrupteur mural (marche)",
+  "arbiter.reason.override-expired": "suspension expirée, pilotage repris",
   "arbiter.reason.export-not-recovered": "l'export n'est pas revenu (un nuage peut le masquer)",
   "arbiter.reason.watts-divergence": "déclarée {{watts}} W",
   "arbiter.waitReason.insufficient": "en attente de surplus (besoin de {{watts}} W)",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1240,7 +1240,7 @@
   "arbiter.reason.user-order": "commande utilisateur",
   "arbiter.reason.wall-switch-off": "interrupteur mural (arrêt)",
   "arbiter.reason.wall-switch-on": "interrupteur mural (marche)",
-  "arbiter.reason.override-expired": "suspension expirée, pilotage repris",
+  "arbiter.reason.override-expired": "suspension expirée",
   "arbiter.reason.export-not-recovered": "l'export n'est pas revenu (un nuage peut le masquer)",
   "arbiter.reason.watts-divergence": "déclarée {{watts}} W",
   "arbiter.waitReason.insufficient": "en attente de surplus (besoin de {{watts}} W)",

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -313,6 +313,8 @@ export interface ArbiterDecision {
   watts?: number;
   reason?: string;
   note?: string;
+  /** Load ON at decision time, when known (#535). Absent on legacy entries. */
+  running?: boolean;
 }
 
 export interface ArbiterPublicState {


### PR DESCRIPTION
## Problem

The Energy arbitrage timeline showed "Marche (hors pilotage)" (`unmanaged`) for loads that were actually OFF, and the state persisted indefinitely. Observed in production on the PAC lane.

## Root causes (#535)

1. **A manual/button/external OFF order painted "on"** — any such order suspends arbitration, and the `suspended` journal entry said nothing about the load's actual state, while the timeline mapped `suspended` unconditionally to `unmanaged`.
2. **`unclaimed-run-ended` was only emitted for recipe OFF orders** — a manual OFF returned early through the suspend path, and a load stopping on its own regulation (the PAC reaching temperature) emits no order at all, so the span never closed.
3. **Suspension TTL expiry was silent** — `overridesUntil` lapsed without a journal event, so the timeline kept the last sustained state past the deadline.

Related defect: `resumed` mapped to `granted` on the timeline, although a resume grants nothing by itself.

## Fix

- `ArbiterDecision` gains an optional `running` flag (nullable `running` column on `arbiter_decision_log`, migration 021; NULL = legacy/unknown), journaled on `suspended` and `resumed`.
- An unclaimed run now ends on **any** observed OFF: an order from any source, or a reported boolean OFF state. State observation covers every profiled load class (the PAC is `comfort`); the wall-switch divergence reaction (FR-6) stays deferrable-only.
- TTL expiry journals `resumed` with reason `override-expired` (translated FR/EN) and the observed load state.
- Timeline mapping: `suspended` with `running=false` → `idle` (legacy rows keep `unmanaged`); `resumed` → `unmanaged` if `running=true`, else `idle` (legacy rows → `idle`, was `granted`).

## Tests

- 5 timeline mapping cases (OFF suspension → idle, ON suspension → unmanaged, resumed off/on/legacy).
- 8 arbiter regression tests: manual OFF closes the run + journals `running=false`, manual ON journals `running=true`, reported OFF closes the run (deferrable and comfort/PAC), wall-switch-off suspension journals `running=false`, TTL expiry journals `override-expired` with state, explicit resume journals state, comfort state never triggers FR-6.
- Journal store round-trips `running` (true/false/unknown).

All new behavioral tests verified to fail without the fix. Full suite green (1383 backend+UI), tsc + eslint clean on both sides.

Two independent review passes were run on the diff:

- **Pass 1**: main finding (comfort-class loads not covered by the reported-OFF path — the exact prod scenario) fixed in commit 2.
- **Pass 2**: main finding (the state observation was alias-blind — any boolean-valued alias such as window detection or an eco toggle would close a run and poison the `running` flag) fixed in commits 3-4 with an `isStateAlias` gate mirroring `isPowerAlias`. A read-only check of the production equipments confirmed both sides of it: the PAC's on/off surfaces as a boolean-valued `power` alias (now recognized as the state binding), and the PAC does expose `nanoe` (`on`/`off`, generic) that an alias-blind observation would have misread.

Deferred as pre-existing/acceptable: TTL expiry does not force a status emit (API view already correct); the wall-switch-on re-suspend loop now visible in the journal (predates this fix, output correct); a load switched off physically mid-suspension stays `unmanaged` until the TTL-expiry event (indefinite before, now bounded by `overrideTtlS`).

Closes #535
