### PR TITLE
fix(energy): rehydrate open unclaimed runs from the journal on startup (#543)

### DIFF
--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -3,6 +3,8 @@ import { CapacityArbiter, trimmedMedian } from "./capacity-arbiter.js";
 import { EventBus } from "../core/event-bus.js";
 import { RETRY_CHANNEL } from "../equipments/order-confirmation-tracker.js";
 import type {
+  ArbiterDecision,
+  ArbiterDecisionKind,
   CapacityClaimHandle,
   CapacityClaimRequest,
   EnergyLoadProfile,
@@ -36,6 +38,10 @@ function makeHarness(opts?: {
   profiles?: Record<string, EnergyLoadProfile | undefined>;
   bindings?: Record<string, Array<{ alias: string; category: string; value?: unknown }>>;
   shadow?: boolean;
+  /** Seed a fake persisted journal store (#543 restart tests). Entries must be
+   *  chronological; the fake mimics ArbiterJournalStore ordering (loadRecent =
+   *  most recent `limit` ascending, range = ascending within [from, to]). */
+  journal?: ArbiterDecision[];
 }) {
   const settingsMap = new Map<string, string>(
     Object.entries({
@@ -132,12 +138,24 @@ function makeHarness(opts?: {
     if (e.type.startsWith("energy.")) events.push(e);
   });
 
+  const journalRows: ArbiterDecision[] = [...(opts?.journal ?? [])];
+  const journalStore = opts?.journal
+    ? ({
+        insert: (d: ArbiterDecision) => journalRows.push(d),
+        loadRecent: (limit: number) => journalRows.slice(-limit),
+        range: (fromIso: string, toIso: string) =>
+          journalRows.filter((d) => d.atIso >= fromIso && d.atIso <= toIso),
+        purgeOlderThan: () => 0,
+      } as never)
+    : undefined;
+
   const arbiter = new CapacityArbiter(
     eventBus,
     settingsManager,
     equipmentManager,
     silentLogger,
     opts?.shadow ?? false,
+    journalStore,
   );
   arbiter.start();
 
@@ -211,6 +229,7 @@ function makeHarness(opts?: {
     events,
     settingsMap,
     equipments,
+    journalRows,
     learnedCalls,
     feedMeter,
     feedLoadPower,
@@ -1231,5 +1250,151 @@ describe("capacity arbiter — review hardening", () => {
     // Smoothed: still sees most of the surplus one sample later, not snapped to 0.
     expect(afterStep).toBeGreaterThan(1000);
     expect(afterStep).toBeLessThan(settled);
+  });
+});
+
+// ============================================================
+// #543 — restart during an unclaimed run: rehydration from the
+// persisted journal so the first observed OFF closes the span.
+// ============================================================
+
+describe("capacity arbiter — unclaimed-run rehydration on restart (#543)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-12T10:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const dec = (
+    kind: ArbiterDecisionKind,
+    equipmentId: string,
+    atIso: string,
+    running?: boolean,
+  ): ArbiterDecision => ({ kind, equipmentId, equipmentName: equipmentId, atIso, running });
+
+  const endedCount = (h: ReturnType<typeof makeHarness>) =>
+    h.arbiter.getPublicState().journal.filter((j) => j.kind === "unclaimed-run-ended").length;
+
+  it("a reported OFF after restart closes a rehydrated open run and repaints the timeline", () => {
+    const h = makeHarness({
+      journal: [dec("unclaimed-run", "pump", "2026-08-12T08:00:00.000Z")],
+    });
+    // Rehydration itself journals nothing.
+    expect(h.journalRows).toHaveLength(1);
+
+    h.feedState("pump", false);
+    expect(endedCount(h)).toBe(1);
+
+    // The span now has an end: quarters after the OFF paint idle, the run
+    // before it stays unmanaged. (Advance past the quarter boundary — the
+    // window is quantized to :15 steps and a cell only shows events strictly
+    // before its end.)
+    vi.advanceTimersByTime(15 * 60_000);
+    const tl = h.arbiter.getTimeline(Date.now(), 6);
+    const pump = tl.loads.find((l) => l.equipmentId === "pump");
+    expect(pump?.quarters.at(-1)).toBe("idle");
+    // Mid-run quarter (window 04:15-10:15, run 08:00-10:00): still unmanaged.
+    expect(pump?.quarters[16]).toBe("unmanaged");
+  });
+
+  it("an OFF order after restart closes a rehydrated open run (manual OFF journals suspended running=false after it)", () => {
+    const h = makeHarness({
+      journal: [dec("unclaimed-run", "pump", "2026-08-12T08:00:00.000Z")],
+    });
+    h.order("pump", false, { kind: "manual" });
+    // Newest-first public journal: the suspension is journaled after the close.
+    const kinds = h.arbiter.getPublicState().journal.map((j) => j.kind);
+    expect(kinds.slice(0, 2)).toEqual(["suspended", "unclaimed-run-ended"]);
+    const suspended = h.arbiter.getPublicState().journal.find((j) => j.kind === "suspended");
+    expect(suspended?.running).toBe(false);
+  });
+
+  it.each([
+    ["unclaimed-run-ended", dec("unclaimed-run-ended", "pump", "2026-08-12T08:30:00.000Z")],
+    ["granted", dec("granted", "pump", "2026-08-12T08:30:00.000Z")],
+    ["suspended running=false", dec("suspended", "pump", "2026-08-12T08:30:00.000Z", false)],
+  ])("a run already closed in the journal by %s is not rehydrated", (_label, closing) => {
+    const h = makeHarness({
+      journal: [dec("unclaimed-run", "pump", "2026-08-12T08:00:00.000Z"), closing],
+    });
+    const before = endedCount(h);
+    h.feedState("pump", false);
+    expect(endedCount(h)).toBe(before); // OFF journals nothing — no open run
+  });
+
+  it.each([
+    ["running=true", true],
+    ["legacy running unknown", undefined],
+  ])("a suspended entry with %s does NOT close the pending run", (_label, running) => {
+    const h = makeHarness({
+      journal: [
+        dec("unclaimed-run", "pump", "2026-08-12T08:00:00.000Z"),
+        dec("suspended", "pump", "2026-08-12T08:30:00.000Z", running),
+      ],
+    });
+    h.feedState("pump", false);
+    expect(endedCount(h)).toBe(1); // still open → the OFF closes it
+  });
+
+  it("only the last unresolved unclaimed-run per equipment counts across cycles", () => {
+    const h = makeHarness({
+      journal: [
+        dec("unclaimed-run", "pump", "2026-08-12T07:00:00.000Z"),
+        dec("unclaimed-run-ended", "pump", "2026-08-12T07:30:00.000Z"),
+        dec("unclaimed-run", "pump", "2026-08-12T08:00:00.000Z"),
+      ],
+    });
+    h.feedState("pump", false);
+    expect(endedCount(h)).toBe(2); // the seeded one + exactly one new close
+    h.feedState("pump", false);
+    expect(endedCount(h)).toBe(2); // idempotent — the set is empty now
+  });
+
+  it("rehydrates from the store even when the opening entry fell off the in-memory ring cap", () => {
+    // 250 later entries for another equipment push the pump's opening entry
+    // beyond loadRecent(200) — the store range scan must still see it.
+    const filler = Array.from({ length: 250 }, (_, i) =>
+      dec(
+        "denied",
+        "heater",
+        `2026-08-12T09:00:${String(i % 60).padStart(2, "0")}.${String(i).padStart(3, "0")}Z`,
+      ),
+    );
+    const h = makeHarness({
+      journal: [dec("unclaimed-run", "pump", "2026-08-12T08:00:00.000Z"), ...filler],
+    });
+    h.feedState("pump", false);
+    expect(h.journalRows.filter((j) => j.kind === "unclaimed-run-ended")).toHaveLength(1);
+  });
+
+  it("an open run for an equipment that no longer exists is skipped without crashing", () => {
+    const h = makeHarness({
+      journal: [dec("unclaimed-run", "ghost", "2026-08-12T08:00:00.000Z")],
+    });
+    // Nothing to observe for a deleted equipment — just no spurious journaling.
+    expect(h.journalRows).toHaveLength(1);
+    h.feedState("pump", false);
+    expect(endedCount(h)).toBe(0);
+  });
+
+  it("a load still running across the restart does not journal a duplicate unclaimed-run on the next recipe ON", () => {
+    const h = makeHarness({
+      journal: [dec("unclaimed-run", "pump", "2026-08-12T08:00:00.000Z")],
+    });
+    h.order("pump", true, { kind: "recipe", instanceId: "i1" });
+    const runs = h.arbiter.getPublicState().journal.filter((j) => j.kind === "unclaimed-run");
+    expect(runs).toHaveLength(1); // the rehydrated one, no duplicate
+    h.feedState("pump", false);
+    expect(endedCount(h)).toBe(1); // the original span finally closes
+  });
+
+  it("entries older than the 72h lookback are ignored", () => {
+    const h = makeHarness({
+      journal: [dec("unclaimed-run", "pump", "2026-08-08T08:00:00.000Z")], // 4 days old
+    });
+    h.feedState("pump", false);
+    expect(endedCount(h)).toBe(0); // not rehydrated → nothing to close
   });
 });

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -138,6 +138,19 @@ function makeHarness(opts?: {
     if (e.type.startsWith("energy.")) events.push(e);
   });
 
+  // The arbiter gets a capturing logger so tests can observe behavior that
+  // has no other public surface (#543 — the deleted-equipment skip).
+  const logLines: Array<{ ctx: unknown; msg: string | undefined }> = [];
+  const capturingLogger = {
+    child: () => capturingLogger,
+    info: (ctx: unknown, msg?: string) => logLines.push({ ctx, msg }),
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+  } as never;
+
   const journalRows: ArbiterDecision[] = [...(opts?.journal ?? [])];
   const journalStore = opts?.journal
     ? ({
@@ -153,7 +166,7 @@ function makeHarness(opts?: {
     eventBus,
     settingsManager,
     equipmentManager,
-    silentLogger,
+    capturingLogger,
     opts?.shadow ?? false,
     journalStore,
   );
@@ -230,6 +243,7 @@ function makeHarness(opts?: {
     settingsMap,
     equipments,
     journalRows,
+    logLines,
     learnedCalls,
     feedMeter,
     feedLoadPower,
@@ -1315,6 +1329,7 @@ describe("capacity arbiter — unclaimed-run rehydration on restart (#543)", () 
     ["unclaimed-run-ended", dec("unclaimed-run-ended", "pump", "2026-08-12T08:30:00.000Z")],
     ["granted", dec("granted", "pump", "2026-08-12T08:30:00.000Z")],
     ["suspended running=false", dec("suspended", "pump", "2026-08-12T08:30:00.000Z", false)],
+    ["resumed running=false", dec("resumed", "pump", "2026-08-12T08:30:00.000Z", false)],
   ])("a run already closed in the journal by %s is not rehydrated", (_label, closing) => {
     const h = makeHarness({
       journal: [dec("unclaimed-run", "pump", "2026-08-12T08:00:00.000Z"), closing],
@@ -1325,14 +1340,13 @@ describe("capacity arbiter — unclaimed-run rehydration on restart (#543)", () 
   });
 
   it.each([
-    ["running=true", true],
-    ["legacy running unknown", undefined],
-  ])("a suspended entry with %s does NOT close the pending run", (_label, running) => {
+    ["suspended running=true", dec("suspended", "pump", "2026-08-12T08:30:00.000Z", true)],
+    ["suspended legacy running unknown", dec("suspended", "pump", "2026-08-12T08:30:00.000Z")],
+    ["resumed running=true", dec("resumed", "pump", "2026-08-12T08:30:00.000Z", true)],
+    ["resumed legacy running unknown", dec("resumed", "pump", "2026-08-12T08:30:00.000Z")],
+  ])("a %s entry does NOT close the pending run", (_label, entry) => {
     const h = makeHarness({
-      journal: [
-        dec("unclaimed-run", "pump", "2026-08-12T08:00:00.000Z"),
-        dec("suspended", "pump", "2026-08-12T08:30:00.000Z", running),
-      ],
+      journal: [dec("unclaimed-run", "pump", "2026-08-12T08:00:00.000Z"), entry],
     });
     h.feedState("pump", false);
     expect(endedCount(h)).toBe(1); // still open → the OFF closes it
@@ -1359,7 +1373,7 @@ describe("capacity arbiter — unclaimed-run rehydration on restart (#543)", () 
       dec(
         "denied",
         "heater",
-        `2026-08-12T09:00:${String(i % 60).padStart(2, "0")}.${String(i).padStart(3, "0")}Z`,
+        `2026-08-12T09:${String(Math.floor(i / 60)).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}.000Z`,
       ),
     );
     const h = makeHarness({
@@ -1369,11 +1383,13 @@ describe("capacity arbiter — unclaimed-run rehydration on restart (#543)", () 
     expect(h.journalRows.filter((j) => j.kind === "unclaimed-run-ended")).toHaveLength(1);
   });
 
-  it("an open run for an equipment that no longer exists is skipped without crashing", () => {
+  it("an open run for an equipment that no longer exists is skipped", () => {
     const h = makeHarness({
       journal: [dec("unclaimed-run", "ghost", "2026-08-12T08:00:00.000Z")],
     });
-    // Nothing to observe for a deleted equipment — just no spurious journaling.
+    // The Set stayed empty: the rehydration log line (emitted only when at
+    // least one run was rehydrated) is absent, and nothing was journaled.
+    expect(h.logLines.filter((l) => l.msg?.includes("rehydrated"))).toHaveLength(0);
     expect(h.journalRows).toHaveLength(1);
     h.feedState("pump", false);
     expect(endedCount(h)).toBe(0);
@@ -1390,11 +1406,19 @@ describe("capacity arbiter — unclaimed-run rehydration on restart (#543)", () 
     expect(endedCount(h)).toBe(1); // the original span finally closes
   });
 
-  it("entries older than the 72h lookback are ignored", () => {
+  it("entries older than the 84h lookback are ignored, entries inside it count", () => {
     const h = makeHarness({
-      journal: [dec("unclaimed-run", "pump", "2026-08-08T08:00:00.000Z")], // 4 days old
+      journal: [dec("unclaimed-run", "pump", "2026-08-08T08:00:00.000Z")], // 98h old
     });
     h.feedState("pump", false);
     expect(endedCount(h)).toBe(0); // not rehydrated → nothing to close
+
+    // 80h old — still paintable by the deepest timeline page (48h depth +
+    // 12h window + 24h entering-state lookback), so it must rehydrate.
+    const h2 = makeHarness({
+      journal: [dec("unclaimed-run", "pump", "2026-08-09T02:00:00.000Z")],
+    });
+    h2.feedState("pump", false);
+    expect(endedCount(h2)).toBe(1);
   });
 });

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -40,9 +40,10 @@ import type {
 const SETTING_PREFIX = "energy.arbiter.";
 const JOURNAL_CAP = 200;
 // #543 — how far back start() scans the persisted journal for open unclaimed
-// runs: the deepest timeline view (48h window) plus its 24h entering-state
-// lookback. Anything older can no longer paint a quarter.
-const REHYDRATE_LOOKBACK_MS = 72 * 3_600_000;
+// runs. The deepest timeline page ends 48h back (route depth cap), spans up
+// to 12h, and getTimeline adds a 24h entering-state lookback — decisions up
+// to 84h old can still paint a quarter.
+const REHYDRATE_LOOKBACK_MS = (48 + 12 + 24) * 3_600_000;
 const LIVE_DRAW_TAU_S = 30; // per-load EMA time constant
 const LIVE_DRAW_FRESH_MS = 120_000; // tier-1 freshness window
 const LEARN_SAMPLE_FLOOR = 0.25; // learner ignores samples below 25 % of nominal
@@ -515,6 +516,9 @@ export class CapacityArbiter {
    */
   private rehydrateUnclaimedRuns(): void {
     const now = Date.now();
+    // Accepted degradation: range() returns [] on a DB error (it never
+    // throws), and the ring is NOT used as a fallback then — it may hold
+    // entries older than the lookback, which must not rehydrate.
     const decisions =
       this.journalStore?.range(
         new Date(now - REHYDRATE_LOOKBACK_MS).toISOString(),
@@ -542,6 +546,12 @@ export class CapacityArbiter {
         // `unclaimed-run-ended` — without this case the scan would rehydrate
         // a load that is known off.
         case "suspended":
+          if (d.running === false) open.delete(d.equipmentId);
+          break;
+        // Same reasoning for a TTL/manual resume observed with the load OFF:
+        // the timeline already paints it idle, so a stale open flag would
+        // only suppress the journaling of the next genuine unclaimed run.
+        case "resumed":
           if (d.running === false) open.delete(d.equipmentId);
           break;
         default:

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -39,6 +39,10 @@ import type {
 
 const SETTING_PREFIX = "energy.arbiter.";
 const JOURNAL_CAP = 200;
+// #543 — how far back start() scans the persisted journal for open unclaimed
+// runs: the deepest timeline view (48h window) plus its 24h entering-state
+// lookback. Anything older can no longer paint a quarter.
+const REHYDRATE_LOOKBACK_MS = 72 * 3_600_000;
 const LIVE_DRAW_TAU_S = 30; // per-load EMA time constant
 const LIVE_DRAW_FRESH_MS = 120_000; // tier-1 freshness window
 const LEARN_SAMPLE_FLOOR = 0.25; // learner ignores samples below 25 % of nominal
@@ -203,6 +207,7 @@ export class CapacityArbiter {
         this.logger.info({ count: recent.length }, "Arbiter decision journal restored from store");
       }
     }
+    this.rehydrateUnclaimedRuns();
     this.resolveMeter();
     this.unsubscribes.push(
       this.eventBus.onType("equipment.data.changed", (e) => {
@@ -493,6 +498,66 @@ export class CapacityArbiter {
       }
       // The unclaimed-run END is handled above for orders of every source, not
       // just recipes (#535).
+    }
+  }
+
+  /**
+   * Rebuild the open unclaimed runs from the persisted journal (#543): the
+   * Set is live control state and starts empty after a restart, so without
+   * this the first observed OFF early-returns in endUnclaimedRun and the
+   * matching `unclaimed-run-ended` is never journaled — the timeline keeps
+   * painting the load "unmanaged" until its next full run cycle.
+   *
+   * Scans the store, not the in-memory ring: the ring is capped at
+   * JOURNAL_CAP entries and a chatty journal can evict the opening entry
+   * while the timeline (which reads the store directly) still paints it.
+   * Journals nothing — it only refills the Set.
+   */
+  private rehydrateUnclaimedRuns(): void {
+    const now = Date.now();
+    const decisions =
+      this.journalStore?.range(
+        new Date(now - REHYDRATE_LOOKBACK_MS).toISOString(),
+        new Date(now).toISOString(),
+      ) ?? this.journalEntries;
+    const open = new Set<string>();
+    for (const d of decisions) {
+      if (!d.equipmentId) continue;
+      switch (d.kind) {
+        case "unclaimed-run":
+          open.add(d.equipmentId);
+          break;
+        case "unclaimed-run-ended":
+          open.delete(d.equipmentId);
+          break;
+        // Deliberate divergence from live semantics (grant() leaves the Set
+        // untouched): after a `granted` the timeline paints the load as
+        // managed anyway, and a stale open flag would only suppress the
+        // journaling of its next genuine unclaimed run.
+        case "granted":
+          open.delete(d.equipmentId);
+          break;
+        // An OFF-triggered suspension left the load stopped (#536). Rows
+        // written before v1.48.1 carry it WITHOUT a preceding
+        // `unclaimed-run-ended` — without this case the scan would rehydrate
+        // a load that is known off.
+        case "suspended":
+          if (d.running === false) open.delete(d.equipmentId);
+          break;
+        default:
+          break;
+      }
+    }
+    for (const id of open) {
+      // Deleted since the entry was journaled — mirror forgetEquipment.
+      if (!this.equipments.getById(id)) continue;
+      this.unclaimedRunning.add(id);
+    }
+    if (this.unclaimedRunning.size > 0) {
+      this.logger.info(
+        { count: this.unclaimedRunning.size },
+        "Open unclaimed runs rehydrated from journal",
+      );
     }
   }
 


### PR DESCRIPTION
## Root cause

The arbiter's `unclaimedRunning` Set is live control state and starts empty after every restart, while the decision journal (spec 147) is persisted and restored. An unclaimed run open across a restart could therefore never be closed: `endUnclaimedRun()` early-returned on the first observed OFF (order or reported state) and the matching `unclaimed-run-ended` entry was never journaled — the timeline kept painting the load "Marche (hors pilotage)" until its next full run cycle. Observed in production on the PAC right after the v1.48.1 update: an `unclaimed-run` open since the previous day survived the restart while the PAC had been OFF for 11 hours.

## Fix

`start()` now rehydrates the Set from the persisted journal after restoring it:

- Scans `journalStore.range(now - 84h, now)` — 84h covers the deepest timeline page (48h depth cap + 12h window) plus its 24h entering-state lookback, i.e. everything that can still paint a quarter. The scan reads the store, not the 200-entry in-memory ring, so a chatty journal cannot evict an opening entry the timeline still paints.
- An equipment is rehydrated when its last `unclaimed-run` has no later close: `unclaimed-run-ended`, `granted` (deliberate divergence from live semantics — after a grant a stale open flag would only suppress the next genuine `unclaimed-run` entry), or `suspended`/`resumed` with `running=false` (pre-v1.48.1 rows carry these without a preceding `ended`).
- Equipment deleted since is skipped. Rehydration journals nothing — it only refills the Set.

Side effect fixed: a load still running across a restart no longer journals a duplicate `unclaimed-run` on its next recipe ON.

## Review

Independently agent-reviewed twice (issue qualification + branch diff, mutation-tested). Applied findings: 72h→84h lookback, `resumed running=false` as closer, deleted-equipment skip made observable in tests, chronological test fixtures. Deferred with an inline comment: no ring fallback when the store's `range()` fails (the ring may hold entries older than the lookback).

## Tests

12 new cases in `capacity-arbiter.test.ts` (fake persisted journal store added to the harness); 7 fail without the fix, the deleted-equipment guard is mutation-verified:

- reported OFF / OFF order after restart closes the rehydrated span and repaints the timeline quarter to idle
- runs already closed by `ended` / `granted` / `suspended(false)` / `resumed(false)` are not rehydrated; `suspended`/`resumed` with `running=true` or legacy unknown keep the run open
- only the last unresolved run per equipment counts; close is idempotent
- opening entry beyond the ring cap but inside the store range is still found
- deleted equipment skipped; entries older than 84h ignored, 80h-old entries rehydrated
- no duplicate `unclaimed-run` on the next recipe ON of a still-running load

Closes #543
