### PR TITLE
refactor(api): schema-validate settings, logs and push routes (#482)

### DIFF
--- a/src/api/routes/logs.test.ts
+++ b/src/api/routes/logs.test.ts
@@ -1,0 +1,100 @@
+import Fastify from "fastify";
+import { describe, it, expect, afterEach } from "vitest";
+import { createLogger } from "../../core/logger.js";
+import { registerLogRoutes } from "./logs.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Characterization tests for the #482 schema-validation conversion of the log
+// routes: admin gating moved to an onRequest hook (403 before the 400), and the
+// PUT /logs/level body validated by an enum instead of the hand-rolled
+// `!level || !VALID_LEVELS.includes(...)` check.
+
+const logger = createLogger("silent").logger;
+
+interface BuildOpts {
+  authed?: boolean;
+  role?: "admin" | "user" | "viewer";
+}
+
+async function buildApp(opts: BuildOpts = {}) {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+
+  if (opts.authed) {
+    app.addHook("onRequest", async (request) => {
+      request.auth = { userId: "u1", role: opts.role ?? "admin" };
+    });
+  }
+
+  registerLogRoutes(app, {
+    logBuffer: {
+      query: () => [],
+      getCapacity: () => 100,
+      getModules: () => [],
+    } as never,
+    logger,
+  });
+  await app.ready();
+  return app;
+}
+
+describe("log routes (schema validation, #482)", () => {
+  let app: Awaited<ReturnType<typeof buildApp>> | null = null;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = null;
+  });
+
+  it("403s a non-admin on GET /logs (admin gate)", async () => {
+    app = await buildApp({ authed: true, role: "user" });
+    const res = await app.inject({ method: "GET", url: "/api/v1/logs" });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns the buffer to an admin on GET /logs", async () => {
+    app = await buildApp({ authed: true, role: "admin" });
+    const res = await app.inject({ method: "GET", url: "/api/v1/logs" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveProperty("entries");
+  });
+
+  it("403s a non-admin BEFORE body validation on PUT /logs/level (precedence preserved)", async () => {
+    app = await buildApp({ authed: true, role: "user" });
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/logs/level",
+      payload: { level: "not-a-level" },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("400s an admin with an invalid level, in { error } shape", async () => {
+    app = await buildApp({ authed: true, role: "admin" });
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/logs/level",
+      payload: { level: "verbose" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(typeof res.json().error).toBe("string");
+  });
+
+  it("400s an admin with a missing level", async () => {
+    app = await buildApp({ authed: true, role: "admin" });
+    const res = await app.inject({ method: "PUT", url: "/api/v1/logs/level", payload: {} });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("accepts a valid level change and reports the previous level", async () => {
+    app = await buildApp({ authed: true, role: "admin" });
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/logs/level",
+      payload: { level: "debug" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().level).toBe("debug");
+    expect(res.json()).toHaveProperty("previous");
+  });
+});

--- a/src/api/routes/logs.ts
+++ b/src/api/routes/logs.ts
@@ -2,8 +2,18 @@ import type { FastifyInstance } from "fastify";
 import type { Logger } from "../../core/logger.js";
 import type { LogRingBuffer } from "../../core/log-buffer.js";
 import type { LogLevel } from "../../shared/types.js";
+import { requireAdmin } from "../../auth/auth-middleware.js";
 
 const VALID_LEVELS: LogLevel[] = ["debug", "info", "warn", "error", "fatal", "silent"];
+
+// The runtime log level must be one of VALID_LEVELS. The enum rejects a missing
+// or invalid level exactly like the old `!level || !VALID_LEVELS.includes(...)`
+// check; admin gating is an onRequest hook so 403 still precedes 400.
+const logLevelBodySchema = {
+  type: "object",
+  required: ["level"],
+  properties: { level: { type: "string", enum: VALID_LEVELS } },
+} as const;
 
 interface LogsDeps {
   logBuffer: LogRingBuffer;
@@ -14,6 +24,17 @@ export function registerLogRoutes(app: FastifyInstance, deps: LogsDeps): void {
   const { logBuffer, logger: rootLogger } = deps;
   const logger = rootLogger.child({ module: "logs-routes" });
 
+  // All log routes are admin-only. The hook runs before body-schema validation,
+  // preserving the original 403-before-400 ordering. Bounded to the /logs
+  // subtree (exact path or a `/`-separated child) so it can't over-match a
+  // future sibling route that merely shares the "logs" prefix.
+  app.addHook("onRequest", async (request, reply) => {
+    const path = request.url.split("?")[0];
+    if (path === "/api/v1/logs" || path.startsWith("/api/v1/logs/")) {
+      requireAdmin(request, reply);
+    }
+  });
+
   // GET /api/v1/logs — Query ring buffer
   app.get<{
     Querystring: {
@@ -23,11 +44,7 @@ export function registerLogRoutes(app: FastifyInstance, deps: LogsDeps): void {
       search?: string;
       since?: string;
     };
-  }>("/api/v1/logs", async (request, reply) => {
-    if (!request.auth || request.auth.role !== "admin") {
-      return reply.code(403).send({ error: "Admin access required" });
-    }
-
+  }>("/api/v1/logs", async (request) => {
     const limit = Math.min(Math.max(Number(request.query.limit) || 100, 1), 2000);
     const { level, module, search, since } = request.query;
 
@@ -43,31 +60,22 @@ export function registerLogRoutes(app: FastifyInstance, deps: LogsDeps): void {
   });
 
   // GET /api/v1/logs/level — Get current log level
-  app.get("/api/v1/logs/level", async (request, reply) => {
-    if (!request.auth || request.auth.role !== "admin") {
-      return reply.code(403).send({ error: "Admin access required" });
-    }
-
+  app.get("/api/v1/logs/level", async () => {
     return { level: rootLogger.level };
   });
 
   // PUT /api/v1/logs/level — Change runtime log level
-  app.put<{ Body: { level: string } }>("/api/v1/logs/level", async (request, reply) => {
-    if (!request.auth || request.auth.role !== "admin") {
-      return reply.code(403).send({ error: "Admin access required" });
-    }
+  app.put<{ Body: { level: string } }>(
+    "/api/v1/logs/level",
+    { schema: { body: logLevelBodySchema } },
+    async (request) => {
+      const { level } = request.body;
 
-    const { level } = request.body ?? {};
-    if (!level || !VALID_LEVELS.includes(level as LogLevel)) {
-      return reply.code(400).send({
-        error: `Invalid level. Must be one of: ${VALID_LEVELS.join(", ")}`,
-      });
-    }
+      const previous = rootLogger.level;
+      rootLogger.level = level;
+      logger.info({ level, previous }, "Log level changed");
 
-    const previous = rootLogger.level;
-    rootLogger.level = level;
-    logger.info({ level, previous }, "Log level changed");
-
-    return { level, previous };
-  });
+      return { level, previous };
+    },
+  );
 }

--- a/src/api/routes/push.test.ts
+++ b/src/api/routes/push.test.ts
@@ -1,0 +1,127 @@
+import Fastify from "fastify";
+import { describe, it, expect, afterEach } from "vitest";
+import { registerPushRoutes } from "./push.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Characterization tests for the #482 schema-validation conversion of the push
+// subscription routes: the POST/DELETE bodies are validated by schema
+// (endpoint + browser keys, non-empty) instead of the hand-rolled checks.
+// Authentication stays enforced by the global middleware; here it is the
+// in-handler `!request.auth` guard that answers 401 in isolation.
+
+interface BuildOpts {
+  authed?: boolean;
+}
+
+async function buildApp(opts: BuildOpts = {}) {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+
+  if (opts.authed) {
+    app.addHook("onRequest", async (request) => {
+      request.auth = { userId: "u1", role: "user" };
+    });
+  }
+
+  const upserts: unknown[] = [];
+  const deletes: string[] = [];
+  registerPushRoutes(app, {
+    pushSubscriptionManager: {
+      listByUser: () => [],
+      upsert: (_userId: string, sub: unknown) => {
+        upserts.push(sub);
+        return { id: "sub1", ...(sub as object) };
+      },
+      deleteByEndpoint: (endpoint: string) => {
+        deletes.push(endpoint);
+      },
+    } as never,
+    vapidKeys: { publicKey: "pub", privateKey: "priv" } as never,
+  });
+  await app.ready();
+  return { app, upserts, deletes };
+}
+
+describe("push subscription routes (schema validation, #482)", () => {
+  let app: Awaited<ReturnType<typeof buildApp>>["app"] | null = null;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = null;
+  });
+
+  const validSubscription = {
+    endpoint: "https://push.example/abc",
+    keys: { p256dh: "key-p256dh", auth: "key-auth" },
+    userAgent: "Firefox",
+  };
+
+  it("401s an unauthenticated POST (auth guard)", async () => {
+    const built = await buildApp({ authed: false });
+    app = built.app;
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/push/subscriptions",
+      payload: validSubscription,
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("registers a valid subscription (201)", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/push/subscriptions",
+      payload: validSubscription,
+    });
+    expect(res.statusCode).toBe(201);
+    expect(built.upserts).toHaveLength(1);
+  });
+
+  it("400s a POST missing the browser keys, in { error } shape", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/push/subscriptions",
+      payload: { endpoint: "https://push.example/abc" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(typeof res.json().error).toBe("string");
+  });
+
+  it("400s a POST with an empty endpoint (non-empty rule preserved)", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/push/subscriptions",
+      payload: { endpoint: "", keys: { p256dh: "a", auth: "b" } },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("400s a DELETE with no endpoint", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/api/v1/push/subscriptions",
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("removes a subscription on a valid DELETE (204)", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/api/v1/push/subscriptions",
+      payload: { endpoint: "https://push.example/abc" },
+    });
+    expect(res.statusCode).toBe(204);
+    expect(built.deletes).toEqual(["https://push.example/abc"]);
+  });
+});

--- a/src/api/routes/push.ts
+++ b/src/api/routes/push.ts
@@ -7,6 +7,33 @@ interface PushDeps {
   vapidKeys: VapidKeys;
 }
 
+// A subscription needs a non-empty endpoint and both browser keys. `minLength:1`
+// (with coerceTypes:false, issue #452) rejects empty strings exactly like the
+// old `!endpoint || !keys?.p256dh || !keys?.auth` check. Authentication stays
+// enforced by the global auth middleware (runs before schema validation).
+const pushSubscriptionBodySchema = {
+  type: "object",
+  required: ["endpoint", "keys"],
+  properties: {
+    endpoint: { type: "string", minLength: 1 },
+    keys: {
+      type: "object",
+      required: ["p256dh", "auth"],
+      properties: {
+        p256dh: { type: "string", minLength: 1 },
+        auth: { type: "string", minLength: 1 },
+      },
+    },
+    userAgent: { type: "string" },
+  },
+} as const;
+
+const pushUnsubscribeBodySchema = {
+  type: "object",
+  required: ["endpoint"],
+  properties: { endpoint: { type: "string", minLength: 1 } },
+} as const;
+
 // ============================================================
 // Web Push subscription routes (spec 127)
 // ============================================================
@@ -25,29 +52,30 @@ export function registerPushRoutes(app: FastifyInstance, deps: PushDeps): void {
 
   // POST /api/v1/push/subscriptions — register/upsert this device's subscription.
   app.post<{
-    Body: { endpoint?: string; keys?: { p256dh?: string; auth?: string }; userAgent?: string };
-  }>("/api/v1/push/subscriptions", async (request, reply) => {
-    if (!request.auth) return reply.code(401).send({ error: "Not authenticated" });
-    const { endpoint, keys, userAgent } = request.body ?? {};
-    if (!endpoint || !keys?.p256dh || !keys?.auth) {
-      return reply.code(400).send({ error: "endpoint and keys.p256dh/keys.auth are required" });
-    }
-    const subscription = pushSubscriptionManager.upsert(request.auth.userId, {
-      endpoint,
-      p256dh: keys.p256dh,
-      auth: keys.auth,
-      userAgent,
-    });
-    return reply.code(201).send(subscription);
-  });
-
-  // DELETE /api/v1/push/subscriptions — remove this device's subscription.
-  app.delete<{ Body: { endpoint?: string } }>(
+    Body: { endpoint: string; keys: { p256dh: string; auth: string }; userAgent?: string };
+  }>(
     "/api/v1/push/subscriptions",
+    { schema: { body: pushSubscriptionBodySchema } },
     async (request, reply) => {
       if (!request.auth) return reply.code(401).send({ error: "Not authenticated" });
-      const endpoint = request.body?.endpoint;
-      if (!endpoint) return reply.code(400).send({ error: "endpoint is required" });
+      const { endpoint, keys, userAgent } = request.body;
+      const subscription = pushSubscriptionManager.upsert(request.auth.userId, {
+        endpoint,
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+        userAgent,
+      });
+      return reply.code(201).send(subscription);
+    },
+  );
+
+  // DELETE /api/v1/push/subscriptions — remove this device's subscription.
+  app.delete<{ Body: { endpoint: string } }>(
+    "/api/v1/push/subscriptions",
+    { schema: { body: pushUnsubscribeBodySchema } },
+    async (request, reply) => {
+      if (!request.auth) return reply.code(401).send({ error: "Not authenticated" });
+      const { endpoint } = request.body;
       pushSubscriptionManager.deleteByEndpoint(endpoint, request.auth.userId);
       return reply.code(204).send();
     },

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -1,0 +1,126 @@
+import Fastify from "fastify";
+import { describe, it, expect, afterEach } from "vitest";
+import { createLogger } from "../../core/logger.js";
+import { registerSettingsRoutes } from "./settings.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Characterization tests for the #482 schema-validation conversion of the
+// settings routes: admin gating moved to an onRequest hook (403 before the body
+// schema's 400), and the PUT body validated by `additionalProperties: string`
+// instead of the hand-rolled per-entry typeof check.
+
+const logger = createLogger("silent").logger;
+
+interface BuildOpts {
+  authed?: boolean;
+  role?: "admin" | "user" | "viewer";
+}
+
+async function buildApp(opts: BuildOpts = {}) {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+
+  // Registered before the routes so it runs first: it stands in for the global
+  // auth middleware that populates request.auth ahead of the route's own
+  // onRequest admin gate.
+  if (opts.authed) {
+    app.addHook("onRequest", async (request) => {
+      request.auth = { userId: "u1", role: opts.role ?? "admin" };
+    });
+  }
+
+  const store: Record<string, string> = {};
+  registerSettingsRoutes(app, {
+    settingsManager: {
+      getAll: () => ({ ...store }),
+      get: (k: string) => store[k],
+      setMany: (entries: Record<string, string>) => Object.assign(store, entries),
+    } as never,
+    eventBus: { emit: () => {} } as never,
+    auditLogger: { log: () => {} } as never,
+    userManager: { getById: () => ({ username: "admin" }) } as never,
+    logger,
+  });
+
+  // Stand-in for a foreign route that borrows the /settings namespace (e.g.
+  // energy tariff, energy.ts): the settings admin hook must NOT gate it.
+  app.get("/api/v1/settings/energy/tariff", async () => ({ ok: true }));
+
+  await app.ready();
+  return app;
+}
+
+describe("settings routes (schema validation, #482)", () => {
+  let app: Awaited<ReturnType<typeof buildApp>> | null = null;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = null;
+  });
+
+  it("403s a non-admin on GET /settings (admin gate)", async () => {
+    app = await buildApp({ authed: true, role: "user" });
+    const res = await app.inject({ method: "GET", url: "/api/v1/settings" });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns all settings to an admin on GET /settings", async () => {
+    app = await buildApp({ authed: true, role: "admin" });
+    const res = await app.inject({ method: "GET", url: "/api/v1/settings" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({});
+  });
+
+  it("403s a non-admin BEFORE body validation on PUT (precedence preserved)", async () => {
+    app = await buildApp({ authed: true, role: "user" });
+    // Malformed body (number value) from a non-admin must 403, not 400.
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/settings",
+      payload: { "some.key": 123 },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("400s an admin with a non-string value, in { error } shape", async () => {
+    app = await buildApp({ authed: true, role: "admin" });
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/settings",
+      payload: { "home.timezone": 42 },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toHaveProperty("error");
+    expect(typeof res.json().error).toBe("string");
+  });
+
+  it("accepts a valid admin write and persists it", async () => {
+    app = await buildApp({ authed: true, role: "admin" });
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/settings",
+      payload: { "home.timezone": "Europe/Paris" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ success: true });
+
+    const after = await app.inject({ method: "GET", url: "/api/v1/settings" });
+    expect(after.json()).toEqual({ "home.timezone": "Europe/Paris" });
+  });
+
+  it("accepts an empty object (no-op write)", async () => {
+    app = await buildApp({ authed: true, role: "admin" });
+    const res = await app.inject({ method: "PUT", url: "/api/v1/settings", payload: {} });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ success: true });
+  });
+
+  it("does NOT admin-gate a foreign route sharing the /settings prefix", async () => {
+    // The hook matches the exact settings path, so /api/v1/settings/energy/tariff
+    // (owned by energy.ts, which self-guards) is reachable by a non-admin here.
+    app = await buildApp({ authed: true, role: "user" });
+    const res = await app.inject({ method: "GET", url: "/api/v1/settings/energy/tariff" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true });
+  });
+});

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -4,6 +4,7 @@ import type { EventBus } from "../../core/event-bus.js";
 import type { SettingsManager } from "../../core/settings-manager.js";
 import { AuditLogger } from "../../core/audit-logger.js";
 import type { UserManager } from "../../auth/user-manager.js";
+import { requireAdmin } from "../../auth/auth-middleware.js";
 import { buildActor } from "../audit-context.js";
 
 interface SettingsDeps {
@@ -14,68 +15,71 @@ interface SettingsDeps {
   logger: Logger;
 }
 
+// A settings write is a flat key -> string map. `additionalProperties` typed as
+// string (with coerceTypes:false, issue #452) rejects non-string values exactly
+// like the old per-entry `typeof value !== "string"` check did. Admin gating is
+// an onRequest hook (runs before schema validation, so 403 precedes 400).
+const settingsBodySchema = {
+  type: "object",
+  additionalProperties: { type: "string" },
+} as const;
+
 export function registerSettingsRoutes(app: FastifyInstance, deps: SettingsDeps): void {
   const { settingsManager, eventBus, auditLogger, userManager, logger: parentLogger } = deps;
   const logger = parentLogger.child({ module: "settings-routes" });
 
-  // GET /api/v1/settings — Get all settings (admin only)
-  app.get("/api/v1/settings", async (request, reply) => {
-    if (!request.auth || request.auth.role !== "admin") {
-      return reply.code(403).send({ error: "Admin access required" });
-    }
+  // Both settings routes are admin-only. The hook runs before body-schema
+  // validation, preserving the original 403-before-400 ordering. Matched on the
+  // exact path (not a prefix) so it never reaches foreign routes that borrow the
+  // namespace, e.g. GET/PUT /api/v1/settings/energy/tariff which self-guard.
+  app.addHook("onRequest", async (request, reply) => {
+    if (request.url.split("?")[0] === "/api/v1/settings") requireAdmin(request, reply);
+  });
 
+  // GET /api/v1/settings — Get all settings (admin only)
+  app.get("/api/v1/settings", async () => {
     return settingsManager.getAll();
   });
 
   // PUT /api/v1/settings — Update settings (admin only)
-  app.put<{ Body: Record<string, string> }>("/api/v1/settings", async (request, reply) => {
-    if (!request.auth || request.auth.role !== "admin") {
-      return reply.code(403).send({ error: "Admin access required" });
-    }
+  app.put<{ Body: Record<string, string> }>(
+    "/api/v1/settings",
+    { schema: { body: settingsBodySchema } },
+    async (request) => {
+      const entries = request.body;
 
-    const entries = request.body;
-    if (!entries || typeof entries !== "object") {
-      return reply.code(400).send({ error: "Body must be a key-value object" });
-    }
+      // Capture old values BEFORE the write for the audit meta
+      const oldValues: Record<string, string | undefined> = {};
+      for (const k of Object.keys(entries)) oldValues[k] = settingsManager.get(k);
 
-    // Validate all values are strings
-    for (const [key, value] of Object.entries(entries)) {
-      if (typeof key !== "string" || typeof value !== "string") {
-        return reply.code(400).send({ error: `Invalid entry: ${key}` });
+      settingsManager.setMany(entries);
+      const keys = Object.keys(entries);
+      logger.info({ keys }, "Settings updated");
+      eventBus.emit({ type: "settings.changed", keys });
+
+      // Audit one entry per changed key (spec 113).
+      const actor = buildActor(request, userManager);
+      for (const [key, newValue] of Object.entries(entries)) {
+        auditLogger.log({
+          ...actor,
+          action: "settings.update",
+          targetType: "settings",
+          targetId: key,
+          ip: request.ip,
+          meta: AuditLogger.redactSettingMeta(key, oldValues[key], newValue),
+        });
       }
-    }
 
-    // Capture old values BEFORE the write for the audit meta
-    const oldValues: Record<string, string | undefined> = {};
-    for (const k of Object.keys(entries)) oldValues[k] = settingsManager.get(k);
+      // Home location changed → timezone may need to be re-derived via restart
+      if (keys.includes("home.latitude") || keys.includes("home.longitude")) {
+        logger.warn("Home location changed. Restart Sowel for timezone changes to apply.");
+        eventBus.emit({
+          type: "system.restart_required",
+          reason: "home_location_changed",
+        });
+      }
 
-    settingsManager.setMany(entries);
-    const keys = Object.keys(entries);
-    logger.info({ keys }, "Settings updated");
-    eventBus.emit({ type: "settings.changed", keys });
-
-    // Audit one entry per changed key (spec 113).
-    const actor = buildActor(request, userManager);
-    for (const [key, newValue] of Object.entries(entries)) {
-      auditLogger.log({
-        ...actor,
-        action: "settings.update",
-        targetType: "settings",
-        targetId: key,
-        ip: request.ip,
-        meta: AuditLogger.redactSettingMeta(key, oldValues[key], newValue),
-      });
-    }
-
-    // Home location changed → timezone may need to be re-derived via restart
-    if (keys.includes("home.latitude") || keys.includes("home.longitude")) {
-      logger.warn("Home location changed. Restart Sowel for timezone changes to apply.");
-      eventBus.emit({
-        type: "system.restart_required",
-        reason: "home_location_changed",
-      });
-    }
-
-    return { success: true };
-  });
+      return { success: true };
+    },
+  );
 }


### PR DESCRIPTION
## What

**Lot A** of the #452 follow-up (#482). Converts the hand-rolled body validation on three routes to Fastify JSON schemas, reusing the infrastructure #452 already shipped:
- `installValidationErrorHandler` normalises every schema 400 to `{ error: string }` (body shape unchanged);
- `validationAjvOptions` keeps `coerceTypes: false` (a numeric value is rejected, not coerced, exactly like the old `typeof` checks).

## Routes

| Route | Change |
| --- | --- |
| `PUT /settings` | body schema `additionalProperties:{type:string}`; admin gate → onRequest hook |
| `PUT /logs/level` | body schema `level` enum (== `VALID_LEVELS`); admin gate → onRequest hook (covers the GETs too) |
| `POST` / `DELETE /push/subscriptions` | body schemas (endpoint + browser keys, non-empty) |

## Precedence preserved

Admin gating on settings/logs moves to a file-level `onRequest` hook, which runs **before** body-schema validation, so a non-admin still gets **403 before 400**. The hooks match the **exact path / bounded subtree** so they never reach foreign routes that borrow the namespace (notably `GET/PUT /api/v1/settings/energy/tariff` in energy.ts, which self-guards). `push` POST/DELETE stay user-level (they are in `STANDARD_WRITE_ALLOWLIST`); their in-handler 401 guard remains and the global middleware owns 401.

## Tests

New characterization suites (`settings.test.ts`, `logs.test.ts`, `push.test.ts`, 19 tests) pin:
- the accept/reject matrix per route,
- the `{ error }` 400 shape,
- the **403-before-400** precedence (non-admin + malformed body → 403, not 400),
- the hook **not** over-matching a foreign `/settings` child.

Full backend suite green (1531 passed), `tsc` + `eslint` clean.

Refs #482 (Lot A of 3 — routes checked off in the issue; B/C to follow).