### PR TITLE
docs(release-notes): finalize v1.52.5 notes (#625)

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -20,6 +20,7 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 - Feat (ui) : **le tableau des charges de l'arbitre est désormais trié par priorité configurée** au lieu de l'état, pour rester cohérent avec la timeline. La pastille d'état de chaque ligne indique toujours si la charge est autorisée, en attente, suspendue ou inactive. (#621)
 - Correctif (énergie) : **une charge sous-comptée inactive bascule désormais son total quotidien à la frontière de l'heure et de minuit**. Un sous-compteur de puissance seule resté à 0 W pouvait continuer d'afficher l'énergie cumulée de la veille pendant la nuit (par exemple un chauffe-eau bloqué à 2,92 kWh) ; un rafraîchissement aligné sur l'heure le recalcule maintenant depuis l'historique. (#619)
 - Correctif (ui) : **les cellules « en attente » de la timeline de l'arbitre utilisent la même teinte douce que le tableau des charges** au lieu d'un orange d'avertissement plein, pour une lecture plus apaisée. (#620)
+- Correctif (ui) : **un équipement de ventilation deux vitesses (VMC) apparaît désormais dans sa zone et la vue maison**. Il relève d'un nouveau groupe « Ventilation » ; il était auparavant filtré en silence de la liste de zone bien qu'il fonctionne. Son sélecteur OFF/V1/V2 devient aussi une pastille segmentée compacte. (#625)
 
 ### v1.52.4 — 2026-08-18 { #v1-52-4 }
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,6 +20,7 @@ This page summarises every published version, newest first. For the full diff be
 - Feat (ui): **the arbiter roster table is now ordered by configured priority** instead of by state, so it reads consistently with the timeline. Each row's state pill still shows whether the load is granted, waiting, suspended or idle. (#621)
 - Fix (energy): **an idle submetered load now rolls its daily total over at the hour and midnight boundary**. A power-only submeter that sat at 0 W could keep showing the previous day's cumulative energy overnight (for example a water heater stuck at 2.92 kWh); an hour-aligned refresh now recomputes it from history. (#619)
 - Fix (ui): **the "en attente" cells on the arbiter timeline use the same soft waiting tint as the roster table** instead of a solid warning orange, so the timeline reads calmer. (#620)
+- Fix (ui): **a two-speed ventilation (VMC) equipment now appears in its zone and home view**. It belongs to a new "Ventilation" group; previously it was silently filtered out of the zone list even though it worked. Its OFF/V1/V2 control is also now a compact segmented pill. (#625)
 
 ### v1.52.4 — 2026-08-18 { #v1-52-4 }
 


### PR DESCRIPTION
The v1.52.5 version bump and release-notes block already landed on main via #625 (its branch was cut from the release branch, so it carried the bump + notes). This PR adds the one missing entry: #625 itself (VMC now visible in the zone list).

After merge, main is ready to tag `v1.52.5`.

## Full v1.52.5 content (since v1.52.4)
- feat(equipments): per-equipment invert direction for shutters/awnings (#623)
- feat(ui): recipe logs on the PWA via a bottom sheet (#622)
- feat(ui): arbiter roster ordered by configured priority (#621)
- fix(energy): roll idle submeter cumuls over the hour/midnight boundary (#619)
- fix(ui): soften arbiter timeline 'en attente' cell (#620)
- fix(ui): show vmc equipments in the zone list (#625)