### PR TITLE
fix(ui): soften arbiter timeline 'en attente' cell to the table waiting tint (#617)

### DIFF
--- a/ui/src/components/energy/ArbiterTimeline.tsx
+++ b/ui/src/components/energy/ArbiterTimeline.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import type { ArbiterQuarterState, ArbiterTimeline as ArbiterTimelineData } from "../../types";
+import type { ArbiterTimeline as ArbiterTimelineData } from "../../types";
 import { getArbiterTimeline } from "../../api";
 import { useArbiter } from "../../store/useArbiter";
-import { journalDotColor } from "./arbiterColors";
+import { cellColor, journalDotColor, PENDING_FILL } from "./arbiterColors";
 import { journalReasonLabel } from "./arbiterReason";
 
 // Spec 148 (Phase B) — the redesigned Energy → arbitrage timeline: a signed
@@ -43,21 +43,6 @@ function useWindowHours(): number {
     return () => mq.removeEventListener("change", onChange);
   }, []);
   return hours;
-}
-
-function cellColor(s: ArbiterQuarterState): string {
-  switch (s) {
-    case "granted":
-      return "var(--color-solar-auto)"; // accordé (auto-conso)
-    case "pending":
-      return "var(--color-warning)"; // en attente de surplus (#561, jaune a-500)
-    case "revoked":
-      return "var(--color-error)"; // surplus retiré
-    case "unmanaged":
-      return "var(--color-slate)"; // On (hors arbitrage)
-    default:
-      return "color-mix(in srgb, var(--color-text-tertiary) 15%, transparent)"; // idle
-  }
 }
 
 function hhmm(ms: number): string {
@@ -430,7 +415,7 @@ export function ArbiterTimeline() {
         <span className="flex items-center gap-1.5">
           <span
             className="w-3 h-2.5 rounded-sm flex-none"
-            style={{ backgroundColor: "var(--color-warning)" }}
+            style={{ backgroundColor: PENDING_FILL }}
           />
           {t("arbiter.legend.pending")}
         </span>

--- a/ui/src/components/energy/arbiterColors.test.ts
+++ b/ui/src/components/energy/arbiterColors.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { journalDotColor, surplusStickerColor, isArbiterDormant } from "./arbiterColors";
+import {
+  journalDotColor,
+  surplusStickerColor,
+  isArbiterDormant,
+  cellColor,
+  PENDING_FILL,
+} from "./arbiterColors";
 
 describe("journalDotColor (spec 148)", () => {
   it("maps granted/resumed to the auto-consumption green token", () => {
@@ -21,6 +27,26 @@ describe("journalDotColor (spec 148)", () => {
   it("falls back to a neutral token for other kinds", () => {
     expect(journalDotColor("unclaimed-run-ended")).toBe("var(--color-text-tertiary)");
     expect(journalDotColor("denied")).toBe("var(--color-text-tertiary)");
+  });
+});
+
+describe("cellColor (timeline ribbon, #617)", () => {
+  it("paints the 'en attente' cell with the muted table-pill tint, not the solid warning", () => {
+    // #617 — the solid orange read as aggressive; the pending cell must reuse
+    // the same 15% warning mix the roster's waiting pill uses.
+    expect(cellColor("pending")).toBe(PENDING_FILL);
+    expect(PENDING_FILL).toBe("color-mix(in srgb, var(--color-warning) 15%, transparent)");
+    expect(cellColor("pending")).not.toBe("var(--color-warning)");
+  });
+
+  it("keeps the other states on their solid tokens", () => {
+    expect(cellColor("granted")).toBe("var(--color-solar-auto)");
+    expect(cellColor("revoked")).toBe("var(--color-error)");
+    expect(cellColor("unmanaged")).toBe("var(--color-slate)");
+  });
+
+  it("uses a faint neutral tint for idle", () => {
+    expect(cellColor("idle")).toBe("color-mix(in srgb, var(--color-text-tertiary) 15%, transparent)");
   });
 });
 

--- a/ui/src/components/energy/arbiterColors.ts
+++ b/ui/src/components/energy/arbiterColors.ts
@@ -1,4 +1,27 @@
-import type { ArbiterDecision } from "../../types";
+import type { ArbiterDecision, ArbiterQuarterState } from "../../types";
+
+/**
+ * "En attente" cells reuse the muted 15% warning tint of the roster table's
+ * waiting pill (ArbitrationSurface StatePill) rather than the solid orange,
+ * which read as too aggressive on the timeline ribbon (#617).
+ */
+export const PENDING_FILL = "color-mix(in srgb, var(--color-warning) 15%, transparent)";
+
+/** Spec 148 — map an arbiter timeline quarter state to its ribbon-cell fill. */
+export function cellColor(s: ArbiterQuarterState): string {
+  switch (s) {
+    case "granted":
+      return "var(--color-solar-auto)"; // accordé (auto-conso)
+    case "pending":
+      return PENDING_FILL; // en attente de surplus (#561, muted per #617)
+    case "revoked":
+      return "var(--color-error)"; // surplus retiré
+    case "unmanaged":
+      return "var(--color-slate)"; // On (hors arbitrage)
+    default:
+      return "color-mix(in srgb, var(--color-text-tertiary) 15%, transparent)"; // idle
+  }
+}
 
 /**
  * Spec 148 — map an arbiter decision kind to its journal-dot color token.


### PR DESCRIPTION
## Problem

The "en attente" (waiting-for-surplus) quarter cells on the energy arbiter
timeline were painted with the solid warning orange (`var(--color-warning)`),
which read as aggressive next to the calmer green (accordé) and slate cells.

## Fix

Reuse the roster table's waiting-pill background instead: the same warning
token mixed to 15% (`color-mix(in srgb, var(--color-warning) 15%, transparent)`),
applied to both the timeline ribbon cells and the legend swatch. The other
states keep their solid tokens.

`cellColor` and the shared `PENDING_FILL` constant moved from
`ArbiterTimeline.tsx` into `arbiterColors.ts` (the `react-refresh` lint rule
forbids non-component exports from a component file), so they can be unit tested.

## Tests

- `arbiterColors.test.ts`: `cellColor("pending")` equals the 15% warning mix and
  is no longer the solid `var(--color-warning)`; other states keep their tokens;
  idle keeps its faint neutral tint.
- Full UI suite green (512), `tsc -b` and eslint clean.

Closes #617
