### PR TITLE
chore(registry): bump pool-pump-schedule to 1.5.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -326,21 +326,21 @@
     "type": "recipe",
     "category": "water",
     "name": "Pool Pump Schedule",
-    "description": "Pool pump control: daily schedule windows, an optional water-temperature filtration-time target, and optional solar-surplus running.",
+    "description": "Pool pump control: daily schedule windows, an optional water-temperature filtration-time target, optional solar-surplus running, and optional heat-pump pool heating on solar surplus.",
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.4.2",
-    "tags": ["pool", "pump", "schedule", "automation", "temperature", "solar", "energy"],
+    "version": "1.5.0",
+    "tags": ["pool", "pump", "heating", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
         "name": "Programmation pompe piscine",
-        "description": "Pilotage de pompe de piscine : créneaux horaires quotidiens, cible de temps de filtration selon la température de l'eau (option) et fonctionnement sur surplus solaire (option)."
+        "description": "Pilotage de pompe de piscine : créneaux horaires quotidiens, cible de temps de filtration selon la température de l'eau (option), fonctionnement sur surplus solaire (option) et chauffage PAC sur surplus solaire (option)."
       }
     },
     "sowelVersion": ">=1.3.0",
     "owner": "mchacher",
-    "sha256": "c81f2ab285e62e59776afd7886c7eef7fc71c43d6050aa28d462f10b87842f71"
+    "sha256": "c7096695c5931772af0c105ffd607fb6ac29b56095f2c973f2c01158d903dddb"
   },
   {
     "id": "freecooling",


### PR DESCRIPTION
Bumps the `pool-pump-schedule` registry entry to **v1.5.0** (solar-surplus pool heating through the heat pump setpoint — see [recipe PR #11](https://github.com/mchacher/sowel-recipe-pool-pump-schedule/pull/11) and the [v1.5.0 release](https://github.com/mchacher/sowel-recipe-pool-pump-schedule/releases/tag/v1.5.0)).

- `version` 1.4.2 → 1.5.0, descriptions (EN/FR) and tags updated to mention heating
- `sha256` refreshed via `scripts/backfill-registry-sha256.mjs` and verified equal to the local `shasum -a 256` of the built tarball: `c7096695c5931772af0c105ffd607fb6ac29b56095f2c973f2c01158d903dddb`
- Formatting of the rest of the file untouched