### PR TITLE
chore(registry): bump pool-pump-schedule to 1.6.2 (#564)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "tags": ["pool", "pump", "heating", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -340,7 +340,7 @@
     },
     "sowelVersion": ">=1.50.0",
     "owner": "mchacher",
-    "sha256": "727807e5fe1dec3adb890e645ceafcf127937168596e3df2d2207567aa26c1a2"
+    "sha256": "f63a0348fcc6589fb50f4caec41ba4655683b9d55a76f5743298d4bd903b8aed"
   },
   {
     "id": "freecooling",


### PR DESCRIPTION
Bumps `pool-pump-schedule` to **v1.6.2** with the matching SHA256.

## What shipped

Fixes the pool heater running with no water circulation after the pump's surplus grant is revoked. The recipe now makes the PAC depend structurally on the pump's own arbiter grant: it heats only while the pump is granted, and the instant the arbiter revokes the pump the recipe releases the PAC claim (it leaves "accordé" for "au repos" in the arbiter, with a `released` line in the journal) and idles the setpoint.

Recipe PR: mchacher/sowel-recipe-pool-pump-schedule#17 · release [v1.6.2](https://github.com/mchacher/sowel-recipe-pool-pump-schedule/releases/tag/v1.6.2)

- `sha256` verified against the published `sowel-recipe-pool-pump-schedule-1.6.2.tar.gz` asset (`f63a0348…`).
- Minimal diff (version + hash only).

Closes #564