### PR TITLE
fix(energy): dedup suspended load on arbiter surface + release v1.52.1

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.52.x : Ventilation deux vitesses et arbitre plus stable
 
+### v1.52.1 — 2026-08-18 { #v1-52-1 }
+
+- Fix (énergie) : **une charge en dérogation manuelle n'apparaît plus deux fois sur la surface de l'arbitre**. Une charge flexible qui avait une demande en attente au moment où elle est allumée à l'interrupteur mural n'apparaît plus que « Suspendu », et non plus aussi « En attente ». (#599)
+
 ### v1.52.0 — 2026-08-18 { #v1-52-0 }
 
 - Feat (équipements) : **la ventilation deux vitesses (VMC) devient un type d'équipement dédié**. Une VMC 2 vitesses se modélise directement ; son ordre de vitesse est décomposé en une séquence relais coupure-avant-établissement, de sorte que les deux enroulements ne sont jamais alimentés en même temps. Se marie avec la recette vmc-humidity. (#573, #586)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.52.x: Two-speed ventilation and a steadier arbiter
 
+### v1.52.1 — 2026-08-18 { #v1-52-1 }
+
+- Fix (energy): **a load that is manually overridden is no longer listed twice on the arbiter surface**. A flexible load that had a pending request when it was switched on at the wall now appears only as "Suspended", not also as "Waiting". (#599)
+
 ### v1.52.0 — 2026-08-18 { #v1-52-0 }
 
 - Feat (equipments): **two-speed ventilation (VMC) is now a dedicated equipment type**. A 2-speed controlled-mechanical-ventilation unit can be modelled directly; its speed order is decomposed into a break-before-make relay sequence so the two windings are never energised at once. Pairs with the vmc-humidity recipe. (#573, #586)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.52.0",
+  "version": "1.52.1",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -503,6 +503,24 @@ describe("capacity arbiter", () => {
     expect(h.arbiter.getPublicState().suspensions[0]?.equipmentId).toBe("pump");
   });
 
+  it("does not list a suspended load in BOTH pending and suspensions", () => {
+    // A claim that was still pending (insufficient surplus) when a wall-switch-on
+    // override fires lingers as pending — `suspend()` only revokes GRANTED
+    // claims. The read model must surface the load once ("Suspendu"), not also
+    // as "En attente (override-active)". Regression: prod showed "Pompe Piscine"
+    // twice at once.
+    const h = makeHarness();
+    h.claim("i1", { equipmentId: "pump" }); // needs 600+100
+    h.feedMeter(-200); // below engage threshold → stays pending
+    h.run(-200, 300);
+    expect(h.arbiter.getPublicState().pending[0]?.equipmentId).toBe("pump");
+    // User turns the pump on at the wall while it is still pending.
+    h.order("pump", true, { kind: "manual", instanceId: undefined });
+    const state = h.arbiter.getPublicState();
+    expect(state.suspensions.map((s) => s.equipmentId)).toEqual(["pump"]);
+    expect(state.pending.map((p) => p.equipmentId)).not.toContain("pump");
+  });
+
   it("a recipe order on a granted equipment does NOT suspend", () => {
     const h = makeHarness();
     h.claim("i1", { equipmentId: "pump" });

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -821,8 +821,24 @@ export class CapacityArbiter {
         sinceIso: new Date(c.grantedAt ?? now).toISOString(),
         note: c.note,
       }));
+    const suspensions = [...this.overridesUntil.entries()]
+      .filter(([, until]) => until > now)
+      .map(([equipmentId, until]) => ({
+        equipmentId,
+        equipmentName: this.nameOf(equipmentId),
+        untilIso: new Date(until).toISOString(),
+      }));
+    const suspendedIds = new Set(suspensions.map((s) => s.equipmentId));
+    // A load can hold a pending claim (created before a manual override) AND be
+    // suspended at the same time: `suspend()` revokes only a GRANTED claim, so a
+    // claim that was still `pending` when the wall-switch-on / user-order
+    // override fired lingers. It cannot be granted while suspended (`evaluate`
+    // skips suspended loads), so it is dormant — the suspension is the truthful
+    // dominant state. Excluding suspended IDs here (mirroring `idle` below)
+    // stops the same equipment surfacing twice: once "En attente
+    // (override-active)" and once "Suspendu".
     const pending = [...this.claims.values()]
-      .filter((c) => c.status === "pending")
+      .filter((c) => c.status === "pending" && !suspendedIds.has(c.equipmentId))
       .map((c) => ({
         equipmentId: c.equipmentId,
         equipmentName: this.nameOf(c.equipmentId),
@@ -836,13 +852,6 @@ export class CapacityArbiter {
         // the UI relabels it "running (no surplus)" instead of "waiting" (#491).
         running: this.unclaimedRunning.has(c.equipmentId),
       }));
-    const suspensions = [...this.overridesUntil.entries()]
-      .filter(([, until]) => until > now)
-      .map(([equipmentId, until]) => ({
-        equipmentId,
-        equipmentName: this.nameOf(equipmentId),
-        untilIso: new Date(until).toISOString(),
-      }));
     // #561 — declared flexible loads (priority order) that hold no claim and are
     // not suspended: neither granted nor pending. They have a timeline lane but
     // were absent from the read model, so the UI could not show them "at rest".
@@ -851,7 +860,6 @@ export class CapacityArbiter {
         .filter((c) => c.status === "granted" || c.status === "pending")
         .map((c) => c.equipmentId),
     );
-    const suspendedIds = new Set(suspensions.map((s) => s.equipmentId));
     const idle = this.config.priority
       .filter((id) => !claimedIds.has(id) && !suspendedIds.has(id))
       // Still declared flexible and still present (profile dropped / deleted →

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.52.0",
+  "version": "1.52.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Problem

On prod the arbiter surface showed **"Pompe Piscine" twice at once**: the same equipment listed in both `pending` ("En attente", reason `override-active`) and `suspensions` ("Suspendu").

Root cause: `suspend()` revokes only a **granted** claim. A claim that was still `pending` when a wall-switch-on / user-order override fires lingers, and `getPublicState()` did not exclude suspended equipments from the `pending` list (whereas `idle` already does).

Note: the reported "PAC piscine granted while pump waits" was a **misread** — the green row is `PAC` (house smart-cooling, precool boost), not `PAC Piscine` (idle). No priority inversion.

## Fix

- Exclude suspended equipment IDs from the `pending` list in `getPublicState()`, mirroring `idle`. A suspended load surfaces only as "Suspendu".
- Regression test (red pre-fix, green post-fix). 99 tests pass, typecheck clean.

## Release

Bundles the version bump to **v1.52.1** + release notes (EN/FR).