### PR TITLE
chore(registry): add community recipe vmc-humidity (adn-dev-adrien)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -540,5 +540,26 @@
     "sowelVersion": ">=1.31.0",
     "owner": "alpitux",
     "sha256": "b26b62f2bc0c6ce2e4bf65c8b87148f9e0e98659b0547bc400030076a3a5c4d5"
+  },
+  {
+    "id": "vmc-humidity",
+    "type": "recipe",
+    "category": "climate",
+    "name": "VMC Humidity Control",
+    "description": "Runs the ventilation to extract humidity from the rooms it serves, only when the outdoor air can actually dry them, and on presence in the toilets. Use it alone on a given ventilation.",
+    "icon": "Fan",
+    "author": "adn-dev-adrien",
+    "repo": "adn-dev-adrien/sowel-recipe-vmc-humidity",
+    "version": "0.4.2",
+    "tags": ["ventilation", "vmc", "humidity", "comfort", "automation"],
+    "i18n": {
+      "fr": {
+        "name": "VMC hygro-pilotée",
+        "description": "Fait tourner la VMC pour extraire l'humidité des pièces qu'elle dessert, uniquement quand l'air extérieur peut réellement les assécher, et sur détection de présence aux WC. À utiliser seule sur une VMC donnée."
+      }
+    },
+    "sowelVersion": ">=1.35.0",
+    "owner": "adn-dev-adrien",
+    "sha256": "3024d2edbfb3a2050cd7c79057efe0e0984245cd1649c6149d3d1187662b71fd"
   }
 ]


### PR DESCRIPTION
## What

Adds the community recipe **VMC Humidity Control** (`adn-dev-adrien/sowel-recipe-vmc-humidity`, v0.4.2) to the official registry so it appears directly in the Store, instead of requiring users to add it as a personal source.

## Community, not official

`owner` is `adn-dev-adrien`, which is not in `OFFICIAL_OWNERS` (`["mchacher"]`). The install flow therefore flags it community and shows the confirmation modal, exactly like the existing `alpitux` entries (`runtime-guard`, `netatmo_camera`).

## Supply chain (spec 089)

- `owner` and `sha256` are both present.
- `sha256` = `3024d2ed…62b71fd`, computed from the published `sowel-recipe-vmc-humidity-0.4.2.tar.gz` release asset (same bytes `backfill-registry-sha256.mjs` would fetch from `releases/latest`).
- `sowelVersion` `>=1.35.0` is satisfied by current cores (latest is 1.51.0).

## Notes

- Single-line addition; no reformatting of existing entries (compact `tags` preserved).
- `src/packages/package-manager.test.ts` passes (50).
- v0.4.2 carries a known minor bug (an external manual ON of the VMC is force-stopped after a prior cycle); a fix is open upstream as adn-dev-adrien/sowel-recipe-vmc-humidity#2. Once the author releases the fixed version, bump this entry's `version` + `sha256` via `backfill-registry-sha256.mjs`.
