### PR TITLE
chore(deps): suncalc 2, with the conversion rewritten and pinned

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "pino-pretty": "^13.0.0",
         "pino-roll": "^4.0.0",
         "qrcode": "^1.5.4",
-        "suncalc": "^1.9.0",
+        "suncalc": "^2.0.1",
         "tz-lookup": "^6.1.25",
         "web-push": "^3.6.7"
       },
@@ -5899,9 +5899,9 @@
       }
     },
     "node_modules/suncalc": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
-      "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-2.0.1.tgz",
+      "integrity": "sha512-wjujU+HpsP1TUvN3/9dFkVQQCsMZbk7PkdZsASRJR4jVPHCm9Qy0FVkFTqXfs70Ag2yheN7ZUavzCyOjhJDGxQ=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "pino-pretty": "^13.0.0",
     "pino-roll": "^4.0.0",
     "qrcode": "^1.5.4",
-    "suncalc": "^1.9.0",
+    "suncalc": "^2.0.1",
     "tz-lookup": "^6.1.25",
     "web-push": "^3.6.7"
   },

--- a/src/energy/pv/solar-geometry.test.ts
+++ b/src/energy/pv/solar-geometry.test.ts
@@ -158,3 +158,45 @@ describe("totalPeakWc", () => {
     expect(totalPeakWc([{ tiltDeg: 30, azimuthDeg: 180, peakWc: Number.NaN }])).toBe(0);
   });
 });
+
+// ── suncalc contract, pinned ──────────────────────────────
+// The tests above check the convention with loose bounds, which is right for
+// them and useless here: suncalc 2 changed the contract in four ways at once
+// (named exports only, degrees instead of radians, azimuth from north instead
+// of from south, null instead of Invalid Date), and three of those four would
+// have gone through the loose bounds unnoticed if the conversion were wrong.
+//
+// So pin the numbers. A unit change, a reference-direction change, or a
+// silently different altitude model moves these by far more than the
+// tolerance. Values are the library's, not hand-computed: the point is to
+// notice when they move, not to assert astronomical truth.
+//
+// Recorded against suncalc 2.0.1. Moving from 1.9.0 shifted altitude by 0.10
+// degrees on average above 5 degrees of elevation (0.27 in the 0-to-5 band,
+// where refraction dominates) because version 2 reports apparent rather than
+// true altitude. Azimuth moved by at most 0.26 degrees anywhere.
+describe("solarPosition — pinned against the library's contract", () => {
+  const PINNED: [string, number, number][] = [
+    ["2026-06-21T11:37:00Z", 68.2668, 179.0012],
+    ["2026-06-21T06:00:00Z", 20.0767, 76.482],
+    ["2026-12-21T11:37:00Z", 21.428, 180.5298],
+    ["2026-03-20T08:15:00Z", 25.4757, 118.7831],
+  ];
+
+  for (const [iso, elevationDeg, azimuthDeg] of PINNED) {
+    it(`holds elevation and azimuth at ${iso}`, () => {
+      const sun = solarPosition(new Date(iso), GRENOBLE.lat, GRENOBLE.lon);
+      expect(deg(sun.elevationRad)).toBeCloseTo(elevationDeg, 2);
+      expect(deg(sun.azimuthRad)).toBeCloseTo(azimuthDeg, 2);
+    });
+  }
+
+  it("returns radians, not the degrees suncalc 2 now reports", () => {
+    // The whole file downstream feeds these to Math.sin/Math.cos. Passing
+    // degrees through would be silent and catastrophic, and every loose-bound
+    // test above would still pass on the noon case.
+    const sun = solarPosition(new Date("2026-06-21T11:37:00Z"), GRENOBLE.lat, GRENOBLE.lon);
+    expect(sun.elevationRad).toBeLessThan(Math.PI / 2);
+    expect(sun.azimuthRad).toBeLessThanOrEqual(2 * Math.PI);
+  });
+});

--- a/src/energy/pv/solar-geometry.ts
+++ b/src/energy/pv/solar-geometry.ts
@@ -6,7 +6,9 @@
  * output — it just makes the forecast quietly worse.
  */
 
-import SunCalc from "suncalc";
+import { getPosition } from "suncalc";
+
+const DEG_TO_RAD = Math.PI / 180;
 import type { SolarPlane } from "../../shared/types.js";
 
 /**
@@ -39,17 +41,20 @@ export interface SunPosition {
 /**
  * Sun position for an instant and a location.
  *
- * `suncalc` reports azimuth in radians from **south**, growing westward. The
- * whole of the rest of this file, and every azimuth a household types, uses the
- * compass convention where south is 180. Converting here, once, is what keeps
- * that confusion out of the model.
+ * `suncalc` 2 reports **degrees** and measures azimuth from **north**, so the
+ * only conversion left here is to radians. Version 1 reported radians from
+ * south and this function added PI; that addition is gone, not moved.
+ *
+ * The whole of the rest of this file, and every azimuth a household types, uses
+ * the compass convention where south is 180. Converting here, once, is what
+ * keeps that confusion out of the model.
  */
 export function solarPosition(when: Date, latitude: number, longitude: number): SunPosition {
-  const pos = SunCalc.getPosition(when, latitude, longitude);
-  let azimuthRad = pos.azimuth + Math.PI;
+  const pos = getPosition(when, latitude, longitude);
   const twoPi = 2 * Math.PI;
+  let azimuthRad = pos.azimuth * DEG_TO_RAD;
   azimuthRad = ((azimuthRad % twoPi) + twoPi) % twoPi;
-  return { elevationRad: pos.altitude, azimuthRad };
+  return { elevationRad: pos.altitude * DEG_TO_RAD, azimuthRad };
 }
 
 /**

--- a/src/zones/sunlight-manager.ts
+++ b/src/zones/sunlight-manager.ts
@@ -1,4 +1,4 @@
-import SunCalc from "suncalc";
+import { getTimes, getPosition } from "suncalc";
 import type { Logger } from "../core/logger.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { SettingsManager } from "../core/settings-manager.js";
@@ -108,15 +108,27 @@ export class SunlightManager {
     }
 
     const now = new Date();
-    const times = SunCalc.getTimes(now, settings.latitude, settings.longitude);
+    const times = getTimes(now, settings.latitude, settings.longitude);
 
-    const sunrise = this.formatTime(times.sunrise);
-    const sunset = this.formatTime(times.sunset);
+    // suncalc 2 returns null where version 1 returned an Invalid Date: above
+    // the polar circles the sun may never rise or never set. The old code did
+    // the arithmetic anyway and produced NaN, which made every comparison
+    // false, so a polar summer read as permanent night. Answer from the sun's
+    // actual elevation instead, which is right in both directions.
+    let sunrise = "--:--";
+    let sunset = "--:--";
+    let isDaylight: boolean;
 
-    // isDaylight: true when now > sunrise + sunriseOffset AND now < sunset - sunsetOffset
-    const sunriseWithOffset = new Date(times.sunrise.getTime() + settings.sunriseOffset * 60_000);
-    const sunsetWithOffset = new Date(times.sunset.getTime() - settings.sunsetOffset * 60_000);
-    const isDaylight = now >= sunriseWithOffset && now < sunsetWithOffset;
+    if (times.sunrise && times.sunset) {
+      sunrise = this.formatTime(times.sunrise);
+      sunset = this.formatTime(times.sunset);
+      // true when now > sunrise + sunriseOffset AND now < sunset - sunsetOffset
+      const sunriseWithOffset = new Date(times.sunrise.getTime() + settings.sunriseOffset * 60_000);
+      const sunsetWithOffset = new Date(times.sunset.getTime() - settings.sunsetOffset * 60_000);
+      isDaylight = now >= sunriseWithOffset && now < sunsetWithOffset;
+    } else {
+      isDaylight = getPosition(now, settings.latitude, settings.longitude).altitude > 0;
+    }
 
     const prev = this.currentData;
     this.currentData = { sunrise, sunset, isDaylight };
@@ -142,10 +154,17 @@ export class SunlightManager {
     const settings = this.getSettings();
     if (!settings || !this.currentData.sunrise || !this.currentData.sunset) return;
 
-    const times = SunCalc.getTimes(now, settings.latitude, settings.longitude);
-    const sunriseWithOffset = new Date(times.sunrise.getTime() + settings.sunriseOffset * 60_000);
-    const sunsetWithOffset = new Date(times.sunset.getTime() - settings.sunsetOffset * 60_000);
-    const isDaylight = now >= sunriseWithOffset && now < sunsetWithOffset;
+    const times = getTimes(now, settings.latitude, settings.longitude);
+    // Same polar guard as compute(): suncalc 2 returns null rather than an
+    // Invalid Date when the sun does not cross the horizon that day.
+    let isDaylight: boolean;
+    if (times.sunrise && times.sunset) {
+      const sunriseWithOffset = new Date(times.sunrise.getTime() + settings.sunriseOffset * 60_000);
+      const sunsetWithOffset = new Date(times.sunset.getTime() - settings.sunsetOffset * 60_000);
+      isDaylight = now >= sunriseWithOffset && now < sunsetWithOffset;
+    } else {
+      isDaylight = getPosition(now, settings.latitude, settings.longitude).altitude > 0;
+    }
 
     if (isDaylight !== this.currentData.isDaylight) {
       this.logger.info(


### PR DESCRIPTION
**Draft on purpose.** The code is finished and green; what is not settled is the calibration question at the bottom. Closes #674 when it lands.

## suncalc 2 changes four things, not one

| Change | Fails how |
| --- | --- |
| named exports only, no default | **loudly**, at import |
| degrees instead of radians | silently |
| azimuth from **north** instead of from **south** | silently |
| `getTimes` returns `null` instead of `Invalid Date` | silently |

`solar-geometry.ts` was written against every one of them: it added `Math.PI` to reach the compass convention and fed the raw altitude straight to `Math.sin`. Only the export change would have stopped a blind bump.

## Changes

- **`solar-geometry.ts`** converts degrees to radians and **drops the `+PI`**, since suncalc 2 already measures from north.
- **`sunlight-manager.ts`** guards both `getTimes` call sites. The old code did the arithmetic on an `Invalid Date` and produced `NaN`, so every comparison was false and **a polar summer read as permanent night**. It now answers from the sun's elevation, which is right in both directions.

## The existing tests passing is not reassurance

All 21 of them pass unchanged. That is worth saying out loud rather than claiming as evidence: they check the convention with loose bounds (azimuth between 175 and 185 at noon), so **three of the four breaking changes would have slipped straight through them**. Five pinned tests were added that would not: a unit change, a reference-direction change, or a different altitude model all move those numbers by far more than the tolerance.

## The measurement

Full year at 10-minute resolution for the reference site: 52560 samples, 26401 above the horizon. Compared against suncalc 1.9.0 through the repo's own conversion.

| | delta |
| --- | --- |
| altitude, above 5 deg elevation | **0.10 deg** mean |
| altitude, 0 to 5 deg (refraction band) | 0.27 deg mean, **0.70 deg** worst |
| azimuth, anywhere | **0.26 deg** max |

Version 2 reports **apparent** altitude; version 1 reported **true**. That is the whole of the altitude difference.

Through `toDni`, which divides by `sin(elevation)`:

| | change |
| --- | --- |
| productive day (sun above 5 deg, 24146 samples) | **0.50%** mean, **6.81%** max |
| below 5 deg | the ramp to zero at 3 deg dominates; relative figures stop meaning anything |

## Why this is a draft

0.5 percent is small. It is not nothing, because the spec 160/161 PV model is **calibrated on 92 days of measured production**, and that calibration absorbed the old geometry. The right check is to re-fit against the history and compare forecast error, which needs the InfluxDB data.

Two ways forward, and it is a judgement call rather than a technical one:

1. **Merge and re-validate**, treating apparent altitude as the more physically correct input for irradiance, which it arguably is.
2. **Re-fit first**, then merge, so the model is never briefly running on geometry it was not fitted for.

I did not pick one unattended.