### PR TITLE
chore(registry): bump vmc-humidity to 0.6.0 (native vmc support)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -550,7 +550,7 @@
     "icon": "Fan",
     "author": "adn-dev-adrien",
     "repo": "adn-dev-adrien/sowel-recipe-vmc-humidity",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "tags": ["ventilation", "vmc", "humidity", "comfort", "automation"],
     "i18n": {
       "fr": {
@@ -560,6 +560,6 @@
     },
     "sowelVersion": ">=1.35.0",
     "owner": "adn-dev-adrien",
-    "sha256": "f66a07cdae2992893140dc4e3f381aec2d679a6c36aed8c848e3192dfcb1ab2e"
+    "sha256": "00c430369abedd2b1e77e244f63685a67fd425c2ce9d42559452a6e694e9302b"
   }
 ]


### PR DESCRIPTION
Bumps `vmc-humidity` to **0.6.0** (version + sha256).

adn-dev-adrien merged the native-vmc PR (adn-dev-adrien/sowel-recipe-vmc-humidity#5) and released **v0.6.0**, now `releases/latest`. The package manager verifies the latest release against the registry sha256, so the entry at 0.5.2 now fails install; this restores it.

- `sha256` = `00c43036…302b`, from the published `sowel-recipe-vmc-humidity-0.6.0.tar.gz` asset (native support verified present in its `dist/index.js`).
- Metadata unchanged (`sowelVersion >=1.35.0`); only version + hash move.
- `package-manager.test.ts` passes.