### PR TITLE
fix(ui): refresh arbiter + activity on WS reconnect and foreground (#589)

### DIFF
--- a/ui/src/store/useWebSocket.test.ts
+++ b/ui/src/store/useWebSocket.test.ts
@@ -33,8 +33,8 @@ const S = vi.hoisted(() => ({
     handleModeDeactivated: vi.fn(),
     fetchModes: vi.fn(),
   },
-  activity: { addItem: vi.fn() },
-  arbiter: { patchStatus: vi.fn(), refreshSoon: vi.fn() },
+  activity: { addItem: vi.fn(), retry: vi.fn() },
+  arbiter: { patchStatus: vi.fn(), refreshSoon: vi.fn(), fetch: vi.fn() },
 }));
 
 vi.mock("./useDevices", () => ({ useDevices: { getState: () => S.devices } }));
@@ -178,7 +178,7 @@ describe("connect", () => {
 
     expect(useWebSocket.getState().status).toBe("connected");
     expect(ws.sent[0]).toContain('"type":"subscribe"');
-    // All seven store refetches fire so nothing missed while disconnected is stale.
+    // Every WS-driven store refetches so nothing missed while disconnected is stale.
     expect(S.devices.fetchDevices).toHaveBeenCalled();
     expect(S.equipments.fetchEquipments).toHaveBeenCalled();
     expect(S.zones.fetchZones).toHaveBeenCalled();
@@ -186,6 +186,17 @@ describe("connect", () => {
     expect(S.recipes.fetchRecipes).toHaveBeenCalled();
     expect(S.recipes.fetchInstances).toHaveBeenCalled();
     expect(S.modes.fetchModes).toHaveBeenCalled();
+  });
+
+  it("on open: re-syncs the arbiter and the activity feed (issue #589)", () => {
+    const ws = connect();
+    ws.simulateOpen();
+
+    // Both are fed only by live events after their mount fetch, so the reconnect
+    // recovery must refetch them or they stay frozen until the panel remounts.
+    expect(S.arbiter.fetch).toHaveBeenCalled();
+    expect(S.arbiter.refreshSoon).toHaveBeenCalled();
+    expect(S.activity.retry).toHaveBeenCalled();
   });
 
   it("on open: restores integration statuses and error alarms from the health endpoint", async () => {
@@ -452,5 +463,114 @@ describe("reconnect backoff", () => {
     vi.runOnlyPendingTimers();
     latestWs().simulateClose(); // attempt #3
     expect(setTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), 4000);
+  });
+});
+
+describe("foreground reconnect (issue #589)", () => {
+  const docHandlers: Record<string, () => void> = {};
+  const winHandlers: Record<string, () => void> = {};
+  let visibility: "hidden" | "visible";
+
+  async function setupWithForegroundHooks(): Promise<void> {
+    for (const k of Object.keys(docHandlers)) delete docHandlers[k];
+    for (const k of Object.keys(winHandlers)) delete winHandlers[k];
+    visibility = "hidden";
+    vi.stubGlobal("document", {
+      get visibilityState() {
+        return visibility;
+      },
+      addEventListener: (type: string, h: () => void) => {
+        docHandlers[type] = h;
+      },
+    });
+    vi.stubGlobal("window", {
+      location: { hostname: "localhost", host: "localhost:5173", protocol: "http:" },
+      addEventListener: (type: string, h: () => void) => {
+        winHandlers[type] = h;
+      },
+    });
+    // wakeReconnect() guards on a stored token so a logged-out tab stays quiet.
+    localStorage.setItem("sowel_access_token", "tok");
+    await loadStore(); // fresh module so the once-only install guard is reset
+  }
+
+  it("reconnects when the tab returns to foreground after the socket dropped", async () => {
+    vi.useFakeTimers();
+    await setupWithForegroundHooks();
+
+    const ws1 = connect();
+    ws1.simulateOpen();
+    expect(typeof docHandlers.visibilitychange).toBe("function");
+
+    ws1.simulateClose(); // socket dropped while backgrounded
+    const before = FakeWebSocket.instances.length;
+
+    visibility = "visible";
+    docHandlers.visibilitychange();
+    expect(FakeWebSocket.instances.length).toBe(before + 1);
+  });
+
+  it("reconnects when the network comes back online", async () => {
+    vi.useFakeTimers();
+    await setupWithForegroundHooks();
+
+    const ws1 = connect();
+    ws1.simulateOpen();
+    ws1.simulateClose();
+    const before = FakeWebSocket.instances.length;
+
+    winHandlers.online();
+    expect(FakeWebSocket.instances.length).toBe(before + 1);
+  });
+
+  it("stays put while the tab is still hidden", async () => {
+    vi.useFakeTimers();
+    await setupWithForegroundHooks();
+
+    const ws1 = connect();
+    ws1.simulateOpen();
+    ws1.simulateClose();
+    const before = FakeWebSocket.instances.length;
+
+    // visibility stays "hidden" — the handler must not force a reconnect.
+    docHandlers.visibilitychange();
+    expect(FakeWebSocket.instances.length).toBe(before);
+  });
+
+  it("recovers the live-only surfaces without a new socket when foregrounded while OPEN", async () => {
+    vi.useFakeTimers();
+    await setupWithForegroundHooks();
+
+    const ws1 = connect();
+    ws1.simulateOpen(); // still OPEN (possibly a zombie the OS silently killed)
+    const before = FakeWebSocket.instances.length;
+    vi.clearAllMocks(); // drop the arbiter/activity refetch from onopen
+
+    visibility = "visible";
+    docHandlers.visibilitychange();
+
+    // connect() is a no-op while OPEN, so no new socket is created...
+    expect(FakeWebSocket.instances.length).toBe(before);
+    // ...but the live-only surfaces still refetch, so a zombie socket can't
+    // leave the arbiter/activity frozen (issue #589).
+    expect(S.arbiter.fetch).toHaveBeenCalled();
+    expect(S.activity.retry).toHaveBeenCalled();
+  });
+
+  it("stays quiet when the tab has no stored access token (logged out)", async () => {
+    vi.useFakeTimers();
+    await setupWithForegroundHooks();
+
+    const ws1 = connect();
+    ws1.simulateOpen();
+    ws1.simulateClose();
+    const before = FakeWebSocket.instances.length;
+    localStorage.removeItem("sowel_access_token");
+
+    visibility = "visible";
+    docHandlers.visibilitychange();
+    winHandlers.online();
+    // No token → no resurrection of the socket for a logged-out tab.
+    expect(FakeWebSocket.instances.length).toBe(before);
   });
 });

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -86,7 +86,54 @@ let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectAttempts = 0;
 let currentTopics: WsTopic[] = ["system"];
+let foregroundHooksInstalled = false;
 const MAX_RECONNECT_DELAY = 30_000;
+
+/**
+ * Re-sync the two surfaces that are fed only by live events after their mount
+ * fetch (the capacity arbiter, issue #589, and the activity feed). Every other
+ * WS-driven store recovers through its own `fetch*` in the `onopen` block; these
+ * two have no such recovery, so they must be refetched explicitly whenever the
+ * connection is (re)established or the tab returns to foreground.
+ */
+function recoverLiveOnlyStores(): void {
+  useArbiter.getState().fetch();
+  useArbiter.getState().refreshSoon(); // bump timelineRev so the timeline refetches
+  useActivity.getState().retry(); // replay the last loadForZone (no-op if none)
+}
+
+/**
+ * Foreground / network-back recovery. Mobile browsers freeze timers and silently
+ * drop the socket while the PWA is backgrounded, and the `onclose` reconnect timer
+ * is throttled until the tab is visible again. On resume:
+ *  - reconnect if the socket is gone (`connect()` is a no-op when already OPEN or
+ *    CONNECTING, so it only fires when the browser actually dropped it); the
+ *    following `onopen` then resyncs every store.
+ *  - if the socket still claims OPEN, the browser may have torn it down while
+ *    frozen (a "zombie" whose `readyState` is stuck at OPEN), so `connect()`
+ *    no-ops and no `onopen` runs. Refetch the live-only surfaces directly so
+ *    foregrounding always refreshes them.
+ * A logged-out tab must stay quiet: the listeners outlive `disconnect()`, so guard
+ * on a stored access token before resurrecting a socket.
+ */
+function wakeReconnect(): void {
+  if (!localStorage.getItem("sowel_access_token")) return;
+  useWebSocket.getState().connect();
+  if (ws?.readyState === WebSocket.OPEN) recoverLiveOnlyStores();
+}
+
+/** Installed once, on first connect. */
+function installForegroundReconnect(): void {
+  if (foregroundHooksInstalled) return;
+  if (typeof document === "undefined" || typeof document.addEventListener !== "function") return;
+  foregroundHooksInstalled = true;
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") wakeReconnect();
+  });
+  if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
+    window.addEventListener("online", wakeReconnect);
+  }
+}
 
 function getWsUrl(): string {
   // In dev mode, connect directly to the backend to avoid Vite proxy EPIPE issues
@@ -272,6 +319,7 @@ export const useWebSocket = create<WebSocketState>((set) => ({
   setRestartRequired: (reason) => set({ restartRequired: reason }),
 
   connect: () => {
+    installForegroundReconnect();
     if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) {
       return;
     }
@@ -295,6 +343,10 @@ export const useWebSocket = create<WebSocketState>((set) => ({
       useRecipes.getState().fetchRecipes();
       useRecipes.getState().fetchInstances();
       useModes.getState().fetchModes();
+      // The arbiter (issue #589) and the activity feed are fed only by live
+      // `energy.*` / `activity.added` events after their mount fetch, so a
+      // reconnect would otherwise leave them frozen until the panel remounts.
+      recoverLiveOnlyStores();
 
       // Rebuild the alarm banner from server state: integration health, plus
       // the low-battery alerts (spec 143), which outlive both a page reload and


### PR DESCRIPTION
## Root cause

The Energy page arbiter surface (and, found during audit, the activity feed) are fed **only** by live WebSocket events after their one-time mount fetch. The `ws.onopen` reconnect-recovery block in `ui/src/store/useWebSocket.ts` refetched every other WS-driven store (devices, equipments, zones, aggregation, recipes, modes, alarms) but **not** `useArbiter` and `useActivity`.

So when the PWA is backgrounded, the mobile browser drops the socket; on foreground it reconnects and every other surface recovers, but the arbiter and activity feed stay frozen on their last snapshot until the component remounts (tab switch) or the app is killed. That matches the reported symptom exactly.

Secondary gap: there was no `visibilitychange` / `online` listener anywhere in `ui/src`, so reconnection depended entirely on the `onclose` backoff timer, which mobile browsers throttle while backgrounded.

## Changes

- **`onopen` recovery**: re-sync `useArbiter` (`fetch()` + `refreshSoon()` to bump `timelineRev`) and `useActivity` (`retry()`, which replays the last `loadForZone`, no-op if no zone was loaded). Extracted into `recoverLiveOnlyStores()`.
- **Foreground / network-back recovery**: install `visibilitychange` + `online` listeners (once, from `connect()`) that force a fast reconnect instead of waiting for the throttled backoff. `connect()` is a no-op when the socket is already OPEN/CONNECTING.
- **Zombie-socket hardening**: on foreground while the socket still claims OPEN (mobile can silently tear it down while frozen, leaving `readyState` stuck at OPEN so `connect()` no-ops and no `onopen` fires), refetch the live-only surfaces directly so foregrounding always refreshes them.
- **Logged-out guard**: the listeners outlive `disconnect()`, so the wake path guards on a stored access token; a logged-out backgrounded tab stays quiet instead of resurrecting a token-less socket.

## Tests

`ui/src/store/useWebSocket.test.ts` (all verified to fail before the source change):

- `onopen` re-syncs the arbiter and the activity feed.
- Foreground (`visibilitychange` -> visible) and `online` force a reconnect after the socket dropped.
- Tab still hidden -> no reconnect.
- Logged-out tab (no token) -> stays quiet on both wake paths.
- OPEN-zombie -> refetches the live-only surfaces without opening a second socket.

Full UI suite green (507 tests), `tsc -b` and `eslint` clean.

## Notes / deferred

- Kept the arbiter `fetch()` + `refreshSoon()` pair on recovery (one immediate GET for the badge, one debounced bump so the timeline sub-view refetches in step). The extra small GET per reconnect is intentional and negligible.

Closes #589