### PR TITLE
feat(ui): make the whole dashboard tile the on/off control

### DIFF
--- a/docs/user/dashboard.fr.md
+++ b/docs/user/dashboard.fr.md
@@ -20,6 +20,8 @@ Affiche un équipement unique avec son état courant et ses contrôles rapides.
 - **Thermostats** : affichage de température avec indicateur de mode
 - **Interrupteurs** : badge d'état on/off
 
+Les équipements on/off (lumières, interrupteurs, prises, chauffe-eau, vannes, radiateurs, pompes de piscine, lecteurs multimédia, portails à action unique) changent d'état quand vous cliquez **n'importe où sur la tuile**, et pas seulement sur le bouton sous l'icône. Les tuiles à plusieurs contrôles -- volets, thermostats, volets de piscine, VMC -- gardent leurs boutons. En mode édition la tuile n'agit plus, pour que vous puissiez la déplacer et la renommer sans risque.
+
 ### Widget de zone
 
 Affiche les données agrégées d'une zone entière. Vous choisissez quelle **famille** de données afficher :

--- a/docs/user/dashboard.md
+++ b/docs/user/dashboard.md
@@ -20,6 +20,8 @@ Displays a single equipment with its current state and quick controls.
 - **Thermostats**: temperature display with mode indicator
 - **Switches**: on/off state badge
 
+On/off equipments (lights, switches, plugs, water heaters, water valves, heaters, pool pumps, media players, single-action gates) toggle when you click **anywhere on the tile**, not just the button under the icon. Tiles with several controls -- shutters, thermostats, pool covers, VMC -- keep their own buttons. In edit mode the tile stops acting, so you can drag and rename it safely.
+
 ### Zone widget
 
 Displays aggregated data for an entire zone. You choose which **family** of data to show:

--- a/ui/src/components/dashboard/EquipmentWidget.test.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, userEvent } from "../../test-utils";
+import { act, fireEvent, render, screen, userEvent } from "../../test-utils";
 import { EquipmentWidget } from "./EquipmentWidget";
 import type { DashboardWidget, EquipmentWithDetails } from "../../types";
 
@@ -358,5 +358,114 @@ describe("EquipmentWidget", () => {
     // …the whole card is the action.
     await userEvent.click(screen.getByText("Garage"));
     expect(onExecuteOrder).toHaveBeenCalledWith("g-2", "command", null);
+  });
+  // A tile is the control, not just a frame around one: clicking anywhere on a
+  // switch/light/valve card runs the same order as the button under the icon,
+  // the way the mobile card already behaved.
+  it("fires the toggle when the tile itself is clicked", async () => {
+    const onExecuteOrder = vi.fn().mockResolvedValue(undefined);
+    render(
+      <EquipmentWidget
+        widget={makeWidget()}
+        equipment={makeEquipment()}
+        onExecuteOrder={onExecuteOrder}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Plug"));
+    expect(onExecuteOrder).toHaveBeenCalledWith("eq-1", "state", "ON");
+  });
+
+  it("fires the toggle once — not twice — when the button inside the tile is clicked", async () => {
+    const onExecuteOrder = vi.fn().mockResolvedValue(undefined);
+    render(
+      <EquipmentWidget
+        widget={makeWidget()}
+        equipment={makeEquipment()}
+        onExecuteOrder={onExecuteOrder}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button"));
+    expect(onExecuteOrder).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the tile inert in edit mode, where it is a drag and rename target", async () => {
+    const onExecuteOrder = vi.fn().mockResolvedValue(undefined);
+    render(
+      <EquipmentWidget
+        widget={makeWidget()}
+        equipment={makeEquipment()}
+        onExecuteOrder={onExecuteOrder}
+        editMode
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Plug"));
+    expect(onExecuteOrder).not.toHaveBeenCalled();
+  });
+
+  // A brightness drag released off the slider track lands its click on the card
+  // (their common ancestor). Without the pointerdown bookkeeping in WidgetCard,
+  // adjusting a dimmable light would switch it off.
+  it("does not toggle a dimmable light when a slider drag ends on the tile", async () => {
+    const onExecuteOrder = vi.fn().mockResolvedValue(undefined);
+    const dimmable = makeEquipment({
+      id: "l-1",
+      name: "Plafonnier",
+      type: "light_dimmable",
+      dataBindings: [
+        {
+          id: "db-l",
+          equipmentId: "l-1",
+          deviceDataId: "dd-l",
+          alias: "state",
+          deviceId: "dev-l",
+          deviceName: "Lamp",
+          key: "state",
+          type: "boolean",
+          category: "light_state",
+          value: true,
+          lastUpdated: "2026-01-01T00:00:00Z",
+          lastChanged: "2026-01-01T00:00:00Z",
+          stale: false,
+        },
+        {
+          id: "db-b",
+          equipmentId: "l-1",
+          deviceDataId: "dd-b",
+          alias: "brightness",
+          deviceId: "dev-l",
+          deviceName: "Lamp",
+          key: "brightness",
+          type: "number",
+          category: "light_brightness",
+          value: 127,
+          lastUpdated: "2026-01-01T00:00:00Z",
+          lastChanged: "2026-01-01T00:00:00Z",
+          stale: false,
+        },
+      ] as EquipmentWithDetails["dataBindings"],
+    });
+    render(
+      <EquipmentWidget
+        widget={makeWidget({ equipmentId: "l-1" })}
+        equipment={dimmable}
+        onExecuteOrder={onExecuteOrder}
+      />,
+    );
+
+    const slider = screen.getByRole("slider");
+    const label = screen.getByText("Plafonnier");
+    fireEvent.pointerDown(slider);
+    fireEvent.click(label); // pointerup landed outside the track
+    expect(onExecuteOrder).not.toHaveBeenCalled();
+
+    // A plain click on the tile still toggles.
+    await act(async () => {
+      fireEvent.pointerDown(label);
+      fireEvent.click(label);
+    });
+    expect(onExecuteOrder).toHaveBeenCalledWith("l-1", "state", "OFF");
   });
 });

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -75,6 +75,8 @@ interface EquipmentWidgetProps {
   onExecuteOrder: (equipmentId: string, alias: string, value: unknown) => Promise<void>;
   /** Click handler that opens the desktop detail drawer. Currently consumed only by the weather widget. */
   onOpenDetail?: () => void;
+  /** Dashboard in edit mode — tiles are drag/rename targets then, so the tap-to-toggle is off. */
+  editMode?: boolean;
 }
 
 export function EquipmentWidget({
@@ -83,6 +85,7 @@ export function EquipmentWidget({
   equipmentZone,
   onExecuteOrder,
   onOpenDetail,
+  editMode,
 }: EquipmentWidgetProps) {
   const { t } = useTranslation();
   const {
@@ -117,6 +120,7 @@ export function EquipmentWidget({
         equipment={equipment}
         presentation={presentation}
         onExecuteOrder={execOrder}
+        editMode={editMode}
       />
     );
 
@@ -128,6 +132,7 @@ export function EquipmentWidget({
         equipment={equipment}
         onExecuteOrder={execOrder}
         iconKey={widget.icon}
+        editMode={editMode}
       />
     );
   // Awnings share the shutter widget shape (icon + position + 3-button row).
@@ -161,6 +166,7 @@ export function EquipmentWidget({
         equipment={equipment}
         onExecuteOrder={execOrder}
         iconKey={widget.icon}
+        editMode={editMode}
       />
     );
   if (isHeater)
@@ -171,6 +177,7 @@ export function EquipmentWidget({
         equipment={equipment}
         onExecuteOrder={execOrder}
         iconKey={widget.icon}
+        editMode={editMode}
       />
     );
   if (isEnergyMeter) return <EnergyMeterEquipmentWidget label={label} sublabel={sublabel} equipment={equipment} />;
@@ -184,6 +191,7 @@ export function EquipmentWidget({
         equipment={equipment}
         onExecuteOrder={execOrder}
         iconKey={widget.icon}
+        editMode={editMode}
       />
     );
   if (equipment.type === "ups")
@@ -210,6 +218,7 @@ export function EquipmentWidget({
         equipment={equipment}
         onExecuteOrder={execOrder}
         iconKey={widget.icon}
+        editMode={editMode}
       />
     );
   if (isPoolCover)
@@ -250,12 +259,15 @@ function LightEquipmentWidget({
   equipment,
   onExecuteOrder,
   iconKey,
+  editMode,
 }: {
   label: string;
   sublabel?: string;
   equipment: EquipmentWithDetails;
   onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
   iconKey?: string;
+  /** Edit mode disables the tap-to-toggle so the tile can be dragged and renamed. */
+  editMode?: boolean;
 }) {
   const { t } = useTranslation();
   const [executing, setExecuting] = useState(false);
@@ -302,8 +314,14 @@ function LightEquipmentWidget({
 
   const handleBrightnessCommit = () => slider.onCommit((v) => onExecuteOrder("brightness", v));
 
+  const canToggle = hasToggle && equipment.enabled;
+
   return (
-    <WidgetCard label={label} sublabel={sublabel}>
+    <WidgetCard
+      label={label}
+      sublabel={sublabel}
+      onClick={canToggle && !editMode ? () => void handleToggle() : undefined}
+    >
       {/* Zone 2: Picto + État horizontal */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
@@ -343,7 +361,7 @@ function LightEquipmentWidget({
       </div>
 
       {/* Zone 3: Bouton — toggle */}
-      {hasToggle && equipment.enabled && (
+      {canToggle && (
         <div className="flex justify-center gap-3 mt-auto pt-1">
           <button
             onClick={handleToggle}
@@ -378,12 +396,15 @@ function WaterHeaterEquipmentWidget({
   equipment,
   onExecuteOrder,
   iconKey,
+  editMode,
 }: {
   label: string;
   sublabel?: string;
   equipment: EquipmentWithDetails;
   onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
   iconKey?: string;
+  /** Edit mode disables the tap-to-toggle so the tile can be dragged and renamed. */
+  editMode?: boolean;
 }) {
   const { t } = useTranslation();
   const [executing, setExecuting] = useState(false);
@@ -422,8 +443,14 @@ function WaterHeaterEquipmentWidget({
     }
   };
 
+  const canToggle = hasToggle && equipment.enabled;
+
   return (
-    <WidgetCard label={label} sublabel={sublabel}>
+    <WidgetCard
+      label={label}
+      sublabel={sublabel}
+      onClick={canToggle && !editMode ? () => void handleToggle() : undefined}
+    >
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
         {resolveWidgetIcon(iconKey, <WaterHeaterIcon on={isOn} />)}
@@ -450,7 +477,7 @@ function WaterHeaterEquipmentWidget({
         </div>
       </div>
 
-      {hasToggle && equipment.enabled && (
+      {canToggle && (
         <div className="flex justify-center gap-3 mt-auto pt-1">
           <button
             onClick={handleToggle}
@@ -821,12 +848,15 @@ function GateEquipmentWidget({
   equipment,
   onExecuteOrder,
   iconKey,
+  editMode,
 }: {
   label: string;
   sublabel?: string;
   equipment: EquipmentWithDetails;
   onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
   iconKey?: string;
+  /** Edit mode disables the tap-to-toggle so the tile can be dragged and renamed. */
+  editMode?: boolean;
 }) {
   const { t } = useTranslation();
   const [executing, setExecuting] = useState<string | null>(null);
@@ -865,8 +895,7 @@ function GateEquipmentWidget({
     <WidgetCard
       label={label}
       sublabel={sublabel}
-      onClick={hasSingleAction ? () => handleCommand(null) : undefined}
-      className={hasSingleAction ? "cursor-pointer active:scale-[0.98] transition-transform" : ""}
+      onClick={hasSingleAction && !editMode ? () => handleCommand(null) : undefined}
     >
       {/* Icon centered */}
       <div className="flex-1 flex items-center justify-center">
@@ -921,12 +950,15 @@ function HeaterEquipmentWidget({
   equipment,
   onExecuteOrder,
   iconKey,
+  editMode,
 }: {
   label: string;
   sublabel?: string;
   equipment: EquipmentWithDetails;
   onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
   iconKey?: string;
+  /** Edit mode disables the tap-to-toggle so the tile can be dragged and renamed. */
+  editMode?: boolean;
 }) {
   const { t } = useTranslation();
   const [executing, setExecuting] = useState(false);
@@ -957,8 +989,14 @@ function HeaterEquipmentWidget({
     }
   };
 
+  const canToggle = hasToggle && equipment.enabled;
+
   return (
-    <WidgetCard label={label} sublabel={sublabel}>
+    <WidgetCard
+      label={label}
+      sublabel={sublabel}
+      onClick={canToggle && !editMode ? () => void handleToggle() : undefined}
+    >
       {/* Zone 2: Picto + État horizontal */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
@@ -975,7 +1013,7 @@ function HeaterEquipmentWidget({
       </div>
 
       {/* Zone 3: Bouton — toggle */}
-      {hasToggle && equipment.enabled && (
+      {canToggle && (
         <div className="flex justify-center gap-3 mt-auto pt-1">
           <button
             onClick={handleToggle}
@@ -1436,12 +1474,15 @@ function WaterValveEquipmentWidget({
   equipment,
   onExecuteOrder,
   iconKey,
+  editMode,
 }: {
   label: string;
   sublabel?: string;
   equipment: EquipmentWithDetails;
   onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
   iconKey?: string;
+  /** Edit mode disables the tap-to-toggle so the tile can be dragged and renamed. */
+  editMode?: boolean;
 }) {
   const { t } = useTranslation();
   const [executing, setExecuting] = useState(false);
@@ -1471,8 +1512,14 @@ function WaterValveEquipmentWidget({
     }
   };
 
+  const canToggle = hasToggle && equipment.enabled;
+
   return (
-    <WidgetCard label={label} sublabel={sublabel}>
+    <WidgetCard
+      label={label}
+      sublabel={sublabel}
+      onClick={canToggle && !editMode ? () => void handleToggle() : undefined}
+    >
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
         {resolveWidgetIcon(iconKey, <WaterValveWidgetIcon open={isOpen} />)}
@@ -1487,7 +1534,7 @@ function WaterValveEquipmentWidget({
         </div>
       </div>
 
-      {hasToggle && equipment.enabled && (
+      {canToggle && (
         <div className="flex justify-center gap-3 mt-auto pt-1">
           <button
             onClick={handleToggle}

--- a/ui/src/components/dashboard/WidgetCard.tsx
+++ b/ui/src/components/dashboard/WidgetCard.tsx
@@ -1,14 +1,21 @@
-import type { ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 
 interface WidgetCardProps {
   label: string;
   /** Zone qualifier (spec 139) — a second, quieter line under the title. */
   sublabel?: string;
-  /** Optional className extension — used by callers that need to layer behavior (cursor, transitions, edit-mode chrome…). */
+  /** Optional className extension — used by callers that need to layer behavior (transitions, edit-mode chrome…). */
   className?: string;
-  /** Optional click handler — when set, the caller is expected to apply a cursor-pointer class via `className`. */
+  /** Primary action, fired by a click anywhere on the tile that did not start on a nested control. */
   onClick?: () => void;
   children: ReactNode;
+}
+
+/** Nested controls own their own clicks: the tile must stay out of their way. */
+const CONTROL_SELECTOR = "button, input, select, textarea, a, [role='button'], [role='slider']";
+
+function inControl(target: EventTarget | null): boolean {
+  return target instanceof Element && !!target.closest(CONTROL_SELECTOR);
 }
 
 /**
@@ -23,6 +30,15 @@ interface WidgetCardProps {
  * wide, so "Plafonnier — Chambre 1" truncates precisely where it stops being
  * ambiguous. Splitting the two keeps the name readable and the zone legible.
  *
+ * With `onClick`, the whole tile becomes the widget's primary action, the way
+ * the mobile card has always worked. Two gestures must not trigger it: a click
+ * on a nested control, which would fire the action twice, and a slider drag
+ * released off its track, whose click event lands on the card because the card
+ * is the common ancestor of pointerdown and pointerup.
+ * Hence the pointerdown bookkeeping — checking the click target alone misses
+ * the second case. Keyboard users keep the nested button; a role="button" here
+ * would nest an interactive element inside another one.
+ *
  * Per-type widgets (light, shutter, thermostat, etc.) wrap their content
  * with this component. See specs/098-design-system-dashboard.
  */
@@ -33,10 +49,26 @@ export function WidgetCard({
   onClick,
   children,
 }: WidgetCardProps) {
+  const startedInControl = useRef(false);
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    startedInControl.current = inControl(e.target);
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    const fromControl = startedInControl.current;
+    startedInControl.current = false;
+    if (fromControl || inControl(e.target)) return;
+    onClick?.();
+  };
+
   return (
     <div
-      className={`bg-surface border border-border rounded-md p-3 flex flex-col h-[160px] sm:h-[240px] overflow-hidden ${className}`}
-      onClick={onClick}
+      className={`bg-surface border border-border rounded-md p-3 flex flex-col h-[160px] sm:h-[240px] overflow-hidden ${
+        onClick ? "cursor-pointer active:scale-[0.98] transition-transform" : ""
+      } ${className}`}
+      onPointerDown={onClick ? handlePointerDown : undefined}
+      onClick={onClick ? handleClick : undefined}
     >
       <div className="mb-2 text-center">
         <span className="block text-[17px] font-semibold text-text truncate leading-tight">

--- a/ui/src/components/dashboard/WidgetGrid.tsx
+++ b/ui/src/components/dashboard/WidgetGrid.tsx
@@ -461,6 +461,7 @@ function WidgetRenderer({
         equipmentZone={equipmentZone}
         onExecuteOrder={onExecuteOrder}
         onOpenDetail={editMode ? undefined : onOpenDetail}
+        editMode={editMode}
       />
     );
   }

--- a/ui/src/components/dashboard/presentation/PresentationWidget.tsx
+++ b/ui/src/components/dashboard/presentation/PresentationWidget.tsx
@@ -16,6 +16,8 @@ interface PresentationWidgetProps {
   equipment: EquipmentWithDetails;
   presentation: WidgetPresentation;
   onExecuteOrder: (alias: string, value: unknown) => Promise<void>;
+  /** Dashboard in edit mode — the tile is then a drag/rename target, not a control. */
+  editMode?: boolean;
 }
 
 export function PresentationWidget({
@@ -24,6 +26,7 @@ export function PresentationWidget({
   equipment,
   presentation,
   onExecuteOrder,
+  editMode,
 }: PresentationWidgetProps) {
   const { t } = useTranslation();
   const [executing, setExecuting] = useState(false);
@@ -41,8 +44,14 @@ export function PresentationWidget({
     }
   };
 
+  const canToggle = !!toggle && equipment.enabled;
+
   return (
-    <WidgetCard label={label} sublabel={sublabel}>
+    <WidgetCard
+      label={label}
+      sublabel={sublabel}
+      onClick={canToggle && !editMode ? () => void handleToggle() : undefined}
+    >
       {/* Zone 2: icon + state */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
@@ -63,8 +72,8 @@ export function PresentationWidget({
         </div>
       </div>
 
-      {/* Zone 3: toggle button */}
-      {toggle && equipment.enabled && (
+      {/* Zone 3: toggle button — the whole tile fires it too (see WidgetCard) */}
+      {canToggle && (
         <div className="flex justify-center gap-3 mt-auto pt-1">
           <button
             onClick={handleToggle}


### PR DESCRIPTION
## Why

On desktop, acting on a dashboard widget means hitting the 40 px power button under the icon. The mobile card has always toggled on a tap anywhere on the card, and a single-action gate already worked that way on desktop too — the rest of the on/off family did not.

## What changes

A click anywhere on the tile fires the toggle for: switch, media player, pool pump (presentation resolver, spec 149), light, water heater, water valve, heater. The button under the icon stays — it is the state indicator (tint + spinner) and the keyboard path.

The behavior lives in `WidgetCard`, so every widget inherits the same three guards:

- a click on a nested control is ignored → the button fires the order **once**, not twice;
- a click whose gesture *started* on a nested control is ignored too. A brightness drag released off the slider track lands its click on the card (the common ancestor of pointerdown and pointerup), which is otherwise indistinguishable from a tap — adjusting a dimmable light would switch it off;
- edit mode turns the tile action off entirely: there a tile is a drag/rename target. That also closes an existing hole — the single-action gate tile actuated while the dashboard was in edit mode.

Multi-control tiles (shutter, thermostat, pool cover, VMC) are untouched: they have no single "state change" to bind a tile click to.

## Tests

`ui/src/components/dashboard/EquipmentWidget.test.tsx` — four new cases: tile click fires the order, the inner button fires it exactly once, edit mode leaves the tile inert, and a slider drag ending on the tile does not toggle a dimmable light (while a plain tile click still does).

`npm run validate` passes (backend + UI, 537 UI tests).

## Docs

`docs/user/dashboard.{md,fr.md}` — one paragraph under "Equipment widget".