### PR TITLE
release: v1.52.8

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -13,6 +13,11 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ## 1.52.x : Ventilation deux vitesses et arbitre plus stable
 
+### v1.52.8 — 2026-08-21 { #v1-52-8 }
+
+- Sécurité (ws) : **le WebSocket temps réel applique désormais une autorisation par rôle**. Les données sensibles (configuration des brokers MQTT et des publieurs de notification, et le flux de logs serveur) ne sont livrées qu'aux sessions admin ; une session non-admin ne peut plus s'abonner à ces flux. Le comportement admin est inchangé. (#646)
+- Correctif (équipements) : **un équipement ne lit plus un statut d'appareil périmé comme un échec de livraison**. Après un redémarrage, la base contient encore le statut laissé par le dernier arrêt, jusqu'à ce que l'intégration rejoue le vrai une seconde ou deux plus tard ; le chemin rapide de confirmation d'ordre le prenait pour la preuve que la commande ne pouvait pas être délivrée et levait une fausse alarme. Il attend désormais une preuve réelle, et une charge re-commandée ne produit plus d'avertissements erronés répétés pendant une panne d'intégration. (#635)
+
 ### v1.52.7 — 2026-08-20 { #v1-52-7 }
 
 - Feat (énergie) : **un délai d'extinction par équipement pour l'arbitre**. Une charge inertielle (par exemple un chauffe-eau Atlantic Calypso dont la pompe à chaleur continue de tourner environ 30 minutes après l'ouverture de son contact solaire) ne déclenche plus une fausse alarme « révocation non honorée » à chaque relâche. Renseignez le champ optionnel « Délai d'extinction » sur le panneau énergie de l'équipement pour que l'arbitre laisse passer cette traîne avant de la signaler ; la protection anti-cascade des autres charges reste immédiate. Sans délai renseigné, le comportement est inchangé. (#632)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,11 @@ This page summarises every published version, newest first. For the full diff be
 
 ## 1.52.x: Two-speed ventilation and a steadier arbiter
 
+### v1.52.8 — 2026-08-21 { #v1-52-8 }
+
+- Security (ws): **the live WebSocket now enforces role-based authorization**. Privileged data (MQTT broker and notification publisher configuration, and the server log stream) is delivered only to admin sessions; a non-admin session can no longer subscribe to those streams. Admin behaviour is unchanged. (#646)
+- Fix (equipments): **an equipment no longer reads a stale device status as a delivery failure**. After a restart the database still holds the status the last shutdown left behind, until the integration replays the real one a second or two later; the order-confirmation fast path used to treat that as proof the command could not be delivered and raise a false alarm. It now waits for real evidence, and a re-ordered load no longer produces repeated bogus warnings during an integration outage. (#635)
+
 ### v1.52.7 — 2026-08-20 { #v1-52-7 }
 
 - Feat (energy): **a per-equipment shutdown delay for the arbiter**. An inertial load (for example an Atlantic Calypso water heater whose heat pump keeps running about 30 minutes after its solar contact opens) no longer triggers a false "revoke not honored" alarm on every release. Set the optional "Shutdown delay" on the equipment's energy panel so the arbiter waits out the tail before flagging it; the anti-cascade protection for other loads stays prompt. With no delay set, behaviour is unchanged. (#632)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.52.7",
+  "version": "1.52.8",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.52.7",
+  "version": "1.52.8",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Small patch release. Two user-facing fixes already on main.

- **Security (ws)** — the live WebSocket now enforces role-based authorization; privileged data (MQTT broker + notification publisher config, server log stream) is admin-only (#646).
- **Fix (equipments)** — an equipment no longer reads a stale device status as a delivery failure (#635).

Release notes added to both docs/release-notes.md and docs/release-notes.fr.md with the { #v1-52-8 } anchor (spec 108). Version bumped in package.json + ui/package.json.

After merge: tag v1.52.8 on the merged main commit and push the tag to trigger the release workflow. Also unblocks publishing security advisory GHSA-3jmj-36j3-jfhc (coordinated with this release).