### PR TITLE
feat(ui): order arbiter roster table by configured priority (#616)

### DIFF
--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -289,6 +289,11 @@ describe("capacity arbiter", () => {
     expect(state.journal.some((j) => j.kind === "granted")).toBe(true);
   });
 
+  it("exposes the configured priority order for the roster table (#616)", () => {
+    const h = makeHarness({ priority: ["heater", "pac", "pump"] });
+    expect(h.arbiter.getPublicState().priority).toEqual(["heater", "pac", "pump"]);
+  });
+
   it("keeps a claim pending when the surplus is below watts+margin", () => {
     const h = makeHarness();
     h.claim("i1", { equipmentId: "pump" }); // needs 600+100

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -942,6 +942,9 @@ export class CapacityArbiter {
       pending,
       suspensions,
       idle,
+      // #616 — surface the configured order (highest first) so the roster table
+      // can list loads by priority like the timeline, not grouped by state.
+      priority: [...this.config.priority],
       journal: [...this.journalEntries].reverse(),
       surplusSeries: this.surplusSeries.map((s) => ({
         atIso: new Date(s.at).toISOString(),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -814,6 +814,10 @@ export interface ArbiterPublicState {
   /** #561 — declared flexible loads with no active claim (at rest / running
    *  outside arbitration). Completes the roster so every priority load shows. */
   idle: ArbiterIdleInfo[];
+  /** #616 — the configured load priority, highest first (equipmentId order).
+   *  Lets the UI list every load in priority order, matching the timeline,
+   *  instead of grouping the roster by state. */
+  priority: string[];
   journal: ArbiterDecision[];
   /** Today's available-surplus samples (~5 min cadence, in-memory, bounded)
    *  — the curve of the FR-10 day timeline. */

--- a/ui/src/components/energy/ArbitrationSurface.test.tsx
+++ b/ui/src/components/energy/ArbitrationSurface.test.tsx
@@ -23,6 +23,7 @@ function fullState(over: Partial<ArbiterPublicState> = {}): ArbiterPublicState {
     pending: [],
     suspensions: [],
     idle: [],
+    priority: [],
     journal: [],
     surplusSeries: [],
     ...over,
@@ -154,6 +155,46 @@ describe("ArbitrationSurface roster (#561)", () => {
     expect(screen.getByText("Granted")).toBeTruthy();
     expect(screen.getByText("Waiting")).toBeTruthy();
     expect(screen.getByText("At rest")).toBeTruthy();
+  });
+
+  it("orders the roster by configured priority, not by state group (#616)", () => {
+    // Grant / pending / idle deliberately concatenate as pump, pacp, pac, heater;
+    // priority reorders them to pac, heater, pump, pacp — matching the timeline.
+    seed({
+      grants: [
+        {
+          equipmentId: "pump",
+          equipmentName: "Pompe",
+          instanceId: "i-pump",
+          watts: 600,
+          sinceIso: "2026-08-17T08:00:00.000Z",
+        },
+      ],
+      pending: [
+        {
+          equipmentId: "pacp",
+          equipmentName: "PAC Piscine",
+          instanceId: "i-pacp",
+          watts: 1800,
+          needW: 1700,
+          toleratedImportW: 200,
+          reasonWaiting: "insufficient-surplus:0",
+          running: false,
+        },
+      ],
+      idle: [
+        { equipmentId: "pac", equipmentName: "PAC", watts: 1500, toleratedImportW: 0, runningUnmanaged: false },
+        { equipmentId: "heater", equipmentName: "Chauffe-eau", watts: 2000, toleratedImportW: 0, runningUnmanaged: false },
+      ],
+      priority: ["pac", "heater", "pump", "pacp"],
+    });
+    render(<ArbitrationSurface />);
+
+    const names = screen
+      .getAllByRole("row")
+      .slice(1) // drop the header row
+      .map((row) => row.querySelector("td")?.textContent);
+    expect(names).toEqual(["PAC", "Chauffe-eau", "Pompe", "PAC Piscine"]);
   });
 
   it("spells out the deficit context when the meter is importing", () => {

--- a/ui/src/components/energy/ArbitrationSurface.tsx
+++ b/ui/src/components/energy/ArbitrationSurface.tsx
@@ -18,8 +18,9 @@ import { ROOT_ZONE_ID } from "../../lib/constants";
 
 /**
  * One roster row, flattened from the four state arrays of the read model into a
- * single ordered list (granted → waiting/running → suspended → at-rest). Each
- * carries the figures relevant to its state; `null` renders as a dash.
+ * single list ordered by configured priority (#616), matching the timeline. The
+ * `stateKey` pill carries each load's state; figures irrelevant to a state are
+ * `null` and render as a dash.
  */
 interface RosterRow {
   equipmentId: string;
@@ -83,8 +84,10 @@ export function ArbitrationSurface() {
   const dormant = isArbiterDormant(state.state, rootAgg?.isDaylight ?? null, available);
   const stickerColor = dormant ? "var(--color-slate)" : surplusStickerColor(available);
 
-  // Flatten the read model into one ordered roster. Order encodes urgency:
-  // who holds surplus, who is asking, who is paused, who is at rest.
+  // Flatten the read model into one roster. Each source array is state-specific
+  // (grants / pending / suspensions / idle); the state pill carries the state,
+  // so the rows themselves are ordered by configured priority (#616) to match
+  // the timeline — not grouped by state.
   const rows: RosterRow[] = [
     ...state.grants.map<RosterRow>((g) => ({
       equipmentId: g.equipmentId,
@@ -125,6 +128,15 @@ export function ArbitrationSurface() {
       toleratedW: tolerated(i.toleratedImportW),
     })),
   ];
+
+  // #616 — order by the arbiter's configured priority (highest first), matching
+  // the timeline. A load absent from the list (should not happen) sorts last but
+  // keeps a stable relative order.
+  const rank = (id: string) => {
+    const i = state.priority.indexOf(id);
+    return i === -1 ? Number.MAX_SAFE_INTEGER : i;
+  };
+  rows.sort((a, b) => rank(a.equipmentId) - rank(b.equipmentId));
 
   // Deficit context (FR-10a): when the meter is importing, no waiting load can
   // start — spell it out so an empty "need" column does not read as inaction.

--- a/ui/src/lib/arbitration-lanes.test.ts
+++ b/ui/src/lib/arbitration-lanes.test.ts
@@ -28,6 +28,7 @@ function state(journal: ArbiterDecision[], pending: string[] = []): ArbiterPubli
     })),
     suspensions: [],
     idle: [],
+    priority: [],
     journal, // newest-first
     surplusSeries: [],
   };

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -367,6 +367,9 @@ export interface ArbiterPublicState {
      *  arbitration", not "at rest" (mirrors #491). */
     runningUnmanaged: boolean;
   }>;
+  /** #616 — configured load priority, highest first (equipmentId order). Lets
+   *  the roster table list loads in priority order, matching the timeline. */
+  priority: string[];
   journal: ArbiterDecision[];
   surplusSeries: Array<{ atIso: string; availableW: number }>;
 }


### PR DESCRIPTION
## Problem

The energy arbiter roster table listed loads grouped by state (grants → pending
→ suspensions → idle), so the order encoded urgency rather than the configured
priority. The timeline already renders loads in priority order, so the two
surfaces disagreed.

## Fix

Surface the configured order on the public state and sort the table by it:

- Backend: add `priority: string[]` to `ArbiterPublicState`, returned as
  `[...this.config.priority]` from `getPublicState()` (highest first).
- Frontend: sort the flattened roster by `priority.indexOf(equipmentId)`
  ascending (unknown ids last, stable). The per-row state pill still conveys
  granted / waiting / suspended / idle, so no information is lost.

The timeline needs no change: it already maps `config.priority` directly
(`getTimeline` → `buildLoadTimelines` → rendered as received). The table now
sorts by that same array, so the two are driven by one source and cannot drift.

## Tests

- Backend: `getPublicState().priority` equals the configured order.
- Frontend: the roster renders in priority order across state groups (verified
  to fail without the sort — the seed concatenates in a different order).
- Backend energy suite green (204), full UI suite green (513), tsc + eslint clean.

Closes #616
