### PR TITLE
feat(ui): drop 'aujourd'hui' suffix from submetered energy values on compact card (#605)

### DIFF
--- a/ui/src/components/home/CompactEquipmentCard.test.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen } from "../../test-utils";
+import { CompactEquipmentCard } from "./CompactEquipmentCard";
+import type { ComputedDataEntry, EquipmentType, EquipmentWithDetails } from "../../types";
+
+// Issue #605 — the compact card must drop the "aujourd'hui" suffix from every
+// submetered day-energy value (energy meters + submetered water heater) while
+// keeping the kWh/Wh unit. These regression tests fail before the suffix removal.
+
+function makeEquipment(
+  type: EquipmentType,
+  computedData: ComputedDataEntry[],
+  over: Partial<EquipmentWithDetails> = {},
+): EquipmentWithDetails {
+  return {
+    id: "eq-1",
+    name: "Meter",
+    zoneId: "z-1",
+    type,
+    enabled: true,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    status: "online",
+    dataBindings: [] as EquipmentWithDetails["dataBindings"],
+    orderBindings: [] as EquipmentWithDetails["orderBindings"],
+    computedData,
+    ...over,
+  };
+}
+
+function dayEnergy(value: number): ComputedDataEntry {
+  return { alias: "energy_day", value, lastUpdated: "2026-01-01T00:00:00Z" };
+}
+
+function renderCard(equipment: EquipmentWithDetails) {
+  return render(
+    <MemoryRouter>
+      <CompactEquipmentCard equipment={equipment} onExecuteOrder={vi.fn()} />
+    </MemoryRouter>,
+  );
+}
+
+describe("CompactEquipmentCard — submetered day energy (#605)", () => {
+  it("shows an energy meter's day value with its unit and no 'aujourd'hui' suffix", () => {
+    renderCard(makeEquipment("energy_meter", [dayEnergy(1230)]));
+
+    expect(screen.getByText("kWh")).toBeTruthy();
+    expect(screen.getByText("1.23")).toBeTruthy();
+    expect(screen.queryByText(/aujourd'hui/i)).toBeNull();
+  });
+
+  it("shows a submetered water heater's day value with its unit and no 'aujourd'hui' suffix", () => {
+    renderCard(makeEquipment("water_heater", [dayEnergy(850)]));
+
+    expect(screen.getByText("Wh")).toBeTruthy();
+    expect(screen.getByText("850")).toBeTruthy();
+    expect(screen.queryByText(/aujourd'hui/i)).toBeNull();
+  });
+});

--- a/ui/src/components/home/CompactEquipmentCard.tsx
+++ b/ui/src/components/home/CompactEquipmentCard.tsx
@@ -270,7 +270,7 @@ export function CompactEquipmentCard({ equipment, onExecuteOrder, zoneName }: Co
                 ? (waterHeaterDayWh / 1000).toFixed(2)
                 : Math.round(waterHeaterDayWh)}
               <span className="text-[11px] font-normal text-text-tertiary ml-0.5">
-                {waterHeaterDayWh >= 1000 ? "kWh" : "Wh"} {t("energy.today").toLowerCase()}
+                {waterHeaterDayWh >= 1000 ? "kWh" : "Wh"}
               </span>
             </span>
           )}
@@ -456,7 +456,6 @@ function CompactForecast({ equipment }: { equipment: EquipmentWithDetails }) {
 }
 
 function CompactEnergyValues({ equipment }: { equipment: EquipmentWithDetails }) {
-  const { t } = useTranslation();
   const computed = equipment.computedData ?? [];
   const energyDay = computed.find((c) => c.alias === "energy_day");
   // Live instantaneous power (issue #376): generic power binding first,
@@ -482,7 +481,7 @@ function CompactEnergyValues({ equipment }: { equipment: EquipmentWithDetails })
         <span className={`text-[13px] ${valueColor} tabular-nums font-mono font-semibold`}>
           {dayWh >= 1000 ? (dayWh / 1000).toFixed(2) : Math.round(dayWh)}
           <span className="text-[11px] font-normal text-text-tertiary ml-0.5">
-            {dayWh >= 1000 ? "kWh" : "Wh"} {t("energy.today").toLowerCase()}
+            {dayWh >= 1000 ? "kWh" : "Wh"}
           </span>
         </span>
       )}


### PR DESCRIPTION
Closes #605.

## Design
On the compact equipment card (zone / home rows, same component in PWA and desktop), submetered day-energy values rendered a redundant "aujourd'hui" suffix, e.g. `1.23 kWh aujourd'hui`. On a compact row the unit (kWh/Wh) already signals a cumulative reading, so the suffix only added clutter, most noticeably at PWA/mobile width.

Removed the `{t("energy.today").toLowerCase()}` suffix in the two submetered spots:
- `CompactEnergyValues` (energy_meter / main_energy_meter / energy_production_meter)
- the submetered water-heater day-energy block

The kWh/Wh unit is kept. The `energy.today` i18n key stays in place (still used by the detailed `EnergyDataPanel` and `EquipmentWidget`). The detailed equipment view keeps its full labeling. Applies to both PWA and desktop.

## Tests
New `ui/src/components/home/CompactEquipmentCard.test.tsx` — asserts the day value renders with its unit and NO "aujourd'hui" text, for both the energy-meter and submetered water-heater paths (fails before the fix). Full UI suite green (509 tests).