### PR TITLE
fix(energy): roll idle submeter cumuls over the hour/midnight boundary (#618)

### DIFF
--- a/src/energy/energy-aggregator.test.ts
+++ b/src/energy/energy-aggregator.test.ts
@@ -16,6 +16,32 @@ function offlineInflux(): InfluxClient {
   } as unknown as InfluxClient;
 }
 
+/**
+ * Connected InfluxDB whose current-hour raw sum is driven by `hourWh()`. The
+ * hour query reads the raw `bucket`; the day-prev / month / year queries read
+ * the `-energy-hourly` / `-energy-daily` buckets and return nothing here, so
+ * energy_day resolves to exactly the current-hour value. Lets a test flip the
+ * live consumption and assert the cached cumul follows.
+ */
+function influxWithHour(hourWh: () => number): InfluxClient {
+  const queryApi = {
+    async *iterateRows(flux: string) {
+      // Only the raw-bucket (current hour) query yields a value; the derived
+      // buckets are addressed by their suffixed names.
+      if (flux.includes("-energy-hourly") || flux.includes("-energy-daily")) return;
+      const value = hourWh();
+      yield {
+        values: [],
+        tableMeta: { toObject: () => ({ _value: value }) },
+      } as never;
+    },
+  };
+  return {
+    getClient: vi.fn(() => ({ getQueryApi: () => queryApi })),
+    getConfig: vi.fn(() => ({ org: "org", bucket: "sowel" })),
+  } as unknown as InfluxClient;
+}
+
 const power = [{ alias: "power", category: "power", value: 0 }];
 const energy = [{ alias: "energy", category: "energy", value: 100 }];
 const state = [{ alias: "state", category: "light_state", value: "ON" }];
@@ -100,6 +126,88 @@ describe("EnergyAggregator submeter enrolment (#527)", () => {
     const wh = agg.getComputedDataForEquipment("wh2");
     expect(wh).toHaveLength(4);
     expect(wh.every((e) => e.value === 0)).toBe(true);
+  });
+
+  it("recomputes an idle submeter's cumuls on the hour rollover, not just on energy events (#618)", async () => {
+    // Start mid-morning so we know how long until the next hour boundary.
+    vi.setSystemTime(new Date(2026, 7, 19, 8, 30, 0));
+    const mgr = managerWith([{ id: "wh", type: "water_heater", dataBindings: power }]);
+
+    // Yesterday's consumption is still the current cached value; the heater then
+    // goes idle (0 W) and emits no further `energy` events.
+    let hourWh = 2920;
+    const agg = new EnergyAggregator(
+      mgr,
+      influxWithHour(() => hourWh),
+      bus,
+      logger,
+    );
+    await agg.start();
+
+    expect(agg.getComputedDataForEquipment("wh").find((e) => e.alias === "energy_day")?.value).toBe(
+      2920,
+    );
+
+    // Real consumption drops to zero. Without a scheduled rollover the cached
+    // 2920 would keep being served all through the idle period.
+    hourWh = 0;
+
+    // Cross the next hour boundary (08:30 → 09:00 is 30 min away).
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000 + 1000);
+
+    expect(agg.getComputedDataForEquipment("wh").find((e) => e.alias === "energy_day")?.value).toBe(
+      0,
+    );
+
+    agg.stop();
+  });
+
+  it("rolls day/month/year cumuls over the local midnight boundary (#618)", async () => {
+    // 23:45 local: the midnight tick must recompute against the new day.
+    vi.setSystemTime(new Date(2026, 7, 19, 23, 45, 0));
+    const mgr = managerWith([{ id: "wh", type: "water_heater", dataBindings: power }]);
+
+    let hourWh = 2920;
+    const agg = new EnergyAggregator(
+      mgr,
+      influxWithHour(() => hourWh),
+      bus,
+      logger,
+    );
+    await agg.start();
+    expect(agg.getComputedDataForEquipment("wh").find((e) => e.alias === "energy_day")?.value).toBe(
+      2920,
+    );
+
+    // New day starts idle.
+    hourWh = 0;
+    await vi.advanceTimersByTimeAsync(15 * 60 * 1000 + 1000); // cross 00:00
+
+    const cumuls = agg.getComputedDataForEquipment("wh");
+    expect(cumuls.find((e) => e.alias === "energy_day")?.value).toBe(0);
+    expect(cumuls.find((e) => e.alias === "energy_month")?.value).toBe(0);
+    expect(cumuls.find((e) => e.alias === "energy_year")?.value).toBe(0);
+
+    agg.stop();
+  });
+
+  it("stop() prevents a rollover refresh in flight from re-arming the timer (#618)", async () => {
+    vi.setSystemTime(new Date(2026, 7, 19, 8, 30, 0));
+    const mgr = managerWith([{ id: "wh", type: "water_heater", dataBindings: power }]);
+    const agg = new EnergyAggregator(
+      mgr,
+      influxWithHour(() => 0),
+      bus,
+      logger,
+    );
+    await agg.start();
+
+    agg.stop();
+    // Advancing well past several hour boundaries must fire nothing: no timer
+    // should have survived stop(). If one did, this would throw on the cleared
+    // Influx client or leave a dangling timer that clearAllTimers would report.
+    await vi.advanceTimersByTimeAsync(3 * 60 * 60 * 1000);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("does not enrol a bare relay (switch with no metering) on update", async () => {

--- a/src/energy/energy-aggregator.ts
+++ b/src/energy/energy-aggregator.ts
@@ -41,6 +41,10 @@ export class EnergyAggregator {
   private energyEquipmentIds = new Set<string>();
   /** Debounce timers per equipment. */
   private pendingRefresh = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Hour-aligned timer that recomputes every enrolled equipment (#618). */
+  private rolloverTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Set by stop() so a refresh in flight cannot re-arm the rollover timer. */
+  private stopped = false;
 
   constructor(
     equipmentManager: EquipmentManager,
@@ -59,6 +63,7 @@ export class EnergyAggregator {
    * Must be called after integrations have started and equipment bindings are set up.
    */
   async start(): Promise<void> {
+    this.stopped = false;
     // Discover which equipments have energy bindings
     this.discoverEnergyEquipments();
 
@@ -100,7 +105,60 @@ export class EnergyAggregator {
       }
     });
 
+    // Recompute every enrolled equipment on each local hour boundary. Without
+    // this, a submeter that goes idle (0 W) never emits another `energy` event,
+    // so its cached cumuls freeze and keep serving the previous hour/day/month
+    // total across the boundary — the "2.92 kWh shown all night" bug (#618).
+    this.scheduleRollover();
+
     this.logger.info({ equipmentCount: this.energyEquipmentIds.size }, "Energy aggregator started");
+  }
+
+  /** Clear timers so the aggregator can be torn down without leaks. */
+  stop(): void {
+    this.stopped = true;
+    if (this.rolloverTimer) {
+      clearTimeout(this.rolloverTimer);
+      this.rolloverTimer = null;
+    }
+    for (const timer of this.pendingRefresh.values()) {
+      clearTimeout(timer);
+    }
+    this.pendingRefresh.clear();
+  }
+
+  /**
+   * Arm a one-shot timer for the next local hour boundary. On fire it refreshes
+   * all enrolled equipments (rolling the hour cumul, and — at the midnight tick —
+   * the day/month/year cumuls) then re-arms itself for the following hour.
+   */
+  private scheduleRollover(): void {
+    if (this.stopped) return;
+    const now = new Date();
+    const nextHour = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+      now.getHours() + 1,
+      0,
+      0,
+      0,
+    );
+    const delay = Math.max(1, nextHour.getTime() - now.getTime());
+    this.rolloverTimer = setTimeout(() => {
+      this.refreshAll()
+        .catch((err) => this.logger.warn({ err }, "Energy rollover refresh failed"))
+        .finally(() => this.scheduleRollover());
+    }, delay);
+  }
+
+  /** Recompute cumuls for every enrolled equipment from InfluxDB. */
+  private async refreshAll(): Promise<void> {
+    for (const equipmentId of this.energyEquipmentIds) {
+      await this.refreshFromInfluxDB(equipmentId).catch((err) =>
+        this.logger.warn({ err, equipmentId }, "Failed to refresh energy cumuls on rollover"),
+      );
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -727,6 +727,11 @@ async function main() {
       logger.error({ err }, "Error stopping power submeter integrator");
     }
     try {
+      energyAggregator.stop();
+    } catch (err) {
+      logger.error({ err }, "Error stopping energy aggregator");
+    }
+    try {
       await influxClient.disconnect();
     } catch (err) {
       logger.error({ err }, "Error disconnecting InfluxDB");


### PR DESCRIPTION
## Problem

A power-only submeter (e.g. the `Chauffe-eau` water heater) kept showing
yesterday's daily consumption all night. On prod the heater's power dropped to
0 W at 2026-08-18 15:25 and stayed there, yet `energy_day` was still 2.92 kWh
the next morning.

## Root cause

`EnergyAggregator` caches per-equipment cumuls in memory and only recomputes
when an `alias="energy"` event arrives. `PowerSubmeterIntegrator` emits that
event only when a flushed delta is `>= MIN_WRITE_WH` (0.001 Wh). An idle load
(0 W) integrates ~0, so it writes nothing and emits nothing. With no event, the
cached cumuls never rolled over at local midnight, so the previous day's total
kept being served. The main energy meter never hits this because the house
always draws power.

## Fix

Add an hour-aligned rollover timer in `EnergyAggregator`: at each local hour
boundary it recomputes every enrolled energy equipment from InfluxDB, then
re-arms. The midnight tick recomputes with fresh date ranges, so `energy_day`,
`energy_month`, and `energy_year` all roll over correctly for idle equipments.
A `stopped` guard prevents a refresh in flight from re-arming the timer after
`stop()`, which is now wired into graceful shutdown.

Cost is negligible: N enrolled equipments x 4 queries, once per hour.

## Tests

- Regression: an idle submeter's `energy_day` recomputes to 0 on the hour
  rollover (verified to fail before the fix, serving the stale 2920).
- Midnight crossing rolls `energy_day` / `energy_month` / `energy_year` over.
- `stop()` leaves no surviving timer even across several boundaries.

`npx tsc --noEmit`, `npx eslint src/`, and the full `npx vitest run` (1563
passing) are green.

Closes #618
