### PR TITLE
fix(ui): stop equipment-detail page refetching on unrelated equipment changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sowel",
-  "version": "1.48.0",
+  "version": "1.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sowel",
-      "version": "1.48.0",
+      "version": "1.51.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cors": "^10.0.2",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "1.48.0",
+  "version": "1.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "1.48.0",
+      "version": "1.51.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, useNavigate, useLocation, Link } from "react-router-dom";
 import { useDevices } from "../store/useDevices";
@@ -98,6 +98,22 @@ export function EquipmentDetailPage() {
   const EMPTY: EquipmentWithDetails = { id: "", name: "", type: "sensor", zoneId: "", enabled: true, createdAt: "", updatedAt: "", dataBindings: [], orderBindings: [], status: "online" };
   const equipmentState = useEquipmentState(equipment ?? EMPTY);
 
+  // `equipments` changes reference on *any* equipment's WS-pushed update
+  // (handleEquipmentStatusChanged/handleEquipmentDataChanged always produce
+  // a new array, and the coalesced fetchEquipments() list refresh replaces
+  // every entry wholesale) — depending on the array directly re-triggers
+  // this effect, and its GET /equipments/:id call, for unrelated equipment
+  // changing state anywhere in the house. Confirmed live (2026-08-17): a
+  // single flapping equipment elsewhere produced a sustained 429 storm on
+  // this endpoint while this page was open. Depending on a snapshot of
+  // just *this* equipment's own entry keeps the "refetch when server data
+  // for what we're viewing changes" behavior without firing on everything
+  // else.
+  const thisEquipmentSnapshot = useMemo(
+    () => JSON.stringify(equipments.find((eq) => eq.id === id) ?? null),
+    [id, equipments],
+  );
+
   useEffect(() => {
     if (!id) return;
     let cancelled = false;
@@ -125,7 +141,7 @@ export function EquipmentDetailPage() {
 
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps -- equipment is set inside effect, adding it would cause infinite loop
-  }, [id, equipments]); // Re-fetch when store updates
+  }, [id, thisEquipmentSnapshot]); // Re-fetch when *this* equipment's store entry changes
 
   // Eagerly load history bindings so HistoryPanel can render immediately
   const loadHistoryBindings = useCallback(async () => {


### PR DESCRIPTION
Fixes #578

## Summary

`EquipmentDetailPage`'s data-loading effect re-fetches `GET /api/v1/equipments/:id` whenever *any* equipment's state changes anywhere in the house, not just the equipment currently being viewed — see #578 for the full root-cause writeup, reproduction, and evidence.

Affects **every equipment type** (lights, switches, thermostats, sensors, cameras, everything) since it's a bug in the shared detail page component.

## Fix

Depend on a snapshot of just *this* equipment's own store entry instead of the whole `equipments` array reference, so the effect only re-fires when server-pushed data for what's actually being viewed changes.

## Test plan

### Automated tests

- Rebased onto `v1.51.0` (fetched fresh from `upstream` before starting).
- `tsc --noEmit`: clean, backend + UI.
- Full backend suite: 91 test files / 1466 tests passed, 2 pre-existing skips unrelated to this change.
- Full UI suite: 52 test files / 489 tests passed.
- `eslint` on the changed file: clean.
- No dedicated automated test added for the effect-dependency behavior — no existing precedent for page-level component tests on `EquipmentDetailPage` in this codebase, and this is a reference-identity/timing bug rather than a logic bug, so a live re-reproduction felt like more meaningful confirmation than a synthetic harness. Happy to add one if preferred.

### Real-instance testing (dev VM, not mocks)

1. Confirmed broken on unmodified `v1.51.0`: reproduced a sustained `429 (Too Many Requests)` storm on `GET /equipments/:id` for one equipment's open detail page while a *different*, unrelated equipment was flapping status in the background.
2. Manual backup taken before touching the instance (`POST /api/v1/backup`).
3. Deployed this fix to the same instance (verified `/app/package.json` version before/after to confirm no version mismatch).
4. Re-tested the identical scenario: clean browser console, no 429s, sustained over multiple minutes of observation.
5. Confirmed via server logs the instance came back up cleanly with no side effects on other integrations/plugins.

Full detail on root cause and reproduction is in #578.