### PR TITLE
fix(energy): tell the household where the PV health reference stands while it builds

### DIFF
--- a/src/api/routes/energy.test.ts
+++ b/src/api/routes/energy.test.ts
@@ -1084,7 +1084,14 @@ describe("Spec 162 — GET /energy/pv-health/:id", () => {
     hasIrradianceSeries: () => false,
   });
 
-  const empty = { days: [], normal: null, latest: null, alert: null, detection: null };
+  const empty = {
+    days: [],
+    normal: null,
+    latest: null,
+    alert: null,
+    detection: null,
+    sinceCutoff: null,
+  };
 
   it("returns an empty series rather than 404 when nothing qualifies yet", async () => {
     const app = await buildApp({
@@ -1098,6 +1105,21 @@ describe("Spec 162 — GET /energy/pv-health/:id", () => {
     // FR6 — no declared array: the card must render nothing, not a "waiting for
     // clear hours" promise that can never come true.
     expect(res.json().active).toBe(false);
+    await app.close();
+  });
+
+  it("ships the building-progress fields: target and capacity cutoff (#724)", async () => {
+    // While the reference builds, the card says "N of M clear days since
+    // <date>". M and the date come from the server so the display cannot
+    // drift from the actual rule.
+    const app = await buildApp({
+      equipments: [solarMeter],
+      pvForecaster: forecasterReturning({ ...empty, sinceCutoff: "2026-08-05" }),
+    });
+    const res = await app.inject({ method: "GET", url });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().normalTarget).toBe(30);
+    expect(res.json().sinceCutoff).toBe("2026-08-05");
     await app.close();
   });
 

--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -27,7 +27,7 @@ import { requireAdmin } from "../../auth/auth-middleware.js";
 import type { PvForecaster } from "../../energy/pv/pv-forecaster.js";
 import { queryPvAccuracy } from "../../energy/pv/pv-accuracy.js";
 import { isActiveSolarProfile } from "../../energy/pv/solar-profile.js";
-import { ALERT_DAYS } from "../../energy/pv/pv-health.js";
+import { ALERT_DAYS, MIN_NORMAL_DAYS } from "../../energy/pv/pv-health.js";
 
 /** Trailing days of the health series shipped to the card. */
 const HEALTH_DISPLAY_DAYS = 120;
@@ -730,6 +730,12 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
         latest: health.latest,
         alert: health.alert,
         detection: health.detection,
+        // #724 — while the reference is building, the card states its progress:
+        // how many qualifying days it has (days.length), how many it needs, and
+        // since when they count. Constants stay server-side so the UI cannot
+        // drift from the rules.
+        normalTarget: MIN_NORMAL_DAYS,
+        sinceCutoff: health.sinceCutoff,
       };
     },
   );

--- a/src/energy/pv/pv-forecaster.health.test.ts
+++ b/src/energy/pv/pv-forecaster.health.test.ts
@@ -435,6 +435,21 @@ describe("getHealth", () => {
     expect(h.normal).toBeNull();
     expect(h.detection).toBeNull();
   });
+
+  it("exposes the capacity cutoff the series counts from (#724)", () => {
+    // The building-progress line needs "since when": the stamped change day,
+    // as a local date, or null when nothing was ever stamped.
+    const f = build(db);
+    expect(f.getHealth(equipment).sinceCutoff).toBeNull();
+
+    // Midday UTC so the expected local date holds in any test-runner timezone.
+    db.prepare("UPDATE pv_forecast_model SET capacity_changed_at = ? WHERE equipment_id = ?").run(
+      "2026-08-05T12:00:00.000Z",
+      EQUIPMENT_ID,
+    );
+    expect(f.getHealth(equipment).sinceCutoff).toBe("2026-08-05");
+    f.stop();
+  });
 });
 
 /**

--- a/src/energy/pv/pv-forecaster.ts
+++ b/src/energy/pv/pv-forecaster.ts
@@ -852,6 +852,13 @@ export class PvForecaster {
     latest: DayRatio | null;
     alert: { since: string; deficit: number } | null;
     detection: ReturnType<typeof detectionSpeed>;
+    /**
+     * The capacity-change day the series is filtered by, when one is stamped
+     * (#724). While the reference is still building, the card needs to say
+     * *since when* the days are being counted — otherwise a household with a
+     * year of history reads the wait as the history being ignored.
+     */
+    sinceCutoff: string | null;
   } {
     // The same cutoff the alarm path applies: days from before the declared
     // array last changed describe hardware that is gone.
@@ -883,6 +890,7 @@ export class PvForecaster {
       // Null exactly when no day qualified in the window: the card reads that
       // as "nothing recent to judge on" rather than carrying a separate flag.
       detection: detectionSpeed(recent, DETECTION_WINDOW_DAYS),
+      sinceCutoff: cutoffDay,
     };
   }
 

--- a/ui/src/api/energy.ts
+++ b/ui/src/api/energy.ts
@@ -118,6 +118,14 @@ export interface PvHealthResponse {
     qualifyingDays: number;
     windowDays: number;
   } | null;
+  /**
+   * Qualifying days the reference needs before it asserts anything (#724).
+   * Server-side constant, sent so the card's progress line cannot drift from
+   * the actual rule.
+   */
+  normalTarget: number;
+  /** The capacity-change day the series counts from, when one is stamped. */
+  sinceCutoff: string | null;
 }
 
 /** Spec 162 — a standing health alert, for the alarm banner rebuild. */

--- a/ui/src/components/equipments/PvHealthPanel.test.tsx
+++ b/ui/src/components/equipments/PvHealthPanel.test.tsx
@@ -25,6 +25,8 @@ function response(over: Partial<PvHealthResponse> = {}): PvHealthResponse {
     latest: days[days.length - 1],
     alert: null,
     detection: { minDetectableLoss: 0.1, calendarDays: 6, qualifyingDays: 8, windowDays: 14 },
+    normalTarget: 30,
+    sinceCutoff: null,
     ...over,
   };
 }
@@ -53,6 +55,38 @@ describe("PvHealthPanel", () => {
   it("says it is waiting while nothing has qualified yet", async () => {
     await renderPanel(response({ days: [], normal: null, latest: null, detection: null }));
     expect(await screen.findByText(/clear midday hours/i)).toBeTruthy();
+  });
+
+  it("states its progress while the reference is building (#724)", async () => {
+    // 15 qualifying days, no reference yet, a stamped capacity change: the
+    // card must say how far along it is and since when the days count. The
+    // generic waiting line here read as "your history is being ignored".
+    const days = Array.from({ length: 15 }, (_, i) => ({
+      day: `2026-08-${String(i + 6).padStart(2, "0")}`,
+      ratio: 3.8,
+      hours: 6,
+    }));
+    await renderPanel(
+      response({
+        days,
+        normal: null,
+        latest: days[days.length - 1],
+        sinceCutoff: "2026-08-05",
+      }),
+    );
+    expect(await screen.findByText(/15 of the 30 clear days/i)).toBeTruthy();
+    expect(screen.getByText(/august 5/i)).toBeTruthy();
+    expect(screen.queryByText(/clear midday hours/i)).toBeNull();
+  });
+
+  it("states its progress without a date when no change was ever stamped", async () => {
+    const days = Array.from({ length: 4 }, (_, i) => ({
+      day: `2026-08-${String(i + 20).padStart(2, "0")}`,
+      ratio: 3.8,
+      hours: 6,
+    }));
+    await renderPanel(response({ days, normal: null, latest: days[3], sinceCutoff: null }));
+    expect(await screen.findByText(/4 of the 30 clear days/i)).toBeTruthy();
   });
 
   it("says it has nothing recent to judge on when no day qualified in the window", async () => {

--- a/ui/src/components/equipments/PvHealthPanel.tsx
+++ b/ui/src/components/equipments/PvHealthPanel.tsx
@@ -67,6 +67,16 @@ export const PvHealthPanel = memo(function PvHealthPanel({
   );
   const ticks = useMemo(() => dailyTicks(chart.map((p) => p.ts)), [chart]);
 
+  // Display anchor while the reference is still building (#724): the 80th
+  // centile of the days accumulated so far. Display-only — the rules' own
+  // reference stays server-side; this just lets the building chart read in
+  // "percent of what looks usual so far" instead of a unit-less ratio.
+  const provisional = useMemo(() => {
+    if (chart.length === 0) return null;
+    const sorted = chart.map((p) => p.ratio).sort((a, b) => a - b);
+    return sorted[Math.min(sorted.length - 1, Math.floor(0.8 * sorted.length))];
+  }, [chart]);
+
   if (failed || !data) return null;
 
   // FR6 — no declared array means the feature is silent. Rendering the waiting
@@ -76,11 +86,42 @@ export const PvHealthPanel = memo(function PvHealthPanel({
 
   // Nothing has qualified yet. Say what the detector is waiting for rather than
   // rendering an empty chart that looks broken.
-  if (data.days.length === 0 || data.normal === null) {
+  if (data.days.length === 0) {
     return (
       <div className="mb-6 bg-surface rounded-[10px] border border-border p-4">
         <Header t={t} />
         <p className="text-[13px] text-text-secondary">{t("equipments.pvHealth.waiting")}</p>
+      </div>
+    );
+  }
+
+  // Days exist but the reference does not yet: say exactly where it stands and
+  // show the days it has (#724). A generic waiting line here read as "your
+  // history is being ignored" to a household that just backfilled a year of
+  // production — the wait is the capacity-change reset doing its job, and the
+  // card has to say so.
+  if (data.normal === null) {
+    return (
+      <div className="mb-6 bg-surface rounded-[10px] border border-border p-4">
+        <Header t={t} />
+        <p className="text-[13px] text-text-secondary mb-3">
+          {data.sinceCutoff
+            ? t("equipments.pvHealth.building", {
+                have: data.days.length,
+                need: data.normalTarget,
+                date: localDayToDate(data.sinceCutoff).toLocaleDateString(locale, {
+                  day: "numeric",
+                  month: "long",
+                }),
+              })
+            : t("equipments.pvHealth.buildingNoDate", {
+                have: data.days.length,
+                need: data.normalTarget,
+              })}
+        </p>
+        {provisional !== null && (
+          <RatioChart chart={chart} ticks={ticks} anchor={provisional} locale={locale} t={t} />
+        )}
       </div>
     );
   }
@@ -129,56 +170,7 @@ export const PvHealthPanel = memo(function PvHealthPanel({
         </p>
       )}
 
-      <div className="h-40">
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={chart} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light)" />
-            <XAxis
-              dataKey="ts"
-              type="number"
-              scale="time"
-              domain={["dataMin", "dataMax"]}
-              ticks={ticks}
-              tickFormatter={(ts: number) =>
-                new Date(ts).toLocaleDateString(locale, { day: "numeric", month: "short" })
-              }
-              tick={{ fontSize: 11, fill: "var(--color-text-tertiary)" }}
-              stroke="var(--color-border)"
-            />
-            <YAxis
-              // Relative to the normal, because the ratio's own scale means
-              // nothing to a household. 100 % is "as usual".
-              tickFormatter={(r: number) => `${Math.round((r / normal) * 100)} %`}
-              domain={["dataMin", "dataMax"]}
-              tick={{ fontSize: 11, fill: "var(--color-text-tertiary)" }}
-              stroke="var(--color-border)"
-              width={48}
-            />
-            <Tooltip
-              labelFormatter={(ts) => new Date(ts as number).toLocaleDateString(locale)}
-              formatter={(v) => [
-                `${Math.round(((v as number) / normal) * 100)} %`,
-                t("equipments.pvHealth.ofNormal"),
-              ]}
-              contentStyle={{
-                background: "var(--color-surface)",
-                border: "1px solid var(--color-border)",
-                borderRadius: 6,
-                fontSize: 12,
-              }}
-            />
-            <ReferenceLine y={normal} stroke="var(--color-text-tertiary)" strokeDasharray="2 3" />
-            <Line
-              type="monotone"
-              dataKey="ratio"
-              stroke="var(--color-primary)"
-              strokeWidth={1.5}
-              dot={{ r: 2 }}
-              connectNulls={false}
-            />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
+      <RatioChart chart={chart} ticks={ticks} anchor={normal} showReference locale={locale} t={t} />
 
       {/* What the detector can and cannot do, from the days it has actually had. */}
       {data.detection && (
@@ -201,6 +193,84 @@ function Header({ t }: { t: (k: string) => string }) {
     <div className="flex items-center gap-2 mb-3">
       <Activity size={16} strokeWidth={1.5} className="text-accent" />
       <h3 className="text-[14px] font-semibold text-text">{t("equipments.pvHealth.title")}</h3>
+    </div>
+  );
+}
+
+/**
+ * The ratio series, read in percent of `anchor` — the established normal, or
+ * the provisional centile while the reference is still building. The dashed
+ * reference line is drawn only for an established normal: drawing it on the
+ * provisional anchor would present a figure still under construction as a
+ * standard the array is being held to.
+ */
+function RatioChart({
+  chart,
+  ticks,
+  anchor,
+  showReference = false,
+  locale,
+  t,
+}: {
+  chart: { ts: number; ratio: number; hours: number }[];
+  ticks: number[];
+  anchor: number;
+  showReference?: boolean;
+  locale: string;
+  t: (k: string) => string;
+}) {
+  return (
+    <div className="h-40">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={chart} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light)" />
+          <XAxis
+            dataKey="ts"
+            type="number"
+            scale="time"
+            domain={["dataMin", "dataMax"]}
+            ticks={ticks}
+            tickFormatter={(ts: number) =>
+              new Date(ts).toLocaleDateString(locale, { day: "numeric", month: "short" })
+            }
+            tick={{ fontSize: 11, fill: "var(--color-text-tertiary)" }}
+            stroke="var(--color-border)"
+          />
+          <YAxis
+            // Relative to the anchor, because the ratio's own scale means
+            // nothing to a household. 100 % is "as usual".
+            tickFormatter={(r: number) => `${Math.round((r / anchor) * 100)} %`}
+            domain={["dataMin", "dataMax"]}
+            tick={{ fontSize: 11, fill: "var(--color-text-tertiary)" }}
+            stroke="var(--color-border)"
+            width={48}
+          />
+          <Tooltip
+            labelFormatter={(ts) => new Date(ts as number).toLocaleDateString(locale)}
+            formatter={(v) => [
+              `${Math.round(((v as number) / anchor) * 100)} %`,
+              t("equipments.pvHealth.ofNormal"),
+            ]}
+            contentStyle={{
+              background: "var(--color-surface)",
+              border: "1px solid var(--color-border)",
+              borderRadius: 6,
+              fontSize: 12,
+            }}
+          />
+          {showReference && (
+            <ReferenceLine y={anchor} stroke="var(--color-text-tertiary)" strokeDasharray="2 3" />
+          )}
+          <Line
+            type="monotone"
+            dataKey="ratio"
+            stroke="var(--color-primary)"
+            strokeWidth={1.5}
+            dot={{ r: 2 }}
+            connectNulls={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
     </div>
   );
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1433,6 +1433,8 @@
   "equipments.solar.cardinal.NW": "NW",
   "equipments.pvHealth.title": "Panel health",
   "equipments.pvHealth.waiting": "Waiting for enough clear midday hours to judge on. Overcast days are skipped rather than counted as poor performance.",
+  "equipments.pvHealth.building": "Building the reference: {{have}} of the {{need}} clear days needed since your installation changed on {{date}}. Days from before that describe the previous installation and are not used.",
+  "equipments.pvHealth.buildingNoDate": "Building the reference: {{have}} of the {{need}} clear days needed.",
   "equipments.pvHealth.blind": "No clear midday hours recently, so there is nothing recent to judge on. The figures below are the last ones measured.",
   "equipments.pvHealth.normal": "{{date}}, the last clear day: {{pct}} % {{direction}} the usual level.",
   "equipments.pvHealth.above": "above",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1433,6 +1433,8 @@
   "equipments.solar.cardinal.NW": "NO",
   "equipments.pvHealth.title": "Santé des panneaux",
   "equipments.pvHealth.waiting": "En attente d'assez d'heures claires en milieu de journée pour se prononcer. Les jours couverts sont ignorés, pas comptés comme une contre-performance.",
+  "equipments.pvHealth.building": "Référence en construction : {{have}} jours clairs sur les {{need}} nécessaires depuis le changement d'installation du {{date}}. Les jours antérieurs décrivent l'ancienne installation et ne sont pas utilisés.",
+  "equipments.pvHealth.buildingNoDate": "Référence en construction : {{have}} jours clairs sur les {{need}} nécessaires.",
   "equipments.pvHealth.blind": "Aucune heure claire en milieu de journée récemment : il n'y a rien de récent sur quoi se prononcer. Les chiffres ci-dessous sont les derniers mesurés.",
   "equipments.pvHealth.normal": "{{date}}, dernier jour clair : {{pct}} % {{direction}} du niveau habituel.",
   "equipments.pvHealth.above": "au-dessus",


### PR DESCRIPTION
## Summary

Fixes #724. Observed on a live installation right after the v1.58.0 update: the health check was working (15 qualifying days computed), but the card showed only the generic "waiting for clear midday hours" sentence, because the reference needs `MIN_NORMAL_DAYS = 30` qualifying days since the declared capacity change (2026-08-05 there). The wait is correct by design (spec 162: days before a declared change describe hardware that is gone); the card just communicated none of it, and a household with a year of history read it as the history being ignored.

## Changes

- `GET /energy/pv-health/:id` ships two new fields: `normalTarget` (`MIN_NORMAL_DAYS`, server-side so the UI cannot drift from the rule) and `sinceCutoff` (the capacity-change day the series counts from, from `getHealth`)
- `PvHealthPanel` splits the old `days empty OR normal null` branch: empty keeps the waiting sentence; days-but-no-reference now shows a progress line ("Building the reference: 15 of the 30 clear days needed since your installation changed on August 5. Days from before that describe the previous installation and are not used.") plus the chart of the accumulated days
- The building-state chart reads in percent of the provisional 80th centile of the days so far, **without** the dashed reference line: a figure under construction is not drawn as a standard
- Chart JSX extracted into a shared `RatioChart` (anchor + optional reference line) used by both states
- i18n: `equipments.pvHealth.building` / `buildingNoDate` in EN and FR

## Test plan

- [x] Backend: route test for the two new fields; `getHealth` test for `sinceCutoff` (null, then stamped, TZ-safe timestamp) - 1948 passed
- [x] UI: building state with date, building state without date, empty state unchanged - 680 passed
- [x] `tsc` backend + UI zero errors, `eslint` zero errors