### PR TITLE
chore(registry): bump pool-pump-schedule to 1.6.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "tags": ["pool", "pump", "heating", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -340,7 +340,7 @@
     },
     "sowelVersion": ">=1.50.0",
     "owner": "mchacher",
-    "sha256": "1b2c85a84eb1a0af1b746f130945e83c7356693023d2fa7494a167193b4a9244"
+    "sha256": "727807e5fe1dec3adb890e645ceafcf127937168596e3df2d2207567aa26c1a2"
   },
   {
     "id": "freecooling",


### PR DESCRIPTION
Propagates pool-pump-schedule **v1.6.1** to all Sowel instances.

- Ships the #12 fix (recipe PR #13): while heating on solar surplus, the pump now holds a claim in its own name (heater reserves only its own watts), so both loads read *accordé* on the arbiter timeline instead of the pump showing *hors pilotage*.
- `version` 1.6.0 → 1.6.1, `sha256` refreshed via `backfill-registry-sha256.mjs`.
- Hash verified against the published release asset: `727807e5fe1dec3adb890e645ceafcf127937168596e3df2d2207567aa26c1a2`.