### PR TITLE
chore(registry): add community plugin nut (UPS via Network UPS Tools)

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -599,7 +599,7 @@
         "description": "Onduleurs exposés par un serveur Network UPS Tools (NUT) — état, charge et autonomie de la batterie, charge, alarmes"
       }
     },
-    "sowelVersion": ">=1.43.0",
+    "sowelVersion": ">=1.53.0",
     "owner": "adn-dev-adrien",
     "sha256": "07974d1dde193c8359ead021947bd650324a70e10bc11763edb488e896a8461c"
   }

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -582,5 +582,25 @@
     "sowelVersion": ">=1.52.0",
     "owner": "mchacher",
     "sha256": "65570863aa52e4be29561d65d0e60abf4ba05181e9de358f01dfc6a5214290a0"
+  },
+  {
+    "id": "nut",
+    "type": "integration",
+    "name": "NUT (UPS)",
+    "description": "Uninterruptible power supplies exposed by a Network UPS Tools (NUT) server — status, battery charge and runtime, load, alarms",
+    "icon": "BatteryCharging",
+    "author": "adn-dev-adrien",
+    "repo": "adn-dev-adrien/sowel-plugin-nut",
+    "version": "0.1.1",
+    "tags": ["nut", "ups", "battery", "power", "backup", "monitoring"],
+    "i18n": {
+      "fr": {
+        "name": "NUT (onduleur)",
+        "description": "Onduleurs exposés par un serveur Network UPS Tools (NUT) — état, charge et autonomie de la batterie, charge, alarmes"
+      }
+    },
+    "sowelVersion": ">=1.43.0",
+    "owner": "adn-dev-adrien",
+    "sha256": "07974d1dde193c8359ead021947bd650324a70e10bc11763edb488e896a8461c"
   }
 ]


### PR DESCRIPTION
Lists [`adn-dev-adrien/sowel-plugin-nut`](https://github.com/adn-dev-adrien/sowel-plugin-nut) **v0.1.1** in the official registry, so UPS monitoring is installable from the Store instead of requiring a personal source.

## The plugin

Reads a [Network UPS Tools](https://networkupstools.org/) (`upsd`) server — Synology DSM, QNAP, Proxmox, or any Linux host running NUT — over the native text protocol on `node:net`. **No runtime dependency.** One device per UPS, ~29 data points, Sowel alarms for `on_battery` / `low_battery` / `replace_battery`. 52 tests.

**Strictly read-only.** It never sends a command to a UPS: no beeper mute, no self-test, no load-segment shutdown. An accidental shutdown order to a UPS is unrecoverable, and the orderly-shutdown chain belongs to `upsmon` on each protected host, where it can actually stop services before the power goes.

Running in production since 2026-08-21 against an APC Back-UPS BX950MI behind a Synology `upsd`.

## Three deliberate choices worth knowing when reviewing

- **The estimated wattage never carries the `power` category** (`estimated_power`, `generic`). Sub-meter enrolment is a blocklist: any device with a numeric `power` binding joins the house consumption split, and this value is an estimate (load % × nominal VA) that would double-count against the real meter.
- **`powerSource: "mains"` on the device**, so the low-battery monitor (spec 143) does not shout "replace the battery" on every mains cut.
- **`on_battery` also covers `low_battery`** — scoping them separately would resolve the outage alarm exactly as things get worse, which reads as "power restored" in a notification feed.

⚠️ Poll interval defaults to 300 s, which is also the outage detection latency. This is monitoring, not real-time alerting — a micro-cut goes unseen.

## Registry mechanics

- `owner: adn-dev-adrien` is not in `OFFICIAL_OWNERS`, so installs go through the community confirmation modal.
- `sha256` computed by `scripts/backfill-registry-sha256.mjs` from the published v0.1.1 release asset (`07974d1d…`, matches the GitHub asset digest).
- `sowelVersion: ">=1.43.0"` — the version that brought `powerSource`, deliberately **not** 1.53.0. The `ups` equipment type (spec 156, #676) is still under review; until it lands the plugin is still useful: devices and values show in the Devices page and the alarms fire. Binding to a UPS equipment comes for free once #676 ships, without a registry bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)