### PR TITLE
feat(ui): show forecast confidence and source on the weather card

### DIFF
--- a/docs/planning/2026-08-24-weather-multi-model.md
+++ b/docs/planning/2026-08-24-weather-multi-model.md
@@ -1,0 +1,731 @@
+# Weather forecast: multi-model and ensemble
+
+Status: draft, not a spec yet. Written 2026-08-24.
+Scope: `sowel-plugin-weather-forecast` (specs 041/042), with a small core
+touchpoint for the forecast equipment view. Unblocks Phase 3 of
+`docs/planning/2026-08-23-arbiter-predictive.md`.
+Not published on the docs site (`docs/planning/` is excluded in `mkdocs.yml`).
+
+## 1. Where this came from
+
+The trigger was `lachand/releve-meteo`, a static PWA that displays several
+weather models side by side for France and shows how much they diverge. The
+repository itself is not reusable here: no backend, no library, no API, it is a
+front end that calls the public Open-Meteo endpoints from the browser. But it
+points at a real gap, and investigating that gap turned up something sharper
+than "show more models".
+
+## 2. Measured findings
+
+All figures below were measured against the live Open-Meteo API on 2026-08-24
+(reference point 45.75/4.85, plus Brest and Toulouse where noted).
+
+### 2.1 `best_match` does not use the French models
+
+The plugin calls `api.open-meteo.com/v1/forecast` with no `models` parameter,
+so it gets `best_match`. Comparing `best_match` hourly `temperature_2m` against
+each candidate model over 48 hours, counting exact matches:
+
+| Location   | best_match is           | AROME France HD    |
+| ---------- | ----------------------- | ------------------ |
+| 45.75/4.85 | `icon_d2` 48/48         | 5/48 (coincidence) |
+| Toulouse   | `icon_d2` 48/48         | 2/48               |
+| Brest      | (out of ICON-D2 domain) | 32/48              |
+
+Beyond 48 hours the reference point switches to `icon_eu` 48/48, never to
+ARPEGE.
+
+So over a large part of France the forecast driving Sowel today is ICON-D2, a
+2.2 km DWD model, and AROME (1.5 to 2.5 km, Meteo-France, the national
+reference) is never consulted. ICON-D2 is not a bad model. The problem is that
+which model runs is a function of the household's coordinates, it is invisible
+in the UI, and it is not configurable.
+
+### 2.2 Multi-model works, but the variables are not uniform
+
+`&models=a,b,c` returns one suffixed series per model
+(`temperature_2m_max_meteofrance_arome_france`). Measured availability:
+
+| Variable                        | AROME HD (1.5 km) | AROME France (2.5 km) | ARPEGE EU (11 km) | ICON-EU / GFS  |
+| ------------------------------- | ----------------- | --------------------- | ----------------- | -------------- |
+| `temperature_2m_min/max`        | yes               | yes                   | yes               | yes            |
+| `wind_gusts_10m_max`            | yes               | yes                   | yes               | yes            |
+| `weather_code`                  | **null**          | yes                   | yes               | yes            |
+| `precipitation_probability_max` | **null**          | **null**              | **null**          | yes            |
+| `precipitation_sum`             | yes               | yes                   | yes               | yes            |
+| `shortwave_radiation` (hourly)  | **null**          | yes                   | yes               | yes            |
+| `cloud_cover` (hourly)          | **null**          | yes                   | yes               | yes            |
+| Horizon                         | J+1               | J+1                   | J+3               | J+4 and beyond |
+
+Two consequences that a naive `models=` swap would get wrong:
+
+- `jN_condition` breaks on AROME HD (`weather_code` null). The 2.5 km
+  `meteofrance_arome_france` variant is the right pick, not the HD one.
+- `jN_rain_prob` breaks on **every** Meteo-France model. This matters: the
+  `auto-watering` recipe branches on it through `forecastThreshold` ("do not
+  water if tomorrow's rain probability exceeds N%"). Swapping the model without
+  handling this would silently disable that guard.
+
+### 2.3 The ensemble API is free, and it is the real prize
+
+`ensemble-api.open-meteo.com` is in the same free tier. `models=icon_eu`
+returns **40 members**, `gfs025` and `icon_d2` also work (no Meteo-France
+ensemble is exposed). One call, 6.8 KB for 3 days of daily data.
+
+Measured at the reference point:
+
+| Day | P(rain >= 0.5 mm) from members | tmax p10 / p50 / p90 | min to max |
+| --- | ------------------------------ | -------------------- | ---------- |
+| J0  | 75 %                           | 32.2 / 32.8 / 33.3   | 1.8 C      |
+| J+1 | 32 %                           | 28.5 / 29.8 / 31.1   | 4.4 C      |
+| J+2 | 0 %                            | 31.8 / 32.6 / 33.3   | 2.7 C      |
+
+That is a genuine probability computed from members, not a model-side
+heuristic, and it is available where `precipitation_probability_max` is null.
+(Section 3.2 quotes p90 minus p10 for the same days, which is the narrower and
+more robust of the two ways to read a spread. Both are listed on purpose.)
+
+And it is the only way to get **the number Sowel is actually missing**: how
+much to trust tomorrow's figure. A blended `best_match` value cannot express
+that by construction, because there is only one of it.
+
+For irradiance the same call gives 40 members of `shortwave_radiation`. At 13 h
+the members spanned 553 to 748 W/m2 (p10 about 625, p90 about 745). That is
+precisely the confidence interval Phase 4 of the arbiter roadmap asks for
+("a confidence interval that widens with forecast age and cloud variability").
+
+### 2.4 Budget
+
+Free tier: 600 calls/min, 5 000/hour, 10 000/day. A request over 10 variables
+counts as more than one unit. The design below is 3 calls per poll, about 14 KB.
+At the default 30 minute interval that is about 144 calls and 700 KB per day,
+two orders of magnitude under the limit.
+
+## 3. Design
+
+One plugin, one poll, three calls, no new dependency, no API key.
+
+### 3.1 Every model every day, two different jobs
+
+All the models are fetched on every poll, in a single HTTP call. What the
+resolution rules below decide is not _which models to download_, it is which
+one feeds **the value** of a binding, because a binding is one number.
+
+The models that do not feed the value are not discarded: they feed the
+confidence (3.2). Those are two distinct jobs and they want two different
+rules.
+
+**The value.** Two regimes, because model skill is not uniform across the
+horizon:
+
+```
+J0, J+1     AROME France 2.5 km alone
+            No other model competes at that range over France: 2.5 km against
+            11 km (ARPEGE), 7 km (ICON-EU), 25 km (GFS, ECMWF).
+
+J+2 .. J+5  median of the available deterministic models
+            ARPEGE Europe, ICON-EU, GFS, ECMWF IFS 0.25, UKMO 10 km.
+            Beyond J+2 no model has a clear edge, and a median absorbs an
+            outlier where a single pick would follow it.
+
+rain_prob   P(precipitation >= 0.5 mm) over the 40 ensemble members, all days.
+            Fallback: best_match precipitation_probability_max.
+```
+
+The J+2 rule is not a preference, it is what the data shows. Measured at the
+reference point for J+3 `temperature_2m_max`: ARPEGE 34.1, ICON-EU 29.5, GFS
+33.2, ECMWF 33.1, UKMO 32.2. Picking ARPEGE because it is the French model
+gives 34.1; picking ICON-EU gives 29.5; the median gives 33.1. Committing to
+one model at that range is a bet, and the earlier version of this document was
+making it.
+
+Both rules are data-driven rather than hard-coded per horizon: a model that
+returns null (end of its horizon, variable not carried) simply drops out of the
+set for that day. AROME disappearing after J+1 is the same mechanism as ARPEGE
+disappearing after J+3. If every French model is unreachable the set degrades to
+ICON and GFS, which is today's behaviour.
+
+The 25 existing `jN_*` bindings keep their aliases, their units and their
+semantics. Nothing to migrate, no recipe to touch, no equipment to re-bind.
+What changes is what is behind the number.
+
+Expose the resolution as a `model_used` text data point (`"arome_france"`, or
+`"median(5)"`), so the forecast card can say where the figure came from. That
+is the honest version of what `releve-meteo` shows visually.
+
+### 3.2 Confidence, from two independent spreads
+
+Two things can be wrong in a forecast, and they are measured differently:
+
+- **Model error** (physics, resolution, parameterisation): read from the spread
+  between the deterministic models. Already in the call above, costs nothing.
+- **Initial-condition error**: read from the 40 members of the ICON-EU
+  ensemble. One extra call, 6.8 KB.
+
+They do not measure the same thing and neither subsumes the other. Measured
+over five days at the reference point, on `temperature_2m_max`:
+
+| Day | Inter-model spread (6 models) | Ensemble spread (p10 to p90, 40 members) |
+| --- | ----------------------------- | ---------------------------------------- |
+| J0  | 1.9 C                         | 1.1 C                                    |
+| J+1 | 2.1 C                         | 2.6 C                                    |
+| J+2 | 2.6 C                         | 1.5 C                                    |
+| J+3 | **4.6 C**                     | **8.1 C**                                |
+| J+4 | 2.9 C                         | 4.8 C                                    |
+
+They rank the days consistently (J+3 is the shaky one either way), but they
+disagree on magnitude by a factor of two in both directions. Take **the wider of
+the two**: claiming more confidence than the most pessimistic available measure
+is the one failure mode that would actually hurt, since a recipe acts on it.
+
+Bindings, per day J+1 to J+3:
+
+- `jN_temp_max_spread` (number, C): the wider of the two spreads.
+- `jN_confidence` (enum `high` / `medium` / `low`): derived from that spread,
+  thresholds in the plugin settings, defaults around 2 C and 5 C.
+
+Six data points, plus `model_used`, plus `jN_rain_prob` gaining a real
+probability under an unchanged alias. Seven new entries against 25 today.
+
+`jN_confidence` is what a recipe branches on. "Pre-cool because J+3 is 34 C" is
+a different decision when the models agree within 1 C and when ARPEGE and ICON
+are 4.6 C apart. Today no recipe can tell those two apart, and neither can the
+user.
+
+### 3.3 The hourly series, and the roadmap's open question
+
+Phase 3 of the arbiter roadmap needs hourly irradiance and leaves the shape
+open: "a new data category, or a dedicated store outside the binding model?"
+
+There is a third answer, and it needs no core change at all:
+`DataType` already includes `"json"`, and `normalizeValue` passes a `json`
+value through untouched (`src/shared/value-normalization.ts:43`). A plugin can
+publish an entire series as one data point today:
+
+```
+key: "irradiance_48h", type: "json", category: "solar_radiation"
+value: { issuedAt, model, hours: [{ t, ghi, ghi_p10, ghi_p90, cloud }] }
+```
+
+48 points, about 6 KB, one row, one `device.data.updated` event per poll. The
+Phase 4 PV forecaster reads it as a device data value like any other. No
+migration, no new store, no new category, and `history-writer` already refuses
+to historise it (it is not a numeric binding).
+
+The limit is honest and worth writing down: this is a snapshot, not a time
+series. It is overwritten at each poll and nothing keeps yesterday's forecast,
+so forecast-versus-actual scoring (which Phase 4 will eventually want, to
+calibrate) needs a real store later. That is a Phase 4 problem, not a reason to
+build the store now.
+
+### 3.4 What the UI does with it
+
+Minimal core touch. `ui/src/components/equipments/weatherForecastUtils.ts`
+parses `jN_<metric>` and drops metrics it does not know, so the new bindings are
+inert until the parser learns them. Adding `confidence` and `spread` to
+`ForecastDay`, then rendering a discreet marker on the forecast card (a dot, or
+`+/- 4.4 C` under the max) is a contained change in the `weather_forecast`
+branch of `EquipmentDetailPage.tsx:427`.
+
+## 4. Learning the weights from the local station
+
+The open question left by 3.1 is "who decides which model feeds the value".
+The static answer (AROME at short range, median beyond) is defensible but
+arbitrary. The better answer is to let the installation decide, by scoring each
+model against what the household's own weather station actually measured.
+
+This is the one place in this whole subject where learning is genuinely
+warranted, and it is honest ML of the same family as Phase 4 of the arbiter
+roadmap: no heavy runtime, a few hundred rows, plain TypeScript.
+
+### 4.1 The training set already exists, on both sides
+
+This was the feasibility risk, and it is measured, not assumed.
+
+**Forecast side.** `previous-runs-api.open-meteo.com` returns, for each model,
+what the run from N days ago predicted for a given hour
+(`temperature_2m_previous_day1`, `..._day3`, ...). Measured 2026-08-24 with
+`past_days=92`: HTTP 200 on the free tier, **2 232 hourly points, 92 days,
+non-null at every lead, 65 KB in one call**. There is no need to wait a month
+accumulating forecasts before the learner means anything: it can be trained
+retroactively on install.
+
+**Observation side.** `buildDownsampleHourlyFlux` filters on
+`_measurement == "equipment_data"` and `_field == "value_number"`, so it
+downsamples **every** numeric equipment binding, not just energy. Outdoor
+temperature is therefore already in `sowel-hourly` with 90 days of retention
+(`DEFAULT_RETENTION.hourly`, `src/core/influx-client.ts:15`), and in the daily
+bucket for 5 years.
+
+92 days of per-model forecasts, against 90 days of hourly local observations.
+The learner is warm on day one.
+
+Note what is _not_ usable: `weather_temp_extremes` (spec 134) is keyed
+`PRIMARY KEY (equipment_id, alias)`, one row per equipment, overwritten every
+day. It is a live envelope, not a history. Influx is the history.
+
+### 4.2 What is learned
+
+Per `(model, variable, lead day)`, two numbers, both EWMA over the residuals:
+
+- **A bias.** `b = EWMA(forecast - observed)`. Corrected forecast `f' = f - b`.
+- **A skill.** `mae = EWMA(|f' - observed|)`, and a weight
+  `w proportional to 1 / (mae^2 + eps)`, normalised over the models available
+  that day. Inverse-variance weighting is the principled combination of
+  unbiased estimators, and it degrades gracefully when a model drops out of the
+  set at the end of its horizon.
+
+Final value: `sum(w_i * f'_i)`.
+
+**The bias correction is the bigger win, and it should be stated plainly.** A
+Netatmo outdoor module sitting on a south wall reads 2 to 3 C above the grid
+point on a sunny afternoon. That error is larger than the spread between AROME
+and ARPEGE. Correcting it turns the forecast from "what the 2.5 km grid cell
+will do" into "what my station will read tomorrow", which is exactly the
+quantity every recipe compares against, since recipes read the station. The
+per-model weighting is the refinement on top; the debiasing is the part that
+changes decisions.
+
+Second effect, and it is free: the learner knows each model's historical MAE,
+so `jN_confidence` stops being three heuristic buckets over a raw spread and
+becomes calibrated. "29.8 C, +/- 1.4 C at this lead, on 90 days of this
+station" is a statement the household can check.
+
+### 4.3 Guardrails
+
+Same spirit as the arbiter roadmap's, because the failure modes rhyme.
+
+1. **Never worse than the best single model.** Track the blend's rolling MAE
+   alongside each model's. If the blend loses to the best single model over the
+   trailing window, fall back to that model and log the switch. A blend that
+   quietly underperforms AROME would be the worst outcome of this whole
+   exercise, and it must be impossible to reach silently.
+2. **Cold start is the static rule.** Below N observations for a
+   `(model, lead)` pair, uniform weights and section 3.1's rule. No partial
+   learning on 4 samples.
+3. **Explainable, always.** Expose the weights as data
+   (`{"arome_france": 0.52, "arpege_europe": 0.21, ...}`), so the forecast card
+   can show why the number is the number. Same reasoning as the arbiter
+   journal: a figure nobody can explain is a regression even when it is more
+   accurate.
+4. **Reject bad observations.** A station outage, a gap in the hourly series,
+   or a physically implausible reading poisons the residuals. Skip the day, do
+   not interpolate.
+5. **One station, chosen explicitly.** The reference station is a setting
+   pointing at a `weather` equipment, not an inferred default. A household with
+   two stations must not have the learner silently pick one.
+
+### 4.4 Where it lives: the core, as equipment computed data
+
+An earlier draft of this section put the learner inside the plugin. That was
+wrong, and the reason is worth writing down because it is a layering rule, not
+a preference.
+
+An integration plugin's contract is to report faithfully what its source says.
+It lives in the world of **devices**: what is on the network. Equipments, zones
+and recipes are the engine's world: what is in the room. Calibrating a forecast
+against a household sensor **joins two integrations through a user-level
+notion** ("my outdoor reference"), which by construction is not integration
+work. A plugin that did it would be the only integration in Sowel that knows
+what an equipment is.
+
+Technically it could: a plugin can persist state in its own
+`integration.<id>.*` settings (`scoped-deps.ts:63`, writes to its own namespace
+are allowed and do not emit `settings.changed`, so no reload loop), and spec 111
+explicitly lets it read any device's current data (`scoped-deps.ts:246`). The
+capability is there. The mandate is not.
+
+So the learner is core, in `src/weather/`, next to `weather-aggregator.ts`. And
+the objection that earlier drafts raised against core, that the calibrated value
+cannot reuse the `jN_temp_max` alias the plugin owns, is not the fork it was
+made out to be. It is the layering working exactly as designed:
+
+- `j1_temp_max`, device data, owned by the plugin: **what Open-Meteo said**.
+- the calibrated entry, equipment computed data: **what it means at this
+  address**.
+
+That is the same distinction spec 134 already makes when it adds
+`<alias>_max_today` on top of a raw temperature binding, and spec 153 when it
+derives `speed` from relay states. `registerComputedDataProvider` takes a list
+and already has two entries (`src/index.ts:278`); this is the third. What is
+left is a naming decision for the calibrated aliases, not an architectural one.
+
+The consequence is a simplification. Earlier drafts wanted two additions to the
+plugin surface, an equipment-typed setting and a read-only history accessor in
+`PluginDeps`. **Both disappear.** The core already holds the database, the
+InfluxDB history, the equipments and the user's choice of reference. Nothing in
+`PluginDeps` changes, `IntegrationSettingDef` is untouched, and there is no
+isolation question to argue about.
+
+The plugin therefore stays a plugin: sections 3.1 to 3.3, fetch the models,
+publish what they said, and nothing else.
+
+## 5. Measured on the production installation
+
+Everything below is a walk-forward simulation on the real installation:
+92 days of archived per-model forecasts from the Previous Runs API against
+2 149 hourly observations from the household's own station, pulled read-only
+from `sowel-hourly`. At every hour the learner only ever sees past data; the
+first 21 days are warm-up and are excluded from the scores. 1 645 evaluated
+hours per lead.
+
+### 5.1 The site sits about 2 C above every model
+
+| Local sensor                    | Mean offset vs `best_match` at 24 h |
+| ------------------------------- | ----------------------------------- |
+| Weather station (`temperature`) | **+2.07 C**                         |
+| Heat pump outdoor probe         | +1.90 C                             |
+| Pool heat pump outdoor probe    | +0.96 C                             |
+
+Three sensors, three vendors, all warmer than six independent models. They
+agree with each other to within about 1 C (station versus heat pump: 0.16 C).
+The AROME grid cell is at 535 m and the house is at 530 m, so this is not an
+elevation artefact, and it is not one badly sited probe. It is a local warm
+anomaly that a 2.5 km grid cell does not resolve.
+
+The offset has a strong diurnal structure. Bias of `best_match` at 24 h lead,
+by local hour (forecast minus station):
+
+| h        | 00   | 04   | 08   | 10  | 14   | 18       | 21       | 23   |
+| -------- | ---- | ---- | ---- | --- | ---- | -------- | -------- | ---- |
+| bias (C) | -2.5 | -1.5 | +0.1 | 0.0 | -2.0 | **-4.1** | **-4.3** | -3.0 |
+
+Mid-morning the models are right. Evenings they are 4 C too cold relative to
+what this household's sensors read. Note also the extremes: over the 92 days the
+models topped out at 36.6 C where the station saw 39.8 C and the heat pump
+probes 42 C. The gap is widest exactly in the regime where a cooling decision
+matters.
+
+### 5.2 What the correction is worth
+
+Out-of-sample MAE and RMS in C, with the per-hour-of-day bias variant:
+
+| Lead | Today (`best_match` raw)         | Debiased    | Debiased + model selection | Gain      |
+| ---- | -------------------------------- | ----------- | -------------------------- | --------- |
+| 24 h | MAE 2.45 / RMS 3.10 / bias -1.98 | 1.82 / 2.36 | **1.35 / 1.82**            | **-45 %** |
+| 48 h | MAE 3.16 / RMS 3.73 / bias -2.61 | 1.80 / 2.30 | **1.64 / 2.07**            | **-48 %** |
+| 72 h | MAE 3.23 / RMS 3.79 / bias -2.62 | 1.92 / 2.42 | **1.51 / 1.99**            | **-53 %** |
+
+Three readings of that table.
+
+**The bias correction carries most of the gain**, as predicted in 4.2: it alone
+takes 48 h from 3.16 to 1.80. Per-model selection and weighting add a further 5
+to 20 points on top. At 24 h the model term is larger than section 4.2 assumed,
+so the claim "debiasing is the whole story" would be too strong; it is roughly
+two thirds of it.
+
+**Per-hour-of-day bias beats a single scalar here**, which is the opposite of
+what the same experiment showed at an arbitrary grid point 100 km away
+(scalar 1.69 versus per-hour 1.35 at 24 h). The 24 EWMAs each see 24 times
+fewer samples, so they are noisier, and they only pay off where the bias has a
+real diurnal shape. It does here. That argues for keeping both estimators and
+letting the walk-forward score pick, rather than hard-coding either.
+
+**The blend does not always beat the best single debiased model.** At 48 and
+72 h with a scalar bias, best-single won (1.76 and 1.87) over the
+inverse-variance blend (1.88 and 1.95). That is the guardrail of 4.3.1 firing
+on real data before a line of production code exists, and it is the reason the
+guardrail is not optional.
+
+### 5.3 Verdict
+
+A forecast that is 2 C off on average and 4 C off in the evening is not a
+forecast a recipe can compare against a local sensor. Halving that error, with
+an EWMA and a weighted mean, is comfortably worth the 2 to 3 days of section
+4's phase. The measurement also re-scopes section 3: the multi-model ladder is
+worth having, but on this installation it is second order next to learning what
+the site does to the numbers.
+
+Caveat: 92 days of summer, at one installation. The learned bias is a summer
+bias, the EWMA will track the seasonal drift, and none of these figures should
+be quoted as a general result. What generalises is the method, not the 45 %.
+
+## 6. Solar production forecast
+
+Section 3.3 published hourly irradiance without saying what would consume it.
+This section is that consumer, measured on the same installation: archived
+Open-Meteo forecasts against the household's own production meter, walk-forward,
+learning from the past only.
+
+### 6.1 Two traps that had to be cleared first
+
+**The array changed size mid-period.** The household added about 1 kW at the
+start of August. It shows up unambiguously in the data as a step in the daily
+production / daily GHI ratio: stable around 2.55 through July, 3.6 from
+**4 August** onward. Everything below is therefore evaluated on the
+constant-capacity window, 26 May to 3 August, 70 days. A first pass that ignored
+the step inflated every error by roughly a third and produced a nonsense array
+orientation.
+
+**`direct_radiation` is on the horizontal plane, not normal to the sun.** Using
+it directly as DNI under-estimates the plane-of-array irradiance at low sun
+angles, which manufactured a fake efficiency peak at 18 h. The conversion is
+`DNI = direct_radiation / sin(elevation)`, guarded below a few degrees of
+elevation. Any implementation of this must get that right or ask Open-Meteo for
+`direct_normal_irradiance` instead.
+
+### 6.2 The model
+
+Geometry is known, not learned. The household knows its tilt and azimuth
+(here 35 degrees, due south, free-standing in a field), and asking is both more
+accurate and more honest than fitting: over a single summer the three geometry
+regressors are badly collinear, so a fit predicts well while returning
+meaningless angles (12 degrees and north, on data whose truth is 35 degrees and
+south).
+
+```
+POA  = DNI * max(0, cos theta) + diffuse * (1 + cos tilt) / 2
+P(h) = gain * shape(h) * POA * (1 + gamma * (T - 25))      gamma = -0.004 / C
+```
+
+`gain` is the array's effective capacity, one number. `shape(h)` is one
+coefficient per local hour, refit on a rolling 45-day window. Thirteen numbers
+in total, refit nightly, plain arithmetic.
+
+| Model (constant-capacity window) | Hourly MAE | Hourly RMS |
+| -------------------------------- | ---------- | ---------- |
+| Single global coefficient        | 178 W      | 297 W      |
+| **With the hourly shape**        | **158 W**  | **291 W**  |
+
+Daily energy: **MAE 1.19 kWh on a 17.9 kWh/day average, 6.7 %**. 73 % of days
+land within 10 %, 93 % within 20 %, worst day 5.1 kWh.
+
+### 6.3 What `shape(h)` actually measures
+
+It is not a fudge factor, it is a readable diagnosis of the site. Normalised to
+its best hour, on this installation:
+
+| Local hour | 08       | 09  | 10  | 11  | 12  | 13  | 14  | 15  | 16  | 17  | 18  | 19  | 20       |
+| ---------- | -------- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | -------- |
+| Efficiency | **53 %** | 79  | 89  | 93  | 89  | 85  | 85  | 86  | 88  | 93  | 100 | 92  | **61 %** |
+
+Two features, both physical. The collapse at 08 h and 20 h is **tree shading at
+low sun angles**, which the household confirmed independently. The gentle 85 %
+dip from 13 h to 15 h is the **thermal derating** of the panels at the hottest
+hours, and 15 % is the textbook order of magnitude, so the explicit `gamma` term
+above only captures the day-to-day variation around it.
+
+A model that asked the user to declare their shading would be unusable. A model
+that measures it costs thirteen numbers.
+
+### 6.4 Separating gain from shape pays for itself
+
+The same profile, normalised, is identical before and after the +1 kW: only the
+scale moved. That is worth exploiting, because a household that adds panels
+should not wait 45 days for the rolling window to catch up.
+
+| After the 4 August capacity change       | Hourly MAE |
+| ---------------------------------------- | ---------- |
+| Old profile, gain not recalibrated       | 523 W      |
+| Old profile, gain recalibrated on 2 days | 264 W      |
+| Old profile, gain recalibrated on 3 days | 253 W      |
+
+So: keep `shape(h)` on its slow window, and detect a step in the
+production / POA ratio to re-estimate `gain` alone. Recovery in two or three
+days instead of six weeks. The same detector protects against the opposite case,
+a panel failing or an inverter dropping out, which is a monitoring feature the
+household gets for free.
+
+### 6.5 The irradiance forecast is not the bottleneck
+
+Feeding the model the analysis irradiance instead of the 24 h forecast barely
+moves the error. Open-Meteo's 24 h irradiance forecast has a 35 W/m2 MAE on a
+505 W/m2 mean, about 7 %. Nearly the whole error budget is in the
+irradiance-to-production conversion.
+
+Consequence for section 3: **no multi-model and no ensemble irradiance is needed
+for a useful PV forecast.** A single model's hourly `direct_radiation` and
+`diffuse_radiation` is enough, and AROME HD carries neither (use
+`meteofrance_arome_france` at 2.5 km, or any global model).
+
+### 6.6 Placement, and what it does not do
+
+Same split as section 4: the plugin publishes what the source said, the core
+learns what it means here. Solar geometry needs no new dependency, `suncalc` is
+already one (`src/zones/sunlight-manager.ts:1`) and `getPosition()` returns
+altitude and azimuth. Tilt, azimuth and peak power become plugin-independent
+settings on the production equipment.
+
+This is Phase 4 of `2026-08-23-arbiter-predictive.md` and it stays inert until
+something consumes it. A 6.7 % daily energy forecast answers "will there be
+surplus tomorrow afternoon", which is what the Phase 6 daily planner needs. It
+does not answer "will the surplus hold for the next twenty minutes", which is
+what the Phase 5 engage gate needs and which is a question about clouds at the
+minute scale. This is a **planning** input, not a control input.
+
+## 7. PV health and performance tracking
+
+The capacity-step detector of 6.4 was introduced to protect the forecast. Turned
+around, it is a monitoring feature in its own right. Everything below was
+validated against the production installation's own history.
+
+The design constraint that shapes it: **per-panel data cannot be the
+foundation.** On the reference installation it exists only because the owner
+reverse-engineered the APsystems protocol, and it covers six of eight panels,
+the two most recent micro-inverter channels speaking a protocol the hack does
+not handle. Most installations have a production meter and nothing else. So the
+feature is two tiers, and tier 1 must stand alone.
+
+### 7.1 Tier 1: the aggregate detector, available everywhere
+
+Inputs: one production meter, plus the declared peak power, tilt and azimuth of
+7.4. Nothing else. The quantity tracked is the performance ratio, measured
+production over the POA model of 6.2.
+
+The whole question is sensitivity, and it is a matter of noise. Measured on the
+constant-capacity window:
+
+| Hours used for the ratio       | Days kept | Day-to-day noise | Step detectable at 3 sigma over 3 days |
+| ------------------------------ | --------- | ---------------- | -------------------------------------- |
+| All daylight, all weather      | 69        | 10.5 %           | 18.2 %                                 |
+| 10 h to 16 h local             | 69        | 10.3 %           | 17.8 %                                 |
+| 10 h to 16 h, cloud < 30 %     | 54        | 7.2 %            | 12.5 %                                 |
+| **10 h to 16 h, cloud < 15 %** | **51**    | **6.8 %**        | **11.8 %**                             |
+
+Restricting to clear midday hours cuts the noise by a third, and it costs little:
+51 of 69 summer days still qualify. Winter will be slower, and the feature should
+say so rather than pretend otherwise.
+
+Against that noise floor, on this 8 x 500 Wc array:
+
+- One panel lost: 12.5 % of the array, detected in about **3 clear days**.
+- A whole micro-inverter lost (two channels): 25 %, detected in **1 clear day**.
+- Progressive soiling: visible as a drift rather than a step, which is why the
+  baseline has to be a slow-moving reference and not a fixed constant.
+
+That is a real monitoring feature on an installation with no per-panel data at
+all, which is the common case.
+
+### 7.2 Tier 2: peer comparison, when per-panel data exists
+
+Where it exists it is much sharper. Comparing each panel to the median of its
+peers, four of the six monitored panels sit within 1.5 % of their own normal,
+day after day, for two months. Against that noise floor the incident is
+unmissable:
+
+> **2026-07-05, INV_0.** PV_03 at 0 W for nine consecutive hours (08 h to 16 h
+> UTC) while its peers ran at 450 to 500 W, and PV_04, the other channel of the
+> same micro-inverter, degraded to 40 % over three of them.
+
+The household confirmed independently that a micro-inverter had lost a channel.
+The signature is in the history, with a date, and nothing surfaced it at the
+time.
+
+The grouping needed to attribute the fault to INV_0 rather than to two unrelated
+panels is **already in the data model**: PV_03 and PV_04 bind to the same device,
+as do PV_05/PV_06 and PV_07/PV_08. Nothing to declare.
+
+### 7.3 A naive peer rule would cry wolf every day
+
+The same scan surfaces two patterns that are **not** faults:
+
+| Panel | When                                              | Level               | What it is   |
+| ----- | ------------------------------------------------- | ------------------- | ------------ |
+| PV_03 | every morning 08-09 h UTC, mid-June to early July | 37 to 49 % of peers | tree shading |
+| PV_08 | every evening 16 h UTC, June through August       | 72 to 88 % of peers | tree shading |
+
+"A panel below 90 % of its peers is faulty" would have fired on 27 of 70 days.
+The baseline cannot be "equal to its peers": it has to be **the panel's own
+learned normal for that hour**, and the alert is a departure from it. Shading is
+stable and repeats; a fault breaks a pattern. Same discipline as section 4.
+
+### 7.4 The two tiers measure different things, and must not be mixed
+
+Tier 1 is blind to nothing that affects the whole array, and that is exactly
+what tier 2 cannot see: peer comparison moves its own median, so uniform soiling,
+snow, or the aggregate low-sun shading of 6.3 are invisible to it. Conversely
+tier 1 needs three clear days where tier 2 needs one hour.
+
+But they must not be cross-validated against each other. On this installation
+the sum of the six monitored panels is 121 % of the aggregate meter before the
+August expansion and 90 % after, even with the impossible readings rejected.
+Those are different physical quantities: DC at the micro-inverter input against
+AC at the meter, over a partial subset. Each tier tracks its own baseline.
+
+### 7.5 What the user should declare, and what each field buys
+
+| Field               | Where                               | What it unlocks                                       |
+| ------------------- | ----------------------------------- | ----------------------------------------------------- |
+| Peak power (Wc)     | the array, and per panel when known | Tier 1 entirely; makes impossible readings rejectable |
+| Tilt and azimuth    | the array, per panel if they differ | The POA model of 6.2, hence the forecast and tier 1   |
+| (inverter grouping) | **not declared**                    | Already known from the device binding                 |
+
+Peak power matters more than it looks. This installation's history contains four
+physically impossible readings, 12 kW to 31 kW on panels rated 500 Wc, always
+both channels of one micro-inverter at once (INV_0 on 2026-08-10, INV_1 on
+2026-07-03). They are in the stored history now and would poison any model
+fitted on it. A declared 500 Wc makes them a one-line rejection.
+
+Declaring geometry is the conclusion of 6.2: over a single season a fit returns
+confident nonsense (12 degrees facing north where the truth is 35 degrees facing
+south). Ask, do not infer.
+
+### 7.6 What it should expose
+
+- A performance ratio for the array, and per panel and per inverter where tier 2
+  is available, always shown against its learned normal rather than as a bare
+  number.
+- An alert on departure from that normal, attributed to the **inverter** when
+  both its channels move together, which is the 2026-07-05 signature and what
+  the owner can actually act on.
+- A shading profile per panel, a by-product of the learned baseline that costs
+  nothing extra and tells the household something no datasheet can.
+- **Explicit coverage.** Tier 2 monitors whatever reports; on this installation
+  that is six panels of eight. A health feature that silently watches a subset
+  is worse than one that says which panels it cannot see.
+
+## 8. Phasing
+
+**v2.0, plugin only, no core change.** Model ladder, ensemble rain probability,
+`jN_temp_max_spread`, `jN_confidence`, `model_used`. Ships as a plugin release
+plus the mandatory registry SHA bump. Reversible: a `models` setting back to
+`auto` restores today's behaviour exactly. Effort: about a day. Risk: low, the
+existing aliases are untouched.
+
+**v2.1, plugin plus a small core change.** `irradiance_48h` json series, and the
+forecast card showing confidence and source model. Effort: half a day plugin,
+half a day UI. Risk: low. This closes Phase 3 of the arbiter roadmap.
+
+**v2.2, core only, the learner of section 4.** Per-model bias and skill against
+the user-selected reference equipment, exposed as computed data, calibrated on
+day one from the 90 days already in `sowel-hourly`. No plugin change, no plugin
+API change. Own spec. Effort: 2 to 3 days. Risk: low in blast radius
+(a wrong weight degrades a forecast, never a relay), which is precisely why this
+is a better place to prove the learn-from-the-installation pattern than the
+control loop is.
+
+**v3.0, the solar production forecast of section 6.** Plugin side: add
+`direct_radiation` and `diffuse_radiation` to the hourly series of v2.1. Core
+side: the per hour-of-day model, refit nightly on a rolling 45-day window,
+exposed as an hourly expected-production curve. Effort: half a day plugin, about
+2 days core. Own spec, and it is Phase 4 of the arbiter roadmap, so it stays
+inert until something consumes it.
+
+**v3.1, PV health and performance of section 7.** Peer ratio plus absolute
+performance ratio, both on the baselines the forecast already learns, alerts
+attributed per inverter, shading profile as a by-product. Requires the declared
+peak power and geometry of 7.4. Effort: about 2 days on top of v3.0, since the
+POA model and the learned baselines are shared. Arguably the most immediately
+useful thing in this document for a household with panels: it found a real
+micro-inverter fault in existing history, after the fact.
+
+**Then, and only then.** `smart-cooling` gating its pre-cooling on
+`j1_confidence`, and the arbiter's Phase 5/6 consuming the production curve.
+Separate specs, inert until someone writes them.
+
+## 9. What this deliberately is not
+
+- **Not a second provider.** Multi-model gives meteorological confidence, not
+  service redundancy: every call still goes to Open-Meteo. Adding
+  Meteo-France's own API (AROME via the public data portal) would give
+  redundancy, at the cost of an API key and a second parser. Not worth it until
+  Open-Meteo actually proves unreliable.
+- **Not a model comparison UI.** `releve-meteo` shows four curves because
+  comparing models is its product. Sowel's product is a decision. Four curves in
+  a home automation UI is noise; one number plus a confidence marker is not.
+- **Not sub-hourly nowcasting.** `meteofrance_arome_france_15min` exists and is
+  tempting for PV, but the arbiter roadmap already ruled sub-15-minute
+  nowcasting out of scope, and its horizon is 6 hours.
+- **Not a vendored copy of `releve-meteo`.** It is MIT, so its WMO code mapping
+  and model list can be referenced with credit. There is nothing else in it that
+  a backend plugin needs.

--- a/specs/159-weather-forecast-multi-model/architecture.md
+++ b/specs/159-weather-forecast-multi-model/architecture.md
@@ -1,0 +1,230 @@
+# Architecture — Spec 159
+
+Two repos, two PRs, one spec. The data side lives in
+`sowel-plugin-weather-forecast`; the core side is **UI only**, in
+`WeatherForecastPanel`. No new `DataCategory`, no migration, no event, no API
+route. Release ordering between the two does not matter: each side degrades to
+today's behaviour without the other.
+
+## Flow diagram
+
+```
+poll (every 30 min, min 15)
+  │
+  ├─ call A  api.open-meteo.com/v1/forecast
+  │          daily = weather_code, temperature_2m_min/max,
+  │                  wind_gusts_10m_max
+  │          models = <superset>                       ~2.4 KB
+  │            │
+  │            └─ models absent from the response do not cover this point
+  │
+  ├─ call B  ensemble-api.open-meteo.com/v1/ensemble
+  │          daily = temperature_2m_max, precipitation_sum
+  │          models = <one global ensemble>            ~6.8 KB
+  │
+  ▼
+resolve.ts        per day, per variable:
+                    J+1        -> best available resolution, alone
+                    J+2..J+5   -> median of available models
+                    null       -> model drops out of the set for that day
+  │
+  ▼
+ensemble.ts       P(precip >= 0.5 mm) over members  -> jN_rain_prob
+                  p10/p50/p90 of temperature_2m_max -> ensemble spread
+  │
+  ▼
+confidence.ts     spread = max(model spread, ensemble spread)
+                  level  = high | medium | low   (two settings thresholds)
+  │
+  ▼
+deviceManager.updateDeviceData("weather-forecast", "Weather Forecast", payload)
+  │
+  └─ 32 keys: 25 unchanged + 6 confidence + model_used
+```
+
+Downstream is untouched: `device.data.updated` → equipment bindings → zone →
+WebSocket, exactly as today.
+
+## Components
+
+The current plugin is a single 479-line `src/index.ts` with the HTTP call, the
+parsing and the lifecycle interleaved, which is untestable. The logic is
+extracted into pure modules, following the pattern already used by
+`sowel-plugin-apsystems` (`apsystems-parser.ts` + `apsystems-parser.test.ts`).
+
+### New: `src/models.ts`
+
+The candidate superset and the per-day resolution of FR2.
+
+```ts
+export const CANDIDATE_MODELS: readonly string[]; // regional + global, no geography
+export const MODEL_RESOLUTION_KM: Record<string, number>;
+
+/** One day of one variable, resolved across the models that carry it. */
+export function resolveDay(
+  values: Record<string, number | null>, // model id -> value
+  horizonDays: number,
+): { value: number | null; source: string };
+
+export function median(xs: number[]): number;
+```
+
+`resolveDay` returns the source label that feeds `model_used`: a model id at
+J+1, `median(<n>)` beyond.
+
+### New: `src/ensemble.ts`
+
+```ts
+export function rainProbability(members: (number | null)[], thresholdMm: number): number | null;
+export function quantiles(
+  members: (number | null)[],
+): { p10: number; p50: number; p90: number } | null;
+```
+
+Both ignore null members and return `null` below a minimum member count rather
+than fabricating a figure from two members.
+
+### New: `src/confidence.ts`
+
+```ts
+export function spread(
+  modelValues: number[],
+  ensembleP10P90: [number, number] | null,
+): number | null;
+export function level(
+  spreadC: number | null,
+  thresholds: { high: number; medium: number },
+): "high" | "medium" | "low" | null;
+```
+
+`spread` takes the wider of the two measures (FR5). `level` returns `null` rather
+than `high` when there is nothing to measure, so a missing signal never reads as
+a confident one.
+
+### New: `src/open-meteo.ts`
+
+URL builders and response shape parsing, kept separate from `fetch` so the
+parsers are testable without network.
+
+```ts
+export function buildDailyUrl(lat: string, lon: string, models: string[], days: number): string;
+export function buildEnsembleUrl(lat: string, lon: string, model: string, days: number): string;
+export function parseDaily(json: unknown): Record<string, Record<string, (number | null)[]>>;
+export function parseEnsembleDaily(json: unknown): Record<string, (number | null)[][]>;
+```
+
+`parseDaily` demultiplexes Open-Meteo's `<variable>_<model_id>` suffixed keys back
+into a `model -> variable -> values` map, and tolerates the `"latitude": nan` the
+API emits when part of the requested set is out of domain.
+
+### Changed: `src/index.ts`
+
+Keeps the lifecycle (`start`, `stop`, `poll`, `refresh`, retry/backoff) and the
+device definition. `poll()` becomes: two fetches, then a call into the pure
+modules, then one `updateDeviceData`. The settings schema gains three entries.
+
+### Changed: `manifest.json`
+
+Version `2.0.0`, plus the three new settings. `sowelVersion` is **unchanged**:
+nothing here needs a newer core.
+
+### New: `vitest.config.ts`, dev dependency `vitest`
+
+The repo has no test setup today. Added exactly as in `sowel-plugin-apsystems`:
+`"test": "vitest run"` and vitest in `devDependencies`.
+
+### Changed (core): `ui/src/components/equipments/weatherForecastUtils.ts`
+
+`ForecastDay` gains two optional fields and `parseForecastDays` learns two more
+`jN_` metrics. A separate helper reads `model_used`, which is a flat binding
+rather than a `jN_` one:
+
+```ts
+export interface ForecastDay {
+  // ... existing fields unchanged
+  tempMaxSpread: number | null; // new
+  confidence: "high" | "medium" | "low" | null; // new
+}
+
+export function parseModelUsed(bindings: DataBindingWithValue[]): string | null;
+```
+
+Both stay `null` on plugin v1.0.0 data, which is what keeps the card unchanged
+for households that have not upgraded.
+
+### Changed (core): `ui/src/components/equipments/WeatherForecastPanel.tsx`
+
+- In `ForecastDayCard`, under the maximum: `± {spread}` in 11 px
+  `text-text-tertiary`, rendered only when `tempMaxSpread` is a positive number.
+  A spread of 0, which means a single model and no ensemble, renders nothing
+  rather than a misleading `± 0`.
+- Under the scrollable row: one 12 px `text-text-tertiary` line naming the
+  source, rendered only when `model_used` exists.
+
+No new colour, no new icon, no layout change. Tailwind utilities only, per
+`CLAUDE.md`.
+
+### New (core): `ui/src/i18n/locales/{en,fr}.json`
+
+Two keys for the source line. No other copy is added.
+
+## Device data points
+
+25 unchanged, 7 added, 32 total.
+
+| Key                                         | Type   | Category            | Unit | Status                         |
+| ------------------------------------------- | ------ | ------------------- | ---- | ------------------------------ |
+| `j1_condition` … `j5_condition`             | enum   | weather_condition   | —    | unchanged key, better source   |
+| `j1_temp_min` … `j5_temp_min`               | number | temperature_outdoor | °C   | unchanged key, better source   |
+| `j1_temp_max` … `j5_temp_max`               | number | temperature_outdoor | °C   | unchanged key, better source   |
+| `j1_rain_prob` … `j5_rain_prob`             | number | rain                | %    | unchanged key, ensemble source |
+| `j1_wind_gusts` … `j5_wind_gusts`           | number | wind                | km/h | unchanged key, better source   |
+| `j1_temp_max_spread` … `j3_temp_max_spread` | number | temperature_outdoor | °C   | **new**                        |
+| `j1_confidence` … `j3_confidence`           | enum   | generic             | —    | **new**                        |
+| `model_used`                                | text   | generic             | —    | **new**                        |
+
+`jN_confidence` uses category `generic` deliberately: it is not a weather
+measurement and must not be aggregated by zones or historised as one.
+
+## Settings
+
+| Key                     | Type   | Default        | Purpose                                              |
+| ----------------------- | ------ | -------------- | ---------------------------------------------------- |
+| `polling_interval`      | number | 30             | unchanged                                            |
+| `models`                | text   | (empty = auto) | FR7 override; `best_match` restores v1 behaviour     |
+| `confidence_high_max`   | number | 2              | spread in °C below which confidence is `high`        |
+| `confidence_medium_max` | number | 5              | spread below which it is `medium`, above which `low` |
+
+All under `integration.weather-forecast.*`, which is the plugin's own namespace,
+so the spec 111 settings Proxy allows read and write.
+
+## Files changed
+
+| Repo   | File                                                        | Change                                                             |
+| ------ | ----------------------------------------------------------- | ------------------------------------------------------------------ |
+| plugin | `src/models.ts`                                             | **new** — candidate set, per-day resolution, median                |
+| plugin | `src/ensemble.ts`                                           | **new** — member-based probability and quantiles                   |
+| plugin | `src/confidence.ts`                                         | **new** — spread combination and level                             |
+| plugin | `src/open-meteo.ts`                                         | **new** — URL builders, response demultiplexing                    |
+| plugin | `src/*.test.ts`                                             | **new** — one per pure module                                      |
+| plugin | `src/index.ts`                                              | rewritten `poll()`, extended device definition and settings schema |
+| plugin | `manifest.json`                                             | version 2.0.0, three new settings                                  |
+| plugin | `package.json`                                              | version 2.0.0, vitest dev dependency, `test` script                |
+| plugin | `vitest.config.ts`                                          | **new**                                                            |
+| plugin | `README.md`                                                 | document the new data points and settings                          |
+| core   | `ui/src/components/equipments/weatherForecastUtils.ts`      | 2 optional fields, 2 parsed metrics, `parseModelUsed`              |
+| core   | `ui/src/components/equipments/weatherForecastUtils.test.ts` | **new**                                                            |
+| core   | `ui/src/components/equipments/WeatherForecastPanel.tsx`     | spread under the max, source line under the row                    |
+| core   | `ui/src/i18n/locales/{en,fr}.json`                          | source line copy                                                   |
+| core   | `plugins/registry.json`                                     | `sha256` bump after the release (separate PR)                      |
+| core   | `specs/159-*`                                               | this spec                                                          |
+
+## Failure modes
+
+| Failure                             | Behaviour                                                                                                                        |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Call B (ensemble) fails             | `jN_rain_prob` falls back to `best_match`, confidence uses the model spread alone, poll succeeds, one `warn` with `{ err }`      |
+| Call A fails                        | One retry with `models=best_match`; if that fails, the poll throws as it does today and the existing exponential backoff applies |
+| A model missing from the response   | Not an error: it does not cover the point, it is simply not a candidate                                                          |
+| Fewer than 2 models and no ensemble | `jN_confidence` and `jN_temp_max_spread` are `null`, never a fabricated `high`                                                   |
+| Malformed JSON                      | Caught by the existing try/catch in `poll()`, logged with `{ err }`, backoff applies                                             |

--- a/specs/159-weather-forecast-multi-model/plan.md
+++ b/specs/159-weather-forecast-multi-model/plan.md
@@ -1,0 +1,145 @@
+# Implementation Plan — Spec 159
+
+Two repos, two branches, two PRs. Slices A and B land in
+`sowel-plugin-weather-forecast` on `feat/multi-model`; slice C lands in the core
+on `feat/weather-forecast-confidence-ui`. Neither depends on the other at
+runtime, so they can ship in either order.
+
+## Slices
+
+### Slice A — Test harness and pure modules
+
+- A.1 — Add `vitest` to `devDependencies`, a `test` script and
+  `vitest.config.ts`, mirroring `sowel-plugin-apsystems`.
+- A.2 — `src/open-meteo.ts`: URL builders, and `parseDaily` demultiplexing the
+  `<variable>_<model_id>` keys into `model -> variable -> values`. Must tolerate
+  the `"latitude": nan` the API emits when part of the requested set is out of
+  domain.
+- A.3 — `src/models.ts`: `CANDIDATE_MODELS`, `MODEL_RESOLUTION_KM`, `median`,
+  and `resolveDay` implementing the FR2 rule.
+- A.4 — `src/ensemble.ts`: `rainProbability` and `quantiles` over members.
+- A.5 — `src/confidence.ts`: `spread` (wider of the two) and `level`.
+
+### Slice B — Wiring
+
+- B.1 — Extend the discovered device definition: 6 confidence points for J+1 to
+  J+3, plus `model_used`. 32 total.
+- B.2 — Rewrite `poll()`: two fetches, pure-module resolution, one
+  `updateDeviceData`. Keep the existing structured logging and never let a
+  handler throw outside the existing try/catch.
+- B.3 — Extend the settings schema with `models`, `confidence_high_max` and
+  `confidence_medium_max`; parse and clamp them in `start()` next to
+  `polling_interval`.
+- B.4 — Degradation paths: ensemble failure, call A failure with a
+  `best_match` retry, missing models.
+
+### Slice C — Core UI (separate repo, separate PR)
+
+- C.1 — `weatherForecastUtils.ts`: two optional fields on `ForecastDay`, two
+  more parsed `jN_` metrics, and `parseModelUsed` for the flat binding.
+- C.2 — `WeatherForecastPanel.tsx`: `± {spread}` under the maximum, one source
+  line under the row. Both conditional, so v1.0.0 plugin data renders exactly
+  today's card.
+- C.3 — i18n keys for the source line, `en` and `fr`.
+- C.4 — `weatherForecastUtils.test.ts` (the module has no test today).
+
+### Slice D — Release
+
+- D.1 — README: new data points, new settings, and the `models=best_match`
+  escape hatch.
+- D.2 — Bump `manifest.json` and `package.json` to 2.0.0. `sowelVersion` stays
+  as it is, nothing here needs a newer core.
+- D.3 — PR on the plugin repo, then a GitHub release with the tarball.
+- D.4 — **Separate PR on the core repo**: run
+  `node scripts/backfill-registry-sha256.mjs` and commit
+  `plugins/registry.json` (CLAUDE.md, spec 089). Mandatory: installs of the new
+  version fail with `ChecksumMismatchError` until the registry catches up.
+
+## Test Plan
+
+### Modules to test
+
+- `src/open-meteo.ts` — URL construction and response demultiplexing
+- `src/models.ts` — median and the per-day resolution rule
+- `src/ensemble.ts` — probability and quantiles over members
+- `src/confidence.ts` — spread combination and level classification
+
+- `ui/src/components/equipments/weatherForecastUtils.ts` — parsing of the two
+  new metrics and of `model_used`
+
+`src/index.ts` is not unit tested: it is lifecycle and I/O wiring, which matches
+how the other plugins draw the line. `WeatherForecastPanel` is not unit tested
+either; its logic is two conditional renders over data the utils already test.
+
+### Scenarios
+
+| Module        | Scenario                                                   | Expected                                                          |
+| ------------- | ---------------------------------------------------------- | ----------------------------------------------------------------- |
+| open-meteo    | `buildDailyUrl` with 4 models                              | `models=a,b,c,d`, `timezone=auto`, `forecast_days=6`              |
+| open-meteo    | `buildDailyUrl` with an empty model list                   | No `models` parameter at all (equivalent to `best_match`)         |
+| open-meteo    | `parseDaily` on a 2-model response                         | `{ arome: { temperature_2m_max: [...] }, icon_eu: {...} }`        |
+| open-meteo    | `parseDaily` on a single-model response with no suffix     | Keys map to that model id                                         |
+| open-meteo    | `parseDaily` with `"latitude": nan` in the payload         | Parses without throwing; models present are returned              |
+| open-meteo    | `parseDaily` on a payload with no `daily` key              | Throws a typed error, not a `TypeError`                           |
+| open-meteo    | `parseEnsembleDaily` on members                            | `{ temperature_2m_max: [[m1...], [m2...]] }` per day              |
+| models        | `median` on an odd count                                   | Middle value                                                      |
+| models        | `median` on an even count                                  | Mean of the two middle values                                     |
+| models        | `median` on a single value                                 | That value                                                        |
+| models        | `resolveDay` at J+1 with AROME and ICON present            | AROME value, source `meteofrance_arome_france`                    |
+| models        | `resolveDay` at J+1 with AROME null                        | Next best resolution, source is that model                        |
+| models        | `resolveDay` at J+3 with 5 models                          | Median, source `median(5)`                                        |
+| models        | `resolveDay` at J+3 with ARPEGE 34.1 and ICON 29.5 outlier | Median, not the outlier (the measured case from the planning doc) |
+| models        | `resolveDay` with all values null                          | `{ value: null, source: "none" }`                                 |
+| models        | `resolveDay` with exactly one non-null model               | That value, source is that model id, not `median(1)`              |
+| ensemble      | `rainProbability` with 40 members, 30 above 0.5 mm         | 75                                                                |
+| ensemble      | `rainProbability` with all members dry                     | 0                                                                 |
+| ensemble      | `rainProbability` with nulls mixed in                      | Nulls ignored, computed over the rest                             |
+| ensemble      | `rainProbability` with fewer than the minimum members      | `null`                                                            |
+| ensemble      | `quantiles` on a known series                              | p10/p50/p90 match hand-computed values                            |
+| ensemble      | `quantiles` on an empty or all-null series                 | `null`                                                            |
+| confidence    | `spread` with model spread 2.1 and ensemble p10/p90 2.6    | 2.6 (the wider)                                                   |
+| confidence    | `spread` with model spread 4.6 and ensemble 8.1            | 8.1 (the measured J+3 case)                                       |
+| confidence    | `spread` with no ensemble                                  | Model spread alone                                                |
+| confidence    | `spread` with a single model and no ensemble               | `null`                                                            |
+| confidence    | `level` with spread 0.8 and defaults                       | `high`                                                            |
+| confidence    | `level` with spread 3.0                                    | `medium`                                                          |
+| confidence    | `level` with spread 6.0                                    | `low`                                                             |
+| confidence    | `level` with spread `null`                                 | `null`, never `high`                                              |
+| confidence    | `level` at exactly the threshold                           | Documented boundary respected (inclusive on the lower side)       |
+| retro-compat  | `models=best_match` end to end on a captured payload       | Same 25 values as v1.0.0 on the same input                        |
+| forecastUtils | `parseForecastDays` on v2 bindings                         | `tempMaxSpread` and `confidence` populated on J+1..J+3            |
+| forecastUtils | `parseForecastDays` on v1.0.0 bindings                     | Both fields `null`, all existing fields unchanged                 |
+| forecastUtils | `parseForecastDays` with a spread but no confidence        | Spread kept, confidence `null`                                    |
+| forecastUtils | `parseForecastDays` with a non-numeric spread value        | Field stays `null`, no throw                                      |
+| forecastUtils | `parseModelUsed` with the binding present                  | Returns the string                                                |
+| forecastUtils | `parseModelUsed` with no such binding                      | Returns `null`                                                    |
+| forecastUtils | `parseModelUsed` on a non-string value                     | Returns `null`                                                    |
+
+### Fixtures
+
+Real captured Open-Meteo payloads, trimmed, committed under `src/__fixtures__/`:
+one multi-model daily response for a French point, one for New York (proving the
+regional models drop out on their own), one ensemble response. Recorded from the
+live API on 2026-08-24, so the tests exercise the real shape rather than an
+idealised one.
+
+## Validation Plan
+
+- `npx tsc --noEmit` in the plugin repo — zero errors
+- `npm test` in the plugin repo — green
+- `cd ui && npx tsc -b --noEmit` and `npx vitest run` in the core repo — green
+- `npx eslint src/ --ext .ts` and `cd ui && npx eslint .` — zero errors
+- Build the tarball and install it on the **shadow** instance, never on prod
+  (`feedback_no_prod_deploy_without_authorization`), and verify:
+  - the 25 existing aliases still populate,
+  - `model_used` names a plausible model,
+  - `jN_confidence` is not uniformly `low`,
+  - the logs show one poll line, no error.
+- Compare one poll's `jN_temp_max` against `best_match` for the same point to
+  confirm the values moved in the expected direction.
+
+## Out of this plan
+
+- Hourly irradiance series (deferred with its consumer)
+- Local bias correction (core, separate spec)
+- Colour-coding the confidence, and any model-comparison view

--- a/specs/159-weather-forecast-multi-model/spec.md
+++ b/specs/159-weather-forecast-multi-model/spec.md
@@ -1,0 +1,257 @@
+# Spec 159 — Weather forecast: multi-model and ensemble confidence
+
+## Context
+
+`sowel-plugin-weather-forecast` (spec 041) calls Open-Meteo without a `models`
+parameter, so it gets `best_match`. Measured on 2026-08-24 by comparing
+`best_match` hourly `temperature_2m` against every candidate model over 48 h:
+
+| Location          | `best_match` resolves to | AROME France HD    |
+| ----------------- | ------------------------ | ------------------ |
+| 45.75/4.85 (Lyon) | `icon_d2` 48/48          | 5/48 (coincidence) |
+| Toulouse          | `icon_d2` 48/48          | 2/48               |
+| Brest             | (outside ICON-D2 domain) | 32/48              |
+
+Beyond 48 h the reference point falls to `icon_eu`, never to ARPEGE. So over a
+large part of France the forecast driving Sowel is a German 2.2 km model and the
+national high-resolution models are never consulted. Which model runs is a
+function of the household's coordinates, is invisible in the UI, and cannot be
+configured.
+
+The second gap is that a blended `best_match` value cannot express **how much to
+trust itself**. A recipe deciding to pre-cool because tomorrow reaches 34 C has
+no way to distinguish forty ensemble members agreeing within 0.8 C from members
+spread over 5 C. Measured at the reference point, the day-ahead temperature
+spread ranged from 1.1 C to 8.1 C across five days.
+
+Design rationale and all measurements:
+`docs/planning/2026-08-24-weather-multi-model.md`, sections 2 and 3.
+
+## Goals
+
+1. Query every deterministic model that covers the household's coordinates, and
+   resolve each daily value from the best model available for that day, instead
+   of accepting Open-Meteo's undisclosed pick.
+2. Expose a per-day confidence derived from two independent spreads, so recipes
+   can branch on how trustworthy a forecast is.
+3. Replace the rain probability with a genuine probability computed over
+   ensemble members, which is also the only way to keep it working once
+   Meteo-France models are in the set.
+4. Change nothing about the 25 existing `jN_*` aliases: no migration, no
+   re-binding, no recipe change.
+
+## Non-Goals
+
+- **Hourly irradiance series.** Deferred to the release that ships its consumer
+  (the PV production model). A `json` device data value currently renders as
+  `[object Object]` in generic UI views, so publishing an inert series now would
+  be a visible wart with no benefit.
+- **Local bias correction** against a household sensor. That is core work and
+  its own spec: it joins two integrations through a user-level notion, which is
+  not an integration plugin's mandate.
+- **A second weather provider.** Multi-model buys meteorological confidence, not
+  service redundancy; every call still goes to Open-Meteo.
+- **Model comparison curves in the UI.** Showing four models side by side is
+  `releve-meteo`'s product; Sowel's product is a decision. One figure plus a
+  spread, not four curves.
+- **Colour-coding the confidence.** It would compete with the condition colours
+  already on the card.
+
+## Functional Requirements
+
+### FR1 — Candidate model discovery
+
+The plugin requests a fixed superset of models on the existing daily call. Models
+that do not cover the coordinates are simply absent from Open-Meteo's response,
+which was verified: the same request that returns AROME/ARPEGE/ICON-EU in France
+returns HRRR/GFS/ECMWF/UKMO in New York. Whatever comes back is the candidate set
+for that installation.
+
+No geography is hard-coded. A German household gets ICON-D2, an American one
+HRRR, a French one AROME, with no configuration.
+
+### FR2 — Per-day value resolution
+
+For each forecast day and each variable, the value is resolved from the available
+models by this rule:
+
+| Horizon        | Rule                                                          |
+| -------------- | ------------------------------------------------------------- |
+| J+1            | Median of the models within 1.5x of the finest grid available |
+| J+2 and beyond | Median of every available deterministic model                 |
+
+The rationale is measured (planning doc 3.1): at short range a high-resolution
+regional model is not in the same class as a global one, while beyond J+2 no
+model has a clear edge and a single pick is a bet. At J+3 at the reference point,
+ARPEGE said 34.1 C, ICON-EU 29.5 C, and the median 33.1 C.
+
+At J+1 the rule is a median over a **class**, not an election. Measured at the
+reference point, four models answer at 2 to 2.5 km: ICON-2I, DMI Harmonie,
+ICON-D2 and AROME. Electing the 2 km one would be arbitrary, since nothing says a
+foreign 2 km grid beats the national 2.5 km one there, and it would make the
+published value hostage to a single provider. A 7 km model has no business in
+that class, which is what the 1.5x factor excludes. Where a single model is alone
+in its class it is named directly rather than reported as `median(1)`: measured
+at New York, HRRR at 3 km with nothing else finer than 10 km.
+
+The rule is data-driven, not hard-coded per horizon: a model returning `null`
+(end of its horizon, variable not carried) drops out of the set for that day.
+If every model fails, the plugin falls back to `best_match`, i.e. today's
+behaviour.
+
+### FR3 — Variable availability handling
+
+Measured availability differs per model and this MUST be handled explicitly:
+
+| Variable                        | AROME HD | AROME 2.5 km | ARPEGE   | ICON / GFS |
+| ------------------------------- | -------- | ------------ | -------- | ---------- |
+| `temperature_2m_min/max`        | yes      | yes          | yes      | yes        |
+| `wind_gusts_10m_max`            | yes      | yes          | yes      | yes        |
+| `weather_code`                  | **null** | yes          | yes      | yes        |
+| `precipitation_probability_max` | **null** | **null**     | **null** | yes        |
+
+Two consequences:
+
+- The 2.5 km `meteofrance_arome_france` variant is used, never the HD variant,
+  which carries no `weather_code`.
+- `precipitation_probability_max` is null on **every** Meteo-France model, so
+  `jN_rain_prob` must not be sourced from the deterministic call (see FR4).
+
+### FR4 — Rain probability from ensemble members
+
+`jN_rain_prob` keeps its alias, unit and category. Its value becomes
+`P(precipitation >= 0.5 mm)` counted over the members of a global ensemble model,
+which is a genuine probability rather than a model-side heuristic, and is
+available for every day.
+
+If the ensemble call fails, the value falls back to
+`best_match precipitation_probability_max`, then to `null`.
+
+This is a deliberate silent improvement: the `auto-watering` recipe reads this
+alias through its `forecastThreshold` parameter and benefits with no user action.
+The threshold keeps the same meaning; only the underlying figure changes.
+
+### FR5 — Confidence, from two independent spreads
+
+Two error sources are measured differently and neither subsumes the other:
+
+- **Model error** (physics, resolution): the spread between the deterministic
+  models, already in the FR1 call, free.
+- **Initial-condition error**: the spread across the ensemble members.
+
+Measured over five days at the reference point, the two rank the days
+consistently but disagree on magnitude by a factor of two in both directions. The
+plugin therefore takes **the wider of the two**: claiming more confidence than the
+most pessimistic available measure is the failure mode that would actually hurt,
+since a recipe acts on it.
+
+Both terms must be the same _kind_ of statistic, or the comparison is
+meaningless. The inter-model term is therefore a p10-p90 band once at least five
+models answer, not a min-max range: a range grows with the number of models, so a
+French household seeing ten of them would systematically report less confidence
+than an American one seeing five, for identical meteorological uncertainty. Below
+five models the plain range is used, a band over four points being noise.
+
+New data points, for J+1 to J+3 only (beyond J+3 the spread is wide enough that
+the index would read `low` permanently and carry no information):
+
+| Key                                         | Type   | Category            | Unit |
+| ------------------------------------------- | ------ | ------------------- | ---- |
+| `j1_temp_max_spread` … `j3_temp_max_spread` | number | temperature_outdoor | °C   |
+| `j1_confidence` … `j3_confidence`           | enum   | generic             | —    |
+
+`jN_confidence` is `high` / `medium` / `low`, derived from the spread against two
+thresholds exposed as settings (defaults 2 C and 5 C).
+
+### FR6 — Source transparency
+
+A `model_used` text data point reports what fed J+1: a model id when one model is
+alone in its class, `median(n)` otherwise. The forecast stays auditable either
+way. This is the honest
+version of what a multi-model comparison UI shows visually.
+
+### FR7 — Model override setting
+
+A `models` setting accepts:
+
+- empty or `auto` (default): the discovery of FR1;
+- `best_match`: the escape hatch, restoring the pre-2.0 **deterministic source**
+  for every `jN_*` value;
+- a comma-separated list of Open-Meteo model ids: forced set.
+
+An unknown id is dropped and named in a `warn` rather than sent. This matters
+more than it looks: Open-Meteo rejects the _entire_ request when a single id is
+unknown, so passing a typo straight through would silently drop the household
+back to `best_match` on every poll, forever. If every id in the list is unknown,
+the setting falls back to the FR1 superset rather than to an empty list, which
+would mean `best_match` and is a different setting.
+
+`best_match` restores the deterministic source, not the whole of v1.0.0: the
+ensemble call still runs, so `jN_rain_prob` keeps the improvement of FR4 and
+`jN_confidence` is still published. Restoring the deterministic values is the
+point of the escape hatch; giving up a better rain probability is not.
+
+### FR8 — Budget
+
+Free tier limits are 600 calls/min, 5 000/hour, 10 000/day, with requests over
+10 variables counting as more than one unit. The design is 2 HTTP calls per poll
+for about 16 KB, but they are not one unit each: call A is 5 variables over up to
+12 models and call B is 2 variables over 51 members, so a poll weighs roughly 15
+units. At the default 30 minute interval that is about **750 units and 800 KB per
+day**, an order of magnitude under the daily cap and far under the hourly one.
+
+### FR9 — Forecast card shows confidence and source
+
+`WeatherForecastPanel` renders one card per day. Two additions, in the existing
+visual language:
+
+- Under the daily maximum, the spread as a figure: `± 2.6` in 11 px
+  `text-tertiary`. Rendered only for the days that carry it. A spread of 8 °C
+  reads immediately as "this day is not actionable", which no colour code
+  conveys as well.
+- Under the row, one discreet 12 px line naming the source: `Source: AROME
+2.5 km`, or `Source: median of 5 models`. The raw Open-Meteo id is mapped to a
+  provider-and-grid label; an id absent from the map is shown as is rather than
+  guessed at.
+
+The plugin publishes the **full width** of the uncertainty band, so the card
+renders half of it behind the `±`, which is what that notation means. Publishing
+a width and displaying it as a half-width would double the apparent uncertainty.
+
+Both degrade to nothing when absent, so a household still running plugin v1.0.0
+sees exactly today's card. Release ordering between the core and the plugin
+therefore does not matter.
+
+## Acceptance Criteria
+
+- [ ] The daily call carries `models=` and the response is resolved per FR2
+- [ ] The 25 existing `jN_*` aliases keep their key, type, category and unit
+- [ ] `jN_condition` is never null when at least one model carries `weather_code`
+- [ ] `jN_rain_prob` is populated from ensemble members, with the documented
+      fallback chain, and is never null when the ensemble call succeeds
+- [ ] `j1..j3_temp_max_spread` and `j1..j3_confidence` are published
+- [ ] `model_used` reports the J+1 source
+- [ ] `models=best_match` reproduces v1.0.0's deterministic values exactly
+- [ ] A failing ensemble call degrades the forecast but never fails the poll
+- [ ] Total device data points: 25 existing + 7 new = 32
+- [ ] The forecast card shows `± <spread>` under the maximum where available
+- [ ] The forecast card shows the source model line where `model_used` exists
+- [ ] With plugin v1.0.0 data (no new keys), the card renders exactly as before
+- [ ] Unit tests cover every scenario of the plan's test plan
+- [ ] Registry `sha256` bumped after the GitHub release (CLAUDE.md, spec 089)
+
+## Edge Cases
+
+| Case                                                                               | Expected                                                                                                                                   |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Ensemble endpoint down or 429                                                      | `jN_rain_prob` falls back to `best_match`, confidence falls back to the model spread alone, poll succeeds, one `warn`                      |
+| Deterministic multi-model call fails                                               | Retry the same call with `models=best_match`; if that fails too, the poll fails as it does today                                           |
+| Every model returns null for a variable on a day                                   | That `jN_*` value is `null`; the alias is still published                                                                                  |
+| Only one model covers the point                                                    | Median of one is that model; the model spread is 0, so confidence rests on the ensemble spread alone                                       |
+| No ensemble model covers the point                                                 | `jN_confidence` is derived from the model spread only; if fewer than two models, `jN_confidence` is `null` rather than a fabricated `high` |
+| `home.latitude` / `home.longitude` missing                                         | Unchanged: status `not_configured`, no call                                                                                                |
+| Open-Meteo returns `nan` for latitude when some requested models are out of domain | Response is still valid JSON for the models that do cover; parse defensively and ignore non-finite metadata                                |
+| A model returns a physically absurd value                                          | Out of scope here; no sanitisation is introduced by this spec                                                                              |
+| UI receives `jN_confidence` but no `jN_temp_max_spread`                            | Card renders the day normally without the `±` line                                                                                         |
+| UI receives `model_used` but no forecast days                                      | Panel returns null as it does today, no orphan source line                                                                                 |
+| Spread is 0 (a single model, no ensemble)                                          | No `±` line rather than a misleading `± 0`                                                                                                 |

--- a/ui/src/components/equipments/WeatherForecastPanel.tsx
+++ b/ui/src/components/equipments/WeatherForecastPanel.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from "react-i18next";
 import type { DataBindingWithValue } from "../../types";
 import {
   parseForecastDays,
+  parseModelUsed,
+  modelLabel,
   CONDITION_ICONS,
   CONDITION_COLORS,
   type ForecastDay,
@@ -13,7 +15,7 @@ interface WeatherForecastPanelProps {
 }
 
 export function WeatherForecastPanel({ bindings }: WeatherForecastPanelProps) {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const days = parseForecastDays(bindings);
 
   if (days.length === 0) {
@@ -21,6 +23,17 @@ export function WeatherForecastPanel({ bindings }: WeatherForecastPanelProps) {
   }
 
   const locale = i18n.language === "fr" ? "fr-FR" : "en-US";
+  // Absent before plugin 2.0, which is what keeps the card unchanged for
+  // households that have not upgraded.
+  const modelUsed = parseModelUsed(bindings);
+  // `median(5)` is the plugin's own notation for "no single model, the median
+  // of five". Anything else is a raw Open-Meteo id, shown as is: renaming a
+  // dozen ids in two languages would be upkeep for no gain, and the id is what
+  // a household would search for.
+  const medianMatch = modelUsed?.match(/^median\((\d+)\)$/);
+  const sourceLabel = medianMatch
+    ? t("equipments.forecast.medianOf", { count: Number(medianMatch[1]) })
+    : modelUsed && modelLabel(modelUsed);
 
   return (
     <div className="mb-6">
@@ -29,11 +42,17 @@ export function WeatherForecastPanel({ bindings }: WeatherForecastPanelProps) {
           <ForecastDayCard key={day.dayIndex} day={day} locale={locale} />
         ))}
       </div>
+      {modelUsed && (
+        <p className="mt-1 text-[12px] text-text-tertiary">
+          {t("equipments.forecast.source", { model: sourceLabel })}
+        </p>
+      )}
     </div>
   );
 }
 
 function ForecastDayCard({ day, locale }: { day: ForecastDay; locale: string }) {
+  const { t } = useTranslation();
   const today = new Date();
   const dayDate = new Date(today);
   dayDate.setDate(today.getDate() + day.dayIndex);
@@ -63,6 +82,22 @@ function ForecastDayCard({ day, locale }: { day: ForecastDay; locale: string }) 
           </span>
           <span className="text-[13px] text-text-tertiary">&deg;C</span>
         </div>
+      )}
+
+      {/* Spread behind the maximum — published for the first days only, and
+          only when several sources actually disagree. The plugin publishes the
+          full width of the band, so half of it goes behind the `±`. */}
+      {day.tempMaxSpread !== null && day.tempMaxSpread > 0 && (
+        <span
+          className="text-[11px] text-text-tertiary tabular-nums font-mono leading-none"
+          title={
+            day.confidence
+              ? t(`equipments.forecast.confidence.${day.confidence}`)
+              : undefined
+          }
+        >
+          &plusmn; {(day.tempMaxSpread / 2).toFixed(1)}
+        </span>
       )}
 
       {/* Temperature min */}

--- a/ui/src/components/equipments/weatherForecastUtils.test.ts
+++ b/ui/src/components/equipments/weatherForecastUtils.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import type { DataBindingWithValue } from "../../types";
+import { modelLabel, parseForecastDays, parseModelUsed } from "./weatherForecastUtils";
+
+function binding(
+  alias: string,
+  value: unknown,
+  type: DataBindingWithValue["type"] = "number",
+): DataBindingWithValue {
+  return {
+    id: "b-" + alias,
+    equipmentId: "eq",
+    deviceDataId: "dd-" + alias,
+    deviceId: "d1",
+    deviceName: "Weather Forecast",
+    alias,
+    key: alias,
+    type,
+    category: "temperature_outdoor" as DataBindingWithValue["category"],
+    value,
+    unit: "°C",
+    lastUpdated: "2026-08-24 10:00:00Z",
+    lastChanged: "2026-08-24 10:00:00Z",
+    stale: false,
+  };
+}
+
+/** What plugin 1.0.0 publishes: five metrics per day, no confidence. */
+function legacyBindings(): DataBindingWithValue[] {
+  return [
+    binding("j1_condition", "sunny", "enum"),
+    binding("j1_temp_min", 18),
+    binding("j1_temp_max", 30.5),
+    binding("j1_rain_prob", 20),
+    binding("j1_wind_gusts", 41),
+  ];
+}
+
+describe("parseForecastDays", () => {
+  it("parses the confidence metrics published from plugin 2.0", () => {
+    const days = parseForecastDays([
+      ...legacyBindings(),
+      binding("j1_temp_max_spread", 2.6),
+      binding("j1_confidence", "medium", "enum"),
+    ]);
+    expect(days).toHaveLength(1);
+    expect(days[0].tempMaxSpread).toBe(2.6);
+    expect(days[0].confidence).toBe("medium");
+  });
+
+  it("leaves both fields null on plugin 1.0.0 data and keeps every other field", () => {
+    const days = parseForecastDays(legacyBindings());
+    expect(days[0]).toEqual({
+      dayIndex: 1,
+      condition: "sunny",
+      tempMin: 18,
+      tempMax: 30.5,
+      rainProb: 20,
+      windGusts: 41,
+      tempMaxSpread: null,
+      confidence: null,
+    });
+  });
+
+  it("keeps a spread published without a confidence level", () => {
+    const days = parseForecastDays([...legacyBindings(), binding("j1_temp_max_spread", 4.2)]);
+    expect(days[0].tempMaxSpread).toBe(4.2);
+    expect(days[0].confidence).toBeNull();
+  });
+
+  it("ignores a non-numeric spread rather than throwing", () => {
+    const days = parseForecastDays([
+      ...legacyBindings(),
+      binding("j1_temp_max_spread", "n/a", "text"),
+    ]);
+    expect(days[0].tempMaxSpread).toBeNull();
+  });
+
+  it("ignores a confidence value outside the known enum", () => {
+    const days = parseForecastDays([
+      ...legacyBindings(),
+      binding("j1_confidence", "excellent", "enum"),
+    ]);
+    expect(days[0].confidence).toBeNull();
+  });
+
+  it("does not confuse temp_max_spread with temp_max", () => {
+    const days = parseForecastDays([
+      binding("j1_temp_max", 30.5),
+      binding("j1_temp_max_spread", 2.6),
+    ]);
+    expect(days[0].tempMax).toBe(30.5);
+    expect(days[0].tempMaxSpread).toBe(2.6);
+  });
+
+  it("keeps days sorted and only carries confidence on the days that publish it", () => {
+    const days = parseForecastDays([
+      binding("j5_temp_max", 25),
+      binding("j1_temp_max", 30),
+      binding("j1_temp_max_spread", 1.2),
+      binding("j3_temp_max", 28),
+      binding("j3_temp_max_spread", 5.4),
+    ]);
+    expect(days.map((d) => d.dayIndex)).toEqual([1, 3, 5]);
+    expect(days[2].tempMaxSpread).toBeNull();
+  });
+});
+
+describe("parseModelUsed", () => {
+  it("returns the published model id", () => {
+    const bindings = [...legacyBindings(), binding("model_used", "meteofrance_arome_france", "text")];
+    expect(parseModelUsed(bindings)).toBe("meteofrance_arome_france");
+  });
+
+  it("returns the median notation as published", () => {
+    expect(parseModelUsed([binding("model_used", "median(5)", "text")])).toBe("median(5)");
+  });
+
+  it("returns null when the binding is absent, i.e. on plugin 1.0.0", () => {
+    expect(parseModelUsed(legacyBindings())).toBeNull();
+  });
+
+  it("returns null on a non-string value", () => {
+    expect(parseModelUsed([binding("model_used", 42)])).toBeNull();
+  });
+
+  it("treats the plugin's `none` sentinel as nothing to show", () => {
+    expect(parseModelUsed([binding("model_used", "none", "text")])).toBeNull();
+    expect(parseModelUsed([binding("model_used", "   ", "text")])).toBeNull();
+  });
+});
+
+describe("modelLabel", () => {
+  it("humanises a known model id with its provider and grid", () => {
+    expect(modelLabel("meteofrance_arome_france")).toBe("AROME 2.5 km");
+    expect(modelLabel("dmi_harmonie_arome_europe")).toBe("DMI HARMONIE 2 km");
+  });
+
+  it("returns an unknown id unchanged rather than guessing", () => {
+    expect(modelLabel("some_new_model")).toBe("some_new_model");
+  });
+});

--- a/ui/src/components/equipments/weatherForecastUtils.ts
+++ b/ui/src/components/equipments/weatherForecastUtils.ts
@@ -32,6 +32,11 @@ export const CONDITION_COLORS: Record<string, string> = {
   stormy: "text-purple-500",
 };
 
+/** Forecast confidence published by the plugin from spec 159 onwards. */
+export type ForecastConfidence = "high" | "medium" | "low";
+
+const CONFIDENCE_VALUES: readonly string[] = ["high", "medium", "low"];
+
 export interface ForecastDay {
   dayIndex: number;
   condition: string | null;
@@ -39,6 +44,10 @@ export interface ForecastDay {
   tempMax: number | null;
   rainProb: number | null;
   windGusts: number | null;
+  /** Spread in °C behind the daily maximum. Null before plugin 2.0. */
+  tempMaxSpread: number | null;
+  /** Null before plugin 2.0, and whenever the plugin cannot honestly claim one. */
+  confidence: ForecastConfidence | null;
 }
 
 /** Parse bindings grouped by jN_ prefix into forecast day objects. */
@@ -54,12 +63,29 @@ export function parseForecastDays(bindings: DataBindingWithValue[]): ForecastDay
 
     let day = dayMap.get(dayIndex);
     if (!day) {
-      day = { dayIndex, condition: null, tempMin: null, tempMax: null, rainProb: null, windGusts: null };
+      day = {
+        dayIndex,
+        condition: null,
+        tempMin: null,
+        tempMax: null,
+        rainProb: null,
+        windGusts: null,
+        tempMaxSpread: null,
+        confidence: null,
+      };
       dayMap.set(dayIndex, day);
     }
 
     if (metric === "condition" && typeof b.value === "string") {
       day.condition = b.value;
+    } else if (metric === "temp_max_spread" && typeof b.value === "number") {
+      day.tempMaxSpread = b.value;
+    } else if (
+      metric === "confidence" &&
+      typeof b.value === "string" &&
+      CONFIDENCE_VALUES.includes(b.value)
+    ) {
+      day.confidence = b.value as ForecastConfidence;
     } else if (metric === "temp_min" && typeof b.value === "number") {
       day.tempMin = b.value;
     } else if (metric === "temp_max" && typeof b.value === "number") {
@@ -72,4 +98,44 @@ export function parseForecastDays(bindings: DataBindingWithValue[]): ForecastDay
   }
 
   return [...dayMap.values()].sort((a, b) => a.dayIndex - b.dayIndex);
+}
+
+/**
+ * The model, or model combination, the plugin resolved the forecast from.
+ *
+ * A flat binding rather than a `jN_` one, and absent before plugin 2.0.
+ */
+export function parseModelUsed(bindings: DataBindingWithValue[]): string | null {
+  const binding = bindings.find((b) => b.alias === "model_used");
+  if (!binding || typeof binding.value !== "string") return null;
+  const value = binding.value.trim();
+  return value === "" || value === "none" ? null : value;
+}
+
+/**
+ * Human labels for the Open-Meteo model ids the plugin can resolve to.
+ *
+ * Kept short and factual: the provider plus the grid, which is what makes one
+ * model different from another to a household. An id absent from the map is
+ * shown as is rather than guessed at.
+ */
+const MODEL_LABELS: Record<string, string> = {
+  meteofrance_arome_france: "AROME 2.5 km",
+  meteofrance_arpege_europe: "ARPEGE 11 km",
+  icon_d2: "ICON-D2 2.2 km",
+  icon_eu: "ICON-EU 7 km",
+  ncep_hrrr_conus: "HRRR 3 km",
+  knmi_harmonie_arome_netherlands: "HARMONIE-AROME 2 km",
+  dmi_harmonie_arome_europe: "DMI HARMONIE 2 km",
+  italia_meteo_arpae_icon_2i: "ICON-2I 2 km",
+  metno_seamless: "MET Norway",
+  ukmo_global_deterministic_10km: "UKMO 10 km",
+  gfs_seamless: "GFS",
+  ecmwf_ifs025: "ECMWF IFS 25 km",
+  best_match: "Open-Meteo best match",
+};
+
+/** Display label for a resolved model id, or the id itself when unknown. */
+export function modelLabel(modelId: string): string {
+  return MODEL_LABELS[modelId] ?? modelId;
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1398,5 +1398,10 @@
   "arbiter.moveUpNamed": "Move {{name}} up",
   "arbiter.moveDownNamed": "Move {{name}} down",
   "arbiter.timelineLabel": "Arbitration timeline: when each load held the surplus, and when it was stepped back.",
-  "arbiter.degradedReason": "Meter data is stale. The arbiter is paused until fresh readings arrive."
+  "arbiter.degradedReason": "Meter data is stale. The arbiter is paused until fresh readings arrive.",
+  "equipments.forecast.source": "Source: {{model}}",
+  "equipments.forecast.medianOf": "median of {{count}} models",
+  "equipments.forecast.confidence.high": "High confidence: the models agree",
+  "equipments.forecast.confidence.medium": "Moderate confidence",
+  "equipments.forecast.confidence.low": "Low confidence: the models disagree"
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1398,5 +1398,10 @@
   "arbiter.moveUpNamed": "Monter {{name}}",
   "arbiter.moveDownNamed": "Descendre {{name}}",
   "arbiter.timelineLabel": "Frise d'arbitrage : quand chaque charge a tenu le surplus, et quand elle s'est effacée.",
-  "arbiter.degradedReason": "Données compteur périmées. L'arbitre est en pause jusqu'au retour de mesures fraîches."
+  "arbiter.degradedReason": "Données compteur périmées. L'arbitre est en pause jusqu'au retour de mesures fraîches.",
+  "equipments.forecast.source": "Source : {{model}}",
+  "equipments.forecast.medianOf": "médiane de {{count}} modèles",
+  "equipments.forecast.confidence.high": "Confiance élevée : les modèles s'accordent",
+  "equipments.forecast.confidence.medium": "Confiance moyenne",
+  "equipments.forecast.confidence.low": "Confiance faible : les modèles divergent"
 }


### PR DESCRIPTION
## Summary

The forecast card shows a number with no way to tell how much to trust it. Plugin 2.0 (spec 159, [plugin PR #2](https://github.com/mchacher/sowel-plugin-weather-forecast/pull/2)) now publishes that information; this makes it visible.

Core side of spec 159. **UI only**: no new `DataCategory`, no migration, no event, no API route.

## Changes

- **Uncertainty under each daily maximum**, as a figure rather than a colour. A day spanning 8 °C reads immediately as not actionable, which no colour code conveys as well, and a figure does not compete with the condition colours already on the card. The plugin publishes the full width of the band, so the card renders half of it behind the `±`, which is what that notation means.
- **A source line under the row**, mapping the raw Open-Meteo id to a provider-and-grid label (`AROME 2.5 km`, `ICON-D2 2.2 km`). An id absent from the map is shown as is rather than guessed at; `median(n)` is humanised.
- The confidence level rides along as the element's `title`, so the enum is not parsed for nothing.

Both are conditional on data only plugin 2.0 publishes, so **a household still on 1.0.0 sees exactly today's card**. Release ordering between the core and the plugin does not matter.

## Also in this PR

`specs/159-weather-forecast-multi-model/` (spec, architecture, plan) and `docs/planning/2026-08-24-weather-multi-model.md`, the measurement write-up the spec is built on: what `best_match` actually resolves to across France, what the ensemble API gives for free, and the walk-forward numbers behind the two follow-up chantiers (local bias correction, PV production forecast).

## Test plan

- [x] `npx tsc --noEmit` (backend) — zero errors
- [x] `cd ui && npx tsc -b --noEmit` — zero errors
- [x] `npx vitest run` — 1704 backend tests pass
- [x] `cd ui && npx vitest run` — **593 tests**, including 14 new on `weatherForecastUtils`
- [x] `npx eslint src/ --ext .ts` and `cd ui && npx eslint .` — zero errors
- [x] Locale completeness check passes with the five new keys in both languages
- [ ] Visual check on a shadow instance once plugin 2.0 is installed

Reviewed by an agent against the spec before opening; it caught the `±` rendering a full width as a half-width, which is fixed here.