### PR TITLE
chore(registry): bump vmc-humidity to 0.5.0 (unbreak install)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -550,7 +550,7 @@
     "icon": "Fan",
     "author": "adn-dev-adrien",
     "repo": "adn-dev-adrien/sowel-recipe-vmc-humidity",
-    "version": "0.4.2",
+    "version": "0.5.0",
     "tags": ["ventilation", "vmc", "humidity", "comfort", "automation"],
     "i18n": {
       "fr": {
@@ -560,6 +560,6 @@
     },
     "sowelVersion": ">=1.35.0",
     "owner": "adn-dev-adrien",
-    "sha256": "3024d2edbfb3a2050cd7c79057efe0e0984245cd1649c6149d3d1187662b71fd"
+    "sha256": "9b9dd56c25634614af8d635d8fbbd9a1e8fe65261d969d7a62d28955cba304d0"
   }
 ]


### PR DESCRIPTION
## What

Bumps the `vmc-humidity` registry entry from `0.4.2` to `0.5.0` (version + sha256).

## Why (this is a fix, not a nicety)

`downloadPrebuiltAsset` always fetches `releases/latest` and verifies its bytes against the registry `sha256` (`package-manager.ts:988`). adn-dev-adrien published **v0.5.0**, so `latest` moved off `0.4.2`. The entry pinned at `0.4.2`'s hash now fails every install/update with `ChecksumMismatchError`. This restores it.

- `sha256` = `9b9dd56c…a304d0`, computed from the published `sowel-recipe-vmc-humidity-0.5.0.tar.gz` asset.
- Manifest metadata (name, description, tags, `sowelVersion >=1.35.0`) is unchanged in 0.5.0, so only version + hash move.
- `src/packages/package-manager.test.ts` passes (50).

## Note

v0.5.0 does **not** include the manual-ON fix (our upstream PR adn-dev-adrien/sowel-recipe-vmc-humidity#2 is still open; issue #1 open). The known minor bug persists in 0.5.0; a follow-up registry bump will ship the fix once the author releases it.
