### PR TITLE
refactor(api): schema-validate backup restore and /me routes (#482)

### DIFF
--- a/src/api/routes/backup.test.ts
+++ b/src/api/routes/backup.test.ts
@@ -1,0 +1,104 @@
+import Fastify from "fastify";
+import { describe, it, expect, afterEach } from "vitest";
+import { createLogger } from "../../core/logger.js";
+import { registerBackupRoutes } from "./backup.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Characterization tests for the #482 schema-validation conversion of the backup
+// routes: admin gating moved to an onRequest hook (403 before the 400), and the
+// local-restore body validated by schema instead of the hand-rolled filename
+// check. POST /api/v1/backup (multipart upload) is intentionally left as-is.
+
+const logger = createLogger("silent").logger;
+
+interface BuildOpts {
+  authed?: boolean;
+  role?: "admin" | "user" | "viewer";
+}
+
+async function buildApp(opts: BuildOpts = {}) {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+
+  if (opts.authed) {
+    app.addHook("onRequest", async (request) => {
+      request.auth = { userId: "u1", role: opts.role ?? "admin" };
+    });
+  }
+
+  const restored: string[] = [];
+  registerBackupRoutes(app, {
+    backupManager: {
+      listLocalBackups: () => [{ filename: "b1.zip" }],
+      restoreFromFile: async (filename: string) => {
+        restored.push(filename);
+        return { restored: true };
+      },
+    } as never,
+    auditLogger: { log: () => {} } as never,
+    userManager: { getById: () => ({ username: "admin" }) } as never,
+    logger,
+  });
+  await app.ready();
+  return { app, restored };
+}
+
+describe("backup routes (schema validation, #482)", () => {
+  let app: Awaited<ReturnType<typeof buildApp>>["app"] | null = null;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = null;
+  });
+
+  it("403s a non-admin on GET /backup/local (admin gate)", async () => {
+    const built = await buildApp({ authed: true, role: "user" });
+    app = built.app;
+    const res = await app.inject({ method: "GET", url: "/api/v1/backup/local" });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("lists local backups for an admin", async () => {
+    const built = await buildApp({ authed: true, role: "admin" });
+    app = built.app;
+    const res = await app.inject({ method: "GET", url: "/api/v1/backup/local" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ backups: [{ filename: "b1.zip" }] });
+  });
+
+  it("403s a non-admin BEFORE body validation on restore-local (precedence)", async () => {
+    const built = await buildApp({ authed: true, role: "user" });
+    app = built.app;
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/backup/restore-local",
+      payload: { filename: 123 },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("400s an admin with a missing filename, in { error } shape", async () => {
+    const built = await buildApp({ authed: true, role: "admin" });
+    app = built.app;
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/backup/restore-local",
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+    expect(typeof res.json().error).toBe("string");
+  });
+
+  it("restores a named local backup for an admin", async () => {
+    const built = await buildApp({ authed: true, role: "admin" });
+    app = built.app;
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/backup/restore-local",
+      payload: { filename: "b1.zip" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ restored: true });
+    expect(built.restored).toEqual(["b1.zip"]);
+  });
+});

--- a/src/api/routes/backup.ts
+++ b/src/api/routes/backup.ts
@@ -5,6 +5,7 @@ import type { Logger } from "../../core/logger.js";
 import type { BackupManager } from "../../backup/backup-manager.js";
 import type { AuditLogger } from "../../core/audit-logger.js";
 import type { UserManager } from "../../auth/user-manager.js";
+import { requireAdmin } from "../../auth/auth-middleware.js";
 import { buildActor } from "../audit-context.js";
 
 interface BackupRouteDeps {
@@ -14,18 +15,34 @@ interface BackupRouteDeps {
   logger: Logger;
 }
 
+// A local-restore request names one backup file. `minLength:1` (with
+// coerceTypes:false, issue #452) reproduces the old `!filename || typeof
+// filename !== "string"` check; admin gating is an onRequest hook so 403
+// still precedes 400.
+const restoreLocalBodySchema = {
+  type: "object",
+  required: ["filename"],
+  properties: { filename: { type: "string", minLength: 1 } },
+} as const;
+
 export function registerBackupRoutes(app: FastifyInstance, deps: BackupRouteDeps): void {
   const { backupManager, auditLogger, userManager, logger: parentLogger } = deps;
   const logger = parentLogger.child({ module: "backup-routes" });
+
+  // Every backup route is admin-only. The hook runs before body-schema
+  // validation, preserving the original 403-before-400 ordering; bounded to the
+  // /backup subtree so it can't over-match a sibling route.
+  app.addHook("onRequest", async (request, reply) => {
+    const path = request.url.split("?")[0];
+    if (path === "/api/v1/backup" || path.startsWith("/api/v1/backup/")) {
+      requireAdmin(request, reply);
+    }
+  });
 
   // ============================================================
   // GET /api/v1/backup — Export full system as ZIP
   // ============================================================
   app.get("/api/v1/backup", async (request, reply) => {
-    if (!request.auth || request.auth.role !== "admin") {
-      return reply.code(403).send({ error: "Admin access required" });
-    }
-
     const dateStr = localDateStr();
     reply
       .header("Content-Type", "application/zip")
@@ -55,10 +72,6 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupRouteDeps
   // POST /api/v1/backup — Restore from uploaded ZIP
   // ============================================================
   app.post("/api/v1/backup", async (request, reply) => {
-    if (!request.auth || request.auth.role !== "admin") {
-      return reply.code(403).send({ error: "Admin access required" });
-    }
-
     const data = await request.file();
     if (!data) {
       return reply.code(400).send({ error: "No file uploaded" });
@@ -90,11 +103,7 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupRouteDeps
   // ============================================================
   // GET /api/v1/backup/local — List local backups (data/backups/)
   // ============================================================
-  app.get("/api/v1/backup/local", async (request, reply) => {
-    if (!request.auth || request.auth.role !== "admin") {
-      return reply.code(403).send({ error: "Admin access required" });
-    }
-
+  app.get("/api/v1/backup/local", async () => {
     const backups = backupManager.listLocalBackups();
     return { backups };
   });
@@ -104,15 +113,9 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupRouteDeps
   // ============================================================
   app.post<{ Body: { filename: string } }>(
     "/api/v1/backup/restore-local",
+    { schema: { body: restoreLocalBodySchema } },
     async (request, reply) => {
-      if (!request.auth || request.auth.role !== "admin") {
-        return reply.code(403).send({ error: "Admin access required" });
-      }
-
-      const { filename } = request.body ?? {};
-      if (!filename || typeof filename !== "string") {
-        return reply.code(400).send({ error: "filename is required" });
-      }
+      const { filename } = request.body;
 
       try {
         const result = await backupManager.restoreFromFile(filename);

--- a/src/api/routes/me.test.ts
+++ b/src/api/routes/me.test.ts
@@ -1,0 +1,178 @@
+import Fastify from "fastify";
+import { describe, it, expect, afterEach } from "vitest";
+import { createLogger } from "../../core/logger.js";
+import { registerMeRoutes } from "./me.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+
+// Characterization tests for the #482 schema-validation conversion of the /me
+// routes: the PUT/POST bodies are validated by schema instead of the hand-rolled
+// checks. These routes are user-level (allowlisted); authentication is enforced
+// by the global auth middleware in production. Existence (404) and semantic
+// (401 "wrong password") checks stay in the handler, after the body.
+
+const logger = createLogger("silent").logger;
+
+interface BuildOpts {
+  authed?: boolean;
+}
+
+const currentUser = {
+  id: "u1",
+  username: "bob",
+  displayName: "Bob",
+  role: "user" as const,
+  enabled: true,
+  passwordHash: "hash",
+};
+
+async function buildApp(opts: BuildOpts = {}) {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+
+  if (opts.authed) {
+    app.addHook("onRequest", async (request) => {
+      request.auth = { userId: "u1", role: "user" };
+    });
+  }
+
+  const created: unknown[] = [];
+  registerMeRoutes(app, {
+    authService: {
+      getUserApiTokens: () => [],
+      createApiToken: (_userId: string, name: string) => {
+        created.push(name);
+        return { id: "t1", token: "swl_secret" };
+      },
+      deleteApiToken: () => true,
+    } as never,
+    mfaService: { revokeAllTrustedDevices: () => {} } as never,
+    userManager: {
+      getById: () => currentUser,
+      getByUsername: () => currentUser,
+      updateUser: (id: string, patch: Record<string, unknown>) => ({
+        ...currentUser,
+        ...patch,
+        id,
+      }),
+      updatePreferences: () => {},
+      // Only "correct" verifies, so a wrong current password can be exercised.
+      verifyPassword: async (_hash: string, pw: string) => pw === "correct",
+      updatePassword: async () => {},
+    } as never,
+    auditLogger: { log: () => {} } as never,
+    logger,
+  });
+  await app.ready();
+  return { app, created };
+}
+
+describe("me routes (schema validation, #482)", () => {
+  let app: Awaited<ReturnType<typeof buildApp>>["app"] | null = null;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = null;
+  });
+
+  it("401s an unauthenticated PUT /me (in-handler guard)", async () => {
+    const built = await buildApp({ authed: false });
+    app = built.app;
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/me",
+      payload: { displayName: "X" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("400s PUT /me with a missing displayName, in { error } shape", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({ method: "PUT", url: "/api/v1/me", payload: {} });
+    expect(res.statusCode).toBe(400);
+    expect(typeof res.json().error).toBe("string");
+  });
+
+  it("updates the display name on a valid PUT /me", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/me",
+      payload: { displayName: "Bobby" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().displayName).toBe("Bobby");
+  });
+
+  it("400s PUT /me/preferences with a missing preferences object", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({ method: "PUT", url: "/api/v1/me/preferences", payload: {} });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("accepts a valid PUT /me/preferences", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/me/preferences",
+      payload: { preferences: { theme: "dark" } },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("400s PUT /me/password when newPassword is too short", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/me/password",
+      payload: { currentPassword: "correct", newPassword: "short" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("401s PUT /me/password with a wrong current password (semantic, after body)", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/me/password",
+      payload: { currentPassword: "wrong", newPassword: "longenough" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("changes the password on a valid PUT /me/password", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/me/password",
+      payload: { currentPassword: "correct", newPassword: "longenough" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ success: true });
+  });
+
+  it("400s POST /me/tokens with a missing name", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({ method: "POST", url: "/api/v1/me/tokens", payload: {} });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("creates an API token on a valid POST /me/tokens (201)", async () => {
+    const built = await buildApp({ authed: true });
+    app = built.app;
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/tokens",
+      payload: { name: "my-token" },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(built.created).toEqual(["my-token"]);
+  });
+});

--- a/src/api/routes/me.ts
+++ b/src/api/routes/me.ts
@@ -15,6 +15,42 @@ interface MeDeps {
   logger: Logger;
 }
 
+// Body schemas for the #482 conversion. `minLength` (with coerceTypes:false,
+// issue #452) reproduces the old `!field` empty-string rejections; the password
+// `newPassword` min length matches the old `.length < 6` check. Authentication
+// stays enforced by the global auth middleware (runs before schema validation);
+// existence (404) / semantic (401 "wrong password") checks stay in the handler,
+// after the body — exactly where the old code ran them.
+const displayNameBodySchema = {
+  type: "object",
+  required: ["displayName"],
+  properties: { displayName: { type: "string", minLength: 1 } },
+} as const;
+
+const preferencesBodySchema = {
+  type: "object",
+  required: ["preferences"],
+  properties: { preferences: { type: "object" } },
+} as const;
+
+const passwordChangeBodySchema = {
+  type: "object",
+  required: ["currentPassword", "newPassword"],
+  properties: {
+    currentPassword: { type: "string", minLength: 1 },
+    newPassword: { type: "string", minLength: 6 },
+  },
+} as const;
+
+const createTokenBodySchema = {
+  type: "object",
+  required: ["name"],
+  properties: {
+    name: { type: "string", minLength: 1 },
+    expiresAt: { type: "string" },
+  },
+} as const;
+
 export function registerMeRoutes(app: FastifyInstance, deps: MeDeps): void {
   const { authService, mfaService, userManager, auditLogger } = deps;
 
@@ -30,11 +66,10 @@ export function registerMeRoutes(app: FastifyInstance, deps: MeDeps): void {
   // PUT /api/v1/me — Update display name
   app.put<{
     Body: { displayName: string };
-  }>("/api/v1/me", async (request, reply) => {
+  }>("/api/v1/me", { schema: { body: displayNameBodySchema } }, async (request, reply) => {
     if (!request.auth) return reply.code(401).send({ error: "Not authenticated" });
 
-    const { displayName } = request.body ?? {};
-    if (!displayName) return reply.code(400).send({ error: "displayName is required" });
+    const { displayName } = request.body;
 
     const user = userManager.getById(request.auth.userId);
     if (!user) return reply.code(404).send({ error: "User not found" });
@@ -50,58 +85,57 @@ export function registerMeRoutes(app: FastifyInstance, deps: MeDeps): void {
   // PUT /api/v1/me/preferences — Update preferences
   app.put<{
     Body: { preferences: UserPreferences };
-  }>("/api/v1/me/preferences", async (request, reply) => {
-    if (!request.auth) return reply.code(401).send({ error: "Not authenticated" });
+  }>(
+    "/api/v1/me/preferences",
+    { schema: { body: preferencesBodySchema } },
+    async (request, reply) => {
+      if (!request.auth) return reply.code(401).send({ error: "Not authenticated" });
 
-    const { preferences } = request.body ?? {};
-    if (!preferences || typeof preferences !== "object") {
-      return reply.code(400).send({ error: "preferences object is required" });
-    }
-    // Spec 151 — trusted-device duration is a stored preference, not a
-    // per-request parameter: clamp here so a tampered/stale value can never
-    // push a trusted-device expiry outside the allowed range.
-    if (preferences.mfaTrustedDeviceDays !== undefined) {
-      preferences.mfaTrustedDeviceDays = clampTrustedDeviceDays(preferences.mfaTrustedDeviceDays);
-    }
+      const { preferences } = request.body;
+      // Spec 151 — trusted-device duration is a stored preference, not a
+      // per-request parameter: clamp here so a tampered/stale value can never
+      // push a trusted-device expiry outside the allowed range.
+      if (preferences.mfaTrustedDeviceDays !== undefined) {
+        preferences.mfaTrustedDeviceDays = clampTrustedDeviceDays(preferences.mfaTrustedDeviceDays);
+      }
 
-    userManager.updatePreferences(request.auth.userId, preferences);
-    const user = userManager.getById(request.auth.userId);
-    return user;
-  });
+      userManager.updatePreferences(request.auth.userId, preferences);
+      const user = userManager.getById(request.auth.userId);
+      return user;
+    },
+  );
 
   // PUT /api/v1/me/password — Change password
   app.put<{
     Body: { currentPassword: string; newPassword: string };
-  }>("/api/v1/me/password", async (request, reply) => {
-    if (!request.auth) return reply.code(401).send({ error: "Not authenticated" });
+  }>(
+    "/api/v1/me/password",
+    { schema: { body: passwordChangeBodySchema } },
+    async (request, reply) => {
+      if (!request.auth) return reply.code(401).send({ error: "Not authenticated" });
 
-    const { currentPassword, newPassword } = request.body ?? {};
-    if (!currentPassword || !newPassword) {
-      return reply.code(400).send({ error: "currentPassword and newPassword are required" });
-    }
-    if (newPassword.length < 6) {
-      return reply.code(400).send({ error: "Password must be at least 6 characters" });
-    }
+      const { currentPassword, newPassword } = request.body;
 
-    const user = userManager.getByUsername(userManager.getById(request.auth.userId)!.username);
-    if (!user) return reply.code(404).send({ error: "User not found" });
+      const user = userManager.getByUsername(userManager.getById(request.auth.userId)!.username);
+      if (!user) return reply.code(404).send({ error: "User not found" });
 
-    const valid = await userManager.verifyPassword(user.passwordHash, currentPassword);
-    if (!valid) return reply.code(401).send({ error: "Current password is incorrect" });
+      const valid = await userManager.verifyPassword(user.passwordHash, currentPassword);
+      if (!valid) return reply.code(401).send({ error: "Current password is incorrect" });
 
-    await userManager.updatePassword(request.auth.userId, newPassword);
-    // Spec 151 — defense in depth: a new password invalidates any browser
-    // previously trusted to skip the MFA step.
-    mfaService.revokeAllTrustedDevices(request.auth.userId);
-    auditLogger.log({
-      ...buildActor(request, userManager),
-      action: "user.password_change",
-      targetType: "user",
-      targetId: request.auth.userId,
-      ip: request.ip,
-    });
-    return { success: true };
-  });
+      await userManager.updatePassword(request.auth.userId, newPassword);
+      // Spec 151 — defense in depth: a new password invalidates any browser
+      // previously trusted to skip the MFA step.
+      mfaService.revokeAllTrustedDevices(request.auth.userId);
+      auditLogger.log({
+        ...buildActor(request, userManager),
+        action: "user.password_change",
+        targetType: "user",
+        targetId: request.auth.userId,
+        ip: request.ip,
+      });
+      return { success: true };
+    },
+  );
 
   // GET /api/v1/me/tokens — List my API tokens
   app.get("/api/v1/me/tokens", async (request, reply) => {
@@ -112,11 +146,10 @@ export function registerMeRoutes(app: FastifyInstance, deps: MeDeps): void {
   // POST /api/v1/me/tokens — Create API token
   app.post<{
     Body: { name: string; expiresAt?: string };
-  }>("/api/v1/me/tokens", async (request, reply) => {
+  }>("/api/v1/me/tokens", { schema: { body: createTokenBodySchema } }, async (request, reply) => {
     if (!request.auth) return reply.code(401).send({ error: "Not authenticated" });
 
-    const { name, expiresAt } = request.body ?? {};
-    if (!name) return reply.code(400).send({ error: "name is required" });
+    const { name, expiresAt } = request.body;
 
     const result = authService.createApiToken(request.auth.userId, name, expiresAt ?? null);
     auditLogger.log({


### PR DESCRIPTION
## What

**Lot A2** of the #452 follow-up (#482). Converts the remaining hand-rolled body checks that have a real JSON body.

| Route | Change |
| --- | --- |
| `POST /backup/restore-local` | body schema `{ filename }`; admin gate → bounded onRequest hook (covers all backup routes) |
| `POST /backup` (multipart upload) | admin gate → hook; imperative file parsing kept (not JSON) |
| `PUT /me` | body schema `{ displayName }` |
| `PUT /me/preferences` | body schema `{ preferences }` |
| `PUT /me/password` | body schema `{ currentPassword, newPassword(min 6) }` |
| `POST /me/tokens` | body schema `{ name, expiresAt? }` |

## Not applicable (examined, left unchanged)

`integrations.ts` and `system.ts` were checked: **none of their routes take a request body** — every non-2xx is an auth / existence / state check (e.g. "Integration not connected", "No update available"), not body shape. Nothing to schema-validate. Checked off in the issue with that note.

## Precedence preserved

- **backup**: all routes are admin, so the gate moves to a bounded onRequest hook (`path === "/api/v1/backup" || startsWith("/api/v1/backup/")`) that runs before schema validation (403 before 400) and covers the GET routes the global role-gate does not (it only gates mutations). No over-match.
- **me**: user-level (allowlisted), so no hook is added — the global middleware owns 401. The 404 existence and 401 "wrong password" checks stay in the handler **after** the body, which is exactly where the original code ran them, so the 400-vs-404/401 order is unchanged.

## Tests

New characterization suites (`backup.test.ts`, `me.test.ts`, 15 tests) pin the accept/reject matrix, the `{ error }` 400 shape, the backup **403-before-400** precedence, and the `/me/password` **401-after-body** ordering (wrong current password + valid-length new password → 401, not 400).

Full backend suite green (1546 passed), `tsc` + `eslint` clean.

Refs #482 (Lot A2; backup + me done, integrations + system marked n/a — remaining: auth/setup, users PUT/:id, dashboard, plugins, energy).