### PR TITLE
fix(ui): hide submeters with no power measurement from the consumption breakdown (#560)

### DIFF
--- a/ui/src/components/energy/LiveSubmeterBreakdown.tsx
+++ b/ui/src/components/energy/LiveSubmeterBreakdown.tsx
@@ -259,7 +259,6 @@ function LegendRow({
   t: (key: string, opts?: Record<string, unknown>) => string;
 }) {
   const isOffline = row.status === "offline";
-  const noData = row.power === null && !isOffline;
   const pct =
     row.power !== null && total > 0
       ? Math.round((row.power / total) * 100)
@@ -269,7 +268,7 @@ function LegendRow({
   return (
     <div
       className={`grid grid-cols-[10px_1fr_auto_auto] gap-x-3 items-center text-[13px] ${
-        isOffline || noData ? "opacity-60" : ""
+        isOffline ? "opacity-60" : ""
       }`}
     >
       <span
@@ -282,11 +281,6 @@ function LegendRow({
           <span className="text-[11px] text-text-tertiary">
             {t("energy.live.breakdown.offline")}
             {row.offlineSince && ` · ${formatRelative(row.offlineSince)}`}
-          </span>
-        )}
-        {noData && (
-          <span className="text-[11px] text-text-tertiary">
-            {t("energy.live.breakdown.noData")}
           </span>
         )}
       </div>

--- a/ui/src/components/energy/submeter-helpers.test.ts
+++ b/ui/src/components/energy/submeter-helpers.test.ts
@@ -146,7 +146,7 @@ describe("buildSubmeterRows", () => {
     expect(rows.map((r) => r.name)).toEqual(["High", "Mid", "Low"]);
   });
 
-  it("places null-power rows last (offline / no data)", () => {
+  it("places offline (null-power) rows last", () => {
     const rows = buildSubmeterRows([
       makeEquipment("a", "Online1", { power: 100 }),
       makeEquipment("b", "OfflineOne", { power: 500, status: "offline" }),
@@ -154,6 +154,24 @@ describe("buildSubmeterRows", () => {
     ]);
     expect(rows.map((r) => r.name)).toEqual(["Online1", "Online2", "OfflineOne"]);
     expect(rows[2].power).toBeNull();
+  });
+
+  it("drops online submeters with no power measurement (#560)", () => {
+    const rows = buildSubmeterRows([
+      makeEquipment("a", "PAC", { power: 100 }),
+      makeEquipment("b", "Lave-linge", { power: null }),
+    ]);
+    // The washing machine has no power binding while online → omitted.
+    expect(rows.map((r) => r.name)).toEqual(["PAC"]);
+  });
+
+  it("keeps offline submeters even without a power value (#560)", () => {
+    const rows = buildSubmeterRows([
+      makeEquipment("a", "PAC", { power: 100 }),
+      makeEquipment("b", "Piscine", { power: null, status: "offline" }),
+    ]);
+    expect(rows.map((r) => r.name)).toEqual(["PAC", "Piscine"]);
+    expect(rows[1].power).toBeNull();
   });
 
   it("wraps palette when more than 8 submeters", () => {

--- a/ui/src/components/energy/submeter-helpers.ts
+++ b/ui/src/components/energy/submeter-helpers.ts
@@ -40,8 +40,12 @@ export function readSubmeterPower(eq: EquipmentWithDetails): number | null {
  *   2. Sort by `id` ascending and assign a palette color by index — this is
  *      the SAME indexing rule the backend uses for the historical By-usage
  *      chart, so a given equipment gets the same color in both views.
- *   3. Re-sort the rows for display: by power descending, then null-power
- *      (offline / no data) last.
+ *   3. Drop rows that carry no power measurement at all (null power while the
+ *      equipment is *online*): a declared submeter with no `power` binding
+ *      contributes nothing and is pure noise in the legend (#560). Offline
+ *      rows keep their null power — they are meaningful and stay.
+ *   4. Re-sort the rows for display: by power descending, then null-power
+ *      (offline) last.
  *
  * `labels` optionally overrides display names by equipment id (spec 139 —
  * `name — zone` for homonym submeters); sorting uses the displayed name.
@@ -54,14 +58,17 @@ export function buildSubmeterRows(
     .filter((eq) => isSubmeterEquipment(eq))
     .sort((a, b) => a.id.localeCompare(b.id));
 
-  const rows: SubmeterRow[] = byId.map((eq, idx) => ({
-    id: eq.id,
-    name: labels?.get(eq.id) ?? eq.name,
-    power: readSubmeterPower(eq),
-    status: eq.status,
-    offlineSince: eq.statusReason?.offlineSince ?? null,
-    color: pickSubmeterColor(idx),
-  }));
+  const rows: SubmeterRow[] = byId
+    .map((eq, idx) => ({
+      id: eq.id,
+      name: labels?.get(eq.id) ?? eq.name,
+      power: readSubmeterPower(eq),
+      status: eq.status,
+      offlineSince: eq.statusReason?.offlineSince ?? null,
+      color: pickSubmeterColor(idx),
+    }))
+    // No measurement and not offline → nothing to show (#560).
+    .filter((row) => row.power !== null || row.status === "offline");
 
   rows.sort((a, b) => {
     const aNull = a.power === null;

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1029,7 +1029,6 @@
   "energy.live.breakdown.title": "Consumption breakdown",
   "energy.live.breakdown.other": "Other",
   "energy.live.breakdown.offline": "offline",
-  "energy.live.breakdown.noData": "no measurement",
   "energy.live.breakdown.houseIdle": "House idle",
   "energy.live.breakdown.overshoot": "Σ submeters ≥ house total",
   "energy.live.phases.title": "Phase breakdown",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1029,7 +1029,6 @@
   "energy.live.breakdown.title": "Décomposition consommation",
   "energy.live.breakdown.other": "Autre",
   "energy.live.breakdown.offline": "hors-ligne",
-  "energy.live.breakdown.noData": "pas de mesure",
   "energy.live.breakdown.houseIdle": "Maison à l'arrêt",
   "energy.live.breakdown.overshoot": "Σ sous-compteurs ≥ total maison",
   "energy.live.phases.title": "Répartition par phase",


### PR DESCRIPTION
## Problem

The "Décomposition consommation" donut (`LiveSubmeterBreakdown`) on the Live energy page rendered one legend row per declared submeter. A submeter exposing **no `power` binding** while online showed up as a greyed "pas de mesure" row with a `—` value — it contributed nothing to the donut and was pure visual noise ("Lave-linge" in the report screenshot).

## Root cause

`readSubmeterPower` returns `null` for a non-offline equipment with no `power` binding, and `buildSubmeterRows` kept those rows, which `LegendRow` rendered via its `noData` branch.

## Fix

- `buildSubmeterRows` now filters out rows where `power === null && status !== "offline"`. Color indexing (by sorted id, shared with the historical By-usage chart) is still assigned before the filter, so surviving rows keep their stable colors.
- **Offline** submeters are unaffected — they legitimately have `null` power and keep their "offline · since …" caption.
- Removed the now-dead `noData` rendering branch and the unused `energy.live.breakdown.noData` i18n keys (en + fr).

## Tests

- `drops online submeters with no power measurement (#560)` — regression test, fails before the fix.
- `keeps offline submeters even without a power value (#560)` — guards the offline exception.
- Existing null-power sort test renamed to reflect it now only covers offline rows.

`npx tsc -b --noEmit`, eslint, and `vitest run` on the energy + i18n suites all pass.

Closes #560