### PR TITLE
fix(ui): show vmc equipments in the zone list (spec 153 follow-up)

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,14 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.52.x : Ventilation deux vitesses et arbitre plus stable
 
+### v1.52.5 — 2026-08-19 { #v1-52-5 }
+
+- Feat (équipements) : **une bascule « inverser le sens » par équipement pour les volets et stores** (spec 154). Quand le moteur a l'ouverture et la fermeture câblées à l'inverse de ce que Sowel suppose, et que l'intégration n'offre pas d'inversion côté passerelle, un admin peut désormais inverser le sens sur l'équipement lui-même. Cela s'applique à tous les chemins de commande (carte, actions groupées de zone, recettes, modes). (#623)
+- Feat (ui) : **les journaux de recette sont désormais accessibles sur le téléphone (PWA)**. Le point d'entrée des journaux était masqué en dessous de 640 px ; il s'ouvre maintenant dans une feuille inférieure sur mobile, tout en conservant le panneau intégré sur ordinateur. (#622)
+- Feat (ui) : **le tableau des charges de l'arbitre est désormais trié par priorité configurée** au lieu de l'état, pour rester cohérent avec la timeline. La pastille d'état de chaque ligne indique toujours si la charge est autorisée, en attente, suspendue ou inactive. (#621)
+- Correctif (énergie) : **une charge sous-comptée inactive bascule désormais son total quotidien à la frontière de l'heure et de minuit**. Un sous-compteur de puissance seule resté à 0 W pouvait continuer d'afficher l'énergie cumulée de la veille pendant la nuit (par exemple un chauffe-eau bloqué à 2,92 kWh) ; un rafraîchissement aligné sur l'heure le recalcule maintenant depuis l'historique. (#619)
+- Correctif (ui) : **les cellules « en attente » de la timeline de l'arbitre utilisent la même teinte douce que le tableau des charges** au lieu d'un orange d'avertissement plein, pour une lecture plus apaisée. (#620)
+
 ### v1.52.4 — 2026-08-18 { #v1-52-4 }
 
 - Correctif (ui) : **l'arbitre indique désormais « hors arbitrage » pour une charge non gérée**, au lieu de l'ancienne formulation moins claire, de sorte qu'une charge que l'arbitre d'énergie ne pilote pas se lit sans ambiguïté. (#611)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,14 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.52.x: Two-speed ventilation and a steadier arbiter
 
+### v1.52.5 — 2026-08-19 { #v1-52-5 }
+
+- Feat (equipments): **a per-equipment "invert direction" toggle for shutters and awnings** (spec 154). When a motor's open and close are wired the reverse of what Sowel assumes, and the integration has no bridge-side invert, an admin can now flip the direction on the equipment itself. It applies to every command path (card, zone bulk actions, recipes, modes). (#623)
+- Feat (ui): **recipe logs are now reachable on the phone (PWA)**. The log entry point was hidden below 640px; it now opens in a bottom sheet on mobile while keeping the inline panel on desktop. (#622)
+- Feat (ui): **the arbiter roster table is now ordered by configured priority** instead of by state, so it reads consistently with the timeline. Each row's state pill still shows whether the load is granted, waiting, suspended or idle. (#621)
+- Fix (energy): **an idle submetered load now rolls its daily total over at the hour and midnight boundary**. A power-only submeter that sat at 0 W could keep showing the previous day's cumulative energy overnight (for example a water heater stuck at 2.92 kWh); an hour-aligned refresh now recomputes it from history. (#619)
+- Fix (ui): **the "en attente" cells on the arbiter timeline use the same soft waiting tint as the roster table** instead of a solid warning orange, so the timeline reads calmer. (#620)
+
 ### v1.52.4 — 2026-08-18 { #v1-52-4 }
 
 - Fix (ui): **the arbiter now labels a load outside arbitration as "hors arbitrage"** instead of the previous, less clear wording, so a load that the energy arbiter is not managing reads unambiguously. (#611)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.52.4",
+  "version": "1.52.5",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.52.4",
+  "version": "1.52.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/src/components/equipments/VmcControl.tsx
+++ b/ui/src/components/equipments/VmcControl.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
 import type { EquipmentWithDetails } from "../../types";
@@ -18,9 +18,24 @@ interface VmcControlProps {
 export function VmcControl({ equipment, onExecuteOrder, compact }: VmcControlProps) {
   const { t } = useTranslation();
   const [executing, setExecuting] = useState<Speed | null>(null);
+  // Optimistic target: going V1<->V2 the core does break-before-make, so the
+  // observed speed dips through OFF for a moment. Keep the requested pill lit
+  // until reality catches up (or a timeout), so that transient OFF never shows.
+  const [pending, setPending] = useState<Speed | null>(null);
 
   const hasHigh = equipment.orderBindings.some((ob) => ob.alias === "high");
-  const current = vmcSpeedOf(equipment);
+  const observed = vmcSpeedOf(equipment);
+  const current = pending ?? observed;
+
+  useEffect(() => {
+    if (pending === null) return;
+    if (observed === pending) {
+      setPending(null);
+      return;
+    }
+    const id = setTimeout(() => setPending(null), 6000); // safety net
+    return () => clearTimeout(id);
+  }, [pending, observed]);
 
   const options: { speed: Speed; label: string }[] = [
     { speed: "off", label: t("equipments.vmc.off") },
@@ -31,6 +46,7 @@ export function VmcControl({ equipment, onExecuteOrder, compact }: VmcControlPro
   const setSpeed = async (speed: Speed) => {
     if (executing) return;
     setExecuting(speed);
+    setPending(speed); // light the target immediately, hide the transient OFF
     try {
       await onExecuteOrder("speed", speed);
     } finally {

--- a/ui/src/components/equipments/VmcControl.tsx
+++ b/ui/src/components/equipments/VmcControl.tsx
@@ -54,12 +54,44 @@ export function VmcControl({ equipment, onExecuteOrder, compact }: VmcControlPro
     }
   };
 
+  // Compact card: small separate buttons, same size/shape as the light toggle
+  // (bg-border-light when off, filled when selected). Detail page: a grouped
+  // segmented pill.
+  if (compact) {
+    return (
+      <div className="flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+        {options.map(({ speed, label }) => {
+          const active = current === speed;
+          return (
+            <button
+              key={speed}
+              type="button"
+              onClick={() => setSpeed(speed)}
+              disabled={!!executing}
+              aria-pressed={active}
+              title={label}
+              className={`
+                px-2.5 py-1.5 rounded-[6px] text-[12px] font-medium transition-colors duration-150 cursor-pointer
+                ${
+                  active
+                    ? "bg-primary text-white hover:bg-primary/90"
+                    : "bg-border-light text-text-tertiary hover:bg-border hover:text-text-secondary"
+                }
+                disabled:opacity-50 disabled:cursor-not-allowed
+              `}
+            >
+              {executing === speed ? <Loader2 size={13} className="animate-spin" /> : label}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
-    // Compact segmented control: a neutral track with small pills sized to
-    // their label, so it never stretches into full-width blocks on the detail
-    // page.
+    // Detail page: a grouped segmented control (neutral track, small pills).
     <div
-      className={`inline-flex items-center gap-0.5 rounded-lg bg-border-light p-0.5 ${compact ? "" : "mt-1"}`}
+      className="inline-flex items-center gap-0.5 rounded-lg bg-border-light p-0.5 mt-1"
       onClick={(e) => e.stopPropagation()}
     >
       {options.map(({ speed, label }) => {
@@ -74,11 +106,7 @@ export function VmcControl({ equipment, onExecuteOrder, compact }: VmcControlPro
             className={`
               min-w-[42px] px-3 py-1 rounded-md text-[13px] font-medium
               flex items-center justify-center transition-colors
-              ${
-                active
-                  ? "bg-primary text-white shadow-sm"
-                  : "text-text-secondary hover:text-primary"
-              }
+              ${active ? "bg-primary text-white shadow-sm" : "text-text-secondary hover:text-primary"}
               ${executing ? "opacity-60" : ""}
             `}
           >

--- a/ui/src/components/equipments/VmcControl.tsx
+++ b/ui/src/components/equipments/VmcControl.tsx
@@ -39,8 +39,11 @@ export function VmcControl({ equipment, onExecuteOrder, compact }: VmcControlPro
   };
 
   return (
+    // Compact segmented control: a neutral track with small pills sized to
+    // their label, so it never stretches into full-width blocks on the detail
+    // page.
     <div
-      className={`flex items-center gap-1 ${compact ? "" : "mt-2"}`}
+      className={`inline-flex items-center gap-0.5 rounded-lg bg-border-light p-0.5 ${compact ? "" : "mt-1"}`}
       onClick={(e) => e.stopPropagation()}
     >
       {options.map(({ speed, label }) => {
@@ -53,17 +56,17 @@ export function VmcControl({ equipment, onExecuteOrder, compact }: VmcControlPro
             disabled={!!executing}
             aria-pressed={active}
             className={`
-              flex-1 min-w-[44px] px-3 py-1.5 rounded-md text-[13px] font-medium
-              flex items-center justify-center gap-1 transition-colors
+              min-w-[42px] px-3 py-1 rounded-md text-[13px] font-medium
+              flex items-center justify-center transition-colors
               ${
                 active
-                  ? "bg-primary text-white"
-                  : "bg-primary-light text-primary hover:bg-primary/10"
+                  ? "bg-primary text-white shadow-sm"
+                  : "text-text-secondary hover:text-primary"
               }
               ${executing ? "opacity-60" : ""}
             `}
           >
-            {executing === speed ? <Loader2 size={14} className="animate-spin" /> : label}
+            {executing === speed ? <Loader2 size={13} className="animate-spin" /> : label}
           </button>
         );
       })}

--- a/ui/src/components/home/ZoneEquipmentsView.tsx
+++ b/ui/src/components/home/ZoneEquipmentsView.tsx
@@ -11,6 +11,7 @@ import {
   WashingMachine,
   Waves,
   Camera,
+  Fan,
 } from "lucide-react";
 import { ShutterClosedIcon } from "../icons/ShutterIcons";
 import { WaterValveIcon } from "../icons/WaterValveIcon";
@@ -41,6 +42,7 @@ const EQUIPMENT_GROUPS: EquipmentGroup[] = [
   { labelKey: "equipments.group.appliances", types: ["appliance"], icon: <WashingMachine size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.water", types: ["water_valve", "water_heater"], icon: <WaterValveIcon size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.pool", types: ["pool_pump", "pool_cover", "pool_heat_pump"], icon: <Waves size={14} strokeWidth={1.5} /> },
+  { labelKey: "equipments.group.ventilation", types: ["vmc"], icon: <Fan size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.displays", types: ["display"], icon: <Monitor size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.cameras", types: ["camera"], icon: <Camera size={14} strokeWidth={1.5} /> },
   { labelKey: "equipments.group.other", types: ["switch", "button", "gate"], icon: <ToggleRight size={14} strokeWidth={1.5} /> },

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -324,6 +324,7 @@
   "equipments.group.appliances": "Appliances",
   "equipments.group.water": "Water",
   "equipments.group.pool": "Pool",
+  "equipments.group.ventilation": "Ventilation",
   "equipments.group.displays": "Displays",
   "equipments.group.cameras": "Cameras",
   "equipments.group.other": "Other",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -324,6 +324,7 @@
   "equipments.group.appliances": "Électroménager",
   "equipments.group.water": "Eau",
   "equipments.group.pool": "Piscine",
+  "equipments.group.ventilation": "Ventilation",
   "equipments.group.displays": "Afficheurs",
   "equipments.group.cameras": "Caméras",
   "equipments.group.other": "Autres",


### PR DESCRIPTION
## Bug

A `vmc` equipment placed in a zone does not appear in the zone/home equipment list. Confirmed on prod: the equipment exists, is online, and works (computed `speed = v1`), but is invisible in its zone.

## Cause

`ZoneEquipmentsView` renders a zone's equipments grouped by `EQUIPMENT_GROUPS` and filters with `group.types.includes(eq.type)` (ZoneEquipmentsView.tsx:71). `vmc` (spec 153, #586) was added to the widget families but **not** to this per-type group list, so it matched no group and was dropped.

## Fix

Add a **Ventilation** group (`types: ["vmc"]`, Fan icon) + `equipments.group.ventilation` EN/FR i18n. tsc + locale parity green.