### PR TITLE
fix(ui): widen the chart tooltip formatters for the recharts Formatter type

### DIFF
--- a/ui/src/components/history/HistoryBarChart.tsx
+++ b/ui/src/components/history/HistoryBarChart.tsx
@@ -11,6 +11,7 @@ import {
 import type { HistoryPoint } from "../../types";
 import type { TimeRange } from "./history-utils";
 import { aggregateToBuckets, formatLabel, pickTickInterval } from "./chart-utils";
+import { formatBarTooltip } from "./tooltip-format";
 
 interface HistoryBarChartProps {
   points: HistoryPoint[];
@@ -48,23 +49,6 @@ function formatTooltipTime(iso: string, range: TimeRange): string {
     hour: "2-digit",
     minute: "2-digit",
   });
-}
-
-/** Format a value with its unit for tooltip display. */
-function formatValueWithUnit(value: number, unit?: string): string {
-  // Energy: convert Wh to kWh when appropriate
-  if (unit === "Wh" || unit === "kWh") {
-    const kwh = unit === "kWh" ? value : value / 1000;
-    if (kwh >= 100) return `${Math.round(kwh)} kWh`;
-    if (kwh >= 10) return `${kwh.toFixed(1)} kWh`;
-    if (kwh >= 1) return `${kwh.toFixed(2)} kWh`;
-    const wh = unit === "kWh" ? value * 1000 : value;
-    return `${Math.round(wh)} Wh`;
-  }
-
-  // Generic: show value with appropriate precision + unit
-  const formatted = Number.isInteger(value) ? String(value) : value.toFixed(1);
-  return unit ? `${formatted} ${unit}` : formatted;
 }
 
 /** Format Y-axis tick value — adapts to unit. */
@@ -244,7 +228,7 @@ export function HistoryBarChart({ points, range, unit, height = 200 }: HistoryBa
             borderRadius: "6px",
             fontSize: "12px",
           }}
-          formatter={(value: number | undefined) => [formatValueWithUnit(value ?? 0, unit), tooltipLabel]}
+          formatter={(value: unknown) => formatBarTooltip(value, unit, tooltipLabel)}
           labelFormatter={(_, payload) => {
             if (payload?.[0]?.payload?.time) {
               return formatTooltipTime(payload[0].payload.time as string, range);

--- a/ui/src/components/history/TimeSeriesChart.tsx
+++ b/ui/src/components/history/TimeSeriesChart.tsx
@@ -12,6 +12,7 @@ import {
 } from "recharts";
 import type { HistoryPoint } from "../../types";
 import { rangeToDurationMs, type TimeRange } from "./history-utils";
+import { formatSeriesTooltip } from "./tooltip-format";
 
 interface TimeSeriesChartProps {
   points: HistoryPoint[];
@@ -46,16 +47,6 @@ function formatTooltipTime(iso: string): string {
     hour: "2-digit",
     minute: "2-digit",
   });
-}
-
-function formatValue(v: number, unit?: string): string {
-  const formatted = Number.isInteger(v) ? String(v) : v.toFixed(1);
-  return unit ? `${formatted} ${unit}` : formatted;
-}
-
-function formatPower(w: number): string {
-  if (w >= 1000) return `${(w / 1000).toFixed(1)} kW`;
-  return `${Math.round(w)} W`;
 }
 
 /** Returns a human-readable relative time string, or null if gap < 5 minutes. */
@@ -196,16 +187,9 @@ export function TimeSeriesChart({ points, range, resolution, unit, height = 200,
             }
             return "";
           }}
-          formatter={(value?: number, name?: string) => {
-            const v = value ?? 0;
-            if (isPower) {
-              if (name === "min" || name === "max") return [formatPower(v), name];
-              return [formatPower(v), "Puissance"];
-            }
-            if (name === "min" || name === "max") return [formatValue(v, unit), name];
-            if (isDiscrete) return [v === 1 ? "ON" : "OFF", ""];
-            return [formatValue(v, unit), ""];
-          }}
+          formatter={(value: unknown, name: unknown) =>
+            formatSeriesTooltip(value, name, { unit, isPower, isDiscrete })
+          }
         />
 
         {/* Min/Max area fill for aggregated data (non-power) */}

--- a/ui/src/components/history/tooltip-format.test.ts
+++ b/ui/src/components/history/tooltip-format.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from "vitest";
 import type { TFunction } from "i18next";
-import { formatTooltipRow, seriesFullLabel, type TooltipSeries } from "./tooltip-format";
+import {
+  formatBarTooltip,
+  formatSeriesTooltip,
+  formatTooltipRow,
+  formatValueWithUnit,
+  seriesFullLabel,
+  tooltipName,
+  tooltipNumber,
+  type TooltipSeries,
+} from "./tooltip-format";
 
 // Identity t: returns the i18n key, enough to assert which key is picked.
 const t = ((k: string) => k) as unknown as TFunction;
@@ -66,5 +75,110 @@ describe("formatTooltipRow (#498, point 4)", () => {
 describe("seriesFullLabel", () => {
   it("joins zone / equipment / metric", () => {
     expect(seriesFullLabel(measurement, t).startsWith("Salon / Thermostat /")).toBe(true);
+  });
+});
+
+// The recharts <Tooltip formatter> path (#681). Recharts calls a formatter with
+// `(value, name, item, index, payload)` and types value/name wide, so these
+// helpers are what stands between the widened signature and the rendered text.
+describe("tooltipNumber (#681)", () => {
+  it("passes a number through", () => {
+    expect(tooltipNumber(20.5)).toBe(20.5);
+  });
+
+  it("reads 0 for undefined, matching the previous `value ?? 0` call sites", () => {
+    expect(tooltipNumber(undefined)).toBe(0);
+    expect(tooltipNumber(null)).toBe(0);
+  });
+
+  it("coerces the numeric string recharts may hand over", () => {
+    expect(tooltipNumber("42")).toBe(42);
+  });
+
+  it("takes the first entry of a range value (ValueType allows an array)", () => {
+    expect(tooltipNumber([12, 34])).toBe(12);
+  });
+
+  it("reads 0 rather than NaN for a non-numeric value", () => {
+    expect(tooltipNumber("n/a")).toBe(0);
+    expect(tooltipNumber({})).toBe(0);
+  });
+});
+
+describe("tooltipName (#681)", () => {
+  it("passes a string name through", () => {
+    expect(tooltipName("min")).toBe("min");
+  });
+
+  it("stringifies a numeric name (NameType allows a number)", () => {
+    expect(tooltipName(3)).toBe("3");
+  });
+
+  it("reads empty for a missing name", () => {
+    expect(tooltipName(undefined)).toBe("");
+  });
+});
+
+describe("formatBarTooltip (#681)", () => {
+  it("formats a plain measurement with its unit and keeps the series label", () => {
+    expect(formatBarTooltip(20.5, "°C", "Valeur")).toEqual(["20.5 °C", "Valeur"]);
+  });
+
+  it("drops a trailing .0 on an integer", () => {
+    expect(formatBarTooltip(20, "°C", "Valeur")).toEqual(["20 °C", "Valeur"]);
+  });
+
+  it("converts Wh to kWh above 1 kWh", () => {
+    expect(formatBarTooltip(2500, "Wh", "Consommation")[0]).toBe("2.50 kWh");
+    expect(formatBarTooltip(15000, "Wh", "Consommation")[0]).toBe("15.0 kWh");
+    expect(formatBarTooltip(150000, "Wh", "Consommation")[0]).toBe("150 kWh");
+  });
+
+  it("stays in Wh below 1 kWh", () => {
+    expect(formatBarTooltip(750, "Wh", "Consommation")[0]).toBe("750 Wh");
+  });
+
+  it("renders an undefined value as 0 instead of NaN", () => {
+    expect(formatBarTooltip(undefined, "°C", "Valeur")).toEqual(["0 °C", "Valeur"]);
+  });
+});
+
+describe("formatSeriesTooltip (#681)", () => {
+  const plain = { unit: "°C", isPower: false, isDiscrete: false };
+
+  it("formats a measurement with its unit and no row label", () => {
+    expect(formatSeriesTooltip(20.5, "value", plain)).toEqual(["20.5 °C", ""]);
+  });
+
+  it("labels the min/max envelope rows with their own name", () => {
+    expect(formatSeriesTooltip(18, "min", plain)).toEqual(["18 °C", "min"]);
+    expect(formatSeriesTooltip(24, "max", plain)).toEqual(["24 °C", "max"]);
+  });
+
+  it("renders power in W below 1 kW and in kW above", () => {
+    const power = { unit: "W", isPower: true, isDiscrete: false };
+    expect(formatSeriesTooltip(750, "value", power)).toEqual(["750 W", "Puissance"]);
+    expect(formatSeriesTooltip(2500, "value", power)).toEqual(["2.5 kW", "Puissance"]);
+  });
+
+  it("keeps the envelope name on a power series", () => {
+    const power = { unit: "W", isPower: true, isDiscrete: false };
+    expect(formatSeriesTooltip(2500, "max", power)).toEqual(["2.5 kW", "max"]);
+  });
+
+  it("renders a discrete series as ON/OFF", () => {
+    const discrete = { unit: undefined, isPower: false, isDiscrete: true };
+    expect(formatSeriesTooltip(1, "value", discrete)).toEqual(["ON", ""]);
+    expect(formatSeriesTooltip(0, "value", discrete)).toEqual(["OFF", ""]);
+  });
+
+  it("renders an undefined value as 0 instead of NaN", () => {
+    expect(formatSeriesTooltip(undefined, undefined, plain)).toEqual(["0 °C", ""]);
+  });
+});
+
+describe("formatValueWithUnit", () => {
+  it("renders a bare value when no unit is given", () => {
+    expect(formatValueWithUnit(20.5)).toBe("20.5");
   });
 });

--- a/ui/src/components/history/tooltip-format.ts
+++ b/ui/src/components/history/tooltip-format.ts
@@ -72,3 +72,94 @@ export function formatTooltipRow(
 
   return { label: seriesFullLabel(s, t), value: valueText, color: s.color };
 }
+
+// ============================================================
+// Recharts <Tooltip formatter> (#681)
+// ============================================================
+//
+// Recharts hands a tooltip formatter its value as `ValueType`
+// (string | number | (string | number)[]) and its name as `NameType`
+// (string | number). Recharts 3.10 tightened `Formatter<ValueType, NameType>`,
+// so a formatter declared as `(value: number | undefined)` stopped
+// typechecking: a parameter has to accept everything the caller may hand it,
+// not just the shape this chart happens to feed in.
+//
+// Both history charts therefore declare `unknown` at the call site and narrow
+// through the helpers below. That keeps the components off the recharts type
+// surface, so the next tightening of `Formatter` cannot break them again.
+
+/** Narrow a recharts tooltip value to a number. Non-finite input reads 0,
+ *  which is what the previous `value ?? 0` call sites did. */
+export function tooltipNumber(value: unknown): number {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Narrow a recharts tooltip series name to a string. */
+export function tooltipName(name: unknown): string {
+  return typeof name === "string" || typeof name === "number" ? String(name) : "";
+}
+
+/** Format a value with its unit for tooltip display (bar chart). */
+export function formatValueWithUnit(value: number, unit?: string): string {
+  // Energy: convert Wh to kWh when appropriate
+  if (unit === "Wh" || unit === "kWh") {
+    const kwh = unit === "kWh" ? value : value / 1000;
+    if (kwh >= 100) return `${Math.round(kwh)} kWh`;
+    if (kwh >= 10) return `${kwh.toFixed(1)} kWh`;
+    if (kwh >= 1) return `${kwh.toFixed(2)} kWh`;
+    const wh = unit === "kWh" ? value * 1000 : value;
+    return `${Math.round(wh)} Wh`;
+  }
+
+  // Generic: show value with appropriate precision + unit
+  const formatted = Number.isInteger(value) ? String(value) : value.toFixed(1);
+  return unit ? `${formatted} ${unit}` : formatted;
+}
+
+function formatValue(v: number, unit?: string): string {
+  const formatted = Number.isInteger(v) ? String(v) : v.toFixed(1);
+  return unit ? `${formatted} ${unit}` : formatted;
+}
+
+function formatPower(w: number): string {
+  if (w >= 1000) return `${(w / 1000).toFixed(1)} kW`;
+  return `${Math.round(w)} W`;
+}
+
+/** Bar chart tooltip row: the value with its unit, plus the fixed series label. */
+export function formatBarTooltip(
+  value: unknown,
+  unit: string | undefined,
+  label: string,
+): [string, string] {
+  return [formatValueWithUnit(tooltipNumber(value), unit), label];
+}
+
+export interface SeriesTooltipOptions {
+  unit?: string;
+  /** Power series render in W/kW and carry their own label. */
+  isPower: boolean;
+  /** Boolean/enum series render as ON/OFF. */
+  isDiscrete: boolean;
+}
+
+/** Time series tooltip row: power, min/max envelope band, discrete ON/OFF, or
+ *  a plain value with its unit. */
+export function formatSeriesTooltip(
+  value: unknown,
+  name: unknown,
+  { unit, isPower, isDiscrete }: SeriesTooltipOptions,
+): [string, string] {
+  const v = tooltipNumber(value);
+  const key = tooltipName(name);
+  const isBand = key === "min" || key === "max";
+
+  if (isPower) {
+    return [formatPower(v), isBand ? key : "Puissance"];
+  }
+  if (isBand) return [formatValue(v, unit), key];
+  if (isDiscrete) return [v === 1 ? "ON" : "OFF", ""];
+  return [formatValue(v, unit), ""];
+}


### PR DESCRIPTION
Closes #681, and unblocks the Dependabot ui group (#685, 13 libraries) which recharts alone was holding back.

## The problem

Recharts 3.10 tightened `Formatter<ValueType, NameType>`. A tooltip formatter is called with `(value, name, item, index, payload)` and its value and name are typed wide (`string | number | (string | number)[]` and `string | number`). Both history charts declared narrow parameters, so under the new type they fail with TS2322:

- `ui/src/components/history/HistoryBarChart.tsx:247` - `(value: number | undefined) => [string, string]`
- `ui/src/components/history/TimeSeriesChart.tsx:199` - `(value?: number, name?: string) => [string, string]`

## The fix

Both call sites now declare `unknown` and narrow through `tooltip-format.ts`, the module that already owns the Analyse tooltip rendering. Declaring `unknown` keeps the components off the recharts type surface entirely, so the next tightening of `Formatter` cannot break them again.

The three formatting helpers that lived inside the components (`formatValueWithUnit`, `formatValue`, `formatPower`) move there with them. They were used by nothing but the tooltips, and moving them makes the tooltip text reachable from a test instead of only through a rendered chart.

## Behaviour

Unchanged, and pinned by tests: same Wh/kWh thresholds, same W/kW split, same min/max envelope labels, same ON/OFF for discrete series, and a missing value still reads 0 rather than NaN.

## Verification

| Check | recharts 3.7.0 (main) | recharts 3.10.1 (#685) |
| --- | --- | --- |
| `tsc -b --noEmit` | pass | pass |
| `npm run build` | pass | pass |
| `npm run lint` | pass (2 pre-existing warnings, untouched files) | - |
| UI test suite | 706 tests pass, 28 of them new | - |

Reverting just this change under 3.10.1 reproduces the two TS2322 errors, so the fix is doing the work the type change asks for.

## Follow-up

Once this lands, `@dependabot rebase` on #685 should turn it green.