### PR TITLE
chore(registry): bump zigbee2mqtt to 2.5.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -7,11 +7,11 @@
     "icon": "Radio",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-zigbee2mqtt",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "tags": ["zigbee", "mqtt", "z2m", "sensors", "lights", "switches"],
     "sowelVersion": ">=1.38.0",
     "owner": "mchacher",
-    "sha256": "b161bf9d18fd90cbb9597d682c5f88732396ef7b7262e9c0ec43e725b61d2429"
+    "sha256": "0937d823e08465b5d780b444409ffae4ff74820fa123ab60a3538a8d52eaa594"
   },
   {
     "id": "lora2mqtt",


### PR DESCRIPTION
Twin of core #559 (battery_low categorised as generic, not battery). The z2m plugin v2.5.1 GitHub release is published; this points the registry at it.

- version 2.5.0 → 2.5.1
- sha256 refreshed and **verified independently** against the published asset `sowel-plugin-zigbee2mqtt-2.5.1.tar.gz` (0937d823…).

Rides along with the v1.51.0 release cycle.