### PR TITLE
refactor(api): schema-validate auth/setup and users PUT via preValidation (#482)

### DIFF
--- a/src/api/routes/auth.test.ts
+++ b/src/api/routes/auth.test.ts
@@ -4,10 +4,10 @@ import { createLogger } from "../../core/logger.js";
 import { registerAuthRoutes } from "./auth.js";
 import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
 
-// Input-validation characterization (issue #452) for the converted auth routes
-// (login, refresh). setup/logout stay hand-rolled and are not covered here.
+// Input-validation characterization (issue #452 / #482) for the converted auth
+// routes (login, refresh, setup). logout stays hand-rolled and is not covered.
 
-function makeDeps() {
+function makeDeps(overrides: { hasUsers?: boolean } = {}) {
   const tokens = { accessToken: "a", refreshToken: "r" };
   return {
     authService: {
@@ -16,19 +16,20 @@ function makeDeps() {
       logout: () => undefined,
     },
     userManager: {
-      hasUsers: () => true,
+      hasUsers: () => overrides.hasUsers ?? true,
       getByUsername: () => ({ id: "u-1", username: "admin" }),
       getById: () => null,
+      createUser: async () => ({ id: "u-1" }),
     },
     auditLogger: { log: () => undefined },
     logger: createLogger("silent").logger,
   } as unknown as Parameters<typeof registerAuthRoutes>[1];
 }
 
-function buildApp() {
+function buildApp(overrides: { hasUsers?: boolean } = {}) {
   const app = Fastify({ logger: false, ajv: validationAjvOptions });
   installValidationErrorHandler(app);
-  registerAuthRoutes(app, makeDeps());
+  registerAuthRoutes(app, makeDeps(overrides));
   return app;
 }
 
@@ -65,5 +66,41 @@ describe("auth routes — input validation (characterization)", () => {
   it("POST /auth/refresh 200 for a valid body", async () => {
     const res = await post("/api/v1/auth/refresh", { refreshToken: "r" });
     expect(res.statusCode).toBe(200);
+  });
+
+  // #482 — /auth/setup: the "already completed" 403 must beat the body 400.
+  it("POST /auth/setup 403s (before body validation) when users already exist", async () => {
+    // Outer app has hasUsers:true. A malformed body must still 403, not 400.
+    const res = await post("/api/v1/auth/setup", { username: "" });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe("POST /auth/setup — first run (characterization, #482)", () => {
+  let app: ReturnType<typeof Fastify>;
+  beforeEach(async () => {
+    app = buildApp({ hasUsers: false });
+    await app.ready();
+  });
+  afterEach(async () => await app.close());
+
+  const post = (body: unknown) =>
+    app.inject({ method: "POST", url: "/api/v1/auth/setup", payload: body });
+
+  it("400 { error } when a required field is missing", async () => {
+    const res = await post({ username: "admin", password: "longenough" });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: expect.any(String) });
+  });
+
+  it("400 when the password is shorter than 6 chars", async () => {
+    const res = await post({ username: "admin", password: "short", displayName: "Admin" });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("201 and auto-login for a valid first-run setup", async () => {
+    const res = await post({ username: "admin", password: "longenough", displayName: "Admin" });
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toHaveProperty("accessToken");
   });
 });

--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -6,10 +6,11 @@ import type { Logger } from "../../core/logger.js";
 import type { AuditLogger } from "../../core/audit-logger.js";
 import { nonEmptyString } from "../schemas.js";
 
-// Input schemas (issue #452). login/refresh had bare `!x` guards (no trim), so
-// nonEmptyString matches. /auth/setup and /auth/logout stay hand-rolled: setup
-// returns 403 when a user already exists BEFORE its body check (a body schema
-// would flip that 403 to a 400), and logout has no required field.
+// Input schemas (issue #452 / #482). login/refresh had bare `!x` guards (no
+// trim), so nonEmptyString matches. /auth/setup is schema-validated too (#482):
+// its "already completed" 403 precondition would be flipped to a 400 by a body
+// schema, so that check runs in a preValidation hook (before schema validation).
+// /auth/logout stays hand-rolled: it has no required field.
 const loginBodySchema = {
   type: "object",
   required: ["username", "password"],
@@ -26,6 +27,22 @@ const refreshBodySchema = {
   type: "object",
   required: ["refreshToken"],
   properties: { refreshToken: nonEmptyString },
+};
+
+// First-run admin creation. `password` min length 6 reproduces the old
+// `!password || password.length < 6`; username/displayName use nonEmptyString
+// (old bare `!x`). `language` is an optional string (old took it verbatim,
+// defaulting to "fr"); only a non-string language, which was never valid, is
+// newly rejected.
+const setupBodySchema = {
+  type: "object",
+  required: ["username", "password", "displayName"],
+  properties: {
+    username: nonEmptyString,
+    password: { type: "string", minLength: 6 },
+    displayName: nonEmptyString,
+    language: { type: "string" },
+  },
 };
 
 interface AuthDeps {
@@ -46,31 +63,34 @@ export function registerAuthRoutes(app: FastifyInstance, deps: AuthDeps): void {
   // POST /api/v1/auth/setup — Create first admin user (first-run only)
   app.post<{
     Body: { username: string; password: string; displayName: string; language?: "fr" | "en" };
-  }>("/api/v1/auth/setup", async (request, reply) => {
-    if (userManager.hasUsers()) {
-      return reply.code(403).send({ error: "Setup already completed" });
-    }
+  }>(
+    "/api/v1/auth/setup",
+    {
+      // The "already completed" 403 must beat the body 400, so it runs before
+      // schema validation (issue #482).
+      preValidation: async (_request, reply) => {
+        if (userManager.hasUsers()) {
+          reply.code(403).send({ error: "Setup already completed" });
+        }
+      },
+      schema: { body: setupBodySchema },
+    },
+    async (request, reply) => {
+      const { username, password, displayName, language } = request.body;
 
-    const { username, password, displayName, language } = request.body ?? {};
-    if (!username || !password || !displayName) {
-      return reply.code(400).send({ error: "username, password, and displayName are required" });
-    }
-    if (password.length < 6) {
-      return reply.code(400).send({ error: "Password must be at least 6 characters" });
-    }
+      await userManager.createUser({
+        username,
+        password,
+        displayName,
+        role: "admin",
+        preferences: { language: language ?? "fr" },
+      });
 
-    await userManager.createUser({
-      username,
-      password,
-      displayName,
-      role: "admin",
-      preferences: { language: language ?? "fr" },
-    });
-
-    // Auto-login after setup
-    const tokens = await authService.login(username, password);
-    return reply.code(201).send(tokens);
-  });
+      // Auto-login after setup
+      const tokens = await authService.login(username, password);
+      return reply.code(201).send(tokens);
+    },
+  );
 
   // POST /api/v1/auth/login (stricter rate limit: 10 req/min)
   app.post<{

--- a/src/api/routes/users.test.ts
+++ b/src/api/routes/users.test.ts
@@ -4,32 +4,32 @@ import { createLogger } from "../../core/logger.js";
 import { registerUserRoutes } from "./users.js";
 import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
 
-// Input-validation characterization (issue #452) for POST /users. These routes
-// are admin-gated by an onRequest hook (runs before schema validation), so the
-// test app injects an admin request.auth first. PUT /users is not converted.
+// Input-validation characterization (issue #452 / #482) for POST /users and
+// PUT /users/:id. These routes are admin-gated by an onRequest hook (runs before
+// schema validation), so the test app injects an admin request.auth first.
 
-function makeDeps() {
-  const user = { id: "u-1", username: "bob", role: "standard" };
+function makeDeps(overrides: { userExists?: boolean } = {}) {
+  const user = { id: "u-1", username: "bob", displayName: "Bob", role: "standard", enabled: true };
   return {
     userManager: {
       getAll: () => [user],
-      getById: () => user,
+      getById: () => (overrides.userExists === false ? null : user),
       getByUsername: () => null,
       createUser: async () => user,
-      updateUser: async () => user,
+      updateUser: () => user,
     },
     auditLogger: { log: () => undefined },
     logger: createLogger("silent").logger,
   } as unknown as Parameters<typeof registerUserRoutes>[1];
 }
 
-function buildApp() {
+function buildApp(overrides: { userExists?: boolean } = {}) {
   const app = Fastify({ logger: false, ajv: validationAjvOptions });
   installValidationErrorHandler(app);
   app.addHook("onRequest", async (request) => {
     (request as unknown as { auth: unknown }).auth = { userId: "admin", role: "admin" };
   });
-  registerUserRoutes(app, makeDeps());
+  registerUserRoutes(app, makeDeps(overrides));
   return app;
 }
 
@@ -85,5 +85,43 @@ describe("POST /api/v1/users — input validation (characterization)", () => {
         })
       ).statusCode,
     ).toBe(201);
+  });
+});
+
+describe("PUT /api/v1/users/:id — input validation (characterization, #482)", () => {
+  let app: ReturnType<typeof Fastify>;
+  afterEach(async () => await app.close());
+
+  const put = (body: unknown) =>
+    app.inject({ method: "PUT", url: "/api/v1/users/u-1", payload: body });
+
+  it("404s (before body validation) for an unknown id", async () => {
+    app = buildApp({ userExists: false });
+    await app.ready();
+    // Malformed body (invalid role) against a missing user must 404, not 400.
+    const res = await put({ role: "superuser" });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("400 { error } when role is not admin or standard", async () => {
+    app = buildApp({ userExists: true });
+    await app.ready();
+    const res = await put({ role: "superuser" });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: expect.any(String) });
+  });
+
+  it("400 when enabled is not a boolean", async () => {
+    app = buildApp({ userExists: true });
+    await app.ready();
+    const res = await put({ enabled: "yes" });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("200 for a valid partial update", async () => {
+    app = buildApp({ userExists: true });
+    await app.ready();
+    const res = await put({ displayName: "Bobby" });
+    expect(res.statusCode).toBe(200);
   });
 });

--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -13,9 +13,7 @@ import { nonEmptyString } from "../schemas.js";
 // optional-role enum check. nonEmptyString matches the truthiness guards;
 // password gets minLength 6. `role` is optional and enum-checked. The 409
 // unique-username check and admin gating (onRequest hook) stay as-is, both
-// running in the same order as before (403 hook -> body 400 -> 409). PUT /users
-// is left hand-rolled: it returns 404 for an unknown id BEFORE its body check,
-// which a body schema would flip to a 400.
+// running in the same order as before (403 hook -> body 400 -> 409).
 const createUserBodySchema = {
   type: "object",
   required: ["username", "password", "displayName"],
@@ -24,6 +22,20 @@ const createUserBodySchema = {
     password: { type: "string", minLength: 6 },
     displayName: nonEmptyString,
     role: { enum: ["admin", "standard"] },
+  },
+};
+
+// PUT /users/:id (issue #482). All fields optional; the role enum reproduces the
+// old `role && role !== "admin" && role !== "standard"` check. The unknown-id
+// 404 must beat the body 400, so it runs in a preValidation hook (before schema
+// validation); the last-admin business rules stay in the handler after the body,
+// exactly as before.
+const updateUserBodySchema = {
+  type: "object",
+  properties: {
+    displayName: { type: "string" },
+    role: { enum: ["admin", "standard"] },
+    enabled: { type: "boolean" },
   },
 };
 
@@ -88,50 +100,58 @@ export function registerUserRoutes(app: FastifyInstance, deps: UsersDeps): void 
   app.put<{
     Params: { id: string };
     Body: { displayName?: string; role?: UserRole; enabled?: boolean };
-  }>("/api/v1/users/:id", async (request, reply) => {
-    const existing = userManager.getById(request.params.id);
-    if (!existing) return reply.code(404).send({ error: "User not found" });
-
-    const { displayName, role, enabled } = request.body ?? {};
-
-    if (role && role !== "admin" && role !== "standard") {
-      return reply.code(400).send({ error: "role must be 'admin' or 'standard'" });
-    }
-
-    // Prevent removing last admin
-    if (existing.role === "admin" && role === "standard") {
-      const allUsers = userManager.getAll();
-      const adminCount = allUsers.filter((u) => u.role === "admin" && u.enabled).length;
-      if (adminCount <= 1) {
-        return reply.code(400).send({ error: "Cannot remove the last admin" });
-      }
-    }
-
-    const updated = userManager.updateUser(request.params.id, {
-      displayName: displayName ?? existing.displayName,
-      role: role ?? existing.role,
-      enabled: enabled ?? existing.enabled,
-    });
-
-    auditLogger.log({
-      ...buildActor(request, userManager),
-      action: "user.update",
-      targetType: "user",
-      targetId: request.params.id,
-      ip: request.ip,
-      meta: {
-        username: existing.username,
-        roleChange: role && role !== existing.role ? { from: existing.role, to: role } : undefined,
-        enabledChange:
-          enabled !== undefined && enabled !== existing.enabled
-            ? { from: existing.enabled, to: enabled }
-            : undefined,
-        displayNameChanged: displayName !== undefined && displayName !== existing.displayName,
+  }>(
+    "/api/v1/users/:id",
+    {
+      // Unknown-id 404 must beat the body 400, so it runs before schema
+      // validation (issue #482).
+      preValidation: async (request, reply) => {
+        if (!userManager.getById(request.params.id)) {
+          reply.code(404).send({ error: "User not found" });
+        }
       },
-    });
+      schema: { body: updateUserBodySchema },
+    },
+    async (request, reply) => {
+      const existing = userManager.getById(request.params.id)!;
+      const { displayName, role, enabled } = request.body;
 
-    return updated;
-  });
+      // Prevent removing last admin
+      if (existing.role === "admin" && role === "standard") {
+        const allUsers = userManager.getAll();
+        const adminCount = allUsers.filter((u) => u.role === "admin" && u.enabled).length;
+        if (adminCount <= 1) {
+          return reply.code(400).send({ error: "Cannot remove the last admin" });
+        }
+      }
+
+      const updated = userManager.updateUser(request.params.id, {
+        displayName: displayName ?? existing.displayName,
+        role: role ?? existing.role,
+        enabled: enabled ?? existing.enabled,
+      });
+
+      auditLogger.log({
+        ...buildActor(request, userManager),
+        action: "user.update",
+        targetType: "user",
+        targetId: request.params.id,
+        ip: request.ip,
+        meta: {
+          username: existing.username,
+          roleChange:
+            role && role !== existing.role ? { from: existing.role, to: role } : undefined,
+          enabledChange:
+            enabled !== undefined && enabled !== existing.enabled
+              ? { from: existing.enabled, to: enabled }
+              : undefined,
+          displayNameChanged: displayName !== undefined && displayName !== existing.displayName,
+        },
+      });
+
+      return updated;
+    },
+  );
 
   // DELETE /api/v1/users/:id — Delete user
   app.delete<{


### PR DESCRIPTION
## What

**Lot B** of the #452 follow-up (#482): the two routes that returned a **precondition/existence error before their body check**. A body schema alone would move validation ahead of that check and flip the 403/404 to a 400 — so the precondition moves to a `preValidation` hook (which runs before schema validation), and the body gets a schema.

| Route | Precondition → preValidation | Body schema |
| --- | --- | --- |
| `POST /auth/setup` | 403 "already completed" (`hasUsers()`) | `{ username, password(min 6), displayName, language? }` |
| `PUT /users/:id` | 404 unknown id | all optional; `role` enum |

## Precedence preserved

- **setup** is public; its only gate is the new preValidation 403, which precedes the schema 400.
- **users PUT** keeps its existing `onRequest` admin hook. Fastify runs all `onRequest` hooks before any `preValidation`, so the order is **admin 403 → existence 404 → body 400**, exactly as before. The last-admin business rules stay in the handler, after the body.

Confirmed empirically (Fastify halts on a `reply.send()` in an async preValidation without `return`, so `createUser`/`updateUser` never run when the precondition fires).

## Equivalence

Schemas reproduce the old checks (`nonEmptyString` / `minLength:6` / role enum). The only deltas are **stricter rejections of previously-nonsensical input**: a non-string `language`, a non-boolean `enabled`, an empty-string `role` (old would have written it through). No valid input is lost.

## Tests

`auth.test.ts` and `users.test.ts` extended (16 tests total) to pin the **403-before-400** and **404-before-400** precedence — a malformed body against an existing-user / unknown id still yields the precondition status, not 400 (these fail if the check is left post-schema).

Full backend suite green (1554 passed), `tsc` + `eslint` clean.

Refs #482 (Lot B). Remaining: `dashboard`, `plugins`, `energy` (Lot C — conditional / nested schemas).