### PR TITLE
fix(core): pin PRAGMA synchronous instead of inheriting it (#694)

### DIFF
--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -240,6 +240,21 @@ The live list is in `plugins/registry.json` at the repo root.
 
 - **Library**: `better-sqlite3` with intentionally synchronous API (fast, no callback overhead).
 - **WAL mode**: `PRAGMA journal_mode=WAL` for concurrent read/write.
+- **`PRAGMA synchronous=NORMAL`** (issue #694): pinned rather than inherited.
+  The effective value was already NORMAL, but only because better-sqlite3
+  compiles `SQLITE_DEFAULT_WAL_SYNCHRONOUS=1` and SQLite applies it to a
+  database already in WAL mode at open; a brand-new file is created in `delete`
+  mode, takes FULL, and switching it to WAL afterwards does not re-apply the WAL
+  default, so a fresh install ran its first process lifetime at FULL. Setting it
+  explicitly makes the choice ours instead of a dependency's compile flag, and
+  `database.test.ts` pins it. **The trade-off NORMAL accepts**: a power loss or
+  an OS crash can lose transactions committed since the last checkpoint (up to
+  ~4 MB of WAL at the default `wal_autocheckpoint`, so potentially minutes of
+  writes, though Linux writeback makes the realistic loss far smaller). It
+  cannot corrupt the database, recovery is prefix-consistent, and a process
+  crash or container restart loses nothing — but a VM hard-stop is a guest power
+  loss, not a restart. Note this governs _when_ SQLite fsyncs, never how many
+  pages it writes: it is not a write-amplification fix.
 - **Migrations**: SQL files in `migrations/` run automatically on startup.
 - **Transactions**: Used for batch operations.
 - **IDs**: UUID v4 via `crypto.randomUUID()`.

--- a/src/core/database.test.ts
+++ b/src/core/database.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openDatabase } from "./database.js";
+
+// Issue #694 — the pragmas `openDatabase()` sets are a deliberate durability
+// and wear decision, and nothing pinned them until now. They must be asserted
+// against a REAL on-disk database: an in-memory database silently ignores
+// `journal_mode = WAL` (it reports "memory"), so a test built on `:memory:`
+// would pass no matter what the code did.
+
+describe("openDatabase — pragmas", () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sowel-db-test-"));
+    dbPath = join(dir, "sowel.db");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("opens in WAL mode", () => {
+    const db = openDatabase(dbPath);
+    expect(db.pragma("journal_mode", { simple: true })).toBe("wal");
+    db.close();
+  });
+
+  it("sets synchronous to NORMAL, not the SQLite default of FULL", () => {
+    // 0 = OFF, 1 = NORMAL, 2 = FULL. FULL fsyncs on every commit, and the hot
+    // path (one autocommit UPDATE per device data point) has no batching, so
+    // that default meant one fsync per sensor message. See the comment in
+    // database.ts for the trade-off this accepts.
+    const db = openDatabase(dbPath);
+    expect(db.pragma("synchronous", { simple: true })).toBe(1);
+    db.close();
+  });
+
+  it("enforces foreign keys", () => {
+    // Behavioural, not a guard on the pragma line: better-sqlite3 compiles
+    // SQLITE_DEFAULT_FOREIGN_KEYS=1, so removing `db.pragma("foreign_keys =
+    // ON")` would leave this green. What matters is that FK enforcement holds,
+    // however it is obtained — so assert a violation is actually rejected.
+    const db = openDatabase(dbPath);
+    db.exec("CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+    db.exec("CREATE TABLE child (id INTEGER PRIMARY KEY, p INTEGER REFERENCES parent(id))");
+    expect(() => db.prepare("INSERT INTO child (id, p) VALUES (1, 999)").run()).toThrow();
+    db.close();
+  });
+
+  it("re-opens an existing WAL database without changing its pragmas", () => {
+    // The subtle case behind #694: an EXISTING WAL file inherits
+    // SQLITE_DEFAULT_WAL_SYNCHRONOUS at open, a brand-new one does not. Both
+    // paths must land on NORMAL now that we set it explicitly, otherwise the
+    // first process lifetime of a fresh install differs from every later one.
+    const first = openDatabase(dbPath);
+    first.exec("CREATE TABLE probe (id INTEGER PRIMARY KEY, v TEXT)");
+    first.prepare("INSERT INTO probe (id, v) VALUES (1, 'written')").run();
+    first.close();
+
+    const second = openDatabase(dbPath);
+    expect(second.pragma("journal_mode", { simple: true })).toBe("wal");
+    expect(second.pragma("synchronous", { simple: true })).toBe(1);
+    const row = second.prepare("SELECT v FROM probe WHERE id = 1").get() as { v: string };
+    expect(row.v).toBe("written");
+    second.close();
+  });
+
+  it("creates the data directory when it does not exist", () => {
+    const nested = join(dir, "deep", "nested", "sowel.db");
+    const db = openDatabase(nested);
+    expect(existsSync(nested)).toBe(true);
+    db.close();
+  });
+});

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -24,6 +24,39 @@ export function openDatabase(dbPath: string, parentLogger?: Logger): Database.Da
 
   // Enable WAL mode for better concurrent read performance
   db.pragma("journal_mode = WAL");
+
+  // Issue #694 — pin `synchronous` rather than inherit it.
+  //
+  // The effective value today is already NORMAL, but only by accident of a
+  // dependency: better-sqlite3 compiles SQLite with
+  // SQLITE_DEFAULT_WAL_SYNCHRONOUS=1, and SQLite applies that to any database
+  // ALREADY in WAL mode at open time. A brand-new file is different — it is
+  // created in `delete` mode, takes the ordinary default (FULL), and switching
+  // it to WAL afterwards does not re-apply the WAL default. So a fresh install
+  // ran its first process lifetime at FULL, and every boot after that at
+  // NORMAL, with nothing in this repo expressing the intent either way.
+  //
+  // Stating it here makes the choice ours instead of a compile flag's: a
+  // better-sqlite3 bump that drops or flips that define would otherwise
+  // silently move production to one fsync per commit. `database.test.ts` pins
+  // it.
+  //
+  // What NORMAL means under WAL: commits do not fsync, the sync happens at
+  // checkpoint. A power loss or an OS crash can lose transactions committed
+  // since the last checkpoint — with the default wal_autocheckpoint of 1000
+  // pages that is up to ~4 MB of WAL, so potentially many minutes of writes,
+  // not seconds (Linux writeback makes the realistic loss much smaller than
+  // that guaranteed bound). It CANNOT corrupt the database, and recovery is
+  // prefix-consistent: you can never keep transaction N+1 having lost N. A
+  // process crash or a container restart loses nothing, since the host page
+  // cache survives both — but a VM hard-stop is a guest power loss, not a
+  // restart.
+  //
+  // Note this pragma changes WHEN SQLite fsyncs, never how many pages it
+  // writes. It is not a write-amplification fix; batching the per-message
+  // writes in DeviceManager is (see the issue).
+  db.pragma("synchronous = NORMAL");
+
   db.pragma("foreign_keys = ON");
 
   logger?.info({ path: dbPath }, "SQLite database opened");


### PR DESCRIPTION
## What this is, and what it is not

**It is not a performance fix.** Every existing installation already runs at `synchronous=NORMAL`. The issue's original premise was wrong, an agent review caught it before this shipped, and #694 has been rewritten with the corrected facts.

**It is a change of ownership.** `better-sqlite3` compiles SQLite with `SQLITE_DEFAULT_WAL_SYNCHRONOUS=1`, and SQLite applies that to any database already in WAL mode at open time. Verified against a real database opened with no pragmas at all:

```
journal_mode: wal
synchronous : 1     (NORMAL)
```

A brand-new file behaves differently: created in `delete` mode, it takes the ordinary `SQLITE_DEFAULT_SYNCHRONOUS=2`, and switching to WAL afterwards does not re-apply the WAL default:

```
before WAL : delete  sync=2
after  WAL : wal     sync=2
```

So a fresh install ran its **first process lifetime** at FULL and every boot after that at NORMAL, and nothing in this repository expressed the intent either way. A `better-sqlite3` bump that dropped or flipped that define would silently move production to one fsync per commit, with nothing to catch it.

## Two corrections carried into the comment and the doc

1. **Production was never at FULL.** The original probe saw `2` because it created a fresh database, which is exactly the case that does not inherit the WAL default.
2. **`synchronous` does not reduce page writes.** It governs *when* SQLite fsyncs. Measured over 20 000 autocommit UPDATEs, FULL and NORMAL produce **identical WAL volume**. The original flash-wear rationale was wrong on mechanism, and the comment now says explicitly that this is not a write-amplification fix.

## Measured

| | commit rate | peak WAL |
| --- | --- | --- |
| `synchronous=FULL` | ~10 000 commits/s | 4023 KB |
| `synchronous=NORMAL` | ~119 000 commits/s | 4023 KB |

Same bytes written, ~11x commit rate. macOS/APFS, where SQLite uses plain `fsync` rather than `F_FULLFSYNC`, so the latency gap understates Linux. Per the above, production already had this.

## The durability trade-off, restated correctly

The exposure is transactions committed **since the last checkpoint** — up to ~4 MB of WAL at the default `wal_autocheckpoint`, so potentially minutes of writes, not "a few seconds" as the issue originally said. Linux writeback makes the realistic loss far smaller. No corruption, and recovery is prefix-consistent. A process crash or container restart loses nothing; a **VM hard-stop is a guest power loss**, not a restart, which is the realistic scenario for a Proxmox-hosted instance.

Nothing in the codebase depends on FULL: the update flow writes no rows before the swap, `BackupManager` exports logically rather than copying the file (and explicitly excludes `sowel.db`/`-wal`/`-shm`), and the migration runner puts the schema change and the `_migrations` insert in one transaction.

## Changes

- `src/core/database.ts` — the pragma, with a comment that states the real rationale and the real trade-off.
- `src/core/database.test.ts` — new. Pins the pragmas against a **real on-disk** database: an in-memory one silently ignores `journal_mode = WAL`, so a `:memory:` test would pass regardless of the code.
- `docs/technical/architecture.md` — the trade-off documented where the WAL choice already was.

## Test plan

- [x] `npx tsc --noEmit`, `npx eslint src/ --ext .ts` — clean
- [x] `npx vitest run` — 1684 passed, 0 failures (5 new)
- [x] **Mutation-verified**: removing `synchronous = NORMAL` fails its test; removing `journal_mode = WAL` fails another. The `foreign_keys` assertion was vacuous as a pragma read (`SQLITE_DEFAULT_FOREIGN_KEYS=1` is compiled in), so it is now behavioural — a violation must throw.

## Review outcome

An agent review found the premise error above and two vacuous tests; all applied. It also surfaced two things that are **not** in this PR:

- **#697** — `DeviceManager` opens one autocommit transaction per data point, so a ten-attribute message is eleven or twelve commits. This is the real write amplification, and the part of the original report that was right. Not a one-liner: the loop emits events between writes, so persistence has to be separated from notification.
- **#696** — the graceful shutdown never runs. An early `process.exit(0)` SIGTERM handler at `index.ts:84` shadows the real `shutdown` registered at `:793`, so `integrationRegistry.stopAll()` and `db.close()` have apparently never executed in production. Unrelated to this pragma.

Closes #694