### PR TITLE
release: v1.49.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,15 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.49.x : Sous-comptage universel
+
+### v1.49.0 — 2026-08-16 { #v1-49-0 }
+
+- Feat (énergie) : **tout équipement qui mesure une puissance ou une énergie est désormais compté dans le bilan, quel que soit son type**. L'enrôlement en sous-compteur reposait sur une liste blanche par type (compteurs dédiés, prises et chauffe-eau mesureurs) ; c'est maintenant l'inverse, si bien qu'un thermostat mesuré (une climatisation sur sa propre pince de mesure), une pompe de piscine, un électroménager ou une lumière variateur avec mesure entrent tous dans la répartition par usage et voient leur puissance intégrée en énergie, sans liste par type à maintenir. Seuls le compteur principal et les compteurs de production sont exclus. Une liaison doit porter une vraie mesure numérique : un état Marche/Arrêt exposé en « power » (un lecteur multimédia, l'interrupteur d'un thermostat) est un état, pas une mesure, et n'est jamais pris pour un sous-compteur à 0 W. La liste des sous-compteurs de l'afficheur d'énergie est désormais ordonnée compteurs dédiés d'abord pour que sa capacité fixe de 8 conserve les vraies pinces. (#523, #548)
+- Feat (ui) : **les durées minimales de marche et d'arrêt du profil énergie s'éditent en minutes** au lieu de secondes, au plus près de la façon dont on raisonne ces valeurs. (#546, #547)
+- Correctif (énergie) : **les runs hors pilotage ouverts sont restaurés depuis le journal au démarrage**, si bien qu'une charge laissée en marche hors arbitrage garde sa timeline correcte après un redémarrage au lieu d'être peinte hors pilotage jusqu'à son prochain cycle complet. (#543, #544)
+- Chore (registry) : pool-pump-schedule passé en 1.5.0 (la pompe à chaleur de piscine peut désormais chauffer sur le surplus solaire via sa consigne). (#545)
+
 ## 1.48.x : Valeurs typées et portails sur tout relais
 
 ### v1.48.1 — 2026-08-16 { #v1-48-1 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,15 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.49.x: Universal submetering
+
+### v1.49.0 — 2026-08-16 { #v1-49-0 }
+
+- Feat (energy): **any equipment that measures power or energy now counts in the energy balance, whatever its type**. Submeter enrolment used to be a per-type whitelist (dedicated meters plus metering switches and water heaters); it is now the inverse, so a metering thermostat (an air conditioner on its own energy clamp), a pool pump, an appliance or a metering dimmable light all enter the by-usage breakdown and have their power integrated to energy, with no per-type list to maintain. Only the house total and the production meters are excluded. A binding must carry a real numeric measurement: a boolean on/off reading exposed as "power" (a media player, a thermostat's own switch) is a state, not a measurement, and is never mistaken for a 0 W submeter. The energy display's submeter list is now ordered dedicated meters first so its fixed 8-meter capacity keeps the real clamps. (#523, #548)
+- Feat (ui): **the energy profile minimum on and off durations are edited in minutes** instead of seconds, matching how the values are actually reasoned about. (#546, #547)
+- Fix (energy): **open unmanaged runs are restored from the journal on startup**, so a load left running outside arbitration keeps its correct timeline after a restart instead of being painted unmanaged until its next full cycle. (#543, #544)
+- Chore (registry): pool-pump-schedule bumped to 1.5.0 (the pool heat pump can now heat on solar surplus via its setpoint). (#545)
+
 ## 1.48.x: Typed device values and universal gate relays
 
 ### v1.48.1 — 2026-08-16 { #v1-48-1 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.48.1",
+  "version": "1.49.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.48.1",
+  "version": "1.49.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release **v1.49.0**.

Covers everything merged since v1.48.1:

- **Feat (energy)** #523/#548 — any equipment measuring power/energy counts in the energy balance (generalised submetering; the AC thermostat on its clamp now qualifies).
- **Feat (ui)** #546/#547 — energy profile minOn/minOff edited in minutes.
- **Fix (energy)** #543/#544 — open unmanaged runs restored from the journal on startup.
- **Chore (registry)** #545 — pool-pump-schedule 1.5.0.

Release notes added to both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-49-0 }` anchor (spec 108). Version bumped in `package.json` + `ui/package.json`.

After merge: tag `v1.49.0` on the on-main commit and push the tag to trigger the ghcr.io image build.