### PR TITLE
chore(registry): bump water-heater-solar to 0.1.2

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -571,7 +571,7 @@
     "icon": "Sun",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-water-heater-solar",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "tags": ["water-heater", "solar", "energy", "surplus", "automation"],
     "i18n": {
       "fr": {
@@ -581,6 +581,6 @@
     },
     "sowelVersion": ">=1.52.0",
     "owner": "mchacher",
-    "sha256": "a973c221054201cb64bf054167fcd998351a5b355cde93eec39d738bd90fb3ec"
+    "sha256": "65570863aa52e4be29561d65d0e60abf4ba05181e9de358f01dfc6a5214290a0"
   }
 ]


### PR DESCRIPTION
Bumps **water-heater-solar** 0.1.1 -> 0.1.2.

v0.1.2 adds the conventional **zone slot** the recipe was missing: the UI files each recipe instance under a room via `params.zone`, so without a zone slot the instance was attributed to no room and showed nowhere in the UI.

- No behaviour change (the zone slot is for UI filing; the recipe still drives the selected heater on surplus).
- `sha256` verified against the published v0.1.2 release asset.
- Two-line diff (version + sha256).