### PR TITLE
chore(deps): pino 10, and stop building a worker for a silent logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "jsonwebtoken": "^9.0.3",
         "mqtt": "^5.15.2",
         "otplib": "^13.5.0",
-        "pino": "^9.6.0",
+        "pino": "^10.3.1",
         "pino-pretty": "^13.0.0",
         "pino-roll": "^4.0.0",
         "qrcode": "^1.5.4",
@@ -5081,31 +5081,31 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
-      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "license": "MIT",
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
+        "pino-abstract-transport": "^3.0.0",
         "pino-std-serializers": "^7.0.0",
         "process-warning": "^5.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
         "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
+        "thread-stream": "^4.0.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
@@ -5133,15 +5133,6 @@
       },
       "bin": {
         "pino-pretty": "bin.js"
-      }
-    },
-    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
-      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
-      "license": "MIT",
-      "dependencies": {
-        "split2": "^4.0.0"
       }
     },
     "node_modules/pino-roll": {
@@ -5998,13 +5989,22 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
       "license": "MIT",
       "dependencies": {
-        "real-require": "^0.2.0"
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jsonwebtoken": "^9.0.3",
     "mqtt": "^5.15.2",
     "otplib": "^13.5.0",
-    "pino": "^9.6.0",
+    "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",
     "pino-roll": "^4.0.0",
     "qrcode": "^1.5.4",

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -111,11 +111,21 @@ export function purgeLegacyLogFiles(logger: Logger, dir = "data/logs"): void {
  */
 export function createLogger(level: string, logBuffer?: LogRingBuffer): LoggerHandle {
   const isDev = process.env["NODE_ENV"] !== "production";
+  // A silent logger has nothing to pretty-print, so spawning pino-pretty for
+  // one is pure waste. It is also not harmless: `pino.transport()` starts a
+  // worker thread, and the suite builds a silent logger in 66 test files. On
+  // pino 9 that was slow; on pino 10 the workers stop being reaped and the
+  // suite hangs (mfa.test.ts alone sat at 0% CPU for 2005s). Deciding this on
+  // the level rather than on NODE_ENV keeps the dev experience identical and
+  // fixes anything that asks for silence, tests included.
 
   // Build stream entries for multistream
   const streams: pino.StreamEntry[] = [];
-  // Track transports (worker threads) that need closing
-  const transports: NodeJS.WritableStream[] = [];
+  // Track transports (worker threads) that need closing. Typed by what the
+  // close path below actually uses, not by NodeJS.WritableStream: pino 10
+  // returns a ThreadStream from `pino.transport()`, which has no `writable`
+  // property, and widening to the full interface was only ever incidental.
+  const transports: { end(): void }[] = [];
 
   // 1. Ring buffer stream — always captures at debug level
   if (logBuffer) {
@@ -135,7 +145,9 @@ export function createLogger(level: string, logBuffer?: LogRingBuffer): LoggerHa
   }
 
   // 2. Console output
-  if (isDev) {
+  if (level === "silent") {
+    // No console stream at all: nothing would be written through it.
+  } else if (isDev) {
     // Development: use pino-pretty via transport-like stream
     const transport = pino.transport({
       target: "pino-pretty",


### PR DESCRIPTION
**Not merged by me on purpose.** This is the logging backbone, and the change is behavioural in a way a dependency bump normally is not. It wants your eyes. Closes #667.

## Why pino 10 was held

It did not fail the suite, it **hung** it: about 20s became 934s, and `mfa.test.ts` alone sat at **2005s at 0% CPU**. Blocked, not busy, which pointed at worker threads rather than at anything pino 10 changed semantically.

## The cause is ours, not pino's

`createLogger` branches on `NODE_ENV`. Under vitest `NODE_ENV` is `"test"`, so the **dev** branch is taken and `pino.transport({ target: "pino-pretty" })` starts a worker thread. **Sixty six test files build a logger.** pino 9 tolerated sixty six orphaned workers; pino 10 does not.

## The fix

A logger asked for at level `"silent"` now gets **no console stream at all**. There is nothing to pretty-print, so the worker was always waste.

Deciding on the **level** rather than on `NODE_ENV` is the part worth reviewing. It keeps the dev experience byte-identical, and it fixes anything that asks for silence rather than special-casing the test runner.

## This is a speedup, not just an unblock

The backend suite goes from **about 26s to 18s on pino 9 alone**, before the bump, purely from not spawning those workers. That gain is independent of whether you want pino 10.

## Also required by pino 10

`transports` is now typed by what the close path actually calls (`{ end(): void }`) rather than `NodeJS.WritableStream`, because `pino.transport()` returns a `ThreadStream` and `ThreadStream` has no `writable`. The wide type was incidental and never used.

## Verification

The three paths I touched, checked directly rather than inferred:

| mode | result |
| --- | --- |
| dev | still pretty-prints with colour |
| production | still one JSON object per line |
| silent | emits nothing |
| in-app ring buffer at silent level | still captures |

That last row was **compared against the unpatched logger** rather than assumed, because it feeds the in-app log viewer and a regression there would be invisible: both variants report the same counts (`silent=1 info=1`).

`npm run validate` clean: backend 115 files / 2049 tests in 17.7s, ui 68 / 706.

Lockfile drift is 3 changed, 1 added, 1 removed, all inside pino's own tree: `pino` 9.14.0 -> 10.3.1, `pino-abstract-transport` 2 -> 3, `thread-stream` 3 -> 4.