### PR TITLE
chore(ci): keep linters/formatter out of Dependabot groups; group actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,16 @@
 version: 2
+
+# Grouping strategy
+# -----------------
+# The minor/patch groups auto-collect ordinary library bumps into a single PR
+# per ecosystem. Linters, formatters and the TypeScript compiler are excluded
+# from those groups: a version bump to any of them can fail CI on UNCHANGED
+# code (a new lint rule, a reformat, a stricter type check), which would poison
+# the whole group and block every unrelated library update. They still get
+# updated, but as individual PRs so their toolchain upgrade can be reviewed on
+# its own (run the formatter/linter fixups, triage new rules) instead of slipped
+# into an unattended merge.
+
 updates:
   # Backend npm dependencies
   - package-ecosystem: "npm"
@@ -10,6 +22,14 @@ updates:
       - "dependencies"
     groups:
       backend-minor-patch:
+        exclude-patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "@typescript-eslint/*"
+          - "prettier"
+          - "typescript"
         update-types:
           - "minor"
           - "patch"
@@ -24,14 +44,26 @@ updates:
       - "dependencies"
     groups:
       ui-minor-patch:
+        exclude-patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "@typescript-eslint/*"
+          - "prettier"
+          - "typescript"
         update-types:
           - "minor"
           - "patch"
 
-  # GitHub Actions used in workflows
+  # GitHub Actions used in workflows, grouped into one PR to cut noise
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     labels:
       - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Follow-up to the Dependabot rollout. Closes #652.

**Problem.** The two grouped minor/patch PRs (#657 ui, #655 backend) both fail a required check, and not because a library broke: a linter/formatter bump in the group tightened rules on **unchanged** code.
- #657 (ui): eslint-plugin-react-hooks / typescript-eslint added a new rule, 19 `setState synchronously within an effect` lint errors.
- #655 (backend): prettier changed formatting, so `format:check` fails repo-wide.

One tooling bump poisons the whole group and blocks every unrelated library update in it.

**Fix.**
- Exclude `eslint`, `eslint-*`, `@eslint/*`, `typescript-eslint`, `@typescript-eslint/*`, `prettier`, `typescript` from both npm minor/patch groups. They still get updated, but as **individual, reviewable PRs** where the toolchain upgrade (formatter/linter fixups, new-rule triage) is handled on its own.
- Group the `github-actions` ecosystem into one PR to cut per-action noise (the #652 nit).

**After merge:** close/recreate #657 and #655 so Dependabot regenerates them without the tooling bumps (clean, green groups). The eslint/prettier/typescript upgrades will then arrive as their own PRs to review deliberately.