### PR TITLE
fix(ui): compact-card solar toggle never fired (spec 152)

### DIFF
--- a/ui/src/components/equipments/SolarControl.tsx
+++ b/ui/src/components/equipments/SolarControl.tsx
@@ -32,6 +32,11 @@ export function SolarControl({ equipment, onExecuteOrder, compact }: SolarContro
 
   const handleToggle = async (e?: React.MouseEvent) => {
     e?.preventDefault();
+    // Bubble-phase stopPropagation is enough to keep the surrounding compact
+    // card <Link> from navigating (same as LightControl). Do NOT add an
+    // onClickCapture stopPropagation on the button: in React, stopping in the
+    // capture phase suppresses this element's own onClick, so the toggle would
+    // never fire on the compact card (spec 152 regression).
     e?.stopPropagation();
     if (executing) return;
     setExecuting(true);
@@ -64,7 +69,6 @@ export function SolarControl({ equipment, onExecuteOrder, compact }: SolarContro
           disabled:opacity-50 disabled:cursor-not-allowed
         `}
         title={title}
-        onClickCapture={(e) => e.stopPropagation()}
       >
         <Sun size={16} strokeWidth={1.5} />
       </button>


### PR DESCRIPTION
## Problem

On the compact equipment card, tapping the **Solaire** toggle did nothing. The same toggle on the equipment detail page worked.

## Cause

`SolarControl`'s compact button carried `onClickCapture={(e) => e.stopPropagation()}` alongside `onClick={handleToggle}`. In React, calling `stopPropagation()` in the **capture** phase suppresses the same element's **bubble**-phase `onClick`, so `handleToggle` never ran on the compact card. The detail-page render has no capture handler, which is why it worked.

## Fix

Remove the `onClickCapture` handler. `handleToggle` already calls `e.stopPropagation()` in the bubble phase, which is enough to keep the surrounding compact card `<Link>` from navigating (same pattern as `LightControl`). Added a comment so it is not re-introduced.

One-line change (plus the guard comment).

## Test plan

- [x] `cd ui && npx tsc -b --noEmit` — clean
- [x] UI eslint on the file — clean
- [x] Full UI suite: 507 passed
- [ ] Manual: on prod (1.52.1) the compact "Solaire" toggle now actuates the relay (detail page already did)

No unit test added: the project has no React component tests (CLAUDE.md), and this is a DOM event-phase behavior. Regression guarded by the inline comment.

Regression from #574 (spec 152).