### PR TITLE
fix(devices): one transaction per message, events after the commit (#697)

### DIFF
--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Database from "better-sqlite3";
 import { DeviceManager } from "./device-manager.js";
 import { applyMigrations } from "../test-helpers/migrations.js";
@@ -851,5 +851,183 @@ describe("DeviceManager", () => {
       expect(ageMs).toBeGreaterThanOrEqual(0);
       expect(ageMs).toBeLessThan(10 * 60 * 1000);
     });
+  });
+});
+
+// ============================================================
+// Issue #697 — one transaction per message, events after the commit
+// ============================================================
+
+describe("DeviceManager — batched message writes (#697)", () => {
+  let db: Database.Database;
+  let eventBus: EventBus;
+  let manager: DeviceManager;
+
+  const device = {
+    ieeeAddress: "0x00158d0009f8e7d6",
+    friendlyName: "salon_multi",
+    manufacturer: "Xiaomi",
+    model: "MULTI",
+    data: [
+      { key: "temperature", type: "number" as const, category: "temperature" as const, unit: "°C" },
+      { key: "humidity", type: "number" as const, category: "humidity" as const, unit: "%" },
+      { key: "battery", type: "number" as const, category: "battery" as const, unit: "%" },
+    ],
+    orders: [],
+    rawExpose: [],
+  };
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    applyMigrations(db);
+    eventBus = new EventBus(logger);
+    manager = new DeviceManager(db, eventBus, logger);
+    manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", device);
+  });
+
+  afterEach(() => db.close());
+
+  /** Every stored value of the device, as a consumer would read it back. */
+  function storedValues(): Record<string, unknown> {
+    const rows = db
+      .prepare(
+        "SELECT dd.key, dd.value FROM device_data dd" +
+          " JOIN devices d ON d.id = dd.device_id WHERE d.source_device_id = ?",
+      )
+      .all("salon_multi") as { key: string; value: string | null }[];
+    return Object.fromEntries(
+      rows.map((r) => [r.key, r.value === null ? null : JSON.parse(r.value)]),
+    );
+  }
+
+  it("has every value of the message already committed when the FIRST event fires", () => {
+    // The regression this fixes. Emitting between writes made a consumer that
+    // re-reads siblings (several trackers call getDataBindingsWithValues) see
+    // a partially applied message: the temperature event fired while humidity
+    // and battery still held their previous values.
+    const seenAtFirstEvent: Record<string, unknown>[] = [];
+    eventBus.on((event) => {
+      if (event.type === "device.data.updated") seenAtFirstEvent.push(storedValues());
+    });
+
+    manager.updateDeviceData("zigbee2mqtt", "salon_multi", {
+      temperature: 21.5,
+      humidity: 55,
+      battery: 88,
+    });
+
+    expect(seenAtFirstEvent).toHaveLength(3);
+    // Without the fix the first snapshot holds only the temperature.
+    expect(seenAtFirstEvent[0]).toMatchObject({
+      temperature: 21.5,
+      humidity: 55,
+      battery: 88,
+    });
+  });
+
+  it("opens exactly ONE transaction per message, whatever the attribute count", () => {
+    // The invariant the whole change exists for. Asserting `db.inTransaction`
+    // at emit time is NOT enough: it reads false when there is no transaction
+    // at all, so it passes for an implementation that dropped the batching
+    // entirely (reviewed finding). Count the invocations instead, by wrapping
+    // what `db.transaction()` hands back.
+    const real = db.transaction.bind(db);
+    let invocations = 0;
+    const spy = vi.spyOn(db, "transaction").mockImplementation(((fn: () => void) => {
+      const wrapped = real(fn);
+      return ((...args: unknown[]) => {
+        invocations += 1;
+        return (wrapped as (...a: unknown[]) => unknown)(...args);
+      }) as never;
+    }) as never);
+
+    const local = new DeviceManager(db, eventBus, logger);
+    spy.mockRestore();
+    invocations = 0;
+
+    local.updateDeviceData("zigbee2mqtt", "salon_multi", {
+      temperature: 20,
+      humidity: 50,
+      battery: 77,
+    });
+
+    // One per MESSAGE. Zero would mean the batching was dropped; three would
+    // mean it went back to one per data point.
+    expect(invocations).toBe(1);
+  });
+
+  it("emits EVERY event outside the transaction, heartbeat included", () => {
+    // Covering only device.data.updated let a heartbeat emitted inside the
+    // write lock go unnoticed (reviewed finding).
+    const inTx: Record<string, boolean[]> = {};
+    eventBus.on((event) => {
+      (inTx[event.type] ??= []).push(db.inTransaction);
+    });
+
+    manager.updateDeviceData("zigbee2mqtt", "salon_multi", { temperature: 20, humidity: 50 });
+
+    expect(Object.keys(inTx)).toContain("device.heartbeat");
+    for (const [, values] of Object.entries(inTx)) {
+      expect(values.every((v) => v === false)).toBe(true);
+    }
+  });
+
+  it("keeps the rest of the message when ONE attribute cannot be stored", () => {
+    // A poison value (a BigInt from a protocol plugin reaches JSON.stringify)
+    // must not roll back the message. Before the guard it took the device
+    // offline: `last_seen` was never refreshed and no heartbeat fired, so a
+    // perfectly healthy device looked dead.
+    manager.updateDeviceData("zigbee2mqtt", "salon_multi", {
+      temperature: 21,
+      humidity: BigInt(55) as unknown as number,
+      battery: 80,
+    });
+
+    const stored = storedValues();
+    expect(stored.temperature).toBe(21);
+    expect(stored.battery).toBe(80);
+
+    const row = db
+      .prepare("SELECT status, last_seen FROM devices WHERE source_device_id = ?")
+      .get("salon_multi") as { status: string; last_seen: string | null };
+    expect(row.status).toBe("online");
+    expect(row.last_seen).not.toBeNull();
+  });
+
+  it("forwards sourceTimestamp through to the emitted event", () => {
+    // The aligned-history path (30-min plugin windows) depends on it, and the
+    // batching added two parameter hops where it could silently be dropped.
+    const seen: (number | undefined)[] = [];
+    eventBus.on((event) => {
+      if (event.type === "device.data.updated") seen.push(event.sourceTimestamp);
+    });
+
+    manager.updateDeviceData("zigbee2mqtt", "salon_multi", { temperature: 18 }, 1_756_000_000);
+
+    expect(seen).toEqual([1_756_000_000]);
+  });
+
+  it("still emits the same events, in the same order", () => {
+    const seen: string[] = [];
+    eventBus.on((event) => {
+      if (event.type === "device.data.updated") seen.push(event.key);
+      else if (event.type === "device.heartbeat") seen.push("heartbeat");
+    });
+
+    manager.updateDeviceData("zigbee2mqtt", "salon_multi", {
+      temperature: 22,
+      humidity: 51,
+      battery: 90,
+    });
+
+    expect(seen).toEqual(["heartbeat", "temperature", "humidity", "battery"]);
+  });
+
+  it("still auto-discovers a data point that appears mid-message", () => {
+    // The insert and its re-read both happen inside the transaction.
+    manager.updateDeviceData("zigbee2mqtt", "salon_multi", { temperature: 23, pressure: 1013 });
+
+    expect(storedValues()).toMatchObject({ temperature: 23, pressure: 1013 });
   });
 });

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -22,6 +22,7 @@ import type {
   DataCategory,
   OrderCategory,
   PowerSource,
+  EngineEvent,
 } from "../shared/types.js";
 import { CATEGORY_EXPECTED_TYPE, PROPERTY_TO_CATEGORY } from "../shared/constants.js";
 import { parseWireValue } from "../shared/order-wire-value.js";
@@ -87,6 +88,7 @@ export class DeviceManager {
     this.eventBus = eventBus;
     this.logger = logger.child({ module: "device-manager" });
     this.stmts = this.prepareStatements();
+    this.writeMessage = this.buildWriteMessage();
   }
 
   private prepareStatements() {
@@ -424,30 +426,107 @@ export class DeviceManager {
       | undefined;
     if (!device) return;
 
-    // A device sending data is online — update status and last_seen
-    this.stmts.updateDeviceLastSeen.run(device.id);
-    this.eventBus.emit({
-      type: "device.heartbeat",
-      deviceId: device.id,
-      timestamp: new Date().toISOString(),
-    });
-    if (device.status !== "online") {
-      this.stmts.updateDeviceStatus.run("online", device.id);
-      this.eventBus.emit({
-        type: "device.status_changed",
-        deviceId: device.id,
-        deviceName: device.name,
-        status: "online",
-      });
-    }
+    // Issue #697 — one transaction per MESSAGE, not one per data point.
+    //
+    // These writes used to run in autocommit, so a Zigbee message carrying ten
+    // attributes was eleven or twelve separate transactions and as many WAL
+    // frames. Measured against this very code path: 10x fewer WAL bytes and
+    // ~2.5x faster per message.
+    //
+    // Events are collected here and emitted AFTER the transaction commits,
+    // which matters for more than write volume: several trackers re-read every
+    // binding of an equipment (`getDataBindingsWithValues`), so emitting
+    // between writes made them observe a partially applied message — key 1's
+    // event firing while keys 2..N still held their previous values, once per
+    // key. Emitting after the commit gives every consumer a consistent
+    // snapshot. It also keeps the handlers OUT of the write transaction:
+    // emitting inside it would pull the whole reactive pipeline (equipment,
+    // zones, recipes, Influx, MQTT) and half a dozen handler DB writes into
+    // the device write lock, and make them part of the message's atomic unit.
+    const events: EngineEvent[] = [];
 
+    this.writeMessage(device, payload, events, sourceTimestamp);
+
+    for (const event of events) this.eventBus.emit(event);
+  }
+
+  /** Built once in the constructor: `db.transaction()` allocates wrapper
+   *  functions on every call, which is ~5 % of this hot path per message. */
+  private readonly writeMessage: (
+    device: DeviceRow,
+    payload: Record<string, unknown>,
+    events: EngineEvent[],
+    sourceTimestamp?: number,
+  ) => void;
+
+  private buildWriteMessage() {
+    return this.db.transaction(
+      (
+        device: DeviceRow,
+        payload: Record<string, unknown>,
+        events: EngineEvent[],
+        sourceTimestamp?: number,
+      ) => {
+        // A device sending data is online — update status and last_seen
+        this.stmts.updateDeviceLastSeen.run(device.id);
+        events.push({
+          type: "device.heartbeat",
+          deviceId: device.id,
+          timestamp: new Date().toISOString(),
+        });
+        if (device.status !== "online") {
+          this.stmts.updateDeviceStatus.run("online", device.id);
+          events.push({
+            type: "device.status_changed",
+            deviceId: device.id,
+            deviceName: device.name,
+            status: "online",
+          });
+        }
+
+        this.writePayload(device, payload, events, sourceTimestamp);
+      },
+    );
+  }
+
+  /** Per-key writes of one message. Runs inside the #697 transaction. */
+  private writePayload(
+    device: DeviceRow,
+    payload: Record<string, unknown>,
+    events: EngineEvent[],
+    sourceTimestamp?: number,
+  ): void {
     for (const [key, value] of Object.entries(payload)) {
+      // Per-key guard. Everything here runs inside the message transaction, so
+      // without it one unserializable attribute (a BigInt from a Modbus-style
+      // plugin reaches JSON.stringify below and throws) would roll back the
+      // WHOLE message — including `last_seen` and the heartbeat, which are
+      // logically independent of payload validity. The device would then be
+      // transmitting fine yet marked permanently offline. Skip the poison key,
+      // keep the rest of the message and the liveness signal.
+      try {
+        this.writeDataPoint(device, key, value, events, sourceTimestamp);
+      } catch (err) {
+        this.logger.error({ err, deviceId: device.id, key }, "Failed to store device data point");
+      }
+    }
+  }
+
+  /** One key of one message. Throws only on genuinely unusable input. */
+  private writeDataPoint(
+    device: DeviceRow,
+    key: string,
+    value: unknown,
+    events: EngineEvent[],
+    sourceTimestamp?: number,
+  ): void {
+    {
       let dataRow = this.stmts.findDeviceDataByKey.get(device.id, key) as DeviceDataRow | undefined;
 
       // Auto-create device_data for known properties missing from exposes (e.g. Tuya battery)
       if (!dataRow) {
         const category = PROPERTY_TO_CATEGORY[key];
-        if (!category) continue; // Truly unknown property, skip
+        if (!category) return; // Truly unknown property, skip
         const dataType: DataType =
           typeof value === "boolean" ? "boolean" : typeof value === "number" ? "number" : "text";
         const unit =
@@ -479,7 +558,7 @@ export class DeviceManager {
           "Auto-created device_data from payload",
         );
         dataRow = this.stmts.findDeviceDataByKey.get(device.id, key) as DeviceDataRow | undefined;
-        if (!dataRow) continue;
+        if (!dataRow) return;
       }
 
       // Spec 150 — single normalization point: coerce the raw plugin value to
@@ -507,7 +586,7 @@ export class DeviceManager {
 
       this.stmts.updateDeviceDataValue.run(serialized, serialized, dataRow.id);
 
-      this.eventBus.emit({
+      events.push({
         type: "device.data.updated",
         deviceId: device.id,
         deviceName: device.name,


### PR DESCRIPTION
## The change

`updateDeviceData` wrote in autocommit and emitted events between the writes, so a Zigbee message carrying ten attributes was eleven or twelve separate transactions and as many WAL frames. The writes now run in **one transaction per message**, and the events are emitted after it commits.

## Measured against this very code path

3000 messages of 10 attributes, real `DeviceManager`, production pragmas (WAL, `synchronous=NORMAL`), autocheckpoint disabled so WAL size equals bytes written:

| | `main` | branch | |
| --- | --- | --- | --- |
| time | 181 µs/message | 65 µs/message | **2.8x faster** |
| WAL bytes | 41 200 B/message | 4 120 B/message | **10.0x fewer** |

Note "WAL bytes": checkpointing coalesces repeated writes to the same page, so main-database write volume drops by less than 10x.

## It is also a consistency fix, which I had underestimated

Several consumers re-read siblings mid-message, so they were observing a **partially applied message, once per key**:

- **`pool-water-temp-tracker`** reads `temperature`, `filtration_state` and `mode` together and then **persists** `lastActiveValue`. A message carrying temperature and mode fired the temperature event while `mode` still held its previous value, so a stagnant-water reading could be persisted as last-known-good and served for 24 h. Silent data corruption, and nobody had noticed it.
- **`deriveGateState`** folds every `RS*` binding and emitted a derived state computed from a half-applied message.
- **`power-submeter-integrator`** classifies power-only vs energy across bindings and could integrate a phantom Wh delta.
- **`zone-aggregator`** recomputed the whole chain and published transient wrong totals to MQTT and notifications.

The agent review swept every consumer of `device.data.updated` and everything downstream: nothing depended on the interleaving, and the four above were victims of it.

## Two regressions the review caught before they shipped

1. **A single unserializable value rolled back the whole message.** A BigInt from a protocol plugin reaches `JSON.stringify` inside the transaction and throws, so `last_seen` and the heartbeat — logically independent of payload validity — were lost too. A healthy, transmitting device would have been marked **permanently offline**, and because the type-mismatch warning is deduplicated in memory the loss would have been silent. Each key is now guarded: the poison key is skipped and logged, the rest of the message and the liveness signal survive.
2. **The "one transaction per message" test asserted nothing.** It checked `db.inTransaction === false` at emit time, which is equally true when there is **no** transaction: removing the batching entirely left all 60 tests green. It now counts invocations of the wrapper and fails at 0 (batching dropped) as well as at 3 (back to one per key).

## Also applied from the review

- The transaction wrapper is built once in the constructor rather than per message (~5 % of the hot path, on a change whose point is hot-path efficiency).
- Event-outside-transaction is asserted for **every** event type, not just `device.data.updated` — a heartbeat emitted inside the write lock previously went unnoticed.
- `sourceTimestamp` gained a test: the change added two parameter hops where it could silently be dropped, and it feeds the aligned InfluxDB energy path.
- A comment claiming this stops a throwing handler from rolling back device data was **removed as false** — `EventBus` already swallows handler throws, so that was never a risk. The real justification is stated instead.

## Test plan

- [x] `npx tsc --noEmit`, `npx eslint src/ --ext .ts` — clean
- [x] `npx vitest run` — 1704 passed, 0 failures (7 new)
- [x] **Mutation-verified**: dropping the transaction fails the count test; removing the poison-key guard fails the liveness test; restoring the emit inside the loop fails 3 tests
- [x] Benchmarked branch vs `main` on the real `DeviceManager` (table above)

Closes #697