### PR TITLE
perf(ci): take the merge gate from ~100s to ~70s without dropping a check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,22 @@ on:
   pull_request:
     branches: [main]
 
+# Supersede a PR's in-flight run when a fixup lands, so the run that matters
+# starts immediately instead of queueing behind one nobody is waiting for.
+# Pushes to main are never cancelled: a half-run on main tells you nothing.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Least privilege: CI only reads the repo. No job here writes to the repo,
 # publishes packages, or posts statuses, so the default token needs no more.
 permissions:
   contents: read
 
 jobs:
+  # NOTE: the `name:` of this job and of `frontend` are the check names the
+  # `main-protection` ruleset requires. Renaming either one silently stops it
+  # from gating merges. Change the ruleset first if you ever need to.
   backend:
     name: Backend (lint, typecheck, test)
     runs-on: ubuntu-latest
@@ -21,15 +31,17 @@ jobs:
         with:
           node-version: 22
           cache: npm
+          # Explicit, and only the root lockfile: this job installs root deps
+          # and nothing else. Left implicit it still keyed on the root
+          # lockfile while the job also installed ui deps, so a ui-only
+          # lockfile change restored a cache missing those tarballs and never
+          # re-saved it.
+          cache-dependency-path: package-lock.json
       - run: npm ci
-      # UI tests run from ui/ (component-test tier, issue #458), so ui deps are
-      # installed here and the UI suite runs after the backend one below.
-      - run: cd ui && npm ci
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run format:check
       - run: npm test
-      - run: cd ui && npm test
 
   frontend:
     name: Frontend (lint, typecheck, build)
@@ -43,6 +55,12 @@ jobs:
           cache-dependency-path: ui/package-lock.json
       - run: cd ui && npm ci
       - run: cd ui && npm run lint
+      # The UI suite (component-test tier, issue #458) runs from ui/ and used
+      # to sit in the backend job, which meant installing ui deps twice and
+      # putting ~30s on the critical path of the slowest job. It belongs where
+      # the ui deps already are. The job's check name is deliberately left
+      # unchanged; see the note above.
+      - run: cd ui && npm test
       - run: cd ui && npm run build
 
   specs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,10 @@ on:
     # Weekly, Monday 03:27 UTC (off-peak, avoids the top-of-hour rush).
     - cron: "27 3 * * 1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,8 +1,16 @@
 name: gitleaks
 
 on:
+  # `push:` was bare, so every push to a PR branch fired a push run AND a
+  # pull_request run: two workflow runs reporting the same required `scan`
+  # check. Branch pushes are still scanned, through the pull_request event.
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Measured before changing anything, because the obvious suspects were wrong.

## What the gate actually is

`cache: npm` was **already** configured on both jobs and hitting in ~1s. And CodeQL's 2m22, the slowest thing on the page, is **not a required check**, so it never blocks a merge.

The `main-protection` ruleset requires exactly three: `Backend (lint, typecheck, test)`, `Frontend (lint, typecheck, build)`, `scan`. So time-to-merge is `max(100s, 50s, 10s)` = **Backend, alone**.

Per-step means across four recent PR runs:

| Backend step | mean |
|---|---|
| checkout + setup-node | 3.8s |
| `npm ci` (root) | 14.5s |
| **`cd ui && npm ci`** | **8.8s** |
| lint + typecheck + format | 16.3s |
| **`npm test`** | **32.3s** |
| **`cd ui && npm test`** | **21.5s** |
| | **~100s** |

## The four changes

**1. The UI suite moves to the frontend job.** It runs from `ui/`, so the backend job was installing ui deps (8.8s) purely to run it (21.5s) - ~30s on the critical path of the slowest job, and a second ui install across the workflow. It now runs where those deps already are.

> Backend ~100s -> **~70s**, frontend ~50s -> ~62s. Gate = **~70s**.

No ruleset change needed, which is why it goes in the existing frontend job rather than a new one: adding a job would have meant adding it to the required checks in the same breath or silently stopping the ui suite from gating merges.

**2. `concurrency` + `cancel-in-progress` on all three PR workflows.** None had a concurrency group. Two full run sets were observed alive simultaneously on both `chore/node-24` (pushes at 07:44:47 and 07:45:25) and `chore/refresh-stale-lockfile` (07:22:59 and 07:28:51). The guard is expression-gated so **pushes to main are never cancelled**; only superseded PR runs are.

**3. gitleaks stops firing twice.** Its `push:` had no branch filter, so every push to a PR branch produced a push run **and** a pull_request run, both reporting the same required `scan` check. That is the duplicate `scan` row. Branch pushes are still scanned via the pull_request event; `main` keeps its full-history push scan.

**4. The backend npm cache key is explicit.** It keyed on the root lockfile while the job also installed ui deps, so a ui-only lockfile change restored a cache missing those tarballs and then declined to re-save it (`Cache hit occurred on the primary key ... not saving cache`). That is the 10s-to-19s `npm ci` swing.

## Deliberately not done

- **Lowering the bcrypt cost in tests.** It is the real prize: **49s of the 68s** of summed test time lives in five auth files, at 269ms per hash at cost 12 versus 1ms at cost 4. It would take the gate to ~50s. But it is the only available speedup that touches **production auth code**, and that is a call to make deliberately, not inside a CI tuning commit.
- **Moving CodeQL off PRs.** It costs a spinner, not merge latency. With change 2 the duplicate-run waste is gone anyway.
- **`paths-ignore`.** Checked #742-#766: all 25 PRs touched at least one non-docs file. It would never fire.
- **Dropping `security-extended`.** Would save ~25s of a 145s job that gates nothing, in exchange for the entire extended query pack. Bad trade.

## Safety note

The `name:` of the `backend` and `frontend` jobs are the check names the ruleset requires. Both are byte-identical to before, verified against `origin/main`, and now carry a comment saying they are load-bearing.

The proof this PR works is its own CI run: the gate should come in around 70s, with a single `scan`.