### PR TITLE
docs(energy): document the load class as derived from equipment type (#555)

### DIFF
--- a/docs/user/energy.fr.md
+++ b/docs/user/energy.fr.md
@@ -158,12 +158,18 @@ Il est **désactivé par défaut** et ne change rien tant que vous ne l'activez 
 
 ### Déclarer une charge pilotable
 
-Sur un équipement qui peut s'allumer et s'éteindre (pompe de piscine, chauffe-eau, un interrupteur pilotant un radiateur), ouvrez sa fiche et activez **Pilotage énergie**. Vous choisissez :
+Sur un équipement dont le type est une charge pilotable (pompe de piscine, chauffe-eau, vanne d'eau, radiateur ou thermostat), ouvrez sa fiche et activez **Pilotage énergie**. Vous réglez :
 
-- **Classe** — _Différable_ (un relais dont marche/arrêt est une commande, comme une pompe de piscine ou un chauffe-eau : l'arbitre peut la couper et la relancer plus tard, et un on/off inattendu est lu comme une reprise en main manuelle) ou _Confort_ (une charge qui se régule seule, comme une climatisation : le surplus ne fait que compléter son fonctionnement, et l'arbitre n'interprète pas son cycling normal comme une action de votre part). Sowel présélectionne la bonne classe selon le type d'équipement ; vous pouvez la corriger.
 - **Puissance nominale** — pré-remplie depuis la mesure de l'équipement quand une pince est associée.
 - **Import toléré (W)** — combien d'import réseau cette charge accepte pour démarrer sur un **surplus partiel**. L'arbitre l'engage dès que le surplus couvre « puissance nominale + marge − import toléré ». À `0` (défaut), elle n'attend qu'un surplus complet ; monter cette valeur la fait démarrer plus tôt, en acceptant d'acheter un peu de réseau. C'est le curseur confort / économie de la charge, réglé une fois ici et respecté par toute automatisation qui la pilote.
 - **Marche / arrêt minimum** — durée minimale de marche une fois démarré, et de repos avant redémarrage (protège un compresseur des cycles courts).
+
+La façon dont l'arbitre traite la charge est **dérivée de son type**, il n'y a donc rien à choisir :
+
+- un **relais** dont marche/arrêt est une commande (pompe de piscine, chauffe-eau) peut être coupé et relancé plus tard sur le surplus, et un on/off inattendu est lu comme une reprise en main manuelle ;
+- une charge **auto-régulée** (un thermostat ou une climatisation) voit son fonctionnement normal seulement complété par le surplus, et l'arbitre n'interprète pas ses propres cycles marche/arrêt comme une action de votre part.
+
+Un type d'équipement sans comportement énergétique (une simple lumière ou un interrupteur générique) ne peut pas être déclaré charge pilotable.
 
 Activer ceci ne fait que _déclarer_ la charge. Rien ne la pilote tant que l'arbitre lui-même n'est pas activé.
 

--- a/docs/user/energy.md
+++ b/docs/user/energy.md
@@ -158,12 +158,18 @@ It is **off by default** and changes nothing until you enable it. On a home with
 
 ### Declaring a flexible load
 
-On an equipment that can be switched on and off (pool pump, water heater, a switch driving a heater), open its page and turn on **Energy management**. You choose:
+On an equipment whose type is a controllable load (pool pump, water heater, water valve, heater or thermostat), open its page and turn on **Energy management**. You set:
 
-- **Class** — _Deferrable_ (a relay whose on/off is a command, like a pool pump or a water heater: the arbiter can switch it off and run it later, and an unexpected on/off is read as you taking manual control) or _Comfort_ (a self-regulating load, like an air conditioner: the surplus only complements its normal operation, and the arbiter does not read its own on/off cycling as an action from you). Sowel pre-selects the right class from the equipment type; you can override it.
 - **Nominal power** — pre-filled from the equipment's own measurement when a clamp is bound.
 - **Tolerated import (W)** — how much grid import this load will accept to start on a **partial surplus**. The arbiter engages it once the surplus covers "nominal power + margin − tolerated import". At `0` (default) it waits for a full surplus; raising it makes the load start sooner, accepting to buy a little grid. It is the load's comfort / economy dial, set once here and honoured by whatever automation drives it.
 - **Minimum on / off** — how long it must stay on once started, and rest before restarting (protects a compressor from short-cycling).
+
+How the arbiter treats the load is **derived from its type**, so there is nothing to pick:
+
+- a **relay** whose on/off is a command (pool pump, water heater) can be switched off and run later on the surplus, and an unexpected on/off is read as you taking manual control;
+- a **self-regulating** load (a thermostat or air conditioner) has its normal operation only complemented by the surplus, and the arbiter does not read its own on/off cycling as an action from you.
+
+An equipment type with no energy behaviour (a plain light or a generic switch) cannot be declared a flexible load.
 
 Enabling this only _declares_ the load. Nothing acts on it until the arbiter itself is enabled.
 


### PR DESCRIPTION
## Summary

Follow-up to #568, which removed the flexible-load **class** picker and derives the class from the equipment type. The user energy guide still described a `Class` field you choose and override, which no longer exists.

## Changes

- `docs/user/energy.md` + `docs/user/energy.fr.md`: the *Declaring a flexible load* section no longer lists a Class choice. It now explains that how the arbiter treats the load (relay whose on/off is a command vs self-regulating) is **derived from the equipment type**, and that a type with no energy semantics cannot be declared a flexible load.

Relates to #555.