### PR TITLE
fix(camera-proxy): recursive HLS rewrite, byte-safe binary segments, EXT-X-MAP support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sowel",
-  "version": "1.48.0",
+  "version": "1.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sowel",
-      "version": "1.48.0",
+      "version": "1.51.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cors": "^10.0.2",

--- a/src/api/routes/camera.test.ts
+++ b/src/api/routes/camera.test.ts
@@ -247,6 +247,67 @@ describe("GET /api/v1/equipments/:id/camera/stream — binding gate mirrors snap
     expect(body.split("\n")).not.toContain("segment1.ts");
   });
 
+  it("rewrites the EXT-X-MAP init-segment URI in an fMP4-packaged manifest — fMP4 points at an init.mp4 via this tag rather than a plain URI line, which the line-rewrite previously skipped as a comment", async () => {
+    const manifest = [
+      "#EXTM3U",
+      "#EXT-X-VERSION:6",
+      '#EXT-X-MAP:URI="init.mp4?id=abc123"',
+      "#EXTINF:0.5,",
+      "segment.m4s?id=abc123&n=0",
+    ].join("\n");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(manifest, {
+            status: 200,
+            headers: { "content-type": "application/vnd.apple.mpegurl" },
+          }),
+      ),
+    );
+
+    app = Fastify({ logger: false });
+    registerCameraRoutes(app, {
+      equipmentManager: makeManager({
+        cam1: cameraFixture({
+          dataBindings: [
+            {
+              id: "b2",
+              equipmentId: "cam1",
+              deviceDataId: "dd2",
+              alias: "stream",
+              deviceId: "d1",
+              deviceName: "Front door camera",
+              key: "stream_url",
+              type: "text",
+              category: "camera_stream_url",
+              value: "https://camera.example.invalid/live/index.m3u8",
+              lastUpdated: new Date().toISOString(),
+              lastChanged: new Date().toISOString(),
+              stale: false,
+            } as unknown as EquipmentWithDetails["dataBindings"][number],
+          ],
+        }),
+      }),
+      logger: createLogger("silent").logger,
+    });
+    await app.ready();
+
+    const res = await app.inject({ method: "GET", url: "/api/v1/equipments/cam1/camera/stream" });
+    expect(res.statusCode).toBe(200);
+    const body = res.body;
+    expect(body).toContain(
+      '#EXT-X-MAP:URI="/api/v1/equipments/cam1/camera/stream/segment?u=' +
+        encodeURIComponent("https://camera.example.invalid/live/init.mp4?id=abc123") +
+        '"',
+    );
+    expect(body).toContain(
+      "/api/v1/equipments/cam1/camera/stream/segment?u=" +
+        encodeURIComponent("https://camera.example.invalid/live/segment.m4s?id=abc123&n=0"),
+    );
+  });
+
   it("rewrites the manifest by sniffing the body even when Content-Type is generic — confirmed live against a real Netatmo Presence (2026-08-04), which serves its HLS manifest as application/octet-stream", async () => {
     const manifest = ["#EXTM3U", "#EXT-X-VERSION:7", "#EXTINF:2.0,", "live0001.ts"].join("\n");
 
@@ -369,5 +430,75 @@ describe("GET /api/v1/equipments/:id/camera/stream/segment — origin allowlist"
         encodeURIComponent("https://camera.example.invalid/live/segment1.ts"),
     });
     expect(res.statusCode).toBe(200);
+  });
+
+  it("recursively rewrites a child playlist fetched through this same route — a two-level relay (master -> variant -> segments) previously 404'd because only the top-level proxyCameraMedia call rewrote HLS, leaving the variant playlist's own segment URIs untouched", async () => {
+    const childPlaylist = ["#EXTM3U", "#EXT-X-VERSION:3", "#EXTINF:0.5,", "segment.ts?n=0"].join(
+      "\n",
+    );
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(childPlaylist, {
+            status: 200,
+            headers: { "content-type": "application/vnd.apple.mpegurl" },
+          }),
+      ),
+    );
+
+    app = Fastify({ logger: false });
+    registerCameraRoutes(app, {
+      equipmentManager: makeManager({ cam1: streamBoundFixture }),
+      logger: createLogger("silent").logger,
+    });
+    await app.ready();
+
+    const res = await app.inject({
+      method: "GET",
+      url:
+        "/api/v1/equipments/cam1/camera/stream/segment?u=" +
+        encodeURIComponent("https://camera.example.invalid/live/variant.m3u8"),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain(
+      "/api/v1/equipments/cam1/camera/stream/segment?u=" +
+        encodeURIComponent("https://camera.example.invalid/live/segment.ts?n=0"),
+    );
+    expect(res.body.split("\n")).not.toContain("segment.ts?n=0");
+  });
+
+  it("passes a real binary segment through byte-for-byte, without corrupting bytes that aren't valid UTF-8 — a live regression (2026-08-15) that broke the already-shipped Netatmo camera plugin: the #EXTM3U sniff used to decode the whole body as UTF-8 text before checking the prefix, which silently mangles binary .ts data", async () => {
+    // 0xFF 0xFE is not valid UTF-8 — decoding-then-re-encoding this as text
+    // replaces it with U+FFFD (the replacement character), corrupting it.
+    const binarySegment = new Uint8Array([0x47, 0xff, 0xfe, 0x00, 0x01, 0x02, 0x03]);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(new Blob([binarySegment]), {
+            status: 200,
+            headers: { "content-type": "video/mp2t" },
+          }),
+      ),
+    );
+
+    app = Fastify({ logger: false });
+    registerCameraRoutes(app, {
+      equipmentManager: makeManager({ cam1: streamBoundFixture }),
+      logger: createLogger("silent").logger,
+    });
+    await app.ready();
+
+    const res = await app.inject({
+      method: "GET",
+      url:
+        "/api/v1/equipments/cam1/camera/stream/segment?u=" +
+        encodeURIComponent("https://camera.example.invalid/live/segment1.ts"),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(Buffer.from(res.rawPayload).equals(Buffer.from(binarySegment))).toBe(true);
   });
 });

--- a/src/api/routes/camera.ts
+++ b/src/api/routes/camera.ts
@@ -75,7 +75,16 @@ export function registerCameraRoutes(app: FastifyInstance, deps: CameraDeps): vo
         return reply.code(403).send({ error: "Segment URL origin mismatch" });
       }
 
-      return fetchAndPipe(request, reply, targetUrl.toString(), log, equipmentId);
+      // Re-apply the same #EXTM3U sniff/rewrite here: a variant/child
+      // playlist referenced by a master manifest is itself proxied through
+      // this same route, and its own relative segment URIs need rewriting
+      // too, or the browser resolves them against this route's own URL and
+      // 404s. Real segment bytes (.ts/.m4s) never start with #EXTM3U, so
+      // this is a no-op for them.
+      return fetchAndPipe(request, reply, targetUrl.toString(), log, equipmentId, {
+        rewriteHls: true,
+        equipmentId,
+      });
     },
   );
 
@@ -153,18 +162,30 @@ async function fetchAndPipe(
     // standard HLS mime type — Content-Type alone is not a reliable
     // signal. Sniff the body instead: `#EXTM3U` is the one thing every
     // HLS manifest starts with, regardless of vendor/Content-Type.
+    //
+    // Regression fixed 2026-08-15 (found live, broke the already-shipped
+    // Netatmo live view): this route is also used for the
+    // /camera/stream/segment sub-resource, which can be a REAL binary
+    // segment (.ts/.m4s), not just a manifest. The previous `.text()`
+    // sniff decoded the whole body as UTF-8 before checking the prefix —
+    // for binary data containing invalid UTF-8 byte sequences (routine
+    // in video segments), that silently replaces them with U+FFFD and
+    // corrupts the bytes irrecoverably once re-sent. Sniffing via a raw
+    // byte-prefix comparison on a Buffer, and only decoding-as-text the
+    // (rare) manifest case, is byte-safe for both cases.
     if (opts?.rewriteHls) {
-      const body = await upstream.text();
-      if (body.startsWith("#EXTM3U")) {
-        const rewritten = rewriteHlsManifest(body, parsed, opts.equipmentId!);
+      const buf = Buffer.from(await upstream.arrayBuffer());
+      if (buf.subarray(0, 7).toString("ascii") === "#EXTM3U") {
+        const rewritten = rewriteHlsManifest(buf.toString("utf-8"), parsed, opts.equipmentId!);
         reply.header("content-type", HLS_CONTENT_TYPE);
         return reply.send(rewritten);
       }
-      // Not actually HLS on this call (e.g. a vendor-specific fallback
-      // format) — pass the already-buffered text through as-is rather
-      // than silently dropping it.
+      // Not actually HLS on this call (e.g. a real binary segment, or a
+      // vendor-specific fallback format) — pass the already-buffered
+      // bytes through unchanged rather than silently dropping or
+      // corrupting them.
       reply.header("content-type", contentType || "application/octet-stream");
-      return reply.send(body);
+      return reply.send(buf);
     }
 
     reply.header("content-type", contentType || "application/octet-stream");
@@ -181,30 +202,36 @@ async function fetchAndPipe(
 }
 
 /**
- * Rewrite every URI line of an HLS manifest (segments or child playlists) to
- * go through the /camera/stream/segment sub-resource proxy, so the browser
- * never talks to the camera's real host directly.
- *
- * Known limitation: a master playlist referencing variant playlists that
- * themselves need rewriting is only rewritten one level deep — each
- * proxied child playlist is re-fetched raw by the browser via the segment
- * route without further rewriting. Revisit once tested against a real
- * camera in the sowel-plugin-netatmo-camera spec.
+ * Rewrite every URI line of an HLS manifest (segments, child playlists, and
+ * the fMP4 init segment) to go through the /camera/stream/segment
+ * sub-resource proxy, so the browser never talks to the camera's real host
+ * directly. Child playlists are proxied through this same route with
+ * `rewriteHls: true` (see the segment route above), so nested master →
+ * variant → segment chains are rewritten recursively, not just one level
+ * deep.
  */
 function rewriteHlsManifest(manifest: string, manifestUrl: URL, equipmentId: string): string {
   const base = `/api/v1/equipments/${equipmentId}/camera/stream/segment`;
+  const rewriteUri = (uri: string): string => {
+    try {
+      return `${base}?u=${encodeURIComponent(new URL(uri, manifestUrl).toString())}`;
+    } catch {
+      return uri;
+    }
+  };
   return manifest
     .split("\n")
     .map((line) => {
       const trimmed = line.trim();
-      if (trimmed === "" || trimmed.startsWith("#")) return line;
-      let absolute: string;
-      try {
-        absolute = new URL(trimmed, manifestUrl).toString();
-      } catch {
-        return line;
+      // fMP4-packaged HLS points at an init segment via an EXT-X-MAP tag
+      // rather than a plain URI line — its URI attribute needs the same
+      // rewrite or the browser resolves it against this route's own URL
+      // and 404s, exactly like an unrewritten segment line.
+      if (trimmed.startsWith("#EXT-X-MAP:")) {
+        return line.replace(/URI="([^"]+)"/, (_match, uri: string) => `URI="${rewriteUri(uri)}"`);
       }
-      return `${base}?u=${encodeURIComponent(absolute)}`;
+      if (trimmed === "" || trimmed.startsWith("#")) return line;
+      return rewriteUri(trimmed);
     })
     .join("\n");
 }


### PR DESCRIPTION
Ref #553

## Summary

Three real bugs in the `camera` equipment type's (spec 133) HLS media-proxy (`src/api/routes/camera.ts`), found while validating an RTSP-to-HLS relay prototype against a real two-level `go2rtc` HLS output — see #553 for the full context and diagnosis.

1. **One-level-deep manifest rewrite** — `rewriteHlsManifest` only rewrote the top-level manifest (this was the documented "Known limitation" in the code). A master playlist referencing a variant playlist that itself needs rewriting left the variant's own segment URIs untouched, 404ing once the browser tried to fetch them. Fixed by passing `rewriteHls: true` through the `/camera/stream/segment` sub-resource route too, so nested master → variant → segment chains rewrite recursively.

2. **Binary corruption on real segments** — the `#EXTM3U` sniff buffered the whole response via `upstream.text()` before checking the prefix. This route also serves real binary segments (`.ts`/`.m4s`) once bug #1 is fixed and the segment route starts receiving them — decoding binary data containing invalid UTF-8 byte sequences as text silently replaces those bytes with U+FFFD, corrupting the segment irrecoverably. **This is a live regression affecting the already-shipped Netatmo camera plugin**, not just a theoretical risk. Fixed by sniffing a raw `Buffer` prefix and only decoding-as-text the (rare) actual-manifest case.

3. **`EXT-X-MAP` not rewritten** — fMP4-packaged HLS (increasingly common, more broadly compatible with browser MSE demuxers than raw MPEG-TS) points at its init segment via an `EXT-X-MAP:URI="..."` tag rather than a plain URI line. The line-rewrite skipped every `#`-prefixed line as a comment, missing this one, so the init segment request 404'd the same way bug #1's segments did. Fixed by extracting and rewriting the URI attribute specifically for `EXT-X-MAP` lines.

## Test plan

- `tsc --noEmit`: clean.
- Full backend suite: 91 test files / 1468 tests passed (2 pre-existing skips, unrelated).
- `eslint` on both changed files: clean.
- **3 new regression tests**, one per fix:
  - Recursive rewrite through the segment route (a child playlist proxied through `/segment` gets its own segment URIs rewritten, previously would 404).
  - Byte-for-byte binary passthrough with deliberately non-UTF-8 bytes (`0xFF 0xFE`) — asserts the response matches the input exactly.
  - `EXT-X-MAP` URI rewriting in an fMP4-packaged manifest.

Also validated live against a real RTSP camera relayed through `go2rtc` (see #553) — this is the exact chain that surfaced all three bugs in the first place.