### PR TITLE
chore(registry): bump weather-forecast to 2.0.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -119,11 +119,11 @@
     "icon": "CloudSun",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-weather-forecast",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "tags": ["weather", "forecast", "open-meteo"],
     "sowelVersion": ">=1.2.11",
     "owner": "mchacher",
-    "sha256": "a7dd13234788bd5b44a1d172750299387a471b45c0d6abc72bd6f2913d5f6a53"
+    "sha256": "c5896e2025ff9020ad3bebd0d94c25b494334d30bf5f9e6744222258e3363174"
   },
   {
     "id": "smartthings",


### PR DESCRIPTION
## Summary

Points the registry at [weather-forecast v2.0.0](https://github.com/mchacher/sowel-plugin-weather-forecast/releases/tag/v2.0.0), published from the multi-model work of spec 159.

Mandatory follow-up to the plugin release: until this lands, installing 2.0.0 fails with `ChecksumMismatchError` (spec 089).

## Verification

The declared `sha256` was **downloaded and recomputed from the published asset**, not taken from the build:

```
c5896e2025ff9020ad3bebd0d94c25b494334d30bf5f9e6744222258e3363174  sowel-plugin-weather-forecast-2.0.0.tar.gz
```

`sowelVersion` stays at `>=1.2.11`. Nothing in 2.0.0 needs a newer core: the seven new data points are inert on an instance whose forecast card does not know how to render them, and the 25 historical `jN_*` aliases keep their key, type, category and unit.

## Note on the diff

`scripts/backfill-registry-sha256.mjs` re-expands every `tags` array when it rewrites the file, which turns a two-line change into a 200-line one. The two fields were applied by hand instead, so the diff is exactly what changed.

## Test plan

- [x] Hash matches the published asset
- [x] `plugins/registry.json` still parses, 33 entries, no other line touched
- [ ] CI green before merge