### PR TITLE
ci: enable Dependabot, CodeQL, SECURITY.md + least-privilege CI token

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # Backend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      backend-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Frontend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      ui-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege: CI only reads the repo. No job here writes to the repo,
+# publishes packages, or posts statuses, so the default token needs no more.
+permissions:
+  contents: read
+
 jobs:
   backend:
     name: Backend (lint, typecheck, test)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, Monday 03:27 UTC (off-peak, avoids the top-of-hour rush).
+    - cron: "27 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities **privately**, not through public issues.
+
+Use GitHub's private vulnerability reporting for this repository:
+**[Report a vulnerability](https://github.com/mchacher/sowel/security/advisories/new)**
+(Security tab → Advisories → Report a vulnerability).
+
+This opens a private channel visible only to the maintainer. Public issues are
+visible to everyone and must not be used for undisclosed vulnerabilities.
+
+When reporting, please include:
+
+- affected version (see `package.json`) and deployment (Docker, bare metal);
+- a description of the issue and its impact;
+- steps to reproduce, or a proof of concept, where possible.
+
+## Supported versions
+
+Security fixes are applied to the latest released version. Please upgrade to the
+most recent release before reporting, in case the issue is already fixed.
+
+## Disclosure process
+
+1. You report privately through the advisory channel above.
+2. The maintainer confirms the report and works on a fix, coordinating with you
+   as needed.
+3. Once a fix is released, the advisory is published (with credit, if you wish).
+
+## Scope
+
+This repository is the Sowel engine. Integration and recipe plugins live in
+their own repositories; please report issues specific to a plugin against that
+plugin's repository. Plugin supply-chain integrity (registry hashes, install
+flow) is in scope here.


### PR DESCRIPTION
From the 2026-08-21 security audit (section 2). Closes #640, partially addresses #638.

The repo is public, so all of this is free. Secret scanning + push protection + gitleaks were already ON; this adds the three missing free pillars.

**Files**
- `.github/dependabot.yml` — weekly npm (root + `ui/`) and github-actions version updates; minor/patch grouped to limit PR noise.
- `.github/workflows/codeql.yml` — CodeQL code scanning for `javascript-typescript` + `actions`, on push/PR to main plus a weekly schedule (security-extended queries).
- `SECURITY.md` — routes vulnerability reports to GitHub private vulnerability reporting instead of public issues.
- `.github/workflows/ci.yml` — top-level `permissions: contents: read` (least-privilege token).

**Repo settings enabled alongside this PR** (not file-based): Dependabot alerts, Dependabot security updates, and private vulnerability reporting.

**Note** — CodeQL here is the committed-workflow form rather than GitHub 'default setup' (the default-setup API rejected the token). If you later prefer default setup, remove this workflow first to avoid a duplicate-analysis conflict.

**Remaining from #638** (not in this PR, higher blast radius on the release pipeline): route `inputs.test_tag` through `env:` in release.yml and drop the docker job's `contents: write`.