### PR TITLE
feat(energy): per-equipment shutdown delay for the arbiter (#631)

### DIFF
--- a/docs/user/energy.md
+++ b/docs/user/energy.md
@@ -163,6 +163,7 @@ On an equipment whose type is a controllable load (pool pump, water heater, wate
 - **Nominal power** — pre-filled from the equipment's own measurement when a clamp is bound.
 - **Tolerated import (W)** — how much grid import this load will accept to start on a **partial surplus**. The arbiter engages it once the surplus covers "nominal power + margin − tolerated import". At `0` (default) it waits for a full surplus; raising it makes the load start sooner, accepting to buy a little grid. It is the load's comfort / economy dial, set once here and honoured by whatever automation drives it.
 - **Minimum on / off** — how long it must stay on once started, and rest before restarting (protects a compressor from short-cycling).
+- **Shutdown delay (min)**, optional: how long this load keeps drawing after the arbiter releases it, before it actually stops (for example a heat-pump water heater whose pump runs about 30 min after its solar contact opens). Leave it empty for a load that stops promptly; declare it for an inertial one so the arbiter does not flag its expected, slow shutdown as "did not turn off on demand". It widens that grace for this load only and never slows the arbiter's reaction for the others.
 
 How the arbiter treats the load is **derived from its type**, so there is nothing to pick:
 

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -952,6 +952,58 @@ describe("capacity arbiter", () => {
     expect(h.revokedEvents().filter((e) => e.equipmentId === "pac")).toHaveLength(0);
   });
 
+  it("releaseDelayS suppresses revoke-not-honored within the declared shutdown window, anti-cascade intact (#631)", () => {
+    const h = makeHarness({
+      priority: ["pac", "heater"],
+      profiles: {
+        pac: { class: "comfort", nominalPowerW: 2000, minOnS: 0, minOffS: 0 },
+        heater: {
+          class: "deferrable",
+          nominalPowerW: 600,
+          minOnS: 0,
+          minOffS: 0,
+          releaseDelayS: 1800, // ~30 min appliance tail, > the 600 s global hold
+        },
+      },
+    });
+    h.claim("pacI", { equipmentId: "pac" });
+    h.claim("heaterI", { equipmentId: "heater" });
+    h.run(-3000, 150);
+    expect(h.grantedEvents()).toHaveLength(2);
+    h.feedLoadPower("heater", 600);
+    // Deficit ~400 W: bottom-up revokes the heater only.
+    h.run(400, 700);
+    expect(h.revokedEvents().map((e) => e.equipmentId)).toContain("heater");
+
+    // Heater keeps drawing its tail. Advance ~15 min: past the global hold
+    // (600 s) but inside the declared inertia (1800 s).
+    for (let i = 0; i < 90; i++) {
+      vi.advanceTimersByTime(10_000);
+      h.feedMeter(400);
+      h.feedLoadPower("heater", 600);
+    }
+    let journal = h.arbiter.getPublicState().journal;
+    // Not flagged yet — the tail is expected, not overdue.
+    expect(journal.some((j) => j.kind === "revoke-not-honored" && j.equipmentId === "heater")).toBe(
+      false,
+    );
+    // Anti-cascade still holds: the heater is excused as background at the
+    // global hold, so the PAC keeps its grant despite the sustained deficit.
+    expect(h.revokedEvents().filter((e) => e.equipmentId === "pac")).toHaveLength(0);
+
+    // Advance past the declared window (~35 min total of unhonored draw): now
+    // genuinely overdue → flagged.
+    for (let i = 0; i < 130; i++) {
+      vi.advanceTimersByTime(10_000);
+      h.feedMeter(400);
+      h.feedLoadPower("heater", 600);
+    }
+    journal = h.arbiter.getPublicState().journal;
+    expect(journal.some((j) => j.kind === "revoke-not-honored" && j.equipmentId === "heater")).toBe(
+      true,
+    );
+  });
+
   // ── Wall-switch divergence (FR-6, review decision 16) ─────
 
   it("a granted load reported OFF at the wall is revoked and suspended", () => {

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -1312,20 +1312,38 @@ export class CapacityArbiter {
   // ── Watchdogs & divergence ──────────────────────────────────
 
   private checkWatchdogs(now: number): void {
-    // The decision point sits at releaseHoldS after the revoke — one hold of
-    // grace to act — so an unhonored revoke is marked BEFORE the deficit
-    // hold can fire again and cascade onto the next load down (acceptance:
-    // "revokes nobody else"). The unresponsive excuse then lasts a further
-    // 2 × releaseHoldS.
-    const graceMs = this.config.releaseHoldS * 1000;
+    // After a revoke the load has a grace window to actually stop (export to
+    // return). Two effects, deliberately DECOUPLED (#631):
+    //
+    //  - at the GLOBAL releaseHoldS, a still-drawing load is excused as
+    //    background (`unresponsive`) so the deficit pass does not cascade onto
+    //    the next load down (FR-9 + review decision 12, acceptance "revokes
+    //    nobody else"). This stays prompt whatever the declared inertia — the
+    //    anti-cascade guarantee must not be delayed.
+    //  - `revoke-not-honored` is JOURNALLED only once the load is genuinely
+    //    OVERDUE: past its declared shutdown inertia `energyProfile.releaseDelayS`
+    //    (default 0 → the global hold). An inertial load (e.g. a thermodynamic
+    //    water heater whose heat pump runs ~30 min after its solar contact
+    //    opens) thus stops emitting a benign, expected signal while the other
+    //    loads keep the tight global grace.
+    //
+    // The `unresponsive` excuse lasts 2 × the per-load grace so it spans the
+    // whole declared shutdown window.
+    const holdMs = this.config.releaseHoldS * 1000;
     const exportNow = -(this.emaPowerW ?? 0);
     this.watchdogs = this.watchdogs.filter((w) => {
       if (this.grantedClaimFor(w.equipmentId)) return false; // re-granted, moot
       if (exportNow - w.exportAtRevoke >= 0.5 * w.expectedW) return false; // honored
-      if (now - w.at >= graceMs) {
-        // FR-9 + review decision 12: bounded guard against cascades — the
-        // draw is excused as background and the release pass skips the load.
+      const graceMs =
+        Math.max(this.config.releaseHoldS, this.profileOf(w.equipmentId)?.releaseDelayS ?? 0) *
+        1000;
+      // Excuse the draw promptly (global hold) to keep the deficit pass from
+      // shedding the next load — independent of the declared inertia.
+      if (now - w.at >= holdMs && !this.unresponsiveUntil.has(w.equipmentId)) {
         this.unresponsiveUntil.set(w.equipmentId, now + 2 * graceMs);
+      }
+      // Flag as unhonored only once genuinely overdue (past the declared inertia).
+      if (now - w.at >= graceMs) {
         this.journal({
           kind: "revoke-not-honored",
           equipmentId: w.equipmentId,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -643,6 +643,14 @@ export interface EnergyLoadProfile {
    *  The arbiter engages it at `watts + engageMarginW - toleratedImportW`. A
    *  capacity claim may still override per call; absent = 0 (no tolerance). */
   toleratedImportW?: number;
+  /** Shutdown inertia (seconds) — how long this load keeps drawing after the
+   *  arbiter revokes it, before its export actually returns (#631). An inertial
+   *  load (e.g. a thermodynamic water heater whose heat pump runs ~30 min after
+   *  its solar contact opens) declares it here so the arbiter widens the
+   *  `revoke-not-honored` grace + `unresponsive` TTL to `max(releaseHoldS,
+   *  releaseDelayS)` for THIS load only, without touching global responsiveness.
+   *  Absent = 0 (the global `releaseHoldS` grace applies as before). */
+  releaseDelayS?: number;
   learned?: EnergyLoadProfileLearned;
 }
 

--- a/ui/src/components/equipments/EnergyManagementPanel.tsx
+++ b/ui/src/components/equipments/EnergyManagementPanel.tsx
@@ -76,6 +76,7 @@ export function EnergyManagementPanel({
   const [toleratedImportW, setToleratedImportW] = useState<number>(profile?.toleratedImportW ?? 0);
   const [minOnS, setMinOnS] = useState<number>(profile?.minOnS ?? defaults.minOnS);
   const [minOffS, setMinOffS] = useState<number>(profile?.minOffS ?? defaults.minOffS);
+  const [releaseDelayS, setReleaseDelayS] = useState<number>(profile?.releaseDelayS ?? 0);
 
   const suspension = arbiterState?.suspensions.find((s) => s.equipmentId === equipment.id);
   const complete = cls !== "" && Number.isFinite(watts) && watts > 0;
@@ -88,6 +89,7 @@ export function EnergyManagementPanel({
     toleratedImportW: number;
     minOnS: number;
     minOffS: number;
+    releaseDelayS: number;
   }) => {
     if (p.cls === "" || !Number.isFinite(p.watts) || p.watts <= 0) return;
     setSaving(true);
@@ -100,6 +102,10 @@ export function EnergyManagementPanel({
         minOnS: p.minOnS,
         minOffS: p.minOffS,
       };
+      // #631 — persisted only when set; absent = the global releaseHoldS grace.
+      if (Number.isFinite(p.releaseDelayS) && p.releaseDelayS > 0) {
+        next.releaseDelayS = Math.max(0, Math.round(p.releaseDelayS));
+      }
       await updateEquipment(equipment.id, { energyProfile: next });
       onUpdated();
     } catch (err) {
@@ -116,10 +122,11 @@ export function EnergyManagementPanel({
       toleratedImportW: number;
       minOnS: number;
       minOffS: number;
+      releaseDelayS: number;
     }>,
   ) => {
     if (!profile) return;
-    void commit({ cls, watts, toleratedImportW, minOnS, minOffS, ...overrides });
+    void commit({ cls, watts, toleratedImportW, minOnS, minOffS, releaseDelayS, ...overrides });
   };
 
   const clear = async () => {
@@ -254,6 +261,26 @@ export function EnergyManagementPanel({
                 className={inputCls}
               />
             </div>
+            <div>
+              <label
+                htmlFor="ep-releasedelay"
+                className="block text-[12px] text-text-secondary mb-1"
+                title={t("energyProfile.releaseDelayHint")}
+              >
+                {t("energyProfile.releaseDelay")}
+              </label>
+              <input
+                id="ep-releasedelay"
+                type="number"
+                min={0}
+                step={0.1}
+                placeholder="0"
+                value={releaseDelayS ? secondsToMinutes(releaseDelayS) : ""}
+                onChange={(e) => setReleaseDelayS(minutesToSeconds(Number(e.target.value)))}
+                onBlur={() => commitEdit({ releaseDelayS })}
+                className={inputCls}
+              />
+            </div>
             {profile?.learned && (
               <div className="text-[12px] text-text-tertiary pb-1">
                 {t("energyProfile.learned", {
@@ -268,7 +295,9 @@ export function EnergyManagementPanel({
           {!profile &&
             (complete ? (
               <button
-                onClick={() => void commit({ cls, watts, toleratedImportW, minOnS, minOffS })}
+                onClick={() =>
+                  void commit({ cls, watts, toleratedImportW, minOnS, minOffS, releaseDelayS })
+                }
                 disabled={saving}
                 className="mt-3 px-3 py-1.5 bg-primary text-white text-[13px] font-medium rounded-md hover:bg-primary-hover disabled:opacity-50"
               >

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1221,6 +1221,8 @@
   "energyProfile.toleratedImport": "Tolerated import (W)",
   "energyProfile.minOn": "Min run (min)",
   "energyProfile.minOff": "Min rest (min)",
+  "energyProfile.releaseDelay": "Shutdown delay (min)",
+  "energyProfile.releaseDelayHint": "How long the load keeps drawing after a revoke before it actually stops (e.g. a heat-pump water heater's 30 min tail). Empty = global default grace.",
   "energyProfile.learned": "Measured: {{watts}} W over {{runs}} runs",
   "energyProfile.manualUntil": "Manual until {{time}}",
   "energyProfile.resumeNow": "Resume control now",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1221,6 +1221,8 @@
   "energyProfile.toleratedImport": "Import toléré (W)",
   "energyProfile.minOn": "Marche mini (min)",
   "energyProfile.minOff": "Arrêt mini (min)",
+  "energyProfile.releaseDelay": "Délai d'extinction (min)",
+  "energyProfile.releaseDelayHint": "Temps que la charge met à réellement s'arrêter après une révocation (ex. la tempo de 30 min d'un chauffe-eau thermodynamique). Vide = délai global par défaut.",
   "energyProfile.learned": "Mesuré : {{watts}} W sur {{runs}} marches",
   "energyProfile.manualUntil": "Manuel jusqu'à {{time}}",
   "energyProfile.resumeNow": "Reprendre le pilotage",

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -299,6 +299,10 @@ export interface EnergyLoadProfile {
   minOffS: number;
   /** Grid import (W) this load accepts to run on a partial surplus (#550). */
   toleratedImportW?: number;
+  /** Shutdown inertia (s) — how long the load keeps drawing after a revoke
+   *  before its export returns; widens the arbiter's revoke-not-honored grace
+   *  for this load only (#631). Absent = global releaseHoldS. */
+  releaseDelayS?: number;
   /** Core-maintained measured estimate; read-only in the UI. */
   learned?: { watts: number; atIso: string; runs: number };
 }


### PR DESCRIPTION
Closes #631

## Problem

Inertial flexible loads keep drawing well past the arbiter's **global** revoke grace (`releaseHoldS`, ~10 min). An Atlantic Calypso thermodynamic water heater driven on its solar contact (spec 152 + `water-heater-solar` recipe) runs its heat pump **~30 min** after the contact opens, so `revoke-not-honored` fired on **every** revoke. The only lever today is the global `releaseHoldS`, which can't be raised to 30 min without slowing deficit reaction for **all** loads.

## Change

Add an optional **`EnergyLoadProfile.releaseDelayS`** (shutdown inertia, seconds).

The subtle part: `checkWatchdogs` used to do two things at one threshold. They are now **decoupled** because they have different consequences:

- **`unresponsive` excuse** (which keeps the deficit-shed pass from cascading onto the next load down — FR-9 / review decision 12, "revokes nobody else") stays **prompt** at the global `releaseHoldS`, whatever the declared inertia. **The anti-cascade guarantee must not be delayed.**
- **`revoke-not-honored` journalling** is delayed to `max(releaseHoldS, releaseDelayS)` — only flagged once the load is genuinely overdue. The unresponsive TTL spans the whole declared window (`2 × grace`).

Naively widening *both* would have let an inertial load's un-excused draw cascade-revoke a peer during the `releaseHoldS..releaseDelayS` window. The regression test asserts exactly that this does **not** happen.

## Scope

- `releaseDelayS?: number` on `EnergyLoadProfile` (+ ui mirror). **No migration** (JSON column).
- `capacity-arbiter.ts` `checkWatchdogs` only; the deficit-shed threshold and every other load are unchanged.
- UI: optional "Shutdown delay (min)" field on the energy panel (persisted only when > 0), FR/EN. Docs: `docs/user/energy.md`.
- With `releaseDelayS` absent/0, behaviour is **byte-identical** to before.

## Test plan

- [x] Backend + UI `tsc`, eslint clean
- [x] Full backend suite **1579 passed** / 2 skipped; full UI **520 passed**
- [x] New arbiter regression test: peer load keeps its grant while the inertial tail is excused; signal only fires past the declared window; the test **fails if the decoupling is reverted** (verified in review)
- [x] Independent agent review: decoupling correct, anti-cascade holds, tick ordering + backward-compat verified
- [ ] Manual: set a shutdown delay on the Calypso water heater; confirm `revoke-not-honored` stops firing on normal revokes

## Acceptance criteria (#631)

AC1–AC6 met (optional field, per-load grace = `max(releaseHoldS, releaseDelayS)`, no flag within the declared window, global threshold + other loads unchanged, UI round-trip no migration, regression test).

## Note (out of scope, pre-existing)

The review flagged that `EnergyManagementPanel`'s save omits `learned`, dropping the core-maintained learned estimate on any profile save. This is pre-existing on `main` (untouched here) — I'll file a separate issue.