### PR TITLE
docs(home): surface the deep-dive articles from the landing page

### DIFF
--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -321,6 +321,15 @@ hide:
   <p><a href="technical/">Guide technique →</a></p>
 </div>
 
+<div class="sowel-card">
+  <div class="sowel-card__icon">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/><path d="M2 12h20"/></svg>
+  </div>
+  <h3>En profondeur</h3>
+  <p>Comment l'arbitre de surplus décide qui reçoit le surplus solaire, et comment Sowel remarque que les panneaux décrochent. Conception, mesures, références.</p>
+  <p><a href="deep-dives/surplus-arbiter/">L'arbitre de surplus →</a>&nbsp;&nbsp;·&nbsp;&nbsp;<a href="deep-dives/pv-health/">Veiller sur les panneaux →</a></p>
+</div>
+
 </div>
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -321,6 +321,15 @@ hide:
   <p><a href="technical/">Technical guide →</a></p>
 </div>
 
+<div class="sowel-card">
+  <div class="sowel-card__icon">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/><path d="M2 12h20"/></svg>
+  </div>
+  <h3>In depth</h3>
+  <p>How the surplus arbiter decides who gets the solar surplus, and how Sowel notices when the panels stop performing. Design, measurements, references.</p>
+  <p><a href="deep-dives/surplus-arbiter/">The surplus arbiter →</a>&nbsp;&nbsp;·&nbsp;&nbsp;<a href="deep-dives/pv-health/">Watching over the panels →</a></p>
+</div>
+
 </div>
 
 </div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -369,6 +369,14 @@
   /* Span the full section width like the four-pillar grid above. */
 }
 
+/* An odd trailing card (the "In depth" door) spans the full row instead of
+   sitting lopsided in the left column. */
+@media (min-width: 720px) {
+  .sowel-cards--two .sowel-card:last-child:nth-child(odd) {
+    grid-column: 1 / -1;
+  }
+}
+
 /* "Take a tour" cards: minimal layout. Same hover as other cards. */
 .sowel-cards--two .sowel-card {
   background: var(--md-default-bg-color);


### PR DESCRIPTION
## Summary

The In Depth section is present in the top tabs, but the landing page hides the nav sidebar and its final "Where to next?" section offered only two doors (users, developers) - the new articles were reachable but not discoverable from the homepage.

## Changes

- Third card "In depth" / "En profondeur" on the EN and FR homepages, linking both articles
- CSS: an odd trailing card in the two-column grid spans the full row instead of sitting lopsided

## Test plan

- [x] `mkdocs build --strict` passes; homepage carries both deep-dives links