### PR TITLE
release: v1.53.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,13 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.53.x : Type d'équipement onduleur
+
+### v1.53.0 — 2026-08-21 { #v1-53-0 }
+
+- Feat (équipements) : **un nouveau type d'équipement onduleur (UPS), en lecture seule** (spec 156). Modélise un onduleur comme une seule unité fonctionnelle avec son état d'alimentation (sur secteur, sur batterie, batterie faible, by-pass, surcharge, sortie coupée), sa charge de batterie, son autonomie restante et sa charge de sortie. Il se lie à la télémétrie que le plugin expose, n'affiche que les valeurs réellement présentes et n'offre aucune commande, volontairement : un ordre d'arrêt accidentel vers un onduleur est irrécupérable, la chaîne d'arrêt propre reste du côté de l'hôte qui fait tourner `upsmon`. Un nouveau groupe « Alimentation » regroupe les onduleurs dans les vues zone et maison. L'intégration compagnon est `sowel-plugin-nut` (Network UPS Tools), qui lit le flux exposé par Synology, QNAP, Proxmox et la plupart des hôtes Linux. (#676)
+- Maintenance : **mises à jour de dépendances et de CI**. React Router, PostCSS, nanoid, js-yaml et fast-uri ont été mis à jour côté interface, ainsi qu'un groupe backend mineur/correctif et les actions GitHub utilisées par la CI, plusieurs corrigeant des avis de sécurité. Aucun changement fonctionnel. (#641, #642, #643, #644, #645, #677, #678, #680)
+
 ## 1.52.x : Ventilation deux vitesses et arbitre plus stable
 
 ### v1.52.8 — 2026-08-21 { #v1-52-8 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,13 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.53.x: UPS equipment type
+
+### v1.53.0 — 2026-08-21 { #v1-53-0 }
+
+- Feat (equipments): **a new read-only UPS (uninterruptible power supply) equipment type** (spec 156). Model an inverter or UPS as one functional unit with its power state (on mains, on battery, battery low, bypass, overload, output off), its battery charge, its remaining autonomy and its output load. It binds whatever telemetry the plugin reports, renders only the values actually present, and carries no command surface on purpose: an accidental shutdown order to a UPS is unrecoverable, so the orderly-shutdown chain stays with the host running `upsmon`. A new "Power" group gathers UPS equipments in the zone and home views. The companion integration is `sowel-plugin-nut` (Network UPS Tools), which reads the stream shipped by Synology, QNAP, Proxmox and most Linux hosts. (#676)
+- Maintenance: **dependency and CI updates**. React Router, PostCSS, nanoid, js-yaml and fast-uri were bumped on the UI, together with a backend minor/patch group and the GitHub Actions used by CI, several of them clearing security advisories. No functional change. (#641, #642, #643, #644, #645, #677, #678, #680)
+
 ## 1.52.x: Two-speed ventilation and a steadier arbiter
 
 ### v1.52.8 — 2026-08-21 { #v1-52-8 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.52.8",
+  "version": "1.53.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.52.8",
+  "version": "1.53.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump + release notes for v1.53.0.

## Content since v1.52.8

- **feat(equipments): UPS equipment type (spec 156)** (#676) — new read-only \`ups\` equipment type: power state, battery charge, remaining autonomy and output load; polymorphic binding, no command surface, new "Power" zone group. Companion integration \`sowel-plugin-nut\`.
- **Maintenance / dependencies** — UI bumps (React Router, PostCSS, nanoid, js-yaml, fast-uri), backend minor/patch group, GitHub Actions group, CI Dependabot grouping tweak (#641, #642, #643, #644, #645, #677, #678, #680).

## Checklist
- [x] \`package.json\` + \`ui/package.json\` bumped to 1.53.0
- [x] Release notes added in both \`docs/release-notes.md\` and \`docs/release-notes.fr.md\` with the \`{ #v1-53-0 }\` anchor
- [x] Covers all merged PRs in \`v1.52.8..main\`