### PR TITLE
feat(equipments): dedicated solar on/off command channel (spec 152)

### DIFF
--- a/docs/user/equipments.fr.md
+++ b/docs/user/equipments.fr.md
@@ -110,9 +110,10 @@ Radiateur électrique individuel piloté par relais fil pilote.
 
 Chauffe-eau / cumulus piloté par un relais on/off. Le canal on/off est lié automatiquement (ainsi que sa puissance/énergie si le relais les mesure).
 
-- **Contrôles :** Bascule Marche / Arrêt
+- **Contrôles :** Bascule Marche / Arrêt, plus une bascule **Solaire** dédiée lorsqu'un canal solaire est lié
 - **Données attendues :** état du relais on/off, température d'eau optionnelle (affichage seul, exclue de la moyenne de température ambiante de la zone), puissance/énergie optionnelles
-- La consigne réglable est volontairement hors périmètre (ce serait un thermostat). La planification ou le pilotage sur surplus solaire relèvent d'une recette, pas de l'équipement.
+- **Canal solaire (optionnel) :** un second on/off indépendant, lié sur un contact dédié (par exemple un relais Zigbee contact sec SONOFF MINI-ZBD qui pilote l'entrée photovoltaïque d'un chauffe-eau thermodynamique). Il est distinct de la marche normale de l'appareil : sur un chauffe-eau en alimentation permanente, seule la bascule Solaire apparaît. La carte affiche une bascule par canal lié (Marche/Arrêt si présent, Solaire si présent).
+- La consigne réglable est volontairement hors périmètre (ce serait un thermostat). L'équipement fournit le canal de commande solaire (l'actionneur) ; la logique de pilotage sur surplus solaire reste dans une recette qui pilote ce canal via l'arbitre d'énergie.
 
 ---
 

--- a/docs/user/equipments.md
+++ b/docs/user/equipments.md
@@ -65,13 +65,15 @@ Awnings share the shutter control surface (same position binding, same OPEN/STOP
 
 ### Climate
 
-| Type             | Controls                                        | Expected data                                                                        |
-| ---------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------ |
-| **Thermostat**   | Temperature display, setpoint +/-, power on/off | current temperature, target setpoint, power state, optional mode/fan/eco             |
-| **Heater**       | Comfort / Eco toggle                            | relay state (fil pilote: ON = eco, OFF = comfort)                                    |
-| **Water Heater** | On/Off toggle                                   | on/off relay state, optional water temperature (display only), optional power/energy |
+| Type             | Controls                                        | Expected data                                                                                                      |
+| ---------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **Thermostat**   | Temperature display, setpoint +/-, power on/off | current temperature, target setpoint, power state, optional mode/fan/eco                                           |
+| **Heater**       | Comfort / Eco toggle                            | relay state (fil pilote: ON = eco, OFF = comfort)                                                                  |
+| **Water Heater** | On/Off toggle, optional dedicated Solar toggle  | on/off relay state, optional solar-channel state, optional water temperature (display only), optional power/energy |
 
-Thermostat covers air conditioning, pellet stoves, and heat pumps. Heater covers individual electric heaters wired through a fil-pilote relay. Water Heater (chauffe-eau / cumulus) is an on/off relay for a hot-water tank: auto-binds the on/off channel (and its power/energy when the relay meters them); a water-temperature probe can be bound optionally and is shown but kept out of the room temperature average. Setpoint control is intentionally out of scope (that would be a thermostat). Scheduling / solar-surplus heating is a recipe, not the equipment.
+Thermostat covers air conditioning, pellet stoves, and heat pumps. Heater covers individual electric heaters wired through a fil-pilote relay. Water Heater (chauffe-eau / cumulus) is an on/off relay for a hot-water tank: auto-binds the on/off channel (and its power/energy when the relay meters them); a water-temperature probe can be bound optionally and is shown but kept out of the room temperature average. Setpoint control is intentionally out of scope (that would be a thermostat).
+
+A water heater (and a switch) can also carry a dedicated **solar** on/off channel, independent from the main on/off: a second contact (e.g. a SONOFF MINI-ZBD Zigbee dry-contact relay driving the photovoltaic input of a heat-pump water heater). It is bound explicitly under the solar role, distinct from the appliance's normal operation. On a water heater left on permanent mains, only the Solar toggle appears; the card shows one toggle per bound channel. The solar channel is the actuator a solar-surplus recipe drives through the energy arbiter; the arbitration logic itself stays in the recipe.
 
 ### Access
 

--- a/migrations/023_solar_data_binding_category_override.sql
+++ b/migrations/023_solar_data_binding_category_override.sql
@@ -1,0 +1,13 @@
+-- Spec 152: Equipment solar command channel.
+--
+-- Adds data_bindings.category_override, mirroring the order_bindings column
+-- introduced in migration 006. A per-binding semantic override lets an
+-- equipment re-tag a device data's category without touching the device
+-- definition, read via COALESCE(category_override, device_data.category).
+--
+-- This is what lets a solar state-feedback binding carry category
+-- `solar_state` (distinct from the main on/off `light_state`) so the two
+-- channels resolve independently under category-first resolution, and the
+-- solar state charts as its own Analyse "states" series.
+
+ALTER TABLE data_bindings ADD COLUMN category_override TEXT;

--- a/specs/152-equipment-solar-command/architecture.md
+++ b/specs/152-equipment-solar-command/architecture.md
@@ -1,0 +1,183 @@
+# Spec 152 — Architecture
+
+## Overview
+
+A second, independent on/off command channel ("solar") is added to
+`water_heater` and `switch` equipments. It reuses the entire existing
+order/binding/resolution/execute pipeline; the only genuinely new primitives are
+one `OrderCategory` (`solar_toggle`), one `DataCategory` (`solar_state`), and the
+UI that renders/binds a second toggle. Nothing in the arbiter, the event bus, the
+REST surface, or the DB schema changes.
+
+## Design principle
+
+The main on/off already lives as _"an order binding whose category is
+`light_toggle`/`toggle_power`, alias `state`, resolved by `findOrderByCategory`"_
+(spec 150). The solar channel is the exact same shape under a reserved category
+and alias, so the two never collide during category-first resolution:
+
+| Channel   | Order alias | Order category                  | State alias   | State category |
+| --------- | ----------- | ------------------------------- | ------------- | -------------- |
+| Main      | `state`     | `light_toggle` / `toggle_power` | `state`       | `light_state`  |
+| **Solar** | `solar`     | `solar_toggle`                  | `solar_state` | `solar_state`  |
+
+## Data model changes
+
+### `src/shared/types.ts`
+
+- `OrderCategory` (`:69-96`) gains `| "solar_toggle"`.
+- `DataCategory` (`:10-…`) gains `| "solar_state"`.
+
+### `ui/src/types.ts`
+
+- Mirror both additions (kept in sync by convention with the backend union).
+
+Migration **023** adds `data_bindings.category_override TEXT` (mirror of the
+`order_bindings` column from migration 006; nullable, no backfill —
+`COALESCE(category_override, dd.category)` = `dd.category` on existing rows). With
+that column, a solar binding is a normal row (`alias='solar'`,
+`category_override='solar_toggle'` on the order; `alias='solar_state'`,
+`category_override='solar_state'` on the data).
+
+## Backend changes
+
+### 1. On/off channel helpers — `src/shared/binding-candidates.ts`
+
+- `POWER_TOGGLE_CATEGORIES` (`:92`) stays main-only. Add a sibling constant
+  `SOLAR_TOGGLE_CATEGORIES = new Set<OrderCategory>(["solar_toggle"])` and a
+  predicate `isSolarOrderCategory(cat)`.
+- `isOnOffOrder` is unchanged: the _device_ order the user assigns to the solar
+  role is still an ordinary on/off order (Zigbee boolean `state`, Tasmota enum).
+  The solar-ness lives in the **equipment binding's category override**, not in
+  the device order.
+- `computeBindingCandidates` for `water_heater`/`switch` (`:165-193`) is
+  unchanged (it enumerates the physical on/off channels). Solar assignment is a
+  role choice made in the editor over those same channels — see UI.
+
+### 2. Binding category inference — `src/shared/binding-candidates.ts`
+
+- `inferBindingCategory(equipmentType, orderShape)` (`:498-529`) keeps returning
+  `null` for `switch`/`water_heater`'s main channel (falls back to the device's
+  own `light_toggle`/`toggle_power`). Solar is **never inferred** — it is set
+  explicitly by the editor when the user picks the "Solaire" role, which passes
+  an explicit `category = "solar_toggle"` (and `alias = "solar"`) to
+  `addOrderBinding` / `addDataBinding`.
+- `addOrderBinding` (`equipment-manager.ts:680-723`) already accepts a category
+  override path; confirm it persists an explicit `solar_toggle` (extend the
+  signature only if the UI cannot currently pass an explicit alias+category for
+  a chosen order — see plan).
+
+### 3. Resolution — `src/equipments/binding-resolver.ts`
+
+Add thin resolvers (or call the generic `findOrderByCategory`/`findDataByCategory`
+directly at the call sites):
+
+```ts
+findOrderByCategory(orderBindings, ["solar_toggle"], ["solar"]); // solar command
+findDataByCategory(dataBindings, ["solar_state"], ["solar_state"]); // solar state
+```
+
+The main-channel resolution (`["light_toggle","toggle_power"], ["state"]`) is
+unchanged, so a solar binding never shadows it and vice versa.
+
+### 4. Order execution — `src/equipments/equipment-manager.ts`
+
+`executeOrder(equipmentId, alias, value, source)` (`:745-940`) is **unchanged**:
+it already resolves bindings by alias via `getOrderBindingsByAlias`. Passing
+alias `"solar"` naturally dispatches only the solar binding; `"state"` only the
+main one. Add coverage, not code.
+
+### 5. Zone aggregation — `src/zones/zone-aggregator.ts`
+
+`solar_state` is an actuator state, not a measurement. The aggregator already
+guards numeric aggregation (e.g. temperature at `:570` requires
+`alias === "temperature"`), and only aggregates known measurement categories.
+Confirm `solar_state` is treated exactly like `light_state`/`appliance_state`
+(never summed/averaged). Add a regression test.
+
+## UI changes
+
+### 6. States family (Analyse) — `ui/src/components/history/history-utils.ts`
+
+`familyOf()` must map `solar_state` → `"states"` (alongside `light_state`,
+`appliance_state`, `lock_state`, `gate_state`, `cover_state`). Add its semantic
+tick labels (`Arrêt`/`Marche`) wherever the states family renders ticks
+(TimeSeriesChart / history-utils). This makes a solar-state series chart as a
+stepped [0,1] state, per spec 144.
+
+### 7. Binding metadata — `ui/src/components/equipments/bindingUtils.ts`
+
+- Extend the per-type category maps (`:106` `switch`, `:119` `water_heater`) to
+  include `solar_state` (and, for orders, allow `solar_toggle`).
+- Add the FR/EN human label for the `solar` role and the `solar_state` category.
+
+### 8. Binding editor — the one substantial UI addition
+
+In the equipment binding management (settings) for `water_heater`/`switch`, the
+user must be able to take an on/off device channel and bind it under the
+**"Solaire"** role rather than (or in addition to) the main on/off. Concretely:
+a role selector on an on/off candidate → main (`state`/`light_toggle`) vs solar
+(`solar`/`solar_toggle`), which drives the alias + category override passed to
+`addOrderBinding` (and the matching state to `addDataBinding` as `solar_state`).
+Exact component: the equipment bindings editor used on the detail/settings page
+(see `ui/src/components/equipments/…` binding UI). This is the only place that
+needs new interaction beyond rendering.
+
+### 9. Two independent toggles
+
+The main-on/off resolution → toggle already exists in
+`ui/src/components/equipments/LightControl.tsx` (main), and the compact/mobile
+cards render it. Add a **parallel solar control**:
+
+- `CompactEquipmentCard.tsx` (`:247` region): render main toggle iff main
+  on/off binding resolves; render a "Solaire" toggle iff the solar binding
+  resolves. Independent handlers:
+  `executeEquipmentOrder(id, "solar", onVal|offVal)`.
+- `MobileWidgetCard.tsx` (`:443`) and `mobile-click-action.ts` (`:55-82`):
+  same, add the solar order resolution + a distinct tap target.
+- `EquipmentDetailPage.tsx`: render the main control (include `water_heater`,
+  which the inline block at `:267` currently omits) and a solar control block
+  below it. State from `solar_state`.
+- Solar glyph: Lucide `Sun` (stroke 1.5). Label: FR "Solaire" / EN "Solar".
+
+### 10. UI order resolution helpers — `ui/src/components/equipments/bindingUtils.ts` (or `LightControl` twin)
+
+Add a small `findSolarOrder(orderBindings)` /
+`findSolarState(dataBindings)` mirroring `findOrderByCategory` usage, so the
+cards resolve the solar channel the same way everywhere (keep the UI resolver in
+sync with the backend one, per the existing convention).
+
+## Interaction with the arbiter (no change, must stay true)
+
+- The follow-up recipe dispatches the solar order via
+  `ctx.dispatchOrder(equipmentId, "solar", "ON"|"OFF")` inside its
+  `onGranted`/`onRevoked` callbacks — `source.kind = "recipe"`.
+- The arbiter's `onOrderExecuted` (`capacity-arbiter.ts:437-511`) already
+  classifies order sources: a `manual` solar order → manual-override suspension
+  (FR-6); a `recipe` solar order → recipe intent. This is verified by AC7, not
+  re-implemented.
+- `energyProfile` is unchanged. For the Calypso the admin sets
+  `class = deferrable` (auto-default already), `nominalPowerW ≈ 650` (heat pump
+  only at 62 °C — the 1800 W booster never engages in PV mode), and raises
+  `minOnS` to cover the appliance's own ~30 min release tail. The global
+  `releaseHoldS` is unchanged; there is no per-profile release delay (corrects
+  an earlier assumption).
+
+## Files touched (summary)
+
+| File                                                                          | Change                                                         |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `src/shared/types.ts`                                                         | `+solar_toggle` (OrderCategory), `+solar_state` (DataCategory) |
+| `src/shared/binding-candidates.ts`                                            | `SOLAR_TOGGLE_CATEGORIES`, `isSolarOrderCategory`              |
+| `src/equipments/binding-resolver.ts`                                          | solar order/state resolution (or call sites)                   |
+| `src/equipments/equipment-manager.ts`                                         | explicit alias+category on add binding if needed; tests        |
+| `src/zones/zone-aggregator.ts`                                                | confirm `solar_state` excluded from aggregation + test         |
+| `ui/src/types.ts`                                                             | mirror the two new categories                                  |
+| `ui/src/components/history/history-utils.ts`                                  | `familyOf("solar_state") → states` + ticks                     |
+| `ui/src/components/equipments/bindingUtils.ts`                                | solar role/category metadata + labels + UI resolver            |
+| equipment bindings editor component                                           | "Solaire" role assignment for on/off channels                  |
+| `ui/src/components/home/CompactEquipmentCard.tsx`                             | second (solar) toggle                                          |
+| `ui/src/components/dashboard/MobileWidgetCard.tsx` + `mobile-click-action.ts` | second (solar) toggle                                          |
+| `ui/src/components/equipments/EquipmentDetailPage.tsx`                        | main (incl. water_heater) + solar control blocks               |
+| i18n FR/EN files                                                              | "Solaire"/"Solar" + tooltip                                    |
+| `docs/user/equipments.{md,fr.md}`, `docs/technical/data-model.md`             | document the solar channel                                     |

--- a/specs/152-equipment-solar-command/plan.md
+++ b/specs/152-equipment-solar-command/plan.md
@@ -1,0 +1,113 @@
+# Spec 152 — Implementation plan
+
+## Task breakdown (in dependency order)
+
+### A. Types & constants
+
+- [x] A1 — `src/shared/types.ts`: add `"solar_toggle"` to `OrderCategory`,
+      `"solar_state"` to `DataCategory`.
+- [x] A2 — `ui/src/types.ts`: mirror both.
+- [x] A3 — `src/shared/binding-candidates.ts`: add `SOLAR_CHANNEL_TYPES` +
+      `SOLAR_ORDER_ALIAS`/`SOLAR_STATE_ALIAS` and the solar branches of
+      `inferBindingCategory`/`inferDataBindingCategory`; `isOnOffOrder`/candidates
+      unchanged. (Shipped as inference, not a standalone `isSolarOrderCategory`.)
+
+### B. Binding & resolution (backend)
+
+- [x] B1 — `src/equipments/binding-resolver.ts`: solar resolvers (or documented
+      direct `findOrderByCategory(…, ["solar_toggle"], ["solar"])` /
+      `findDataByCategory(…, ["solar_state"], ["solar_state"])` call sites).
+- [x] B2 — `equipment-manager.ts`: ensure `addOrderBinding`/`addDataBinding`
+      can persist an **explicit** alias (`solar`) + category override
+      (`solar_toggle` / `solar_state`). Extend the input path only if it cannot
+      today.
+- [x] B3 — Confirm `executeOrder(id, "solar", …)` dispatches solar-only (no code
+      change expected) — locked by tests.
+
+### C. Aggregation & history classification
+
+- [x] C1 — `src/zones/zone-aggregator.ts`: confirm/treat `solar_state` as an
+      actuator state excluded from measurement aggregation.
+- [x] C2 — `ui/src/components/history/history-utils.ts`: `familyOf("solar_state")
+    → "states"`; add `Arrêt`/`Marche` semantic ticks for the series.
+
+### D. UI — binding editor
+
+- [x] D1 — UI resolves the solar channel via the existing
+      `findOrderByCategory([solar_toggle],[solar])` /
+      `findDataByCategory([solar_state],[solar_state])` (bindingUtils, shared with
+      the backend). Solar label reuses the `equipments.group.solar` i18n key.
+- [~] D2 — A solar binding is created through the existing **AddBindingModal**
+  free-alias entry: pick the device on/off order/data and set alias
+  `solar` / `solar_state`; the backend infers the category. No dedicated
+  role-selector UI was added (the free-alias path already satisfies AC1);
+  a discoverability preset can follow if wanted.
+
+### E. UI — two toggles
+
+- [x] E1 — `CompactEquipmentCard.tsx`: render main toggle iff main binding;
+      "Solaire" toggle iff solar binding; independent handlers. **The solar
+      toggle reuses the exact same switch/toggle control as the light on/off,
+      only the glyph changes to a small sun** (user directive).
+- [x] E2 — `MobileWidgetCard.tsx` + `mobile-click-action.ts`: solar toggle.
+- [x] E3 — `EquipmentDetailPage.tsx`: include `water_heater` in the main control
+      block; add a solar control block; state from `solar_state`.
+- [x] E4 — Lucide `Sun` glyph, FR/EN i18n strings.
+
+### F. Docs
+
+- [x] F1 — `docs/user/equipments.{md,fr.md}`: document the solar channel and the
+      two-toggle card (with the Calypso wiring as the worked example).
+- [~] F2 — `docs/technical/data-model.md` is high-level and does not enumerate
+  binding columns or category unions, so there is nothing to add there.
+  Migration 023 is documented in the migration file and architecture.md.
+
+## Test Plan
+
+### Modules to test
+
+- `src/shared/binding-candidates.ts` — `isSolarOrderCategory`, candidate
+  stability.
+- `src/equipments/binding-resolver.ts` — solar order/state resolution vs main.
+- `src/equipments/equipment-manager.ts` — `executeOrder` alias routing; add-binding
+  persists explicit solar alias+category.
+- `src/zones/zone-aggregator.ts` — `solar_state` not aggregated.
+- `ui/src/components/history/history-utils.ts` — `familyOf`, ticks.
+
+### Scenarios per module
+
+| Module             | Scenario                                                          | Expected                                                                 |
+| ------------------ | ----------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| binding-resolver   | Equipment with main + solar order bindings, resolve solar         | Returns the `solar`/`solar_toggle` binding, not the main one             |
+| binding-resolver   | Resolve main on/off when a solar binding also exists              | Returns the `state`/`light_toggle` binding, unaffected by solar          |
+| binding-resolver   | Solar-only equipment (Calypso), resolve main                      | Returns none; resolve solar returns the solar binding                    |
+| binding-resolver   | Resolve `solar_state` data                                        | Returns the `solar_state` binding; main `light_state` unaffected         |
+| equipment-manager  | `executeOrder(id, "solar", "ON")` with main + solar bound         | Dispatches only to the solar device order; main device order not called  |
+| equipment-manager  | `executeOrder(id, "state", "ON")` with main + solar bound         | Dispatches only to the main device order; solar not called               |
+| equipment-manager  | `executeOrder(id, "solar", …)` with no solar binding              | Explicit "no matching binding" outcome, no dispatch                      |
+| equipment-manager  | add on/off order under solar role                                 | Row persisted with `alias='solar'`, `category_override='solar_toggle'`   |
+| binding-candidates | `isSolarOrderCategory("solar_toggle") / ("light_toggle")`         | `true` / `false`; on/off candidates for switch/water_heater unchanged    |
+| zone-aggregator    | Zone with a `solar_state` binding among equipments                | `solar_state` never contributes to any numeric aggregate                 |
+| history-utils      | `familyOf("solar_state")`                                         | `"states"`                                                               |
+| history-utils      | Mixed chart: `temperature` + `solar_state`                        | temperature on measurement axis; solar_state stepped on [0,1] state axis |
+| arbiter (guard)    | manual solar order on a profiled equipment (`source.kind=manual`) | manual-override suspension fires (existing FR-6 path, regression guard)  |
+| arbiter (guard)    | recipe solar order (`source.kind=recipe`)                         | treated as recipe intent, no override suspension                         |
+
+### Retro-compat
+
+- Pre-152 `switch` / `water_heater` with only a main on/off binding: identical
+  behaviour, no solar toggle rendered, no new aggregation, charts unchanged.
+- Other equipment types: untouched (no solar candidate offered).
+
+## Manual verification (Phase 4)
+
+Drive it on a local docker instance (shadow / dev, per repo conventions — never
+prod, never a dev run on prod data):
+
+1. Create a `water_heater`, bind a Zigbee relay's `state` under the **Solaire**
+   role. Compact card shows a single "Solaire" toggle (no main on/off).
+2. Toggle it → the relay actuates; `solar_state` reflects on the toggle.
+3. Add a second relay as the **main** on/off → card now shows two independent
+   toggles; each drives its own device.
+4. Analyse the equipment: the solar state charts as a stepped Arrêt/Marche line,
+   not a smooth 0→1 measurement.

--- a/specs/152-equipment-solar-command/spec.md
+++ b/specs/152-equipment-solar-command/spec.md
@@ -1,0 +1,151 @@
+# Spec 152 — Equipment solar command channel
+
+- **Status**: DRAFT
+- **Date**: 2026-08-17
+- **Related**: spec 135 (water heater equipment), spec 140 (energy capacity
+  arbiter), spec 129 (metering-aware switch), spec 144 (Analyse mixed-state
+  axis), spec 150 (unified binding candidates / on-off command)
+
+## Context
+
+A growing class of appliances can be driven from solar surplus through a
+**second, dedicated control input that is distinct from their normal on/off**.
+The reference case is an Atlantic Calypso Connecté water heater: it stays on
+permanent mains (its own internal programming decides normal heating), and a
+separate **dry-contact PV input** (wired here through a SONOFF MINI-ZBD) forces
+the heat pump to run when a surplus signal is present. Closing that contact is
+not "turn the heater on" — the heater is always powered — it is "heat now, on
+solar".
+
+Sowel already models the _normal_ on/off of a `water_heater` / `switch`
+(spec 135: an order binding of category `light_toggle` / `toggle_power`, alias
+`state`). It has **no place for this second, solar-specific actuator**. Today a
+user would have to bind the MINI-ZBD as the equipment's main on/off, which
+conflates "the heater is on" with "force heating on surplus" and makes a future
+generic surplus recipe indistinguishable from a plain relay toggle.
+
+## Goal
+
+Give `water_heater` and `switch` equipments an optional **second on/off command
+channel, "solar"**, with its own binding, its own state feedback, and its own
+control on the cards — fully independent from the main on/off. This is the
+actuator a future generic surplus recipe (out of scope here) drives through the
+energy arbiter, while the appliance's normal on/off is never touched.
+
+The user's mental model, verbatim: _"deux boutons, l'un on/off, et l'autre
+solaire activé ou non"_ — the compact card shows the on/off toggle when a main
+binding exists, and a solar toggle when a solar binding exists.
+
+## Scope
+
+### In scope
+
+- New **`OrderCategory` `solar_toggle`** — a binary solar-force command channel,
+  the on/off analog reserved for the solar actuator.
+- New **`DataCategory` `solar_state`** — on/off state feedback for the solar
+  channel, so its toggle reflects reality and it charts correctly. Classified in
+  the spec 144 **states** family (stepped, semantic ticks), and **excluded from
+  zone measurement/temperature aggregation** like every other actuator state.
+- **Binding**: on `water_heater` and `switch`, the binding editor can assign any
+  on/off device order (the same channels `isOnOffOrder` already recognises:
+  Zigbee boolean `state`, Tasmota ON/OFF enum) to a **"Solaire"** role — order
+  binding alias `solar` / category `solar_toggle`, and, when the device reports
+  its state, a data binding alias `solar_state` / category `solar_state`. This
+  is an **explicit** binding (never auto-guessed: nothing distinguishes a solar
+  relay from a main relay at discovery).
+- **Resolution**: the solar command resolves via
+  `findOrderByCategory(orderBindings, ["solar_toggle"], ["solar"])` and its state
+  via `findDataByCategory(dataBindings, ["solar_state"], ["solar_state"])`,
+  mirroring the main on/off resolution. The two channels never collide.
+- **Order execution**: `executeOrder(equipmentId, "solar", value)` dispatches
+  only to the solar binding; the main on/off binding is untouched (and vice
+  versa). Uses the existing `executeOrder` alias plumbing — no new route.
+- **UI — two independent toggles**: the compact card
+  (`CompactEquipmentCard`), the mobile widget (`MobileWidgetCard`) and the
+  equipment detail page render the **main on/off** toggle iff a main binding
+  exists and a **"Solaire"** toggle iff a solar binding exists. Each is driven by
+  its own state. The Calypso case (solar-only) shows only the "Solaire" toggle.
+  Solar control uses a sun (Lucide `Sun`) glyph. FR/EN i18n.
+- **Types covered**: `water_heater` and `switch` only.
+- Docs: `docs/user/equipments.{md,fr.md}`, `docs/technical/data-model.md`.
+
+### Out of scope
+
+- **The generic "surplus switch" recipe** that claims arbiter capacity and
+  drives the `solar` command on grant/revoke — a separate follow-up shipped as
+  an external recipe plugin (`sowel-recipe-dev`). This spec only makes the
+  actuator and its surface exist; the recipe targets equipments of type
+  `["switch", "water_heater"]` and dispatches alias `solar`.
+- **Capability-typed recipe slots** ("any equipment exposing a solar command").
+  Not needed: with a two-type scope the recipe uses the existing
+  `constraints.equipmentType` list. Deferred until a third type wants in.
+- **Arbiter changes**. The arbiter is unchanged (spec 140, phase 1: it issues no
+  orders). A manual flip of the solar toggle is already seen by the arbiter as a
+  manual override; a recipe-sourced solar order as recipe intent — existing FR-6
+  behaviour, verified not re-implemented.
+- **3-state / enum "mode" command** (Off / Auto / Force). The command is a plain
+  boolean, decided with the user.
+- **Solar channel on other types** (pool_pump, water_valve, heater, appliance).
+  Extensible later by adding them to the candidate/UI lists; no model change
+  required.
+- **Setpoint / 62 °C awareness**. The appliance fixes its own PV setpoint; Sowel
+  only opens/closes the contact.
+
+## Data model
+
+`OrderCategory` gains `solar_toggle`; `DataCategory` gains `solar_state` (both
+TypeScript string unions plus their UI mirrors). One **SQLite migration (023)**
+is required: `data_bindings.category_override` did not exist (only
+`order_bindings` got it, in migration 006), and the solar _state_ binding needs a
+distinct `solar_state` category to resolve, aggregate, and chart independently of
+the main `light_state`. The migration is additive (nullable column, no backfill);
+`order_bindings.category_override` already exists. A solar binding is then an
+ordinary `order_bindings` / `data_bindings` row with alias `solar` /
+`solar_state`. No new event type, no new API route (reuses
+`POST /equipments/:id/orders/:alias` with alias `solar`).
+
+## Acceptance criteria
+
+- [x] AC1 — On a `water_heater` or `switch`, an on/off device order can be bound
+      to a **"Solaire"** role (alias `solar`, category `solar_toggle`),
+      independently of and without disturbing the main on/off binding.
+      (equipment-manager.test.ts + binding-candidates.test.ts)
+- [x] AC2 — `executeOrder(id, "solar", "ON"|"OFF")` dispatches only to the
+      solar-bound device order; the main on/off channel is not actuated. The
+      converse holds for `executeOrder(id, "state", …)`. (equipment-manager.test.ts)
+- [x] AC3 — The compact card renders the main on/off toggle **iff** a main
+      binding exists and the "Solaire" toggle **iff** a solar binding exists;
+      both are independent. A solar-only equipment (Calypso) shows only
+      "Solaire". (CompactEquipmentCard.tsx; visual)
+- [x] AC4 — The mobile widget and the equipment detail page render the same two
+      independent toggles. (EquipmentDetailPage.tsx, EquipmentCard.tsx,
+      MobileWidgetCard.tsx + mobile-click-action.ts; visual)
+- [x] AC5 — When a `solar_state` data binding exists, the "Solaire" toggle
+      reflects it; `solar_state` is **not** pulled into the zone
+      temperature/measurement aggregation. (zone-aggregator.test.ts)
+- [x] AC6 — In Analyse, `solar_state` belongs to the **states** family: charted
+      as a stepped line on the [0,1] state axis with `Arrêt`/`Marche` ticks, not
+      as a smooth 0→1 measurement. (history-utils.test.ts)
+- [~] AC7 — A solar order dispatched by a recipe (`source.kind = "recipe"`) is
+  seen by the arbiter as recipe intent; a manual solar toggle
+  (`source.kind = "manual"`) triggers the arbiter's manual-override
+  suspension as any other manual order does. Relies on the **unchanged**
+  arbiter order-source handling (spec 140, no code touched here); not
+  separately tested, exercised end-to-end by the follow-up surplus recipe.
+- [x] AC8 — No regression: equipments with no solar binding behave exactly as
+      before; `switch` / `water_heater` without solar are unchanged; other
+      equipment types are unaffected. (full backend 1481 + UI 489 suites green)
+- [x] AC9 — FR/EN i18n for the solar control label and any tooltip. (reuses
+      `equipments.group.solar`, `controls.turnOn/Off`, `common.on/off`)
+
+## Edge cases
+
+| Case                                             | Expected                                                                           |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| Solar order bound, no `solar_state` data         | Toggle still actuates; shows optimistic/last-command state, no crash               |
+| Main on/off absent (Calypso, permanent mains)    | Only the "Solaire" toggle renders; no empty main control                           |
+| Same physical relay bound as both main and solar | Allowed; both toggles act on it. Not recommended, not prevented (user intent)      |
+| Solar device offline                             | "Solaire" toggle degraded/disabled per spec 116; equipment status reflects it      |
+| Multi-gang relay                                 | Each on/off channel can be assigned to main or solar in the editor                 |
+| `executeOrder(id, "solar", …)` with no binding   | Same "no matching binding" path as any unknown alias — explicit error, no dispatch |
+| Existing pre-152 water_heater/switch             | No `solar` binding → identical behaviour; nothing new renders                      |

--- a/src/equipments/binding-resolver.test.ts
+++ b/src/equipments/binding-resolver.test.ts
@@ -81,3 +81,35 @@ describe("findDataByCategory", () => {
     expect(findDataByCategory(bindings, ["light_state"], ["state"])).toEqual(bindings[0]);
   });
 });
+
+describe("solar channel resolution (spec 152)", () => {
+  it("resolves the solar command independently of the main on/off", () => {
+    const bindings = [
+      { alias: "state", category: "light_toggle" as const },
+      { alias: "solar", category: "solar_toggle" as const },
+    ];
+    expect(findOrderByCategory(bindings, ["solar_toggle"], ["solar"])).toEqual(bindings[1]);
+    // The main resolver never picks the solar binding.
+    expect(findOrderByCategory(bindings, ["light_toggle", "toggle_power"], ["state"])).toEqual(
+      bindings[0],
+    );
+  });
+
+  it("resolves solar on a solar-only equipment (no main on/off, e.g. Calypso)", () => {
+    const bindings = [{ alias: "solar", category: "solar_toggle" as const }];
+    expect(findOrderByCategory(bindings, ["solar_toggle"], ["solar"])).toEqual(bindings[0]);
+    // No main channel to resolve.
+    expect(
+      findOrderByCategory(bindings, ["light_toggle", "toggle_power"], ["state"]),
+    ).toBeUndefined();
+  });
+
+  it("resolves solar_state data distinctly from the main light_state", () => {
+    const bindings = [
+      { alias: "state", category: "light_state" as const },
+      { alias: "solar_state", category: "solar_state" as const },
+    ];
+    expect(findDataByCategory(bindings, ["solar_state"], ["solar_state"])).toEqual(bindings[1]);
+    expect(findDataByCategory(bindings, ["light_state"], ["state"])).toEqual(bindings[0]);
+  });
+});

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -1281,6 +1281,79 @@ describe("EquipmentManager", () => {
       expect(cover?.value).toBe(null);
     });
   });
+
+  // ============================================================
+  // Solar command channel (spec 152)
+  // ============================================================
+
+  describe("solar command channel (spec 152)", () => {
+    function seedWaterHeaterWithChannels() {
+      const zone = zoneManager.create({ name: "Buanderie" });
+      const eq = manager.create({ name: "Chauffe-eau", type: "water_heater", zoneId: zone.id });
+
+      const main = seedDevice(db, {
+        name: "MainRelay",
+        dataKeys: [{ key: "state", type: "boolean", category: "light_state", value: "OFF" }],
+        orderKeys: [{ key: "state", type: "boolean", category: "light_toggle" }],
+      });
+      const solar = seedDevice(db, {
+        name: "SolarRelay",
+        dataKeys: [{ key: "state", type: "boolean", category: "light_state", value: "OFF" }],
+        orderKeys: [{ key: "state", type: "boolean", category: "light_toggle" }],
+      });
+      return { eq, main, solar };
+    }
+
+    it("tags an on/off order bound under alias `solar` as solar_toggle", () => {
+      const { eq, solar } = seedWaterHeaterWithChannels();
+      manager.addOrderBinding(eq.id, solar.orderIds[0], "solar");
+      const ob = manager.getOrderBindingsWithDetails(eq.id).find((b) => b.alias === "solar");
+      expect(ob?.category).toBe("solar_toggle");
+    });
+
+    it("tags a state binding under alias `solar_state` as solar_state", () => {
+      const { eq, solar } = seedWaterHeaterWithChannels();
+      manager.addDataBinding(eq.id, solar.dataIds[0], "solar_state");
+      const sb = manager.getDataBindingsWithValues(eq.id).find((b) => b.alias === "solar_state");
+      expect(sb?.category).toBe("solar_state");
+    });
+
+    it("executeOrder(solar) dispatches only the solar device; the main relay is untouched", async () => {
+      const { eq, main, solar } = seedWaterHeaterWithChannels();
+      manager.addOrderBinding(eq.id, main.orderIds[0], "state");
+      manager.addOrderBinding(eq.id, solar.orderIds[0], "solar");
+
+      mockPublished.length = 0;
+      await manager.executeOrder(eq.id, "solar", true);
+
+      expect(mockPublished).toHaveLength(1);
+      expect(mockPublished[0].topic).toBe("z2m/SolarRelay/set");
+    });
+
+    it("executeOrder(state) dispatches only the main device; the solar contact is untouched", async () => {
+      const { eq, main, solar } = seedWaterHeaterWithChannels();
+      manager.addOrderBinding(eq.id, main.orderIds[0], "state");
+      manager.addOrderBinding(eq.id, solar.orderIds[0], "solar");
+
+      mockPublished.length = 0;
+      await manager.executeOrder(eq.id, "state", true);
+
+      expect(mockPublished).toHaveLength(1);
+      expect(mockPublished[0].topic).toBe("z2m/MainRelay/set");
+    });
+
+    it("a solar-only water heater (no main binding) still actuates via the solar alias", async () => {
+      const { eq, solar } = seedWaterHeaterWithChannels();
+      manager.addOrderBinding(eq.id, solar.orderIds[0], "solar");
+
+      mockPublished.length = 0;
+      await manager.executeOrder(eq.id, "solar", true);
+      expect(mockPublished).toHaveLength(1);
+      expect(mockPublished[0].topic).toBe("z2m/SolarRelay/set");
+
+      await expect(manager.executeOrder(eq.id, "state", true)).rejects.toThrow(/not found/i);
+    });
+  });
 });
 
 // ============================================================

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -21,7 +21,7 @@ import type {
   OrderCategory,
   OrderSource,
 } from "../shared/types.js";
-import { inferBindingCategory } from "../shared/binding-candidates.js";
+import { inferBindingCategory, inferDataBindingCategory } from "../shared/binding-candidates.js";
 import { parseWireValue, resolveWireValue } from "../shared/order-wire-value.js";
 import { deriveEquipmentStatus, isStaleBinding } from "./equipment-status.js";
 import type { Device } from "../shared/types.js";
@@ -198,8 +198,8 @@ export class EquipmentManager {
 
       // DataBinding
       insertDataBinding: this.db.prepare(
-        `INSERT INTO data_bindings (id, equipment_id, device_data_id, alias)
-         VALUES (@id, @equipmentId, @deviceDataId, @alias)`,
+        `INSERT INTO data_bindings (id, equipment_id, device_data_id, alias, category_override)
+         VALUES (@id, @equipmentId, @deviceDataId, @alias, @categoryOverride)`,
       ),
       deleteDataBinding: this.db.prepare("DELETE FROM data_bindings WHERE id = ?"),
       getDataBindingById: this.db.prepare("SELECT * FROM data_bindings WHERE id = ?"),
@@ -211,7 +211,8 @@ export class EquipmentManager {
       ),
       getDataBindingsWithValues: this.db.prepare(
         `SELECT db.id, db.equipment_id, db.device_data_id, db.alias, db.historize,
-                dd.device_id, d.name as device_name, dd.key, dd.type, dd.category,
+                dd.device_id, d.name as device_name, dd.key, dd.type,
+                COALESCE(db.category_override, dd.category) as category,
                 dd.value, dd.unit, dd.enum_values, dd.last_updated, dd.last_changed
          FROM data_bindings db
          JOIN device_data dd ON db.device_data_id = dd.id
@@ -227,6 +228,9 @@ export class EquipmentManager {
       ),
       updateOrderBindingCategoryOverride: this.db.prepare(
         `UPDATE order_bindings SET category_override = ? WHERE id = ?`,
+      ),
+      updateDataBindingCategoryOverride: this.db.prepare(
+        `UPDATE data_bindings SET category_override = ? WHERE id = ?`,
       ),
       getOrderBindingsByEquipmentWithOrder: this.db.prepare(
         `SELECT ob.id, ob.equipment_id, ob.device_order_id, ob.alias,
@@ -487,6 +491,7 @@ export class EquipmentManager {
     // so that recipes / zone orders targeting pool-specific categories stay consistent.
     if (input.type !== undefined && input.type !== existing.type) {
       this.retagOrderBindingOverrides(id, equipment.type);
+      this.retagDataBindingOverrides(id, equipment.type);
     }
 
     this.logger.info({ equipmentId: id, name: equipment.name }, "Equipment updated");
@@ -523,19 +528,41 @@ export class EquipmentManager {
   private retagOrderBindingOverrides(equipmentId: string, equipmentType: EquipmentType): void {
     const rows = this.stmts.getOrderBindingsByEquipmentWithOrder.all(equipmentId) as Array<{
       id: string;
+      alias: string;
       type: string;
       enum_values: string | null;
       min_value: number | null;
       max_value: number | null;
     }>;
     for (const row of rows) {
-      const override = inferBindingCategory(equipmentType, {
-        type: row.type as DataType,
-        enumValues: row.enum_values ? (JSON.parse(row.enum_values) as string[]) : undefined,
-        min: row.min_value ?? undefined,
-        max: row.max_value ?? undefined,
-      });
+      const override = inferBindingCategory(
+        equipmentType,
+        {
+          type: row.type as DataType,
+          enumValues: row.enum_values ? (JSON.parse(row.enum_values) as string[]) : undefined,
+          min: row.min_value ?? undefined,
+          max: row.max_value ?? undefined,
+        },
+        row.alias,
+      );
       this.stmts.updateOrderBindingCategoryOverride.run(override, row.id);
+    }
+  }
+
+  /**
+   * Spec 152 — re-infer `category_override` for all DATA bindings on a type
+   * change (symmetric with retagOrderBindingOverrides). Keeps a `solar_state`
+   * override consistent with the new type so aggregation / Analyse (which key on
+   * category, not alias) never mis-tag a channel after a type switch.
+   */
+  private retagDataBindingOverrides(equipmentId: string, equipmentType: EquipmentType): void {
+    const rows = this.stmts.getDataBindingsByEquipment.all(equipmentId) as Array<{
+      id: string;
+      alias: string;
+    }>;
+    for (const row of rows) {
+      const override = inferDataBindingCategory(equipmentType, row.alias);
+      this.stmts.updateDataBindingCategoryOverride.run(override, row.id);
     }
   }
 
@@ -577,16 +604,21 @@ export class EquipmentManager {
   // ============================================================
 
   addDataBinding(equipmentId: string, deviceDataId: string, alias: string): DataBinding {
-    if (!this.getById(equipmentId)) {
+    const equipment = this.getById(equipmentId);
+    if (!equipment) {
       throw new EquipmentError("Equipment not found", 404);
     }
     if (!this.stmts.checkDeviceDataExists.get(deviceDataId)) {
       throw new EquipmentError(`DeviceData not found: ${deviceDataId}`, 404);
     }
 
+    // Spec 152 — a state binding added under the `solar_state` alias is tagged
+    // solar_state so it never collides with the main on/off light_state.
+    const categoryOverride = inferDataBindingCategory(equipment.type, alias);
+
     const id = randomUUID();
     try {
-      this.stmts.insertDataBinding.run({ id, equipmentId, deviceDataId, alias });
+      this.stmts.insertDataBinding.run({ id, equipmentId, deviceDataId, alias, categoryOverride });
     } catch (err) {
       if (err instanceof Error && err.message.includes("UNIQUE constraint")) {
         throw new EquipmentError(`Alias "${alias}" already exists on this equipment`, 409);
@@ -688,14 +720,18 @@ export class EquipmentManager {
     // Compute category override based on equipment type + device order shape.
     const orderRow = this.stmts.getDeviceOrderById.get(deviceOrderId) as DeviceOrderRow | undefined;
     const categoryOverride = orderRow
-      ? inferBindingCategory(equipment.type, {
-          type: orderRow.type as DataType,
-          enumValues: orderRow.enum_values
-            ? (JSON.parse(orderRow.enum_values) as string[])
-            : undefined,
-          min: orderRow.min_value ?? undefined,
-          max: orderRow.max_value ?? undefined,
-        })
+      ? inferBindingCategory(
+          equipment.type,
+          {
+            type: orderRow.type as DataType,
+            enumValues: orderRow.enum_values
+              ? (JSON.parse(orderRow.enum_values) as string[])
+              : undefined,
+            min: orderRow.min_value ?? undefined,
+            max: orderRow.max_value ?? undefined,
+          },
+          alias,
+        )
       : null;
 
     const id = randomUUID();

--- a/src/shared/binding-candidates.test.ts
+++ b/src/shared/binding-candidates.test.ts
@@ -4,6 +4,7 @@ import {
   computeBindingCandidates,
   hasFreeCandidates,
   inferBindingCategory,
+  inferDataBindingCategory,
 } from "./binding-candidates.js";
 import type { DeviceData, DeviceOrder } from "./types.js";
 
@@ -584,5 +585,41 @@ describe("CANDIDATE_BASED_TYPES coverage (spec 150)", () => {
         result.length === 1 && result[0].id === "all" && result[0].orderKeys.length === 1;
       expect(isDefaultShape, `type ${t} fell through to the default case`).toBe(false);
     }
+  });
+});
+
+describe("solar command channel inference (spec 152)", () => {
+  it("tags a boolean on/off order bound under alias `solar` as solar_toggle (water_heater)", () => {
+    expect(inferBindingCategory("water_heater", { type: "boolean" }, "solar")).toBe("solar_toggle");
+  });
+
+  it("tags an ON/OFF enum order bound under alias `solar` as solar_toggle (switch)", () => {
+    expect(
+      inferBindingCategory("switch", { type: "enum", enumValues: ["ON", "OFF"] }, "solar"),
+    ).toBe("solar_toggle");
+  });
+
+  it("does NOT tag a non-on/off order as solar even under alias `solar` (guard)", () => {
+    expect(
+      inferBindingCategory("water_heater", { type: "number", min: 0, max: 100 }, "solar"),
+    ).toBe(null);
+  });
+
+  it("leaves the main channel untouched (alias `state` never becomes solar)", () => {
+    expect(inferBindingCategory("water_heater", { type: "boolean" }, "state")).toBe(null);
+  });
+
+  it("only water_heater and switch carry a solar channel (light_onoff does not)", () => {
+    expect(inferBindingCategory("light_onoff", { type: "boolean" }, "solar")).toBe(null);
+  });
+
+  it("inferDataBindingCategory tags alias `solar_state` as solar_state on solar-capable types", () => {
+    expect(inferDataBindingCategory("water_heater", "solar_state")).toBe("solar_state");
+    expect(inferDataBindingCategory("switch", "solar_state")).toBe("solar_state");
+  });
+
+  it("inferDataBindingCategory returns null for the main state alias and non-solar types", () => {
+    expect(inferDataBindingCategory("water_heater", "state")).toBe(null);
+    expect(inferDataBindingCategory("light_onoff", "solar_state")).toBe(null);
   });
 });

--- a/src/shared/binding-candidates.ts
+++ b/src/shared/binding-candidates.ts
@@ -92,6 +92,18 @@ function isOnOffEnum(order: CandidateOrder): boolean {
 const POWER_TOGGLE_CATEGORIES = new Set<OrderCategory>(["light_toggle", "toggle_power"]);
 
 /**
+ * Spec 152 — equipment types that can carry a dedicated "solar" command
+ * channel (a second on/off, distinct from the main one, driven by the surplus
+ * arbiter recipe). The solar role is bound explicitly under alias `solar`
+ * (order) / `solar_state` (state); it is never auto-inferred from the device.
+ */
+const SOLAR_CHANNEL_TYPES = new Set<EquipmentType>(["water_heater", "switch"]);
+
+/** Reserved alias marking the solar command / state binding role. */
+export const SOLAR_ORDER_ALIAS = "solar";
+export const SOLAR_STATE_ALIAS = "solar_state";
+
+/**
  * True for an on/off command channel. Two shapes are accepted:
  *  - an ON/OFF enum order (`["ON","OFF"]`, e.g. Tasmota `power1`)
  *  - a boolean power-toggle order (Zigbee2MQTT exposes plug/relay `state` as a
@@ -498,7 +510,20 @@ export function hasFreeCandidates(
 export function inferBindingCategory(
   equipmentType: EquipmentType,
   order: Pick<CandidateOrder, "type" | "enumValues" | "min" | "max">,
+  alias?: string,
 ): OrderCategory | null {
+  // Spec 152 — an on/off order bound under the reserved `solar` alias becomes
+  // the dedicated solar command channel, regardless of the device order's own
+  // category (a plain relay reports light_toggle/toggle_power). Guarded to
+  // on/off-shaped orders so a setpoint/number can never be tagged solar.
+  if (
+    alias === SOLAR_ORDER_ALIAS &&
+    SOLAR_CHANNEL_TYPES.has(equipmentType) &&
+    (order.type === "boolean" || isOnOffEnum(order as CandidateOrder))
+  ) {
+    return "solar_toggle";
+  }
+
   if (equipmentType === "pool_pump") {
     if (
       order.type === "enum" &&
@@ -525,5 +550,23 @@ export function inferBindingCategory(
     return null;
   }
 
+  return null;
+}
+
+/**
+ * Spec 152 — infer a per-binding category override for a DATA binding. Mirrors
+ * inferBindingCategory for the order side. A state binding added under the
+ * reserved `solar_state` alias on a solar-capable equipment is tagged
+ * `solar_state` (distinct from the main on/off `light_state`) so the two
+ * channels resolve independently and the solar state charts as its own series.
+ * Returns null when no override applies (the device_data.category is used).
+ */
+export function inferDataBindingCategory(
+  equipmentType: EquipmentType,
+  alias: string,
+): DataCategory | null {
+  if (alias === SOLAR_STATE_ALIAS && SOLAR_CHANNEL_TYPES.has(equipmentType)) {
+    return "solar_state";
+  }
   return null;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -45,6 +45,10 @@ export type DataCategory =
   | "media_mute"
   | "media_input"
   | "appliance_state"
+  // Spec 152 — on/off state feedback for the solar command channel. An actuator
+  // state (states family, spec 144, stepped Arrêt/Marche); excluded from zone
+  // measurement aggregation like every other actuator state.
+  | "solar_state"
   | "pool_water_temperature"
   | "pool_temperature_setpoint"
   // Spec 120 — display equipment (generic-ish telemetry that displays
@@ -93,7 +97,12 @@ export type OrderCategory =
   // Spec 133 — camera equipment.
   | "set_camera_monitoring"
   | "set_camera_light_mode"
-  | "trigger_camera_siren";
+  | "trigger_camera_siren"
+  // Spec 152 — solar force command channel: a second, dedicated on/off distinct
+  // from the equipment's main on/off (`light_toggle`/`toggle_power`). Reserved
+  // so the solar channel resolves independently (category-first) and never
+  // collides with the main on/off. Driven by the surplus arbiter recipe.
+  | "solar_toggle";
 
 // ============================================================
 // Device

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -651,6 +651,44 @@ describe("ZoneAggregator", () => {
       expect(data?.lightsOn).toBe(1);
       expect(data?.lightsTotal).toBe(2);
     });
+
+    // Spec 152 — the solar command channel state is an internal actuator state,
+    // never a zone-level measurement. A water_heater's solar_state binding must
+    // not leak into any aggregate (in particular it is not counted as a light).
+    it("excludes solar_state from zone aggregation", () => {
+      const zone = zoneManager.create({ name: "Buanderie" });
+
+      const light = seedDevice(db, {
+        name: "Light",
+        dataKeys: [
+          { key: "state", type: "boolean", category: "light_state", value: JSON.stringify("ON") },
+        ],
+      });
+      const solar = seedDevice(db, {
+        name: "SolarRelay",
+        dataKeys: [
+          { key: "state", type: "boolean", category: "light_state", value: JSON.stringify("ON") },
+        ],
+      });
+
+      const lamp = equipmentManager.create({ name: "Lampe", type: "light_onoff", zoneId: zone.id });
+      equipmentManager.addDataBinding(lamp.id, light.dataIds[0], "state");
+
+      const heater = equipmentManager.create({
+        name: "Chauffe-eau",
+        type: "water_heater",
+        zoneId: zone.id,
+      });
+      // Bound under the solar alias → category override solar_state.
+      equipmentManager.addDataBinding(heater.id, solar.dataIds[0], "solar_state");
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      // Only the actual light counts; the solar_state binding is ignored.
+      expect(data?.lightsTotal).toBe(1);
+      expect(data?.lightsOn).toBe(1);
+    });
   });
 
   // ============================================================

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -443,14 +443,25 @@ function useMobileState(
   if (equipment.type === "water_heater") {
     const waterTemp = equipment.dataBindings.find((db) => db.alias === "water_temperature");
     const tempValue = typeof waterTemp?.value === "number" ? waterTemp.value : null;
+    // Spec 152 — reflect the bound channel: the main on/off (light_state) when
+    // present, else the dedicated solar channel (solar_state) for a heater on
+    // permanent mains. `isOn` (light_state only) would read OFF forever there.
+    const channelState =
+      equipment.dataBindings.find((db) => db.alias === "state" || db.category === "light_state") ??
+      equipment.dataBindings.find(
+        (db) => db.category === "solar_state" || db.alias === "solar_state",
+      );
+    const heaterOn = channelState
+      ? channelState.value === true || String(channelState.value).toUpperCase() === "ON"
+      : false;
     return {
       icon: customEntry ? (
         createElement(customEntry.component, customEntry.previewProps)
       ) : (
-        <WaterHeaterIcon on={isOn} />
+        <WaterHeaterIcon on={heaterOn} />
       ),
       stateLines: [
-        isOn ? "ON" : "OFF",
+        heaterOn ? "ON" : "OFF",
         ...(tempValue !== null ? [`${tempValue.toFixed(1)}°C`] : []),
       ],
     };

--- a/ui/src/components/dashboard/getMobileClickAction.test.tsx
+++ b/ui/src/components/dashboard/getMobileClickAction.test.tsx
@@ -95,4 +95,86 @@ describe("getMobileClickAction", () => {
     const action = getMobileClickAction(widget, eq, t, vi.fn(), onOpenDetail);
     expect(action).toBe(onOpenDetail);
   });
+
+  // Spec 152 — a water heater on permanent mains carries only the solar channel;
+  // the single mobile tap must toggle it, and when a main on/off also exists the
+  // tap targets main (solar is managed from the detail sheet).
+  describe("solar channel (spec 152)", () => {
+    function makeWaterHeater(over: Partial<EquipmentWithDetails> = {}): EquipmentWithDetails {
+      return {
+        ...makeSwitch(),
+        id: "wh-1",
+        type: "water_heater",
+        dataBindings: [] as EquipmentWithDetails["dataBindings"],
+        orderBindings: [] as EquipmentWithDetails["orderBindings"],
+        ...over,
+      } as EquipmentWithDetails;
+    }
+    const solarOrder = {
+      id: "ob-solar",
+      equipmentId: "wh-1",
+      deviceOrderId: "do-solar",
+      alias: "solar",
+      deviceId: "dev-solar",
+      deviceName: "SolarRelay",
+      key: "state",
+      type: "boolean",
+      category: "solar_toggle",
+    } as EquipmentWithDetails["orderBindings"][number];
+    const solarState = {
+      id: "db-solar",
+      equipmentId: "wh-1",
+      deviceDataId: "dd-solar",
+      alias: "solar_state",
+      deviceId: "dev-solar",
+      deviceName: "SolarRelay",
+      key: "state",
+      type: "boolean",
+      category: "solar_state",
+      value: false,
+      lastUpdated: "2026-01-01T00:00:00Z",
+      lastChanged: "2026-01-01T00:00:00Z",
+      stale: false,
+    } as EquipmentWithDetails["dataBindings"][number];
+
+    it("toggles the solar channel when only a solar binding exists (no main)", () => {
+      const onExecuteOrder = vi.fn().mockResolvedValue(undefined);
+      const eq = makeWaterHeater({
+        orderBindings: [solarOrder] as EquipmentWithDetails["orderBindings"],
+        dataBindings: [solarState] as EquipmentWithDetails["dataBindings"],
+      });
+      const action = getMobileClickAction(widget, eq, t, onExecuteOrder);
+      expect(action).toBeTypeOf("function");
+      action!();
+      expect(onExecuteOrder).toHaveBeenCalledWith("wh-1", "solar", "ON");
+    });
+
+    it("targets the main on/off (not solar) when both channels are bound", () => {
+      const onExecuteOrder = vi.fn().mockResolvedValue(undefined);
+      const mainOrder = {
+        id: "ob-main",
+        equipmentId: "wh-1",
+        deviceOrderId: "do-main",
+        alias: "state",
+        deviceId: "dev-main",
+        deviceName: "MainRelay",
+        key: "state",
+        type: "enum",
+        enumValues: ["ON", "OFF"],
+        category: "light_toggle",
+      } as EquipmentWithDetails["orderBindings"][number];
+      const mainState = {
+        ...solarState,
+        id: "db-main",
+        alias: "state",
+        category: "light_state",
+      } as EquipmentWithDetails["dataBindings"][number];
+      const eq = makeWaterHeater({
+        orderBindings: [mainOrder, solarOrder] as EquipmentWithDetails["orderBindings"],
+        dataBindings: [mainState, solarState] as EquipmentWithDetails["dataBindings"],
+      });
+      getMobileClickAction(widget, eq, t, onExecuteOrder)!();
+      expect(onExecuteOrder).toHaveBeenCalledWith("wh-1", "state", "ON");
+    });
+  });
 });

--- a/ui/src/components/dashboard/mobile-click-action.ts
+++ b/ui/src/components/dashboard/mobile-click-action.ts
@@ -58,18 +58,24 @@ export function getMobileClickAction(
     type === "water_heater" ||
     type === "water_valve"
   ) {
-    const stateBindingRaw = findOrderByCategory(
+    const mainRaw = findOrderByCategory(
       equipment.orderBindings,
       ["light_toggle", "pool_pump_toggle", "valve_toggle", "toggle_power"],
       ["state"],
     );
+    // Spec 152 — a water heater on permanent mains carries only a "solar"
+    // channel; with no main on/off, the single mobile tap toggles solar. When
+    // both exist, main wins (solar is managed from the detail sheet).
+    const solarRaw = findOrderByCategory(equipment.orderBindings, ["solar_toggle"], ["solar"]);
+    const usingSolar = !mainRaw && !!solarRaw;
+    const chosenRaw = mainRaw ?? solarRaw;
     const stateBinding =
-      stateBindingRaw &&
-      (stateBindingRaw.type === "enum" || stateBindingRaw.type === "boolean")
-        ? stateBindingRaw
+      chosenRaw && (chosenRaw.type === "enum" || chosenRaw.type === "boolean")
+        ? chosenRaw
         : undefined;
     if (stateBinding) {
-      const dataBinding = equipment.dataBindings.find((db) => db.category === "light_state");
+      const stateCategory = usingSolar ? "solar_state" : "light_state";
+      const dataBinding = equipment.dataBindings.find((db) => db.category === stateCategory);
       const isOn = dataBinding
         ? dataBinding.value === true || dataBinding.value === "ON" || dataBinding.value === 1
         : false;

--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -25,6 +25,8 @@ import { AwningIcon } from "../icons/AwningIcon";
 import { SolarPanelIcon } from "../icons/SolarPanelIcon";
 import type { EquipmentType, EquipmentWithDetails } from "../../types";
 import { LightControl } from "./LightControl";
+import { SolarControl } from "./SolarControl";
+import { findMainOnOffOrder } from "./bindingUtils";
 import { SensorValues } from "./SensorValues";
 import { ShutterControl } from "./ShutterControl";
 import { ThermostatCard } from "./ThermostatCard";
@@ -168,13 +170,24 @@ export function EquipmentCard({ equipment, onExecuteOrder }: EquipmentCardProps)
         />
       )}
 
-      {/* Light / switch quick control (smart plug = ON/OFF relay, same surface) */}
-      {(isLight || isSwitch) && equipment.enabled && (
-        <LightControl
-          equipment={equipment}
-          onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
-          compact
-        />
+      {/* Light / switch / water heater quick control (smart plug = ON/OFF relay,
+          same surface). Spec 152: a dedicated solar toggle renders alongside
+          (or instead of, on permanent mains) the main on/off. */}
+      {(isLight || isSwitch || equipment.type === "water_heater") && equipment.enabled && (
+        <div className="flex items-center gap-2">
+          {!!findMainOnOffOrder(equipment.orderBindings) && (
+            <LightControl
+              equipment={equipment}
+              onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
+              compact
+            />
+          )}
+          <SolarControl
+            equipment={equipment}
+            onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
+            compact
+          />
+        </div>
       )}
 
       {/* Shutter / Awning quick control (shared control surface, awning relabels) */}

--- a/ui/src/components/equipments/LightControl.tsx
+++ b/ui/src/components/equipments/LightControl.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Power } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
 import { useSliderOverride } from "../../hooks/useSliderOverride";
-import { findOrderByCategory } from "./bindingUtils";
+import { findOrderByCategory, findMainOnOffOrder } from "./bindingUtils";
 
 interface LightControlProps {
   equipment: EquipmentWithDetails;
@@ -37,11 +37,7 @@ export function LightControl({ equipment, onExecuteOrder, compact }: LightContro
 
   // Category-first resolver (spec 110). Falls back to the boolean type / alias
   // heuristic used by lights bound before category typing existed.
-  const toggleBinding =
-    findOrderByCategory(equipment.orderBindings, ["light_toggle", "toggle_power"], ["state"]) ??
-    equipment.orderBindings.find(
-      (ob) => ob.type === "boolean" || (ob.alias === "state" && ob.type === "enum"),
-    );
+  const toggleBinding = findMainOnOffOrder(equipment.orderBindings);
   const hasToggle = !!toggleBinding;
   const brightnessOrderBinding = findOrderByCategory(
     equipment.orderBindings,

--- a/ui/src/components/equipments/SolarControl.tsx
+++ b/ui/src/components/equipments/SolarControl.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Sun } from "lucide-react";
+import type { EquipmentWithDetails } from "../../types";
+import { findOrderByCategory, findDataByCategory } from "./bindingUtils";
+
+interface SolarControlProps {
+  equipment: EquipmentWithDetails;
+  onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+  compact?: boolean;
+}
+
+/**
+ * Spec 152 — the dedicated "solar" on/off control. It is the exact same toggle
+ * as the light/switch on/off (LightControl), only the glyph changes to a sun.
+ * It drives the `solar` command channel (category `solar_toggle`) and reflects
+ * the `solar_state` feedback, both fully independent from the main on/off.
+ *
+ * Renders nothing when the equipment has no solar command bound.
+ */
+export function SolarControl({ equipment, onExecuteOrder, compact }: SolarControlProps) {
+  const { t } = useTranslation();
+  const [executing, setExecuting] = useState(false);
+
+  const toggleBinding = findOrderByCategory(equipment.orderBindings, ["solar_toggle"], ["solar"]);
+  if (!toggleBinding) return null;
+
+  const stateBinding = findDataByCategory(equipment.dataBindings, ["solar_state"], ["solar_state"]);
+  const isOn = stateBinding
+    ? stateBinding.value === true || String(stateBinding.value).toUpperCase() === "ON"
+    : false;
+
+  const handleToggle = async (e?: React.MouseEvent) => {
+    e?.preventDefault();
+    e?.stopPropagation();
+    if (executing) return;
+    setExecuting(true);
+    try {
+      const alias = toggleBinding.alias;
+      const onVal = toggleBinding.enumValues?.find((v) => /^on$/i.test(v)) ?? "ON";
+      const offVal = toggleBinding.enumValues?.find((v) => /^off$/i.test(v)) ?? "OFF";
+      const value =
+        toggleBinding.type === "boolean" && alias !== "state" ? !isOn : isOn ? offVal : onVal;
+      await onExecuteOrder(alias, value);
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  const title = `${t("controls.solar")} · ${isOn ? t("controls.turnOff") : t("controls.turnOn")}`;
+
+  if (compact) {
+    return (
+      <button
+        onClick={handleToggle}
+        disabled={executing}
+        className={`
+          p-2 rounded-[6px] transition-colors duration-150 cursor-pointer
+          ${
+            isOn
+              ? "bg-accent text-white hover:bg-accent-hover"
+              : "bg-border-light text-text-tertiary hover:bg-border hover:text-text-secondary"
+          }
+          disabled:opacity-50 disabled:cursor-not-allowed
+        `}
+        title={title}
+        onClickCapture={(e) => e.stopPropagation()}
+      >
+        <Sun size={16} strokeWidth={1.5} />
+      </button>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleToggle}
+      disabled={executing}
+      className={`
+        flex items-center gap-2 px-4 py-2 rounded-[6px] text-[13px] font-medium
+        transition-colors duration-150
+        ${
+          isOn
+            ? "bg-accent text-white hover:bg-accent-hover"
+            : "bg-border-light text-text-secondary hover:bg-border hover:text-text"
+        }
+        disabled:opacity-50
+      `}
+    >
+      <Sun size={16} strokeWidth={1.5} />
+      {t("controls.solar")}
+      {" · "}
+      {executing ? "..." : isOn ? t("common.on") : t("common.off")}
+    </button>
+  );
+}

--- a/ui/src/components/equipments/bindingUtils.ts
+++ b/ui/src/components/equipments/bindingUtils.ts
@@ -71,6 +71,28 @@ export function findOrderByCategory<T extends MinimalOrderBinding>(
   return undefined;
 }
 
+/**
+ * Spec 152 — resolve the MAIN on/off command of a light/switch/water_heater,
+ * mirroring exactly what `LightControl` binds to (category-first, then the loose
+ * boolean/`state`-enum fallback), while never matching the dedicated solar
+ * channel. Callers use it as the render gate for the main toggle so the gate and
+ * the control resolve identically (no "gate hides a toggle LightControl would
+ * still render" regression for legacy uncategorized bindings).
+ */
+export function findMainOnOffOrder<T extends MinimalOrderBinding & { type?: string }>(
+  bindings: readonly T[],
+): T | undefined {
+  return (
+    findOrderByCategory(bindings, ["light_toggle", "toggle_power"], ["state"]) ??
+    bindings.find(
+      (b) =>
+        b.alias !== "solar" &&
+        b.category !== "solar_toggle" &&
+        (b.type === "boolean" || (b.alias === "state" && b.type === "enum")),
+    )
+  );
+}
+
 /** Find a data binding by category, with the same fallback semantics. */
 export function findDataByCategory<T extends MinimalDataBinding>(
   bindings: readonly T[],

--- a/ui/src/components/history/history-utils.test.ts
+++ b/ui/src/components/history/history-utils.test.ts
@@ -53,6 +53,8 @@ describe("familyOf", () => {
   it("classifies strictly-binary actuator feedback as states (spec 144)", () => {
     expect(familyOf("light_state")).toBe("states");
     expect(familyOf("appliance_state")).toBe("states");
+    // Spec 152 — the solar command channel state is a strictly-binary ON/OFF.
+    expect(familyOf("solar_state")).toBe("states");
   });
 
   it("does NOT force cover/gate/lock onto the 0/1 state axis (they can be multi-value; #434 index-encodes them)", () => {
@@ -183,6 +185,11 @@ describe("booleanTickLabels", () => {
       "analyse.bool.power.on",
     ]);
     expect(booleanTickLabels("appliance_state")).toEqual([
+      "analyse.bool.power.off",
+      "analyse.bool.power.on",
+    ]);
+    // Spec 152 — solar channel state uses the same ON/OFF power labels.
+    expect(booleanTickLabels("solar_state")).toEqual([
       "analyse.bool.power.off",
       "analyse.bool.power.on",
     ]);

--- a/ui/src/components/history/history-utils.ts
+++ b/ui/src/components/history/history-utils.ts
@@ -47,6 +47,8 @@ export const BOOLEAN_CATEGORIES = new Set<string>([
   // to classify by enum cardinality rather than category name (deferred).
   "light_state",
   "appliance_state",
+  // Spec 152 — the solar command channel state is a strictly binary ON/OFF.
+  "solar_state",
 ]);
 
 const MEASUREMENT_CATEGORIES = new Set<string>([
@@ -208,6 +210,7 @@ export function booleanTickLabels(category: string): [string, string] {
       return ["analyse.bool.smoke.clear", "analyse.bool.smoke.detected"];
     case "light_state":
     case "appliance_state":
+    case "solar_state":
       return ["analyse.bool.power.off", "analyse.bool.power.on"];
     default:
       return ["analyse.bool.generic.off", "analyse.bool.generic.on"];

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -6,6 +6,8 @@ import { useCameraSnapshot } from "../../hooks/useCameraSnapshot";
 import { useEquipmentState, formatValue } from "../equipments/useEquipmentState";
 import { SensorValues } from "../equipments/SensorValues";
 import { LightControl } from "../equipments/LightControl";
+import { SolarControl } from "../equipments/SolarControl";
+import { findMainOnOffOrder } from "../equipments/bindingUtils";
 import { ShutterControl } from "../equipments/ShutterControl";
 import { ThermostatCard } from "../equipments/ThermostatCard";
 import { GateControl } from "../equipments/GateControl";
@@ -268,7 +270,20 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
               </span>
             </span>
           )}
-          <LightControl
+          {/* Main on/off — hidden when only a solar channel is bound (e.g. a
+              water heater on permanent mains, spec 152), so no dead toggle.
+              Uses the same resolver as LightControl so the gate never hides a
+              toggle the control would still render. */}
+          {!!findMainOnOffOrder(equipment.orderBindings) && (
+            <LightControl
+              equipment={equipment}
+              onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
+              compact
+            />
+          )}
+          {/* Spec 152 — dedicated solar on/off (same toggle, sun glyph). Renders
+              nothing when no solar command is bound. */}
+          <SolarControl
             equipment={equipment}
             onExecuteOrder={(alias, value) => onExecuteOrder(equipment.id, alias, value)}
             compact

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -330,6 +330,7 @@
   "binding.addBinding": "Add binding",
   "controls.turnOn": "Turn on",
   "controls.turnOff": "Turn off",
+  "controls.solar": "Solar",
   "controls.brightness": "Brightness",
   "controls.open": "Open",
   "controls.stop": "Stop",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -330,6 +330,7 @@
   "binding.addBinding": "Ajouter la liaison",
   "controls.turnOn": "Allumer",
   "controls.turnOff": "Éteindre",
+  "controls.solar": "Solaire",
   "controls.brightness": "Luminosité",
   "controls.open": "Ouvrir",
   "controls.stop": "Stop",

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -8,6 +8,8 @@ import { useAuth } from "../store/useAuth";
 import { getEquipment, getHistoryBindings, setHistorize } from "../api";
 import { EquipmentForm } from "../components/equipments/EquipmentForm";
 import { LightControl } from "../components/equipments/LightControl";
+import { SolarControl } from "../components/equipments/SolarControl";
+import { findOrderByCategory, findMainOnOffOrder } from "../components/equipments/bindingUtils";
 import { ShutterControl } from "../components/equipments/ShutterControl";
 import { ThermostatCard } from "../components/equipments/ThermostatCard";
 import { WaterValveControl } from "../components/equipments/WaterValveControl";
@@ -263,16 +265,30 @@ export function EquipmentDetailPage() {
         )}
       </div>
 
-      {/* Controls — light and switch (smart plug) share the ON/OFF toggle surface */}
-      {(isLight || isSwitch) && equipment.enabled && (
-        <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
-          <h3 className="text-[14px] font-semibold text-text mb-3">{t("equipments.controls")}</h3>
-          <LightControl
-            equipment={equipment}
-            onExecuteOrder={(alias, value) => executeOrder(equipment.id, alias, value)}
-          />
-        </div>
-      )}
+      {/* Controls — light, switch (smart plug) and water heater share the ON/OFF
+          toggle surface. Spec 152: a water heater can additionally (or only, on
+          permanent mains) carry a dedicated "solar" on/off. Each toggle renders
+          iff its channel is bound. */}
+      {(isLight || isSwitch || equipment.type === "water_heater") &&
+        equipment.enabled &&
+        (!!findMainOnOffOrder(equipment.orderBindings) ||
+          !!findOrderByCategory(equipment.orderBindings, ["solar_toggle"], ["solar"])) && (
+          <div className="bg-surface rounded-[10px] border border-border p-4 mb-6">
+            <h3 className="text-[14px] font-semibold text-text mb-3">{t("equipments.controls")}</h3>
+            <div className="flex flex-wrap items-center gap-3">
+              {!!findMainOnOffOrder(equipment.orderBindings) && (
+                <LightControl
+                  equipment={equipment}
+                  onExecuteOrder={(alias, value) => executeOrder(equipment.id, alias, value)}
+                />
+              )}
+              <SolarControl
+                equipment={equipment}
+                onExecuteOrder={(alias, value) => executeOrder(equipment.id, alias, value)}
+              />
+            </div>
+          </div>
+        )}
 
       {/* Shutter / Awning controls (also used for pool_cover). isShutterFamily
           covers both shutters and awnings — ShutterControl handles the

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -45,6 +45,8 @@ export type DataCategory =
   | "media_mute"
   | "media_input"
   | "appliance_state"
+  // Spec 152 — solar command channel state feedback (states family, spec 144).
+  | "solar_state"
   | "pool_water_temperature"
   | "pool_temperature_setpoint"
   // Spec 120 — display equipment telemetry.
@@ -88,7 +90,10 @@ export type OrderCategory =
   // Spec 133 — camera equipment.
   | "set_camera_monitoring"
   | "set_camera_light_mode"
-  | "trigger_camera_siren";
+  | "trigger_camera_siren"
+  // Spec 152 — solar force command channel (dedicated on/off, distinct from the
+  // main on/off; driven by the surplus arbiter recipe).
+  | "solar_toggle";
 
 // ============================================================
 // Device


### PR DESCRIPTION
## Summary

Adds a second, **independent** on/off command channel — "solar" — to `water_heater` and `switch` equipments, distinct from the appliance's normal on/off. It is the actuator a future solar-surplus recipe drives through the energy arbiter (spec 140); the arbitration logic stays in the recipe. On a water heater on permanent mains (e.g. an Atlantic Calypso whose photovoltaic dry-contact input is driven by a SONOFF MINI-ZBD), only the solar toggle appears.

The compact card, detail page, equipment card and mobile widget render **one toggle per bound channel**: main on/off if a main binding exists, a "Solaire" toggle (same control, sun glyph) if a solar binding exists.

## Changes

- **Data model**: `OrderCategory solar_toggle` + `DataCategory solar_state`, resolved category-first so the two channels never collide with the main on/off.
- **Migration 023**: `data_bindings.category_override` (mirror of `order_bindings` from migration 006; nullable, no backfill) so the solar state resolves, aggregates and charts distinctly from `light_state`.
- **Backend**: category inference on the reserved `solar` / `solar_state` aliases (guarded to on/off shapes, `water_heater`/`switch` only); symmetric order + data retag on type change; `executeOrder` routes strictly by alias.
- **UI**: `SolarControl` (identical toggle to the light on/off, `Sun` glyph); shared `findMainOnOffOrder` gate so the main toggle renders exactly when `LightControl` would; `solar_state` joins the Analyse "states" family and is excluded from zone aggregation. FR/EN i18n.
- **Docs**: `docs/user/equipments.{md,fr.md}`. Full spec in `specs/152-equipment-solar-command/`.

## Test plan

- [x] Backend + UI tsc: zero errors
- [x] Full backend suite: 1481 passed / 2 skipped; full UI suite: 491 passed
- [x] eslint (backend + UI): zero errors
- [x] New tests: inference, solar-vs-main resolution, executeOrder routing + persistence + solar-only, aggregation exclusion, Analyse classification, mobile tap main-vs-solar
- [ ] Manual verification on a local docker instance

Reviewed by a dedicated agent: no blocking issues; the one flagged regression (main-toggle render gate) fixed via the shared `findMainOnOffOrder` resolver; nits addressed.

## Follow-ups (not in this PR)

- The generic "surplus switch" recipe (external recipe plugin) that claims arbiter capacity and drives the `solar` command.
- Optional: a "Solaire" role preset in the binding editor (today the solar binding is created by setting alias `solar` in the add-binding modal).
