### PR TITLE
fix(energy): arbiter surplus curve + pill show the true signed grid balance (#563)

### DIFF
--- a/docs/technical/recipe-development.md
+++ b/docs/technical/recipe-development.md
@@ -284,7 +284,10 @@ const claim = ctx.helpers.energy?.claimCapacity({
 `claimCapacity` returns a handle (`status()`, `deniedReason`, `release()`).
 Denials are typed: `not-profiled`, `equipment-already-claimed`,
 `arbiter-disabled`, `override-active`. `energy.getCapacityState()` is a
-read-only snapshot (`enabled`, `availableSurplusW`, `grants`).
+read-only snapshot (`enabled`, `availableSurplusW`, `grants`). `availableSurplusW`
+is the true signed grid balance in watts (positive = exporting/surplus, negative
+= importing/deficit), not a reservation total, so it dips as your own granted
+load draws.
 
 Rules for authors (spec 140, enforced socially and audited by the core):
 

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -385,8 +385,31 @@ describe("capacity arbiter", () => {
     // no deficit, whatever the hold. This is the anti-oscillation core.
     h.run(-400, 700);
     expect(h.revokedEvents()).toHaveLength(0);
-    // availableSurplusW stays on the true surplus (export + reserved).
-    expect(h.arbiter.getPublicState().availableSurplusW).toBe(1000);
+    // #563 — the DISPLAYED figure is the true grid balance (exportW), so the
+    // grant's own draw legitimately dents it: still exporting 400 W. The
+    // no-revoke behaviour above is what reservation accounting protects.
+    expect(h.arbiter.getPublicState().availableSurplusW).toBe(400);
+  });
+
+  it("shows a deficit while importing, not a phantom surplus equal to production (#563)", () => {
+    // The bug: a home importing 1.2 kW while its managed loads soak up all of
+    // the production read as "Actif +1.3 kW" (≈ production) because the pill
+    // showed the reservation availableW (export + reserved), which stays
+    // positive as long as the reclaimable reserved draw exceeds the import.
+    const h = makeHarness();
+    h.claim("i1", { equipmentId: "pump" });
+    h.run(-1000, 150); // granted while exporting 1 kW
+    expect(h.grantedEvents()).toHaveLength(1);
+    // Clouds roll in: the granted pump keeps drawing ~600 W but the meter now
+    // IMPORTS 400 W. The pump stays granted — its minOnS (900 s) anti-short-
+    // cycle floor is far from elapsed — exactly the screenshot state.
+    h.feedLoadPower("pump", 600);
+    h.run(400, 30); // settle the EMA on the import
+    const st = h.arbiter.getPublicState();
+    expect(st.grants).toHaveLength(1); // still granted (minOn protects it)
+    // Reservation availableW here would be export(-400) + reserved(600) = +200,
+    // a phantom surplus. The fix reports the true grid balance: a 400 W deficit.
+    expect(st.availableSurplusW).toBe(-400);
   });
 
   it("a background surge revokes bottom-up after releaseHoldS", () => {
@@ -612,11 +635,11 @@ describe("capacity arbiter", () => {
     h.claim("pacI", { equipmentId: "pac" });
     h.run(-2200, 150);
     expect(h.grantedEvents()[0].equipmentId).toBe("pac");
-    // PAC ramps down to 1.2 kW → export rises accordingly; available stays
-    // on the true surplus through the live-draw reservation.
+    // PAC ramps down to 1.2 kW → export rises accordingly. #563 — the
+    // displayed figure is the true grid balance (exportW): now exporting 1 kW.
     h.feedLoadPower("pac", 1200);
     h.run(-1000, 50);
-    expect(h.arbiter.getPublicState().availableSurplusW).toBe(2200);
+    expect(h.arbiter.getPublicState().availableSurplusW).toBe(1000);
     // The freed headroom serves the pump without any release.
     h.claim("pumpI", { equipmentId: "pump" });
     h.run(-1000, 150);
@@ -662,8 +685,10 @@ describe("capacity arbiter", () => {
       h.feedLoadPower("pump", 600);
     }
     expect(h.grantedEvents()).toHaveLength(1);
-    // Books become exact: available = export + live draw.
-    expect(h.arbiter.getPublicState().availableSurplusW).toBe(800);
+    // #563 — displayed figure is the true grid balance (exportW): 200 W export.
+    // The own-draw reservation (used internally so the grant holds) is not
+    // added to the user-facing surplus any more.
+    expect(h.arbiter.getPublicState().availableSurplusW).toBe(200);
   });
 
   it("journals unclaimed-run once for a grantless recipe run", () => {
@@ -1178,8 +1203,13 @@ describe("capacity arbiter — review hardening", () => {
     h.feedLoadPower("pump", -50); // bidirectional-clamp noise
     h.feedMeter(-1000);
     const st = h.arbiter.getPublicState();
-    // available = export(1000) + reserved(max(0,-50)=0); never < export.
-    expect(st.availableSurplusW).toBeGreaterThanOrEqual(1000);
+    // The clamp lives in the reservation, now surfaced on the grant's effective
+    // watts (not on availableSurplusW, which is the raw grid balance since
+    // #563): a −50 W sample reserves 0, never a negative draw that would
+    // inflate the internal deficit.
+    expect(st.grants[0]?.watts).toBe(0);
+    // The displayed surplus is the true grid export, unaffected by the draw.
+    expect(st.availableSurplusW).toBe(1000);
   });
 
   // test review M2 — the manual-override suspension actually expires after

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -2,13 +2,16 @@
  * CapacityArbiter — spec 140.
  *
  * Single reader of the grid meter, arbitrating solar surplus between declared
- * flexible loads through reservation accounting:
+ * flexible loads through reservation accounting: the release pass keys off the
+ * SIGNED grid reading (`signedGridW − tolerances`) and the grant pass off the
+ * live export (`exportW`) plus each claim's own draw, so a drop in export
+ * caused by its own grants never reads as "surplus gone" (the only honest
+ * deficit signal is a real net import, per review decision 10).
  *
- *   availableW = exportW + Σ effectiveWatts(granted claims)
- *
- * A drop in export caused by its own grants never reads as "surplus gone";
- * the only honest deficit signal is the SIGNED grid reading (an import), per
- * review decision 10. The arbiter issues no orders in phase 1 — recipes act,
+ * The user-facing "Surplus / déficit" figure (`availableSurplusW`, curve +
+ * pill) is the true signed grid balance `exportW` (>0 exporting, <0 importing)
+ * — NOT a reservation-inflated total, which read as a phantom surplus equal to
+ * production while importing (#563). The arbiter issues no orders in phase 1 — recipes act,
  * the arbiter decides — and everything it does lands in a bounded decision
  * journal ("why" first-class, FR-8).
  */
@@ -167,7 +170,12 @@ export class CapacityArbiter {
   private deficitSince: number | null = null;
   private watchdogs: RevokeWatchdog[] = [];
   private lastStatus: { state: ArbiterRunState; availableSurplusW: number | null } | null = null;
-  /** ~5 min samples of availableW for the day-timeline curve (FR-10). */
+  /**
+   * ~5 min samples of the signed grid surplus for the day-timeline curve
+   * (FR-10). #563 — this holds exportW (>0 surplus, <0 déficit), the true grid
+   * balance, not the reservation availableW. The field keeps its `availableW`
+   * name to match the persisted store / API shape.
+   */
   private surplusSeries: Array<{ at: number; availableW: number }> = [];
   private lastSurplusSampleAt = 0;
 
@@ -869,7 +877,13 @@ export class CapacityArbiter {
       // Control paths still gate on `config.enabled`; this is display only.
       enabled: this.settings.get(SETTING_PREFIX + "enabled") === "true",
       state,
-      availableSurplusW: state === "active" ? Math.round(accounting.availableW) : null,
+      // #563 — the user-facing figure is the TRUE signed grid balance
+      // (headroomW ≡ exportW: >0 exporting, <0 importing), NOT the
+      // reservation-inflated availableW. A home importing while its managed
+      // loads soak up production must read as a deficit, not a phantom surplus
+      // equal to production. Reservation accounting stays internal to the
+      // grant/revoke passes (it keeps a grant from reading "surplus gone").
+      availableSurplusW: state === "active" ? Math.round(accounting.headroomW) : null,
       productionDetected: this.equipments
         .getAll()
         .some((e) => e.type === "energy_production_meter" || e.type === "solar_panel"),
@@ -954,7 +968,7 @@ export class CapacityArbiter {
     this.checkStateDivergence(now);
     this.checkWatchdogs(now);
 
-    const { signedGridW, exportW, availableW } = this.accounting();
+    const { signedGridW, exportW } = this.accounting();
 
     // ── Release pass (bottom-up). deficit ≡ signed import − tolerances −
     // the known draw of unresponsive equipments (excused as background). ──
@@ -1067,9 +1081,13 @@ export class CapacityArbiter {
     }
 
     // Day-timeline curve sample (FR-10): ~5 min cadence, bounded to 24 h.
+    // #563 — persist the TRUE signed grid balance (exportW: >0 surplus, <0
+    // déficit), matching the "Surplus / déficit" axis. The reservation
+    // availableW would keep the curve positive while importing (a grant does
+    // not dent it), which read as a phantom surplus equal to production.
     if (now - this.lastSurplusSampleAt >= 5 * 60_000) {
       this.lastSurplusSampleAt = now;
-      const sample = { at: now, availableW: Math.round(availableW) };
+      const sample = { at: now, availableW: Math.round(exportW) };
       this.surplusSeries.push(sample);
       this.surplusStore?.insert(sample); // spec 148 — persist for the 48h timeline
       const dayAgo = now - 24 * 3_600_000;
@@ -1078,7 +1096,7 @@ export class CapacityArbiter {
       }
     }
 
-    this.emitStatus(availableW);
+    this.emitStatus(exportW);
   }
 
   // ── Accounting helpers ──────────────────────────────────────
@@ -1086,14 +1104,17 @@ export class CapacityArbiter {
   private accounting(): {
     signedGridW: number;
     exportW: number;
-    reservedW: number;
-    availableW: number;
     headroomW: number;
   } {
+    // #563 — decisions key off the signed grid reading directly: the release
+    // pass on `signedGridW − tolerances`, the grant pass on `exportW` (headroom)
+    // plus each claim's own draw. The reservation is applied per-claim through
+    // `effectiveWatts` in those passes; there is no longer a summed
+    // `availableW`/`reservedW`, which used to feed the display only and made a
+    // grant read as phantom surplus while importing. `headroomW ≡ exportW`.
     const signedGridW = this.emaPowerW ?? 0;
     const exportW = -signedGridW;
-    const reservedW = this.grantedClaims().reduce((s, c) => s + this.effectiveWatts(c), 0);
-    return { signedGridW, exportW, reservedW, availableW: exportW + reservedW, headroomW: exportW };
+    return { signedGridW, exportW, headroomW: exportW };
   }
 
   /** FR-2 three-tier effective watts: live draw → learned → claim watts. */
@@ -1422,12 +1443,14 @@ export class CapacityArbiter {
     return "active";
   }
 
-  private emitStatus(availableW?: number): void {
+  private emitStatus(signedSurplusW?: number): void {
     const state = this.runState();
     // Coarsen to the nearest 25 W so the status event fires on a meaningful
     // change, not on every meter sample (the raw surplus jitters by >1 W
     // almost continuously — review #7; the architecture wants "on change").
-    const raw = availableW ?? this.accounting().availableW;
+    // #563 — the emitted figure is the TRUE signed grid balance (headroomW ≡
+    // exportW), consistent with the pill in getPublicState.
+    const raw = signedSurplusW ?? this.accounting().headroomW;
     const availableSurplusW = state === "active" ? Math.round(raw / 25) * 25 : null;
     const prev = this.lastStatus;
     if (prev && prev.state === state && prev.availableSurplusW === availableSurplusW) return;


### PR DESCRIPTION
## Problem

The "Surplus / déficit" curve and the top-right pill on **Energy → Live → Arbitrage du surplus** showed **solar production instead of the real grid balance**. On a home importing 1.2 kW while producing 1.3 kW (net deficit), the pill read **"Actif 1.3 kW"** and the curve stayed green/positive all day.

| Live diagram (ground truth) | Arbiter card (wrong) |
| --- | --- |
| Réseau ↑1.2 kW (importing), Prod 1.3 kW, "Appoint réseau" | pill "Actif **1.3 kW**", curve positive all day |

## Root cause

The pill (`availableSurplusW`) and the persisted timeline curve both showed the arbiter's **reservation** figure:

```
availableW = exportW + reservedW      (reservedW = live draw of granted loads)
```

This is deliberately grant-insensitive so the arbiter's own grants don't make it think surplus vanished (internal invariant, spec 140). But when the managed loads (Pompe + PAC Piscine) absorb ~the whole house consumption, `reservedW ≈ house`, so `availableW ≈ house − import = production`, staying positive even while importing.

## Fix

The user-facing figure (`availableSurplusW`, the persisted curve sample, and the `energy.arbiter.status` event) now reports the **true signed grid balance** `exportW`/`headroomW`:

- `> 0` exporting → surplus (green)
- `< 0` importing → deficit (red, and the existing "En déficit de X kW…" banner now correctly fires)

**No control-logic change.** The grant/release passes already key off the signed grid reading (`signedGridW − tolerances`) and each claim's own draw, not the summed `availableW`, so grant/revoke behaviour is untouched. The reservation is still applied per-claim via `effectiveWatts`. The now-unused summed `availableW`/`reservedW` were dropped from `accounting()`.

The UI needed no change: the pill already renders signed kW, `surplusStickerColor` reds out ≤ 0, the deficit banner exists in both locales, and `ArbitrationSurface.test.tsx` already seeded a negative value.

The recipe-facing `energy.getCapacityState().availableSurplusW` shares this value; its meaning is now the signed grid balance (documented in `recipe-development.md`). No shipped recipe reads it (both read only `enabled`), so no behavioural break.

## Tests

- New regression test **"shows a deficit while importing…(#563)"**: grant a load, then import 400 W while it draws 600 W → asserts `availableSurplusW === -400`. The old reservation figure returned `+200` (phantom surplus), so it fails before the fix (verified).
- Updated the three display assertions that encoded the old reservation semantics (400 / 1000 / 200) and retargeted the negative-live-draw clamp test to assert on the grant's effective watts (the clamp's real surface) instead of the display.
- `npx tsc --noEmit`, `npx eslint`, full backend suite (1464 passed) all green.

## Note

Persisted `arbiter_surplus_log` rows written before deploy hold the old reservation value; the curve mixes them with new signed samples until they age out. The route caps the window at 48h, so the curve fully self-heals within ~2 days. No migration needed — the store field was already documented as "signed: >0 surplus, <0 déficit".

Closes #563