### PR TITLE
release: v1.56.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,13 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.56.x : Savoir à quel point faire confiance à la météo
+
+### v1.56.0 — 2026-08-24 { #v1-56-0 }
+
+- Feat (ui) : **la carte de prévision indique désormais la confiance à accorder à ses propres chiffres** (spec 159). Jusqu'ici elle affichait une température par jour sans permettre de distinguer une valeur sur laquelle les modèles s'accordent d'une valeur sur laquelle ils divergent, et se fier à « demain il fera 34 °C » ne disait pas s'il fallait comprendre 33 à 35 ou 29 à 37. La carte affiche maintenant l'incertitude sous chaque maximum et nomme sa source sous la rangée : `AROME 2.5 km`, ou `médiane de 4 modèles`. Une journée sur laquelle les modèles s'écartent de 8 °C se lit immédiatement comme non exploitable, ce qu'aucun chiffre unique ne peut exprimer. Ces valeurs viennent de la **version 2.0 du plugin Weather Forecast**, qui résout chaque jour à partir de tous les modèles couvrant la maison au lieu d'accepter un choix non divulgué, et calcule une vraie probabilité de pluie sur 51 membres d'ensemble. Tant que ce plugin n'est pas mis à jour, la carte s'affiche exactement comme avant : les deux peuvent donc être mis à jour dans n'importe quel ordre. (#704)
+- Maintenance (packages) : **un plugin NUT communautaire rejoint le registre**. `sowel-plugin-nut` expose les onduleurs servis par un serveur Network UPS Tools, le flux fourni par Synology, QNAP, Proxmox et la plupart des hôtes Linux, et se marie avec le type d'équipement UPS ajouté en v1.53.0. Il provient d'un auteur hors de la liste officielle : Sowel le signale donc comme paquet communautaire et demande une confirmation explicite à l'installation, empreinte de l'archive à l'appui. Il nécessite Sowel 1.53.0 ou plus récent. Contribution de adn-dev-adrien. (#703)
+
 ## 1.55.x : Mesurer l'arbitre, et réparer ce que chaque redémarrage perdait
 
 ### v1.55.0 — 2026-08-23 { #v1-55-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,13 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.56.x: Knowing how much to trust the forecast
+
+### v1.56.0 — 2026-08-24 { #v1-56-0 }
+
+- Feat (ui): **the forecast card now shows how much to trust its own numbers** (spec 159). Until now it showed one temperature per day with no way to tell a figure the models agree on from one they do not, and a household acting on "tomorrow reaches 34 °C" had no way to know whether that meant 33 to 35 or 29 to 37. The card now prints the uncertainty under each daily maximum and names its source under the row: `AROME 2.5 km`, or `median of 4 models`. A day whose models span 8 °C reads immediately as not actionable, which no single blended number can express. The figures come from **version 2.0 of the Weather Forecast plugin**, which resolves each day across every model that covers the home instead of accepting an undisclosed pick, and derives a genuine rain probability from 51 ensemble members. Until that plugin is updated the card renders exactly as before, so the two can be updated in either order. (#704)
+- Maintenance (packages): **a community NUT plugin joins the registry**. `sowel-plugin-nut` exposes the uninterruptible power supplies served by a Network UPS Tools server, the stream shipped by Synology, QNAP, Proxmox and most Linux hosts, and pairs with the UPS equipment type added in v1.53.0. It comes from outside the official author list, so Sowel flags it as a community package and asks for an explicit confirmation at install, showing the archive's fingerprint. It requires Sowel 1.53.0 or later. Contributed by adn-dev-adrien. (#703)
+
 ## 1.55.x: Measuring the arbiter, and fixing what every restart was losing
 
 ### v1.55.0 — 2026-08-23 { #v1-55-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.55.0",
+  "version": "1.56.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Version bump to **v1.56.0** plus the release notes in both languages, per spec 108.

Covers everything merged since `v1.55.0`:

- **#704** — `feat(ui)`: forecast confidence and source on the weather card (spec 159)
- **#703** — `chore(registry)`: the community NUT plugin joins the registry

## Release notes

Added under a new `## 1.56.x: Knowing how much to trust the forecast` section in `docs/release-notes.md` and `docs/release-notes.fr.md`, with the explicit `{ #v1-56-0 }` anchor the in-app updates sheet links to.

The forecast entry states plainly that the figures come from **version 2.0 of the Weather Forecast plugin** and that the card renders exactly as before until that plugin is updated, so the two can be updated in either order.

## Test plan

- [x] Both release-notes files carry `{ #v1-56-0 }` (the `verify-release-notes` job greps for it in the tagged commit)
- [x] `package.json` and `ui/package.json` both at 1.56.0, no other line touched
- [ ] CI green before merge
- [ ] Tag `v1.56.0` pushed on the merged commit, not on this branch

Merging this does not publish anything: the tag does. Tagging follows once this lands on main.