### PR TITLE
docs(energy): tolerated-import field + fix the class wording (#550, #555)

### DIFF
--- a/docs/technical/recipe-development.md
+++ b/docs/technical/recipe-development.md
@@ -269,11 +269,14 @@ reacts to callbacks:
 const claim = ctx.helpers.energy?.claimCapacity({
   equipmentId: pumpId,
   watts: 600, // sizes the engage decision only
-  toleratedImportW: 0, // grid draw you accept to buy (resistive loads)
+  // Omit `toleratedImportW`: since core 1.50 (#550) the surplus-import
+  // tolerance is a property of the equipment (its energy profile's
+  // "Tolerated import (W)"), set once by the user and read by the arbiter.
+  // Pass it here only to override the profile for a specific claim.
   slack: "none", // "some"/"high" steps DOWN the user's list, never up
   note: "filtration on surplus",
   onGranted: () => pumpOn(),
-  onRevoked: (reason) => pumpOff(), // comfort loads degrade instead — never off
+  onRevoked: (reason) => pumpOff(), // a comfort-class recipe drops its surplus boost instead of switching off
 });
 // later: claim.release() when the need disappears
 ```

--- a/docs/user/energy.fr.md
+++ b/docs/user/energy.fr.md
@@ -160,8 +160,9 @@ Il est **désactivé par défaut** et ne change rien tant que vous ne l'activez 
 
 Sur un équipement qui peut s'allumer et s'éteindre (pompe de piscine, chauffe-eau, un interrupteur pilotant un radiateur), ouvrez sa fiche et activez **Pilotage énergie**. Vous choisissez :
 
-- **Classe** — _Différable_ (peut être coupée puis rattrapée plus tard, comme une pompe de piscine) ou _Confort_ (ne reçoit qu'un bonus par-dessus son fonctionnement normal, jamais coupée par l'arbitre, comme une climatisation). Sowel présélectionne la bonne classe selon le type d'équipement ; vous pouvez la corriger.
+- **Classe** — _Différable_ (un relais dont marche/arrêt est une commande, comme une pompe de piscine ou un chauffe-eau : l'arbitre peut la couper et la relancer plus tard, et un on/off inattendu est lu comme une reprise en main manuelle) ou _Confort_ (une charge qui se régule seule, comme une climatisation : le surplus ne fait que compléter son fonctionnement, et l'arbitre n'interprète pas son cycling normal comme une action de votre part). Sowel présélectionne la bonne classe selon le type d'équipement ; vous pouvez la corriger.
 - **Puissance nominale** — pré-remplie depuis la mesure de l'équipement quand une pince est associée.
+- **Import toléré (W)** — combien d'import réseau cette charge accepte pour démarrer sur un **surplus partiel**. L'arbitre l'engage dès que le surplus couvre « puissance nominale + marge − import toléré ». À `0` (défaut), elle n'attend qu'un surplus complet ; monter cette valeur la fait démarrer plus tôt, en acceptant d'acheter un peu de réseau. C'est le curseur confort / économie de la charge, réglé une fois ici et respecté par toute automatisation qui la pilote.
 - **Marche / arrêt minimum** — durée minimale de marche une fois démarré, et de repos avant redémarrage (protège un compresseur des cycles courts).
 
 Activer ceci ne fait que _déclarer_ la charge. Rien ne la pilote tant que l'arbitre lui-même n'est pas activé.

--- a/docs/user/energy.md
+++ b/docs/user/energy.md
@@ -160,8 +160,9 @@ It is **off by default** and changes nothing until you enable it. On a home with
 
 On an equipment that can be switched on and off (pool pump, water heater, a switch driving a heater), open its page and turn on **Energy management**. You choose:
 
-- **Class** — _Deferrable_ (can be switched off and caught up later, like a pool pump) or _Comfort_ (only ever gets a bonus on top of its normal operation, never switched off by the arbiter, like an air conditioner). Sowel pre-selects the right class from the equipment type; you can override it.
+- **Class** — _Deferrable_ (a relay whose on/off is a command, like a pool pump or a water heater: the arbiter can switch it off and run it later, and an unexpected on/off is read as you taking manual control) or _Comfort_ (a self-regulating load, like an air conditioner: the surplus only complements its normal operation, and the arbiter does not read its own on/off cycling as an action from you). Sowel pre-selects the right class from the equipment type; you can override it.
 - **Nominal power** — pre-filled from the equipment's own measurement when a clamp is bound.
+- **Tolerated import (W)** — how much grid import this load will accept to start on a **partial surplus**. The arbiter engages it once the surplus covers "nominal power + margin − tolerated import". At `0` (default) it waits for a full surplus; raising it makes the load start sooner, accepting to buy a little grid. It is the load's comfort / economy dial, set once here and honoured by whatever automation drives it.
 - **Minimum on / off** — how long it must stay on once started, and rest before restarting (protects a compressor from short-cycling).
 
 Enabling this only _declares_ the load. Nothing acts on it until the arbiter itself is enabled.


### PR DESCRIPTION
Fills the doc gaps from the recent energy work:

- **User energy guide (EN + FR)** — document the new **Tolerated import (W)** field on a controllable load (`energyProfile.toleratedImportW`, core #550): how much grid import a load accepts to start on a partial surplus, set once on the equipment, the comfort/economy dial.
- **Fix the class wording** — comfort was described as "never switched off by the arbiter", which is false (the deficit/release pass revokes comfort loads too; only the wall-switch divergence detection is deferrable-only). Reworded to the real distinction: comfort = self-regulating load whose cycling is not read as a manual override; deferrable = relay whose unexpected on/off is. Addresses the help-text part of #555.
- **recipe-development** — the `claimCapacity` example no longer hardcodes `toleratedImportW: 0`; recipes omit it so the arbiter reads the equipment profile (core #550).

`mkdocs build --strict` passes. Docs auto-deploy to GitHub Pages on merge to main.