### PR TITLE
feat(energy): count any numeric-metered load as a submeter (#523)

### DIFF
--- a/src/api/routes/energy.test.ts
+++ b/src/api/routes/energy.test.ts
@@ -93,10 +93,16 @@ async function buildApp(opts: BuildOpts = {}) {
       }) as never,
   };
 
-  // Mock EquipmentManager — only `getAll()` is consumed by the routes.
+  // Mock EquipmentManager. Since #523 the by-usage route inspects each
+  // non-excluded equipment's bindings for a numeric power/energy channel;
+  // return one so the test's energy_meter submeters qualify (the excluded
+  // main/production types never reach this fetch).
   const equipments = opts.equipments ?? [];
   const equipmentManager = {
     getAll: () => equipments,
+    getDataBindingsWithValues: () => [
+      { alias: "power", category: "power", type: "number", value: 0 },
+    ],
   } as never;
 
   // tariffClassifier returns the injected config (spec 123 — used for cost wiring).

--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -6,7 +6,7 @@ import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import type { TariffClassifier } from "../../energy/tariff-classifier.js";
 import type { CapacityArbiter } from "../../energy/capacity-arbiter.js";
 import { blendedRate, computeCost } from "../../energy/cost-calculator.js";
-import { isSubmeterEquipment, METERING_RELAY_TYPES } from "../../equipments/metering.js";
+import { isSubmeterEquipment, NON_SUBMETER_TYPES } from "../../equipments/metering.js";
 import type { InfluxClient } from "../../core/influx-client.js";
 import type {
   EnergyPoint,
@@ -238,12 +238,11 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
       return reply.status(503).send({ error: "InfluxDB not configured" });
     }
 
-    // Dedicated energy_meters + metering relays (switch/water_heater, spec 129/#521).
-    // energy_meter qualifies on type alone; only metering-relay types need their
-    // bindings inspected, so lights/sensors never trigger a binding fetch.
+    // Any equipment carrying a numeric power/energy channel, except the house
+    // total / production meters (#523). Only the non-excluded types trigger a
+    // binding fetch, which isSubmeterEquipment inspects for a numeric channel.
     const submeterEquipments = equipmentManager.getAll().filter((eq) => {
-      if (eq.type === "energy_meter") return true;
-      if (!METERING_RELAY_TYPES.has(eq.type)) return false;
+      if (NON_SUBMETER_TYPES.has(eq.type)) return false;
       return isSubmeterEquipment(eq.type, equipmentManager.getDataBindingsWithValues(eq.id));
     });
     const mainEquipmentId = findEnergyEquipmentId(equipmentManager);

--- a/src/api/routes/equipments.test.ts
+++ b/src/api/routes/equipments.test.ts
@@ -9,8 +9,9 @@ import { installValidationErrorHandler, validationAjvOptions } from "../error-ha
 // tests. A mocked EquipmentManager keeps this test fast and isolated.
 interface FixtureEq {
   id: string;
+  name: string;
   type: string;
-  dataBindings?: Array<{ alias?: string; category?: string }>;
+  dataBindings?: Array<{ alias?: string; category?: string; type?: string }>;
 }
 function makeManager(fixture: FixtureEq[]) {
   return {
@@ -25,16 +26,23 @@ function makeManager(fixture: FixtureEq[]) {
 describe("GET /api/v1/equipments — ?type / ?role filter", () => {
   let app: ReturnType<typeof Fastify>;
 
-  const power = [{ alias: "power", category: "power" }];
-  const state = [{ alias: "state", category: "light_state" }];
+  const power = [{ alias: "power", category: "power", type: "number" }];
+  const energyCh = [{ alias: "energy", category: "energy", type: "number" }];
+  const state = [{ alias: "state", category: "light_state", type: "boolean" }];
+  const booleanPower = [{ alias: "power", category: "power", type: "boolean" }];
   const fixture: FixtureEq[] = [
-    { id: "1", type: "light_onoff", dataBindings: [] },
-    { id: "2", type: "energy_meter", dataBindings: [] },
-    { id: "3", type: "energy_meter", dataBindings: [] },
-    { id: "4", type: "main_energy_meter", dataBindings: power }, // house total, never a submeter
-    { id: "5", type: "water_heater", dataBindings: power }, // metering relay (#521) → submeter
-    { id: "6", type: "switch", dataBindings: power }, // metering plug (spec 129) → submeter
-    { id: "7", type: "switch", dataBindings: state }, // bare relay → not a submeter
+    { id: "1", name: "Lampe", type: "light_onoff", dataBindings: [] },
+    { id: "2", name: "Cuisine", type: "energy_meter", dataBindings: [] },
+    { id: "3", name: "Salon", type: "energy_meter", dataBindings: [] },
+    { id: "4", name: "Compteur", type: "main_energy_meter", dataBindings: power }, // house total, never a submeter
+    { id: "5", name: "Chauffe-eau", type: "water_heater", dataBindings: power }, // metering relay (#521) → submeter
+    { id: "6", name: "Prise", type: "switch", dataBindings: power }, // metering plug (spec 129) → submeter
+    { id: "7", name: "Relais", type: "switch", dataBindings: state }, // bare relay → not a submeter
+    { id: "8", name: "Clim", type: "thermostat", dataBindings: power }, // #523 metered load → submeter
+    { id: "9", name: "Clim ecran", type: "thermostat", dataBindings: booleanPower }, // boolean gate → NOT
+    { id: "10", name: "TV", type: "media_player", dataBindings: booleanPower }, // boolean gate → NOT
+    { id: "11", name: "Solaire", type: "solar_panel", dataBindings: power }, // production, never a submeter
+    { id: "12", name: "Seche-linge", type: "appliance", dataBindings: energyCh }, // #523 metered load → submeter
   ];
 
   beforeEach(async () => {
@@ -53,7 +61,7 @@ describe("GET /api/v1/equipments — ?type / ?role filter", () => {
   it("returns all equipments when ?type is omitted", async () => {
     const res = await app.inject({ method: "GET", url: "/api/v1/equipments" });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toHaveLength(7);
+    expect(res.json()).toHaveLength(12);
   });
 
   it("narrows the result set to a single type for a non-meter ?type", async () => {
@@ -63,20 +71,23 @@ describe("GET /api/v1/equipments — ?type / ?role filter", () => {
     expect(body.map((e) => e.id)).toEqual(["1"]);
   });
 
-  it("?role=submeter returns energy_meters + metering relays, never the house total or bare relays (#526)", async () => {
+  it("?role=submeter returns ANY numeric-metered load except house/production, ordered clamps-first (#523)", async () => {
     const res = await app.inject({ method: "GET", url: "/api/v1/equipments?role=submeter" });
     expect(res.statusCode).toBe(200);
     const body = res.json() as FixtureEq[];
-    // energy_meter x2 + metering water_heater + metering switch; NOT main_energy_meter, NOT bare switch, NOT light
-    expect(body.map((e) => e.id).sort()).toEqual(["2", "3", "5", "6"]);
+    // energy_meters (2,3) → metering relays (5 water_heater, 6 switch) → other
+    // metered loads (8 thermostat #523, 12 appliance #523), each group by name.
+    // NOT: main_energy_meter (4), solar_panel (11), bare relay (7), no-channel
+    // light (1), or boolean-`power` loads (9 thermostat, 10 media_player).
+    // Deterministic order so the display's 8-slot cap keeps clamps first.
+    expect(body.map((e) => e.id)).toEqual(["2", "3", "5", "6", "8", "12"]);
   });
 
-  it("?type=energy_meter is honoured as the submeter role for the legacy display client (#224/#526)", async () => {
+  it("?type=energy_meter is honoured as the submeter role for the legacy display client, same ordered set (#224/#523)", async () => {
     const res = await app.inject({ method: "GET", url: "/api/v1/equipments?type=energy_meter" });
     expect(res.statusCode).toBe(200);
     const body = res.json() as FixtureEq[];
-    // Includes the metering water_heater so the unflashed energy display sees it.
-    expect(body.map((e) => e.id).sort()).toEqual(["2", "3", "5", "6"]);
+    expect(body.map((e) => e.id)).toEqual(["2", "3", "5", "6", "8", "12"]);
   });
 
   it("returns an empty list for an unknown type (pass-through, no 400)", async () => {

--- a/src/api/routes/equipments.ts
+++ b/src/api/routes/equipments.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import { EquipmentError } from "../../equipments/equipment-manager.js";
-import { isSubmeterEquipment } from "../../equipments/metering.js";
+import { isSubmeterEquipment, METERING_RELAY_TYPES } from "../../equipments/metering.js";
 import type { EnergyLoadProfile, EquipmentType } from "../../shared/types.js";
 import type { Logger } from "../../core/logger.js";
 
@@ -71,15 +71,20 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
 
   // GET /api/v1/equipments — List all equipments with bindings and current data.
   // Optional ?type=<EquipmentType> narrows the response to a single type.
-  // Optional ?role=submeter returns the consumption submeter set — dedicated
-  // energy_meters plus metering relays (water_heater, switch...), i.e. every
-  // equipment isSubmeterEquipment considers a per-usage meter (#526).
+  // Optional ?role=submeter returns the consumption submeter set: ANY equipment
+  // carrying a numeric power/energy channel except the house total / production
+  // meters (#523 — a metering thermostat, appliance, pool_pump, ... all qualify),
+  // i.e. every equipment isSubmeterEquipment considers a per-usage meter.
   //
   // The energy display (#224) has long queried ?type=energy_meter to get "the
-  // submeter clamps". Since metering relays became submeters (#521) that literal
-  // type filter dropped them, so ?type=energy_meter is honoured as the submeter
-  // role too — the unflashed display picks up a metering water_heater without a
-  // reflash. New clients should use ?role=submeter.
+  // submeter clamps". Since metering relays (#521) and then any metered load
+  // (#523) became submeters, that literal type filter would drop them, so
+  // ?type=energy_meter is honoured as the submeter role too — the unflashed
+  // display picks up the broader set without a reflash. New clients should use
+  // ?role=submeter. The result is ORDERED so a fixed-capacity client (the
+  // display caps at 8) keeps dedicated meters/clamps first, then metering
+  // relays, then other metered loads, each group by name — a deterministic
+  // truncation instead of unstable insertion order.
   //
   // Unknown ?type values yield an empty list rather than 400 so callers can
   // safely pass-through user input without their own validation.
@@ -89,7 +94,11 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
       const all = equipmentManager.getAllWithDetails();
       const { type, role } = request.query;
       if (role === "submeter" || type === "energy_meter") {
-        return all.filter((eq) => isSubmeterEquipment(eq.type, eq.dataBindings));
+        const rank = (t: EquipmentType): number =>
+          t === "energy_meter" ? 0 : METERING_RELAY_TYPES.has(t) ? 1 : 2;
+        return all
+          .filter((eq) => isSubmeterEquipment(eq.type, eq.dataBindings))
+          .sort((a, b) => rank(a.type) - rank(b.type) || a.name.localeCompare(b.name));
       }
       return type ? all.filter((eq) => eq.type === type) : all;
     },

--- a/src/energy/energy-aggregator.ts
+++ b/src/energy/energy-aggregator.ts
@@ -16,7 +16,7 @@ import type { Logger } from "../core/logger.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { InfluxClient } from "../core/influx-client.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
-import { isSubmeterEquipment, METERING_RELAY_TYPES } from "../equipments/metering.js";
+import { isSubmeterEquipment, NON_SUBMETER_TYPES } from "../equipments/metering.js";
 import type { ComputedDataEntry } from "../shared/types.js";
 
 /** Minimum interval between two InfluxDB refreshes per equipment (ms). */
@@ -86,9 +86,9 @@ export class EnergyAggregator {
         if (event.type === "equipment.created" || event.type === "equipment.updated") {
           const { id, type } = event.equipment;
           if (this.energyEquipmentIds.has(id)) return;
-          // Only submeter-capable types can qualify; skip lights/sensors/etc.
-          // before touching the DB for their bindings.
-          if (type !== "energy_meter" && !METERING_RELAY_TYPES.has(type)) return;
+          // Skip only the house total / production meters before touching the DB
+          // for bindings (#523); isSubmeterEquipment then gates on a numeric channel.
+          if (NON_SUBMETER_TYPES.has(type)) return;
           const bindings = this.equipmentManager.getDataBindingsWithValues(id);
           if (isSubmeterEquipment(type, bindings)) {
             this.enrol(id);

--- a/src/energy/power-submeter-integrator.ts
+++ b/src/energy/power-submeter-integrator.ts
@@ -4,7 +4,7 @@ import type { EventBus } from "../core/event-bus.js";
 import type { Logger } from "../core/logger.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { InfluxClient } from "../core/influx-client.js";
-import { isSubmeterEquipment, METERING_RELAY_TYPES } from "../equipments/metering.js";
+import { isSubmeterEquipment, NON_SUBMETER_TYPES } from "../equipments/metering.js";
 
 /**
  * Power-only submeter integration.
@@ -140,11 +140,11 @@ export class PowerSubmeterIntegrator {
    * the energy counter moving when the device only reports on change.
    */
   private catchUpFromBindings(): void {
-    // energy_meter submeters + metering relays (switch/water_heater, spec 129/#521).
-    // Bare relays are filtered out by isPowerOnlySubmeter (no power binding).
+    // Any equipment except the house/production meters (#523); isPowerOnlySubmeter
+    // then refines to those actually carrying a power-but-no-energy channel.
     const equipments = this.equipmentManager
       .getAll()
-      .filter((e) => e.type === "energy_meter" || METERING_RELAY_TYPES.has(e.type));
+      .filter((e) => !NON_SUBMETER_TYPES.has(e.type));
     for (const eq of equipments) {
       if (!this.isPowerOnlySubmeter(eq.id)) continue;
       const bindings = this.equipmentManager.getDataBindingsWithValues(eq.id);

--- a/src/equipments/metering.test.ts
+++ b/src/equipments/metering.test.ts
@@ -53,6 +53,10 @@ describe("metering helpers (spec 129 / #523)", () => {
     expect(isSubmeterEquipment("thermostat", [])).toBe(false);
     expect(isSubmeterEquipment("switch", state)).toBe(false);
     expect(isSubmeterEquipment("media_player", booleanPower)).toBe(false);
+    // The real old-vs-new regression guard: under the OLD code a metering
+    // `switch` with a boolean `power` was a submeter (no numeric gate); the
+    // #523 numeric gate now excludes it.
+    expect(isSubmeterEquipment("switch", booleanPower)).toBe(false);
 
     // The three exclusions: house total + production must never be submeters.
     expect(isSubmeterEquipment("main_energy_meter", power)).toBe(false);

--- a/src/equipments/metering.test.ts
+++ b/src/equipments/metering.test.ts
@@ -1,40 +1,62 @@
 import { describe, it, expect } from "vitest";
 import { hasMeteringBinding, isMeteringSwitch, isSubmeterEquipment } from "./metering.js";
 
-const power = [{ alias: "power", category: "power" }];
-const energy = [{ alias: "energy", category: "energy" }];
-const state = [{ alias: "state", category: "light_state" }];
-const battery = [{ alias: "battery", category: "battery" }];
+const power = [{ alias: "power", category: "power", type: "number" }];
+const energy = [{ alias: "energy", category: "energy", type: "number" }];
+const state = [{ alias: "state", category: "light_state", type: "boolean" }];
+const battery = [{ alias: "battery", category: "battery", type: "number" }];
+// An on/off switch mis-categorised as `power` (Panasonic AC, media_player): a
+// STATE, not a measurement. Must not count as a metering channel (#523).
+const booleanPower = [{ alias: "power", category: "power", type: "boolean" }];
 
-describe("metering helpers (spec 129)", () => {
-  it("hasMeteringBinding detects power or energy channels", () => {
+describe("metering helpers (spec 129 / #523)", () => {
+  it("hasMeteringBinding detects NUMERIC power or energy channels", () => {
     expect(hasMeteringBinding(power)).toBe(true);
     expect(hasMeteringBinding(energy)).toBe(true);
     expect(hasMeteringBinding([...state, ...battery])).toBe(false);
     expect(hasMeteringBinding([])).toBe(false);
+    // #523 numeric gate: a boolean on/off `power` is not a measurement.
+    expect(hasMeteringBinding(booleanPower)).toBe(false);
+    // Absent type stays lenient (bare callers/tests) — treated as numeric.
+    expect(hasMeteringBinding([{ alias: "power", category: "power" }])).toBe(true);
   });
 
-  it("isMeteringSwitch: switch with power/energy is a metering plug", () => {
+  it("isMeteringSwitch: switch/water_heater card concern is unchanged (spec 129)", () => {
     expect(isMeteringSwitch("switch", power)).toBe(true);
     expect(isMeteringSwitch("switch", energy)).toBe(true);
     expect(isMeteringSwitch("switch", state)).toBe(false); // bare relay
-    expect(isMeteringSwitch("light_onoff", power)).toBe(false); // not a switch
-    expect(isMeteringSwitch("energy_meter", power)).toBe(false); // not a switch
+    expect(isMeteringSwitch("light_onoff", power)).toBe(false); // not a relay type
+    expect(isMeteringSwitch("energy_meter", power)).toBe(false); // not a relay type
+    expect(isMeteringSwitch("water_heater", power)).toBe(true); // #521
+    expect(isMeteringSwitch("water_heater", state)).toBe(false);
   });
 
-  it("isMeteringSwitch: water_heater with power/energy is a metering relay (#521)", () => {
-    expect(isMeteringSwitch("water_heater", power)).toBe(true);
-    expect(isMeteringSwitch("water_heater", energy)).toBe(true);
-    expect(isMeteringSwitch("water_heater", state)).toBe(false); // bare relay, no metering
-  });
+  it("isSubmeterEquipment: ANY numeric-metered load except house/production (#523)", () => {
+    // The headline: a metering thermostat (the AC on its clamp) now enrols.
+    expect(isSubmeterEquipment("thermostat", power)).toBe(true);
+    // Numeric gate: the thermostat's own boolean on/off must NOT enrol it.
+    expect(isSubmeterEquipment("thermostat", booleanPower)).toBe(false);
 
-  it("isSubmeterEquipment: energy_meter OR metering relay", () => {
-    expect(isSubmeterEquipment("energy_meter", [])).toBe(true);
+    // Other generic metered loads enrol without a per-type whitelist.
+    expect(isSubmeterEquipment("appliance", power)).toBe(true);
+    expect(isSubmeterEquipment("pool_pump", energy)).toBe(true);
+    expect(isSubmeterEquipment("light_dimmable", power)).toBe(true);
+
+    // Still-valid prior cases.
+    expect(isSubmeterEquipment("energy_meter", power)).toBe(true);
     expect(isSubmeterEquipment("switch", power)).toBe(true);
-    expect(isSubmeterEquipment("switch", state)).toBe(false); // bare relay
     expect(isSubmeterEquipment("water_heater", power)).toBe(true); // #521
-    expect(isSubmeterEquipment("water_heater", state)).toBe(false); // no metering binding
-    expect(isSubmeterEquipment("main_energy_meter", power)).toBe(false); // house total, not a submeter
-    expect(isSubmeterEquipment("light_onoff", power)).toBe(false);
+    // A declared energy_meter qualifies on type alone (card renders at 0, #527).
+    expect(isSubmeterEquipment("energy_meter", [])).toBe(true);
+
+    // A non-meter load with no numeric channel does not enrol.
+    expect(isSubmeterEquipment("thermostat", [])).toBe(false);
+    expect(isSubmeterEquipment("switch", state)).toBe(false);
+    expect(isSubmeterEquipment("media_player", booleanPower)).toBe(false);
+
+    // The three exclusions: house total + production must never be submeters.
+    expect(isSubmeterEquipment("main_energy_meter", power)).toBe(false);
+    expect(isSubmeterEquipment("energy_production_meter", power)).toBe(false);
+    expect(isSubmeterEquipment("solar_panel", power)).toBe(false);
   });
 });

--- a/src/equipments/metering.ts
+++ b/src/equipments/metering.ts
@@ -18,30 +18,52 @@ export { METERING_CATEGORIES };
 
 /**
  * On/off relay equipment types that carry the same candidate shape as a
- * `switch` (spec 129) and can therefore double as a consumption submeter when
- * they report power/energy. A `water_heater` (spec 135) is a relay with an
- * optional metering attach, exactly like a metering plug (#521). Extend this
- * set to enroll further pilotable loads (`heater`, `pool_pump`, `appliance`).
+ * `switch` (spec 129). Kept ONLY for the card-display concern (`isMeteringSwitch`
+ * — a plug/relay that shows live power on its own card, spec 129/#521). Since
+ * #523, submeter ENROLMENT no longer keys off this whitelist: it is a blocklist
+ * (`isSubmeterEquipment` below). Extend this only for card rendering.
  */
 export const METERING_RELAY_TYPES: ReadonlySet<EquipmentType> = new Set<EquipmentType>([
   "switch",
   "water_heater",
 ]);
 
+/**
+ * The only types that carry a power/energy channel yet must NEVER count as a
+ * consumption submeter (#523): the grid total and the two production surfaces.
+ * Counting them would double-count the house balance and fold production into
+ * consumption. This is the sole exclusion list for submeter enrolment.
+ */
+export const NON_SUBMETER_TYPES: ReadonlySet<EquipmentType> = new Set<EquipmentType>([
+  "main_energy_meter",
+  "energy_production_meter",
+  "solar_panel",
+]);
+
 interface BindingLike {
   alias?: string | null;
   category?: string | null;
+  type?: string | null;
 }
 
-/** True when the bindings carry a meaningful metering channel (power or energy). */
+/**
+ * True when the bindings carry a meaningful, NUMERIC metering channel (power or
+ * energy). The numeric gate (#523) rejects an on/off reading mis-categorised as
+ * `power` — a `media_player`, or a thermostat's own boolean power switch — which
+ * is a STATE, not a measurement, and would otherwise enrol as a 0 W submeter.
+ * `type` is absent on the bare BindingLike shape used by some callers/tests;
+ * absent is treated as numeric to preserve their behaviour (production callers
+ * always pass the resolved `DataType`).
+ */
 export function hasMeteringBinding(bindings: readonly BindingLike[]): boolean {
-  return bindings.some(
-    (b) =>
+  return bindings.some((b) => {
+    const isPowerOrEnergy =
       b.category === "power" ||
       b.category === "energy" ||
       b.alias === "power" ||
-      b.alias === "energy",
-  );
+      b.alias === "energy";
+    return isPowerOrEnergy && (b.type === undefined || b.type === null || b.type === "number");
+  });
 }
 
 /** A metering relay (`switch`, `water_heater`, ...) that also reports power/energy. */
@@ -50,13 +72,19 @@ export function isMeteringSwitch(type: EquipmentType, bindings: readonly Binding
 }
 
 /**
- * Equipments that count as per-equipment consumption submeters: dedicated
- * `energy_meter`s and metering switches. (Not `main_energy_meter` /
- * `energy_production_meter`, which are the house total and production.)
+ * Equipments that count as per-equipment consumption submeters (#523): ANY
+ * equipment carrying a numeric power/energy channel, EXCEPT the house total and
+ * the production meters (`NON_SUBMETER_TYPES`). A blocklist, not a whitelist —
+ * a new metered load (a metering thermostat, `pool_pump`, `appliance`, ...) is
+ * enrolled automatically, no per-type list to extend.
+ *
+ * A dedicated `energy_meter` qualifies on its type alone: it is a declared
+ * meter, so its card renders at 0 before it has reported any binding (#527).
  */
 export function isSubmeterEquipment(
   type: EquipmentType,
   bindings: readonly BindingLike[],
 ): boolean {
-  return type === "energy_meter" || isMeteringSwitch(type, bindings);
+  if (NON_SUBMETER_TYPES.has(type)) return false;
+  return type === "energy_meter" || hasMeteringBinding(bindings);
 }

--- a/ui/src/lib/metering.test.ts
+++ b/ui/src/lib/metering.test.ts
@@ -4,7 +4,7 @@ import { isMeteringSwitch, isSubmeterEquipment } from "./metering";
 
 function eq(
   type: EquipmentWithDetails["type"],
-  bindings: { alias: string; category?: string }[],
+  bindings: { alias: string; category?: string; type?: "number" | "boolean" }[],
 ): EquipmentWithDetails {
   return {
     id: "e",
@@ -22,7 +22,7 @@ function eq(
       deviceName: "D",
       key: b.alias,
       alias: b.alias,
-      type: "number",
+      type: b.type ?? "number",
       category: (b.category ?? "generic") as EquipmentWithDetails["dataBindings"][number]["category"],
       value: 0,
       lastUpdated: null,
@@ -34,26 +34,45 @@ function eq(
   } as EquipmentWithDetails;
 }
 
-describe("metering (UI) — spec 129", () => {
-  it("isMeteringSwitch: switch with power/energy only", () => {
-    expect(isMeteringSwitch(eq("switch", [{ alias: "power", category: "power" }]))).toBe(true);
-    expect(isMeteringSwitch(eq("switch", [{ alias: "energy", category: "energy" }]))).toBe(true);
-    expect(isMeteringSwitch(eq("switch", [{ alias: "state", category: "light_state" }]))).toBe(false);
-    expect(isMeteringSwitch(eq("light_onoff", [{ alias: "power", category: "power" }]))).toBe(false);
+const power = [{ alias: "power", category: "power" }];
+const energy = [{ alias: "energy", category: "energy" }];
+const relayState = [{ alias: "state", category: "light_state", type: "boolean" as const }];
+const booleanPower = [{ alias: "power", category: "power", type: "boolean" as const }];
+
+describe("metering (UI) — spec 129 / #523", () => {
+  it("isMeteringSwitch: switch/water_heater card concern is unchanged (spec 129)", () => {
+    expect(isMeteringSwitch(eq("switch", power))).toBe(true);
+    expect(isMeteringSwitch(eq("switch", energy))).toBe(true);
+    expect(isMeteringSwitch(eq("switch", relayState))).toBe(false);
+    expect(isMeteringSwitch(eq("light_onoff", power))).toBe(false);
+    expect(isMeteringSwitch(eq("water_heater", power))).toBe(true); // #521
+    expect(isMeteringSwitch(eq("water_heater", relayState))).toBe(false);
   });
 
-  it("isMeteringSwitch: water_heater with power/energy is a metering relay (#521)", () => {
-    expect(isMeteringSwitch(eq("water_heater", [{ alias: "power", category: "power" }]))).toBe(true);
-    expect(isMeteringSwitch(eq("water_heater", [{ alias: "energy", category: "energy" }]))).toBe(true);
-    expect(isMeteringSwitch(eq("water_heater", [{ alias: "state", category: "light_state" }]))).toBe(false);
-  });
+  it("isSubmeterEquipment: ANY numeric-metered load except house/production (#523)", () => {
+    // The headline: a metering thermostat (the AC on its clamp) now enrols.
+    expect(isSubmeterEquipment(eq("thermostat", power))).toBe(true);
+    // Numeric gate: the thermostat's own boolean on/off must NOT enrol it.
+    expect(isSubmeterEquipment(eq("thermostat", booleanPower))).toBe(false);
 
-  it("isSubmeterEquipment: energy_meter or metering relay", () => {
+    // Generic metered loads enrol without a per-type whitelist.
+    expect(isSubmeterEquipment(eq("appliance", energy))).toBe(true);
+    expect(isSubmeterEquipment(eq("pool_pump", power))).toBe(true);
+
+    // Still-valid prior cases.
+    expect(isSubmeterEquipment(eq("energy_meter", power))).toBe(true);
+    expect(isSubmeterEquipment(eq("switch", power))).toBe(true);
+    expect(isSubmeterEquipment(eq("water_heater", power))).toBe(true);
+    // A declared energy_meter qualifies on type alone (card renders at 0, #527).
     expect(isSubmeterEquipment(eq("energy_meter", []))).toBe(true);
-    expect(isSubmeterEquipment(eq("switch", [{ alias: "power", category: "power" }]))).toBe(true);
-    expect(isSubmeterEquipment(eq("switch", [{ alias: "state", category: "light_state" }]))).toBe(false);
-    expect(isSubmeterEquipment(eq("water_heater", [{ alias: "power", category: "power" }]))).toBe(true);
-    expect(isSubmeterEquipment(eq("water_heater", [{ alias: "state", category: "light_state" }]))).toBe(false);
-    expect(isSubmeterEquipment(eq("main_energy_meter", [{ alias: "power", category: "power" }]))).toBe(false);
+
+    // A non-meter load with no numeric channel → not a submeter.
+    expect(isSubmeterEquipment(eq("thermostat", []))).toBe(false);
+    expect(isSubmeterEquipment(eq("switch", relayState))).toBe(false);
+
+    // The three exclusions.
+    expect(isSubmeterEquipment(eq("main_energy_meter", power))).toBe(false);
+    expect(isSubmeterEquipment(eq("energy_production_meter", power))).toBe(false);
+    expect(isSubmeterEquipment(eq("solar_panel", power))).toBe(false);
   });
 });

--- a/ui/src/lib/metering.ts
+++ b/ui/src/lib/metering.ts
@@ -13,25 +13,43 @@ export const METERING_CATEGORIES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * On/off relay types that can double as a consumption submeter when they
- * report power/energy: a metering plug (spec 129) and a water_heater relay
- * (spec 135 / #521). Mirror of METERING_RELAY_TYPES in src/equipments/metering.ts.
+ * On/off relay types kept ONLY for the card-display concern (`isMeteringSwitch`,
+ * spec 129/#521). Mirror of METERING_RELAY_TYPES in src/equipments/metering.ts.
+ * Since #523, submeter enrolment keys off NON_SUBMETER_TYPES below, not this list.
  */
 export const METERING_RELAY_TYPES: ReadonlySet<string> = new Set(["switch", "water_heater"]);
 
-export function isMeteringSwitch(eq: EquipmentWithDetails): boolean {
-  return (
-    METERING_RELAY_TYPES.has(eq.type) &&
-    eq.dataBindings.some(
-      (b) =>
-        b.category === "power" ||
+/**
+ * Types that carry a power/energy channel but must never count as a consumption
+ * submeter (#523): the grid total and the two production surfaces. Mirror of
+ * NON_SUBMETER_TYPES in src/equipments/metering.ts.
+ */
+export const NON_SUBMETER_TYPES: ReadonlySet<string> = new Set([
+  "main_energy_meter",
+  "energy_production_meter",
+  "solar_panel",
+]);
+
+/** A meaningful, NUMERIC power/energy channel (#523): a boolean on/off reading
+ *  mis-categorised as `power` (a media_player, a thermostat's own switch) is a
+ *  STATE, not a measurement, and must not enrol as a submeter. */
+function hasMeteringBinding(eq: EquipmentWithDetails): boolean {
+  return eq.dataBindings.some(
+    (b) =>
+      (b.category === "power" ||
         b.category === "energy" ||
         b.alias === "power" ||
-        b.alias === "energy",
-    )
+        b.alias === "energy") &&
+      b.type === "number",
   );
 }
 
+export function isMeteringSwitch(eq: EquipmentWithDetails): boolean {
+  return METERING_RELAY_TYPES.has(eq.type) && hasMeteringBinding(eq);
+}
+
 export function isSubmeterEquipment(eq: EquipmentWithDetails): boolean {
-  return eq.type === "energy_meter" || isMeteringSwitch(eq);
+  if (NON_SUBMETER_TYPES.has(eq.type)) return false;
+  // A declared energy_meter qualifies on type alone (card renders at 0, #527).
+  return eq.type === "energy_meter" || hasMeteringBinding(eq);
 }


### PR DESCRIPTION
## Context

Follow-up to #521 (metering `water_heater` enrolled as an energy submeter). Generalises submeter enrolment so **any equipment carrying a numeric power/energy channel counts in the energy balance**, regardless of its type — no more hand-maintained type whitelist.

Motivating case: an air conditioner (`thermostat`) whose real power is measured by a Legrand clamp bound onto the equipment should be integrated to energy by the `PowerSubmeterIntegrator` and counted in the by-usage balance, exactly like the water heater.

## Change (Level 1 — balance inclusion)

Invert `isSubmeterEquipment` from a per-type **whitelist** (`energy_meter` + `METERING_RELAY_TYPES = {switch, water_heater}`) to a **blocklist**:

> a consumption submeter = carries a **numeric** `power`/`energy` binding, EXCEPT `main_energy_meter`, `energy_production_meter`, `solar_panel` (`NON_SUBMETER_TYPES`).

- **Numeric gate** (not in the original issue): `hasMeteringBinding` now requires a numeric channel. A boolean on/off reading mis-categorised as `power` (a `media_player`, a thermostat's own on/off switch) is a STATE, not a measurement, and must not enrol as a 0 W submeter.
- A dedicated `energy_meter` still qualifies on type alone, so its card renders at 0 before first data (#527).
- The three type pre-filters (integrator `catchUpFromBindings`, aggregator create/update handler, by-usage route) widen to iterate all non-excluded types. `METERING_RELAY_TYPES` is kept for the switch/water_heater card concern (spec 129) and to rank the display list.

## Review follow-up (clamps-first ordering)

The `/api/v1/equipments?role=submeter` / `?type=energy_meter` endpoint inherits the generalized set. The energy display (#224) queries `?type=energy_meter` and caps at 8 meters, previously relying on insertion order. The result is now **ordered deterministically** — dedicated `energy_meter`s, then metering relays, then other metered loads, each group by name — so a fixed-capacity client truncates stably and keeps real clamps first.

## Tests

- `metering.test.ts` (backend + UI): blocklist + numeric gate; the real old-vs-new regression guard (`isSubmeterEquipment("switch", booleanPower)` was `true` before, `false` after); the 3 exclusions; `energy_meter` type-alone; generalized loads (thermostat, appliance, pool_pump).
- `equipments.test.ts`: route fixture extended with a metered thermostat/appliance and boolean-`power` loads the gate must exclude; asserts the deterministic clamps-first ordering.
- `energy.test.ts`: mock `getDataBindingsWithValues` added (the by-usage route now inspects bindings for every non-excluded type).
- Full suite green: 1399 backend + 463 UI.

## Validated end-to-end on a shadow instance (real data)

Rebuilt the shadow on this branch, seeded from a prod backup, and rehearsed the full operation on the household's actual AC + Legrand clamp:
1. Bound the clamp's numeric power onto the `thermostat` → it enrols as a submeter and appears in the by-usage breakdown (the `?role=submeter` set stays small and correct — 4 loads, the numeric gate excludes all the dimmable lights / sensors).
2. Migrated the AC's ~100 days of energy history (raw + hourly + daily buckets) from the separate `energy_meter` equipment onto the `thermostat` (Influx `set(equipmentId)` + `to()`), source deleted, counts verified.
3. The Sowel by-usage API then shows the AC's real daily Wh under the `thermostat`; the old `energy_meter` reads 0.

The history migration is an **operational step, not part of this PR's code**, and will only run on prod with explicit authorization.

## Scope

Level 1 (data inclusion) only. Level 2 of #523 (a generic "is submeter → show energy + live power" per-card rendering path, replacing the per-type card hardcoding) is a deliberate follow-up.

Closes #523
