### PR TITLE
chore(registry): bump pool-pump-schedule to 1.8.1

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "tags": ["pool", "pump", "heating", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -340,7 +340,7 @@
     },
     "sowelVersion": ">=1.52.0",
     "owner": "mchacher",
-    "sha256": "a5abcbfabcdbd5521e490507b2773255ec337e4e01ed74b1e047bd50eb287635"
+    "sha256": "2a2676844f242347c7310ea38238699313cd3ffccf4a6f0154ac8bec12fa0d0c"
   },
   {
     "id": "freecooling",

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "tags": ["pool", "pump", "heating", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -340,7 +340,7 @@
     },
     "sowelVersion": ">=1.52.0",
     "owner": "mchacher",
-    "sha256": "2a2676844f242347c7310ea38238699313cd3ffccf4a6f0154ac8bec12fa0d0c"
+    "sha256": "f7495b1e5eab7b1fc95ded3f4af266a8c8421edeff4f7c8612a292ecd22b324d"
   },
   {
     "id": "freecooling",


### PR DESCRIPTION
Picks up [pool-pump-schedule v1.8.1](https://github.com/mchacher/sowel-recipe-pool-pump-schedule/releases/tag/v1.8.1), which hands the pool heat pump's exit back to the arbiter (v1.8.0) plus its review follow-ups (v1.8.1).

The recipe no longer runs a surplus test of its own. v1.6.3 had it watch the signed grid balance and release the heater claim after ~3 min of import, to escape the arbiter's `minOnS` shield. On the reference installation that made the recipe a second, faster surplus authority: the heat pump took 27 grants over a week and was **never revoked once**, so the arbitration timeline showed a mute "libéré" instead of "surplus retiré", the spec 158 short-cycle metric counted zero, and `minOffS` never armed.

The shield is configuration, not code: setting the heat pump's `energyProfile.minOnS` to `0` lets the arbiter revoke on its own `releaseHoldS`. Recipe [#22](https://github.com/mchacher/sowel-recipe-pool-pump-schedule/pull/22) has the detail; [#23](https://github.com/mchacher/sowel-recipe-pool-pump-schedule/pull/23) pins the revoke/re-grant contract in the tests and corrects two operator notes in the README.

No core change. Registry entry only:

- `version` 1.7.0 -> 1.8.1
- `sha256` refreshed via `scripts/backfill-registry-sha256.mjs`, verified by hand against the published `sowel-recipe-pool-pump-schedule-1.8.1.tar.gz` (`f7495b1e5eab7b1fc95ded3f4af266a8c8421edeff4f7c8612a292ecd22b324d`)

Context: #785.
