### PR TITLE
fix(equipments): stop reading a stale device status as a delivery failure

### DIFF
--- a/specs/141-order-delivery-confirmation/architecture.md
+++ b/specs/141-order-delivery-confirmation/architecture.md
@@ -22,14 +22,19 @@ interface PendingOrder {
   orderedAt: number; // epoch ms
   timer: NodeJS.Timeout | null;
   unconfirmed: boolean; // timeout elapsed or device_offline fast path
-  alarmRaised: boolean;
+  alarmRaised: boolean; // inherited from the order this one supersedes
   retried: boolean; // one reconnect re-dispatch max
+  offlineAtDispatch: boolean; // every target device believed offline at dispatch
   deviceIds: string[]; // devices behind the order bindings, for reconnect matching
   source?: OrderSource;
 }
 ```
 
 Entries are dropped on confirmation or supersession. The map is bounded by the number of distinct `(equipment, alias)` pairs that ever receive orders, so no periodic pruning is needed.
+
+## Trusting a device status
+
+`offlineIsEvidence(deviceIds)` gates the `device_offline` fast path. The tracker records every device id it sees on `device.status_changed` and stamps `startedAt` in `init()`: a status it has watched move is evidence, and so is any status once `STATUS_SETTLE_MS` (60 s) has elapsed since start. Before then, a status restored from SQLite is not — integrations repopulate it asynchronously, so an order dispatched in the seconds after boot would read the previous shutdown's snapshot. The fallback is the ordinary watchdog, which re-reads the statuses when it fires and reports `device_offline` if they are still offline: the alarm is delayed by the timeout, never lost.
 
 ## Value comparison
 
@@ -59,7 +64,7 @@ Consumers today: none required (alarms carry the user-facing path); the event ex
 ## Alarm contract
 
 - raise: `system.alarm.raised { alarmId: "order-unconfirmed:<equipmentId>:<alias>", level: "warning", source: "order-confirmation", message }`
-- resolve: same `alarmId` on late confirmation or supersession
+- resolve: same `alarmId` on late confirmation (supersession transfers the raised flag to the new entry instead)
 
 `notification-publish-service` already forwards both to every configured channel; no changes there.
 

--- a/specs/141-order-delivery-confirmation/spec.md
+++ b/specs/141-order-delivery-confirmation/spec.md
@@ -39,10 +39,10 @@ Everything else is exempt: orders with no mirror data binding (scenes, stateless
 On every confirmable `equipment.order.executed`:
 
 1. If the equipment's mirror binding already reports the ordered value, the order is confirmed immediately.
-2. If every device behind the order bindings is offline, the order is marked **unconfirmed** immediately with reason `device_offline` (no point waiting).
-3. Otherwise a watchdog timer is armed: 30 s, stretched to **twice the poll interval** when a target device belongs to a polling integration (its mirror binding cannot move before the next poll; a fixed 30 s would false-alarm on every order to a cloud device). If no `equipment.data.changed` reports the ordered value before it fires, the order is marked **unconfirmed** with reason `timeout`.
+2. If every device behind the order bindings is offline **and that status is evidence**, the order is marked **unconfirmed** immediately with reason `device_offline` (no point waiting). A status is evidence once the tracker has seen it move since start, or once 60 s of settle window have passed. Device statuses survive a restart in SQLite and integrations restore the real one asynchronously — Zigbee2MQTT replays its retained availability topics a second or two after the MQTT connect — so a status read before then is whatever the last shutdown left behind, not what the network says.
+3. Otherwise a watchdog timer is armed: 30 s, stretched to **twice the poll interval** when a target device belongs to a polling integration (its mirror binding cannot move before the next poll; a fixed 30 s would false-alarm on every order to a cloud device). If no `equipment.data.changed` reports the ordered value before it fires, the order is marked **unconfirmed**, with reason `device_offline` when every target device is offline by then and `timeout` otherwise.
 
-A new order on the same `(equipment, alias)` supersedes the pending one (its alarm, if raised, is resolved).
+A new order on the same `(equipment, alias)` supersedes the pending one and **inherits its alarm** if one was raised: the engine trying again is not a recovery, and a recipe re-asserting its intent every few minutes at an unreachable device would otherwise push a resolved/raised pair per attempt.
 
 ### Surfacing
 
@@ -52,11 +52,11 @@ Marking an order unconfirmed:
 - raises `system.alarm.raised` with `alarmId = order-unconfirmed:<equipmentId>:<alias>`, level `warning`, and a human message naming the equipment, the ordered value, and the reason
 - the existing notification pipeline already forwards system alarms to Telegram/ntfy/FCM/web push, so the user gets a push notification with no additional wiring
 
-The alarm resolves (`system.alarm.resolved`) when a later state report finally matches the ordered value, or when a newer order supersedes it.
+The alarm resolves (`system.alarm.resolved`) when a later state report finally matches the ordered value — including when the superseding order finds the equipment already in the ordered state. It is not resolved by supersession alone.
 
 ### Reconnect re-dispatch
 
-When a device comes back online (`device.status_changed` to `online`), every unconfirmed order bound to that device that is less than 1 hour old and has not been retried yet is re-dispatched **once**, with `OrderSource {kind: "external", channel: "delivery-retry"}` so the journal shows who acted. The re-dispatch re-arms the watchdog; confirmation then resolves the alarm.
+When a device comes back online (`device.status_changed` to `online`), every order bound to that device that is less than 1 hour old and has not been retried yet is re-dispatched **once**, with `OrderSource {kind: "external", channel: "delivery-retry"}` so the journal shows who acted. Eligible are the orders already marked unconfirmed and those still inside their watchdog after being dispatched at a device believed offline — the stale-status case above, where the command may equally never have landed. The re-dispatch re-arms the watchdog; confirmation then resolves the alarm.
 
 One retry, bounded at 1 hour, is deliberate: it heals the incident case (device back 14 s after the missed OFF) without surprise actuations long after the intent expired, and without fighting a device that keeps refusing.
 
@@ -75,8 +75,17 @@ Total wrong-state time: 16 seconds instead of 15.5 hours, and the user was told.
 | Parameter            | Value                        | Rationale                                                                                                                                                                   |
 | -------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Confirmation timeout | max(30 s, 2 x poll interval) | MQTT devices report within seconds; polling integrations (Panasonic, MCZ, ...) reflect the effect only on their next poll, so the watchdog stretches via `getPollingInfo()` |
+| Status settle window | 60 s                         | A device status restored from SQLite is not evidence until its integration has had time to report                                                                           |
 | Re-dispatch TTL      | 1 h                          | Heals transients, avoids stale intent                                                                                                                                       |
 | Re-dispatch count    | 1                            | No fighting, no loops                                                                                                                                                       |
 | Alarm level          | warning                      | Self-recoverable degradation per the log-level policy                                                                                                                       |
 
 Constants in v1; settings keys can come later if real installations need tuning.
+
+## Revisions
+
+**2026-08-21** — three amendments, after a production restart turned the fast path into a false alarm. The VMC recipe asserted ON 2.8 s after the tracker started, the tracker read the `offline` status the previous shutdown had persisted, and raised `Order not confirmed: VMC state → true (device offline)`; the retained availability landed 76 ms later and the order confirmed 7 ms after that.
+
+1. The `device_offline` fast path now requires the status to be evidence (rule 2 above).
+2. The watchdog names its reason when it fires rather than at dispatch (rule 3), so a device that went offline meanwhile is reported as such.
+3. Supersession carries the alarm over instead of resolving it. During a Zigbee outage the same night, a water heater re-ordered every 11 min produced six warnings and five "recovered" pushes in under an hour, none of which meant anything had recovered.

--- a/src/equipments/order-confirmation-tracker.test.ts
+++ b/src/equipments/order-confirmation-tracker.test.ts
@@ -117,6 +117,17 @@ describe("OrderConfirmationTracker", () => {
     });
   }
 
+  /** Move a device's status the way an integration would, and let the bus see it. */
+  function emitDeviceStatus(status: "online" | "offline"): void {
+    deviceStatus["dev-1"] = status;
+    eventBus.emit({
+      type: "device.status_changed",
+      deviceId: "dev-1",
+      deviceName: "SONOFF",
+      status,
+    });
+  }
+
   function alarmsRaised(): EngineEvent[] {
     return emitted.filter((e) => e.type === "system.alarm.raised");
   }
@@ -195,7 +206,7 @@ describe("OrderConfirmationTracker", () => {
 
   it("marks unconfirmed immediately when every target device is offline", () => {
     bindingValue = "ON";
-    deviceStatus["dev-1"] = "offline";
+    emitDeviceStatus("offline");
     emitOrder("OFF");
 
     const unconfirmed = unconfirmedEvents();
@@ -206,27 +217,16 @@ describe("OrderConfirmationTracker", () => {
 
   it("re-dispatches once when the device comes back online (incident case)", () => {
     bindingValue = "ON";
-    deviceStatus["dev-1"] = "offline";
+    emitDeviceStatus("offline");
     emitOrder("OFF");
     expect(unconfirmedEvents().length).toBe(1);
 
-    deviceStatus["dev-1"] = "online";
-    eventBus.emit({
-      type: "device.status_changed",
-      deviceId: "dev-1",
-      deviceName: "SONOFF",
-      status: "online",
-    });
+    emitDeviceStatus("online");
 
     expect(executeOrderCalls).toEqual([{ equipmentId: "eq-1", alias: "state", value: "OFF" }]);
 
     // A second reconnect must not re-dispatch again.
-    eventBus.emit({
-      type: "device.status_changed",
-      deviceId: "dev-1",
-      deviceName: "SONOFF",
-      status: "online",
-    });
+    emitDeviceStatus("online");
     expect(executeOrderCalls.length).toBe(1);
 
     // The device acts after the retry: alarm resolves.
@@ -236,7 +236,7 @@ describe("OrderConfirmationTracker", () => {
 
   it("the retry's own order.executed event re-arms the entry without creating a new one", () => {
     bindingValue = "ON";
-    deviceStatus["dev-1"] = "offline";
+    emitDeviceStatus("offline");
     emitOrder("OFF");
 
     // Echo of the tracker's re-dispatch coming back through the bus.
@@ -248,18 +248,80 @@ describe("OrderConfirmationTracker", () => {
     expect(alarmsRaised().length).toBe(1);
   });
 
-  it("a newer order supersedes the pending one and resolves its alarm", () => {
+  it("carries a raised alarm over to the order that supersedes it", () => {
     bindingValue = "ON";
     emitOrder("OFF");
     vi.advanceTimersByTime(31_000);
     expect(alarmsRaised().length).toBe(1);
 
+    // The recipe re-asserts its intent: the new order gets its own watchdog,
+    // but no fake recovery and no duplicate warning are pushed meanwhile.
+    emitOrder("OFF");
+    vi.advanceTimersByTime(31_000);
+    expect(unconfirmedEvents().length).toBe(2);
+    expect(alarmsResolved().length).toBe(0);
+    expect(alarmsRaised().length).toBe(1);
+
+    // Only the equipment reporting the ordered value resolves it.
+    emitData("OFF");
+    expect(alarmsResolved().length).toBe(1);
+  });
+
+  it("resolves a carried-over alarm when the state already holds the new order", () => {
+    bindingValue = "ON";
+    emitOrder("OFF");
+    vi.advanceTimersByTime(31_000);
+    expect(alarmsRaised().length).toBe(1);
+
+    bindingValue = "OFF";
     emitOrder("OFF");
     expect(alarmsResolved().length).toBe(1);
+  });
 
-    // The new order gets its own watchdog.
+  it("ignores an offline status left behind by the last shutdown", () => {
+    // Boot: the database still holds what the previous shutdown persisted and
+    // the integration has not replayed its availability topics yet.
+    deviceStatus["dev-1"] = "offline";
+    emitOrder("ON");
+
+    expect(unconfirmedEvents().length).toBe(0);
+    expect(alarmsRaised().length).toBe(0);
+
+    // Availability lands a second later, the state follows: silent confirmation.
+    emitDeviceStatus("online");
+    vi.advanceTimersByTime(1_000);
+    emitData("ON");
+    vi.advanceTimersByTime(60_000);
+
+    expect(alarmsRaised().length).toBe(0);
+  });
+
+  it("re-dispatches on reconnect for an order sent at a device believed offline", () => {
+    deviceStatus["dev-1"] = "offline";
+    emitOrder("ON");
+    expect(alarmsRaised().length).toBe(0);
+
+    emitDeviceStatus("online");
+    expect(executeOrderCalls).toEqual([{ equipmentId: "eq-1", alias: "state", value: "ON" }]);
+  });
+
+  it("falls back to the watchdog when a boot-time offline status turns out true", () => {
+    deviceStatus["dev-1"] = "offline";
+    emitOrder("ON");
     vi.advanceTimersByTime(31_000);
-    expect(alarmsRaised().length).toBe(2);
+
+    // Delayed by the watchdog, but named for what the status says by then.
+    expect(unconfirmedEvents()[0]).toMatchObject({ reason: "device_offline" });
+    expect(alarmsRaised().length).toBe(1);
+  });
+
+  it("trusts a persisted offline status once the settle window has passed", () => {
+    vi.advanceTimersByTime(61_000);
+    deviceStatus["dev-1"] = "offline";
+    emitOrder("ON");
+
+    expect(unconfirmedEvents()[0]).toMatchObject({ reason: "device_offline" });
+    expect(alarmsRaised().length).toBe(1);
   });
 
   it("exempts orders without a mirror data binding", () => {
@@ -285,17 +347,11 @@ describe("OrderConfirmationTracker", () => {
 
   it("does not re-dispatch entries older than the TTL", () => {
     bindingValue = "ON";
-    deviceStatus["dev-1"] = "offline";
+    emitDeviceStatus("offline");
     emitOrder("OFF");
 
     vi.advanceTimersByTime(3_700_000); // beyond the 1h TTL
-    deviceStatus["dev-1"] = "online";
-    eventBus.emit({
-      type: "device.status_changed",
-      deviceId: "dev-1",
-      deviceName: "SONOFF",
-      status: "online",
-    });
+    emitDeviceStatus("online");
 
     expect(executeOrderCalls.length).toBe(0);
   });

--- a/src/equipments/order-confirmation-tracker.ts
+++ b/src/equipments/order-confirmation-tracker.ts
@@ -26,6 +26,15 @@ import type { OrderSource } from "../shared/types.js";
 const CONFIRMATION_TIMEOUT_MS = 30_000;
 /** Maximum age of an unconfirmed order eligible for the reconnect re-dispatch. */
 const REDISPATCH_TTL_MS = 3_600_000;
+/**
+ * Settle window after start during which a device's persisted "offline" is not
+ * evidence on its own. Statuses survive a restart in SQLite and integrations
+ * restore the real one asynchronously — Zigbee2MQTT replays its retained
+ * availability topics a second or two after the MQTT connect — so an order
+ * dispatched right after boot would otherwise alarm on the status the previous
+ * shutdown left behind.
+ */
+const STATUS_SETTLE_MS = 60_000;
 /** OrderSource channel identifying the tracker's own re-dispatches. */
 export const RETRY_CHANNEL = "delivery-retry";
 
@@ -42,6 +51,8 @@ interface PendingOrder {
   unconfirmed: boolean;
   alarmRaised: boolean;
   retried: boolean;
+  /** Every target device was believed offline when the order was dispatched. */
+  offlineAtDispatch: boolean;
   deviceIds: string[];
   source?: OrderSource | undefined;
 }
@@ -81,6 +92,9 @@ export class OrderConfirmationTracker {
   private readonly logger: Logger;
   private readonly pending: Map<string, PendingOrder> = new Map();
   private readonly unsubs: Array<() => void> = [];
+  /** Devices whose status we have observed since start — see offlineIsEvidence. */
+  private readonly statusSeen: Set<string> = new Set();
+  private startedAt = 0;
 
   constructor(
     private readonly eventBus: EventBus,
@@ -93,6 +107,7 @@ export class OrderConfirmationTracker {
   }
 
   init(): void {
+    this.startedAt = Date.now();
     this.unsubs.push(
       this.eventBus.onType("equipment.order.executed", (event) => {
         try {
@@ -110,6 +125,7 @@ export class OrderConfirmationTracker {
       }),
       this.eventBus.onType("device.status_changed", (event) => {
         try {
+          this.statusSeen.add(event.deviceId);
           if (event.status === "online") this.handleDeviceOnline(event.deviceId);
         } catch (err) {
           this.logger.error({ err }, "Reconnect re-dispatch failed");
@@ -126,6 +142,7 @@ export class OrderConfirmationTracker {
       if (entry.timer) clearTimeout(entry.timer);
     }
     this.pending.clear();
+    this.statusSeen.clear();
   }
 
   // ── Order dispatch ───────────────────────────────────────────
@@ -146,20 +163,26 @@ export class OrderConfirmationTracker {
       return;
     }
 
-    // A newer order supersedes the pending one.
+    // A newer order supersedes the pending one. Its alarm is carried over
+    // rather than resolved and raised again: "recovered" has to mean the
+    // equipment finally reported the ordered value, not that the engine tried
+    // once more. Re-ordering every few minutes at an unreachable device would
+    // otherwise push a recovery/failure pair per attempt.
     const previous = this.pending.get(key);
     if (previous) {
       if (previous.timer) clearTimeout(previous.timer);
-      if (previous.alarmRaised) {
-        this.resolveAlarm(previous, "superseded by a new order");
-      }
       this.pending.delete(key);
     }
 
     const bindings = this.equipmentManager.getDataBindingsWithValues(equipmentId);
     const mirror = bindings.find((b) => b.alias === alias);
-    if (!mirror) return; // no observable effect — exempt (scenes, stateless orders)
-    if (!isConfirmableValue(value, mirror.enumValues)) return; // cross-vocabulary enum — exempt
+    // No observable effect (scenes, stateless orders) or a cross-vocabulary
+    // enum (cover CLOSE vs state CLOSED) — exempt. A carried-over alarm has
+    // nothing left to confirm it, so it is released here.
+    if (!mirror || !isConfirmableValue(value, mirror.enumValues)) {
+      if (previous?.alarmRaised) this.resolveAlarm(previous, "superseded by an exempt order");
+      return;
+    }
 
     const deviceIds = this.equipmentManager
       .getOrderBindingsWithDetails(equipmentId)
@@ -174,27 +197,49 @@ export class OrderConfirmationTracker {
       timer: null,
       timeoutMs: this.confirmationTimeoutFor(deviceIds),
       unconfirmed: false,
-      alarmRaised: false,
+      alarmRaised: previous?.alarmRaised ?? false,
       retried: false,
+      offlineAtDispatch: this.allTargetsOffline(deviceIds),
       deviceIds,
       source,
     };
 
     // Already in the ordered state (e.g. OFF ordered while already OFF):
     // nothing will change, confirm immediately.
-    if (valuesMatch(value, mirror.value)) return;
+    if (valuesMatch(value, mirror.value)) {
+      if (entry.alarmRaised) this.resolveAlarm(entry, "state finally confirmed");
+      return;
+    }
 
     this.pending.set(key, entry);
 
-    // Every target device offline: the command cannot have been delivered,
-    // no point waiting for the timeout.
-    const devices = deviceIds.map((id) => this.deviceManager.getById(id)).filter((d) => d !== null);
-    if (devices.length > 0 && devices.every((d) => d.status === "offline")) {
+    // Every target device offline: the command cannot have been delivered, no
+    // point waiting for the timeout — as long as that status is evidence and
+    // not a leftover from the last shutdown.
+    if (entry.offlineAtDispatch && this.offlineIsEvidence(deviceIds)) {
       this.markUnconfirmed(entry, "device_offline");
       return;
     }
 
     this.armTimer(entry);
+  }
+
+  /** Whether every device behind the order bindings is currently offline. */
+  private allTargetsOffline(deviceIds: string[]): boolean {
+    const devices = deviceIds.map((id) => this.deviceManager.getById(id)).filter((d) => d !== null);
+    return devices.length > 0 && devices.every((d) => d.status === "offline");
+  }
+
+  /**
+   * Whether an "offline" status can be read as proof that the command could
+   * not be delivered. A status we have seen move since start always can be;
+   * one restored from the database cannot, until the settle window has passed
+   * and every integration has had the time to report. Until then the watchdog
+   * decides — the alarm is delayed by the timeout, not lost.
+   */
+  private offlineIsEvidence(deviceIds: string[]): boolean {
+    if (Date.now() - this.startedAt >= STATUS_SETTLE_MS) return true;
+    return deviceIds.every((id) => this.statusSeen.has(id));
   }
 
   /**
@@ -219,7 +264,11 @@ export class OrderConfirmationTracker {
     if (entry.timer) clearTimeout(entry.timer);
     entry.timer = setTimeout(() => {
       entry.timer = null;
-      this.markUnconfirmed(entry, "timeout");
+      // Read the reason now rather than at dispatch: a device that went — or
+      // stayed — offline meanwhile explains the silence better than a bare
+      // timeout, and by now its status has had every chance to settle.
+      const reason = this.allTargetsOffline(entry.deviceIds) ? "device_offline" : "timeout";
+      this.markUnconfirmed(entry, reason);
     }, entry.timeoutMs);
   }
 
@@ -303,7 +352,11 @@ export class OrderConfirmationTracker {
 
   private handleDeviceOnline(deviceId: string): void {
     for (const entry of this.pending.values()) {
-      if (!entry.unconfirmed || entry.retried) continue;
+      if (entry.retried) continue;
+      // Unconfirmed, or still inside its watchdog after being dispatched at a
+      // device believed offline: either way the command may never have landed,
+      // and this reconnect is the moment to re-assert it.
+      if (!entry.unconfirmed && !entry.offlineAtDispatch) continue;
       if (!entry.deviceIds.includes(deviceId)) continue;
       if (Date.now() - entry.orderedAt > REDISPATCH_TTL_MS) continue;
 


### PR DESCRIPTION
## Problem

`order-confirmation` pushes `Order not confirmed: <equipment> <alias> → <value> (device offline)` when every device behind the order bindings is offline at dispatch. That status comes from SQLite, where it survives restarts, and integrations only restore the real one asynchronously — Zigbee2MQTT replays its retained `<device>/availability` topics a second or two after the MQTT connect. An order dispatched before then is judged against what the previous shutdown left behind.

Caught on a live install right after a restart (2026-08-21, UTC):

```
05:11:30.990  order-confirmation tracker started
05:11:32.731  VMC Humidity Control instances start
05:11:33.832  equipment order executed — VMC state → true
05:11:33.833  WARN  Order not confirmed ... reason=device_offline   ← push sent
05:11:33.909  GiteRdcVmc availability lands: online
05:11:33.916  equipment reports true — alarm resolved 83 ms after it fired
```

The order was fine: Z2M was up the whole time, only Sowel's view of the device was stale. The user gets a warning push and a recovery push for a non-event, every restart.

The same log also shows the noise side of the feature. During a Zigbee outage that night the water heater recipe re-ordered every 11 min, and each re-order resolved the standing alarm before raising it again — six warnings and five "Order confirmation recovered" pushes in under an hour, while nothing had recovered.

## Changes

1. **The `device_offline` fast path requires the status to be evidence.** `offlineIsEvidence()` accepts a status the tracker has watched move since start (it already listens to `device.status_changed`), or any status once a 60 s settle window has passed. Otherwise the ordinary watchdog decides: the alarm is delayed by the timeout, never lost.
2. **The watchdog reads its reason when it fires**, not at dispatch. A device that went — or stayed — offline meanwhile is reported as `device_offline` rather than a bare `timeout`, and by then its status has had every chance to settle.
3. **A superseding order inherits the raised alarm** instead of resolving it and raising it again. `system.alarm.resolved` now means the equipment finally reported the ordered value (including when the new order finds it already there), not that the engine tried once more.

The reconnect re-dispatch keeps its reach: an order dispatched at a device believed offline stays eligible while its watchdog runs (`offlineAtDispatch`), so spec 141's healing path works whether or not the status turned out to be true.

Point 3 changes a documented behaviour, so `specs/141-order-delivery-confirmation/{spec,architecture}.md` are updated, with a `## Revisions` section recording why.

## Tests

`order-confirmation-tracker.test.ts`: 22 tests, 6 new — boot-time stale status ignored, reconnect re-dispatch on a stale status, watchdog fallback when the boot-time offline turns out true, fast path restored after the settle window, alarm carried over across supersession, and carried-over alarm resolved when the new order finds the state already right. `npm run validate` green (backend + UI).
