### PR TITLE
release: v1.52.3

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.52.x : Ventilation deux vitesses et arbitre plus stable
 
+### v1.52.3 — 2026-08-18 { #v1-52-3 }
+
+- Correctif (énergie) : **la timeline d'activité de l'arbitre n'affiche plus de bandeau « autorisé » fantôme après un redémarrage**. Quand Sowel redémarrait alors qu'une charge flexible était autorisée ou en attente, la timeline rejouait cet état jusqu'à maintenant alors même que la charge était redevenue inactive. Sowel ferme désormais le segment en suspens à la frontière du redémarrage et répare le journal persisté pour que tous les futurs rejeux soient corrects. Le tableau des charges a toujours été exact. (#606)
+
 ### v1.52.2 — 2026-08-18 { #v1-52-2 }
 
 - Correctif (ui) : **la bascule « Solaire » de la carte d'équipement compacte fonctionne à nouveau**. Un appui ne faisait rien (la page détail de l'équipement n'était pas concernée) ; le gestionnaire de clic du bouton était neutralisé. Le pilotage solaire par l'arbitre d'énergie n'a jamais été impacté. (#600)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.52.x: Two-speed ventilation and a steadier arbiter
 
+### v1.52.3 — 2026-08-18 { #v1-52-3 }
+
+- Fix (energy): **the arbiter activity timeline no longer shows a phantom "granted" ribbon after a restart**. When Sowel restarted while a flexible load was granted or waiting, the timeline replayed that state forward to the present even though the load had gone idle. Sowel now closes the dangling segment at the restart boundary, and repairs the persisted journal so every future replay is correct. The load table was always accurate. (#606)
+
 ### v1.52.2 — 2026-08-18 { #v1-52-2 }
 
 - Fix (ui): **the "Solar" toggle on the compact equipment card now actuates again**. Tapping it did nothing (the equipment detail page was unaffected); the button's own click handler was being suppressed. Solar automation driven by the energy arbiter was never affected. (#600)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.52.2",
+  "version": "1.52.3",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.52.2",
+  "version": "1.52.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump + release notes for v1.52.3.

## Included since v1.52.2
- fix(energy): close phantom arbiter timeline tail after a restart (#606, #604)

## Not in release notes (non user-facing)
- chore(registry): add water-heater-solar recipe (#607) — registry entry, propagates via CDN independently
- fix: stop tracking a machine-specific node_modules symlink (#608) — repo hygiene

Release notes added to both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-52-3 }` anchor.