### PR TITLE
feat(ui): view recipe logs on the PWA via a bottom sheet (#615)

### DIFF
--- a/ui/src/components/recipes/RecipeInstanceRow.test.tsx
+++ b/ui/src/components/recipes/RecipeInstanceRow.test.tsx
@@ -88,9 +88,32 @@ function seedStores(instance: RecipeInstance, overrides: Partial<Parameters<type
   });
 }
 
+/** Report a viewport to `useIsMobile` (matchMedia `(max-width: 639px)`). */
+function setViewport(mobile: boolean): void {
+  window.matchMedia = ((query: string) => ({
+    matches: mobile,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+const LOG_ENTRY = {
+  id: 1,
+  instanceId: "ri-1",
+  timestamp: "2026-01-01T12:00:00Z",
+  message: "Recipe fired",
+  level: "info" as const,
+};
+
 describe("RecipeInstanceRow", () => {
   beforeEach(() => {
     useAuth.setState({ user: adminUser() });
+    setViewport(false); // desktop by default; a test opts into mobile explicitly
   });
 
   it("renders the recipe display name", () => {
@@ -137,6 +160,35 @@ describe("RecipeInstanceRow", () => {
     await userEvent.clear(delay);
     await userEvent.type(delay, "9");
     expect(screen.getByRole("button", { name: "Save" })).toHaveProperty("disabled", false);
+  });
+
+  it("opens recipe logs in a bottom sheet on the PWA/mobile (#615)", async () => {
+    setViewport(true);
+    const getLog = vi.fn().mockResolvedValue([LOG_ENTRY]);
+    seedStores(makeInstance(), { getLog });
+    render(<RecipeInstanceRow instance={makeInstance()} recipes={[RECIPE]} zoneId="z-salon" />);
+
+    // The log button is reachable on mobile (unlike duplicate/delete).
+    await userEvent.click(screen.getByTitle("View log"));
+
+    expect(await screen.findByText("Recipe fired")).toBeTruthy();
+    expect(getLog).toHaveBeenCalledWith("ri-1");
+    // Rendered in the bottom sheet: it carries a "View log" heading (the inline
+    // desktop panel has none).
+    expect(screen.getByRole("heading", { name: "View log" })).toBeTruthy();
+  });
+
+  it("opens recipe logs inline (no sheet) on desktop (#615)", async () => {
+    setViewport(false);
+    const getLog = vi.fn().mockResolvedValue([LOG_ENTRY]);
+    seedStores(makeInstance(), { getLog });
+    render(<RecipeInstanceRow instance={makeInstance()} recipes={[RECIPE]} zoneId="z-salon" />);
+
+    await userEvent.click(screen.getByTitle("View log"));
+
+    expect(await screen.findByText("Recipe fired")).toBeTruthy();
+    // Inline panel, not the bottom sheet — no sheet heading.
+    expect(screen.queryByRole("heading", { name: "View log" })).toBeNull();
   });
 
   it("hides admin controls for a non-admin user", () => {

--- a/ui/src/components/recipes/RecipeInstanceRow.tsx
+++ b/ui/src/components/recipes/RecipeInstanceRow.tsx
@@ -24,6 +24,8 @@ import {
 } from "./recipe-form-fields";
 import { useZoneOptions } from "./useZoneOptions";
 import { DuplicateRecipeModal } from "./DuplicateRecipeModal";
+import { BottomSheet } from "../dashboard/BottomSheet";
+import { useIsMobile } from "../../hooks/useIsMobile";
 
 // ============================================================
 // Instance row
@@ -41,6 +43,7 @@ export function RecipeInstanceRow({
   const { t, i18n } = useTranslation();
   const lang = i18n.language.startsWith("fr") ? "fr" : "en";
   const isAdmin = useAuth((s) => s.user?.role === "admin");
+  const isMobile = useIsMobile();
   const deleteInstance = useRecipes((s) => s.deleteInstance);
   const updateInstance = useRecipes((s) => s.updateInstance);
   const enableInstance = useRecipes((s) => s.enableInstance);
@@ -275,6 +278,32 @@ export function RecipeInstanceRow({
 
   // (paramsSummary removed per spec 100 — recipe row keeps name + actions only, no description line)
 
+  // Shared log list body — rendered inline on desktop and inside a bottom sheet
+  // on the PWA/mobile (#615). Kept in one place so both stay in sync.
+  const logBody =
+    logs.length === 0 ? (
+      <p className="text-[11px] text-text-tertiary text-center py-2">{t("common.noLogs")}</p>
+    ) : (
+      <div className="space-y-0.5">
+        {logs.map((log) => (
+          <div key={log.id} className="flex gap-2 text-[11px] font-mono">
+            <span className="text-text-tertiary whitespace-nowrap">{formatTime(log.timestamp)}</span>
+            <span
+              className={
+                log.level === "error"
+                  ? "text-error"
+                  : log.level === "warn"
+                    ? "text-warning"
+                    : "text-text-secondary"
+              }
+            >
+              {log.message}
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+
   return (
     <div className={instance.enabled ? "" : "opacity-50"}>
       <div className="grid grid-cols-[32px_1fr_auto] gap-x-[0.85rem] gap-y-0 items-center px-[1.1rem] py-[0.35rem] min-h-[52px] border-t border-border-light">
@@ -344,19 +373,21 @@ export function RecipeInstanceRow({
           />
         </button>
         )}
-        {/* Row 2: compact action buttons — admin only (log / duplicate / delete are config) */}
+        {/* Row 2: compact action buttons — admin only. The log button stays
+            visible on mobile (read-only, opens a bottom sheet on the PWA, #615);
+            duplicate / delete are config/destructive and stay desktop-only. */}
         {isAdmin && (
-        <div className="col-start-2 col-span-2 row-start-2 hidden sm:flex items-center gap-[2px]">
+        <div className="col-start-2 col-span-2 row-start-2 flex items-center gap-[2px]">
           <button
             onClick={handleShowLog}
-            className="w-[22px] h-[20px] inline-flex items-center justify-center rounded-[4px] text-text-tertiary hover:text-text hover:bg-border-light/60 transition-colors duration-150"
+            className="w-8 h-8 sm:w-[22px] sm:h-[20px] inline-flex items-center justify-center rounded-[4px] text-text-tertiary hover:text-text hover:bg-border-light/60 transition-colors duration-150"
             title={t("recipes.viewLog")}
           >
-            <ScrollText size={12} strokeWidth={1.5} />
+            <ScrollText className="w-3.5 h-3.5 sm:w-3 sm:h-3" strokeWidth={1.5} />
           </button>
           <button
             onClick={() => setShowDuplicate(true)}
-            className="w-[22px] h-[20px] inline-flex items-center justify-center rounded-[4px] text-text-tertiary hover:text-primary hover:bg-primary/5 transition-colors duration-150"
+            className="w-[22px] h-[20px] hidden sm:inline-flex items-center justify-center rounded-[4px] text-text-tertiary hover:text-primary hover:bg-primary/5 transition-colors duration-150"
             title={t("recipes.duplicate")}
           >
             <Copy size={12} strokeWidth={1.5} />
@@ -364,7 +395,7 @@ export function RecipeInstanceRow({
           <button
             onClick={handleDelete}
             disabled={deleting}
-            className="w-[22px] h-[20px] inline-flex items-center justify-center rounded-[4px] text-text-tertiary hover:text-error hover:bg-error/5 transition-colors duration-150 disabled:opacity-50"
+            className="w-[22px] h-[20px] hidden sm:inline-flex items-center justify-center rounded-[4px] text-text-tertiary hover:text-error hover:bg-error/5 transition-colors duration-150 disabled:opacity-50"
             title={t("common.delete")}
           >
             <Trash2 size={12} strokeWidth={1.5} />
@@ -684,37 +715,22 @@ export function RecipeInstanceRow({
         </div>
       )}
 
-      {/* Log panel */}
-      {showLog && (
+      {/* Log panel — inline on desktop, a bottom sheet on the PWA/mobile (#615). */}
+      {showLog && !isMobile && (
         <div className="px-4 pb-3">
           <div className="bg-border-light/40 rounded-[6px] p-2 max-h-[200px] overflow-y-auto">
-            {logs.length === 0 ? (
-              <p className="text-[11px] text-text-tertiary text-center py-2">{t("common.noLogs")}</p>
-            ) : (
-              <div className="space-y-0.5">
-                {logs.map((log) => (
-                  <div key={log.id} className="flex gap-2 text-[11px] font-mono">
-                    <span className="text-text-tertiary whitespace-nowrap">
-                      {formatTime(log.timestamp)}
-                    </span>
-                    <span
-                      className={
-                        log.level === "error"
-                          ? "text-error"
-                          : log.level === "warn"
-                            ? "text-warning"
-                            : "text-text-secondary"
-                      }
-                    >
-                      {log.message}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            )}
+            {logBody}
           </div>
         </div>
       )}
+      <BottomSheet
+        open={showLog && isMobile}
+        onClose={() => setShowLog(false)}
+        title={t("recipes.viewLog")}
+        icon={<ScrollText size={18} strokeWidth={1.5} className="text-primary" />}
+      >
+        {logBody}
+      </BottomSheet>
     </div>
   );
 }

--- a/ui/src/test-setup.ts
+++ b/ui/src/test-setup.ts
@@ -28,3 +28,21 @@ const existing = globalThis.localStorage as Storage | undefined;
 if (!existing || typeof existing.getItem !== "function") {
   globalThis.localStorage = makeStorage();
 }
+
+// jsdom does not implement `matchMedia`; `useIsMobile` (useSyncExternalStore over
+// matchMedia) throws without it. Install a minimal desktop-default stub so any
+// component reading a media query renders under test. A test that needs the
+// mobile branch overrides `window.matchMedia` to report `matches: true`.
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  window.matchMedia = (query: string): MediaQueryList =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList;
+}


### PR DESCRIPTION
## Problem

Recipe execution logs were viewable only on desktop. The "view log" button lived
in an admin action row gated `hidden sm:flex` (log + duplicate + delete), so on
the PWA/phone (<640px) the whole row — and the only way to open the logs — was
hidden. The log data is viewport-agnostic; only the entry point was missing.

## Fix

- Keep the log button visible on mobile; duplicate/delete stay desktop-only
  (`hidden sm:inline-flex`) as config/destructive actions.
- Present the logs in the app's existing `BottomSheet` on the PWA, keeping the
  inline panel on desktop. The log-list body is shared between both (single
  source), gated by `useIsMobile` (matchMedia, reactive).
- Enlarge the mobile log button to a 32px touch target (compact 22x20 on desktop).
- Add a `matchMedia` polyfill to the component-test setup (jsdom lacks it, so
  `useIsMobile` would throw) — defaults to desktop.

## Tests

- `RecipeInstanceRow.test.tsx`: opening logs on mobile renders the bottom sheet
  (verified to fail without it), and on desktop renders the inline panel (no
  sheet). Existing row tests still pass.
- Full UI suite green (515), `tsc -b` and eslint clean.

## Review

Independent agent review: correct and complete. Confirmed synchronous
`useIsMobile` (no first-paint flash), clean presentation swap across the
breakpoint, and that the test polyfill masks nothing. The one actionable finding
(small mobile touch target) is applied.

Closes #615
