### PR TITLE
release: v1.52.5

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,14 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.52.x : Ventilation deux vitesses et arbitre plus stable
 
+### v1.52.5 — 2026-08-19 { #v1-52-5 }
+
+- Feat (équipements) : **une bascule « inverser le sens » par équipement pour les volets et stores** (spec 154). Quand le moteur a l'ouverture et la fermeture câblées à l'inverse de ce que Sowel suppose, et que l'intégration n'offre pas d'inversion côté passerelle, un admin peut désormais inverser le sens sur l'équipement lui-même. Cela s'applique à tous les chemins de commande (carte, actions groupées de zone, recettes, modes). (#623)
+- Feat (ui) : **les journaux de recette sont désormais accessibles sur le téléphone (PWA)**. Le point d'entrée des journaux était masqué en dessous de 640 px ; il s'ouvre maintenant dans une feuille inférieure sur mobile, tout en conservant le panneau intégré sur ordinateur. (#622)
+- Feat (ui) : **le tableau des charges de l'arbitre est désormais trié par priorité configurée** au lieu de l'état, pour rester cohérent avec la timeline. La pastille d'état de chaque ligne indique toujours si la charge est autorisée, en attente, suspendue ou inactive. (#621)
+- Correctif (énergie) : **une charge sous-comptée inactive bascule désormais son total quotidien à la frontière de l'heure et de minuit**. Un sous-compteur de puissance seule resté à 0 W pouvait continuer d'afficher l'énergie cumulée de la veille pendant la nuit (par exemple un chauffe-eau bloqué à 2,92 kWh) ; un rafraîchissement aligné sur l'heure le recalcule maintenant depuis l'historique. (#619)
+- Correctif (ui) : **les cellules « en attente » de la timeline de l'arbitre utilisent la même teinte douce que le tableau des charges** au lieu d'un orange d'avertissement plein, pour une lecture plus apaisée. (#620)
+
 ### v1.52.4 — 2026-08-18 { #v1-52-4 }
 
 - Correctif (ui) : **l'arbitre indique désormais « hors arbitrage » pour une charge non gérée**, au lieu de l'ancienne formulation moins claire, de sorte qu'une charge que l'arbitre d'énergie ne pilote pas se lit sans ambiguïté. (#611)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,14 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.52.x: Two-speed ventilation and a steadier arbiter
 
+### v1.52.5 — 2026-08-19 { #v1-52-5 }
+
+- Feat (equipments): **a per-equipment "invert direction" toggle for shutters and awnings** (spec 154). When a motor's open and close are wired the reverse of what Sowel assumes, and the integration has no bridge-side invert, an admin can now flip the direction on the equipment itself. It applies to every command path (card, zone bulk actions, recipes, modes). (#623)
+- Feat (ui): **recipe logs are now reachable on the phone (PWA)**. The log entry point was hidden below 640px; it now opens in a bottom sheet on mobile while keeping the inline panel on desktop. (#622)
+- Feat (ui): **the arbiter roster table is now ordered by configured priority** instead of by state, so it reads consistently with the timeline. Each row's state pill still shows whether the load is granted, waiting, suspended or idle. (#621)
+- Fix (energy): **an idle submetered load now rolls its daily total over at the hour and midnight boundary**. A power-only submeter that sat at 0 W could keep showing the previous day's cumulative energy overnight (for example a water heater stuck at 2.92 kWh); an hour-aligned refresh now recomputes it from history. (#619)
+- Fix (ui): **the "en attente" cells on the arbiter timeline use the same soft waiting tint as the roster table** instead of a solid warning orange, so the timeline reads calmer. (#620)
+
 ### v1.52.4 — 2026-08-18 { #v1-52-4 }
 
 - Fix (ui): **the arbiter now labels a load outside arbitration as "hors arbitrage"** instead of the previous, less clear wording, so a load that the energy arbiter is not managing reads unambiguously. (#611)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.52.4",
+  "version": "1.52.5",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.52.4",
+  "version": "1.52.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump + release notes for v1.52.5.

## Included since v1.52.4
- feat(equipments): per-equipment invert direction for shutters/awnings (spec 154, #623, #614)
- feat(ui): view recipe logs on the PWA via a bottom sheet (#622, #615)
- feat(ui): order arbiter roster table by configured priority (#621, #616)
- fix(energy): roll idle submeter cumuls over the hour/midnight boundary (#619, #618)
- fix(ui): soften arbiter timeline 'en attente' cell to the table waiting tint (#620, #617)

Release notes added to both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-52-5 }` anchor.