### PR TITLE
fix(energy): drop energy-only submeters from the live-power display feed (#590)

### DIFF
--- a/src/api/routes/equipments.test.ts
+++ b/src/api/routes/equipments.test.ts
@@ -11,6 +11,7 @@ interface FixtureEq {
   id: string;
   name: string;
   type: string;
+  status?: string;
   dataBindings?: Array<{ alias?: string; category?: string; type?: string }>;
 }
 function makeManager(fixture: FixtureEq[]) {
@@ -71,23 +72,26 @@ describe("GET /api/v1/equipments — ?type / ?role filter", () => {
     expect(body.map((e) => e.id)).toEqual(["1"]);
   });
 
-  it("?role=submeter returns ANY numeric-metered load except house/production, ordered clamps-first (#523)", async () => {
+  it("?role=submeter returns numeric-metered loads except house/production, ordered clamps-first (#523/#590)", async () => {
     const res = await app.inject({ method: "GET", url: "/api/v1/equipments?role=submeter" });
     expect(res.statusCode).toBe(200);
     const body = res.json() as FixtureEq[];
     // energy_meters (2,3) → metering relays (5 water_heater, 6 switch) → other
-    // metered loads (8 thermostat #523, 12 appliance #523), each group by name.
+    // metered load (8 thermostat #523), each group by name.
     // NOT: main_energy_meter (4), solar_panel (11), bare relay (7), no-channel
-    // light (1), or boolean-`power` loads (9 thermostat, 10 media_player).
+    // light (1), boolean-`power` loads (9 thermostat, 10 media_player), or
+    // 12 appliance — it enrols as a submeter via its cumulative `energy` channel
+    // (#523) but carries NO numeric `power`, so it has no live segment and is
+    // dropped from this live-power feed (#590; see the dedicated block below).
     // Deterministic order so the display's 8-slot cap keeps clamps first.
-    expect(body.map((e) => e.id)).toEqual(["2", "3", "5", "6", "8", "12"]);
+    expect(body.map((e) => e.id)).toEqual(["2", "3", "5", "6", "8"]);
   });
 
-  it("?type=energy_meter is honoured as the submeter role for the legacy display client, same ordered set (#224/#523)", async () => {
+  it("?type=energy_meter is honoured as the submeter role for the legacy display client, same ordered set (#224/#523/#590)", async () => {
     const res = await app.inject({ method: "GET", url: "/api/v1/equipments?type=energy_meter" });
     expect(res.statusCode).toBe(200);
     const body = res.json() as FixtureEq[];
-    expect(body.map((e) => e.id)).toEqual(["2", "3", "5", "6", "8", "12"]);
+    expect(body.map((e) => e.id)).toEqual(["2", "3", "5", "6", "8"]);
   });
 
   it("returns an empty list for an unknown type (pass-through, no 400)", async () => {
@@ -97,6 +101,99 @@ describe("GET /api/v1/equipments — ?type / ?role filter", () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual([]);
+  });
+});
+
+// The submeter feed is the energy display's live-power breakdown source. A load
+// that enrols as a submeter only through a cumulative `energy` (Wh) channel — a
+// SmartThings appliance whose sole `power` binding is a boolean on/off state —
+// has no live watts and used to surface as a "pas de mesure" row on the display
+// (#590). The web UI already drops such rows (#560); this pins the same rule on
+// the API path that the (unflashed) display consumes.
+describe("GET /api/v1/equipments — submeter live-power filter (#590)", () => {
+  let app: ReturnType<typeof Fastify>;
+
+  const energyOnly = [{ alias: "energy", category: "energy", type: "number" }];
+  const numericPower = [{ alias: "power", category: "power", type: "number" }];
+  const booleanPower = [{ alias: "power", category: "power", type: "boolean" }];
+
+  const fixture: FixtureEq[] = [
+    // Declared clamp with no reading yet (#527) — kept (renders pending).
+    { id: "clamp", name: "AAA Clamp", type: "energy_meter", status: "online", dataBindings: [] },
+    // Real clamp reporting watts — kept.
+    {
+      id: "live",
+      name: "BBB Live",
+      type: "energy_meter",
+      status: "online",
+      dataBindings: numericPower,
+    },
+    // Appliance reporting real watts — kept (has a live segment).
+    {
+      id: "wattbox",
+      name: "Wattbox",
+      type: "appliance",
+      status: "online",
+      dataBindings: numericPower,
+    },
+    // Energy-only appliance, ONLINE — dropped: enrols via `energy`, no live watts.
+    {
+      id: "washer-on",
+      name: "Washer On",
+      type: "appliance",
+      status: "online",
+      dataBindings: energyOnly,
+    },
+    // Same appliance but OFFLINE — kept: an offline legend row is meaningful.
+    {
+      id: "washer-off",
+      name: "Washer Off",
+      type: "appliance",
+      status: "offline",
+      dataBindings: energyOnly,
+    },
+    // Appliance whose only `power` binding is a boolean on/off state (the exact
+    // SmartThings shape) with an `energy` channel — dropped when online.
+    {
+      id: "smartthings",
+      name: "Lave-linge",
+      type: "appliance",
+      status: "online",
+      dataBindings: [...booleanPower, ...energyOnly],
+    },
+  ];
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    registerEquipmentRoutes(app, {
+      equipmentManager: makeManager(fixture),
+      logger: createLogger("silent").logger,
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => await app.close());
+
+  it("keeps live-power submeters, offline rows and declared meters; drops online energy-only loads", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/equipments?type=energy_meter" });
+    expect(res.statusCode).toBe(200);
+    const ids = (res.json() as FixtureEq[]).map((e) => e.id);
+    // Kept: declared clamp, live clamp, watt appliance, offline washer.
+    expect(ids).toContain("clamp");
+    expect(ids).toContain("live");
+    expect(ids).toContain("wattbox");
+    expect(ids).toContain("washer-off");
+    // Dropped: online energy-only appliance and the boolean-`power` SmartThings load.
+    expect(ids).not.toContain("washer-on");
+    expect(ids).not.toContain("smartthings");
+  });
+
+  it("?role=submeter applies the same live-power filter", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/equipments?role=submeter" });
+    const ids = (res.json() as FixtureEq[]).map((e) => e.id);
+    expect(ids).not.toContain("smartthings");
+    expect(ids).not.toContain("washer-on");
+    expect(ids).toContain("washer-off");
   });
 });
 

--- a/src/api/routes/equipments.ts
+++ b/src/api/routes/equipments.ts
@@ -87,6 +87,25 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
   // relays, then other metered loads, each group by name — a deterministic
   // truncation instead of unstable insertion order.
   //
+  // This feed is the LIVE-power breakdown source (the energy display is its sole
+  // consumer). An equipment that qualifies as a submeter only through a
+  // cumulative `energy` (Wh) channel — e.g. a SmartThings appliance whose sole
+  // `power` binding is a boolean on/off state, not watts — has no live watts to
+  // draw and would otherwise render as a "no measurement" row on the display.
+  // Mirror the web UI fix (#560, ui submeter-helpers `readSubmeterPower`): keep
+  // a submeter only when it can contribute a live segment or is meaningful as a
+  // legend row. See #590.  Kept when the equipment:
+  //   - is offline — an "offline since X" row is meaningful, not noise; OR
+  //   - is a declared `energy_meter` — it renders pending before its first
+  //     report (#527), same carve-out isSubmeterEquipment makes on type alone.
+  //     Deliberate divergence from #560: an online energy_meter with no numeric
+  //     `power` still shows "pas de mesure" on current firmware, kept on purpose
+  //     because a declared meter awaiting data is not noise the way an
+  //     energy-only appliance is; OR
+  //   - carries a NUMERIC `power` binding — the only shape that yields live
+  //     watts. The `type === "number"` gate rejects a boolean `power` state
+  //     (SmartThings on/off) exactly as `hasMeteringBinding` does.
+  //
   // Unknown ?type values yield an empty list rather than 400 so callers can
   // safely pass-through user input without their own validation.
   app.get<{ Querystring: { type?: string; role?: string } }>(
@@ -97,8 +116,13 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
       if (role === "submeter" || type === "energy_meter") {
         const rank = (t: EquipmentType): number =>
           t === "energy_meter" ? 0 : METERING_RELAY_TYPES.has(t) ? 1 : 2;
+        const hasLivePower = (eq: (typeof all)[number]): boolean =>
+          eq.status === "offline" ||
+          eq.type === "energy_meter" ||
+          eq.dataBindings.some((b) => b.alias === "power" && b.type === "number");
         return all
           .filter((eq) => isSubmeterEquipment(eq.type, eq.dataBindings))
+          .filter(hasLivePower)
           .sort((a, b) => rank(a.type) - rank(b.type) || a.name.localeCompare(b.name));
       }
       return type ? all.filter((eq) => eq.type === type) : all;


### PR DESCRIPTION
## Root cause

The energy display polls `GET /api/v1/equipments?type=energy_meter` (aka `?role=submeter`) and, per equipment, reads the `alias:"power"` binding expecting **numeric watts** to draw the live breakdown donut.

A SmartThings washing machine (`Lave-linge`, type `appliance`) enrols as a submeter because it carries a numeric cumulative `energy` (Wh) channel (`isSubmeterEquipment`, #523). But its only `power` binding is a **boolean** on/off state (`type:"boolean"`, category `power`), not watts. The firmware finds the boolean `power`, can't read watts, and renders the row as **"pas de mesure"** instead of omitting it.

The web UI already fixed the equivalent in **#560** (`readSubmeterPower` / `buildSubmeterRows` drop online submeters with no numeric power). That fix was UI-only; the submeter feed endpoint the display consumes never received the same rule.

## Change

Apply the #560 semantics server-side in the `?role=submeter` / `?type=energy_meter` handler. A submeter is kept in this live-power feed only when it:

- is **offline** — an "offline since X" legend row is meaningful; OR
- is a declared **`energy_meter`** — renders pending before its first report (#527), same carve-out `isSubmeterEquipment` makes on type alone; OR
- carries a **numeric `power`** binding (`type === "number"`) — the only shape that yields live watts. The type gate rejects a boolean `power` state exactly as `hasMeteringBinding` does.

Net effect: energy-only appliances (the SmartThings washer) drop off the display's live breakdown, matching the web UI. No firmware reflash needed — self-corrects on the next poll. This endpoint's sole consumer is the energy display, so no other surface is affected (the historical by-usage breakdown is computed separately in `energy.ts`).

## Tests

- New `#590` regression block in `equipments.test.ts`: online energy-only appliance dropped, offline kept, numeric-power kept, declared meter kept, boolean-`power` SmartThings load dropped — on both `?type=energy_meter` and `?role=submeter`.
- Existing `#523`/`#224` assertions updated: the energy-only appliance (id 12) is now correctly excluded from the live-power feed.
- Full backend suite green (`npx vitest run`, tsc, eslint).

## Notes

- The deeper root cause is the SmartThings plugin emitting a boolean under category `power`, tracked separately as `mchacher/sowel-plugin-smartthings#2`. This server-side filter is a defense-in-depth mitigation that fixes the symptom for any plugin of this shape without a reflash.
- Deliberate divergence from #560: an online declared `energy_meter` with no numeric `power` is still kept here (renders pending per #527), whereas the UI drops it. A declared meter awaiting data is not noise the way an energy-only appliance is. Documented in the handler comment.

Closes #590
