### PR TITLE
fix(energy): draw measured production even with no forecast history

### DIFF
--- a/src/energy/pv/pv-accuracy.test.ts
+++ b/src/energy/pv/pv-accuracy.test.ts
@@ -180,3 +180,65 @@ describe("the buckets the query reads", () => {
     expect(queries[0]).toContain(`range(start: -${MAX_ACCURACY_DAYS}d`);
   });
 });
+
+/**
+ * The measured series is not gated on the pairing.
+ *
+ * The chart draws production for the past whether or not a forecast was ever
+ * issued for those hours. Tying the two together meant a household that had just
+ * declared its installation saw its own production vanish from the chart while
+ * it sat in the database.
+ */
+describe("the measured series", () => {
+  const silent = createLogger("silent").logger;
+
+  /** An influx stub with a forecast series and a measured series of given sizes. */
+  function stub(forecastHours: number, measuredHours: number): InfluxClient {
+    const row = (at: string, v: number) =>
+      ({ values: [], tableMeta: { toObject: () => ({ _time: at, _value: v }) } }) as never;
+    return {
+      getConfig: () => ({ bucket: "sowel", org: "sowel" }),
+      getClient: () => ({
+        getQueryApi: () => ({
+          iterateRows: (flux: string) =>
+            (async function* () {
+              const isForecast = flux.includes(FORECAST_MEASUREMENT);
+              const n = isForecast ? forecastHours : measuredHours;
+              for (let i = 0; i < n; i++) {
+                yield row(
+                  `2026-08-25T${String(i).padStart(2, "0")}:00:00Z`,
+                  isForecast ? 900 : 800,
+                );
+              }
+            })(),
+        }),
+      }),
+    } as unknown as InfluxClient;
+  }
+
+  it("comes back even when nothing was ever forecast", async () => {
+    const res = await queryPvAccuracy(stub(0, 5), { equipmentId: "eq", alias: "power" }, silent);
+    expect(res.samples).toBe(0);
+    expect(res.maeW).toBeNull();
+    // The point of the fix: the line has data even though the figure does not.
+    expect(res.measured).toHaveLength(5);
+    expect(res.measured[0].watts).toBe(800);
+  });
+
+  it("carries every measured hour, not only the paired ones", async () => {
+    const res = await queryPvAccuracy(stub(3, 8), { equipmentId: "eq", alias: "power" }, silent);
+    expect(res.samples).toBe(3);
+    expect(res.measured).toHaveLength(8);
+  });
+
+  it("comes back sorted oldest first", async () => {
+    const res = await queryPvAccuracy(stub(0, 6), { equipmentId: "eq", alias: "power" }, silent);
+    const ats = res.measured.map((p) => p.at);
+    expect([...ats].sort()).toEqual(ats);
+  });
+
+  it("is empty, not absent, when the meter reported nothing", async () => {
+    const res = await queryPvAccuracy(stub(4, 0), { equipmentId: "eq", alias: "power" }, silent);
+    expect(res.measured).toEqual([]);
+  });
+});

--- a/src/energy/pv/pv-accuracy.ts
+++ b/src/energy/pv/pv-accuracy.ts
@@ -53,6 +53,12 @@ export interface AccuracyPoint {
   actualW: number;
 }
 
+export interface MeasuredPoint {
+  /** Hour, UTC ISO. */
+  at: string;
+  watts: number;
+}
+
 export interface PvAccuracy {
   /** Hours compared. Zero means nothing to say, not a perfect score. */
   samples: number;
@@ -60,9 +66,19 @@ export interface PvAccuracy {
   maeW: number | null;
   /** The paired series, newest last, for the chart. */
   points: AccuracyPoint[];
+  /**
+   * Every hour the meter recorded over the window, paired or not.
+   *
+   * Separate from `points` on purpose. The error figure may only count hours
+   * where a forecast was issued to compare against; the *line* on the chart has
+   * no such requirement, and tying it to the pairing meant a household that had
+   * just declared its installation saw a forecast drawn over an empty past
+   * while its own production sat in the database, plainly known and invisible.
+   */
+  measured: MeasuredPoint[];
 }
 
-const EMPTY: PvAccuracy = { samples: 0, maeW: null, points: [] };
+const EMPTY: PvAccuracy = { samples: 0, maeW: null, points: [], measured: [] };
 
 /**
  * Pair the forecast with the production for the same hours.
@@ -112,7 +128,11 @@ export async function queryPvAccuracy(
       if (typeof v === "number") forecast.set(at, v);
     }
 
-    if (forecast.size === 0) return EMPTY;
+    // No early return on an empty forecast. The measured series is wanted
+    // whether or not anything was ever promised for those hours: a household
+    // that has just declared its installation has no forecast history at all,
+    // and skipping the query here is what left its own production invisible
+    // under a curve drawn over an empty past.
 
     // What the meter actually recorded, on the same hourly grid.
     //
@@ -146,7 +166,18 @@ export async function queryPvAccuracy(
     return EMPTY;
   }
 
-  return pairSeries(forecast, actual);
+  return { ...pairSeries(forecast, actual), measured: toMeasured(actual) };
+}
+
+/** The measured series as the chart wants it: sorted, finite, oldest first. */
+export function toMeasured(actual: ReadonlyMap<string, number>): MeasuredPoint[] {
+  const out: MeasuredPoint[] = [];
+  for (const [at, watts] of actual) {
+    if (!Number.isFinite(watts)) continue;
+    out.push({ at, watts });
+  }
+  out.sort((a, b) => a.at.localeCompare(b.at));
+  return out;
 }
 
 /**
@@ -154,7 +185,8 @@ export async function queryPvAccuracy(
  *
  * Only hours present on both sides count. An hour the meter never reported is
  * not a forecast miss, and scoring it as one would make an outage look like a
- * bad model.
+ * bad model. The measured series rides along untouched, so the chart can draw
+ * production for hours nothing was ever promised for.
  */
 export function pairSeries(
   forecast: ReadonlyMap<string, number>,
@@ -169,7 +201,7 @@ export function pairSeries(
     points.push({ at, forecastW, actualW });
   }
 
-  if (points.length === 0) return EMPTY;
+  if (points.length === 0) return { ...EMPTY, measured: toMeasured(actual) };
   points.sort((a, b) => a.at.localeCompare(b.at));
 
   const totalError = points.reduce((sum, p) => sum + Math.abs(p.forecastW - p.actualW), 0);
@@ -177,5 +209,6 @@ export function pairSeries(
     samples: points.length,
     maeW: Math.round(totalError / points.length),
     points,
+    measured: toMeasured(actual),
   };
 }

--- a/ui/src/components/equipments/PvForecastPanel.tsx
+++ b/ui/src/components/equipments/PvForecastPanel.tsx
@@ -82,7 +82,7 @@ export function PvForecastPanel({ equipmentId }: PvForecastPanelProps) {
   const now = Date.now();
   // One timeline. Past hours carry what was promised for them, future hours the
   // current curve; see `mergeTimeline`.
-  const chart = mergeTimeline(data.accuracy.points, data.curve, now);
+  const chart = mergeTimeline(data.accuracy.points, data.curve, now, data.accuracy.measured);
   const spanDays = chart.length > 1 ? (chart[chart.length - 1].ts - chart[0].ts) / 86_400_000 : 0;
   // A weekday name stops helping once the span passes a fortnight.
   const tickFormat: Intl.DateTimeFormatOptions =
@@ -181,7 +181,7 @@ export function PvForecastPanel({ equipmentId }: PvForecastPanelProps) {
                   />
                   {t("equipments.pv.expected")}
                 </span>
-                {data.accuracy.maeW !== null && (
+                {chart.some((p) => p.actualW !== undefined) && (
                   <span className="flex items-center gap-1 text-[11px] text-text-secondary">
                     <span
                       aria-hidden

--- a/ui/src/components/equipments/pvForecastUtils.test.ts
+++ b/ui/src/components/equipments/pvForecastUtils.test.ts
@@ -221,3 +221,62 @@ describe("mergeTimeline", () => {
     expect(mergeTimeline([], [], NOW)).toEqual([]);
   });
 });
+
+describe("mergeTimeline with a measured series and no forecast history", () => {
+  const NOW = Date.parse("2026-08-25T12:00:00Z");
+  const at = (h: number) => new Date(NOW + h * 3_600_000).toISOString();
+
+  it("draws production for the past even when nothing was ever forecast", () => {
+    // The reported bug: an installation declared this morning showed a forecast
+    // over an empty past while its own production sat in the database. The
+    // measured line was fed from the comparison, which needs a forecast issued
+    // the day before to exist at all.
+    const out = mergeTimeline(
+      [],
+      [{ at: at(2), watts: 1500 }],
+      NOW,
+      [
+        { at: at(-3), watts: 700 },
+        { at: at(-2), watts: 900 },
+      ],
+    );
+    expect(out).toHaveLength(3);
+    expect(out.filter((p) => p.actualW !== undefined)).toHaveLength(2);
+    expect(out[0].actualW).toBe(700);
+    expect(out[0].forecastW).toBeUndefined();
+  });
+
+  it("lets the comparison win where both describe the same hour", () => {
+    // `points.actualW` and `measured.watts` are the same reading; taking either
+    // is fine, but the pair must not end up split across two entries.
+    const out = mergeTimeline(
+      [{ at: at(-2), forecastW: 950, actualW: 900 }],
+      [],
+      NOW,
+      [{ at: at(-2), watts: 900 }],
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].forecastW).toBe(950);
+    expect(out[0].actualW).toBe(900);
+  });
+
+  it("still works with no measured series at all, as older payloads have", () => {
+    const out = mergeTimeline([{ at: at(-1), forecastW: 800, actualW: 780 }], [], NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].actualW).toBe(780);
+  });
+
+  it("keeps measured hours ordered with the rest", () => {
+    const out = mergeTimeline(
+      [],
+      [{ at: at(1), watts: 100 }],
+      NOW,
+      [{ at: at(-1), watts: 200 }, { at: at(-5), watts: 300 }],
+    );
+    expect(out.map((p) => p.ts)).toEqual([...out.map((p) => p.ts)].sort((a, b) => a - b));
+  });
+
+  it("ignores an unparseable measured timestamp", () => {
+    expect(mergeTimeline([], [], NOW, [{ at: "hier", watts: 1 }])).toEqual([]);
+  });
+});

--- a/ui/src/components/equipments/pvForecastUtils.ts
+++ b/ui/src/components/equipments/pvForecastUtils.ts
@@ -96,13 +96,25 @@ export function mergeTimeline(
   accuracy: ReadonlyArray<{ at: string; forecastW: number; actualW: number }>,
   curve: ReadonlyArray<{ at: string; watts: number }>,
   now: number,
+  measured: ReadonlyArray<{ at: string; watts: number }> = [],
 ): TimelinePoint[] {
   const byTs = new Map<number, TimelinePoint>();
 
+  // Everything the meter recorded, first. Not gated on there being a forecast
+  // to compare it against: an installation declared this morning has no
+  // forecast history at all, and drawing the curve over an empty past while its
+  // own production sat in the database is exactly what this argument fixes.
+  for (const p of measured) {
+    const ts = Date.parse(p.at);
+    if (!Number.isFinite(ts)) continue;
+    byTs.set(ts, { ts, actualW: p.watts });
+  }
+
+  // Then what was promised for those hours, where anything was.
   for (const p of accuracy) {
     const ts = Date.parse(p.at);
     if (!Number.isFinite(ts)) continue;
-    byTs.set(ts, { ts, forecastW: p.forecastW, actualW: p.actualW });
+    byTs.set(ts, { ...(byTs.get(ts) ?? { ts }), forecastW: p.forecastW, actualW: p.actualW });
   }
 
   for (const p of curve) {

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -318,6 +318,12 @@ export interface PvForecastResponse {
     samples: number;
     maeW: number | null;
     points: PvAccuracyPoint[];
+    /**
+     * Every hour the meter recorded over the window, paired or not. The chart's
+     * measured line comes from here, never from `points` — a household with no
+     * forecast history yet still has production worth drawing.
+     */
+    measured: { at: string; watts: number }[];
   };
   model: {
     gain: number;


### PR DESCRIPTION
Reported from production, an hour after v1.57.0 went live there: the chart showed the forecast over an empty past while the meter's own readings sat in the database, plainly known and invisible.

## Cause

The measured line was fed from `accuracy.points`, which by design only contains hours where a forecast **issued 6-24 h earlier** can be paired with what actually happened. An installation declared this morning has no forecast history at all, so that array is empty and the line had nothing to draw — for a full day, which is exactly when someone is looking hardest.

The error figure needs the pairing. The line does not.

## Fix

`queryPvAccuracy` returns a new `measured` array — every hour the meter recorded over the window, paired or not — and the chart draws the blue line from that. The MAE still counts only paired hours, so the figure is unchanged.

Two consequences worth naming:

- The early `return EMPTY` on an empty forecast is gone. It skipped the measurement query entirely, which is what made this *invisible* rather than merely unpaired.
- The legend's measured swatch now keys off the series actually drawn, not off the error figure existing.

## Verified

By reproducing the production state on a shadow instance: injected forecast history deleted, leaving 0 paired comparisons exactly as on prod. The API then returns `samples: 0` with **158 measured hours**, and the past draws them where it drew nothing before.

## Test plan

- [x] `npx tsc --noEmit` and `cd ui && npx tsc -b --noEmit` clean
- [x] `npx vitest run` — 1868 passed; `cd ui && npx vitest run` — 649 passed
- [x] eslint 0 errors both roots
- [x] Reproduced the reported state on a shadow and confirmed the line appears

## Note

This needs a patch release to reach the instance that reported it.