### PR TITLE
fix(energy): stop accusing a load that draws nothing of ignoring a revoke (#732)

### DIFF
--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -1004,9 +1004,9 @@ describe("capacity arbiter", () => {
     );
   });
 
-  // ── Unhonored revokes: no accusation without a measured draw ──
+  // ── Unhonored revokes: no accusation without a measured draw (#732) ──
 
-  it("a load that was drawing nothing is never accused of ignoring the revoke", () => {
+  it("a load that was drawing nothing is never accused of ignoring the revoke (#732)", () => {
     const h = makeHarness({
       priority: ["pump", "heater"],
       profiles: {
@@ -1045,7 +1045,7 @@ describe("capacity arbiter", () => {
     expect(h.revokedEvents().map((e) => e.equipmentId)).toContain("pump");
   });
 
-  it("an unmetered load that reports itself OFF is not accused either", () => {
+  it("an unmetered load that reports itself OFF is not accused either (#732)", () => {
     const h = makeHarness({
       priority: ["pump", "heater"],
       profiles: {
@@ -1077,7 +1077,7 @@ describe("capacity arbiter", () => {
     );
   });
 
-  it("a load that stops late drops its background excuse and can be granted again", () => {
+  it("a load that stops late drops its background excuse and can be granted again (#732)", () => {
     const h = makeHarness({
       priority: ["pac", "heater"],
       profiles: {

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -1004,6 +1004,126 @@ describe("capacity arbiter", () => {
     );
   });
 
+  // ── Unhonored revokes: no accusation without a measured draw ──
+
+  it("a load that was drawing nothing is never accused of ignoring the revoke", () => {
+    const h = makeHarness({
+      priority: ["pump", "heater"],
+      profiles: {
+        pump: { class: "deferrable", nominalPowerW: 600, minOnS: 0, minOffS: 0 },
+        heater: { class: "deferrable", nominalPowerW: 2200, minOnS: 0, minOffS: 0 },
+      },
+    });
+    h.claim("pumpI", { equipmentId: "pump" });
+    h.claim("heaterI", { equipmentId: "heater" });
+    h.run(-3000, 150);
+    expect(h.grantedEvents()).toHaveLength(2);
+    // The heater has its grant and its order, but draws nothing — breaker left
+    // off while the household is away (the prod case). The pump is the only
+    // real consumer.
+    h.feedLoadPower("pump", 600);
+    h.feedLoadPower("heater", 0);
+    // Evening: production collapses into a sustained, DEEPENING import. The
+    // bottom of the list (heater) is revoked first.
+    h.run(400, 700);
+    expect(h.revokedEvents().map((e) => e.equipmentId)).toContain("heater");
+
+    // Export never "recovers" — the sun is setting, not the heater refusing.
+    for (let i = 0; i < 130; i++) {
+      vi.advanceTimersByTime(10_000);
+      h.feedMeter(600);
+      h.feedLoadPower("pump", 600);
+      h.feedLoadPower("heater", 0);
+    }
+    const journal = h.arbiter.getPublicState().journal;
+    expect(journal.some((j) => j.kind === "revoke-not-honored" && j.equipmentId === "heater")).toBe(
+      false,
+    );
+    // And the deficit keeps being worked: the heater is not excused as
+    // background draw, so the pass moves on to the load that is actually
+    // consuming instead of stopping at a phantom.
+    expect(h.revokedEvents().map((e) => e.equipmentId)).toContain("pump");
+  });
+
+  it("an unmetered load that reports itself OFF is not accused either", () => {
+    const h = makeHarness({
+      priority: ["pump", "heater"],
+      profiles: {
+        pump: { class: "deferrable", nominalPowerW: 600, minOnS: 0, minOffS: 0 },
+        heater: { class: "deferrable", nominalPowerW: 2200, minOnS: 0, minOffS: 0 },
+      },
+      // No power binding on the heater: its reported state is all the arbiter
+      // gets, so that state must be enough to clear the watchdog.
+      bindings: { heater: [{ alias: "state", category: "generic" }] },
+    });
+    h.claim("pumpI", { equipmentId: "pump" });
+    h.claim("heaterI", { equipmentId: "heater" });
+    h.run(-3000, 150);
+    expect(h.grantedEvents()).toHaveLength(2);
+    h.feedLoadPower("pump", 600);
+    h.feedState("heater", true);
+    h.run(400, 700);
+    expect(h.revokedEvents().map((e) => e.equipmentId)).toContain("heater");
+    // The recipe honors the revoke: the relay opens and says so.
+    h.feedState("heater", false);
+    for (let i = 0; i < 130; i++) {
+      vi.advanceTimersByTime(10_000);
+      h.feedMeter(600);
+      h.feedLoadPower("pump", 600);
+    }
+    const journal = h.arbiter.getPublicState().journal;
+    expect(journal.some((j) => j.kind === "revoke-not-honored" && j.equipmentId === "heater")).toBe(
+      false,
+    );
+  });
+
+  it("a load that stops late drops its background excuse and can be granted again", () => {
+    const h = makeHarness({
+      priority: ["pac", "heater"],
+      profiles: {
+        pac: { class: "comfort", nominalPowerW: 2000, minOnS: 0, minOffS: 0 },
+        heater: {
+          class: "deferrable",
+          nominalPowerW: 2200,
+          minOnS: 0,
+          minOffS: 0,
+          releaseDelayS: 1800, // declared shutdown inertia, > the 600 s hold
+        },
+      },
+    });
+    h.claim("pacI", { equipmentId: "pac" });
+    const heaterClaim = h.claim("heaterI", { equipmentId: "heater" });
+    h.run(-5000, 150);
+    expect(h.grantedEvents()).toHaveLength(2);
+    h.feedLoadPower("heater", 2200);
+    h.run(400, 700);
+    expect(h.revokedEvents().map((e) => e.equipmentId)).toContain("heater");
+    // Past the global hold with the draw still there: excused as background.
+    for (let i = 0; i < 70; i++) {
+      vi.advanceTimersByTime(10_000);
+      h.feedMeter(400);
+      h.feedLoadPower("heater", 2200);
+    }
+    // It does stop — late, but it stops. Export does not recover (a cloud, or
+    // the evening), so only the load's own measurement tells the truth.
+    for (let i = 0; i < 10; i++) {
+      vi.advanceTimersByTime(10_000);
+      h.feedMeter(400);
+      h.feedLoadPower("heater", 0);
+    }
+    const journal = h.arbiter.getPublicState().journal;
+    expect(journal.some((j) => j.kind === "revoke-not-honored" && j.equipmentId === "heater")).toBe(
+      false,
+    );
+    // The excuse is lifted with the watchdog: surplus returns and the heater
+    // is grantable again, instead of sitting out the 2 x grace window.
+    expect(heaterClaim.status()).toBe("pending");
+    h.run(-5000, 150);
+    h.feedLoadPower("heater", 0);
+    h.run(-5000, 150);
+    expect(heaterClaim.status()).toBe("granted");
+  });
+
   // ── Wall-switch divergence (FR-6, review decision 16) ─────
 
   it("a granted load reported OFF at the wall is revoked and suspended", () => {

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -1124,6 +1124,66 @@ describe("capacity arbiter", () => {
     expect(heaterClaim.status()).toBe("granted");
   });
 
+  it("an inertial load's own OFF report does not hand back the anti-cascade excuse (#733)", () => {
+    const h = makeHarness({
+      priority: ["pac", "heater"],
+      profiles: {
+        pac: { class: "comfort", nominalPowerW: 2000, minOnS: 0, minOffS: 0 },
+        heater: {
+          class: "deferrable",
+          nominalPowerW: 2200,
+          minOnS: 0,
+          minOffS: 0,
+          releaseDelayS: 1800, // the Calypso case: contact opens, pump runs on
+        },
+      },
+      // No power binding: the relay's state report is all the arbiter gets,
+      // and on this load it says nothing about the current still flowing.
+      bindings: { heater: [{ alias: "state", category: "generic" }] },
+    });
+    h.claim("pacI", { equipmentId: "pac" });
+    h.claim("heaterI", { equipmentId: "heater" });
+    h.run(-5000, 150);
+    expect(h.grantedEvents()).toHaveLength(2);
+    h.feedState("heater", true);
+    h.run(400, 700);
+    expect(h.revokedEvents().map((e) => e.equipmentId)).toContain("heater");
+    // The contact opens immediately — the tail does not.
+    h.feedState("heater", false);
+    for (let i = 0; i < 130; i++) {
+      vi.advanceTimersByTime(10_000);
+      h.feedMeter(400);
+    }
+    // The excuse must hold: the PAC keeps its grant instead of paying for a
+    // shutdown that has not electrically happened yet.
+    expect(h.revokedEvents().filter((e) => e.equipmentId === "pac")).toHaveLength(0);
+  });
+
+  it("a large load still importing hundreds of watts does not count as idle (#733)", () => {
+    const h = makeHarness({
+      priority: ["pac", "heater"],
+      profiles: {
+        pac: { class: "comfort", nominalPowerW: 2000, minOnS: 0, minOffS: 0 },
+        heater: { class: "deferrable", nominalPowerW: 5000, minOnS: 0, minOffS: 0 },
+      },
+    });
+    h.claim("pacI", { equipmentId: "pac" });
+    h.claim("heaterI", { equipmentId: "heater" });
+    h.run(-8000, 150);
+    expect(h.grantedEvents()).toHaveLength(2);
+    h.feedLoadPower("heater", 5000);
+    h.run(400, 700);
+    expect(h.revokedEvents().map((e) => e.equipmentId)).toContain("heater");
+    // It winds down to 400 W and stays there — 8 % of nominal, but 400 W of
+    // real import. An idle threshold scaled to nominal would call this idle.
+    for (let i = 0; i < 130; i++) {
+      vi.advanceTimersByTime(10_000);
+      h.feedMeter(400);
+      h.feedLoadPower("heater", 400);
+    }
+    expect(h.revokedEvents().filter((e) => e.equipmentId === "pac")).toHaveLength(0);
+  });
+
   // ── Wall-switch divergence (FR-6, review decision 16) ─────
 
   it("a granted load reported OFF at the wall is revoked and suspended", () => {

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -53,12 +53,15 @@ const LEARN_SAMPLE_FLOOR = 0.25; // learner ignores samples below 25 % of nomina
 const LEARN_MIN_SAMPLES = 3;
 const LEARN_SAMPLE_CAP = 500;
 const DIVERGENCE_RATIO = 0.3; // watts-divergence threshold vs declared nominal
-// A load measured below this fraction of its declared nominal (or below the
-// absolute floor, for a load whose nominal is tiny/unset) is not running:
-// standby, a thermostat that has opened, a breaker left off. Used by the
-// revoke watchdog, which must never accuse a load that draws nothing.
+// Below this, a load is not running: standby, a thermostat that has opened, a
+// breaker left off. A fraction of the declared nominal, BOUNDED at both ends —
+// unbounded, 10 % of a 5 kW load would read 400 W of real import as "idle" and
+// hand the anti-cascade excuse away (review #733), while 10 % of a 100 W pump
+// would never be reached. Used by the revoke watchdog, which must never accuse
+// a load that draws nothing, and must never excuse one that still draws.
 const IDLE_DRAW_RATIO = 0.1;
 const IDLE_DRAW_FLOOR_W = 20;
+const IDLE_DRAW_CEIL_W = 100;
 const TICK_MS = 10_000;
 
 interface ArbiterConfig {
@@ -1197,16 +1200,31 @@ export class CapacityArbiter {
    * Direct evidence that a load is NOT consuming right now (#732).
    *
    * Measurement first — a fresh own-power reading below the idle threshold is
-   * proof, whatever the relay reports. Failing that, the load's own reported
-   * on/off STATE. A load with neither (no power binding, never reported a
-   * state) is unknown, and callers fall back to the grid-export proxy.
+   * proof, whatever the relay reports.
+   *
+   * Failing that, the load's own reported on/off STATE, but ONLY for a load
+   * that declares no shutdown inertia (review #733). `releaseDelayS` exists
+   * for the appliance whose contact opens — reporting itself OFF — while its
+   * heat pump keeps drawing for half an hour (#631); on such a load the state
+   * report says nothing about the current, and trusting it would hand back the
+   * anti-cascade excuse exactly when the tail needs it.
+   *
+   * A load with neither (no power binding, never reported a state, or an
+   * inertial load with no measurement) is unknown, and callers fall back to
+   * the grid-export proxy.
    */
   private notDrawing(equipmentId: string): boolean {
+    const profile = this.profileOf(equipmentId);
     const live = this.freshLiveDraw(equipmentId);
     if (live !== null) {
-      const nominal = this.profileOf(equipmentId)?.nominalPowerW ?? 0;
-      return live < Math.max(IDLE_DRAW_FLOOR_W, nominal * IDLE_DRAW_RATIO);
+      const nominal = profile?.nominalPowerW ?? 0;
+      const threshold = Math.min(
+        IDLE_DRAW_CEIL_W,
+        Math.max(IDLE_DRAW_FLOOR_W, nominal * IDLE_DRAW_RATIO),
+      );
+      return live < threshold;
     }
+    if ((profile?.releaseDelayS ?? 0) > 0) return false;
     const reportedOn = this.reportedOnOff.get(equipmentId);
     if (reportedOn !== undefined) return !reportedOn;
     return false;
@@ -1368,20 +1386,21 @@ export class CapacityArbiter {
     const exportNow = -(this.emaPowerW ?? 0);
     this.watchdogs = this.watchdogs.filter((w) => {
       if (this.grantedClaimFor(w.equipmentId)) return false; // re-granted, moot
-      // Honored, by direct evidence (#732): the load's own measurement (or its
-      // reported state) says it has stopped. This outranks the export proxy,
-      // which never recovers when the production falls or another load picks
-      // up the slack in the same window — an evening revoke used to be flagged
-      // unhonored for that reason alone. Drop the background excuse with it:
-      // a load that has genuinely stopped must be back in the release pass.
+      // Honored, by direct evidence (#732): the load's own measurement (or, for
+      // a load declaring no inertia, its reported state) says it has stopped.
+      // This outranks the export proxy, which never recovers when the
+      // production falls or another load picks up the slack in the same window
+      // — an evening revoke used to be flagged unhonored for that reason alone.
+      // Drop the background excuse with it: a load that has genuinely stopped
+      // must be back in the release pass, and grantable again.
       if (this.notDrawing(w.equipmentId)) {
         this.unresponsiveUntil.delete(w.equipmentId);
         return false;
       }
-      if (exportNow - w.exportAtRevoke >= 0.5 * w.expectedW) {
-        this.unresponsiveUntil.delete(w.equipmentId);
-        return false; // honored, export recovered
-      }
+      // NOT lifting `unresponsiveUntil` here is deliberate (review #733): an
+      // export that rose can be the sun coming back or a sibling stopping, so
+      // this branch closes the watchdog without claiming the load is idle.
+      if (exportNow - w.exportAtRevoke >= 0.5 * w.expectedW) return false; // honored
       const graceMs =
         Math.max(this.config.releaseHoldS, this.profileOf(w.equipmentId)?.releaseDelayS ?? 0) *
         1000;

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -1194,7 +1194,7 @@ export class CapacityArbiter {
   }
 
   /**
-   * Direct evidence that a load is NOT consuming right now.
+   * Direct evidence that a load is NOT consuming right now (#732).
    *
    * Measurement first — a fresh own-power reading below the idle threshold is
    * proof, whatever the relay reports. Failing that, the load's own reported
@@ -1261,7 +1261,7 @@ export class CapacityArbiter {
         at: Date.now(),
       });
     }
-    // Arm the watchdog only when there is something to honor. A load
+    // Arm the watchdog only when there is something to honor (#732). A load
     // that was drawing nothing at the revoke — physically off, breaker open,
     // thermostat satisfied — cannot make the export "recover", so the proxy
     // below would accuse it the moment the sun drops or another load starts.
@@ -1368,7 +1368,7 @@ export class CapacityArbiter {
     const exportNow = -(this.emaPowerW ?? 0);
     this.watchdogs = this.watchdogs.filter((w) => {
       if (this.grantedClaimFor(w.equipmentId)) return false; // re-granted, moot
-      // Honored, by direct evidence: the load's own measurement (or its
+      // Honored, by direct evidence (#732): the load's own measurement (or its
       // reported state) says it has stopped. This outranks the export proxy,
       // which never recovers when the production falls or another load picks
       // up the slack in the same window — an evening revoke used to be flagged

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -53,6 +53,12 @@ const LEARN_SAMPLE_FLOOR = 0.25; // learner ignores samples below 25 % of nomina
 const LEARN_MIN_SAMPLES = 3;
 const LEARN_SAMPLE_CAP = 500;
 const DIVERGENCE_RATIO = 0.3; // watts-divergence threshold vs declared nominal
+// A load measured below this fraction of its declared nominal (or below the
+// absolute floor, for a load whose nominal is tiny/unset) is not running:
+// standby, a thermostat that has opened, a breaker left off. Used by the
+// revoke watchdog, which must never accuse a load that draws nothing.
+const IDLE_DRAW_RATIO = 0.1;
+const IDLE_DRAW_FLOOR_W = 20;
 const TICK_MS = 10_000;
 
 interface ArbiterConfig {
@@ -1187,6 +1193,25 @@ export class CapacityArbiter {
     return profile?.learned?.watts ?? profile?.nominalPowerW ?? 0;
   }
 
+  /**
+   * Direct evidence that a load is NOT consuming right now.
+   *
+   * Measurement first — a fresh own-power reading below the idle threshold is
+   * proof, whatever the relay reports. Failing that, the load's own reported
+   * on/off STATE. A load with neither (no power binding, never reported a
+   * state) is unknown, and callers fall back to the grid-export proxy.
+   */
+  private notDrawing(equipmentId: string): boolean {
+    const live = this.freshLiveDraw(equipmentId);
+    if (live !== null) {
+      const nominal = this.profileOf(equipmentId)?.nominalPowerW ?? 0;
+      return live < Math.max(IDLE_DRAW_FLOOR_W, nominal * IDLE_DRAW_RATIO);
+    }
+    const reportedOn = this.reportedOnOff.get(equipmentId);
+    if (reportedOn !== undefined) return !reportedOn;
+    return false;
+  }
+
   private freshLiveDraw(equipmentId: string): number | null {
     const entry = this.liveDraw.get(equipmentId);
     if (!entry) return null;
@@ -1236,7 +1261,17 @@ export class CapacityArbiter {
         at: Date.now(),
       });
     }
-    if (reason === "surplus-deficit" || reason === "priority-preempted") {
+    // Arm the watchdog only when there is something to honor. A load
+    // that was drawing nothing at the revoke — physically off, breaker open,
+    // thermostat satisfied — cannot make the export "recover", so the proxy
+    // below would accuse it the moment the sun drops or another load starts.
+    // `watts <= 0` is the same case seen through the effective-watts tier: a
+    // 0 W threshold makes any noise dip read as unhonored.
+    if (
+      (reason === "surplus-deficit" || reason === "priority-preempted") &&
+      watts > 0 &&
+      !this.notDrawing(claim.equipmentId)
+    ) {
       this.watchdogs.push({
         equipmentId: claim.equipmentId,
         at: Date.now(),
@@ -1333,7 +1368,20 @@ export class CapacityArbiter {
     const exportNow = -(this.emaPowerW ?? 0);
     this.watchdogs = this.watchdogs.filter((w) => {
       if (this.grantedClaimFor(w.equipmentId)) return false; // re-granted, moot
-      if (exportNow - w.exportAtRevoke >= 0.5 * w.expectedW) return false; // honored
+      // Honored, by direct evidence: the load's own measurement (or its
+      // reported state) says it has stopped. This outranks the export proxy,
+      // which never recovers when the production falls or another load picks
+      // up the slack in the same window — an evening revoke used to be flagged
+      // unhonored for that reason alone. Drop the background excuse with it:
+      // a load that has genuinely stopped must be back in the release pass.
+      if (this.notDrawing(w.equipmentId)) {
+        this.unresponsiveUntil.delete(w.equipmentId);
+        return false;
+      }
+      if (exportNow - w.exportAtRevoke >= 0.5 * w.expectedW) {
+        this.unresponsiveUntil.delete(w.equipmentId);
+        return false; // honored, export recovered
+      }
       const graceMs =
         Math.max(this.config.releaseHoldS, this.profileOf(w.equipmentId)?.releaseDelayS ?? 0) *
         1000;


### PR DESCRIPTION
Closes #732.

## The bug

The revoke watchdog had a single proof that a load had stopped: the grid export had to rise by half the revoked watts within the grace window. That proof is worthless for a load that was consuming nothing — the export cannot recover for watts that were never taken, and in the evening it keeps falling for reasons that have nothing to do with the load.

Production, 2026-08-26: the household is away, the water heater is not working this week. It is granted, ordered on, draws nothing, and is revoked with the rest when the evening deficit arrives. Ten minutes later (`releaseHoldS` = 600 s) the journal reads "did not turn off on request" about an appliance that was off all along. With a metered load it is worse: `effectiveWatts` returns the live draw, so the revoked watts are `0` and the threshold becomes `0.5 * 0` — any noise dip trips it.

It is not only a false line in the journal. The same watchdog marks the load `unresponsive` for `2 x grace`, and the grant pass skips a pending claim on an unresponsive equipment: the innocent load was locked out of any new grant for about twenty minutes. For a load with no power measurement, `drawEstimate` also falls back to learned or nominal watts, and that invented figure is subtracted from a real import as excused background draw.

## The change

The watchdog now takes the load's own evidence over the grid proxy:

- it is armed only when there is something to honor — non-zero effective watts, and no direct evidence that the load was already idle at the revoke;
- a pending watchdog resolves as honored the moment that evidence says the load has stopped, which also lifts the background excuse: a load that has genuinely stopped belongs back in the release pass and back in the grant pass.

`notDrawing()` is what "direct evidence" means, and it is deliberately narrow:

- **the load's own measurement first** — a fresh own-power reading below the idle threshold, which is a fraction of the nominal bounded at both ends (20 W .. 100 W). Unbounded, 10 % of a 5 kW load would read 400 W of real import as idle;
- **then its reported on/off state, but only on a load declaring no shutdown inertia.** `releaseDelayS` exists for the appliance whose contact opens — reporting itself OFF — while its heat pump keeps drawing for half an hour (#631). On such a load the state report says nothing about the current;
- **anything else is unknown** and falls back to the export proxy exactly as before, so a recipe that genuinely ignores a revoke is still caught. That signal is the reason FR-9 exists and it is untouched.

The export-recovery branch keeps closing the watchdog but no longer lifts the `unresponsive` excuse: an export that rose can be the sun returning or a sibling stopping, which is not evidence about this load.

## Scope left out

For an unmetered load the phantom excuse remains possible: `drawEstimate` still answers with an estimate when nothing is measured. Excusing only measured watts would trade away the anti-cascade guarantee of review decision 12, which is a design call rather than a fix — noted in #732 rather than decided here.

## Tests

Five regression tests, each verified to fail without the commit that introduces it:

- a metered load drawing nothing through a deepening evening deficit is never accused, and the deficit pass moves on to the load that is actually consuming;
- an unmetered load that reports itself off is not accused either;
- a load with a declared shutdown inertia that stops late drops its background excuse and can be granted again, instead of sitting out the `2 x grace` window;
- an inertial load's immediate OFF report does not hand back the anti-cascade excuse — the load above it keeps its grant through the tail;
- a 5 kW load still pulling 400 W does not count as idle.

`npm run validate` passes (1953 backend tests, 680 UI tests, tsc, eslint, prettier).