### PR TITLE
release: v1.60.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,13 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.60.x : Décrire une charge qui n'a pas de compteur
+
+### v1.60.0 — 2026-08-27 { #v1-60-0 }
+
+- Feat (energy) : **une recette peut désormais dire à l'arbitre si sa charge a réellement besoin de courant** (spec 166). Depuis la v1.59.0 le ruban sait dire qu'une charge accordée ne consomme rien, mais uniquement à partir de la mesure propre à cette charge, ce qui laisse toute charge non mesurée décrite indéfiniment comme « accordée », si longtemps soit-elle à l'arrêt. Sur l'installation de référence, cela concerne deux charges arbitrées sur quatre : une pompe de piscine qui n'expose qu'un état marche/arrêt, et une pompe à chaleur de piscine à inverter pilotée en consigne, dont l'état rapporté vient d'un autre appareil que celui que Sowel commande. Lire cet état relais a été envisagé puis écarté : il ment sur une charge à inertie, et ne dit rien du tout d'un inverter. Celui qui sait, c'est celui qui a demandé le surplus, alors la poignée de demande gagne un moyen de le déclarer, et l'arbitre reste hors des affaires de l'appareil : il reçoit un oui ou un non et ne demande jamais pourquoi une piscine est assez chaude. Une mesure fraîche l'emporte toujours, parce que la déclaration dit ce que la recette veut tandis que le compteur dit ce que l'appareil fait, et l'écart entre les deux est précisément ce que la version précédente a été écrite pour montrer. Deux règles sont venues de la relecture et non de la conception : un état posé par le compteur est tenu pendant un trou de report plutôt que rendu à la recette, sinon une charge qui parle moins souvent que la fenêtre de fraîcheur de deux minutes bascule entre les deux sources à chaque trou ; et la première mesure contradictoire renverse une déclaration immédiatement, puisque sur une telle charge la fenêtre de confirmation ne pourrait jamais arriver à terme et qu'une charge tirant 2 kW serait restée « accordée, ne consomme rien » indéfiniment. Ce n'est délibérément pas une panne : une pompe à chaleur entre deux cycles de compresseur et un chauffe-eau dont le thermostat a coupé sont tous deux déclarés en besoin et mesurés inactifs, et tous deux en parfaite santé. Rien ne change pour une charge dotée de son compteur, et une installation où aucune recette ne déclare quoi que ce soit se comporte exactement comme avant. (#746)
+- Maintenance (packages) : **le plugin Zigbee2MQTT passe en 2.6.0** dans la registry, avec les littéraux de fil des lectures booléennes ajoutés en v1.59.0. (#743)
+
 ## 1.59.x : Un seul état pour la surface d'arbitrage
 
 ### v1.59.0 — 2026-08-27 { #v1-59-0 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,13 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.60.x: Describing a load that has no meter of its own
+
+### v1.60.0 — 2026-08-27 { #v1-60-0 }
+
+- Feat (energy): **a recipe can now tell the arbiter whether its load actually needs current** (spec 166). Since v1.59.0 the ribbon can say that a granted load is consuming nothing, but only from the load's own power measurement, which leaves every unmetered load permanently described as "granted" however long it sits idle. On the reference installation that is two of four arbitrated loads: a pool pump exposing only an on/off state, and an inverter pool heat pump driven by a setpoint whose reported state comes from a different device than the one Sowel commands. Reading that relay state was considered and rejected, since it lies on a load with shutdown inertia and says nothing at all about an inverter. The component that knows is the one that asked for the surplus, so a claim handle gains a way to declare it, and the arbiter stays out of the appliance's business: it receives a yes or no and never asks why a pool is warm enough. A fresh measurement always wins, because the declaration says what the recipe wants while the meter says what the appliance does, and the gap between the two is exactly what the previous version was built to show. Two rules came from the review rather than the design: a state the meter has already set is held through a gap in reporting rather than handed back to the recipe, otherwise a load reporting more slowly than the two-minute freshness window flips between the two sources at every gap; and the first contradicting measurement overturns a declaration at once, since on such a load the confirmation window could never mature and a load drawing 2 kW would have read "granted, consuming nothing" for ever. Deliberately not a fault: a heat pump between compressor cycles and a water heater whose thermostat has cut off are both declared needing and measured idle, and both perfectly healthy. Nothing changes for a load with its own meter, and an installation where no recipe declares anything behaves exactly as it did. (#746)
+- Maintenance (packages): **the Zigbee2MQTT plugin is bumped to 2.6.0** in the registry, carrying the wire literals of boolean readings added in v1.59.0. (#743)
+
 ## 1.59.x: One state for the arbitration surface
 
 ### v1.59.0 — 2026-08-27 { #v1-59-0 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.59.0",
+  "version": "1.60.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Cuts **v1.60.0**, covering the two commits merged since v1.59.0.

## Contents

- **spec 166** (#746): a claimant can declare whether its granted load needs current, which is the only way a load with no meter of its own can be described as at rest. A fresh measurement always wins.
- **registry** (#743): the Zigbee2MQTT plugin at 2.6.0.

## Why this release matters beyond its size

Two recipes are waiting on it and are inert without a core carrying spec 166:

- `sowel-recipe-pool-pump-schedule` 1.7.0, where both loads are unmetered on the reference installation;
- `sowel-recipe-water-heater-solar` 0.2.0, which gives its claim back once the tank is hot.

Both are merged on their own `main` and will be tagged after this.

## Release-notes contract (spec 108)

Both `docs/release-notes.md` and `docs/release-notes.fr.md` carry a `### v1.60.0 — 2026-08-27 { #v1-60-0 }` block with the explicit anchor, so `verify-release-notes` passes and the in-app updates sheet links to a real heading.

The version bump touches the same four files as every previous release.