### PR TITLE
feat(activity): record alarm resolutions in the zone activity feed

### DIFF
--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -462,7 +462,7 @@ L'image runtime fait environ 950 Mo non compressée (environ 210 Mo de contenu).
 
 ### Flux d'événements
 
-1. Le buffer souscrit à un sous-ensemble curé d'`EngineEvent`s : `equipment.order.executed`, `equipment.data.changed` (filtré sur la catégorie de binding `motion`, `water_leak`, `smoke`), `recipe.instance.started/stopped/error`, `mode.activated/deactivated`, `sunlight.changed`, `system.alarm.raised`, `system.alarm.resolved`.
+1. Le buffer souscrit à un sous-ensemble curé d'`EngineEvent`s : `equipment.order.executed`, `equipment.data.changed` (filtré sur la catégorie de binding `motion`, `water_leak`, `smoke`), `recipe.instance.started/stopped/error`, `mode.activated/deactivated`, `sunlight.changed`, `system.alarm.raised`, `system.alarm.resolved`. Une résolution est classée dans la zone portée par son événement, à défaut dans celle de la levée vue par le buffer (globale s'il n'a ni l'une ni l'autre, par exemple une alarme levée avant un redémarrage).
 2. Pour chaque événement, il résout le nom d'équipement / de recette et le `zoneId` pertinent via les managers (equipment, recipe, zone, sunlight), puis construit un `ActivityItem`.
 3. Il pousse l'item dans le ring buffer (cap par count, purge des entrées dépassant le TTL) et émet un événement `activity.added` sur le bus.
 4. La couche WebSocket diffuse cet événement aux clients abonnés au topic `activity`. Les clients bootstrapent également via `GET /api/v1/activity` au montage.

--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -462,7 +462,7 @@ L'image runtime fait environ 950 Mo non compressée (environ 210 Mo de contenu).
 
 ### Flux d'événements
 
-1. Le buffer souscrit à un sous-ensemble curé d'`EngineEvent`s : `equipment.order.executed`, `equipment.data.changed` (filtré sur la catégorie de binding `motion`, `water_leak`, `smoke`), `recipe.instance.started/stopped/error`, `mode.activated/deactivated`, `sunlight.changed`, `system.alarm.raised`.
+1. Le buffer souscrit à un sous-ensemble curé d'`EngineEvent`s : `equipment.order.executed`, `equipment.data.changed` (filtré sur la catégorie de binding `motion`, `water_leak`, `smoke`), `recipe.instance.started/stopped/error`, `mode.activated/deactivated`, `sunlight.changed`, `system.alarm.raised`, `system.alarm.resolved`.
 2. Pour chaque événement, il résout le nom d'équipement / de recette et le `zoneId` pertinent via les managers (equipment, recipe, zone, sunlight), puis construit un `ActivityItem`.
 3. Il pousse l'item dans le ring buffer (cap par count, purge des entrées dépassant le TTL) et émet un événement `activity.added` sur le bus.
 4. La couche WebSocket diffuse cet événement aux clients abonnés au topic `activity`. Les clients bootstrapent également via `GET /api/v1/activity` au montage.

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -564,7 +564,7 @@ Runtime image is ~950 MB uncompressed (~210 MB content). The Python 3.13 require
 
 ### Event flow
 
-1. The buffer subscribes to a curated set of `EngineEvent`s: `equipment.order.executed`, `equipment.data.changed` (filtered by binding category to `motion`, `water_leak`, `smoke`), `recipe.instance.started/stopped/error`, `mode.activated/deactivated`, `sunlight.changed`, `system.alarm.raised`, `system.alarm.resolved`.
+1. The buffer subscribes to a curated set of `EngineEvent`s: `equipment.order.executed`, `equipment.data.changed` (filtered by binding category to `motion`, `water_leak`, `smoke`), `recipe.instance.started/stopped/error`, `mode.activated/deactivated`, `sunlight.changed`, `system.alarm.raised`, `system.alarm.resolved`. A resolution is filed in the zone its event carries, falling back to the zone of the raise the buffer saw (global when it has neither, e.g. an alarm raised before a restart).
 2. For each event it resolves equipment / recipe names and the relevant `zoneId` via the equipment, recipe, zone and sunlight managers, then builds an `ActivityItem`.
 3. It pushes the item to the ring buffer (capping by count, purging stale entries past the TTL) and emits an `activity.added` event on the bus.
 4. The WebSocket layer broadcasts that event to clients subscribed to the `activity` topic. Clients also bootstrap from `GET /api/v1/activity` on mount.

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -564,7 +564,7 @@ Runtime image is ~950 MB uncompressed (~210 MB content). The Python 3.13 require
 
 ### Event flow
 
-1. The buffer subscribes to a curated set of `EngineEvent`s: `equipment.order.executed`, `equipment.data.changed` (filtered by binding category to `motion`, `water_leak`, `smoke`), `recipe.instance.started/stopped/error`, `mode.activated/deactivated`, `sunlight.changed`, `system.alarm.raised`.
+1. The buffer subscribes to a curated set of `EngineEvent`s: `equipment.order.executed`, `equipment.data.changed` (filtered by binding category to `motion`, `water_leak`, `smoke`), `recipe.instance.started/stopped/error`, `mode.activated/deactivated`, `sunlight.changed`, `system.alarm.raised`, `system.alarm.resolved`.
 2. For each event it resolves equipment / recipe names and the relevant `zoneId` via the equipment, recipe, zone and sunlight managers, then builds an `ActivityItem`.
 3. It pushes the item to the ring buffer (capping by count, purging stale entries past the TTL) and emits an `activity.added` event on the bus.
 4. The WebSocket layer broadcasts that event to clients subscribed to the `activity` topic. Clients also bootstrap from `GET /api/v1/activity` on mount.

--- a/docs/user/zones.fr.md
+++ b/docs/user/zones.fr.md
@@ -99,14 +99,15 @@ Le panneau regroupe les événements par heure. Le bucket le plus récent porte 
 
 ### Ce qui est tracé
 
-| Catégorie     | Déclencheur                                                                       | Exemple                                                 |
-| ------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| **Ordre**     | Tout ordre dispatché sur un équipement par une recette, un mode, un bouton, l'API | `Lumière → ON manuel`, `Lumière → OFF par Motion Light` |
-| **Mouvement** | Front montant d'un capteur de présence (catégorie binding `motion`)               | `Mouvement détecté sur PIR Salon`                       |
-| **Recette**   | Démarrage ou arrêt d'une instance de recette                                      | `Recette Motion Light démarrée`                         |
-| **Mode**      | Activation ou désactivation d'un mode                                             | `Mode Nuit activé`                                      |
-| **Soleil**    | Lever ou coucher du soleil                                                        | `Coucher du soleil`                                     |
-| **Alarme**    | Alarme système, erreur de recette, détection fuite d'eau ou fumée                 | `Détecteur Cuisine : Fumée détectée`                    |
+| Catégorie        | Déclencheur                                                                               | Exemple                                                       |
+| ---------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| **Ordre**        | Tout ordre dispatché sur un équipement par une recette, un mode, un bouton, l'API         | `Lumière → ON manuel`, `Lumière → OFF par Motion Light`       |
+| **Mouvement**    | Front montant d'un capteur de présence (catégorie binding `motion`)                       | `Mouvement détecté sur PIR Salon`                             |
+| **Recette**      | Démarrage ou arrêt d'une instance de recette                                              | `Recette Motion Light démarrée`                               |
+| **Mode**         | Activation ou désactivation d'un mode                                                     | `Mode Nuit activé`                                            |
+| **Soleil**       | Lever ou coucher du soleil                                                                | `Coucher du soleil`                                           |
+| **Alarme**       | Alarme système, erreur de recette, détection fuite d'eau ou fumée                         | `Détecteur Cuisine : Fumée détectée`                          |
+| **Alarme levée** | La fin de la même alarme — secteur revenu, batterie remontée, plugin de nouveau joignable | `nut : Retour secteur — ups est réalimenté (batterie à 58 %)` |
 
 Chaque ligne indique **qui a déclenché l'événement** : nom de la recette, nom du mode, « manuel » pour les actions directes via l'UI, identifiant du bouton, ou « externe » pour un MQTT entrant.
 

--- a/docs/user/zones.md
+++ b/docs/user/zones.md
@@ -99,15 +99,15 @@ The panel groups events by hour. The most recent bucket is labeled `HH:00 → no
 
 ### What is tracked
 
-| Category            | Triggered by                                                                        | Example                                                 |
-| ------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| **Order**           | Any equipment order dispatched by a recipe, mode, button, manual API call           | `Lumière → ON manuel`, `Lumière → OFF par Motion Light` |
-| **Motion**          | Motion sensor rising edge (binding category `motion`)                               | `Motion detected on PIR Living Room`                    |
-| **Recipe**          | Recipe instance start / stop                                                        | `Recipe Motion Light started`                           |
-| **Mode**            | Mode activation / deactivation                                                      | `Mode Night activated`                                  |
-| **Sunlight**        | Sunrise or sunset transition                                                        | `Sunset`                                                |
-| **Alarm**           | System alarm raised, recipe errors, water leak, smoke detection                     | `Smoke detector Kitchen: Smoke detected`                |
-| **Alarm (cleared)** | The same alarm going away — mains restored, battery back up, plugin reachable again | `nut: Mains restored — ups is back on utility power`    |
+| Category            | Triggered by                                                                        | Example                                                      |
+| ------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| **Order**           | Any equipment order dispatched by a recipe, mode, button, manual API call           | `Lumière → ON manuel`, `Lumière → OFF par Motion Light`      |
+| **Motion**          | Motion sensor rising edge (binding category `motion`)                               | `Motion detected on PIR Living Room`                         |
+| **Recipe**          | Recipe instance start / stop                                                        | `Recipe Motion Light started`                                |
+| **Mode**            | Mode activation / deactivation                                                      | `Mode Night activated`                                       |
+| **Sunlight**        | Sunrise or sunset transition                                                        | `Sunset`                                                     |
+| **Alarm**           | System alarm raised, recipe errors, water leak, smoke detection                     | `Smoke detector Kitchen: Smoke detected`                     |
+| **Alarm (cleared)** | The same alarm going away — mains restored, battery back up, plugin reachable again | `nut: Retour secteur — ups est réalimenté (batterie à 58 %)` |
 
 Each item shows **who triggered it**: a recipe name, a mode name, "manual" for direct UI actions, the button id, or "external" for inbound MQTT.
 

--- a/docs/user/zones.md
+++ b/docs/user/zones.md
@@ -99,14 +99,15 @@ The panel groups events by hour. The most recent bucket is labeled `HH:00 → no
 
 ### What is tracked
 
-| Category     | Triggered by                                                              | Example                                                 |
-| ------------ | ------------------------------------------------------------------------- | ------------------------------------------------------- |
-| **Order**    | Any equipment order dispatched by a recipe, mode, button, manual API call | `Lumière → ON manuel`, `Lumière → OFF par Motion Light` |
-| **Motion**   | Motion sensor rising edge (binding category `motion`)                     | `Motion detected on PIR Living Room`                    |
-| **Recipe**   | Recipe instance start / stop                                              | `Recipe Motion Light started`                           |
-| **Mode**     | Mode activation / deactivation                                            | `Mode Night activated`                                  |
-| **Sunlight** | Sunrise or sunset transition                                              | `Sunset`                                                |
-| **Alarm**    | System alarm raised, recipe errors, water leak, smoke detection           | `Smoke detector Kitchen: Smoke detected`                |
+| Category            | Triggered by                                                                        | Example                                                 |
+| ------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| **Order**           | Any equipment order dispatched by a recipe, mode, button, manual API call           | `Lumière → ON manuel`, `Lumière → OFF par Motion Light` |
+| **Motion**          | Motion sensor rising edge (binding category `motion`)                               | `Motion detected on PIR Living Room`                    |
+| **Recipe**          | Recipe instance start / stop                                                        | `Recipe Motion Light started`                           |
+| **Mode**            | Mode activation / deactivation                                                      | `Mode Night activated`                                  |
+| **Sunlight**        | Sunrise or sunset transition                                                        | `Sunset`                                                |
+| **Alarm**           | System alarm raised, recipe errors, water leak, smoke detection                     | `Smoke detector Kitchen: Smoke detected`                |
+| **Alarm (cleared)** | The same alarm going away — mains restored, battery back up, plugin reachable again | `nut: Mains restored — ups is back on utility power`    |
 
 Each item shows **who triggered it**: a recipe name, a mode name, "manual" for direct UI actions, the button id, or "external" for inbound MQTT.
 

--- a/src/activity/activity-buffer.test.ts
+++ b/src/activity/activity-buffer.test.ts
@@ -349,6 +349,58 @@ describe("ActivityBuffer", () => {
         message: { template: "alarm.raised" },
       });
     });
+
+    it("records system.alarm.resolved so the end of an incident is in the feed", () => {
+      h.bus.emit({
+        type: "system.alarm.resolved",
+        alarmId: "a1",
+        source: "nut",
+        message: "Retour secteur — ups est réalimenté (batterie à 58 %)",
+      });
+      expect(h.buffer.getItems()[0]).toMatchObject({
+        category: "alarm",
+        zoneId: null,
+        message: {
+          template: "alarm.resolved",
+          params: {
+            source: "nut",
+            message: "Retour secteur — ups est réalimenté (batterie à 58 %)",
+          },
+        },
+      });
+    });
+
+    it("files a resolution in the zone its alarm was raised in", () => {
+      h.bus.emit({
+        type: "system.alarm.raised",
+        alarmId: "battery-low:dd-1",
+        level: "warning",
+        source: "Détecteur salon",
+        message: "Low battery: 12%",
+        zoneId: "zone-A",
+      });
+      h.bus.emit({
+        type: "system.alarm.resolved",
+        alarmId: "battery-low:dd-1",
+        source: "Détecteur salon",
+        message: "Battery back to 80%",
+      });
+
+      const resolved = (items: { message: { template: string } }[]) =>
+        items.some((i) => i.message.template === "alarm.resolved");
+      expect(resolved(h.buffer.getItems({ zoneId: "zone-A" }))).toBe(true);
+      expect(resolved(h.buffer.getItems({ zoneId: "zone-B" }))).toBe(false);
+    });
+
+    it("keeps a resolution global when the raise was never seen (restart)", () => {
+      h.bus.emit({
+        type: "system.alarm.resolved",
+        alarmId: "raised-before-the-restart",
+        source: "nut",
+        message: "Serveur NUT de nouveau joignable",
+      });
+      expect(h.buffer.getItems({ zoneId: "zone-A" })[0]).toMatchObject({ zoneId: null });
+    });
   });
 
   describe("filter by zone", () => {

--- a/src/activity/activity-buffer.test.ts
+++ b/src/activity/activity-buffer.test.ts
@@ -392,6 +392,43 @@ describe("ActivityBuffer", () => {
       expect(resolved(h.buffer.getItems({ zoneId: "zone-B" }))).toBe(false);
     });
 
+    it("files a resolution in the zone the event carries, raise seen or not", () => {
+      h.bus.emit({
+        type: "system.alarm.resolved",
+        alarmId: "battery-low:dd-9",
+        source: "Détecteur salon",
+        message: "Battery back to 80%",
+        zoneId: "zone-A",
+      });
+
+      const resolved = (items: { message: { template: string } }[]) =>
+        items.some((i) => i.message.template === "alarm.resolved");
+      expect(resolved(h.buffer.getItems({ zoneId: "zone-A" }))).toBe(true);
+      expect(resolved(h.buffer.getItems({ zoneId: "zone-B" }))).toBe(false);
+    });
+
+    it("honours an explicit global zone on the event over the remembered raise", () => {
+      h.bus.emit({
+        type: "system.alarm.raised",
+        alarmId: "battery-low:dd-2",
+        level: "warning",
+        source: "Détecteur salon",
+        message: "Low battery: 12%",
+        zoneId: "zone-A",
+      });
+      h.bus.emit({
+        type: "system.alarm.resolved",
+        alarmId: "battery-low:dd-2",
+        source: "Détecteur salon",
+        message: "Battery back to 80%",
+        zoneId: null,
+      });
+      expect(h.buffer.getItems()[0]).toMatchObject({
+        zoneId: null,
+        message: { template: "alarm.resolved" },
+      });
+    });
+
     it("keeps a resolution global when the raise was never seen (restart)", () => {
       h.bus.emit({
         type: "system.alarm.resolved",
@@ -400,6 +437,40 @@ describe("ActivityBuffer", () => {
         message: "Serveur NUT de nouveau joignable",
       });
       expect(h.buffer.getItems({ zoneId: "zone-A" })[0]).toMatchObject({ zoneId: null });
+    });
+
+    it("bounds the zones it remembers for alarms that never resolve", () => {
+      for (let i = 0; i < 600; i++) {
+        h.bus.emit({
+          type: "system.alarm.raised",
+          alarmId: `never-resolved-${i}`,
+          level: "warning",
+          source: "plugin",
+          message: "Boom",
+          zoneId: "zone-A",
+        });
+      }
+      // The oldest entries were evicted, so their resolution falls back to
+      // global instead of the map growing for the process lifetime.
+      h.bus.emit({
+        type: "system.alarm.resolved",
+        alarmId: "never-resolved-0",
+        source: "plugin",
+        message: "Recovered",
+      });
+      expect(h.buffer.getItems()[0]).toMatchObject({
+        zoneId: null,
+        message: { template: "alarm.resolved" },
+      });
+
+      // The most recent raise is still remembered.
+      h.bus.emit({
+        type: "system.alarm.resolved",
+        alarmId: "never-resolved-599",
+        source: "plugin",
+        message: "Recovered",
+      });
+      expect(h.buffer.getItems()[0]).toMatchObject({ zoneId: "zone-A" });
     });
   });
 

--- a/src/activity/activity-buffer.ts
+++ b/src/activity/activity-buffer.ts
@@ -33,6 +33,12 @@ export class ActivityBuffer {
   private readonly items: ActivityItem[] = [];
   private readonly logger: Logger;
   private prevIsDaylight: boolean | null = null;
+  /**
+   * Zone each currently-raised alarm was filed under. `system.alarm.resolved`
+   * carries no zone, so without this the end of an outage would surface in
+   * every zone while its start stayed scoped to one.
+   */
+  private readonly alarmZones = new Map<string, string | null>();
 
   constructor(
     private readonly bus: EventBus,
@@ -66,6 +72,7 @@ export class ActivityBuffer {
     this.bus.onType("mode.deactivated", (e) => this.onModeDeactivated(e));
     this.bus.onType("sunlight.changed", () => this.onSunlightChanged());
     this.bus.onType("system.alarm.raised", (e) => this.onAlarmRaised(e));
+    this.bus.onType("system.alarm.resolved", (e) => this.onAlarmResolved(e));
     this.logger.info("Activity buffer started");
   }
 
@@ -245,12 +252,34 @@ export class ActivityBuffer {
     this.push("sunlight", null, { template, params: {} });
   }
 
-  private onAlarmRaised(event: { source: string; message: string; zoneId?: string | null }): void {
+  private onAlarmRaised(event: {
+    alarmId: string;
+    source: string;
+    message: string;
+    zoneId?: string | null;
+  }): void {
     // A zone-scoped alarm (a battery alert bound to an equipment, spec 143/#472)
     // lands in that zone; an alarm with no zone (integrations, unbound device)
     // stays global and shows in every zone, as before.
-    this.push("alarm", event.zoneId ?? null, {
+    const zoneId = event.zoneId ?? null;
+    this.alarmZones.set(event.alarmId, zoneId);
+    this.push("alarm", zoneId, {
       template: "alarm.raised",
+      params: { source: event.source, message: event.message },
+    });
+  }
+
+  /**
+   * The other half of an alarm's life. A feed that only ever records the bad
+   * news reads as an unbroken run of failures: the mains outage is in there,
+   * the moment the power came back is not. The zone is the one the alarm was
+   * raised in — global when it was raised before this process started.
+   */
+  private onAlarmResolved(event: { alarmId: string; source: string; message: string }): void {
+    const zoneId = this.alarmZones.get(event.alarmId) ?? null;
+    this.alarmZones.delete(event.alarmId);
+    this.push("alarm", zoneId, {
+      template: "alarm.resolved",
       params: { source: event.source, message: event.message },
     });
   }

--- a/src/activity/activity-buffer.ts
+++ b/src/activity/activity-buffer.ts
@@ -15,6 +15,10 @@ interface GetItemsOptions {
 }
 
 const MAX_ITEMS = 2000;
+// Zones remembered for alarms still raised. Far above any realistic count of
+// standing alarms; only there so an alarm that never resolves cannot grow the
+// map without bound.
+const MAX_TRACKED_ALARM_ZONES = 500;
 // Spec 147 — keep the live ring aligned with the persisted retention so a
 // restart restores the same window it will then maintain (bounded by MAX_ITEMS).
 const TTL_MS = ACTIVITY_RETENTION_DAYS * 24 * 60 * 60 * 1000;
@@ -34,9 +38,10 @@ export class ActivityBuffer {
   private readonly logger: Logger;
   private prevIsDaylight: boolean | null = null;
   /**
-   * Zone each currently-raised alarm was filed under. `system.alarm.resolved`
-   * carries no zone, so without this the end of an outage would surface in
-   * every zone while its start stayed scoped to one.
+   * Zone each currently-raised alarm was filed under, used only when a
+   * `system.alarm.resolved` arrives without a zone of its own (a plugin that
+   * does not send one). Emitters that know the zone send it on both halves,
+   * which also survives a restart; this map does not.
    */
   private readonly alarmZones = new Map<string, string | null>();
 
@@ -100,6 +105,7 @@ export class ActivityBuffer {
   /** Internal: clear all items (used in tests). */
   clear(): void {
     this.items.length = 0;
+    this.alarmZones.clear();
   }
 
   /** Internal: get raw count (used in tests). */
@@ -262,7 +268,7 @@ export class ActivityBuffer {
     // lands in that zone; an alarm with no zone (integrations, unbound device)
     // stays global and shows in every zone, as before.
     const zoneId = event.zoneId ?? null;
-    this.alarmZones.set(event.alarmId, zoneId);
+    this.rememberAlarmZone(event.alarmId, zoneId);
     this.push("alarm", zoneId, {
       template: "alarm.raised",
       params: { source: event.source, message: event.message },
@@ -272,16 +278,39 @@ export class ActivityBuffer {
   /**
    * The other half of an alarm's life. A feed that only ever records the bad
    * news reads as an unbroken run of failures: the mains outage is in there,
-   * the moment the power came back is not. The zone is the one the alarm was
-   * raised in — global when it was raised before this process started.
+   * the moment the power came back is not. The zone comes from the event when
+   * the emitter sends one (the reliable path, restart included), otherwise
+   * from the raise we saw — global when we saw neither.
    */
-  private onAlarmResolved(event: { alarmId: string; source: string; message: string }): void {
-    const zoneId = this.alarmZones.get(event.alarmId) ?? null;
+  private onAlarmResolved(event: {
+    alarmId: string;
+    source: string;
+    message: string;
+    zoneId?: string | null;
+  }): void {
+    const zoneId =
+      event.zoneId !== undefined ? event.zoneId : (this.alarmZones.get(event.alarmId) ?? null);
     this.alarmZones.delete(event.alarmId);
     this.push("alarm", zoneId, {
       template: "alarm.resolved",
       params: { source: event.source, message: event.message },
     });
+  }
+
+  /**
+   * Entries leave the map when their alarm resolves, but an alarm raised on an
+   * equipment that is then deleted (or by a plugin minting a fresh id every
+   * time) never resolves. Cap the map like the ring itself is capped: oldest
+   * out first, so a leak stays bounded instead of growing for the process
+   * lifetime.
+   */
+  private rememberAlarmZone(alarmId: string, zoneId: string | null): void {
+    this.alarmZones.delete(alarmId);
+    if (this.alarmZones.size >= MAX_TRACKED_ALARM_ZONES) {
+      const oldest = this.alarmZones.keys().next();
+      if (!oldest.done) this.alarmZones.delete(oldest.value);
+    }
+    this.alarmZones.set(alarmId, zoneId);
   }
 }
 

--- a/src/devices/battery-monitor.test.ts
+++ b/src/devices/battery-monitor.test.ts
@@ -329,9 +329,29 @@ describe("BatteryMonitor", () => {
     expect(harness.resolved()).toHaveLength(1);
     expect(harness.resolved()[0]).toMatchObject({
       alarmId: "battery-low:dd-1",
+      source: "Capteur porte",
       message: "Battery back to 87%",
+      zoneId: null,
     });
     expect(harness.rows()).toHaveLength(0);
+  });
+
+  it("closes the incident under the same equipment name and zone as it opened", () => {
+    harness = createHarness([makeDevice({ powerSource: "battery" })], {
+      "dev-1": [eq("e1", "Détecteur salon", "zone-salon")],
+    });
+    harness.monitor.init();
+    harness.monitor.sweep();
+
+    harness.setDevices([makeDevice({ powerSource: "battery", data: [{ value: 87 }] })]);
+    harness.monitor.sweep();
+
+    expect(harness.raised()[0]).toMatchObject({ source: "Détecteur salon", zoneId: "zone-salon" });
+    expect(harness.resolved()[0]).toMatchObject({
+      source: "Détecteur salon",
+      message: "Battery back to 87%",
+      zoneId: "zone-salon",
+    });
   });
 
   it("keeps the alarm inside the hysteresis band", () => {

--- a/src/devices/battery-monitor.ts
+++ b/src/devices/battery-monitor.ts
@@ -291,11 +291,16 @@ export class BatteryMonitor {
       { deviceId: alert.deviceId, deviceName: alert.deviceName, value: newValue },
       "Low battery cleared",
     );
+    // Same equipment context as the raise: an incident must open and close
+    // under one name, and in one zone, or the feed reads as two unrelated
+    // events. Resolved live, so a re-binding is picked up here too.
+    const { equipmentNames, zoneId } = this.resolveEquipmentContext(alert.deviceId);
     this.eventBus.emit({
       type: "system.alarm.resolved",
       alarmId: `${ALARM_PREFIX}${alert.deviceDataId}`,
-      source: alert.deviceName,
+      source: equipmentNames.length > 0 ? equipmentNames.join(", ") : alert.deviceName,
       message: isPercentage(newValue) ? `Battery back to ${newValue}%` : "Battery back to normal",
+      zoneId,
     });
   }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1274,7 +1274,17 @@ export type EngineEvent =
        *  or null = a global alarm shown in every zone (spec 143/#472). */
       zoneId?: string | null;
     }
-  | { type: "system.alarm.resolved"; alarmId: string; source: string; message: string }
+  | {
+      type: "system.alarm.resolved";
+      alarmId: string;
+      source: string;
+      message: string;
+      /** Zone the resolved alarm belongs to, mirroring `system.alarm.raised`.
+       *  Emitters that know the zone should send it: the activity feed then
+       *  files the end of an incident where its start went, even across a
+       *  restart. Absent or null = global, shown in every zone. */
+      zoneId?: string | null;
+    }
   // Self-update events
   | { type: "system.update.available"; current: string; latest: string; releaseUrl: string }
   | { type: "system.update.progress"; step: string; message: string }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1121,7 +1121,8 @@ export type ActivityMessage =
   | { template: "mode.deactivated"; params: { modeName: string } }
   | { template: "sunlight.sunrise"; params: Record<string, never> }
   | { template: "sunlight.sunset"; params: Record<string, never> }
-  | { template: "alarm.raised"; params: { source: string; message: string } };
+  | { template: "alarm.raised"; params: { source: string; message: string } }
+  | { template: "alarm.resolved"; params: { source: string; message: string } };
 
 export interface ActivityItem {
   id: string;

--- a/ui/src/components/zones/ActivityItemRow.tsx
+++ b/ui/src/components/zones/ActivityItemRow.tsx
@@ -1,4 +1,13 @@
-import { ChefHat, Layers, PersonStanding, Sun, Moon, AlertTriangle, Circle } from "lucide-react";
+import {
+  ChefHat,
+  Layers,
+  PersonStanding,
+  Sun,
+  Moon,
+  AlertTriangle,
+  CircleCheck,
+  Circle,
+} from "lucide-react";
 import { Trans, useTranslation } from "react-i18next";
 import type { ActivityItem, ActivityCategory, OrderSource } from "../../types";
 
@@ -61,6 +70,7 @@ function interpolation(item: ActivityItem): Record<string, string | number> {
     case "mode.activated":
     case "mode.deactivated":
     case "alarm.raised":
+    case "alarm.resolved":
       return m.params as unknown as Record<string, string | number>;
     case "sunlight.sunrise":
     case "sunlight.sunset":
@@ -99,6 +109,15 @@ function CategoryIcon({
     );
   }
   if (category === "alarm") {
+    // A resolution is an alarm-category item, but the red triangle would read
+    // as a second failure. Green tick, same slot.
+    if (template === "alarm.resolved") {
+      return (
+        <div className="w-6 h-6 rounded-[4px] flex items-center justify-center flex-shrink-0 bg-[var(--green-50)] text-[var(--green-700)]">
+          <CircleCheck size={12} strokeWidth={2} />
+        </div>
+      );
+    }
     return (
       <div className="w-6 h-6 rounded-[4px] flex items-center justify-center flex-shrink-0 bg-[var(--red-50)] text-[var(--red-500)]">
         <AlertTriangle size={12} strokeWidth={2} />

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1249,6 +1249,7 @@
   "activity.templates.sunlight.sunrise": "<b>Sunrise</b>",
   "activity.templates.sunlight.sunset": "<b>Sunset</b>",
   "activity.templates.alarm.raised": "<b>{{source}}</b>: {{message}}",
+  "activity.templates.alarm.resolved": "<b>{{source}}</b>: {{message}}",
   "activity.source.recipe": "by {{recipeName}}",
   "activity.source.mode": "by mode {{modeName}}",
   "activity.source.manual": "manual",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1249,6 +1249,7 @@
   "activity.templates.sunlight.sunrise": "<b>Lever du soleil</b>",
   "activity.templates.sunlight.sunset": "<b>Coucher du soleil</b>",
   "activity.templates.alarm.raised": "<b>{{source}}</b> : {{message}}",
+  "activity.templates.alarm.resolved": "<b>{{source}}</b> : {{message}}",
   "activity.source.recipe": "par {{recipeName}}",
   "activity.source.mode": "par le mode {{modeName}}",
   "activity.source.manual": "manuel",

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -564,7 +564,8 @@ export type ActivityMessage =
   | { template: "mode.deactivated"; params: { modeName: string } }
   | { template: "sunlight.sunrise"; params: Record<string, never> }
   | { template: "sunlight.sunset"; params: Record<string, never> }
-  | { template: "alarm.raised"; params: { source: string; message: string } };
+  | { template: "alarm.raised"; params: { source: string; message: string } }
+  | { template: "alarm.resolved"; params: { source: string; message: string } };
 
 export interface ActivityItem {
   id: string;


### PR DESCRIPTION
## Problem

The activity buffer subscribes to `system.alarm.raised` and never to `system.alarm.resolved`, so the feed tells half of each incident.

Concretely, with the NUT plugin on a mains outage the zone feed reads:

```
19:04  nut : Mains lost — ups is running on battery
```

…and that is all it will ever say. The moment the power came back is absent from the one surface meant to answer "what just happened here", even though `NotificationPublishService` has been sending `✅ <source> : <message>` on resolution all along. Same story for a low battery that recovers, a plugin that becomes reachable again, or an order dispatch that starts working.

## Change

- `ActivityMessage` gains an `alarm.resolved` template, `{ source, message }`, mirroring `alarm.raised`.
- `ActivityBuffer` subscribes to `system.alarm.resolved` and pushes it under the `alarm` category.
- `ActivityItemRow` renders it with a green tick (`CircleCheck`, `--green-50` / `--green-700`, the same pair the mode icon uses) rather than the red triangle — the end of an incident is not a second failure.
- `activity.templates.alarm.resolved` added to both locales.

### Zone scoping

`system.alarm.resolved` carries no `zoneId` (the raise does, since spec 143/#472). Rather than widen the event, the buffer remembers the zone per `alarmId` when the alarm is raised and drops the entry when it resolves, so a battery alert scoped to the living room clears in the living room. An alarm raised before this process started resolves as global — the same fallback an untagged alarm already gets.

## Notes

- No new event, no migration; persisted `ActivityItem`s already store `message` as JSON.
- The feed gets one extra line per incident, only ever on a real transition — alarm sources already de-duplicate raises and resolutions themselves.
- Extends spec 101 (activity buffer). Happy to write it up as its own spec folder if you would rather have one.

## Tests

`npx vitest run` — 102 files, 1707 passed. Four new cases in `activity-buffer.test.ts`: resolution recorded, resolution filed in the zone of its raise, resolution kept out of other zones, resolution global when the raise was never seen. Backend + UI typecheck and eslint clean.