### PR TITLE
feat(devices): let integrations declare the wire literals of a boolean reading

### DIFF
--- a/migrations/028_device_data_value_on_off.sql
+++ b/migrations/028_device_data_value_on_off.sql
@@ -1,0 +1,8 @@
+-- Wire representations for boolean data points, mirroring 014 on device_orders.
+-- Integrations already declare them at discovery (e.g. a Z2M binary expose
+-- carries value_on/value_off, "ON"/"OFF" or "LOCK"/"UNLOCK"); until now they
+-- were kept for the outgoing order and dropped on the incoming reading, which
+-- left normalizeValue guessing from a hard-coded vocabulary and flagging
+-- everything else. JSON-encoded so string and boolean forms round-trip.
+ALTER TABLE device_data ADD COLUMN value_on TEXT;
+ALTER TABLE device_data ADD COLUMN value_off TEXT;

--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -1031,3 +1031,65 @@ describe("DeviceManager — batched message writes (#697)", () => {
     expect(storedValues()).toMatchObject({ temperature: 23, pressure: 1013 });
   });
 });
+
+describe("DeviceManager — inbound wire values (#727)", () => {
+  let db: Database.Database;
+  let manager: DeviceManager;
+
+  const lockDevice = {
+    ieeeAddress: "0xa4c138000000beef",
+    friendlyName: "prise_sdb",
+    manufacturer: "Tuya",
+    model: "TS011F",
+    data: [
+      {
+        key: "child_lock",
+        type: "boolean" as const,
+        category: "generic" as const,
+        valueOn: "LOCK",
+        valueOff: "UNLOCK",
+      },
+      { key: "state", type: "boolean" as const, category: "light_state" as const },
+    ],
+    orders: [],
+    rawExpose: [],
+  };
+
+  const valueOf = (key: string) =>
+    manager
+      .getAllWithData()
+      .find((d) => d.name === "prise_sdb")
+      ?.data.find((d) => d.key === key)?.value;
+
+  beforeEach(() => {
+    db = createTestDb();
+    manager = new DeviceManager(db, new EventBus(logger), logger);
+    manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", lockDevice);
+  });
+
+  afterEach(() => db.close());
+
+  it("coerces a declared vocabulary instead of storing it raw", () => {
+    // Before: child_lock was declared boolean, the plug reported "UNLOCK",
+    // normalizeValue could not guess the polarity, and the string was stored
+    // with a "does not match declared type" warning on every discovery.
+    manager.updateDeviceData("zigbee2mqtt", "prise_sdb", { child_lock: "UNLOCK" });
+    expect(valueOf("child_lock")).toBe(false);
+
+    manager.updateDeviceData("zigbee2mqtt", "prise_sdb", { child_lock: "LOCK" });
+    expect(valueOf("child_lock")).toBe(true);
+  });
+
+  it("keeps the pair across a re-discovery", () => {
+    // Second announcement takes the UPDATE path, which must carry the columns
+    // too — otherwise the pair is dropped at every plugin reconnect.
+    manager.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", lockDevice);
+    manager.updateDeviceData("zigbee2mqtt", "prise_sdb", { child_lock: "LOCK" });
+    expect(valueOf("child_lock")).toBe(true);
+  });
+
+  it("leaves a key without a declared pair on the usual vocabulary", () => {
+    manager.updateDeviceData("zigbee2mqtt", "prise_sdb", { state: "ON" });
+    expect(valueOf("state")).toBe(true);
+  });
+});

--- a/src/devices/device-manager.ts
+++ b/src/devices/device-manager.ts
@@ -55,6 +55,9 @@ export interface DiscoveredDevice {
     category: DataCategory;
     unit?: string;
     enumValues?: string[];
+    /** Wire literals of a boolean reading, when the integration knows them. */
+    valueOn?: string | number | boolean;
+    valueOff?: string | number | boolean;
   }[];
   orders: {
     key: string;
@@ -132,11 +135,11 @@ export class DeviceManager {
         "SELECT * FROM device_data WHERE device_id = ? AND key = ?",
       ),
       insertDeviceData: this.db.prepare(
-        `INSERT INTO device_data (id, device_id, key, type, category, unit, enum_values)
-         VALUES (@id, @deviceId, @key, @type, @category, @unit, @enumValues)`,
+        `INSERT INTO device_data (id, device_id, key, type, category, unit, enum_values, value_on, value_off)
+         VALUES (@id, @deviceId, @key, @type, @category, @unit, @enumValues, @valueOn, @valueOff)`,
       ),
       updateDeviceDataDef: this.db.prepare(
-        "UPDATE device_data SET type = ?, category = ?, unit = ?, enum_values = ? WHERE id = ?",
+        "UPDATE device_data SET type = ?, category = ?, unit = ?, enum_values = ?, value_on = ?, value_off = ? WHERE id = ?",
       ),
       updateDeviceDataValue: this.db.prepare(
         "UPDATE device_data SET value = ?, last_updated = datetime('now'), last_changed = CASE WHEN value IS NOT ? OR category = 'action' THEN datetime('now') ELSE last_changed END WHERE id = ?",
@@ -235,12 +238,18 @@ export class DeviceManager {
           | { id: string }
           | undefined;
         const enumJson = d.enumValues ? JSON.stringify(d.enumValues) : null;
+        // JSON-encoded like the order columns, so "ON" and true round-trip
+        // distinctly instead of collapsing into the same TEXT.
+        const onJson = d.valueOn !== undefined ? JSON.stringify(d.valueOn) : null;
+        const offJson = d.valueOff !== undefined ? JSON.stringify(d.valueOff) : null;
         if (existingData) {
           this.stmts.updateDeviceDataDef.run(
             d.type,
             d.category,
             d.unit ?? null,
             enumJson,
+            onJson,
+            offJson,
             existingData.id,
           );
         } else {
@@ -252,6 +261,8 @@ export class DeviceManager {
             category: d.category,
             unit: d.unit ?? null,
             enumValues: enumJson,
+            valueOn: onJson,
+            valueOff: offJson,
           });
         }
       }
@@ -552,6 +563,9 @@ export class DeviceManager {
           category,
           unit: unit ?? null,
           enumValues: null,
+          // Auto-created from a raw payload: no expose to read the pair from.
+          valueOn: null,
+          valueOff: null,
         });
         this.logger.info(
           { deviceId: device.id, key, category },
@@ -568,6 +582,8 @@ export class DeviceManager {
         value,
         dataRow.type as DataType,
         parseEnumValues(dataRow.enum_values),
+        parseWireValue(dataRow.value_on),
+        parseWireValue(dataRow.value_off),
       );
       if (normalized.flagged) {
         const warnKey = `coerce:${device.id}:${key}`;
@@ -873,6 +889,8 @@ interface DeviceDataRow {
   value: string | null;
   unit: string | null;
   enum_values: string | null;
+  value_on: string | null;
+  value_off: string | null;
   last_updated: string | null;
 }
 

--- a/src/shared/value-normalization.test.ts
+++ b/src/shared/value-normalization.test.ts
@@ -132,4 +132,70 @@ describe("normalizeValue", () => {
       expect(normalizeValue("raw", "json")).toEqual({ value: "raw", flagged: false });
     });
   });
+
+  describe("boolean with a declared wire pair (#727)", () => {
+    it("resolves a vocabulary the hard-coded list cannot guess", () => {
+      // The case that motivated this: a Tuya TS011F reports
+      // child_lock: "UNLOCK" on a binary expose. LOCK/UNLOCK is
+      // polarity-ambiguous, so without the pair it is flagged and stored raw.
+      expect(normalizeValue("UNLOCK", "boolean", null, "LOCK", "UNLOCK")).toEqual({
+        value: false,
+        flagged: false,
+      });
+      expect(normalizeValue("LOCK", "boolean", null, "LOCK", "UNLOCK")).toEqual({
+        value: true,
+        flagged: false,
+      });
+    });
+
+    it("is case-insensitive on the declared literals", () => {
+      expect(normalizeValue("unlock", "boolean", null, "LOCK", "UNLOCK")).toEqual({
+        value: false,
+        flagged: false,
+      });
+    });
+
+    it("handles non-string wire literals", () => {
+      expect(normalizeValue(1, "boolean", null, 1, 0)).toEqual({ value: true, flagged: false });
+      expect(normalizeValue("open", "boolean", null, "open", "closed")).toEqual({
+        value: true,
+        flagged: false,
+      });
+    });
+
+    it("wins over the hard-coded vocabulary when they disagree", () => {
+      // A device whose "off" literal is the string "on" would be perverse, but
+      // the declaration is authoritative: it is the device speaking, not a guess.
+      expect(normalizeValue("on", "boolean", null, "off", "on")).toEqual({
+        value: false,
+        flagged: false,
+      });
+    });
+
+    it("still flags a value outside the declared pair", () => {
+      expect(normalizeValue("MAYBE", "boolean", null, "LOCK", "UNLOCK")).toEqual({
+        value: "MAYBE",
+        flagged: true,
+      });
+    });
+
+    it("keeps refusing to guess when nothing is declared", () => {
+      // The spec 150 guard is untouched: half a pair is not a declaration.
+      expect(normalizeValue("UNLOCK", "boolean")).toEqual({ value: "UNLOCK", flagged: true });
+      expect(normalizeValue("UNLOCK", "boolean", null, "LOCK", undefined)).toEqual({
+        value: "UNLOCK",
+        flagged: true,
+      });
+      expect(normalizeValue("OPEN", "boolean")).toEqual({ value: "OPEN", flagged: true });
+    });
+
+    it("leaves the common ON/OFF path working without a declaration", () => {
+      expect(normalizeValue("ON", "boolean")).toEqual({ value: true, flagged: false });
+      expect(normalizeValue("OFF", "boolean")).toEqual({ value: false, flagged: false });
+      expect(normalizeValue(true, "boolean", null, "LOCK", "UNLOCK")).toEqual({
+        value: true,
+        flagged: false,
+      });
+    });
+  });
 });

--- a/src/shared/value-normalization.ts
+++ b/src/shared/value-normalization.ts
@@ -22,18 +22,29 @@ const BOOLEAN_FALSE = new Set(["off", "false", "0"]);
  * JS type. Polarity-ambiguous vocabularies (OPEN/CLOSED, DETECTED, ...) are
  * deliberately NOT coerced: a wrong polarity guess is worse than a visible
  * warning, so they come back flagged with the raw value preserved.
+ *
+ * An integration can lift that ambiguity by declaring the pair itself:
+ * `valueOn` / `valueOff` are the literals the device uses on the wire, and
+ * when both are given they take precedence over the vocabulary below. Nothing
+ * is guessed then — the device said which literal means on — so an exotic
+ * vocabulary such as LOCK/UNLOCK resolves without widening the hard-coded
+ * list, which cannot be exhaustive. This is the inbound mirror of
+ * `resolveWireValue`, which maps booleans onto the same pair when dispatching
+ * an order.
  */
 export function normalizeValue(
   value: unknown,
   type: DataType,
   enumValues?: string[] | null,
+  valueOn?: unknown,
+  valueOff?: unknown,
 ): NormalizationResult {
   // Availability/absence is handled elsewhere — never touch null/undefined.
   if (value === null || value === undefined) return { value, flagged: false };
 
   switch (type) {
     case "boolean":
-      return normalizeBoolean(value);
+      return normalizeBoolean(value, valueOn, valueOff);
     case "number":
       return normalizeNumber(value);
     case "enum":
@@ -77,8 +88,31 @@ export function isCategoryTypeMismatch(
   return true;
 }
 
-function normalizeBoolean(value: unknown): NormalizationResult {
+function normalizeBoolean(
+  value: unknown,
+  valueOn?: unknown,
+  valueOff?: unknown,
+): NormalizationResult {
   if (typeof value === "boolean") return { value, flagged: false };
+
+  // Declared wire pair wins over the hard-coded vocabulary below. The device
+  // states which literal means on and which means off, so there is nothing to
+  // guess — that is what makes LOCK/UNLOCK, and any future vocabulary,
+  // resolvable without widening the polarity-ambiguous list.
+  if (valueOn !== undefined && valueOff !== undefined) {
+    if (value === valueOn) return { value: true, flagged: false };
+    if (value === valueOff) return { value: false, flagged: false };
+    if (typeof value === "string") {
+      const lowered = value.trim().toLowerCase();
+      if (typeof valueOn === "string" && lowered === valueOn.toLowerCase()) {
+        return { value: true, flagged: false };
+      }
+      if (typeof valueOff === "string" && lowered === valueOff.toLowerCase()) {
+        return { value: false, flagged: false };
+      }
+    }
+  }
+
   if (typeof value === "string") {
     const lowered = value.trim().toLowerCase();
     if (BOOLEAN_TRUE.has(lowered)) return { value: true, flagged: false };


### PR DESCRIPTION
First half of a two-repo change; the Zigbee2MQTT side follows and is inert until this lands.

## The problem

`normalizeValue` (spec 150) coerces booleans from a hard-coded vocabulary:

```
true  ← "on"  | "true"  | "1"  | 1
false ← "off" | "false" | "0"  | 0
```

and deliberately refuses everything else — its own comment says a wrong polarity guess on `OPEN/CLOSED` or `DETECTED` is worse than a visible warning. That refusal is correct, and this PR does not weaken it.

But it also fires on devices that are **not ambiguous at all**. A Tuya TS011F plug reports `child_lock: "UNLOCK"` on a binary expose whose `value_on` / `value_off` state precisely which literal means on. Result, on every discovery:

```
warn  device-manager  Device value does not match declared type; stored raw
      key=child_lock  declaredType=boolean  value="UNLOCK"
```

## The asymmetry

The integration already knows the pair. The Zigbee2MQTT plugin reads it off the expose and forwards it — but **only on orders**, where core maps booleans onto it at dispatch (`resolveWireValue`, #360):

```ts
orders.push({ key, type, category, …, valueOn, valueOff })  // outbound: carried
data.push({   key, type, category, unit, enumValues })      // inbound: dropped
```

So core ends up guessing about a device that had already answered the question.

## The change

Carry the pair on data definitions too:

- `migrations/028` adds `value_on` / `value_off` to `device_data`, mirroring `014` on `device_orders`, JSON-encoded so `"ON"` and `true` round-trip distinctly;
- the discovery contract gains the two optional fields, threaded through both the INSERT and the UPDATE path (the latter matters: a plugin reconnect re-announces, and dropping the columns there would silently lose the pair);
- `normalizeValue` takes them and **prefers them** over the vocabulary, exact match first then case-insensitive on string literals.

When they are not declared, nothing changes: same vocabulary, same flagging. Half a pair is not a declaration and is ignored.

## Why this shape rather than widening the list

Adding `LOCK`/`UNLOCK` to `BOOLEAN_TRUE`/`BOOLEAN_FALSE` would re-introduce exactly the guessing spec 150 removed, and the next device with `PRESENT`/`ABSENT` or `CLOSE`/`OPEN` breaks again. The vocabulary of possible literals is unbounded; the declaration is finite and authoritative. This closes the class rather than one key, and it serves every integration — Shelly, Legrand, anything that knows its own wire format — not just Zigbee.

Backward compatible: plugins gain an optional field and keep their current behaviour until they declare it.

## Tests

Nine new cases: the `LOCK`/`UNLOCK` resolution, case-insensitivity, non-string literals, the declaration winning over a contradicting vocabulary, a value outside the declared pair still flagged, and — the guard that matters — **nothing declared still refuses to guess**. Plus three end-to-end `DeviceManager` cases, including one that re-runs discovery to pin the UPDATE path.

Verified as a real guard: neutralising the one condition makes 6 of them fail and leaves the rest green.

`npm run validate` clean — typecheck, lint, format, **1958 tests**, ui validation.
