### PR TITLE
chore(registry): bump weather-forecast to 2.3.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -119,11 +119,11 @@
     "icon": "CloudSun",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-weather-forecast",
-    "version": "2.0.0",
+    "version": "2.3.0",
     "tags": ["weather", "forecast", "open-meteo"],
     "sowelVersion": ">=1.2.11",
     "owner": "mchacher",
-    "sha256": "c5896e2025ff9020ad3bebd0d94c25b494334d30bf5f9e6744222258e3363174"
+    "sha256": "ac340f921d1c79a3b1f02af46a2c19e17937dc07d7ac9834e3ef1ac3287ccb76"
   },
   {
     "id": "smartthings",


### PR DESCRIPTION
First release of this plugin since 2.0.0. It carries three versions' worth of work in one:

- **2.1.0** — ensemble-based confidence and the three-level pill (spec 159)
- **2.2.0** — the hourly irradiance series the PV production forecast consumes (spec 160)
- **2.3.0** — 45 days of past daylight irradiance, so a household can fit its PV model from production already recorded instead of waiting twelve days (spec 161)

Without this bump both PV features stay inert on every instance: the core looks for `irradiance_120h` and `irradiance_history`, which only 2.3.0 publishes.

`sha256` verified against the published asset:

```
published  ac340f921d1c79a3b1f02af46a2c19e17937dc07d7ac9834e3ef1ac3287ccb76
registry   ac340f921d1c79a3b1f02af46a2c19e17937dc07d7ac9834e3ef1ac3287ccb76
```

`sowelVersion` deliberately left at `>=1.2.11`: the new data points are additive and an older core simply ignores them, so gating the plugin on the new core would withhold the confidence pill from instances that can use it.