### PR TITLE
fix(release): stop test builds from moving the :latest-arm64 tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,15 +201,30 @@ jobs:
             echo "is_release=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Compute image tags
+        id: tags
+        env:
+          REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          V: ${{ steps.version.outputs.version }}
+          IS_RELEASE: ${{ steps.version.outputs.is_release }}
+        run: |
+          tags="${REPO}:${V}-arm64"
+          if [[ "$IS_RELEASE" == "true" ]]; then
+            tags="${tags}"$'\n'"${REPO}:latest-arm64"
+          fi
+          {
+            echo 'list<<EOF'
+            echo "$tags"
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
       - name: Build and push (arm64)
         uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/arm64
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-arm64
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-arm64
+          tags: ${{ steps.tags.outputs.list }}
           cache-from: type=gha,scope=arm64
           cache-to: type=gha,scope=arm64,mode=max
 


### PR DESCRIPTION
The `workflow_dispatch` input description promises "Does NOT touch :latest". On the amd64 side that holds: the `docker` job assembles its tag list in a step and only appends `:latest` when `is_release` is true. The `docker-arm64` job hardcoded `:latest-arm64` in its `tags:` block, so **every test build repointed it**. It even computed `is_release` and then never read it.

## How it surfaced

Running the first release-candidate build off main (`workflow_dispatch`, `test_tag: rc-1.61.0`). Afterwards the registry showed:

```
2026-08-28T15:03  rc-1.61.0
2026-08-28T14:59  rc-1.61.0-arm64,latest-arm64     <- here
2026-08-27T19:31  1.60.0,latest
```

## No user impact, and it is worth saying why

The multi-arch `:latest` is assembled in `promote-manifest`, and that step is already gated on `IS_RELEASE`, so it never ran. Verified rather than assumed: `:latest` and `:1.60.0` resolve to the same digest on both architectures.

```
:latest    linux/amd64 sha256:fc2a96cafe2cb9dfea1   linux/arm64 sha256:6bd181a6748e39fc87f
:1.60.0    linux/amd64 sha256:fc2a96cafe2cb9dfea1   linux/arm64 sha256:6bd181a6748e39fc87f
```

But a floating `latest` tag pointing at a release candidate is a trap set for whoever pulls it next, and the promise in the input description was simply false.

## The fix

Mirrors the amd64 pattern rather than inventing a second one: compute the tag list in a step, append `:latest-arm64` only when `is_release` is true.

The currently stale `:latest-arm64` self-heals at the next real release, since the arm64 job re-tags it before `promote-manifest` reads it. Nothing in the repo, the docs or the shipped compose file references `:latest-arm64` directly.

Refs #764