### PR TITLE
release: v1.52.7

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,11 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.52.x : Ventilation deux vitesses et arbitre plus stable
 
+### v1.52.7 — 2026-08-20 { #v1-52-7 }
+
+- Feat (énergie) : **un délai d'extinction par équipement pour l'arbitre**. Une charge inertielle (par exemple un chauffe-eau Atlantic Calypso dont la pompe à chaleur continue de tourner environ 30 minutes après l'ouverture de son contact solaire) ne déclenche plus une fausse alarme « révocation non honorée » à chaque relâche. Renseignez le champ optionnel « Délai d'extinction » sur le panneau énergie de l'équipement pour que l'arbitre laisse passer cette traîne avant de la signaler ; la protection anti-cascade des autres charges reste immédiate. Sans délai renseigné, le comportement est inchangé. (#632)
+- Correctif (énergie) : **l'énergie cumulée n'est plus remise à blanc en début d'heure, de jour, de mois ou d'année**. Une requête InfluxDB de plage nulle (par exemple entre 00:00 et 00:59 en heure locale, quand aucune heure du jour n'est encore close) levait une erreur et écartait toutes les valeurs cumulées de l'équipement, générant des centaines d'avertissements par nuit. Les plages vides valent désormais 0 sans requête, de sorte que les relevés restent stables à ces frontières. (#633)
+
 ### v1.52.6 — 2026-08-19 { #v1-52-6 }
 
 - Feat (équipements) : **la bascule « inverser le sens » par équipement (spec 154) couvre désormais aussi les portails et déclencheurs booléens momentanés**. Un relais câblé pour déclencher sur le front OFF au lieu de ON (constaté sur un SONOFF MINI-ZBD pilotant une porte de garage) s'inverse directement depuis la page de l'équipement, la même bascule que celle utilisée pour inverser l'ouverture/fermeture d'un volet. Elle reste opt-in par équipement, donc les installations existantes ne sont pas affectées. (#628)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,11 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.52.x: Two-speed ventilation and a steadier arbiter
 
+### v1.52.7 — 2026-08-20 { #v1-52-7 }
+
+- Feat (energy): **a per-equipment shutdown delay for the arbiter**. An inertial load (for example an Atlantic Calypso water heater whose heat pump keeps running about 30 minutes after its solar contact opens) no longer triggers a false "revoke not honored" alarm on every release. Set the optional "Shutdown delay" on the equipment's energy panel so the arbiter waits out the tail before flagging it; the anti-cascade protection for other loads stays prompt. With no delay set, behaviour is unchanged. (#632)
+- Fix (energy): **cumulative energy is no longer blanked out at the start of an hour, day, month or year**. A zero-width InfluxDB query (for example between 00:00 and 00:59 local, when no hour of the day is closed yet) used to throw and discard every cumulative value for the equipment, producing hundreds of warnings per night. Empty ranges now resolve to 0 without querying, so the readings stay stable across those boundaries. (#633)
+
 ### v1.52.6 — 2026-08-19 { #v1-52-6 }
 
 - Feat (equipments): **the per-equipment "invert direction" toggle (spec 154) now covers gate and boolean momentary triggers too**. A relay wired to pulse on the OFF edge instead of ON (reported on a SONOFF MINI-ZBD driving a garage door) can be flipped right from the equipment page, the same toggle already used to invert a shutter's open/close. It stays opt-in per equipment, so existing setups are unaffected. (#628)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.52.6",
+  "version": "1.52.7",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.52.6",
+  "version": "1.52.7",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch release: version bump + release notes for v1.52.7.

## Included since v1.52.6
- feat(energy): per-equipment shutdown delay for the arbiter (#632, #631)
- fix(energy): stop querying InfluxDB with a zero-width range (#633)

Release notes added under the existing `## 1.52.x` section in both `docs/release-notes.md` and `docs/release-notes.fr.md` with the `{ #v1-52-7 }` anchor.