### PR TITLE
fix(ui): dedup Analyse chart timestamps so X-axis ticks stay legible (#537)

### DIFF
--- a/ui/src/components/history/AnalyseView.tsx
+++ b/ui/src/components/history/AnalyseView.tsx
@@ -61,6 +61,7 @@ import { SeriesColorPicker } from "./SeriesColorPicker";
 import { fitYAxis } from "./y-axis";
 import { firstChartTarget } from "./analyse-nav";
 import { ChartTooltip } from "./ChartTooltip";
+import { mergeSeriesData } from "./chart-utils";
 
 // ============================================================
 // Types
@@ -548,31 +549,12 @@ export function AnalyseView() {
   // places a tick, and minTickGap controls the spacing.
   // Each row is `{ time, [seriesId]: value, [seriesId:min]: …, [seriesId:max]: … }`
   // — annotated so the fitted-axis pass can read the series keys back out.
-  const chartData = useMemo<Record<string, number>[]>(() => {
-    if (series.length === 0) return [];
-
-    const timeMap = new Map<string, Record<string, number>>();
-
-    for (const s of series) {
-      const data = seriesData[s.id];
-      if (!data?.points) continue;
-      for (const p of data.points) {
-        const existing = timeMap.get(p.time) ?? {};
-        existing[s.id] = p.value;
-        // F1 — carry the envelope band keys when the API returned them
-        // (downsampled buckets at 1h / 1d resolution).
-        if (typeof p.min === "number") existing[`${s.id}:min`] = p.min;
-        if (typeof p.max === "number") existing[`${s.id}:max`] = p.max;
-        timeMap.set(p.time, existing);
-      }
-    }
-
-    const sorted = Array.from(timeMap.entries()).sort(([a], [b]) => a.localeCompare(b));
-    return sorted.map(([time, values]) => ({
-      time: new Date(time).getTime(),
-      ...values,
-    }));
-  }, [series, seriesData]);
+  // Merge + dedup live in `mergeSeriesData` (see #537 for why epoch keying,
+  // not ISO strings, is what keeps the tick culling alive).
+  const chartData = useMemo<Record<string, number>[]>(
+    () => mergeSeriesData(series.map((s) => ({ id: s.id, points: seriesData[s.id]?.points ?? [] }))),
+    [series, seriesData],
+  );
 
   // Families present in the chart. Spec 144 — `measurements` and `states` may
   // coexist (states get their own 0/1 axis); `cumulative` stays alone. An

--- a/ui/src/components/history/HistoryBarChart.test.ts
+++ b/ui/src/components/history/HistoryBarChart.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { aggregateToBuckets, formatLabel, pickTickInterval } from "./chart-utils";
+import { aggregateToBuckets, formatLabel, pickTickInterval, mergeSeriesData } from "./chart-utils";
 
 describe("pickTickInterval", () => {
   describe("without a range (viewport-only cap)", () => {
@@ -181,5 +181,100 @@ describe("formatLabel", () => {
     const labels = days.map((d) => formatLabel(d, "7d").line1);
     expect(new Set(labels).size).toBeLessThan(labels.length);
     expect(new Set(days).size).toBe(days.length);
+  });
+});
+
+describe("mergeSeriesData", () => {
+  it("returns an empty array on empty input", () => {
+    expect(mergeSeriesData([])).toEqual([]);
+    expect(mergeSeriesData([{ id: "a", points: [] }])).toEqual([]);
+  });
+
+  it("keys each row on epoch ms and carries every series value", () => {
+    const out = mergeSeriesData([
+      { id: "temp", points: [{ time: "2026-08-15T10:00:00.000Z", value: 21 }] },
+      { id: "hum", points: [{ time: "2026-08-15T10:00:00.000Z", value: 55 }] },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].time).toBe(new Date("2026-08-15T10:00:00.000Z").getTime());
+    expect(out[0].temp).toBe(21);
+    expect(out[0].hum).toBe(55);
+  });
+
+  it("carries the min/max envelope keys when present", () => {
+    const out = mergeSeriesData([
+      { id: "temp", points: [{ time: "2026-08-15T10:00:00.000Z", value: 21, min: 19, max: 24 }] },
+    ]);
+    expect(out[0]["temp:min"]).toBe(19);
+    expect(out[0]["temp:max"]).toBe(24);
+  });
+
+  it("sorts rows chronologically regardless of input order", () => {
+    const out = mergeSeriesData([
+      {
+        id: "temp",
+        points: [
+          { time: "2026-08-15T12:00:00.000Z", value: 3 },
+          { time: "2026-08-15T08:00:00.000Z", value: 1 },
+          { time: "2026-08-15T10:00:00.000Z", value: 2 },
+        ],
+      },
+    ]);
+    expect(out.map((r) => r.temp)).toEqual([1, 2, 3]);
+    const times = out.map((r) => r.time);
+    expect(times).toEqual([...times].sort((a, b) => a - b));
+  });
+
+  it("dedupes the same instant expressed with different ISO spellings (#537)", () => {
+    // A state event and a measurement bucket can land on the exact same instant
+    // spelled differently. Keying by the raw string would emit two rows at the
+    // same X coordinate; keying by epoch collapses them into one.
+    const out = mergeSeriesData([
+      { id: "state", points: [{ time: "2026-08-15T00:00:00Z", value: 1 }] },
+      { id: "temp", points: [{ time: "2026-08-15T00:00:00.000Z", value: 21 }] },
+      // Same UTC instant via a +02:00 offset — must also collapse.
+      { id: "hum", points: [{ time: "2026-08-15T02:00:00+02:00", value: 55 }] },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ state: 1, temp: 21, hum: 55 });
+  });
+
+  it("guarantees unique, strictly increasing X coordinates (keeps Recharts tick culling alive)", () => {
+    // The concrete #537 failure: two leading rows sharing a coordinate make
+    // Recharts compute sign(tick1.x - tick0.x) === 0, which disables minTickGap
+    // culling and paints every label. Distinct coordinates prevent that.
+    const out = mergeSeriesData([
+      {
+        id: "state",
+        points: [
+          { time: "2026-08-15T00:00:00Z", value: 1 },
+          { time: "2026-08-15T06:00:00Z", value: 0 },
+        ],
+      },
+      {
+        id: "temp",
+        points: [
+          { time: "2026-08-15T00:00:00.000Z", value: 20 },
+          { time: "2026-08-15T06:00:00.000Z", value: 22 },
+        ],
+      },
+    ]);
+    const times = out.map((r) => r.time);
+    expect(new Set(times).size).toBe(times.length);
+    expect(times[1]).toBeGreaterThan(times[0]);
+  });
+
+  it("skips points with an unparseable timestamp", () => {
+    const out = mergeSeriesData([
+      {
+        id: "temp",
+        points: [
+          { time: "not-a-date", value: 1 },
+          { time: "2026-08-15T10:00:00.000Z", value: 2 },
+        ],
+      },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].temp).toBe(2);
   });
 });

--- a/ui/src/components/history/HistoryBarChart.test.ts
+++ b/ui/src/components/history/HistoryBarChart.test.ts
@@ -264,6 +264,20 @@ describe("mergeSeriesData", () => {
     expect(times[1]).toBeGreaterThan(times[0]);
   });
 
+  it("collapses two points of the same series at the same instant (last value wins)", () => {
+    const out = mergeSeriesData([
+      {
+        id: "temp",
+        points: [
+          { time: "2026-08-15T10:00:00Z", value: 20 },
+          { time: "2026-08-15T10:00:00.000Z", value: 22 },
+        ],
+      },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].temp).toBe(22);
+  });
+
   it("skips points with an unparseable timestamp", () => {
     const out = mergeSeriesData([
       {

--- a/ui/src/components/history/chart-utils.ts
+++ b/ui/src/components/history/chart-utils.ts
@@ -1,6 +1,51 @@
 import type { HistoryPoint } from "../../types";
 import type { TimeRange } from "./history-utils";
 
+/** One row of the merged Analyse dataset: an epoch-ms `time` plus one entry
+ *  per series id, and the `id:min` / `id:max` envelope keys when present. */
+export type ChartRow = Record<string, number>;
+
+/** Minimal projection of a series the merge needs: its id and its points. */
+export interface MergeSeries {
+  id: string;
+  points: HistoryPoint[];
+}
+
+/**
+ * Merge every series' points into a single chart dataset indexed by instant.
+ *
+ * Rows are keyed by **epoch milliseconds**, not by the raw ISO string. The
+ * same instant can reach us under two different ISO spellings across series
+ * (an hourly bucket `…T00:00:00Z` vs a raw state event `…T00:00:00.000Z`, or
+ * a `+02:00` offset form of the same UTC instant), and keying by string would
+ * emit two rows at the same X coordinate. That duplicate is not merely
+ * cosmetic: Recharts derives its tick-culling direction from
+ * `sign(tick1.coordinate - tick0.coordinate)`, so two leading rows sharing a
+ * coordinate yield `sign === 0`, which disables `minTickGap` culling and
+ * paints every single label (issue #537). Keying by epoch collapses the
+ * duplicate and keeps the axis legible. Rows are returned sorted
+ * chronologically; points with an unparseable timestamp are skipped.
+ */
+export function mergeSeriesData(series: MergeSeries[]): ChartRow[] {
+  const rows = new Map<number, ChartRow>();
+
+  for (const { id, points } of series) {
+    for (const p of points) {
+      const key = new Date(p.time).getTime();
+      if (Number.isNaN(key)) continue;
+      const row = rows.get(key) ?? { time: key };
+      row[id] = p.value;
+      // F1 — carry the envelope band keys when the API returned them
+      // (downsampled buckets at 1h / 1d resolution).
+      if (typeof p.min === "number") row[`${id}:min`] = p.min;
+      if (typeof p.max === "number") row[`${id}:max`] = p.max;
+      rows.set(key, row);
+    }
+  }
+
+  return Array.from(rows.values()).sort((a, b) => a.time - b.time);
+}
+
 /**
  * Group raw history points into time buckets sized for the range:
  *   - 6h / 24h → hourly buckets


### PR DESCRIPTION
## Problem

On the Analyse page, a chart mixing measurements and states could paint **every** data point's label on the X axis, producing an unreadable overlapping strip of time labels. A measurements-only chart on the same period stayed clean. Reproduced on production v1.48.0 (mobile, day view on the current day): 41 X-axis labels including duplicated ones (`00:00`, `06:00`, `20:24` each twice).

## Root cause

The series merge in `AnalyseView.tsx` keyed rows by the **raw ISO timestamp string**. The same instant can arrive under two different ISO spellings across series:

- an hourly measurement bucket `2026-08-15T00:00:00Z`
- a raw state boundary point `2026-08-15T00:00:00.000Z` (state series stamp their carry-in/out with `Date.toISOString()`)

Keyed by string these become two rows at the **same** X coordinate. Recharts 3.7 derives its tick-culling direction from `sign(tick1.coordinate - tick0.coordinate)`; two leading rows sharing a coordinate yield `sign === 0`, and with `sign === 0` the `minTickGap` collision cursor never advances, so culling is disabled and every candidate label is painted. This also explains why the bug was intermittent: without a duplicate in the first two rows, culling works.

The backend already compares these timestamps numerically internally (see `history-query.ts` "be robust to RFC3339 vs toISOString() formatting differences"); the UI merge was the one place still string-keying.

## Fix

Extract the merge into a pure `mergeSeriesData` helper (`chart-utils.ts`) that:

- keys rows by **epoch milliseconds** (`new Date(p.time).getTime()`), collapsing the duplicate, and
- sorts numerically (the previous `localeCompare` on ISO strings could also mis-order `.000Z` vs `Z` forms of the same instant).

`AnalyseView` now consumes the helper. No behavior change for well-formed, non-duplicate data.

## Tests

`HistoryBarChart.test.ts` (this file already hosts the `chart-utils` tests):

- dedup across mixed ISO spellings (`Z`, `.000Z`, `+02:00` offset) collapses to one row
- unique, strictly increasing X coordinates (the exact invariant the `sign === 0` trigger violated)
- chronological sort regardless of input order
- envelope `min`/`max` keys carried
- intra-series same-instant collapse (last value wins)
- unparseable timestamps skipped

## Verification

- Full UI suite green (`npx vitest run`), `tsc -b --noEmit`, `eslint` clean.
- Shadow build (real prod data): a mixed measures+states day chart renders a legible X axis (2 unique labels, culling active) — no regression from the refactor.
- Independent code review confirmed the root cause and fix (dedup eliminates the `sign === 0` trigger, no data loss, no ordering regression).

Closes #537
