### PR TITLE
fix(energy): close phantom arbiter timeline tail after a restart (#604)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/mchacher/Documents/01_Geekerie/Sowel/node_modules

--- a/src/energy/arbiter-timeline.test.ts
+++ b/src/energy/arbiter-timeline.test.ts
@@ -30,6 +30,14 @@ describe("buildLoadTimelines (spec 148)", () => {
     expect(load.quarters).toEqual(["idle", "granted", "granted", "granted"]);
   });
 
+  it("#604 — a reset closes a grant that would otherwise run to now", () => {
+    // A grant opened before the window and was never revoked in the journal
+    // (its live claim vanished on restart). The startup `reset` at 12:35 closes
+    // the span there instead of painting green across the whole window.
+    const [load] = buildLoadTimelines([dec(-30, "granted"), dec(35, "reset")], LOADS, START, END);
+    expect(load.quarters).toEqual(["granted", "granted", "idle", "idle"]);
+  });
+
   it("flags the quarter that contains a revoke, then idle after", () => {
     const [load] = buildLoadTimelines([dec(-10, "granted"), dec(35, "revoked")], LOADS, START, END);
     // granted until q2 (12:30-12:45) where the 12:35 revoke lands → revoked, then idle

--- a/src/energy/arbiter-timeline.ts
+++ b/src/energy/arbiter-timeline.ts
@@ -23,8 +23,13 @@ export interface TimelineLoad {
   quarters: QuarterState[];
 }
 
-/** The sustained state a decision transitions a load into. */
-function sustainedAfter(kind: ArbiterDecision["kind"], running?: boolean): QuarterState | null {
+/** The sustained state a decision transitions a load into. Exported so the
+ *  arbiter can reconcile the journal tail on startup against the same notion of
+ *  "sustained state" the timeline uses (#604). */
+export function sustainedAfter(
+  kind: ArbiterDecision["kind"],
+  running?: boolean,
+): QuarterState | null {
   switch (kind) {
     case "granted":
       return "granted";
@@ -46,6 +51,7 @@ function sustainedAfter(kind: ArbiterDecision["kind"], running?: boolean): Quart
     case "released":
     case "denied":
     case "unclaimed-run-ended":
+    case "reset": // #604 — a restart closed an open grant/pending claim → idle
       return "idle";
     // A suspension caused by an OFF order (manual OFF, wall-switch-off) leaves
     // the load stopped — painting it "on outside arbitration" was issue #535.

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -1461,6 +1461,45 @@ describe("capacity arbiter — unclaimed-run rehydration on restart (#543)", () 
     expect(suspended?.running).toBe(false);
   });
 
+  it("#604 — a granted tail with no live claim is closed with a reset on startup", () => {
+    const h = makeHarness({
+      journal: [dec("granted", "pump", "2026-08-12T08:00:00.000Z")],
+    });
+    // start() journaled exactly one reset closing the phantom grant.
+    const resets = h.journalRows.filter((d) => d.kind === "reset" && d.equipmentId === "pump");
+    expect(resets).toHaveLength(1);
+    expect(h.arbiter.getPublicState().journal[0]?.kind).toBe("reset");
+    // The timeline no longer paints the grant forward to now.
+    vi.advanceTimersByTime(15 * 60_000);
+    const tl = h.arbiter.getTimeline(Date.now(), 6);
+    const pump = tl.loads.find((l) => l.equipmentId === "pump");
+    expect(pump?.quarters.at(-1)).toBe("idle");
+  });
+
+  it("#604 — a pending (waiting) tail with no live claim is closed on startup", () => {
+    const h = makeHarness({
+      journal: [dec("waiting", "pump", "2026-08-12T08:00:00.000Z")],
+    });
+    expect(h.journalRows.filter((d) => d.kind === "reset")).toHaveLength(1);
+  });
+
+  it("#604 — an already-closed tail is NOT reset on startup", () => {
+    const h = makeHarness({
+      journal: [
+        dec("granted", "pump", "2026-08-12T08:00:00.000Z"),
+        dec("released", "pump", "2026-08-12T09:00:00.000Z"),
+      ],
+    });
+    expect(h.journalRows.some((d) => d.kind === "reset")).toBe(false);
+  });
+
+  it("#604 — an unmanaged (unclaimed-run) tail is left to rehydration, not reset", () => {
+    const h = makeHarness({
+      journal: [dec("unclaimed-run", "pump", "2026-08-12T08:00:00.000Z")],
+    });
+    expect(h.journalRows.some((d) => d.kind === "reset")).toBe(false);
+  });
+
   it.each([
     ["unclaimed-run-ended", dec("unclaimed-run-ended", "pump", "2026-08-12T08:30:00.000Z")],
     ["granted", dec("granted", "pump", "2026-08-12T08:30:00.000Z")],

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -23,7 +23,7 @@ import type { SettingsManager } from "../core/settings-manager.js";
 import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { ArbiterJournalStore } from "./arbiter-journal-store.js";
 import type { ArbiterSurplusStore } from "./arbiter-surplus-store.js";
-import { buildLoadTimelines } from "./arbiter-timeline.js";
+import { buildLoadTimelines, sustainedAfter } from "./arbiter-timeline.js";
 import { RETRY_CHANNEL } from "../equipments/order-confirmation-tracker.js";
 import type {
   ArbiterDecision,
@@ -217,6 +217,7 @@ export class CapacityArbiter {
       }
     }
     this.rehydrateUnclaimedRuns();
+    this.closeStaleClaimTails();
     this.resolveMeter();
     this.unsubscribes.push(
       this.eventBus.onType("equipment.data.changed", (e) => {
@@ -576,6 +577,39 @@ export class CapacityArbiter {
         { count: this.unclaimedRunning.size },
         "Open unclaimed runs rehydrated from journal",
       );
+    }
+  }
+
+  /**
+   * #604 — close a phantom claim span left open by a restart. Live claim state
+   * is rebuilt from scratch on startup (not persisted), so a grant/pending claim
+   * that was live at shutdown has no closing event in the journal: the timeline
+   * replay would paint its `granted`/`pending` state forward to now. For every
+   * equipment whose last *sustained* journal state is granted/pending yet has no
+   * live claim, journal a `reset` (stamped now, i.e. the restart boundary) so
+   * the span closes there instead of running to the present. Runs after
+   * `rehydrateUnclaimedRuns` so `unmanaged` runs are owned by that scan, not
+   * this one (we only touch claim-derived states).
+   */
+  private closeStaleClaimTails(): void {
+    const lastState = new Map<string, ReturnType<typeof sustainedAfter>>();
+    for (const d of this.journalEntries) {
+      if (!d.equipmentId) continue;
+      const s = sustainedAfter(d.kind, d.running);
+      if (s) lastState.set(d.equipmentId, s);
+    }
+    let closed = 0;
+    for (const [equipmentId, state] of lastState) {
+      if (state !== "granted" && state !== "pending") continue;
+      // A live claim (rebuilt by a recipe that already re-claimed) means the tail
+      // is genuine — leave it. At startup this is normally empty.
+      if (this.grantedClaimFor(equipmentId) || this.pendingClaimFor(equipmentId)) continue;
+      if (!this.equipments.getById(equipmentId)) continue; // deleted since
+      this.journal({ kind: "reset", equipmentId, reason: "engine restart" });
+      closed += 1;
+    }
+    if (closed > 0) {
+      this.logger.info({ count: closed }, "Stale arbiter claim tails closed on startup");
     }
   }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -709,7 +709,14 @@ export type ArbiterDecisionKind =
    *  recipe is claiming surplus for it but none is granted yet. Opens a
    *  "pending" span on the timeline; the next `granted`/`released`/`suspended`
    *  (or a `revoked` with no re-claim) closes it. */
-  | "waiting";
+  | "waiting"
+  /** #604 — a grant/pending claim that was live at shutdown is not carried
+   *  across a restart (live claim state is rebuilt from scratch, not persisted).
+   *  On startup the arbiter journals a `reset` for any open journal tail that no
+   *  longer has a live claim, so the timeline replay closes the span at the
+   *  restart boundary instead of painting a phantom "granted"/"pending" ribbon
+   *  forward to now. */
+  | "reset";
 
 /** One line of the decision journal (FR-8/FR-9). Bounded ring buffer. */
 export interface ArbiterDecision {

--- a/ui/src/components/energy/arbiterReason.ts
+++ b/ui/src/components/energy/arbiterReason.ts
@@ -41,6 +41,7 @@ const REDUNDANT_WITH_KIND = new Set([
   "recipe-driven run outside arbitration", // kind unclaimed-run
   "run outside arbitration finished", // kind unclaimed-run-ended
   "resume control", // kind resumed
+  "engine restart", // kind reset (#604) — the kind label already says it
 ]);
 
 /** The one reason that carries dynamic data: `declared <N> W` (watts-divergence). */

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1280,6 +1280,7 @@
   "arbiter.kind.unclaimed-run": "running outside arbitration",
   "arbiter.kind.unclaimed-run-ended": "run outside arbitration ended",
   "arbiter.kind.waiting": "waiting for surplus",
+  "arbiter.kind.reset": "reset on restart",
   "arbiter.reason.surplus-deficit": "surplus deficit",
   "arbiter.reason.priority-preempted": "preempted by priority",
   "arbiter.reason.manual-override": "manual override",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1280,6 +1280,7 @@
   "arbiter.kind.unclaimed-run": "marche hors arbitrage",
   "arbiter.kind.unclaimed-run-ended": "fin de marche hors arbitrage",
   "arbiter.kind.waiting": "en attente de surplus",
+  "arbiter.kind.reset": "réinitialisé au redémarrage",
   "arbiter.reason.surplus-deficit": "déficit de surplus",
   "arbiter.reason.priority-preempted": "préempté par une priorité",
   "arbiter.reason.manual-override": "commande manuelle",

--- a/ui/src/lib/arbitration-lanes.ts
+++ b/ui/src/lib/arbitration-lanes.ts
@@ -98,6 +98,22 @@ export function buildLanes(
             openUnclaimed = null;
           }
           break;
+        // #604 — a restart closes any span that was open at shutdown, at the
+        // restart boundary, so nothing runs phantom-open to now.
+        case "reset":
+          if (openGrant !== null) {
+            segments.push({ startMin: openGrant, endMin: min, kind: "granted" });
+            openGrant = null;
+          }
+          if (openManual !== null) {
+            segments.push({ startMin: openManual, endMin: min, kind: "manual" });
+            openManual = null;
+          }
+          if (openUnclaimed !== null) {
+            segments.push({ startMin: openUnclaimed, endMin: min, kind: "unclaimed" });
+            openUnclaimed = null;
+          }
+          break;
         default:
           break;
       }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -313,7 +313,8 @@ export type ArbiterDecisionKind =
   | "watts-divergence"
   | "unclaimed-run"
   | "unclaimed-run-ended"
-  | "waiting";
+  | "waiting"
+  | "reset";
 
 export interface ArbiterDecision {
   atIso: string;


### PR DESCRIPTION
Closes #604.

## Problem
The arbiter **timeline** paints a *granted* (green) cell at the current time while the load is actually idle in the live **table**. The timeline is a replay of the persisted decision journal (`buildLoadTimelines` carries the last sustained state forward to now); live claim state is rebuilt from scratch on restart (not persisted), so a grant/pending claim that was live at shutdown has no closing event and the ribbon runs green across the restart to now. Observed on prod for PAC Piscine (last journal event `granted` 12:26, uptime ~30 min).

## Fix
On `start()`, after restoring the journal and `rehydrateUnclaimedRuns()`, journal a new **`reset`** decision for every equipment whose last *sustained* journal state is granted/pending but that has **no live claim**. Stamped at startup (the restart boundary), so the span closes there instead of running phantom to now.

- Source-of-truth fix: corrects the persisted journal, so every future replay is right; robust to hard crashes (runs on the next boot). Covers pending tails too. Unmanaged (unclaimed-run) tails are left to `rehydrateUnclaimedRuns`.
- `sustainedAfter('reset') -> idle`.
- UI: new `reset` kind, journal label "réinitialisé au redémarrage" / "reset on restart" (reason suppressed as redundant), and the legacy client lane builder closes open spans on it.

## Tests
- capacity-arbiter: startup closes a granted tail and a pending tail; does NOT reset an already-closed or an unmanaged tail (5 tests).
- arbiter-timeline: `buildLoadTimelines` paints idle after a reset.
- Full suite green (backend 1560, UI arbiter 72), tsc + lint clean.

Cosmetic/display fix only — regulation is unaffected. Ships in a future core release.