### PR TITLE
release: v1.54.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,13 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.54.x : Tuile de tableau de bord cliquable et diagramme de flux partagé
+
+### v1.54.0 — 2026-08-22 { #v1-54-0 }
+
+- Feat (ui) : **toute la tuile du tableau de bord bascule désormais un équipement on/off**. Lumières, interrupteurs, prises, chauffe-eau, vannes, radiateurs, pompes de piscine, lecteurs multimédia et portails à action unique changent d'état quand on clique n'importe où sur la carte, plus seulement sur le petit bouton sous l'icône, comme le faisait déjà la carte mobile. Les tuiles à plusieurs contrôles (volets, thermostats, volets de piscine, VMC) gardent leurs boutons, et en mode édition la tuile n'agit plus pour pouvoir être déplacée et renommée sans risque. Un glissement du curseur de luminosité relâché hors de sa piste n'éteint plus la lumière. (#689)
+- Feat (ui) : **le panneau de détail onduleur est reconstruit sur un diagramme de flux partagé** (spec 157). Le diagramme de routage d'Energy · Live est extrait en composant réutilisable, et le panneau onduleur est rebâti dessus : trois cartes (le diagramme en direct, une carte marges et seuils, une fiche technique repliée) remplacent l'ancienne liste plate de lignes indifférenciées. Les noms de champs sont traduits, les booléens s'affichent par une coche ou un tiret au lieu du mot « false », et aucune valeur n'apparaît deux fois. La page Energy s'affiche exactement comme avant, protégée par un test de caractérisation écrit avant l'extraction. (#688)
+
 ## 1.53.x : Type d'équipement onduleur
 
 ### v1.53.0 — 2026-08-21 { #v1-53-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,13 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.54.x: A tap-to-toggle dashboard and a shared power-flow diagram
+
+### v1.54.0 — 2026-08-22 { #v1-54-0 }
+
+- Feat (ui): **the whole dashboard tile now toggles an on/off equipment**. Lights, switches, plugs, water heaters, water valves, heaters, pool pumps, media players and single-action gates switch when you tap anywhere on the card, not just the small button under the icon, matching how the mobile card already behaved. Tiles with several controls (shutters, thermostats, pool covers, VMC) keep their own buttons, and in edit mode the tile stops acting so it can be dragged and renamed safely. A brightness-slider drag released off its track no longer flips the light off. (#689)
+- Feat (ui): **the UPS detail panel is rebuilt on a shared power-flow diagram** (spec 157). The Energy · Live routing diagram is extracted into a reusable component, and the UPS panel is rebuilt on it: three cards (the live diagram, a margins-and-thresholds card, and a collapsed technical sheet) replace the previous flat list of undifferentiated rows. Field names are translated, booleans render as a check or a dash instead of the word "false", and no value appears twice. The Energy page renders exactly as before, guarded by a characterization test written before the extraction. (#688)
+
 ## 1.53.x: UPS equipment type
 
 ### v1.53.0 — 2026-08-21 { #v1-53-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.53.0",
+  "version": "1.54.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,8 +4,19 @@ set -euo pipefail
 # ============================================================
 # Sowel Release Script
 # Usage: scripts/release.sh <version>
-# Example: scripts/release.sh 1.1.0
+# Example: scripts/release.sh 1.54.0
 # ============================================================
+#
+# Branch protection blocks direct pushes to main, so a release ships in two
+# steps:
+#   1. A normal PR bumps the version in package.json + ui/package.json and adds
+#      the release-notes entries (docs/release-notes.md + .fr.md), and is merged
+#      to main.
+#   2. This script tags that merged commit and pushes the tag, which triggers
+#      the GitHub Actions release build.
+#
+# Run it on main, AFTER the release PR has been merged and pulled. It does not
+# commit or push to main itself — it only validates and tags.
 
 VERSION="${1:-}"
 
@@ -18,7 +29,7 @@ fi
 
 # Validate semver format
 if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-  echo "Error: Invalid version format. Use semver (e.g., 1.1.0)"
+  echo "Error: Invalid version format. Use semver (e.g., 1.54.0)"
   exit 1
 fi
 
@@ -35,36 +46,46 @@ if [ -n "$(git status --porcelain)" ]; then
   exit 1
 fi
 
-CURRENT=$(node -p "require('./package.json').version")
-echo "Releasing Sowel v$VERSION (current: $CURRENT)"
+# Local main must match origin/main (the release PR is merged and pulled)
+git fetch origin main --quiet
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+  echo "Error: local main is not in sync with origin/main. Pull first."
+  exit 1
+fi
+
+# The version bump must already be merged (done by the release PR)
+PKG=$(node -p "require('./package.json').version")
+UIPKG=$(node -p "require('./ui/package.json').version")
+if [ "$PKG" != "$VERSION" ] || [ "$UIPKG" != "$VERSION" ]; then
+  echo "Error: package.json ($PKG) / ui/package.json ($UIPKG) are not at $VERSION."
+  echo "Merge the release PR that bumps the version before tagging."
+  exit 1
+fi
+
+# Release notes must carry the anchored entry in both languages (spec 108)
+ANCHOR="{ #v$(echo "$VERSION" | tr . -) }"
+for f in docs/release-notes.md docs/release-notes.fr.md; do
+  if ! grep -qF "$ANCHOR" "$f"; then
+    echo "Error: missing release-notes entry '$ANCHOR' in $f (spec 108)."
+    exit 1
+  fi
+done
+
+# Tag must not already exist
+if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+  echo "Error: tag v$VERSION already exists."
+  exit 1
+fi
+
+echo "Releasing Sowel v$VERSION on $(git rev-parse --short HEAD)"
 echo ""
 
-# Bump version in package.json and ui/package.json
-node -e "
-const fs = require('fs');
-for (const file of ['package.json', 'ui/package.json']) {
-  const pkg = JSON.parse(fs.readFileSync(file, 'utf-8'));
-  pkg.version = '$VERSION';
-  fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + '\n');
-  console.log('  Updated', file, '→', '$VERSION');
-}
-"
-
-# Commit
-git add package.json ui/package.json
-git commit -m "release: v$VERSION"
-
-# Tag
+# Tag the merged commit and push the tag (this triggers the release build)
 git tag "v$VERSION"
-
-# Push
-echo ""
-echo "Pushing to origin..."
-git push origin main
 git push origin "v$VERSION"
 
 echo ""
-echo "Release v$VERSION tagged and pushed."
+echo "Tagged v$VERSION and pushed."
 echo "GitHub Actions will now build the Docker image and create the release."
 echo ""
 echo "Monitor: gh run list --limit 3"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.53.0",
+  "version": "1.54.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Cuts **v1.54.0** (minor: two UI features shipped since v1.53.0).

## Included
- #689 — the whole dashboard tile toggles an on/off equipment
- #688 — shared FlowDiagram, UPS panel rebuilt on it (spec 157)

## This PR
- Version bump `1.53.0 → 1.54.0` (`package.json`, `ui/package.json`)
- Release notes for v1.54.0 in EN + FR with the `{ #v1-54-0 }` anchor (spec 108)
- `chore(release)`: `scripts/release.sh` reworked to be **tag-only** — branch protection blocks its old `git push origin main`, so the bump/notes now land via this PR and the script only validates (on main, in sync, version bumped, anchors present) then tags the merged commit and pushes the tag.

After merge, tag the merged commit with `scripts/release.sh 1.54.0` to trigger the GitHub Actions build.