### PR TITLE
test(core): bound the shutdown guard to the closure itself

### DIFF
--- a/src/shutdown-completeness.test.ts
+++ b/src/shutdown-completeness.test.ts
@@ -28,11 +28,29 @@ function read(file: string): string {
   return readFileSync(resolve(process.cwd(), file), "utf8");
 }
 
-/** The body of the `shutdown` arrow function, up to the end of the file. */
+/**
+ * The body of the `shutdown` arrow function, bounded at the point the closure
+ * is handed to the shutdown controller.
+ *
+ * Bounding technique taken from @alpitux's own fix for #792 (#793), which was
+ * open before this guard was written.
+ *
+ * What it buys is an accurate diagnosis rather than extra detection. Anything
+ * textually after the closure is also after `db.close()`, so an unbounded
+ * slice still fails on a teardown call placed outside `shutdown()`, but it
+ * fails in the ordering assertion, reporting "stopped after db.close()", which
+ * describes a different fault. Unbounded, the completeness assertions count
+ * that misplaced call as satisfying the requirement. Bounded, they do not, and
+ * the failure names the real problem. It also stops unrelated teardown calls
+ * elsewhere in the file from being read as part of the sequence at all.
+ */
 function shutdownBody(src: string): string {
   const start = src.indexOf("const shutdown = async () =>");
   expect(start, "shutdown() is defined in index.ts").toBeGreaterThanOrEqual(0);
-  return src.slice(start);
+  const rest = src.slice(start);
+  const end = rest.indexOf("shutdownController.setGraceful(");
+  expect(end, "the shutdown closure is handed to the controller").toBeGreaterThan(0);
+  return rest.slice(0, end);
 }
 
 /** `const foo = new Bar(` pairs, i.e. every subsystem the composition root owns. */


### PR DESCRIPTION
Adopts the bounding technique from @alpitux's own fix for #792 (#793), which was open **37 minutes before** the guard in #794 was written and was not looked at first. Credit where it is due.

## The change

The guard sliced `index.ts` from the `shutdown` declaration to the end of the file. It now stops at the point the closure is handed to the controller, which is simply more correct.

## What it actually buys, since my first framing of this was wrong

I told the maintainer the unbounded version "would go blind" if a teardown call appeared elsewhere in the file. That is not true, and the correction matters for how this is reviewed.

Anything textually after the closure is also after `db.close()`, so the unbounded slice **still failed** on a teardown call placed outside `shutdown()`. It failed in the ordering assertion, reporting `stopped after db.close()`, which describes a different fault.

So this is an accurate diagnosis rather than extra detection:

| | teardown removed | teardown moved outside the closure |
| --- | --- | --- |
| unbounded | 2 assertions fail | 1 fails, and with the wrong reason |
| bounded | 2 assertions fail | 2 fail, naming the real problem |

Unbounded, the two completeness assertions counted the misplaced call as satisfying the requirement. Bounded, they do not. It also keeps unrelated teardown calls elsewhere in the file from being read as part of the sequence at all.

Both directions were verified by editing `index.ts` and running the guard, not by reasoning about it.

## Verification

`npm run validate` clean: backend 115 files / 2049 tests, ui 68 / 706.

Refs #792, #793