### PR TITLE
fix(core): destroy equipmentStatusTracker during shutdown (#792)

### DIFF
--- a/src/index-shutdown.test.ts
+++ b/src/index-shutdown.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+// Guard for the shutdown sequence in src/index.ts. That file runs `main()` as
+// a top-level side effect on import, so it cannot be exercised by a normal
+// unit test — the only place a wiring omission there can be caught before it
+// reaches production is a text check against the source, the same technique
+// used in deployment-logging.test.ts for docker-compose.yml.
+//
+// #792 — EquipmentStatusTracker was created and started but never destroyed
+// on shutdown, unlike every sibling tracker. Its debounced/tick timers kept
+// firing after `db.close()`, crashing the process with an uncaught exception
+// on some restarts (worse case: a Pino worker-thread double-fault logging
+// storm). Lock the call here so it cannot silently regress.
+
+const INDEX_TS = readFileSync(resolve(process.cwd(), "src/index.ts"), "utf8");
+
+/** The body of the `shutdown` closure, between its declaration and the controller hookup. */
+function shutdownSequence(text: string): string {
+  const start = text.indexOf("const shutdown = async () => {");
+  expect(start, "shutdown sequence present").toBeGreaterThanOrEqual(0);
+  const rest = text.slice(start);
+  const end = rest.indexOf("shutdownController.setGraceful(");
+  expect(end, "shutdownController.setGraceful call present").toBeGreaterThan(0);
+  return rest.slice(0, end);
+}
+
+describe("src/index.ts shutdown sequence", () => {
+  const sequence = shutdownSequence(INDEX_TS);
+
+  it("destroys every tracker/service it starts, including equipmentStatusTracker (#792)", () => {
+    const destroyedOrStopped = [
+      "capacityArbiter.stop()",
+      "sunlightManager.stop()",
+      "recipeManager.stopAll()",
+      "orderConfirmationTracker.destroy()",
+      "equipmentStatusTracker.destroy()",
+      "batteryMonitor.destroy()",
+      "notificationPublishService.destroy()",
+      "historyWriter.destroy()",
+      "db.close()",
+    ];
+    for (const call of destroyedOrStopped) {
+      expect(sequence, `shutdown sequence calls ${call}`).toContain(call);
+    }
+  });
+
+  it("stops equipmentStatusTracker before the database connection closes", () => {
+    const destroyIndex = sequence.indexOf("equipmentStatusTracker.destroy()");
+    const dbCloseIndex = sequence.indexOf("db.close()");
+    expect(destroyIndex, "equipmentStatusTracker.destroy() present").toBeGreaterThanOrEqual(0);
+    expect(dbCloseIndex, "db.close() present").toBeGreaterThanOrEqual(0);
+    expect(destroyIndex).toBeLessThan(dbCloseIndex);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -767,6 +767,11 @@ async function main() {
       logger.error({ err }, "Error stopping order confirmation tracker");
     }
     try {
+      equipmentStatusTracker.destroy();
+    } catch (err) {
+      logger.error({ err }, "Error stopping equipment status tracker");
+    }
+    try {
       batteryMonitor.destroy();
     } catch (err) {
       logger.error({ err }, "Error stopping battery monitor");


### PR DESCRIPTION
## Summary

`EquipmentStatusTracker` was created and started but never destroyed in the shutdown sequence, unlike every sibling tracker (`orderConfirmationTracker`, `batteryMonitor`, `historyWriter`, etc.). Its debounced (200ms) and wallclock (60s) timers stayed armed after `db.close()`, and if either fired afterward, `EquipmentManager.getAll()` threw on the closed connection, crashing the process on an uncaught exception. In the worst observed case the crash cascaded into a Pino worker-thread double-fault, producing 60+ fatal log lines in under 50ms before the process actually exited.

Found while testing `rc-1.61.0` on a real dev instance — see #792 for the full repro and root-cause writeup.

## Changes

- `src/index.ts`: add the missing `equipmentStatusTracker.destroy()` call in the shutdown sequence, in the same try/catch pattern as its siblings, before `db.close()`.
- `src/index-shutdown.test.ts` (new): `src/index.ts` runs `main()` as a side effect on import, so it can't be exercised by a normal unit test — same situation as `docker-compose.yml` for `deployment-logging.test.ts`. Following that file's text-assertion technique, this locks that the shutdown sequence destroys every known tracker (including `equipmentStatusTracker`) and that it does so before `db.close()`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/ --ext .ts` — clean
- [x] `npx vitest run` — 2044 passed, 2 skipped (115 files)
- [x] `cd ui && npm run lint && npm run typecheck && npm run test` — clean, 706 passed (68 files)
- [x] Independent agent review (code-review skill) — no findings
- [ ] Not re-tested against the real dev instance for this specific fix (the original crash needed several restore→restart attempts to reproduce; the fix itself is a straightforward wiring addition mirroring an already-proven pattern used by every other tracker)

Closes #792