### PR TITLE
chore(registry): bump vmc-humidity to 0.5.2

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -550,7 +550,7 @@
     "icon": "Fan",
     "author": "adn-dev-adrien",
     "repo": "adn-dev-adrien/sowel-recipe-vmc-humidity",
-    "version": "0.5.0",
+    "version": "0.5.2",
     "tags": ["ventilation", "vmc", "humidity", "comfort", "automation"],
     "i18n": {
       "fr": {
@@ -560,6 +560,6 @@
     },
     "sowelVersion": ">=1.35.0",
     "owner": "adn-dev-adrien",
-    "sha256": "9b9dd56c25634614af8d635d8fbbd9a1e8fe65261d969d7a62d28955cba304d0"
+    "sha256": "f66a07cdae2992893140dc4e3f381aec2d679a6c36aed8c848e3192dfcb1ab2e"
   }
 ]


### PR DESCRIPTION
The recipe was promoted into the registry at **0.5.0**. Two fixes have shipped since, so the registry pinned a tarball two versions behind — and any fresh install would have landed on the version that carries both defects.

| Version | What it fixes |
| --- | --- |
| 0.5.1 | Outside the quiet window, a ventilation switched on **by hand** while the recipe was idle received an unsolicited `OFF` about a minute later — the reconciliation copied the observed state into `mainOn`, which `applyOutputs` then read as a true→false transition. |
| 0.5.2 | Stand-down deadlines (manual cut, maximum run, spurious detections) lived in memory, so a recipe update handed the ventilation straight back; and an order for a state the relay already held was re-sent, which spec 141 correctly flagged as `Order not confirmed: VMC state → true (no state change within 30s)`. |

`sha256` recomputed from the published asset:

```
$ shasum -a 256 sowel-recipe-vmc-humidity-0.5.2.tar.gz
f66a07cdae2992893140dc4e3f381aec2d679a6c36aed8c848e3192dfcb1ab2e
```

Running on my instance since this morning; 70 tests green in the recipe repo.