### PR TITLE
fix(core): make the graceful shutdown actually run (#696)

### DIFF
--- a/src/core/shutdown-controller.test.ts
+++ b/src/core/shutdown-controller.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createShutdownController, DEFAULT_SHUTDOWN_TIMEOUT_MS } from "./shutdown-controller.js";
+import type { Logger } from "./logger.js";
+
+// Issue #696 — the graceful shutdown had never run in production because an
+// early `process.exit(0)` listener shadowed it. Nothing asserted the wiring,
+// which is exactly why it went unnoticed. These tests are that assertion.
+
+function makeLogger() {
+  const self = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => self,
+  };
+  return self;
+}
+
+describe("createShutdownController", () => {
+  let exit: ReturnType<typeof vi.fn>;
+  let logger: ReturnType<typeof makeLogger>;
+
+  beforeEach(() => {
+    exit = vi.fn();
+    logger = makeLogger();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("exits immediately when a signal arrives before boot finished", () => {
+    // A hang during startup must stay killable — that is the whole reason the
+    // early handler existed in the first place.
+    const controller = createShutdownController({ exit });
+    controller.handle("SIGTERM");
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("runs the graceful sequence once it is installed", async () => {
+    const graceful = vi.fn(async () => {});
+    const controller = createShutdownController({ exit });
+    controller.setGraceful(graceful, logger as unknown as Logger);
+
+    controller.handle("SIGTERM");
+    await vi.runAllTimersAsync();
+
+    expect(graceful).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("does NOT exit before the graceful sequence resolves", async () => {
+    // The regression that mattered: exiting first is what dropped the InfluxDB
+    // write buffer and skipped db.close() on every container restart.
+    let release!: () => void;
+    const graceful = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const controller = createShutdownController({ exit });
+    controller.setGraceful(graceful, logger as unknown as Logger);
+
+    controller.handle("SIGTERM");
+    await Promise.resolve();
+    expect(exit).not.toHaveBeenCalled();
+
+    release();
+    await vi.runAllTimersAsync();
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("runs the sequence only once even if several signals arrive", async () => {
+    const graceful = vi.fn(async () => {});
+    const controller = createShutdownController({ exit });
+    controller.setGraceful(graceful, logger as unknown as Logger);
+
+    controller.handle("SIGTERM");
+    controller.handle("SIGINT");
+    await vi.runAllTimersAsync();
+
+    expect(graceful).toHaveBeenCalledTimes(1);
+  });
+
+  it("exits at once on a second signal, without waiting for the sequence", () => {
+    const graceful = vi.fn(() => new Promise<void>(() => {})); // never resolves
+    const controller = createShutdownController({ exit });
+    controller.setGraceful(graceful, logger as unknown as Logger);
+
+    controller.handle("SIGTERM");
+    expect(exit).not.toHaveBeenCalled();
+
+    controller.handle("SIGTERM");
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("cuts a hung sequence short rather than being SIGKILLed", async () => {
+    // A stuck integration must not hold the process past the container's grace
+    // period, or the runtime escalates a clean stop into a kill.
+    const graceful = vi.fn(() => new Promise<void>(() => {}));
+    const controller = createShutdownController({ exit, timeoutMs: 500 });
+    controller.setGraceful(graceful, logger as unknown as Logger);
+
+    controller.handle("SIGTERM");
+    expect(exit).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 500 }),
+      expect.stringContaining("timed out"),
+    );
+  });
+
+  it("still exits PROMPTLY when the sequence throws", async () => {
+    // Must not lean on the watchdog: with a huge timeout, only the catch path
+    // can produce the exit. (Reviewed finding — the earlier version of this
+    // test passed even when the error path exited nothing, because
+    // runAllTimersAsync fired the 8 s fallback.)
+    const graceful = vi.fn(async () => {
+      throw new Error("integration blew up");
+    });
+    const controller = createShutdownController({ exit, timeoutMs: 10 * 60_000 });
+    controller.setGraceful(graceful, logger as unknown as Logger);
+
+    controller.handle("SIGTERM");
+    await vi.advanceTimersByTimeAsync(1); // 1 ms, the watchdog is 10 min away
+
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("survives a sequence that throws SYNCHRONOUSLY", async () => {
+    // The declared contract returns a promise, but a synchronous throw would
+    // escape the signal listener into uncaughtException and exit 1.
+    const graceful = vi.fn(() => {
+      throw new Error("threw before returning a promise");
+    }) as unknown as () => Promise<void>;
+    const controller = createShutdownController({ exit, timeoutMs: 10 * 60_000 });
+    controller.setGraceful(graceful, logger as unknown as Logger);
+
+    expect(() => controller.handle("SIGTERM")).not.toThrow();
+    await vi.advanceTimersByTimeAsync(1); // 1 ms, the watchdog is 10 min away
+
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("exits exactly once on the happy path", async () => {
+    // Pins clearTimeout: without it the watchdog fires later and exits again.
+    const graceful = vi.fn(async () => {});
+    const controller = createShutdownController({ exit, timeoutMs: 500 });
+    controller.setGraceful(graceful, logger as unknown as Logger);
+
+    controller.handle("SIGTERM");
+    await vi.runAllTimersAsync();
+
+    expect(exit).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs a signal received during boot instead of exiting silently", () => {
+    // Boot emits dozens of lines before the graceful sequence exists; a silent
+    // exit there is indistinguishable from a crash.
+    const controller = createShutdownController({ exit });
+    controller.setLogger(logger as unknown as Logger);
+
+    controller.handle("SIGINT");
+
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: "SIGINT" }),
+      expect.stringContaining("boot"),
+    );
+  });
+
+  it("defaults to a timeout inside Docker's 10 s stop grace period", () => {
+    expect(DEFAULT_SHUTDOWN_TIMEOUT_MS).toBeLessThan(10_000);
+  });
+});
+
+describe("createShutdownController — install()", () => {
+  let exit: ReturnType<typeof vi.fn>;
+  let before: { int: number; term: number };
+
+  beforeEach(() => {
+    exit = vi.fn();
+    before = {
+      int: process.listenerCount("SIGINT"),
+      term: process.listenerCount("SIGTERM"),
+    };
+  });
+
+  afterEach(() => {
+    // Leave the runner's own handlers alone: drop only what this test added.
+    for (const sig of ["SIGINT", "SIGTERM"] as const) {
+      const added = process.listenerCount(sig) - (sig === "SIGINT" ? before.int : before.term);
+      const listeners = process.listeners(sig);
+      for (let i = 0; i < added; i += 1) {
+        process.removeListener(sig, listeners[listeners.length - 1 - i]);
+      }
+    }
+  });
+
+  it("registers exactly ONE listener per signal", () => {
+    // The bug this whole module exists for: two sites each registered their
+    // own handler, and Node ran them in registration order so the first won.
+    createShutdownController({ exit }).install();
+
+    expect(process.listenerCount("SIGINT")).toBe(before.int + 1);
+    expect(process.listenerCount("SIGTERM")).toBe(before.term + 1);
+  });
+
+  it("routes a real emitted signal to handle()", () => {
+    createShutdownController({ exit }).install();
+
+    process.emit("SIGTERM");
+
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/core/shutdown-controller.ts
+++ b/src/core/shutdown-controller.ts
@@ -1,0 +1,132 @@
+import type { Logger } from "./logger.js";
+
+/**
+ * Issue #696 — one signal handler for the whole process lifetime.
+ *
+ * The engine needs two different shutdown behaviours depending on how far boot
+ * has got, and the previous code expressed that by registering two separate
+ * listeners: an immediate `process.exit(0)` at the top of `main()`, and the
+ * graceful sequence ~700 lines later. Node runs signal listeners in
+ * REGISTRATION ORDER, so the first one always won and the graceful sequence was
+ * dead code — integrations were never stopped, the database was never closed,
+ * and the InfluxDB write buffer was dropped on every container restart.
+ *
+ * A controller fixes that by inverting the relationship: exactly one listener
+ * is registered, at the top of boot, and it dispatches to whichever behaviour
+ * is currently installed. Boot stays killable, and the graceful sequence takes
+ * over the moment it exists.
+ */
+
+/** Docker's default stop grace period is 10 s; finish inside it. */
+export const DEFAULT_SHUTDOWN_TIMEOUT_MS = 8000;
+
+export interface ShutdownControllerOptions {
+  /** Injected so tests do not terminate the runner. */
+  exit?: (code: number) => void;
+  /** How long the graceful sequence may run before it is cut short. */
+  timeoutMs?: number;
+}
+
+export interface ShutdownController {
+  /**
+   * Register the SIGINT/SIGTERM listeners. Owning the registration here is
+   * what makes the bug class testable: a test can assert there is exactly ONE
+   * listener per signal, which is precisely what went wrong when two separate
+   * sites each registered their own.
+   */
+  install(): void;
+  /**
+   * What the listeners call. Exposed so a restart path can reuse the same
+   * sequence rather than calling `process.exit` behind the controller's back.
+   */
+  handle(signal: string): void;
+  /**
+   * Give the controller a logger as soon as one exists, well before the
+   * graceful sequence does. Without it a signal during boot exits silently,
+   * which reads exactly like a crash.
+   */
+  setLogger(logger: Logger): void;
+  /**
+   * Upgrade from "exit immediately" to the real sequence. Called once boot has
+   * produced something worth shutting down cleanly.
+   */
+  setGraceful(fn: () => Promise<void>, logger: Logger): void;
+}
+
+export function createShutdownController(
+  options: ShutdownControllerOptions = {},
+): ShutdownController {
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const timeoutMs = options.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
+
+  let graceful: (() => Promise<void>) | null = null;
+  let logger: Logger | null = null;
+  let running = false;
+
+  const controller: ShutdownController = {
+    install(): void {
+      process.on("SIGINT", () => controller.handle("SIGINT"));
+      process.on("SIGTERM", () => controller.handle("SIGTERM"));
+    },
+
+    setLogger(log: Logger): void {
+      logger = log.child({ module: "shutdown" });
+    },
+
+    setGraceful(fn: () => Promise<void>, log: Logger): void {
+      graceful = fn;
+      logger = log.child({ module: "shutdown" });
+    },
+
+    handle(signal: string): void {
+      // Boot has not finished: nothing to unwind, and a startup hang must stay
+      // killable. Logged when a logger already exists — boot emits dozens of
+      // lines before the graceful sequence is installed, so a silent exit
+      // there would be indistinguishable from a crash.
+      if (!graceful) {
+        logger?.info({ signal }, "Signal during boot, exiting");
+        exit(0);
+        return;
+      }
+
+      // A second signal while the sequence runs means the operator is done
+      // waiting. Exit 0 rather than a failure code: an interrupted stop is not
+      // a crash, and a non-zero code can trip a container restart policy.
+      if (running) {
+        logger?.warn({ signal }, "Second signal during shutdown, exiting now");
+        exit(0);
+        return;
+      }
+
+      running = true;
+      logger?.info({ signal }, "Signal received, shutting down");
+
+      // A hung step must never hold the process past the container's grace
+      // period, or the runtime turns a clean stop into a SIGKILL.
+      const timer = setTimeout(() => {
+        logger?.warn({ timeoutMs }, "Shutdown timed out, exiting now");
+        exit(0);
+      }, timeoutMs);
+      timer.unref?.();
+
+      // Wrapped rather than called directly: the contract is `() => Promise`,
+      // but a synchronous throw would escape the signal listener entirely and
+      // surface as an uncaughtException, exiting 1 instead of taking this path
+      // at all.
+      void Promise.resolve()
+        .then(() => graceful?.())
+        .catch((err: unknown) => {
+          // Load-bearing rather than decorative: the tail of the sequence (the
+          // final log flush) is outside any try/catch, so without this a throw
+          // would leave the process hanging until the watchdog fires.
+          logger?.error({ err }, "Shutdown sequence failed");
+        })
+        .finally(() => {
+          clearTimeout(timer);
+          exit(0);
+        });
+    },
+  };
+
+  return controller;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,10 @@ import { WeatherTempExtremesTracker } from "./equipments/weather-temp-extremes-t
 import { ZoneAggregator } from "./zones/zone-aggregator.js";
 import { SunlightManager } from "./zones/sunlight-manager.js";
 import { RecipeManager } from "./recipes/engine/recipe-manager.js";
+import { createShutdownController } from "./core/shutdown-controller.js";
+
+/** Half the shutdown budget, so the steps after stopAll() always get a share. */
+const INTEGRATION_STOP_TIMEOUT_MS = 4000;
 import { CapacityArbiter } from "./energy/capacity-arbiter.js";
 import { ArbiterJournalStore } from "./energy/arbiter-journal-store.js";
 import { ArbiterSurplusStore } from "./energy/arbiter-surplus-store.js";
@@ -81,12 +85,19 @@ async function main() {
   // 0. Clean up any stale PID file from a previous run
   cleanStalePidFile("./data");
 
-  process.on("SIGINT", () => {
-    process.exit(0);
-  });
-  process.on("SIGTERM", () => {
-    process.exit(0);
-  });
+  // Issue #696 — ONE signal listener for the whole process lifetime.
+  //
+  // This used to be an immediate `process.exit(0)` here plus the graceful
+  // `shutdown` registered at the end of boot. Node runs signal listeners in
+  // registration order, so this one always won and the graceful sequence never
+  // ran: integrations were never stopped, `db.close()` never called, and the
+  // InfluxDB write buffer was dropped on every container restart.
+  //
+  // The controller keeps both behaviours without the ordering trap. Until
+  // `setGraceful` is called it exits immediately, so a hang during boot stays
+  // killable; afterwards the same listener runs the real sequence.
+  const shutdownController = createShutdownController();
+  shutdownController.install();
 
   // 1. Load configuration
   const config = loadConfig();
@@ -113,6 +124,9 @@ async function main() {
   const logBuffer = new LogRingBuffer();
   const logHandle = createLogger(config.log.level, logBuffer);
   const logger = logHandle.logger;
+  // From here on a signal during boot says so instead of exiting silently,
+  // which would read as a crash in the logs (#696).
+  shutdownController.setLogger(logger);
 
   // Spec 124 — run a boot step only outside shadow mode; in shadow mode emit a
   // single consistent "Skipping <label>" line. `config.shadowMode` is read live
@@ -564,7 +578,13 @@ async function main() {
         { module: "instance-identity" },
         "Restarting to complete the takeover (docker restart policy will bring the engine back armed)",
       );
-      setTimeout(() => process.exit(0), 500);
+      // Routed through the controller rather than a bare process.exit: this is
+      // the same bug class #696 fixes, and a takeover restart deserves the
+      // clean sequence (buffered Influx points flushed, WAL checkpointed) just
+      // as much as a SIGTERM does. The delay is preserved so the HTTP response
+      // reaches the caller first.
+      const t = setTimeout(() => shutdownController.handle("RESTART"), 500);
+      t.unref?.();
     },
   });
 
@@ -776,7 +796,24 @@ async function main() {
       logger.error({ err }, "Error closing HTTP server");
     }
     try {
-      await integrationRegistry.stopAll();
+      // Bounded on purpose. `stopAll()` awaits each plugin in sequence with no
+      // per-plugin limit, and it runs BEFORE `db.close()`. A plugin stalling on
+      // a socket to a broker that has gone away (exactly what a `docker compose
+      // stop` produces) would otherwise eat the whole shutdown budget, the
+      // watchdog would hard-exit, and the WAL checkpoint this fix exists to
+      // guarantee still would not happen. Losing a clean plugin stop is the
+      // cheaper failure. Not reordered ahead of `db.close()`: plugins can write
+      // settings while stopping.
+      await Promise.race([
+        integrationRegistry.stopAll(),
+        new Promise<void>((resolve) => {
+          const t = setTimeout(() => {
+            logger.warn({ timeoutMs: INTEGRATION_STOP_TIMEOUT_MS }, "Integration stop timed out");
+            resolve();
+          }, INTEGRATION_STOP_TIMEOUT_MS);
+          t.unref?.();
+        }),
+      ]);
     } catch (err) {
       logger.error({ err }, "Error stopping integrations");
     }
@@ -787,11 +824,12 @@ async function main() {
     }
     logger.info("Shutdown complete");
     await logHandle.close();
-    process.exit(0);
   };
 
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
+  // Hand the sequence to the listener registered at the top of boot. The
+  // controller owns the exit, so `shutdown` no longer calls process.exit
+  // itself — that is what lets it be awaited to completion.
+  shutdownController.setGraceful(shutdown, logger);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## The bug

`main()` registered an immediate `process.exit(0)` on SIGINT/SIGTERM at the top (`src/index.ts:84`), and the real graceful `shutdown` ~700 lines later (`:793`). Node runs signal listeners **in registration order**, and nothing removed the first one, so the graceful sequence was dead code. It has apparently never executed in production.

**Verified empirically, before and after.** Booted the engine on a throwaway database and sent SIGTERM:

| | shutdown log lines |
| --- | --- |
| pre-fix | **0** — process died straight after "started successfully" |
| post-fix | `Signal received, shutting down` → `Shutting down...` → `Shutdown complete`, process gone in ~3 ms |

## What was being skipped, on every container restart / stop / self-update recreate

- `integrationRegistry.stopAll()` — integrations torn down by the socket dying rather than closed
- `influxClient.disconnect()` → `writeApi.close()`, which **flushes the write buffer**. Buffered energy points were dropped: real data loss, a small history gap at every restart
- `db.close()` — the truncating checkpoint, the one guaranteed WAL sync point in the process lifetime
- every timer stop (arbiter, metrics rollup, sunlight, version checker)

## The fix

A controller owns the single registration and dispatches to whichever behaviour boot has reached: exit immediately before `setGraceful` (a hang during startup must stay killable), the real sequence after. It bounds the sequence with an 8 s watchdog, inside Docker's 10 s stop grace, so a stuck step cannot turn a clean stop into a SIGKILL.

Registration lives in `install()` rather than in `index.ts`, which is what lets a test assert **exactly one listener per signal** — pinning the precise bug class without needing `main()` to be testable.

## Applied from the agent review

- **`stopAll()` had no bound and runs before `db.close()`.** A plugin stalling on a broker that has gone away — exactly what `docker compose stop` produces — would eat the whole budget, the watchdog would hard-exit, and the WAL checkpoint this fix exists to guarantee still would not happen. That converts "never runs" into "does not run precisely when it matters". Bounded at 4 s so the later steps always get a share. Not reordered ahead of `db.close()`: plugins can write settings while stopping.
- **`requestRestart` called a bare `process.exit(0)`** — the same bug class, in the same file, well after the controller exists. Routed through it, so a takeover restart also flushes Influx and checkpoints the WAL.
- **A signal during boot exited silently** even though the logger exists by then, which reads as a crash. `setLogger` is called right after the logger is created.
- **A synchronously-throwing sequence** would have escaped the listener into `uncaughtException` and exited 1. The call is wrapped.
- **Two tests were vacuous.** The throw test passed because `runAllTimersAsync` fired the 8 s watchdog, which also exits — it could not tell "exits promptly on a throw" from "exits 8 s later". Both now push the watchdog 10 minutes out and assert promptness.

## Test plan

- [x] `npx tsc --noEmit`, `npx eslint src/ --ext .ts` — clean
- [x] `npx vitest run` — 1697 passed, 0 failures (13 new)
- [x] **Empirical**: real boot + SIGTERM, before and after (table above)
- [x] **Mutation-verified**: the pair of throw tests fails under the exact mutation the reviewer used (catch rethrows + `.finally` → `.then`); exit-before-await fails 3 tests; dropping the `running` guard fails 2
- [x] `install()` pinned by a test asserting one listener per signal, and that a really emitted SIGTERM reaches `handle`

## Not addressed here

The review noted that the release will need `docs/release-notes.md` and `.fr.md` entries (spec 108) — that belongs to the release commit, not this PR.

Closes #696