### PR TITLE
release: v1.50.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,12 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.50.x : Tolérance de surplus par équipement
+
+### v1.50.0 — 2026-08-16 { #v1-50-0 }
+
+- Feat (énergie) : **la quantité d'import réseau qu'une charge pilotable accepte pour tourner sur un surplus partiel se règle désormais sur l'équipement, à côté de sa puissance nominale**. L'arbitre de capacité engage une charge dès que le surplus couvre « puissance nominale + marge - import toléré » ; cette tolérance était jusqu'ici fixée par chaque recette, elle vit maintenant sur le profil énergie de l'équipement (panneau Pilotage énergie), comme la puissance nominale et les durées mini de marche/arrêt. Une automatisation peut toujours la surcharger pour un besoin ponctuel, mais l'équipement est la source de vérité par défaut, si bien que la même charge se comporte de façon cohérente quelle que soit la recette qui la pilote. Le défaut 0 conserve le comportement précédent. (#550, #551)
+
 ## 1.49.x : Sous-comptage universel
 
 ### v1.49.0 — 2026-08-16 { #v1-49-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,12 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.50.x: Per-equipment surplus tolerance
+
+### v1.50.0 — 2026-08-16 { #v1-50-0 }
+
+- Feat (energy): **how much grid import a flexible load will accept to run on a partial surplus is now set on the equipment, next to its nominal power**. The capacity arbiter engages a load once the surplus covers `nominal power + margin - tolerated import`; that tolerance used to be fixed by each recipe, and now lives on the equipment's energy profile (Pilotage énergie panel) alongside the nominal power and the minimum on/off times. An automation may still override it for a specific claim, but the equipment is the default source of truth, so the same load behaves consistently whatever drives it. Default 0 keeps the previous behaviour. (#550, #551)
+
 ## 1.49.x: Universal submetering
 
 ### v1.49.0 — 2026-08-16 { #v1-49-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.49.0",
+  "version": "1.50.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.49.0",
+  "version": "1.50.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release **v1.50.0** — surplus import tolerance on the equipment energy profile (#550, #551).

Only change since v1.49.0. Release notes added to both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-50-0 }` anchor (spec 108). Version bumped in `package.json` + `ui/package.json`.

After merge: tag `v1.50.0` on the on-main commit and push to trigger the ghcr.io build.