### PR TITLE
chore(registry): bump vmc-humidity to 0.5.1 (ships the fix)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -550,7 +550,7 @@
     "icon": "Fan",
     "author": "adn-dev-adrien",
     "repo": "adn-dev-adrien/sowel-recipe-vmc-humidity",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "tags": ["ventilation", "vmc", "humidity", "comfort", "automation"],
     "i18n": {
       "fr": {
@@ -560,6 +560,6 @@
     },
     "sowelVersion": ">=1.35.0",
     "owner": "adn-dev-adrien",
-    "sha256": "9b9dd56c25634614af8d635d8fbbd9a1e8fe65261d969d7a62d28955cba304d0"
+    "sha256": "68792d9478e64773987273eb020f9adb77ef46a06c2b56321d3036734662631b"
   }
 ]


### PR DESCRIPTION
## What

Bumps the `vmc-humidity` registry entry from `0.5.0` to `0.5.1` (version + sha256).

## Why

adn-dev-adrien merged the manual-ON fix (adn-dev-adrien/sowel-recipe-vmc-humidity#2) and released **v0.5.1**, now `releases/latest`. Since `downloadPrebuiltAsset` verifies the latest release against the registry `sha256`, the entry pinned at `0.5.0` fails installs until this lands.

- `sha256` = `68792d94…62631b`, from the published `sowel-recipe-vmc-humidity-0.5.1.tar.gz` asset.
- Fix verified present in the 0.5.1 `dist/index.js` (external-ON branch now clears `vmcAgreed` instead of adopting `mainOn`).
- Manifest metadata unchanged; only version + hash move.
- `src/packages/package-manager.test.ts` passes (50).

This is the first Store version that ships the fix. Closes the loop on issue adn-dev-adrien/sowel-recipe-vmc-humidity#1.
