### PR TITLE
fix(devices): categorise battery_low as generic, not battery

### DIFF
--- a/src/devices/battery-monitor.test.ts
+++ b/src/devices/battery-monitor.test.ts
@@ -8,6 +8,7 @@ import {
   isBatteryData,
   isBatteryPowered,
 } from "./battery-monitor.js";
+import { PROPERTY_TO_CATEGORY, CATEGORY_EXPECTED_TYPE } from "../shared/constants.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
@@ -176,8 +177,17 @@ describe("isBatteryData", () => {
     expect(isBatteryData({ key: "battery", category: "battery" })).toBe(true);
   });
 
-  it("matches a battery_low key whatever its category (plugins before z2m 2.5.0)", () => {
+  it("matches a battery_low key whatever its category", () => {
     expect(isBatteryData({ key: "battery_low", category: "generic" })).toBe(true);
+  });
+
+  it("keeps battery_low out of the battery category, whose contract is numeric", () => {
+    // Mapping it to "battery" made every discovery log "Declared data type
+    // contradicts category contract" (boolean vs number), and made the device
+    // list render the flag instead of a level for sensors whose numeric
+    // battery stays null. The key match above is what keeps it monitored.
+    expect(PROPERTY_TO_CATEGORY.battery_low).toBe("generic");
+    expect(CATEGORY_EXPECTED_TYPE.battery).toBe("number");
   });
 
   it("ignores anything else", () => {

--- a/src/devices/battery-monitor.ts
+++ b/src/devices/battery-monitor.ts
@@ -61,9 +61,10 @@ export function isBatteryPowered(device: DeviceWithDetails): boolean {
  * Is this device data a battery reading?
  *
  * The key-based clause is not redundant with the category: plugins assign the
- * category at discovery, and the Zigbee2MQTT plugin categorized `battery_low`
- * as `generic` until 2.5.0 — the sensors that only expose that boolean would be
- * invisible without it.
+ * category at discovery, and `battery_low` is deliberately categorized
+ * `generic` — it is a boolean, while the `battery` category means a numeric
+ * percentage. The sensors that only expose that boolean would be invisible
+ * without the key match.
  */
 export function isBatteryData(data: { key: string; category: string }): boolean {
   return data.category === "battery" || data.key === "battery_low";

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -70,7 +70,13 @@ export const PROPERTY_TO_CATEGORY: Record<string, DataCategory> = {
 
   // Battery
   battery: "battery",
-  battery_low: "battery",
+  // NOT "battery": that category's contract is a numeric percentage
+  // (CATEGORY_EXPECTED_TYPE), and this is a boolean flag. Mapping it there made
+  // every discovery log a contract violation, and made the device list show the
+  // flag instead of a level for sensors whose numeric battery stays null.
+  // `isBatteryData` matches it by key, so the low-battery monitor (spec 143) is
+  // unaffected.
+  battery_low: "generic",
 
   // Power / energy
   power: "power",


### PR DESCRIPTION
Twin of mchacher/sowel-plugin-zigbee2mqtt#13 — the same mapping exists on both sides, and core's is the one that applies to every integration, not just Zigbee2MQTT.

`PROPERTY_TO_CATEGORY` maps the boolean `battery_low` to the `battery` category, whose contract in `CATEGORY_EXPECTED_TYPE` is `"number"`. On any install with a sensor that exposes only that flag — Tuya ZP01 presence sensors are the common case — this produces two symptoms:

**1. A contract violation at every discovery.** Spec 150's check fires:

```
warn  device-manager  Declared data type contradicts category contract
      key=battery_low  category=battery  declaredType=boolean  expectedType=number
```

Observed twice per restart on a live install with two ZP01s.

**2. A wrong battery level in the device list.** `DeviceList.tsx` takes the *first* row with `category === "battery"` to render a level. On those sensors the numeric `battery` stays `null` while `battery_low` is `false`, so the column shows the flag rather than a percentage.

## The change

`battery_low` → `generic`, which carries no type contract.

The low-battery monitor is untouched: `isBatteryData` is `category === "battery" || data.key === "battery_low"`, so spec 143 keeps seeing these sensors through the key clause. I reworded the comment above it — that clause was documented as a compatibility shim for "plugins before z2m 2.5.0", whereas it is now the intended design — and renamed the test accordingly, plus a new assertion pinning `battery_low → generic` against `battery → number` so the two cannot drift back into contradiction.

## Verification

`npm run validate` green: typecheck, lint, format, **1452 tests**, ui validation.
