### PR TITLE
feat(energy): surplus import tolerance on the equipment energy profile (#550)

### DIFF
--- a/docs/technical/data-model/equipments.md
+++ b/docs/technical/data-model/equipments.md
@@ -44,7 +44,7 @@ interface Equipment {
   icon?: string; // Lucide icon name (overrides type default)
   description?: string;
   enabled: boolean; // Disabled equipments are ignored by the engine
-  energyProfile?: EnergyLoadProfile; // Spec 140 — flexible-load declaration (class, nominal W, min-on/off, learned)
+  energyProfile?: EnergyLoadProfile; // Spec 140 — flexible-load declaration (class, nominal W, min-on/off, tolerated import W, learned)
   createdAt: string;
   updatedAt: string;
 }

--- a/src/api/routes/equipments.ts
+++ b/src/api/routes/equipments.ts
@@ -43,6 +43,7 @@ const updateEquipmentBodySchema = {
         nominalPowerW: { type: "number", exclusiveMinimum: 0, maximum: 30000 },
         minOnS: { type: "number", minimum: 0 },
         minOffS: { type: "number", minimum: 0 },
+        toleratedImportW: { type: "number", minimum: 0, maximum: 30000 },
       },
     },
     requireConfirmation: { type: "boolean" },
@@ -186,6 +187,8 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
           nominalPowerW: Math.round(p.nominalPowerW),
           minOnS: Math.round(p.minOnS),
           minOffS: Math.round(p.minOffS),
+          toleratedImportW:
+            p.toleratedImportW !== undefined ? Math.round(p.toleratedImportW) : undefined,
           learned: existing?.energyProfile?.learned,
         };
       }

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -311,6 +311,47 @@ describe("capacity arbiter", () => {
     expect(pending?.needW).toBe(300); // 600 + 100 margin - 400 tolerated
   });
 
+  it("resolves toleratedImportW from the equipment profile when the claim omits it (#550)", () => {
+    const h = makeHarness({
+      profiles: {
+        pump: {
+          class: "deferrable",
+          nominalPowerW: 600,
+          minOnS: 900,
+          minOffS: 300,
+          toleratedImportW: 400,
+        },
+      },
+    });
+    h.claim("i1", { equipmentId: "pump" }); // claim omits toleratedImportW
+    // 300 W export is short of 700 (600 + 100) without tolerance, but the
+    // profile's 400 W tolerance drops the need to 300 W → it engages.
+    h.run(-300, 300);
+    expect(h.grantedEvents()).toHaveLength(1);
+    expect(h.arbiter.getPublicState().grants[0]?.equipmentId).toBe("pump");
+  });
+
+  it("a claim's explicit toleratedImportW overrides the equipment profile (#550)", () => {
+    const h = makeHarness({
+      profiles: {
+        pump: {
+          class: "deferrable",
+          nominalPowerW: 600,
+          minOnS: 900,
+          minOffS: 300,
+          toleratedImportW: 400,
+        },
+      },
+    });
+    h.claim("i1", { equipmentId: "pump", toleratedImportW: 0 }); // override: no tolerance
+    h.feedMeter(-300);
+    h.run(-300, 300);
+    expect(h.grantedEvents()).toHaveLength(0); // needs 700, only 300 exported
+    const [pending] = h.arbiter.getPublicState().pending;
+    expect(pending?.toleratedImportW).toBe(0);
+    expect(pending?.needW).toBe(700); // 600 + 100 - 0, the profile's 400 is ignored
+  });
+
   it("flags a pending claim as running when its load runs as a recipe must-run fallback (#491)", () => {
     // A recipe keeps a surplus claim but runs the load anyway (hot day). With
     // no surplus the claim stays pending, yet the load draws power — it must

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -344,9 +344,11 @@ describe("capacity arbiter", () => {
       },
     });
     h.claim("i1", { equipmentId: "pump", toleratedImportW: 0 }); // override: no tolerance
-    h.feedMeter(-300);
-    h.run(-300, 300);
-    expect(h.grantedEvents()).toHaveLength(0); // needs 700, only 300 exported
+    // 500 W export WOULD engage the profile's 400 W tolerance (need 300), but the
+    // claim overrides to 0 (need 700) so it stays pending — the override wins over
+    // a would-engage profile (guards the `claim ?? profile` order, not `profile ?? claim`).
+    h.run(-500, 300);
+    expect(h.grantedEvents()).toHaveLength(0);
     const [pending] = h.arbiter.getPublicState().pending;
     expect(pending?.toleratedImportW).toBe(0);
     expect(pending?.needW).toBe(700); // 600 + 100 - 0, the profile's 400 is ignored

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -663,7 +663,10 @@ export class CapacityArbiter {
       equipmentId: req.equipmentId,
       instanceId,
       watts: req.watts ?? profile.nominalPowerW,
-      toleratedImportW: Math.max(0, req.toleratedImportW ?? 0),
+      // #550 — the tolerance is a property of the load: the claim may override
+      // it, but the equipment's energyProfile is the default source of truth
+      // (mirrors how `watts` falls back to nominalPowerW above).
+      toleratedImportW: Math.max(0, req.toleratedImportW ?? profile.toleratedImportW ?? 0),
       slack: req.slack ?? "none",
       note: req.note,
       status: "pending",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -623,6 +623,10 @@ export interface EnergyLoadProfile {
   nominalPowerW: number;
   minOnS: number;
   minOffS: number;
+  /** Grid import (W) this load will accept to run on a partial surplus (#550).
+   *  The arbiter engages it at `watts + engageMarginW - toleratedImportW`. A
+   *  capacity claim may still override per call; absent = 0 (no tolerance). */
+  toleratedImportW?: number;
   learned?: EnergyLoadProfileLearned;
 }
 

--- a/ui/src/components/equipments/EnergyManagementPanel.tsx
+++ b/ui/src/components/equipments/EnergyManagementPanel.tsx
@@ -60,6 +60,7 @@ export function EnergyManagementPanel({
   const [error, setError] = useState<string | null>(null);
   const [cls, setCls] = useState<EnergyLoadClass | "">(profile?.class ?? defaults.class ?? "");
   const [watts, setWatts] = useState<number>(profile?.nominalPowerW ?? defaults.nominalPowerW);
+  const [toleratedImportW, setToleratedImportW] = useState<number>(profile?.toleratedImportW ?? 0);
   const [minOnS, setMinOnS] = useState<number>(profile?.minOnS ?? defaults.minOnS);
   const [minOffS, setMinOffS] = useState<number>(profile?.minOffS ?? defaults.minOffS);
 
@@ -71,6 +72,7 @@ export function EnergyManagementPanel({
   const commit = async (p: {
     cls: EnergyLoadClass | "";
     watts: number;
+    toleratedImportW: number;
     minOnS: number;
     minOffS: number;
   }) => {
@@ -81,6 +83,7 @@ export function EnergyManagementPanel({
       const next: EnergyLoadProfile = {
         class: p.cls,
         nominalPowerW: p.watts,
+        toleratedImportW: Number.isFinite(p.toleratedImportW) ? Math.max(0, p.toleratedImportW) : 0,
         minOnS: p.minOnS,
         minOffS: p.minOffS,
       };
@@ -94,9 +97,17 @@ export function EnergyManagementPanel({
   };
 
   /** Live-save an edit, but only once a profile already exists. */
-  const commitEdit = (overrides: Partial<{ cls: EnergyLoadClass | ""; watts: number; minOnS: number; minOffS: number }>) => {
+  const commitEdit = (
+    overrides: Partial<{
+      cls: EnergyLoadClass | "";
+      watts: number;
+      toleratedImportW: number;
+      minOnS: number;
+      minOffS: number;
+    }>,
+  ) => {
     if (!profile) return;
-    void commit({ cls, watts, minOnS, minOffS, ...overrides });
+    void commit({ cls, watts, toleratedImportW, minOnS, minOffS, ...overrides });
   };
 
   const clear = async () => {
@@ -207,6 +218,20 @@ export function EnergyManagementPanel({
               />
             </div>
             <div>
+              <label htmlFor="ep-tolimport" className="block text-[12px] text-text-secondary mb-1">
+                {t("energyProfile.toleratedImport")}
+              </label>
+              <input
+                id="ep-tolimport"
+                type="number"
+                min={0}
+                value={toleratedImportW || ""}
+                onChange={(e) => setToleratedImportW(Number(e.target.value))}
+                onBlur={() => commitEdit({ toleratedImportW })}
+                className={inputCls}
+              />
+            </div>
+            <div>
               <label htmlFor="ep-minon" className="block text-[12px] text-text-secondary mb-1">
                 {t("energyProfile.minOn")}
               </label>
@@ -253,7 +278,7 @@ export function EnergyManagementPanel({
           {!profile &&
             (complete ? (
               <button
-                onClick={() => void commit({ cls, watts, minOnS, minOffS })}
+                onClick={() => void commit({ cls, watts, toleratedImportW, minOnS, minOffS })}
                 disabled={saving}
                 className="mt-3 px-3 py-1.5 bg-primary text-white text-[13px] font-medium rounded-md hover:bg-primary-hover disabled:opacity-50"
               >

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1164,6 +1164,7 @@
   "energyProfile.deferrable": "Deferrable",
   "energyProfile.comfort": "Comfort",
   "energyProfile.nominalW": "Nominal power (W)",
+  "energyProfile.toleratedImport": "Tolerated import (W)",
   "energyProfile.minOn": "Min run (min)",
   "energyProfile.minOff": "Min rest (min)",
   "energyProfile.learned": "Measured: {{watts}} W over {{runs}} runs",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1164,6 +1164,7 @@
   "energyProfile.deferrable": "Différable",
   "energyProfile.comfort": "Confort",
   "energyProfile.nominalW": "Puissance nominale (W)",
+  "energyProfile.toleratedImport": "Import toléré (W)",
   "energyProfile.minOn": "Marche mini (min)",
   "energyProfile.minOff": "Arrêt mini (min)",
   "energyProfile.learned": "Mesuré : {{watts}} W sur {{runs}} marches",

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -286,6 +286,8 @@ export interface EnergyLoadProfile {
   nominalPowerW: number;
   minOnS: number;
   minOffS: number;
+  /** Grid import (W) this load accepts to run on a partial surplus (#550). */
+  toleratedImportW?: number;
   /** Core-maintained measured estimate; read-only in the UI. */
   learned?: { watts: number; atIso: string; runs: number };
 }


### PR DESCRIPTION
## What

Phase 1 of the surplus-tolerance rework. Moves `toleratedImportW` from per-recipe capacity claims to the equipment's `energyProfile`, where `nominalPowerW` / `minOnS` / `minOffS` / `class` already live — it is a property of the load's economics, not the automation.

## Design

The arbiter resolves the effective tolerance as `claim.toleratedImportW ?? profile.toleratedImportW ?? 0`, mirroring how `watts` falls back to `nominalPowerW`. Resolved once at `claim()` time; every consumer (engageNeedW, the deficit `toleratedSum`, the public state) reads that stored value.

- A claim **may still override** per call, so existing recipes passing an explicit value are unchanged (pool-pump 300, smart-cooling 0).
- When a claim **omits** it, the equipment's configured value applies.
- Default 0 = today's behaviour. `energyProfile` is a JSON column, so **no migration** (absent field parses to `undefined` → 0).

## UI

A new **Import toléré (W)** field in the Pilotage énergie panel, right after *Puissance nominale (W)* (FR + EN), live-saved like the others. Shows for both comfort and deferrable (the tolerance applies to any claim).

![panel](https://github.com/user-attachments/assets/placeholder)

## Tests

- Arbiter precedence: the profile default engages a claim where 0 would not (fails on main); a claim's explicit value overrides a *would-engage* profile (guards the `claim ?? profile` order).
- Update-route schema accepts the field, rejects negatives, round-trips.
- Full suite green (1401 backend + 463 UI).

## Verified on a shadow instance (real data)

Rebuilt the shadow on this branch: set the PAC's tolerance to 1000 W via the panel, it persists and reloads; a negative value is rejected (400); the field renders in the requested position next to the nominal power.

## Follow-up phases (separate)

- pool-pump-schedule: drop its `toleratedImportW` / `heaterToleratedImportW` slots, read from the profile (paired release, `sowelVersion` bump).
- smart-cooling v2.0: drop the hardcoded 0, add surplus-proportional pre-cooling.

Closes #550
