### PR TITLE
fix(energy): close the three spec 165 review findings on the arbitration surface

### DIFF
--- a/src/api/routes/energy.test.ts
+++ b/src/api/routes/energy.test.ts
@@ -1204,3 +1204,47 @@ describe("Spec 162 — GET /energy/pv-health/:id", () => {
     await app.close();
   });
 });
+
+// ============================================================
+// Spec 165 review — GET /api/v1/energy/arbiter with no arbiter wired
+// ============================================================
+
+describe("Spec 165 review — /api/v1/energy/arbiter fallback", () => {
+  let app: Awaited<ReturnType<typeof buildApp>> | null = null;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = null;
+  });
+
+  it("answers the full ArbiterPublicState shape, arrays included", async () => {
+    // The harness wires `capacityArbiter: null`, which is the "arbiter never
+    // started" case. The literal used to omit the fields added after it
+    // (`loads`, `dormant`, `idle`, `priority`), and the inferred return type
+    // hid that from tsc. The UI only survived it by returning early on
+    // `enabled: false`; anything mapping over `loads` first would throw.
+    app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/v1/energy/arbiter" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.enabled).toBe(false);
+    expect(body.state).toBe("disabled");
+    expect(body.dormant).toBe(false);
+    expect(body.availableSurplusW).toBeNull();
+    expect(body.productionDetected).toBe(false);
+    for (const key of [
+      "loads",
+      "grants",
+      "pending",
+      "suspensions",
+      "idle",
+      "priority",
+      "journal",
+      "surplusSeries",
+    ]) {
+      expect(Array.isArray(body[key]), `${key} must be an array`).toBe(true);
+      expect(body[key]).toHaveLength(0);
+    }
+  });
+});

--- a/src/api/routes/energy.ts
+++ b/src/api/routes/energy.ts
@@ -6,6 +6,7 @@ import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import type { TariffClassifier } from "../../energy/tariff-classifier.js";
 import type { CapacityArbiter } from "../../energy/capacity-arbiter.js";
 import type { ArbiterMetricsStore } from "../../energy/arbiter-metrics-store.js";
+import type { ArbiterPublicState } from "../../shared/types.js";
 import { ARBITER_METRICS_RETENTION_DAYS } from "../../energy/arbiter-metrics-store.js";
 import { blendedRate, computeCost } from "../../energy/cost-calculator.js";
 import { isSubmeterEquipment, NON_SUBMETER_TYPES } from "../../equipments/metering.js";
@@ -422,16 +423,26 @@ export function registerEnergyRoutes(app: FastifyInstance, deps: EnergyDeps): vo
   // ============================================================
   // GET /api/v1/energy/arbiter — spec 140 read model (FR-10)
   // ============================================================
-  app.get("/api/v1/energy/arbiter", async () => {
+  // The return type is annotated on purpose: without it the fallback literal
+  // below is inferred, so a field added to ArbiterPublicState (spec 165 added
+  // `loads` and `dormant`, #561 added `idle`, #616 added `priority`) goes
+  // missing here without tsc saying a word. The UI only survives that because
+  // it returns early on `enabled: false`; any other reader mapping over
+  // `state.loads` would throw.
+  app.get("/api/v1/energy/arbiter", async (): Promise<ArbiterPublicState> => {
     if (!capacityArbiter) {
       return {
         enabled: false,
         state: "disabled",
         availableSurplusW: null,
         productionDetected: false,
+        loads: [],
+        dormant: false,
         grants: [],
         pending: [],
         suspensions: [],
+        idle: [],
+        priority: [],
         journal: [],
         surplusSeries: [],
       };

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -2411,3 +2411,88 @@ describe("sunset reaches an open tab (spec 165 review)", () => {
     expect(statusEvents(h).length).toBe(before);
   });
 });
+
+describe("ribbon lanes follow the roster (spec 165 review)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-12T10:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens a timeline lane for a granted load absent from the priority list", () => {
+    // The roster appends a claimed load that no admin ever ordered in the
+    // settings page. Building the lanes from `config.priority` alone left that
+    // roster row with nothing under it in the ribbon.
+    const h = makeHarness({ priority: ["pac"] });
+    h.claim("i1", { equipmentId: "pump" });
+    h.run(-1000, 140);
+
+    const roster = h.arbiter.getPublicState().loads.map((l) => l.equipmentId);
+    const lanes = h.arbiter.getTimeline(Date.now(), 6).loads.map((l) => l.equipmentId);
+    expect(roster).toEqual(["pac", "pump"]);
+    expect(lanes).toEqual(roster);
+  });
+
+  it("opens a lane for a suspended load absent from the priority list", () => {
+    const h = makeHarness({ priority: ["pac"] });
+    h.claim("i1", { equipmentId: "pump" });
+    h.run(-1000, 150);
+    h.order("pump", false, { kind: "manual", instanceId: undefined });
+
+    const roster = h.arbiter.getPublicState().loads.map((l) => l.equipmentId);
+    const lanes = h.arbiter.getTimeline(Date.now(), 6).loads.map((l) => l.equipmentId);
+    expect(roster).toContain("pump");
+    expect(lanes).toEqual(roster);
+  });
+
+  it("opens no lane for a load with neither profile, claim nor suspension", () => {
+    const h = makeHarness({ priority: ["pac", "lamp"] });
+    const lanes = h.arbiter.getTimeline(Date.now(), 6).loads.map((l) => l.equipmentId);
+    expect(lanes).toEqual(["pac"]);
+    expect(lanes).toEqual(h.arbiter.getPublicState().loads.map((l) => l.equipmentId));
+  });
+});
+
+describe("dormancy reads the quantized export (spec 165 review)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-12T22:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const statusEvents = (h: ReturnType<typeof makeHarness>) =>
+    h.events.filter((e) => e.type === "energy.arbiter.status");
+
+  it("does not flip dormancy on sub-quantum jitter around zero export", () => {
+    // A battery home at night sits at ~0 W and crosses the sign constantly.
+    // Comparing the RAW export to 0 flipped `dormant` on every sample, and
+    // since dormancy sits in the coalescing key, each flip emitted a status
+    // event, which refetches the arbiter read model in every open tab.
+    const h = makeHarness({ daylight: false });
+    h.run(1, 60); // importing 1 W
+    expect(h.arbiter.getPublicState().dormant).toBe(true);
+    const before = statusEvents(h).length;
+
+    h.run(-1, 60); // exporting 1 W: same quarter of a quantum, same state
+    h.run(1, 60);
+    h.run(-12, 60);
+
+    expect(h.arbiter.getPublicState().dormant).toBe(true);
+    expect(statusEvents(h).length).toBe(before);
+  });
+
+  it("still leaves dormancy behind on a real export at night", () => {
+    const h = makeHarness({ daylight: false });
+    h.run(1, 60);
+    expect(h.arbiter.getPublicState().dormant).toBe(true);
+    const before = statusEvents(h).length;
+
+    h.run(-800, 60); // the battery starts pushing: a genuine surplus
+    expect(h.arbiter.getPublicState().dormant).toBe(false);
+    expect(statusEvents(h).length).toBeGreaterThan(before);
+  });
+});

--- a/src/energy/capacity-arbiter.ts
+++ b/src/energy/capacity-arbiter.ts
@@ -65,6 +65,14 @@ const DIVERGENCE_RATIO = 0.3; // watts-divergence threshold vs declared nominal
 const IDLE_DRAW_RATIO = 0.1;
 const IDLE_DRAW_FLOOR_W = 20;
 const IDLE_DRAW_CEIL_W = 100;
+// Spec 165 review — the status event coalesces on a 25 W-quantized surplus so
+// it fires on a meaningful change, not on every meter sample. Dormancy is part
+// of that same coalescing key, so it has to read the export through the SAME
+// quantum: comparing the raw export to 0 flips `dormant` on the ±1 W jitter a
+// battery home shows at night, which defeated the guard and made an open tab
+// refetch (and flicker) on every sample.
+const STATUS_QUANTUM_W = 25;
+const quantizeW = (w: number): number => Math.round(w / STATUS_QUANTUM_W) * STATUS_QUANTUM_W;
 const TICK_MS = 10_000;
 // Spec 164 — how long a granted load's measured draw must contradict the state
 // the ribbon is showing before the transition is journaled. Long enough that a
@@ -836,7 +844,10 @@ export class CapacityArbiter {
     const windowEnd = Math.floor(endMs / stepMs) * stepMs;
     const windowStart = windowEnd - hours * 3_600_000;
     const lookback = windowStart - 24 * 3_600_000; // enough to know the entering state
-    const loads = this.config.priority.map((id) => ({ equipmentId: id, name: this.nameOf(id) }));
+    // Spec 165 review — the same roster the read model builds, so a load
+    // claimed before an admin ever opened the settings page gets a ribbon lane
+    // under its roster row instead of a row with nothing beneath it.
+    const loads = this.rosterIds().map((id) => ({ equipmentId: id, name: this.nameOf(id) }));
 
     // Decisions: prefer the persisted store; fall back to the in-memory ring.
     let decisions =
@@ -905,7 +916,7 @@ export class CapacityArbiter {
     const isDaylight = this.sunlight?.getSunlightData().isDaylight ?? null;
     if (isDaylight !== false) return false;
     if (this.runState() !== "active") return false;
-    return (exportW ?? this.accounting().headroomW) <= 0;
+    return quantizeW(exportW ?? this.accounting().headroomW) <= 0;
   }
 
   /**
@@ -936,18 +947,18 @@ export class CapacityArbiter {
   }
 
   /**
-   * Spec 165 — the roster, resolved engine-side: every declared flexible load
-   * in configured priority order, each with its state and its figures.
+   * Spec 165 — the equipment ids the surface shows, in the order it shows them:
+   * the configured priority first, then any load holding a claim or a
+   * suspension without being in that list. A load whose profile was dropped
+   * keeps its place only while it still holds a claim or a suspension,
+   * otherwise there is nothing left to show.
    *
-   * `config.priority` is NOT the list of profiled loads: it is written only
-   * when an admin opens the arbiter settings page, while `claim()` accepts any
-   * equipment carrying an `energyProfile`. A load claimed and granted before
-   * that page is ever visited is absent from the priority list, and the arrays
-   * this replaces (built from the live claim maps) still showed it — so it
-   * must keep its row here too, appended after the ordered ones, exactly where
-   * the UI's own rank() fallback used to put it.
+   * Spec 165 review — the read model roster and the timeline ribbon BOTH read
+   * this. Building the ribbon lanes from `config.priority` alone put a
+   * "Granted" roster row on screen with no lane under it, which is exactly the
+   * roster/ribbon divergence this spec exists to remove.
    */
-  private buildLoads(dormant: boolean, headroomW: number): ArbiterLoadInfo[] {
+  private rosterIds(): string[] {
     const claimedOrSuspended = [
       ...new Set([
         ...[...this.claims.values()]
@@ -956,68 +967,70 @@ export class CapacityArbiter {
         ...[...this.overridesUntil.keys()].filter((id) => this.isSuspended(id)),
       ]),
     ];
-    const roster = [
+    return [
       ...this.config.priority,
       ...claimedOrSuspended.filter((id) => !this.config.priority.includes(id)),
-    ];
-    return (
-      roster
-        // A load whose profile was dropped keeps a row only while it still holds
-        // a claim or a suspension — otherwise there is nothing left to show.
-        .filter(
-          (id) =>
-            this.profileOf(id) !== undefined ||
-            this.grantedClaimFor(id) !== undefined ||
-            this.pendingClaimFor(id) !== undefined ||
-            this.isSuspended(id),
-        )
-        .map((id) => {
-          const state = this.resolveLoadState(id, dormant);
-          const profile = this.profileOf(id);
-          const info: ArbiterLoadInfo = {
-            equipmentId: id,
-            equipmentName: this.nameOf(id),
-            state,
-            watts: null,
-            needW: null,
-            toleratedImportW: profile ? Math.max(0, profile.toleratedImportW ?? 0) : null,
-          };
-          if (state === "granted" || state === "granted-idle") {
-            const granted = this.grantedClaimFor(id);
-            info.watts = granted ? Math.round(this.effectiveWatts(granted)) : null;
-            info.sinceIso = new Date(granted?.grantedAt ?? Date.now()).toISOString();
-            info.instanceId = granted?.instanceId;
-            info.note = granted?.note;
-            return info;
-          }
-          if (state === "suspended") {
-            info.untilIso = new Date(this.overridesUntil.get(id) ?? Date.now()).toISOString();
-            return info;
-          }
-          // Pending, unmanaged and at rest all show what the load draws. A
-          // pending claim knows its own figure; anything else falls back to the
-          // live draw while it runs unmanaged, else its rating (#561: a metered
-          // load that is off reports ~0 W, which would misread as "0 W" rather
-          // than "what it draws when it runs").
-          const pendingClaim = this.pendingClaimFor(id);
-          if (pendingClaim && state === "pending") {
-            info.watts = pendingClaim.watts;
-            info.needW = Math.round(this.engageNeedW(pendingClaim));
-            info.reasonWaiting = this.pendingReason(pendingClaim, headroomW);
-            info.instanceId = pendingClaim.instanceId;
-            info.toleratedImportW = pendingClaim.toleratedImportW;
-            return info;
-          }
-          if (this.unclaimedRunning.has(id)) {
-            info.watts = Math.round(this.drawEstimate(id));
-          } else if (pendingClaim) {
-            info.watts = pendingClaim.watts;
-          } else if (profile) {
-            info.watts = Math.round(profile.learned?.watts ?? profile.nominalPowerW);
-          }
-          return info;
-        })
+    ].filter(
+      (id) =>
+        this.profileOf(id) !== undefined ||
+        this.grantedClaimFor(id) !== undefined ||
+        this.pendingClaimFor(id) !== undefined ||
+        this.isSuspended(id),
     );
+  }
+
+  /**
+   * Spec 165 — the roster, resolved engine-side: every load `rosterIds()` lists,
+   * each with its state and its figures. This is the single source the UI
+   * renders; it decides nothing on its own.
+   */
+  private buildLoads(dormant: boolean, headroomW: number): ArbiterLoadInfo[] {
+    return this.rosterIds().map((id) => {
+      const state = this.resolveLoadState(id, dormant);
+      const profile = this.profileOf(id);
+      const info: ArbiterLoadInfo = {
+        equipmentId: id,
+        equipmentName: this.nameOf(id),
+        state,
+        watts: null,
+        needW: null,
+        toleratedImportW: profile ? Math.max(0, profile.toleratedImportW ?? 0) : null,
+      };
+      if (state === "granted" || state === "granted-idle") {
+        const granted = this.grantedClaimFor(id);
+        info.watts = granted ? Math.round(this.effectiveWatts(granted)) : null;
+        info.sinceIso = new Date(granted?.grantedAt ?? Date.now()).toISOString();
+        info.instanceId = granted?.instanceId;
+        info.note = granted?.note;
+        return info;
+      }
+      if (state === "suspended") {
+        info.untilIso = new Date(this.overridesUntil.get(id) ?? Date.now()).toISOString();
+        return info;
+      }
+      // Pending, unmanaged and at rest all show what the load draws. A
+      // pending claim knows its own figure; anything else falls back to the
+      // live draw while it runs unmanaged, else its rating (#561: a metered
+      // load that is off reports ~0 W, which would misread as "0 W" rather
+      // than "what it draws when it runs").
+      const pendingClaim = this.pendingClaimFor(id);
+      if (pendingClaim && state === "pending") {
+        info.watts = pendingClaim.watts;
+        info.needW = Math.round(this.engageNeedW(pendingClaim));
+        info.reasonWaiting = this.pendingReason(pendingClaim, headroomW);
+        info.instanceId = pendingClaim.instanceId;
+        info.toleratedImportW = pendingClaim.toleratedImportW;
+        return info;
+      }
+      if (this.unclaimedRunning.has(id)) {
+        info.watts = Math.round(this.drawEstimate(id));
+      } else if (pendingClaim) {
+        info.watts = pendingClaim.watts;
+      } else if (profile) {
+        info.watts = Math.round(profile.learned?.watts ?? profile.nominalPowerW);
+      }
+      return info;
+    });
   }
 
   getPublicState(): ArbiterPublicState {
@@ -1844,12 +1857,13 @@ export class CapacityArbiter {
     // #563 — the emitted figure is the TRUE signed grid balance (headroomW ≡
     // exportW), consistent with the pill in getPublicState.
     const raw = signedSurplusW ?? this.accounting().headroomW;
-    const availableSurplusW = state === "active" ? Math.round(raw / 25) * 25 : null;
+    const quantized = quantizeW(raw);
+    const availableSurplusW = state === "active" ? quantized : null;
     // Spec 165 — dormancy is part of what the surface shows and it flips on
     // sunset alone, with no meter change behind it. Without it here, an open
     // tab keeps the deficit sticker (and its loads "waiting") until the next
     // 25 W move, which after sunset can be minutes away.
-    const dormant = this.isDormant(raw);
+    const dormant = this.isDormant(quantized);
     const prev = this.lastStatus;
     if (
       prev &&


### PR DESCRIPTION
Follow-up to #738. A review of the spec 165 merge turned up three defects, all in the surface the spec was meant to make consistent. Each fix is pinned by a test that fails without it.

## 1. A roster row with no ribbon lane

`getTimeline()` built its lanes from `config.priority` alone, while `buildLoads()` also appends loads holding a claim or a suspension without being in that list.

Priority `["pac"]` plus a granted `pump` gave a roster of `[pac, pump]` and lanes of `[pac]`: a "Granted" row on screen with nothing under it. That is exactly the roster/ribbon divergence spec 165 exists to remove, and it hits the common case of a load claimed by a recipe before anyone ever opened the arbiter settings page.

Both paths now read a single `rosterIds()`.

## 2. A status event per meter sample

`emitStatus()` coalesces on a 25 W-quantized surplus so it fires on a meaningful change. It then derived `dormant` from the **raw** export and put it in the same coalescing key.

A battery home at night sits around 0 W and crosses the sign continuously, so `dormant` flipped on the jitter and defeated the guard: one status event per sample, each triggering a full `/energy/arbiter` refetch in every open tab, with a visible flicker between the "At rest" pills and "Active 0.0 kW". Pre-165 the tab never refetched, so this is a regression introduced by the spec.

Dormancy now reads the export through the same quantum, inside `isDormant()`, so the read model, the timeline and the event all agree on when the home is at rest.

## 3. An incomplete route fallback

The `!capacityArbiter` literal in `GET /api/v1/energy/arbiter` never gained `loads` and `dormant` (nor `idle` and `priority` before them), because the handler's return type was inferred and tsc had nothing to check against.

The UI survives only because it returns early on `enabled: false`; any consumer reading `state.loads` before checking `enabled` throws on `.map`. The handler is now annotated `Promise<ArbiterPublicState>`, so the next field added to the read model cannot go missing here quietly.

## Verification

- 5 new tests, each verified to fail with the fix reverted and the test kept.
- Backend suite: 1999 passed, 2 skipped.
- typecheck, eslint and prettier clean.