### PR TITLE
fix(energy): stop querying InfluxDB with a zero-width range

### DIFF
--- a/src/energy/energy-aggregator.test.ts
+++ b/src/energy/energy-aggregator.test.ts
@@ -42,6 +42,38 @@ function influxWithHour(hourWh: () => number): InfluxClient {
   } as unknown as InfluxClient;
 }
 
+/**
+ * Connected InfluxDB that records every Flux query it is handed and rejects an
+ * empty range exactly like the real one, so a test can assert both what was
+ * asked and that nothing threw.
+ */
+function influxRecording(queries: string[]): InfluxClient {
+  const queryApi = {
+    async *iterateRows(flux: string) {
+      queries.push(flux);
+      const m = /range\(start: ([^,]+), stop: ([^)]+)\)/.exec(flux);
+      if (m && m[1] === m[2]) {
+        throw new Error(
+          "error in building plan while starting program: cannot query an empty range",
+        );
+      }
+      yield { values: [], tableMeta: { toObject: () => ({ _value: 7 }) } } as never;
+    },
+  };
+  return {
+    getClient: vi.fn(() => ({ getQueryApi: () => queryApi })),
+    getConfig: vi.fn(() => ({ org: "org", bucket: "sowel" })),
+  } as unknown as InfluxClient;
+}
+
+/** Ranges of the queries issued, as [start, stop] ISO pairs. */
+function rangesOf(queries: string[]): Array<[string, string]> {
+  return queries.map((q) => {
+    const m = /range\(start: ([^,]+), stop: ([^)]+)\)/.exec(q);
+    return [m?.[1] ?? "", m?.[2] ?? ""] as [string, string];
+  });
+}
+
 const power = [{ alias: "power", category: "power", value: 0 }];
 const energy = [{ alias: "energy", category: "energy", value: 100 }];
 const state = [{ alias: "state", category: "light_state", value: "ON" }];
@@ -221,5 +253,70 @@ describe("EnergyAggregator submeter enrolment (#527)", () => {
       equipment: { id: "relay", type: "switch" } as never,
     });
     expect(agg.getComputedDataForEquipment("relay")).toEqual([]);
+  });
+});
+
+describe("EnergyAggregator empty ranges (#620)", () => {
+  afterEach(() => vi.useRealTimers());
+
+  /** Drive one refresh at a chosen local wall-clock instant. */
+  async function refreshAt(iso: string, queries: string[]): Promise<void> {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(iso));
+    const bus = new EventBus(logger);
+    const agg = new EnergyAggregator(
+      managerWith([{ id: "eq-1", type: "energy_meter", dataBindings: energy }]),
+      influxRecording(queries),
+      bus,
+      logger,
+    );
+    await agg.start();
+    bus.emit({
+      type: "equipment.data.changed",
+      equipmentId: "eq-1",
+      alias: "energy",
+      value: 1,
+      previous: null,
+    });
+    await vi.advanceTimersByTimeAsync(6_000);
+    agg.stop();
+  }
+
+  it("never asks InfluxDB for a zero-width range in the first hour of the day", async () => {
+    // 00:30 local: today's midnight and the current hour start are the same
+    // instant, so the day query used to be range(start: t, stop: t). Flux
+    // rejects that, the throw escaped refreshFromInfluxDB, and *every* cumul
+    // was dropped — 288 to 812 warnings a night on a live install.
+    const queries: string[] = [];
+    await refreshAt("2026-08-20T00:30:00", queries);
+
+    expect(queries.length).toBeGreaterThan(0);
+    for (const [start, stop] of rangesOf(queries)) expect(start).not.toBe(stop);
+  });
+
+  it("never asks for a zero-width range on the 1st of the month", async () => {
+    // monthFirst === todayMidnight all day long, not just for an hour.
+    const queries: string[] = [];
+    await refreshAt("2026-09-01T14:00:00", queries);
+
+    for (const [start, stop] of rangesOf(queries)) expect(start).not.toBe(stop);
+  });
+
+  it("never asks for a zero-width range on 1 January", async () => {
+    // jan1 === monthFirst === todayMidnight: all three collapse at once.
+    const queries: string[] = [];
+    await refreshAt("2027-01-01T14:00:00", queries);
+
+    for (const [start, stop] of rangesOf(queries)) expect(start).not.toBe(stop);
+  });
+
+  it("still queries every window once the day is under way", async () => {
+    const queries: string[] = [];
+    await refreshAt("2026-08-20T14:00:00", queries);
+
+    // hour + day-previous-hours + month + year (a refresh may run more than
+    // once in the window, so compare distinct queries).
+    expect(new Set(queries).size).toBe(4);
+    for (const [start, stop] of rangesOf(queries)) expect(start).not.toBe(stop);
   });
 });

--- a/src/energy/energy-aggregator.ts
+++ b/src/energy/energy-aggregator.ts
@@ -19,6 +19,12 @@ import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import { isSubmeterEquipment, NON_SUBMETER_TYPES } from "../equipments/metering.js";
 import type { ComputedDataEntry } from "../shared/types.js";
 
+/** One row as the InfluxDB client hands it over. */
+interface QueryRow {
+  values: string[];
+  tableMeta: { toObject(values: string[]): unknown };
+}
+
 /** Minimum interval between two InfluxDB refreshes per equipment (ms). */
 const DEBOUNCE_MS = 5_000;
 
@@ -210,6 +216,50 @@ export class EnergyAggregator {
     this.pendingRefresh.set(equipmentId, timer);
   }
 
+  /**
+   * Sum the `energy` points of one equipment over `[start, stop)`.
+   *
+   * An empty or inverted range is answered with 0 without touching InfluxDB.
+   * Flux rejects `range(start: t, stop: t)` with "cannot query an empty range",
+   * and every caller has a legitimate moment where the two bounds coincide:
+   *
+   *  - between 00:00 and 00:59 local, no hour of today is completed yet, so
+   *    `todayMidnight === currentHourStart`;
+   *  - on the 1st of the month, no earlier day belongs to it, so
+   *    `monthFirst === todayMidnight`;
+   *  - on 1 January, the same holds for the year.
+   *
+   * Those are states, not failures — the sum of nothing is 0. Letting the query
+   * run threw out of refreshFromInfluxDB, which dropped *every* cumul for that
+   * equipment (hour and year included, not just the empty one) for the whole
+   * window: an hour every night, a full day every 1st of the month.
+   */
+  private async sumEnergy(
+    queryApi: { iterateRows(flux: string): AsyncIterable<QueryRow> },
+    bucket: string,
+    equipmentId: string,
+    start: Date,
+    stop: Date,
+  ): Promise<number> {
+    if (start.getTime() >= stop.getTime()) return 0;
+
+    const flux = `from(bucket: "${bucket}")
+  |> range(start: ${start.toISOString()}, stop: ${stop.toISOString()})
+  |> filter(fn: (r) => r._measurement == "equipment_data")
+  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
+  |> filter(fn: (r) => r.category == "energy")
+  |> filter(fn: (r) => r.alias == "energy")
+  |> filter(fn: (r) => r._field == "value_number")
+  |> sum()`;
+
+    let total = 0;
+    for await (const { values, tableMeta } of queryApi.iterateRows(flux)) {
+      const row = tableMeta.toObject(values) as { _value: number };
+      if (row._value > 0) total = row._value;
+    }
+    return total;
+  }
+
   /** Query InfluxDB to compute all cumuls for an equipment, then emit to UI. */
   private async refreshFromInfluxDB(equipmentId: string): Promise<void> {
     const client = this.influxClient.getClient();
@@ -231,76 +281,45 @@ export class EnergyAggregator {
     const rawBucket = config.bucket;
     const hourlyBucket = `${config.bucket}-energy-hourly`;
     const dailyBucket = `${config.bucket}-energy-daily`;
+    const monthFirst = new Date(now.getFullYear(), now.getMonth(), 1);
+    const jan1 = new Date(now.getFullYear(), 0, 1);
 
-    // Hour cumul: sum raw points in current hour
-    let energyHourWh = 0;
-    const hourFlux = `from(bucket: "${rawBucket}")
-  |> range(start: ${currentHourStart.toISOString()}, stop: ${tomorrowMidnight.toISOString()})
-  |> filter(fn: (r) => r._measurement == "equipment_data")
-  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
-  |> filter(fn: (r) => r.category == "energy")
-  |> filter(fn: (r) => r.alias == "energy")
-  |> filter(fn: (r) => r._field == "value_number")
-  |> sum()`;
+    // Hour cumul: raw points since the top of the current hour.
+    const energyHourWh = await this.sumEnergy(
+      queryApi,
+      rawBucket,
+      equipmentId,
+      currentHourStart,
+      tomorrowMidnight,
+    );
 
-    for await (const { values, tableMeta } of queryApi.iterateRows(hourFlux)) {
-      const row = tableMeta.toObject(values) as { _value: number };
-      if (row._value > 0) energyHourWh = row._value;
-    }
-
-    // Day cumul: previous hours of today come from the hourly bucket
-    // (downsampled at the end of each hour), the current hour is still in
-    // the raw bucket. Sum both — they don't overlap because the hourly
-    // task only writes completed hours.
-    let energyDayPrevHoursWh = 0;
-    const dayFlux = `from(bucket: "${hourlyBucket}")
-  |> range(start: ${todayMidnight.toISOString()}, stop: ${currentHourStart.toISOString()})
-  |> filter(fn: (r) => r._measurement == "equipment_data")
-  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
-  |> filter(fn: (r) => r.category == "energy")
-  |> filter(fn: (r) => r.alias == "energy")
-  |> filter(fn: (r) => r._field == "value_number")
-  |> sum()`;
-
-    for await (const { values, tableMeta } of queryApi.iterateRows(dayFlux)) {
-      const row = tableMeta.toObject(values) as { _value: number };
-      if (row._value > 0) energyDayPrevHoursWh = row._value;
-    }
+    // Day cumul: the hours already completed today come from the hourly bucket
+    // (downsampled at the end of each hour), the current hour is still in the
+    // raw bucket. They don't overlap — the hourly task only writes closed hours.
+    const energyDayPrevHoursWh = await this.sumEnergy(
+      queryApi,
+      hourlyBucket,
+      equipmentId,
+      todayMidnight,
+      currentHourStart,
+    );
     const energyDayWh = energyDayPrevHoursWh + energyHourWh;
 
-    // Month cumul: daily points this month (excluding today) + today's day total
-    const monthFirst = new Date(now.getFullYear(), now.getMonth(), 1);
-    let monthPrevDays = 0;
-    const monthFlux = `from(bucket: "${dailyBucket}")
-  |> range(start: ${monthFirst.toISOString()}, stop: ${todayMidnight.toISOString()})
-  |> filter(fn: (r) => r._measurement == "equipment_data")
-  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
-  |> filter(fn: (r) => r.category == "energy")
-  |> filter(fn: (r) => r.alias == "energy")
-  |> filter(fn: (r) => r._field == "value_number")
-  |> sum()`;
-
-    for await (const { values, tableMeta } of queryApi.iterateRows(monthFlux)) {
-      const row = tableMeta.toObject(values) as { _value: number };
-      if (row._value > 0) monthPrevDays = row._value;
-    }
-
-    // Year cumul: daily points this year (excluding today) + today's day total
-    const jan1 = new Date(now.getFullYear(), 0, 1);
-    let yearPrevDays = 0;
-    const yearFlux = `from(bucket: "${dailyBucket}")
-  |> range(start: ${jan1.toISOString()}, stop: ${todayMidnight.toISOString()})
-  |> filter(fn: (r) => r._measurement == "equipment_data")
-  |> filter(fn: (r) => r.equipmentId == "${equipmentId}")
-  |> filter(fn: (r) => r.category == "energy")
-  |> filter(fn: (r) => r.alias == "energy")
-  |> filter(fn: (r) => r._field == "value_number")
-  |> sum()`;
-
-    for await (const { values, tableMeta } of queryApi.iterateRows(yearFlux)) {
-      const row = tableMeta.toObject(values) as { _value: number };
-      if (row._value > 0) yearPrevDays = row._value;
-    }
+    // Month and year: daily points before today, plus today's own total below.
+    const monthPrevDays = await this.sumEnergy(
+      queryApi,
+      dailyBucket,
+      equipmentId,
+      monthFirst,
+      todayMidnight,
+    );
+    const yearPrevDays = await this.sumEnergy(
+      queryApi,
+      dailyBucket,
+      equipmentId,
+      jan1,
+      todayMidnight,
+    );
 
     const cumul: EnergyCumuls = {
       energyHourWh,


### PR DESCRIPTION
## The symptom

Every night, for the whole 00:00–00:59 local window, `EnergyAggregator` fails on every refresh:

```
warn  energy-aggregator  Failed to refresh energy cumuls from InfluxDB
      err: error in building plan while starting program: cannot query an empty range
```

Measured on a live install, from the `pino-roll` files that survive container recreation — every day the logs go back to, without exception:

| night (UTC hour 22 = 00 local) | occurrences |
| --- | --- |
| 08-09 → 08-11 | 696, 696, 808 |
| 08-12 → 08-16 | 290, 812, 800, 797, 803 |
| 08-17 → 08-19 | 288, 291, 297 |

## Why

`refreshFromInfluxDB` derives four Flux ranges from local calendar boundaries. Three of them have a moment where the two bounds are the same instant:

- **day** — `range(start: todayMidnight, stop: currentHourStart)`. Between 00:00 and 00:59 no hour of today is closed yet, so the two are equal. One hour, every night.
- **month** — `range(start: monthFirst, stop: todayMidnight)`. On the 1st there is no earlier day in the month. That one lasts **all day**, every month.
- **year** — same shape on 1 January, where all three collapse together.

Flux rejects a zero-width range outright, and the throw escapes `refreshFromInfluxDB`. The caller only logs it, so **every cumul for that equipment is discarded — hour, day, month and year — not just the empty one.** The hour query had already returned a perfectly good value; it goes out with the rest.

## The change

The four windows now go through one `sumEnergy(queryApi, bucket, equipmentId, start, stop)` helper that returns `0` for an empty or inverted range without calling InfluxDB. That is the correct answer rather than a workaround: the sum of no points is zero, and each of the three moments legitimately has no points to sum — no closed hour yet today, no earlier day this month, no earlier day this year.

The four near-identical nine-line query blocks collapse into four call sites, which is how the three cases came to be written independently in the first place.

## Tests

Four new cases in `energy-aggregator.test.ts`, driven by `vi.setSystemTime` at 00:30 local, on a 1st of month, on 1 January, and mid-afternoon as the control. The Influx double records every Flux string it receives and throws on a zero-width range exactly like the real one, so the tests assert both that no such query is issued and that nothing escapes.

Verified they are a real guard: reverting the one-line range check makes the three boundary tests fail and leaves the control green.

`npm run validate` clean — typecheck, lint, format, **1582 tests**, ui validation.
