### PR TITLE
feat(ui): confidence as a colour-coded pill on the forecast card

### DIFF
--- a/specs/159-weather-forecast-multi-model/spec.md
+++ b/specs/159-weather-forecast-multi-model/spec.md
@@ -54,8 +54,11 @@ Design rationale and all measurements:
 - **Model comparison curves in the UI.** Showing four models side by side is
   `releve-meteo`'s product; Sowel's product is a decision. One figure plus a
   spread, not four curves.
-- **Colour-coding the confidence.** It would compete with the condition colours
-  already on the card.
+- **A raw uncertainty figure on the card.** The first implementation printed
+  `± 0.9` under the maximum. It is engineering notation on a card the whole
+  household reads, and it sat between the maximum and the minimum where it
+  qualified neither. The number survives in the binding and on the tooltip; the
+  card carries a level instead.
 
 ## Functional Requirements
 
@@ -152,8 +155,11 @@ French household seeing ten of them would systematically report less confidence
 than an American one seeing five, for identical meteorological uncertainty. Below
 five models the plain range is used, a band over four points being noise.
 
-New data points, for J+1 to J+3 only (beyond J+3 the spread is wide enough that
-the index would read `low` permanently and carry no information):
+New data points, for every forecast day. The index was first limited to J+1 to
+J+3 on the grounds that the far days would read `low` permanently. Two things
+overturned that: a card with no index on two of its five days reads as a bug,
+and the assumption is false in the first place — measured on one run, J+4 came
+out `low` on an 8.5 C band while J+5 was `medium` on 3.5 C.
 
 | Key                                         | Type   | Category            | Unit |
 | ------------------------------------------- | ------ | ------------------- | ---- |
@@ -205,22 +211,30 @@ day**, an order of magnitude under the daily cap and far under the hourly one.
 `WeatherForecastPanel` renders one card per day. Two additions, in the existing
 visual language:
 
-- Under the daily maximum, the spread as a figure: `± 2.6` in 11 px
-  `text-tertiary`. Rendered only for the days that carry it. A spread of 8 °C
-  reads immediately as "this day is not actionable", which no colour code
-  conveys as well.
+- At the foot of each card, separated from the temperatures by a rule, the
+  confidence as a **pill**, colour-coded green / amber / red. It qualifies the
+  whole day rather than one figure, which is why it sits at the foot and not
+  under the maximum. The exact band stays on the tooltip for whoever wants the
+  number.
 - Under the row, one discreet 12 px line naming the source: `Source: AROME
 2.5 km`, or `Source: median of 5 models`. The raw Open-Meteo id is mapped to a
   provider-and-grid label; an id absent from the map is shown as is rather than
   guessed at.
 
-The plugin publishes the **full width** of the uncertainty band, so the card
-renders half of it behind the `±`, which is what that notation means. Publishing
-a width and displaying it as a half-width would double the apparent uncertainty.
+Labels are `reliable` / `fairly reliable` / `unreliable`, which read as a scale
+without a legend, where `high` / `medium` / `low` would leave the reader to
+guess what is being measured.
 
-Both degrade to nothing when absent, so a household still running plugin v1.0.0
-sees exactly today's card. Release ordering between the core and the plugin
-therefore does not matter.
+**On the amber.** Sowel's accent is documented in `design-system/tokens.css` as
+"reserved for a light is on right now", so a traffic light makes the same hue
+carry two meanings across the app. This was raised and the maintainer chose the
+traffic light anyway: it is the one colour code that needs no learning, and the
+alternative (green / neutral / brick) was judged less immediate. Recorded here
+so the collision is a known trade-off rather than an oversight.
+
+Both additions are conditional on data only plugin 2.0 publishes, so a household
+still running 1.0.0 sees exactly today's card. Release ordering between the core
+and the plugin therefore does not matter.
 
 ## Acceptance Criteria
 
@@ -229,12 +243,12 @@ therefore does not matter.
 - [ ] `jN_condition` is never null when at least one model carries `weather_code`
 - [ ] `jN_rain_prob` is populated from ensemble members, with the documented
       fallback chain, and is never null when the ensemble call succeeds
-- [ ] `j1..j3_temp_max_spread` and `j1..j3_confidence` are published
+- [ ] `j1..j5_temp_max_spread` and `j1..j5_confidence` are published
 - [ ] `model_used` reports the J+1 source
 - [ ] `models=best_match` reproduces v1.0.0's deterministic values exactly
 - [ ] A failing ensemble call degrades the forecast but never fails the poll
-- [ ] Total device data points: 25 existing + 7 new = 32
-- [ ] The forecast card shows `± <spread>` under the maximum where available
+- [ ] Total device data points: 25 existing + 11 new = 36
+- [ ] The forecast card shows a colour-coded confidence pill at its foot
 - [ ] The forecast card shows the source model line where `model_used` exists
 - [ ] With plugin v1.0.0 data (no new keys), the card renders exactly as before
 - [ ] Unit tests cover every scenario of the plan's test plan

--- a/ui/src/components/equipments/WeatherForecastPanel.tsx
+++ b/ui/src/components/equipments/WeatherForecastPanel.tsx
@@ -8,7 +8,20 @@ import {
   CONDITION_ICONS,
   CONDITION_COLORS,
   type ForecastDay,
+  type ForecastConfidence,
 } from "./weatherForecastUtils";
+
+/**
+ * Traffic-light coding of the confidence level. Green reads "act on it", red
+ * "do not build on this day". The amber middle is a deliberate call by the
+ * maintainer: the accent is otherwise reserved for "a light is on right now",
+ * so the same hue carries two meanings across the app.
+ */
+const CONFIDENCE_STYLES: Record<ForecastConfidence, string> = {
+  high: "border-success text-success bg-success/10",
+  medium: "border-warning text-warning bg-warning/10",
+  low: "border-error text-error bg-error/10",
+};
 
 interface WeatherForecastPanelProps {
   bindings: DataBindingWithValue[];
@@ -84,22 +97,6 @@ function ForecastDayCard({ day, locale }: { day: ForecastDay; locale: string }) 
         </div>
       )}
 
-      {/* Spread behind the maximum — published for the first days only, and
-          only when several sources actually disagree. The plugin publishes the
-          full width of the band, so half of it goes behind the `±`. */}
-      {day.tempMaxSpread !== null && day.tempMaxSpread > 0 && (
-        <span
-          className="text-[11px] text-text-tertiary tabular-nums font-mono leading-none"
-          title={
-            day.confidence
-              ? t(`equipments.forecast.confidence.${day.confidence}`)
-              : undefined
-          }
-        >
-          &plusmn; {(day.tempMaxSpread / 2).toFixed(1)}
-        </span>
-      )}
-
       {/* Temperature min */}
       {day.tempMin !== null && (
         <div className="flex items-baseline gap-0.5">
@@ -126,6 +123,28 @@ function ForecastDayCard({ day, locale }: { day: ForecastDay; locale: string }) 
           <Wind size={13} strokeWidth={1.5} className="text-text-tertiary" />
           <span className="text-[12px] text-text-secondary tabular-nums font-mono">
             {Math.round(day.windGusts)} km/h
+          </span>
+        </div>
+      )}
+
+      {/* How much the sources agree on this day. Sits at the foot, separated
+          from the temperatures: it qualifies the whole day, not one figure.
+          The exact band stays on the tooltip for whoever wants the number. */}
+      {day.confidence && (
+        <div className="mt-0.5 w-full border-t border-border-light pt-2 flex justify-center">
+          <span
+            className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${
+              CONFIDENCE_STYLES[day.confidence]
+            }`}
+            title={
+              day.tempMaxSpread !== null && day.tempMaxSpread > 0
+                ? t("equipments.forecast.confidenceHint", {
+                    spread: day.tempMaxSpread.toFixed(1),
+                  })
+                : undefined
+            }
+          >
+            {t(`equipments.forecast.confidence.${day.confidence}`)}
           </span>
         </div>
       )}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1401,7 +1401,8 @@
   "arbiter.degradedReason": "Meter data is stale. The arbiter is paused until fresh readings arrive.",
   "equipments.forecast.source": "Source: {{model}}",
   "equipments.forecast.medianOf": "median of {{count}} models",
-  "equipments.forecast.confidence.high": "High confidence: the models agree",
-  "equipments.forecast.confidence.medium": "Moderate confidence",
-  "equipments.forecast.confidence.low": "Low confidence: the models disagree"
+  "equipments.forecast.confidence.high": "reliable",
+  "equipments.forecast.confidence.medium": "fairly reliable",
+  "equipments.forecast.confidence.low": "unreliable",
+  "equipments.forecast.confidenceHint": "The sources span {{spread}} °C on this day"
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1401,7 +1401,8 @@
   "arbiter.degradedReason": "Données compteur périmées. L'arbitre est en pause jusqu'au retour de mesures fraîches.",
   "equipments.forecast.source": "Source : {{model}}",
   "equipments.forecast.medianOf": "médiane de {{count}} modèles",
-  "equipments.forecast.confidence.high": "Confiance élevée : les modèles s'accordent",
-  "equipments.forecast.confidence.medium": "Confiance moyenne",
-  "equipments.forecast.confidence.low": "Confiance faible : les modèles divergent"
+  "equipments.forecast.confidence.high": "fiable",
+  "equipments.forecast.confidence.medium": "assez fiable",
+  "equipments.forecast.confidence.low": "peu fiable",
+  "equipments.forecast.confidenceHint": "Les sources s'écartent de {{spread}} °C sur cette journée"
 }


### PR DESCRIPTION
## Summary

Reworks how spec 159's confidence reaches the card, after the first cut was tried on a real household and did not survive contact.

**Before**: `± 0.9` in small grey monospace, under the daily maximum.

Two problems. It is engineering notation on a card the whole household reads — the reaction that prompted this was, verbatim, "ma femme va rien comprendre". And it sat between the maximum and the minimum, qualifying neither and interrupting the pair.

**After**: the level reads as a pill at the foot of the card, separated by a rule, because it qualifies the whole day rather than one figure.

- Labels are a scale in plain words: **fiable / assez fiable / peu fiable** (`reliable` / `fairly reliable` / `unreliable`), where `high` / `medium` / `low` leaves the reader to guess what is being measured.
- Traffic-light colouring, using the existing `success` / `warning` / `error` tokens and the `bg-*/10` pattern already used by `ZoneAggregationPills` and `CompactEquipmentCard`.
- The exact band moves to the tooltip and stays in the `jN_temp_max_spread` binding for recipes: nothing is lost, it is just no longer the first thing a reader meets.

## On the amber

`design-system/tokens.css` documents the accent as *"reserved for a light is on right now"*, so a traffic light makes the same hue carry two meanings across the app. This was raised, alternatives were mocked up (green / neutral / brick, and a single hue at three intensities), and the maintainer chose the traffic light: it is the one code that needs no learning. Recorded in the spec so it stays a known trade-off rather than an oversight.

## Compatibility

Renders only for days that publish a level, so a household still on plugin 1.0.0 sees exactly the previous card. Plugin 2.1.0 extends the level to all five days; with 2.0.0 the last two cards simply carry no pill.

## Test plan

- [x] `cd ui && npx tsc -b --noEmit` — zero errors
- [x] `npx vitest run` (ui) — 593 tests pass
- [x] `npx eslint` — zero errors on the touched files
- [x] Locale completeness passes with the new keys in both languages
- [ ] Visual check once plugin 2.1.0 is installed

Design exploration that led here: five treatments compared on the real card with the instance's real values.