### PR TITLE
chore(registry): bump nut to 0.2.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -591,7 +591,7 @@
     "icon": "BatteryCharging",
     "author": "adn-dev-adrien",
     "repo": "adn-dev-adrien/sowel-plugin-nut",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "tags": ["nut", "ups", "battery", "power", "backup", "monitoring"],
     "i18n": {
       "fr": {
@@ -599,8 +599,8 @@
         "description": "Onduleurs exposés par un serveur Network UPS Tools (NUT) — état, charge et autonomie de la batterie, charge, alarmes"
       }
     },
-    "sowelVersion": ">=1.53.0",
+    "sowelVersion": ">=1.43.0",
     "owner": "adn-dev-adrien",
-    "sha256": "07974d1dde193c8359ead021947bd650324a70e10bc11763edb488e896a8461c"
+    "sha256": "02b9e67a9aeb3f905d7039051bfe84e953a0b72d6e446ba386931977eb76d244"
   }
 ]


### PR DESCRIPTION
Spec 089 follow-up to the release published today on `adn-dev-adrien/sowel-plugin-nut`.

**What changed in the plugin (v0.2.0)**: the alarm messages are what the activity feed and the notification publishers show the user, and they were the only English strings on those surfaces. They are French now, and both mains transitions quote the battery charge at that instant:

```
Secteur perdu — ups passe sur batterie (batterie à 87 %)
Retour secteur — ups est réalimenté (batterie à 58 %)
```

Resolutions used to emit `Resolved: nut:ups:on_battery` — an alarm id where a sentence belongs. The pino logs stay in English.

**Registry changes**

- `version` 0.1.1 → 0.2.0, `sha256` recomputed from the published tarball (`sowel-plugin-nut-0.2.0.tar.gz`).
- `sowelVersion` >=1.53.0 → >=1.43.0, aligning the entry with the manifest, which has said 1.43.0 since v0.1.1. The 1.53.0 floor was the release expected to carry the `ups` equipment type; the real install-time requirement is `powerSource` in device discovery (1.43.0, spec 143), without which the low-battery monitor alarms on every outage. Without the `ups` type the plugin still discovers the device, its values and its alarms — it just has no equipment card.

Entry hand-edited rather than regenerated: `scripts/backfill-registry-sha256.mjs` rewrites the whole file through `JSON.stringify` and unfolds every inline `tags` array, which turns a 3-line bump into a 250-line diff. `prettier --check` passes.

Related: #709 makes the activity feed record alarm resolutions, which is what puts the "retour secteur" line above on screen.