### PR TITLE
chore(ci): group the dev toolchain into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,28 @@ version: 2
 
 # Grouping strategy
 # -----------------
-# The minor/patch groups auto-collect ordinary library bumps into a single PR
-# per ecosystem. Linters, formatters and the TypeScript compiler are excluded
-# from those groups: a version bump to any of them can fail CI on UNCHANGED
-# code (a new lint rule, a reformat, a stricter type check), which would poison
-# the whole group and block every unrelated library update. They still get
-# updated, but as individual PRs so their toolchain upgrade can be reviewed on
-# its own (run the formatter/linter fixups, triage new rules) instead of slipped
-# into an unattended merge.
+# Two groups per npm ecosystem, on purpose.
+#
+# `*-minor-patch` collects ordinary library bumps. Linters, formatters and the
+# TypeScript compiler are kept OUT of it: a bump to any of them can fail CI on
+# UNCHANGED code (a new lint rule, a reformat, a stricter type check), and
+# inside the library group that failure would block every unrelated update.
+#
+# `*-toolchain` then collects those same tools into one PR of their own, minor
+# and patch only. Excluding them from the library group was right; letting them
+# arrive one PR per package was not. Enabling Dependabot produced six separate
+# eslint-ecosystem PRs that could not even install individually, because the
+# packages peer-lock to each other (#797). One toolchain PR per week fixes the
+# noise without slowing anything down.
+#
+# Majors stay individual, for both kinds. A blocked major inside a group blocks
+# the group: typescript 7 has been unlandable for months (typescript-eslint
+# peers on <6.1.0, and 7.0 ships no programmatic compiler API), and it must not
+# be able to hold the rest of the toolchain hostage.
+#
+# The schedule stays weekly. The current backlog is the one-off catch-up from
+# turning Dependabot on, not the steady-state rate, and stretching the interval
+# would slow security patches to fix a problem grouping solves better.
 
 updates:
   # Backend npm dependencies
@@ -33,6 +47,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      backend-toolchain:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "@typescript-eslint/*"
+          - "prettier"
+          - "typescript"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Frontend npm dependencies
   - package-ecosystem: "npm"
@@ -45,6 +71,18 @@ updates:
     groups:
       ui-minor-patch:
         exclude-patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "@typescript-eslint/*"
+          - "prettier"
+          - "typescript"
+        update-types:
+          - "minor"
+          - "patch"
+      ui-toolchain:
+        patterns:
           - "eslint"
           - "eslint-*"
           - "@eslint/*"


### PR DESCRIPTION
Addresses the noise, not the symptom.

## What was wrong

Excluding linters, the formatter and `tsc` from the library groups (#677) was right: a tooling bump fails CI on unchanged code, and inside the library group that failure blocks every unrelated update.

Letting them then arrive **one PR per package** was not right. Enabling Dependabot produced six separate eslint-ecosystem proposals (#770, #771, #772, #775, #776, #777) which could not even install individually, because the four packages peer-lock to each other. Every one of them sat red for weeks until they were bumped together by hand in #797.

## The change

A second group per npm ecosystem, collecting exactly the packages the library group excludes, **minor and patch only**:

```yaml
backend-toolchain:
  patterns: [eslint, eslint-*, "@eslint/*", typescript-eslint, "@typescript-eslint/*", prettier, typescript]
  update-types: [minor, patch]
```

Same for `/ui`.

**Majors stay individual, for both kinds.** A blocked major inside a group blocks the group, and `typescript` 7 has been unlandable for months (`typescript-eslint` peers on `<6.1.0`, and 7.0 ships the Go `tsc` without the programmatic compiler API linters consume, which lands in 7.1). It must not be able to hold the rest of the toolchain hostage.

## What is deliberately not changed

**The weekly schedule.** The tempting fix is to stretch the interval, and it is the wrong one: the current backlog is the **one-off catch-up from turning Dependabot on**, not the steady-state rate. Slowing the cadence would delay security patches to solve a problem that grouping solves properly. This release alone shipped a High-severity IPv6 rate-limit bypass that arrived through this pipeline.

## Expected effect

Routine toolchain churn, which is the bulk of the volume, collapses to one PR per ecosystem per week instead of one per package.

Heads up for whoever sees the churn afterwards: changing a group's membership **closes the existing group PR and opens a new one under a new number**. Do not chase the old numbers.