### PR TITLE
chore(registry): bump pool-pump-schedule to 1.6.3

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "tags": ["pool", "pump", "heating", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -338,9 +338,9 @@
         "description": "Pilotage de pompe de piscine : créneaux horaires quotidiens, cible de temps de filtration selon la température de l'eau (option), fonctionnement sur surplus solaire (option) et chauffage PAC sur surplus solaire (option)."
       }
     },
-    "sowelVersion": ">=1.50.0",
+    "sowelVersion": ">=1.52.0",
     "owner": "mchacher",
-    "sha256": "f63a0348fcc6589fb50f4caec41ba4655683b9d55a76f5743298d4bd903b8aed"
+    "sha256": "fa2b3c9303ae150a9541a5e6b382abe9a47f9a16aac7f129743b33b6f0db1aaa"
   },
   {
     "id": "freecooling",


### PR DESCRIPTION
Bumps the pool-pump-schedule recipe to **v1.6.3** in the registry.

- Strictly surplus-gates pool heating (recipe #18): the heater is released the moment the signed grid balance holds negative past a ~3 min debounce (via `release()`, bypassing the arbiter minOn), so the PAC stops heating when there is no surplus. The pump is untouched.
- `sowelVersion` bumped to `>=1.52.0` (the gate relies on the signed-surplus balance, core #563).
- `sha256` refreshed and verified against the published `sowel-recipe-pool-pump-schedule-1.6.3.tar.gz` asset (`fa2b3c93…`).

Companion equipment-config change (PAC Piscine `toleratedImportW=0`) applied out-of-band.