### PR TITLE
fix(core): keep dotenv quiet so stdout stays newline-delimited JSON

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -108,5 +109,31 @@ describe("config — SOWEL_SHADOW_MODE", () => {
   it("tolerates surrounding whitespace", () => {
     process.env["SOWEL_SHADOW_MODE"] = "  TRUE  ";
     expect(loadConfig().shadowMode).toBe(true);
+  });
+});
+
+describe("config — dotenv loading is silent", () => {
+  // Production logs are newline-delimited JSON on stdout, captured by Docker.
+  // dotenv v17 defaults `quiet` to false and prints a banner on load, and it
+  // does so even with no .env file present, which is exactly the production
+  // case since .env is dockerignored. That banner would be the one line in the
+  // stream that does not parse, so config.ts passes `quiet: true`.
+  //
+  // Observed from a child process: importing the module in-process here would
+  // be too late, the side effect runs at import time and this file has already
+  // imported it.
+  it("prints nothing to stdout when the module is imported", () => {
+    const stdout = execFileSync(
+      process.execPath,
+      ["--import", "tsx", "-e", "import('./src/config.ts').then(() => process.exit(0))"],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, SQLITE_PATH: join(tmpdir(), "sowel-dotenv-quiet-probe.db") },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+
+    expect(stdout).toBe("");
   });
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -130,7 +130,10 @@ describe("config — dotenv loading is silent", () => {
         cwd: process.cwd(),
         env: { ...process.env, SQLITE_PATH: join(tmpdir(), "sowel-dotenv-quiet-probe.db") },
         encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
+        // stderr piped, not ignored: the assertion only reads stdout, but if
+        // the child fails to resolve tsx or throws on import, execFileSync
+        // reports the child's stderr instead of a bare "Command failed".
+        stdio: ["ignore", "pipe", "pipe"],
       },
     );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,12 @@ import { dirname, resolve } from "node:path";
 import { config as dotenvConfig } from "dotenv";
 import type { AppConfig } from "./shared/types.js";
 
-dotenvConfig();
+// `quiet` so dotenv stays silent on load. Since v17 it defaults to printing a
+// banner on stdout, and it does so even when there is no .env file to read,
+// which is the production case (.env is dockerignored). Production logs are
+// newline-delimited JSON on stdout, so that banner is the one line in the
+// stream that will not parse.
+dotenvConfig({ quiet: true });
 
 function env(key: string, fallback?: string): string {
   const value = process.env[key] ?? fallback;


### PR DESCRIPTION
Follow-up to #669.

## The problem

dotenv 17 defaults `quiet` to `false` and prints a banner when it loads:

```
◇ injected env (0) from .env // tip: ◈ encrypted .env [www.dotenvx.com]
```

It fires **even when there is no `.env` file to read**, which is exactly the production case (`.env` is in `.dockerignore`). It goes to stdout via `console.log` from [src/config.ts:7](src/config.ts#L7), which `src/index.ts` imports before `createLogger` runs.

Production logs are newline-delimited JSON on stdout, captured by Docker. That banner is the one line in the stream that will not parse. The tip text is also randomised per run, so it differs between restarts.

## Severity: hygiene, not a live bug

Being explicit about what this does *not* affect:

- `data/logs/sowel.*.log` is written by the pino-roll transport, not by process stdout, so file logs were never touched.
- The in-app log viewer reads from `logBuffer`, fed by the pino multistream Writable, which already ignores non-JSON in a `try/catch`. The banner never reaches it.
- Nothing in the codebase parses container stdout.

So this is worth not emitting rather than something that was breaking.

## The test

It spawns a child process rather than asserting in-process, because the side effect runs at **import time** and `config.test.ts` has already imported the module by the time any case executes.

Verified the test actually guards rather than passing vacuously: reverting to a bare `dotenvConfig()` makes it fail.

```
with    quiet: true  -> 0 bytes on stdout, test passes
without quiet: true  -> banner on stdout, test fails
```

`config.test.ts` goes 14 -> 15 tests.