### PR TITLE
release: v1.52.6

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,10 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.52.x : Ventilation deux vitesses et arbitre plus stable
 
+### v1.52.6 — 2026-08-19 { #v1-52-6 }
+
+- Feat (équipements) : **la bascule « inverser le sens » par équipement (spec 154) couvre désormais aussi les portails et déclencheurs booléens momentanés**. Un relais câblé pour déclencher sur le front OFF au lieu de ON (constaté sur un SONOFF MINI-ZBD pilotant une porte de garage) s'inverse directement depuis la page de l'équipement, la même bascule que celle utilisée pour inverser l'ouverture/fermeture d'un volet. Elle reste opt-in par équipement, donc les installations existantes ne sont pas affectées. (#628)
+
 ### v1.52.5 — 2026-08-19 { #v1-52-5 }
 
 - Feat (équipements) : **une bascule « inverser le sens » par équipement pour les volets et stores** (spec 154). Quand le moteur a l'ouverture et la fermeture câblées à l'inverse de ce que Sowel suppose, et que l'intégration n'offre pas d'inversion côté passerelle, un admin peut désormais inverser le sens sur l'équipement lui-même. Cela s'applique à tous les chemins de commande (carte, actions groupées de zone, recettes, modes). (#623)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,10 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.52.x: Two-speed ventilation and a steadier arbiter
 
+### v1.52.6 — 2026-08-19 { #v1-52-6 }
+
+- Feat (equipments): **the per-equipment "invert direction" toggle (spec 154) now covers gate and boolean momentary triggers too**. A relay wired to pulse on the OFF edge instead of ON (reported on a SONOFF MINI-ZBD driving a garage door) can be flipped right from the equipment page, the same toggle already used to invert a shutter's open/close. It stays opt-in per equipment, so existing setups are unaffected. (#628)
+
 ### v1.52.5 — 2026-08-19 { #v1-52-5 }
 
 - Feat (equipments): **a per-equipment "invert direction" toggle for shutters and awnings** (spec 154). When a motor's open and close are wired the reverse of what Sowel assumes, and the integration has no bridge-side invert, an admin can now flip the direction on the equipment itself. It applies to every command path (card, zone bulk actions, recipes, modes). (#623)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.52.5",
+  "version": "1.52.6",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.52.5",
+  "version": "1.52.6",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch release: version bump + release notes for v1.52.6.

## Included since v1.52.5
- feat(equipments): extend invertDirection to boolean gate triggers (spec 155, #628, #627)

Reviewed #628: clean, minimal, opt-in, reuses the spec 154 `invert_direction` flag (no migration), mirrors the delivery-retry guard. Backend + UI tests green.

Release notes added under the existing `## 1.52.x` section in both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-52-6 }` anchor.