### PR TITLE
fix(ui): portal mobile dashboard pickers out of the jiggling card (#538)

### DIFF
--- a/ui/src/components/dashboard/WidgetGrid.test.tsx
+++ b/ui/src/components/dashboard/WidgetGrid.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "../../test-utils";
+import { PickerOverlay } from "./WidgetGrid";
+
+// #538 — in mobile edit mode every card carries the `animate-jiggle` transform.
+// A transformed ancestor becomes the containing block + stacking context for
+// its `fixed` descendants, which trapped the icon-picker overlay behind sibling
+// cards. The fix portals the mobile overlay to <body> so it escapes that
+// subtree. jsdom does not compute CSS stacking, but it does model DOM parentage
+// exactly — and DOM parentage is what the fix changes.
+describe("PickerOverlay", () => {
+  it("portals the mobile overlay out of the (transformed) card subtree", () => {
+    render(
+      <div data-testid="card" style={{ transform: "rotate(0.7deg)" }}>
+        <PickerOverlay mobile onDismiss={() => {}}>
+          <div data-testid="picker">content</div>
+        </PickerOverlay>
+      </div>,
+    );
+
+    const card = screen.getByTestId("card");
+    const picker = screen.getByTestId("picker");
+
+    // Rendered, but NOT a descendant of the transformed card — it escaped to body.
+    expect(picker).toBeTruthy();
+    expect(card.contains(picker)).toBe(false);
+    expect(document.body.contains(picker)).toBe(true);
+  });
+
+  it("renders a full-screen backdrop on mobile", () => {
+    const onDismiss = vi.fn();
+    render(
+      <PickerOverlay mobile onDismiss={onDismiss}>
+        <div data-testid="picker">content</div>
+      </PickerOverlay>,
+    );
+
+    // The backdrop is a fixed inset-0 sibling of the picker; clicking it dismisses.
+    const backdrop = document.querySelector(".fixed.inset-0.bg-black\\/20");
+    expect(backdrop).not.toBeNull();
+    (backdrop as HTMLElement).click();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the desktop popover inline (anchored under its trigger, no portal)", () => {
+    render(
+      <div data-testid="card">
+        <PickerOverlay mobile={false} onDismiss={() => {}}>
+          <div data-testid="picker">content</div>
+        </PickerOverlay>
+      </div>,
+    );
+
+    const card = screen.getByTestId("card");
+    const picker = screen.getByTestId("picker");
+
+    // Desktop stays in place — the anchored popover must not escape the card.
+    expect(card.contains(picker)).toBe(true);
+    // And no full-screen backdrop on desktop.
+    expect(document.querySelector(".fixed.inset-0.bg-black\\/20")).toBeNull();
+  });
+});

--- a/ui/src/components/dashboard/WidgetGrid.tsx
+++ b/ui/src/components/dashboard/WidgetGrid.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState, useRef, useEffect } from "react";
+import { useCallback, useState, useRef, useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import {
   DndContext,
@@ -201,6 +202,30 @@ function getEquipmentType(widget: DashboardWidget, equipmentMap: Map<string, Equ
   return undefined;
 }
 
+/** Wrapper for the edit-mode popovers (icon + bindings pickers). On mobile the
+ *  card carries the `animate-jiggle` transform, and a transformed ancestor
+ *  becomes the containing block + stacking context for its `fixed` descendants
+ *  — which trapped the full-screen overlay behind sibling cards and shrank its
+ *  backdrop to the card (#538). Portal the mobile overlay to <body> so it
+ *  escapes; the desktop popover stays anchored under its trigger button. */
+export function PickerOverlay({
+  mobile,
+  onDismiss,
+  children,
+}: {
+  mobile: boolean;
+  onDismiss: () => void;
+  children: ReactNode;
+}) {
+  const overlay = (
+    <div className={mobile ? "fixed inset-0 z-50 flex items-start justify-center pt-24" : "absolute top-7 left-0 right-0 z-20"}>
+      {mobile && <div className="fixed inset-0 bg-black/20" onClick={onDismiss} />}
+      {children}
+    </div>
+  );
+  return mobile ? createPortal(overlay, document.body) : overlay;
+}
+
 function SortableWidget({
   widget,
   equipmentMap,
@@ -341,8 +366,7 @@ function SortableWidget({
       )}
       {/* Bindings picker popover */}
       {showBindingsPicker && sensorBindings.length > 0 && (
-        <div className={isMobile ? "fixed inset-0 z-50 flex items-start justify-center pt-24" : "absolute top-7 left-0 right-0 z-20"}>
-          {isMobile && <div className="fixed inset-0 bg-black/20" onClick={() => setShowBindingsPicker(false)} />}
+        <PickerOverlay mobile={isMobile} onDismiss={() => setShowBindingsPicker(false)}>
           <BindingsPicker
             bindings={sensorBindings}
             visibleAliases={widget.config?.visibleBindings}
@@ -354,12 +378,11 @@ function SortableWidget({
             onClose={() => setShowBindingsPicker(false)}
             mobile={isMobile}
           />
-        </div>
+        </PickerOverlay>
       )}
       {/* Icon picker popover */}
       {showIconPicker && (
-        <div className={isMobile ? "fixed inset-0 z-50 flex items-start justify-center pt-24" : "absolute top-7 left-0 right-0 z-20"}>
-          {isMobile && <div className="fixed inset-0 bg-black/20" onClick={() => setShowIconPicker(false)} />}
+        <PickerOverlay mobile={isMobile} onDismiss={() => setShowIconPicker(false)}>
           <IconPicker
             currentIcon={widget.icon}
             equipmentType={eqType}
@@ -369,7 +392,7 @@ function SortableWidget({
             onClose={() => setShowIconPicker(false)}
             mobile={isMobile}
           />
-        </div>
+        </PickerOverlay>
       )}
       <WidgetRenderer
         widget={widget}


### PR DESCRIPTION
## Problem

On the mobile Dashboard in edit mode, opening the icon picker ("Choisir une icône") rendered the picker **behind** the sibling cards below it, and its dark backdrop only covered the current card instead of the whole screen. Icon selection was effectively unusable whenever the card had neighbours below.

## Root cause

In mobile edit mode every card gets the `animate-jiggle` transform (`index.css`). An animated `transform` makes the element the **containing block** and a **stacking context** for its `position: fixed` descendants. The picker's `fixed inset-0 z-50` overlay was therefore trapped inside its card's stacking context:

- its `z-50` could not rise above sibling cards rendered later in the DOM (each its own stacking context at the same level), and
- its "full-screen" backdrop was sized against the card, not the viewport.

A z-index cannot escape a transform-created stacking context from within it, so no z tweak fixes this.

## Fix

Extract a `PickerOverlay` helper in `WidgetGrid.tsx` that portals the **mobile** overlay to `document.body` (via `react-dom` `createPortal`), so it escapes the transformed ancestor and resolves `fixed`/`z-index` against the viewport and body's stacking context. The **desktop** popover is unchanged: it stays anchored inline under its trigger button (`absolute top-7 ...`). Applied to both the icon picker and the sensor bindings picker (same latent defect). This mirrors how the app's `BottomSheet` already portals to body.

## Tests

`WidgetGrid.test.tsx` (new) exercises the extracted `PickerOverlay` contract — jsdom does not compute CSS stacking, but DOM parentage is exactly what the fix changes:

- mobile overlay escapes the (transformed) card subtree: `card.contains(picker) === false`, `document.body.contains(picker) === true`
- mobile renders a full-screen backdrop that dismisses on tap
- desktop popover stays inline (inside the card, no portal, no backdrop)

These are characterization tests of the new component's contract rather than a regression test of the old inline JSX (the old code had no such export). The integration point (`SortableWidget` passing `mobile={isMobile}`) is guarded by tsc.

## Verification

- Full UI suite green (`npx vitest run`), `tsc -b --noEmit`, `eslint` clean.
- Shadow build (real prod data), mobile 390px, edit mode: the icon picker now renders **above** all cards with a full-screen backdrop; runtime introspection confirms it is portaled to `document.body` with no jiggling ancestor and the backdrop covers the full viewport (verified with Playwright on a local shadow container).
- Independent code review confirmed portal is the correct root fix, both pickers and the desktop path are handled, and no other `fixed` overlay remains trapped inside a jiggling card.

Closes #538
