### PR TITLE
release: v1.51.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,18 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.51.x : Double authentification et arbitre énergie affiné
+
+### v1.51.0 — 2026-08-17 { #v1-51-0 }
+
+- Feat (auth) : **double authentification (TOTP) avec codes de secours**. Un compte peut activer la 2FA par application (Google Authenticator, Authy et similaires) : enrôlement par QR code dans les réglages utilisateur, code à six chiffres à la connexion, et codes de secours à usage unique pour récupérer l'accès en cas de perte de l'authentificateur. (#541)
+- Feat (énergie) : **une charge pilotable déclarée sans réservation active apparaît désormais dans la liste de l'arbitre avec un état d'attente**. Une charge que vous avez enrôlée mais qu'aucune automatisation ne réclame s'affiche en attente sur la surface d'arbitrage et la timeline, au lieu d'être invisible jusqu'à sa prochaine marche. (#561, #562)
+- Change (énergie) : **l'arbitre de surplus ne demande plus de choisir la classe de charge ; elle est déduite du type d'équipement**. Le panneau Pilotage énergie a supprimé le sélecteur Confort/Différable. Qu'une charge soit un relais (pompe de piscine, chauffe-eau) ou auto-régulée (thermostat, climatisation) est une propriété du type d'équipement, donc Sowel la déduit, et un type sans sémantique énergie ne peut plus être déclaré charge pilotable. Pas de migration ; les profils existants sont inchangés. (#555, #568, #569)
+- Fix (énergie) : **la courbe et la pastille de surplus de l'arbitre affichent le vrai solde réseau signé** (export positif, import négatif) au lieu d'un chiffre de réservation interne, si bien que la lecture correspond à votre compteur. (#563, #565)
+- Fix (énergie) : **un sous-compteur qui ne rapporte aucune mesure de puissance est retiré de la répartition de consommation** au lieu d'y afficher une ligne à zéro parasite. (#560, #567)
+- Fix (devices) : **un indicateur `battery_low` est classé comme lecture générique, pas comme niveau de batterie**. (#559)
+- Chore (registry) : zigbee2mqtt en 2.5.1 (correctif jumeau battery_low), smart-cooling en 2.1.0 (pré-refroidissement proportionnel au surplus), pool-pump-schedule en 1.6.2. (#554, #556, #558, #564, #566)
+
 ## 1.50.x : Tolérance de surplus par équipement
 
 ### v1.50.0 — 2026-08-16 { #v1-50-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,18 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.51.x: Two-factor authentication and a sharper energy arbiter
+
+### v1.51.0 — 2026-08-17 { #v1-51-0 }
+
+- Feat (auth): **two-factor authentication (TOTP) with backup codes**. Accounts can enable app-based 2FA (Google Authenticator, Authy and the like): a QR-code enrolment in the user settings, a six-digit code at login, and one-time backup codes to recover access if the authenticator is lost. (#541)
+- Feat (energy): **a declared flexible load with no active claim now appears in the arbiter roster with a waiting state**. A load you have enrolled but that no automation is currently claiming shows as waiting on the arbitration surface and timeline, instead of being invisible until it next runs. (#561, #562)
+- Change (energy): **the surplus arbiter no longer asks you to pick a load class; it is inferred from the equipment type**. The Pilotage énergie panel dropped the Comfort/Deferrable selector. Whether a load is a relay (pool pump, water heater) or self-regulating (thermostat, air conditioner) is a property of the equipment type, so Sowel derives it, and a type with no energy semantics can no longer be declared a flexible load. No migration; existing profiles are unchanged. (#555, #568, #569)
+- Fix (energy): **the arbiter surplus curve and pill show the true signed grid balance** (export positive, import negative) instead of an internal reservation figure, so the reading matches your meter. (#563, #565)
+- Fix (energy): **a submeter that reports no power measurement is dropped from the consumption breakdown** instead of showing a spurious zero row. (#560, #567)
+- Fix (devices): **a `battery_low` indicator is categorised as a generic reading, not a battery level**. (#559)
+- Chore (registry): zigbee2mqtt to 2.5.1 (battery_low twin fix), smart-cooling to 2.1.0 (surplus-proportional pre-cooling), pool-pump-schedule to 1.6.2. (#554, #556, #558, #564, #566)
+
 ## 1.50.x: Per-equipment surplus tolerance
 
 ### v1.50.0 — 2026-08-16 { #v1-50-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.50.0",
+  "version": "1.51.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump + release notes for v1.51.0.

Highlights: two-factor authentication (TOTP + backup codes, #541), energy load class now derived from the equipment type (#555), arbiter waiting state for unclaimed flexible loads (#561), true signed grid balance in the surplus curve/pill (#563), and fixes for the consumption breakdown (#560) and battery_low categorisation (#559).

Covers all PRs merged since v1.50.0. Release notes added to both docs/release-notes.md and docs/release-notes.fr.md with the { #v1-51-0 } anchor (spec 108).

Companion (post-merge, paired release): tag z2m plugin v2.5.1 + backfill registry.