### PR TITLE
docs(deep-dives): the real fault was a microinverter channel, not a panel

### DIFF
--- a/docs/deep-dives/pv-health.fr.md
+++ b/docs/deep-dives/pv-health.fr.md
@@ -8,7 +8,7 @@ _Une installation solaire tombe en panne en silence : un panneau perdu ressemble
 
 ### Le problème que ça résout
 
-Les panneaux solaires n'annoncent pas leurs pannes. Un connecteur s'oxyde, une diode de bypass meurt, un panneau sur huit s'éteint — et la production baisse d'un huitième, soit moins que la différence entre une belle journée et une journée voilée. L'installation de référence sur laquelle cette fonctionnalité a été construite a **perdu un panneau sur six pendant huit mois** avant que quiconque s'en aperçoive. Huit mois à payer de l'électricité que le toit aurait dû produire.
+Les panneaux solaires n'annoncent pas leurs pannes — et dans une installation moderne, ce ne sont d'ailleurs presque jamais les panneaux eux-mêmes qui meurent en premier. C'est l'électronique vissée derrière : une voie de micro-onduleur, un optimiseur, un connecteur oxydé, une diode de bypass. Une voie devient muette et la production d'un panneau disparaît — un huitième sur un toit de huit panneaux, moins que la différence entre une belle journée et une journée voilée. L'installation de référence sur laquelle cette fonctionnalité a été construite a **perdu une voie de son micro-onduleur — un panneau sur six, muet — pendant huit mois** avant que quiconque s'en aperçoive. Huit mois à payer de l'électricité que le toit aurait dû produire.
 
 L'instrument habituel du foyer — le graphique de production — ne peut pas attraper ça. La production varie d'un facteur cinq entre un jour clair et un jour couvert ; un défaut de 12 % se cache confortablement dans ce bruit. Il faut comparer ce que les panneaux ont produit à ce que _le ciel leur offrait_, et seulement les jours où cette offre était propre.
 
@@ -18,7 +18,7 @@ Une fois par jour, Sowel divise l'énergie produite par vos panneaux par la lumi
 
 Quand le score reste nettement sous cette référence — plus de 10 % en dessous, trois jours clairs d'affilée — Sowel lève une seule alarme, par le même canal que toutes les autres : une notification, une bannière, une ligne dans le fil d'activité. Quand la production revient, l'alarme se résout et le dit.
 
-![Le panneau de prévision et la carte de santé pendant une panne (simulée) d'un panneau](../screenshots/pv-monitoring-fr.png)
+![Le panneau de prévision et la carte de santé pendant une panne simulée : la production d'un panneau en moins](../screenshots/pv-monitoring-fr.png)
 
 La capture ci-dessus montre les deux cartes de la page Énergie › Production pendant une panne simulée : la prévision attendu/réalisé en haut, et en dessous la carte de santé — la série de ratios plate autour de 100 % pendant six semaines, puis qui chute à 74 % et y reste. La bannière est apparue au troisième jour clair.
 
@@ -32,7 +32,7 @@ Tout ce dont le contrôle a besoin, la prévision de production (v1.57) le colle
 
 La carte est délibérément honnête sur ses propres limites :
 
-- **Elle nomme l'ampleur d'un défaut, jamais quel panneau.** Identifier le panneau demanderait de l'électronique par panneau que rien ne déclare.
+- **Elle nomme l'ampleur d'un défaut, jamais le coupable.** Un panneau mort, une voie de micro-onduleur en panne et un connecteur oxydé laissent la même signature : la production d'un panneau en moins. Dire quel composant — et quel panneau — demanderait de l'électronique par panneau que rien ne déclare.
 - **Elle énonce sa vitesse du moment.** La détection a besoin de jours clairs, et les jours clairs arrivent à des rythmes très différents selon la saison. En été la carte peut dire « une perte de plus de 10 % serait confirmée en 3 jours environ » ; en décembre elle admettra être presque aveugle — ce qui est en soi une information qui vaut d'être sue.
 - **Tout ce qui est plus léger que 10 % n'est pas signalé du tout.** L'encrassement lent, un onduleur qui dérive de 3 % — sous la marge d'alerte, délibérément, parce qu'alerter dans le bruit météo, c'est crier au loup toutes les semaines.
 
@@ -40,7 +40,7 @@ La carte est délibérément honnête sur ses propres limites :
 
 ## Partie 2 — Comment ça marche, précisément
 
-_Chaque nombre ci-dessous a été mesuré sur les 16 mois d'historique de l'installation de référence, y compris une vraie panne d'un panneau avec date de réparation connue. Historique de la fonctionnalité : specs 160 (prévision), 161 (réapprentissage), 162 (santé) dans l'[index des specs](../specs-index.md)._
+_Chaque nombre ci-dessous a été mesuré sur les 16 mois d'historique de l'installation de référence, y compris une vraie panne de huit mois — une voie de micro-onduleur morte — avec date de réparation connue. Historique de la fonctionnalité : specs 160 (prévision), 161 (réapprentissage), 162 (santé) dans l'[index des specs](../specs-index.md)._
 
 ### Le ratio quotidien
 
@@ -80,13 +80,13 @@ Un **changement déclaré de l'installation** (vous avez modifié les panneaux e
 
 Tout le pipeline — les fonctions livrées, pas une re-dérivation — a été rejoué sur 16 mois d'historique de l'installation de référence :
 
-| Événement (vérité terrain du propriétaire) | Comportement du détecteur                                                                                           |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| Un panneau sur six meurt, automne 2025     | Alerte levée après **2 jours clairs** (13 oct. 2025)                                                                |
-| La panne persiste tout l'hiver             | Alerte tenue 8 mois pleins, sans battement                                                                          |
-| Panneau réparé, fin juin 2026              | Alerte résolue à la réparation (25 juin 2026) ; marche de +23 % mesurée contre +20 % prédit pour un panneau sur six |
-| Extension de +1 kWc, déclarée              | Aucune fausse alerte ; référence reconstruite depuis la date déclarée ; +36 % mesuré contre +33 % attendu           |
-| Les 8 mois sains autour de ces événements  | **Zéro** fausse alerte                                                                                              |
+| Événement (vérité terrain du propriétaire)                                       | Comportement du détecteur                                                                                           |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Une voie du micro-onduleur meurt — un panneau sur six devient muet, automne 2025 | Alerte levée après **2 jours clairs** (13 oct. 2025)                                                                |
+| La panne persiste tout l'hiver                                                   | Alerte tenue 8 mois pleins, sans battement                                                                          |
+| Voie réparée, fin juin 2026                                                      | Alerte résolue à la réparation (25 juin 2026) ; marche de +23 % mesurée contre +20 % prédit pour un panneau sur six |
+| Extension de +1 kWc, déclarée                                                    | Aucune fausse alerte ; référence reconstruite depuis la date déclarée ; +36 % mesuré contre +33 % attendu           |
+| Les 8 mois sains autour de ces événements                                        | **Zéro** fausse alerte                                                                                              |
 
 ### Où ça se situe face à la littérature
 

--- a/docs/deep-dives/pv-health.md
+++ b/docs/deep-dives/pv-health.md
@@ -8,7 +8,7 @@ _A solar array fails silently: a lost panel looks exactly like a cloudy month. H
 
 ### The problem it solves
 
-Solar panels don't announce their failures. A connector corrodes, a bypass diode dies, one panel of eight goes dark — and production drops by an eighth, which is less than the difference between a nice day and a hazy one. The reference installation this feature was built on **lost one panel of six for eight months** before anyone noticed. Eight months of paying for electricity the roof should have produced.
+Solar panels don't announce their failures — and in a modern array the panels themselves are rarely what dies first. It is the electronics bolted behind them: a microinverter channel, an optimizer, a corroded connector, a bypass diode. One channel goes silent and one panel's worth of production disappears — an eighth on an eight-panel roof, less than the difference between a nice day and a hazy one. The reference installation this feature was built on **lost one channel of its microinverter — one panel of six, silent — for eight months** before anyone noticed. Eight months of paying for electricity the roof should have produced.
 
 The household's usual instrument — the production chart — cannot catch this. Production varies by a factor of five between a clear day and an overcast one; a 12 % fault hides comfortably inside that noise. You need to compare what the panels produced against what _the sky offered them_, and only on days where that offer was clean.
 
@@ -18,7 +18,7 @@ Once a day, Sowel divides the energy your panels produced by the sunlight that a
 
 When the score stays clearly below that reference — more than 10 % down, three clear days in a row — Sowel raises one alarm, through the same channel as every other alarm: a notification, a banner, a line in the zone activity feed. When production comes back, the alarm resolves and says so.
 
-![The forecast panel and the health card during a real (simulated) single-panel fault](../screenshots/pv-monitoring-en.png)
+![The forecast panel and the health card during a simulated fault: one panel's worth of production lost](../screenshots/pv-monitoring-en.png)
 
 The screenshot above shows the two cards on the Energy › Production page during a simulated fault: the expected-versus-actual forecast on top, and below it the health card — the ratio series flat around 100 % for six weeks, then dropping to 74 % and staying there. The banner appeared on the third clear day.
 
@@ -32,7 +32,7 @@ Everything the check needs, the forecast feature (v1.57) already collects. You d
 
 The card is deliberately honest about its own limits:
 
-- **It names the size of a fault, never which panel.** Identifying the panel would require per-panel electronics nothing declares.
+- **It names the size of a fault, never the culprit.** A dead panel, a failed microinverter channel and a corroded connector leave the same signature: one panel's worth of production missing. Saying which component — and which panel — would require per-panel electronics nothing declares.
 - **It states its current speed.** Detection needs clear days, and clear days arrive at very different rates through the year. In summer the card might say "a loss of more than 10 % would be confirmed in about 3 days"; in December it will admit it is nearly blind — which is itself information worth having.
 - **Anything shallower than 10 % is not flagged at all.** Slow soiling, a drifting inverter losing 3 % — below the alert margin, deliberately, because alerting inside the weather noise means crying wolf weekly.
 
@@ -40,7 +40,7 @@ The card is deliberately honest about its own limits:
 
 ## Part 2 — How it works, precisely
 
-_Every number below was measured on the reference installation's own 16 months of history, including a real single-panel outage with a known repair date. Feature history: specs 160 (forecast), 161 (history backfill), 162 (health) in the [specs index](../specs-index.md)._
+_Every number below was measured on the reference installation's own 16 months of history, including a real eight-month outage — one microinverter channel down — with a known repair date. Feature history: specs 160 (forecast), 161 (history backfill), 162 (health) in the [specs index](../specs-index.md)._
 
 ### The daily ratio
 
@@ -80,13 +80,13 @@ A **declared capacity change** (you changed the panels and updated the declarati
 
 The entire pipeline — the shipped functions, not a re-derivation — was replayed over 16 months of the reference installation's history:
 
-| Event (ground truth from the owner)      | Detector behaviour                                                                                      |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Single panel of six fails, autumn 2025   | Alert raised after **2 clear days** (13 Oct 2025)                                                       |
-| Fault persists through winter            | Alert held for the full 8 months, no flapping                                                           |
-| Panel repaired, late June 2026           | Alert resolved on the repair (25 Jun 2026); measured +23 % step vs +20 % predicted for one panel of six |
-| +1 kWc extension added, declared         | No false alert; reference rebuilt from the declared date; measured +36 % vs +33 % expected              |
-| The 8 healthy months around these events | **Zero** false alerts                                                                                   |
+| Event (ground truth from the owner)                                       | Detector behaviour                                                                                      |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| A microinverter channel fails — one panel of six goes silent, autumn 2025 | Alert raised after **2 clear days** (13 Oct 2025)                                                       |
+| Fault persists through winter                                             | Alert held for the full 8 months, no flapping                                                           |
+| The channel repaired, late June 2026                                      | Alert resolved on the repair (25 Jun 2026); measured +23 % step vs +20 % predicted for one panel of six |
+| +1 kWc extension added, declared                                          | No false alert; reference rebuilt from the declared date; measured +36 % vs +33 % expected              |
+| The 8 healthy months around these events                                  | **Zero** false alerts                                                                                   |
 
 ### Where this stands against the literature
 

--- a/specs/162-pv-health/spec.md
+++ b/specs/162-pv-health/spec.md
@@ -104,8 +104,10 @@ The reference is a **high centile (80th) of the last 180 qualifying days**, not 
 median of the last 20. That is not a refinement; it is the difference between a
 feature and a placebo.
 
-Validated against a real single-panel outage on the reference installation,
-about eight months long, with the repair date known from the owner:
+Validated against a real outage on the reference installation — one
+microinverter channel down, one panel of six silent (initially recorded as a
+panel failure; the owner later identified the channel as the culprit) — about
+eight months long, with the repair date known from the owner:
 
 | reference                  | fault days covered | false-alert days |
 | -------------------------- | ------------------ | ---------------- |


### PR DESCRIPTION
## Summary

Ground-truth correction from the owner of the reference installation: the eight-month outage the PV health feature was validated against was **one channel of the microinverter** failing - one panel of six silent - not the panel itself. The detection math is unchanged (the signature is exactly one panel's worth of production missing), but the story is now accurate and more representative: in modern arrays the electronics behind the panels (microinverter channels, optimizers, connectors) fail long before the panels do.

## Changes

- `pv-health.md` / `.fr.md`: part 1 leads with electronics failures; the validation table names the channel; the "what the card won't tell you" bullet becomes "names the size, never the culprit" (panel, channel and connector share one signature)
- `specs/162-pv-health/spec.md`: validation section records the correction for the historical record

## Test plan

- [x] `mkdocs build --strict` passes