### PR TITLE
fix(energy): close leaked arbiter timeline "pending" spans (#584)

### DIFF
--- a/src/energy/arbiter-timeline.test.ts
+++ b/src/energy/arbiter-timeline.test.ts
@@ -66,6 +66,30 @@ describe("buildLoadTimelines (spec 148)", () => {
     expect(load.quarters).toEqual(["granted", "revoked", "pending", "pending"]);
   });
 
+  it("closes a 'pending' span when the claim is released without ever being granted (#584)", () => {
+    const [load] = buildLoadTimelines([dec(-5, "waiting"), dec(35, "released")], LOADS, START, END);
+    // pending from before the window; q2 (12:30-12:45) holds the 12:35 release
+    // → idle. Without a `released` close the span would bleed to the edge.
+    expect(load.quarters).toEqual(["pending", "pending", "idle", "idle"]);
+  });
+
+  it("reopens 'pending' when an unclaimed run ends over a still-pending claim (#584)", () => {
+    const [load] = buildLoadTimelines(
+      [
+        dec(-5, "waiting"),
+        dec(20, "unclaimed-run"),
+        dec(35, "unclaimed-run-ended"),
+        dec(35, "waiting"),
+      ],
+      LOADS,
+      START,
+      END,
+    );
+    // pending → q1 (12:20 unclaimed-run) unmanaged → q2 (12:35 end resets to
+    // idle, then the re-journaled waiting reopens pending, last wins) → pending.
+    expect(load.quarters).toEqual(["pending", "unmanaged", "pending", "pending"]);
+  });
+
   it("maps suspended and unclaimed-run to 'unmanaged'", () => {
     const [a] = buildLoadTimelines([dec(5, "suspended")], LOADS, START, END);
     expect(a.quarters).toEqual(["unmanaged", "unmanaged", "unmanaged", "unmanaged"]);

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -1021,6 +1021,51 @@ describe("capacity arbiter", () => {
     expect(h.events.filter((e) => e.type === "energy.capacity.released")).toHaveLength(1);
   });
 
+  // ── Timeline pending spans (#584) ─────────────────────────
+
+  it("journals `released` when a pending (never-granted) claim is released (#584)", () => {
+    const h = makeHarness();
+    const handle = h.claim("i1", { equipmentId: "pump" }); // needs 600+100 W
+    h.run(-100, 60); // exporting only 100 W → stays pending, never granted
+    expect(h.arbiter.getPublicState().pending.map((p) => p.equipmentId)).toContain("pump");
+    // The pending claim opened a `waiting` span (#561)…
+    const j0 = h.arbiter.getPublicState().journal;
+    expect(j0.filter((d) => d.kind === "waiting" && d.equipmentId === "pump")).toHaveLength(1);
+    expect(j0.some((d) => d.kind === "granted" && d.equipmentId === "pump")).toBe(false);
+
+    handle.release();
+
+    // …and releasing it must close that span, or buildLoadTimelines paints the
+    // load "en attente" to the window edge forever (the PAC-Piscine bug).
+    const j1 = h.arbiter.getPublicState().journal;
+    expect(j1.some((d) => d.kind === "released" && d.equipmentId === "pump")).toBe(true);
+    expect(h.events.filter((e) => e.type === "energy.capacity.released")).toHaveLength(1);
+    expect(h.arbiter.getPublicState().pending.map((p) => p.equipmentId)).not.toContain("pump");
+  });
+
+  it("re-journals `waiting` when an unclaimed run ends while a claim stays pending (#584)", () => {
+    const h = makeHarness();
+    h.claim("i1", { equipmentId: "pump" });
+    h.run(-100, 30); // pending, no grant
+    // Recipe runs the pump outside arbitration (off-peak fallback) → opens an
+    // unclaimed run that overlays the pending span as "unmanaged".
+    h.order("pump", "ON", { kind: "recipe", instanceId: "i1" });
+    expect(
+      h.arbiter
+        .getPublicState()
+        .journal.some((d) => d.kind === "unclaimed-run" && d.equipmentId === "pump"),
+    ).toBe(true);
+
+    // The run ends while the surplus claim is still pending underneath.
+    h.order("pump", "OFF", { kind: "recipe", instanceId: "i1" });
+
+    const j = h.arbiter.getPublicState().journal;
+    expect(j.some((d) => d.kind === "unclaimed-run-ended" && d.equipmentId === "pump")).toBe(true);
+    // Two `waiting` entries: the initial claim, plus the reopen after the run
+    // ended — so the timeline resumes "en attente" instead of falsely idle.
+    expect(j.filter((d) => d.kind === "waiting" && d.equipmentId === "pump")).toHaveLength(2);
+  });
+
   // ── Zero-behavior default (acceptance) ────────────────────
 
   it("disabled arbiter with no profiles produces no events and denies claims", () => {

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -595,6 +595,15 @@ export class CapacityArbiter {
       reason: "run outside arbitration finished",
     });
     this.finishLearnerRun(equipmentId);
+    // #584 — the unclaimed run overlaid the lane as "unmanaged"; its end resets
+    // the sustained state to "idle" in buildLoadTimelines. If a pending surplus
+    // claim is still held underneath (e.g. the pump kept claiming surplus while
+    // it ran on an off-peak slot), re-open its "waiting" span so the timeline
+    // keeps showing the load waiting for surplus instead of falsely idle.
+    const pending = this.pendingClaimFor(equipmentId);
+    if (pending) {
+      this.journal({ kind: "waiting", equipmentId, watts: pending.watts });
+    }
   }
 
   /**
@@ -1216,9 +1225,15 @@ export class CapacityArbiter {
   private release(claim: ClaimRecord): void {
     if (claim.status === "denied" || claim.status === "released") return;
     const wasGranted = claim.status === "granted";
+    const wasPending = claim.status === "pending";
     claim.status = "released";
-    if (wasGranted) {
-      this.finishLearnerRun(claim.equipmentId);
+    if (wasGranted) this.finishLearnerRun(claim.equipmentId);
+    // #584 — close the timeline span for a pending claim too, not only a
+    // granted one. `claimCapacity` journals `waiting` when a claim stays
+    // pending (#561); without a matching close, a claim released while still
+    // pending leaves its "en attente" span open to the window edge in
+    // buildLoadTimelines (the "PAC en attente toute la nuit" bug).
+    if (wasGranted || wasPending) {
       this.journal({ kind: "released", equipmentId: claim.equipmentId });
       this.emitEvent({
         type: "energy.capacity.released",
@@ -1374,6 +1389,12 @@ export class CapacityArbiter {
 
   private grantedClaimFor(equipmentId: string): ClaimRecord | undefined {
     return this.grantedClaims().find((c) => c.equipmentId === equipmentId);
+  }
+
+  private pendingClaimFor(equipmentId: string): ClaimRecord | undefined {
+    return [...this.claims.values()].find(
+      (c) => c.equipmentId === equipmentId && c.status === "pending",
+    );
   }
 
   private priorityRank(equipmentId: string): number {


### PR DESCRIPTION
Closes #584.

## Problem

The arbiter **timeline ribbon** (spec 148) reconstructs each load's per-quarter state from the decision journal (`buildLoadTimelines`): a `waiting` decision opens a "pending" (en attente) span that holds until a closing decision. Two journal gaps let pending spans leak, so the historical ribbon diverged from the live roster table.

Observed on prod:
- **PAC Piscine** painted "en attente" (yellow) for 12h straight overnight while it was actually **idle**.
- **Pompe Piscine** painted **idle** while it was actually **pending** live.

## Root cause

1. **Release of a pending claim journaled nothing.** `release()` only wrote `released` when the claim `wasGranted`. A claim released while still pending emitted no closing decision, so `sustainedAfter("waiting")` stayed "pending" to the window edge.
2. **Pending state lost under an overlapping unclaimed run.** `endUnclaimedRun()` journaled `unclaimed-run-ended` (→ idle) but dropped the still-pending surplus claim held underneath (e.g. the pump kept claiming surplus while running on an off-peak slot), so the lane read idle while the claim was live-pending.

## Fix

- `release()` journals a `released` close (and emits `energy.capacity.released`) for a **pending** claim too, not only a granted one.
- `endUnclaimedRun()` re-journals `waiting` when a **pending** claim is still held, reopening the span.
- New `pendingClaimFor()` helper mirrors `grantedClaimFor()`.

Display only — no change to grant/revoke control logic. Nothing heats without water flow, no energy behaviour changes.

## Tests

- **Arbiter (journal level):** releasing a never-granted pending claim journals `released` + emits the event; ending an unclaimed run while pending re-journals `waiting` (2 waiting entries). Both **fail without the fix** (verified: `released` absent / 1 waiting instead of 2).
- **Timeline (reconstruction level):** `waiting`→`released` closes the span (`pending, pending, idle, idle`); `unclaimed-run-ended`→`waiting` reopens it (`pending, unmanaged, pending, pending`).
- Full backend suite green (1508 passed), tsc + eslint clean.
