### PR TITLE
fix(ws): authorize WebSocket topics and events by role

### DIFF
--- a/src/api/websocket.test.ts
+++ b/src/api/websocket.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { extractWsToken, isWsOriginAllowed } from "./websocket.js";
+import {
+  extractWsToken,
+  isWsOriginAllowed,
+  isAdminOnlyEvent,
+  resolveSubscribedTopics,
+  canReceiveEvent,
+} from "./websocket.js";
+import type { EngineEvent } from "../shared/types.js";
+
+// The role/topic helpers only read `event.type`, so a minimal cast is enough.
+const ev = (type: string): EngineEvent => ({ type }) as unknown as EngineEvent;
 
 describe("websocket auth helpers", () => {
   describe("extractWsToken", () => {
@@ -91,6 +101,106 @@ describe("websocket auth helpers", () => {
 
     it("tolerates a malformed Origin URL by falling through to deny", () => {
       expect(isWsOriginAllowed("not-a-url", corsOrigins, "domopi.local:3001")).toBe(false);
+    });
+  });
+});
+
+describe("websocket role authorization (S01)", () => {
+  describe("isAdminOnlyEvent", () => {
+    it("flags events routed to an admin-only topic (mqtt-publishers carries broker passwords)", () => {
+      expect(isAdminOnlyEvent(ev("mqtt-broker.updated"))).toBe(true);
+      expect(isAdminOnlyEvent(ev("mqtt-broker.created"))).toBe(true);
+      expect(isAdminOnlyEvent(ev("mqtt-publisher.created"))).toBe(true);
+    });
+
+    it("flags notification-publisher events even though they route to the shared `system` topic", () => {
+      expect(isAdminOnlyEvent(ev("notification-publisher.updated"))).toBe(true);
+      expect(isAdminOnlyEvent(ev("notification-publisher.created"))).toBe(true);
+    });
+
+    it("does not flag ordinary data events", () => {
+      expect(isAdminOnlyEvent(ev("device.data.updated"))).toBe(false);
+      expect(isAdminOnlyEvent(ev("equipment.data.changed"))).toBe(false);
+      expect(isAdminOnlyEvent(ev("zone.data.changed"))).toBe(false);
+      expect(isAdminOnlyEvent(ev("energy.arbiter.status"))).toBe(false);
+    });
+  });
+
+  describe("resolveSubscribedTopics", () => {
+    it("always includes `system`", () => {
+      expect(resolveSubscribedTopics([], "standard").has("system")).toBe(true);
+      expect(resolveSubscribedTopics([], "admin").has("system")).toBe(true);
+    });
+
+    it("grants admin-only topics to admins", () => {
+      const topics = resolveSubscribedTopics(["logs", "mqtt-publishers", "devices"], "admin");
+      expect([...topics].sort()).toEqual(["devices", "logs", "mqtt-publishers", "system"]);
+    });
+
+    it("drops admin-only topics for non-admins but keeps the rest", () => {
+      const topics = resolveSubscribedTopics(["logs", "mqtt-publishers", "devices"], "standard");
+      expect([...topics].sort()).toEqual(["devices", "system"]);
+    });
+
+    it("ignores unknown topics", () => {
+      const topics = resolveSubscribedTopics(["devices", "bogus"], "admin");
+      expect([...topics].sort()).toEqual(["devices", "system"]);
+    });
+  });
+
+  describe("canReceiveEvent", () => {
+    it("delivers ordinary events to a subscribed non-admin", () => {
+      expect(
+        canReceiveEvent(ev("device.data.updated"), {
+          role: "standard",
+          topics: new Set(["system", "devices"]),
+        }),
+      ).toBe(true);
+    });
+
+    it("does not deliver events for topics a client is not subscribed to", () => {
+      expect(
+        canReceiveEvent(ev("zone.data.changed"), {
+          role: "standard",
+          topics: new Set(["system", "devices"]),
+        }),
+      ).toBe(false);
+    });
+
+    it("hides notification-publisher secrets from a non-admin on the `system` topic", () => {
+      expect(
+        canReceiveEvent(ev("notification-publisher.updated"), {
+          role: "standard",
+          topics: new Set(["system"]),
+        }),
+      ).toBe(false);
+    });
+
+    it("delivers notification-publisher events to admins", () => {
+      expect(
+        canReceiveEvent(ev("notification-publisher.updated"), {
+          role: "admin",
+          topics: new Set(["system"]),
+        }),
+      ).toBe(true);
+    });
+
+    it("hides mqtt-broker passwords from a non-admin even if they force the topic into their set", () => {
+      expect(
+        canReceiveEvent(ev("mqtt-broker.updated"), {
+          role: "standard",
+          topics: new Set(["system", "mqtt-publishers"]),
+        }),
+      ).toBe(false);
+    });
+
+    it("delivers mqtt-broker events to a subscribed admin", () => {
+      expect(
+        canReceiveEvent(ev("mqtt-broker.updated"), {
+          role: "admin",
+          topics: new Set(["system", "mqtt-publishers"]),
+        }),
+      ).toBe(true);
     });
   });
 });

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -4,7 +4,7 @@ import type { EventBus } from "../core/event-bus.js";
 import type { AuthService } from "../auth/auth-service.js";
 import type { LogRingBuffer } from "../core/log-buffer.js";
 import type { Logger } from "../core/logger.js";
-import type { EngineEvent } from "../shared/types.js";
+import type { EngineEvent, UserRole } from "../shared/types.js";
 
 interface WebSocketDeps {
   eventBus: EventBus;
@@ -94,8 +94,26 @@ const VALID_TOPICS = new Set<WsTopic>([
 ]);
 const BATCH_INTERVAL_MS = 200;
 
+/**
+ * Topics that carry admin-only data — a non-admin client may neither subscribe
+ * to them nor receive their events. `mqtt-publishers` events carry broker
+ * passwords; `logs` streams the full server log. Both are admin-only over REST,
+ * so the WebSocket must enforce the same boundary (security audit S01).
+ */
+const ADMIN_ONLY_TOPICS = new Set<WsTopic>(["mqtt-publishers", "logs"]);
+
+/**
+ * Event type prefixes that carry admin-only data even though `getEventTopic`
+ * routes them to a topic non-admins share. `notification-publisher.*` events
+ * land on `system` (the default subscription for every client) yet carry the
+ * publisher's `channelConfig` — e.g. a Telegram bot token. Non-admin clients
+ * never receive these regardless of their subscriptions (security audit S01).
+ */
+const ADMIN_ONLY_EVENT_PREFIXES = new Set<string>(["notification-publisher"]);
+
 interface ClientState {
   socket: WebSocket;
+  role: UserRole;
   topics: Set<WsTopic>;
   pending: EngineEvent[];
   logUnsubscribe?: () => void;
@@ -126,6 +144,41 @@ function getEventTopic(event: EngineEvent): WsTopic {
     default:
       return "system";
   }
+}
+
+/**
+ * True when an event must only be delivered to admin clients — either because
+ * its topic is admin-only, or because its type prefix is flagged as carrying
+ * admin-only data (secrets such as the MQTT broker password or Telegram bot
+ * token). See security audit S01.
+ */
+export function isAdminOnlyEvent(event: EngineEvent): boolean {
+  if (ADMIN_ONLY_TOPICS.has(getEventTopic(event))) return true;
+  return ADMIN_ONLY_EVENT_PREFIXES.has(event.type.split(".")[0]);
+}
+
+/**
+ * Resolves the set of topics a client may subscribe to, given its role.
+ * `system` is always included; admin-only topics are silently dropped for
+ * non-admin clients so they cannot subscribe to privileged streams.
+ */
+export function resolveSubscribedTopics(requested: string[], role: UserRole): Set<WsTopic> {
+  const result = new Set<WsTopic>(["system"]);
+  for (const t of requested) {
+    if (!VALID_TOPICS.has(t as WsTopic)) continue;
+    if (ADMIN_ONLY_TOPICS.has(t as WsTopic) && role !== "admin") continue;
+    result.add(t as WsTopic);
+  }
+  return result;
+}
+
+/** True when a client with the given role and subscriptions should receive the event. */
+export function canReceiveEvent(
+  event: EngineEvent,
+  client: { role: UserRole; topics: Set<WsTopic> },
+): boolean {
+  if (isAdminOnlyEvent(event) && client.role !== "admin") return false;
+  return client.topics.has(getEventTopic(event));
 }
 
 /** Returns a dedup key for high-frequency data events, null for structural events */
@@ -191,14 +244,14 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
     }
   }, BATCH_INTERVAL_MS);
 
-  // Listen for all engine events and enqueue for subscribed clients
+  // Listen for all engine events and enqueue for subscribed clients.
+  // canReceiveEvent enforces both the topic subscription and the role gate on
+  // admin-only topics/events (security audit S01).
   eventBus.on((event) => {
     if (clients.size === 0) return;
 
-    const topic = getEventTopic(event);
-
     for (const [, state] of clients) {
-      if (state.topics.has(topic)) {
+      if (canReceiveEvent(event, state)) {
         state.pending.push(event);
       }
     }
@@ -251,6 +304,7 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
       return;
     }
 
+    let role: UserRole;
     try {
       if (token.startsWith("swl_") || token.startsWith("wch_") || token.startsWith("cbl_")) {
         const result = authService.verifyApiToken(token);
@@ -258,8 +312,9 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
           socket.close(4001, "Invalid token");
           return;
         }
+        role = result.role;
       } else {
-        authService.verifyAccessToken(token);
+        role = authService.verifyAccessToken(token).role;
       }
     } catch {
       socket.close(4001, "Invalid token");
@@ -267,7 +322,7 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
     }
 
     // Default subscription: system events only
-    const state: ClientState = { socket, topics: new Set(["system"]), pending: [] };
+    const state: ClientState = { socket, role, topics: new Set(["system"]), pending: [] };
     clients.set(socket, state);
     logger.info({ clients: clients.size }, "WebSocket client connected");
 
@@ -276,12 +331,8 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
       try {
         const msg = JSON.parse(String(raw)) as { type?: string; topics?: string[] };
         if (msg.type === "subscribe" && Array.isArray(msg.topics)) {
-          const newTopics = new Set<WsTopic>(["system"]); // system always included
-          for (const t of msg.topics) {
-            if (VALID_TOPICS.has(t as WsTopic)) {
-              newTopics.add(t as WsTopic);
-            }
-          }
+          // Drops admin-only topics for non-admin clients (security audit S01).
+          const newTopics = resolveSubscribedTopics(msg.topics, state.role);
 
           // Handle logs topic subscription/unsubscription
           const hadLogs = state.topics.has("logs");
@@ -293,7 +344,7 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
           }
 
           state.topics = newTopics;
-          logger.debug({ topics: [...newTopics] }, "Client subscribed");
+          logger.debug({ topics: [...newTopics], role: state.role }, "Client subscribed");
         }
       } catch {
         // Ignore malformed messages


### PR DESCRIPTION
Addresses a privately-tracked security finding (WebSocket authorization).

**Problem.** The `/ws` handshake verified the token but discarded the role, and there was no per-topic or per-event authorization. Any authenticated client (including a non-admin `standard` user) could subscribe to admin-only streams and receive data the REST layer gates as admin-only:
- the `mqtt-publishers` topic broadcasts `MqttBroker` objects (broker password in cleartext);
- `notification-publisher.*` events carry the publisher `channelConfig` (e.g. a Telegram bot token) and route to `system`, the default subscription for every client;
- the `logs` topic streams the full server log buffer.

**Fix.** Capture the verified role into the client state and enforce it centrally:
- `ADMIN_ONLY_TOPICS` (`mqtt-publishers`, `logs`): non-admins cannot subscribe (`resolveSubscribedTopics`);
- `ADMIN_ONLY_EVENT_PREFIXES` (`notification-publisher`): non-admins never receive these even on the shared `system` topic (`canReceiveEvent`);
- broadcast loop now filters through `canReceiveEvent` (topic subscription **and** role gate).

Admin behaviour is unchanged, and the affected UI pages are already `AdminRoute`-only, so no legitimate flow regresses.

**Tests.** Adds unit coverage for `isAdminOnlyEvent`, `resolveSubscribedTopics`, and `canReceiveEvent` (30 tests pass). Typecheck + lint + format clean.

Note: a companion UI fix (JWT still sent in the Logs WS query string) is tracked separately.