### PR TITLE
chore(registry): bump pool-pump-schedule to 1.7.0 and water-heater-solar to 0.2.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.6.3",
+    "version": "1.7.0",
     "tags": ["pool", "pump", "heating", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -340,7 +340,7 @@
     },
     "sowelVersion": ">=1.52.0",
     "owner": "mchacher",
-    "sha256": "fa2b3c9303ae150a9541a5e6b382abe9a47f9a16aac7f129743b33b6f0db1aaa"
+    "sha256": "a5abcbfabcdbd5521e490507b2773255ec337e4e01ed74b1e047bd50eb287635"
   },
   {
     "id": "freecooling",
@@ -571,7 +571,7 @@
     "icon": "Sun",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-water-heater-solar",
-    "version": "0.1.2",
+    "version": "0.2.0",
     "tags": ["water-heater", "solar", "energy", "surplus", "automation"],
     "i18n": {
       "fr": {
@@ -581,7 +581,7 @@
     },
     "sowelVersion": ">=1.52.0",
     "owner": "mchacher",
-    "sha256": "65570863aa52e4be29561d65d0e60abf4ba05181e9de358f01dfc6a5214290a0"
+    "sha256": "1a3457402124ac0dbb98a7130e0e73bf4e960777a3f1850cee3aedfcce89031d"
   },
   {
     "id": "nut",


### PR DESCRIPTION
Registry catch-up for the two recipe releases cut alongside **v1.60.0**. Until this lands, installing either new version fails with `ChecksumMismatchError`, since the registry still points at the previous archives.

| Entry | Version | sha256 |
| --- | --- | --- |
| `pool-pump-schedule` | 1.6.3 → **1.7.0** | `fa2b3c93…` → `a5abcbfa…` |
| `water-heater-solar` | 0.1.2 → **0.2.0** | `65570863…` → `1a345740…` |

## What the two releases carry

- **pool-pump-schedule 1.7.0** declares each load's drawing state to the arbiter (core spec 166). Neither the pump nor the pool heat pump is individually metered on a typical installation, so the arbitration surface could only ever show them "accordé" under a grant, however long they sat there drawing nothing. The heater reports whether heating is actually engaged, which is false in the "attente pompe" window where its watts are reserved but the setpoint is still parked at idle.
- **water-heater-solar 0.2.0** gives its claim back once the tank has stopped drawing for 30 minutes, instead of holding it for the rest of the day, and is strict about what counts as a measurement: a null value, a boolean, or a frozen reading can no longer be read as "idle".

## No version gate

Neither entry gains a `sowelVersion` bump. Both calls are optional (`reportNeed?.()`, `getDataBindingsWithValues?.()`), so on a core without spec 166 the method is absent, the call is skipped, and behaviour is byte for byte what it was. Gating would lock every 1.52 to 1.59 user out of a release that behaves identically for them.

## Hashes

Produced by `node scripts/backfill-registry-sha256.mjs` with the two entries cleared, then **verified independently**: each published asset was downloaded and hashed locally, and both match.

The script reformats the whole file as it writes (234 lines of noise), so that run was reverted and the four values applied by hand, keeping the diff to the two entries that changed.