### PR TITLE
release: v1.53.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,12 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.53.x : Inversion de sens pour les déclencheurs de portail
+
+### v1.53.0 — 2026-08-19 { #v1-53-0 }
+
+- Feat (équipements) : **la bascule « inverser le sens » par équipement (spec 154) couvre désormais aussi les portails et déclencheurs booléens momentanés**. Un relais câblé pour déclencher sur le front OFF au lieu de ON (constaté sur un SONOFF MINI-ZBD pilotant une porte de garage) s'inverse directement depuis la page de l'équipement, la même bascule que celle utilisée pour inverser l'ouverture/fermeture d'un volet. Elle reste opt-in par équipement, donc les installations existantes ne sont pas affectées. (#628)
+
 ## 1.52.x : Ventilation deux vitesses et arbitre plus stable
 
 ### v1.52.5 — 2026-08-19 { #v1-52-5 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,12 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.53.x: Invert direction for gate triggers
+
+### v1.53.0 — 2026-08-19 { #v1-53-0 }
+
+- Feat (equipments): **the per-equipment "invert direction" toggle (spec 154) now covers gate and boolean momentary triggers too**. A relay wired to pulse on the OFF edge instead of ON (reported on a SONOFF MINI-ZBD driving a garage door) can be flipped right from the equipment page, the same toggle already used to invert a shutter's open/close. It stays opt-in per equipment, so existing setups are unaffected. (#628)
+
 ## 1.52.x: Two-speed ventilation and a steadier arbiter
 
 ### v1.52.5 — 2026-08-19 { #v1-52-5 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.52.5",
+  "version": "1.53.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.52.5",
+  "version": "1.53.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Minor release: version bump + release notes for v1.53.0.

## Included since v1.52.5
- feat(equipments): extend invertDirection to boolean gate triggers (spec 155, #628, #627)

Reviewed #628: clean, minimal, opt-in, reuses the spec 154 `invert_direction` flag (no migration), mirrors the delivery-retry guard. Backend + UI tests green.

New `## 1.53.x` minor section opened; release notes added to both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-53-0 }` anchor.