### PR TITLE
chore(registry): bump zigbee2mqtt to 2.6.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -7,11 +7,11 @@
     "icon": "Radio",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-zigbee2mqtt",
-    "version": "2.5.1",
+    "version": "2.6.0",
     "tags": ["zigbee", "mqtt", "z2m", "sensors", "lights", "switches"],
-    "sowelVersion": ">=1.38.0",
+    "sowelVersion": ">=1.59.0",
     "owner": "mchacher",
-    "sha256": "0937d823e08465b5d780b444409ffae4ff74820fa123ab60a3538a8d52eaa594"
+    "sha256": "003944b2fbe09586e850634c9cb4457e7a951d86bccfdf0c81697c1eae762189"
   },
   {
     "id": "lora2mqtt",


### PR DESCRIPTION
Registry catch-up for the Zigbee2MQTT plugin release published a few minutes ago. Until this lands, installing 2.6.0 fails with `ChecksumMismatchError`, since the registry still points at the 2.5.1 archive.

Three fields on the one entry, nothing else touched:

| Field | Was | Now |
| --- | --- | --- |
| `version` | 2.5.1 | 2.6.0 |
| `sowelVersion` | `>=1.38.0` | `>=1.59.0` |
| `sha256` | `0937d823…` | `003944b2…` |

## The version gate

2.6.0 declares `valueOn` / `valueOff` on data definitions, which only a core carrying mchacher/sowel#728 reads. An older core ignores the extra fields, so nothing breaks, but the update would be a silent no-op: the reading keeps being flagged and stored raw. The gate means instances that cannot use it are simply not offered it, and stay on 2.5.1 behaving exactly as today. Core support ships in v1.59.0, tagged today.

## The hash

Produced by `node scripts/backfill-registry-sha256.mjs` (no `FORCE`, one entry with its sha cleared, so it filled exactly one field), then checked independently: the published asset was downloaded and hashed locally, and `003944b2fbe09586e850634c9cb4457e7a951d86bccfdf0c81697c1eae762189` matches on both sides.

The script reformats the whole file as it writes, so the run was reverted and the three values applied by hand, keeping the diff to the entry that actually changed.