### PR TITLE
release: v1.52.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,22 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.52.x : Ventilation deux vitesses et arbitre plus stable
+
+### v1.52.0 — 2026-08-18 { #v1-52-0 }
+
+- Feat (équipements) : **la ventilation deux vitesses (VMC) devient un type d'équipement dédié**. Une VMC 2 vitesses se modélise directement ; son ordre de vitesse est décomposé en une séquence relais coupure-avant-établissement, de sorte que les deux enroulements ne sont jamais alimentés en même temps. Se marie avec la recette vmc-humidity. (#573, #586)
+- Feat (équipements) : **un canal de commande on/off dédié aux équipements solaires** (spec 152), pour piloter une installation de production solaire indépendamment de son canal de mesure. (#574)
+- Feat (énergie) : **la surface de l'arbitre affiche un état nuit dormant** quand aucun surplus n'est attendu la nuit, au lieu d'un vide d'apparence inactive. (#577, #581)
+- Fix (caméras) : **le proxy de vue en direct HLS réécrit désormais les playlists imbriquées (maître vers variante), sert les segments binaires `.ts` octet par octet et prend en charge la balise `EXT-X-MAP`**. Cela répare les segments corrompus qui affectaient la vue en direct de la caméra Netatmo. (#580)
+- Fix (énergie) : **l'arbitre et le flux d'activité se rafraîchissent à la reconnexion ou au retour de l'application au premier plan**, de sorte qu'un onglet en arrière-plan n'affiche plus une arbitration périmée. (#589, #591)
+- Fix (énergie) : **les spans « en attente » de la timeline de l'arbitre sont désormais correctement fermés** au lieu de rester ouverts. (#584, #587)
+- Fix (énergie) : **un sous-compteur purement énergie est exclu du flux d'affichage de la puissance instantanée**, pour ne pas gonfler la lecture. (#590, #592)
+- Fix (ui) : **la page de détail d'un équipement ne recharge plus lors de changements d'équipements non liés**. (#579)
+- Fix (ui) : **les clés de traduction brutes de l'arbitre (comme l'état d'attente) s'affichent désormais en texte correct**. (#575, #576)
+- Sous le capot : **validation des entrées API durcie** (schémas de corps déclaratifs sur davantage de routes, en conservant l'ordre 403/404 avant 400) et chemin d'exécution des ordres d'équipement refactoré en fonctions nommées, le tout couvert par des tests. (#453, #482)
+- Chore (registry) : la recette vmc-humidity publiée et mise à jour pour le support natif de la VMC ; entrée registry zigbee2mqtt rafraîchie. (#571, #572, #582, #585)
+
 ## 1.51.x : Double authentification et arbitre énergie affiné
 
 ### v1.51.0 — 2026-08-17 { #v1-51-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,22 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.52.x: Two-speed ventilation and a steadier arbiter
+
+### v1.52.0 — 2026-08-18 { #v1-52-0 }
+
+- Feat (equipments): **two-speed ventilation (VMC) is now a dedicated equipment type**. A 2-speed controlled-mechanical-ventilation unit can be modelled directly; its speed order is decomposed into a break-before-make relay sequence so the two windings are never energised at once. Pairs with the vmc-humidity recipe. (#573, #586)
+- Feat (equipments): **a dedicated on/off command channel for solar equipment** (spec 152), so a solar production setup can be switched independently of its measurement channel. (#574)
+- Feat (energy): **the arbiter surface shows a dormant night state** when no surplus is expected overnight, instead of an idle-looking blank. (#577, #581)
+- Fix (cameras): **the HLS live-view proxy now rewrites nested master-to-variant playlists, serves binary `.ts` segments byte-for-byte, and honours the `EXT-X-MAP` tag**. This repairs corrupted segments that affected the Netatmo camera live view. (#580)
+- Fix (energy): **the arbiter and activity feed refresh when the connection is re-established or the app returns to the foreground**, so a backgrounded tab no longer shows stale arbitration. (#589, #591)
+- Fix (energy): **arbiter timeline pending spans are now closed correctly** instead of leaking open. (#584, #587)
+- Fix (energy): **an energy-only submeter is kept out of the live-power display feed**, so the instantaneous power reading is not inflated. (#590, #592)
+- Fix (ui): **the equipment detail page no longer refetches on unrelated equipment changes**. (#579)
+- Fix (ui): **raw arbiter translation keys (such as the waiting state) are now shown as proper text**. (#575, #576)
+- Under the hood: **API input validation hardened** (declarative body schemas across more routes, keeping the 403/404-before-400 ordering) and the equipment order-execution path refactored into named helpers, both fully test-covered. (#453, #482)
+- Chore (registry): the vmc-humidity recipe published and updated for native VMC support; zigbee2mqtt registry entry refreshed. (#571, #572, #582, #585)
+
 ## 1.51.x: Two-factor authentication and a sharper energy arbiter
 
 ### v1.51.0 — 2026-08-17 { #v1-51-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.51.0",
+  "version": "1.52.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump + release notes for **v1.52.0** (FR + EN, anchor `{ #v1-52-0 }`).

Covers the full delta since v1.51.0 (17 commits):

**Features**
- Two-speed ventilation (VMC) as a dedicated equipment type (#573, #586)
- Dedicated on/off command channel for solar equipment, spec 152 (#574)
- Arbiter dormant night state (#577, #581)

**Fixes**
- Camera HLS proxy: nested playlist rewrite, byte-safe `.ts` segments, `EXT-X-MAP` (repairs Netatmo live view) (#580)
- Arbiter/activity refresh on WS reconnect + foreground (#589, #591)
- Arbiter timeline pending spans closed (#584, #587)
- Energy-only submeters dropped from live-power feed (#590, #592)
- Equipment detail no longer refetches on unrelated changes (#579)
- Arbiter i18n keys translated (#575, #576)

**Under the hood**
- API input-validation hardening (#453, #482) + executeOrder refactor, fully test-covered

**Registry**
- vmc-humidity published/updated for native VMC support; z2m entry refreshed (#571, #572, #582, #585)

Backend + UI `tsc` clean. After merge: tag `v1.52.0` on main. Follow-up (separate): merge #588 (vmc-humidity registry 0.6.0) once the VMC core support is released here.