### PR TITLE
release: v1.52.2

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.52.x : Ventilation deux vitesses et arbitre plus stable
 
+### v1.52.2 — 2026-08-18 { #v1-52-2 }
+
+- Correctif (ui) : **la bascule « Solaire » de la carte d'équipement compacte fonctionne à nouveau**. Un appui ne faisait rien (la page détail de l'équipement n'était pas concernée) ; le gestionnaire de clic du bouton était neutralisé. Le pilotage solaire par l'arbitre d'énergie n'a jamais été impacté. (#600)
+
 ### v1.52.1 — 2026-08-18 { #v1-52-1 }
 
 - Fix (énergie) : **une charge en dérogation manuelle n'apparaît plus deux fois sur la surface de l'arbitre**. Une charge flexible qui avait une demande en attente au moment où elle est allumée à l'interrupteur mural n'apparaît plus que « Suspendu », et non plus aussi « En attente ». (#599)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.52.x: Two-speed ventilation and a steadier arbiter
 
+### v1.52.2 — 2026-08-18 { #v1-52-2 }
+
+- Fix (ui): **the "Solar" toggle on the compact equipment card now actuates again**. Tapping it did nothing (the equipment detail page was unaffected); the button's own click handler was being suppressed. Solar automation driven by the energy arbiter was never affected. (#600)
+
 ### v1.52.1 — 2026-08-18 { #v1-52-1 }
 
 - Fix (energy): **a load that is manually overridden is no longer listed twice on the arbiter surface**. A flexible load that had a pending request when it was switched on at the wall now appears only as "Suspended", not also as "Waiting". (#599)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.52.1",
+  "version": "1.52.2",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.52.1",
+  "version": "1.52.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch release **v1.52.2**.

Only change since v1.52.1:
- **fix(ui): compact-card solar toggle never fired (spec 152)** (#600) — the "Solaire" toggle on the compact equipment card did nothing; an `onClickCapture` stopPropagation was suppressing the button's own `onClick`. The equipment detail page and arbiter-driven solar automation were unaffected.

Contents:
- Version bump: `package.json` + `ui/package.json` → 1.52.2
- Release notes: EN + FR entries with the `{ #v1-52-2 }` anchor

After merge: tag `v1.52.2` on the on-main commit and push the tag to trigger the build (release only, no prod deploy).