### PR TITLE
release: v1.52.4

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,11 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.52.x : Ventilation deux vitesses et arbitre plus stable
 
+### v1.52.4 — 2026-08-18 { #v1-52-4 }
+
+- Correctif (ui) : **l'arbitre indique désormais « hors arbitrage » pour une charge non gérée**, au lieu de l'ancienne formulation moins claire, de sorte qu'une charge que l'arbitre d'énergie ne pilote pas se lit sans ambiguïté. (#611)
+- Correctif (ui) : **les valeurs d'énergie sous-comptée sur la carte d'équipement compacte n'ajoutent plus le suffixe « aujourd'hui » redondant**, ce qui allège la lecture de la carte. (#612)
+
 ### v1.52.3 — 2026-08-18 { #v1-52-3 }
 
 - Correctif (énergie) : **la timeline d'activité de l'arbitre n'affiche plus de bandeau « autorisé » fantôme après un redémarrage**. Quand Sowel redémarrait alors qu'une charge flexible était autorisée ou en attente, la timeline rejouait cet état jusqu'à maintenant alors même que la charge était redevenue inactive. Sowel ferme désormais le segment en suspens à la frontière du redémarrage et répare le journal persisté pour que tous les futurs rejeux soient corrects. Le tableau des charges a toujours été exact. (#606)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,11 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.52.x: Two-speed ventilation and a steadier arbiter
 
+### v1.52.4 — 2026-08-18 { #v1-52-4 }
+
+- Fix (ui): **the arbiter now labels a load outside arbitration as "hors arbitrage"** instead of the previous, less clear wording, so a load that the energy arbiter is not managing reads unambiguously. (#611)
+- Fix (ui): **submetered energy values on the compact equipment card no longer append a redundant "aujourd'hui" suffix**, keeping the card reading tight. (#612)
+
 ### v1.52.3 — 2026-08-18 { #v1-52-3 }
 
 - Fix (energy): **the arbiter activity timeline no longer shows a phantom "granted" ribbon after a restart**. When Sowel restarted while a flexible load was granted or waiting, the timeline replayed that state forward to the present even though the load had gone idle. Sowel now closes the dangling segment at the restart boundary, and repairs the persisted journal so every future replay is correct. The load table was always accurate. (#606)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.52.3",
+  "version": "1.52.4",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.52.3",
+  "version": "1.52.4",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump + release notes for v1.52.4.

## Included since v1.52.3
- fix(ui): relabel arbiter unmanaged state to 'hors arbitrage' (#611, #603)
- feat(ui): drop 'aujourd'hui' suffix from submetered energy values on compact card (#612, #605)

## Not in release notes (non user-facing)
- chore(registry): bump water-heater-solar to 0.1.2 (#610) — registry entry, propagates via CDN independently

Release notes added to both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-52-4 }` anchor.