### PR TITLE
chore(registry): bump vmc-humidity to 0.6.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -550,7 +550,7 @@
     "icon": "Fan",
     "author": "adn-dev-adrien",
     "repo": "adn-dev-adrien/sowel-recipe-vmc-humidity",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "tags": ["ventilation", "vmc", "humidity", "comfort", "automation"],
     "i18n": {
       "fr": {
@@ -560,7 +560,7 @@
     },
     "sowelVersion": ">=1.35.0",
     "owner": "adn-dev-adrien",
-    "sha256": "00c430369abedd2b1e77e244f63685a67fd425c2ce9d42559452a6e694e9302b"
+    "sha256": "c0ddbd2ad7f6ee5282ca9a3cba261aa16af03a642441b9fa2b7d4db3bb1eca60"
   },
   {
     "id": "water-heater-solar",


### PR DESCRIPTION
0.6.1 fixes a defect worth propagating quickly: an unparseable humidity report from the outdoor sensor turned `outdoorHumidity` null, which made the psychrometric floor null — and a null floor reads as *no outdoor constraint at all* (`gain = Infinity`). One bad Zigbee report therefore removed the guard until the next re-read, and the evaluation triggered by that very event could start a cycle with the outdoor air too wet to dry anything.

Observed on a live installation on 2026-08-21: a cycle started at 11:11 local with a computed gain of +1.5 point, under the 3-point margin required to start.

Also in 0.6.1: a configured-but-silent outdoor sensor is treated as unknown rather than absent, and every start and stop states the floor and the gain it acted on.

```
$ shasum -a 256 sowel-recipe-vmc-humidity-0.6.1.tar.gz
c0ddbd2ad7f6ee5282ca9a3cba261aa16af03a642441b9fa2b7d4db3bb1eca60
```

Running on my instance; 77 tests green.