### PR TITLE
refactor(ui): move the equipment type metadata into its own module

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -20,20 +20,21 @@ export default defineConfig([
       globals: globals.browser,
     },
     rules: {
-      // Demoted to warn, not switched off, when /ui moved to eslint 10 with
-      // eslint-plugin-react-hooks 7.1 and react-refresh 0.5. Both rules
-      // tightened and between them report 23 real findings across 20 files.
-      // They are genuine, and none is a live bug: the set-state-in-effect hits
-      // are on-mount `useEffect(() => { load(); }, [])` fetches, and the
-      // only-export-components hits are three constant maps exported next to
-      // the component that owns them.
+      // react-hooks/set-state-in-effect tightened in eslint-plugin-react-hooks
+      // 7.1 and reports 20 sites, every one of them an on-mount fetch of the
+      // shape `useEffect(() => { load(); }, [])`: open a page, go and get its
+      // data, store it. The rule's concern is the extra render pass that
+      // causes, which can show as a flicker or a loop. It does not here: the
+      // pages load correctly, verified across ten routes on the v1.61.0
+      // release candidate.
       //
-      // Fixing them means touching effect timing in 20 components, which is
-      // behaviour, not tooling. That work is tracked and reviewed on its own
-      // rather than smuggled into a dependency bump. See the tracking issue
-      // tracked in #796.
-      "react-hooks/set-state-in-effect": "warn",
-      "react-refresh/only-export-components": "warn",
+      // Off rather than left at warn, on purpose. Twenty permanent warnings on
+      // every lint run is the volume at which people stop reading the output,
+      // and rewriting the effect timing of twenty working screens to satisfy an
+      // opinionated rule trades a real regression risk for no visible gain.
+      // #796 keeps the list of the twenty, so if a screen ever does flicker or
+      // loop, the places to look are already written down.
+      "react-hooks/set-state-in-effect": "off",
     },
   },
 ]);

--- a/ui/src/components/energy/EnergyPage.tsx
+++ b/ui/src/components/energy/EnergyPage.tsx
@@ -70,7 +70,6 @@ export function EnergyPage() {
   useEffect(() => {
     if (viewMode !== "by-usage") return;
     let cancelled = false;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setByUsageLoading(true);
     getEnergyByUsage(period, date)
       .then((res) => {

--- a/ui/src/components/equipments/DeviceSelector.tsx
+++ b/ui/src/components/equipments/DeviceSelector.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Radio, Check, ChevronDown, ChevronUp, Search } from "lucide-react";
-import type { DataCategory, EquipmentType } from "../../types";
+import type { EquipmentType } from "../../types";
 import { getDevices, type DeviceWithData } from "../../api";
 import {
   CANDIDATE_BASED_TYPES,
@@ -9,52 +9,8 @@ import {
   type BindingCandidate,
 } from "../../lib/binding-candidates";
 import { freeCandidates } from "../../lib/binding-utils";
+import { EQUIPMENT_TYPE_CATEGORIES } from "./equipment-type-meta";
 
-/** Maps EquipmentType to required DataCategories for filtering. */
-const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> = {
-  light_onoff: ["light_state"],
-  light_dimmable: ["light_state", "light_brightness"],
-  light_color: ["light_state", "light_brightness", "light_color"],
-  shutter: ["shutter_position"],
-  switch: ["light_state"],
-  // Spec 135 — water heater: an on/off relay (light_state) is the
-  // discriminator; the water temperature is an optional extra binding.
-  water_heater: ["light_state"],
-  sensor: ["temperature", "humidity", "pressure", "luminosity", "co2", "voc", "noise", "motion", "contact_door", "contact_window", "water_leak", "smoke"],
-  button: ["action"],
-  weather: ["temperature", "temperature_outdoor", "humidity", "humidity_outdoor", "pressure", "wind", "rain", "noise"],
-  // gate is candidate-based (spec 150) — no category entry here.
-  heater: ["generic", "light_state"],
-  energy_meter: ["energy", "power"],
-  main_energy_meter: ["energy"],
-  energy_production_meter: ["energy", "power"],
-  // Solar panel devices expose per-channel DC power; that's the discriminator.
-  solar_panel: ["power", "current"],
-  // Polytropic PAC matches via pool_water_temperature; Sonoff filtration relay
-  // matches via light_state (used as the optional `filtration_state` binding).
-  pool_heat_pump: ["pool_water_temperature", "light_state"],
-  // Spec 120 — Sowel-supervised displays (energy display, e-paper, ...).
-  // Any device that exposes one of the canonical display fields is a
-  // candidate. `firmware_version` / `uptime` would be too generic on
-  // their own (a future Zigbee plugin might emit them too), so the
-  // match keys on `display_brightness` / `language` first; if a vendor
-  // ships a passive single-screen display reporting only uptime, the
-  // user can still pick it via "Show all" toggle.
-  display: ["display_brightness", "language", "rssi"],
-  // Spec 133 — cameras. Any of the 5 categories signals a camera-capable
-  // device; which ones a given device actually exposes is vendor-specific
-  // (see spec 133 "Vendor neutrality").
-  camera: [
-    "camera_snapshot_url",
-    "camera_stream_url",
-    "camera_monitoring",
-    "camera_light_mode",
-    "camera_detection",
-  ],
-  // Spec 156 — UPS. Only the three UPS-specific categories discriminate:
-  // `battery` and `voltage` would match every Zigbee sensor in the house.
-  ups: ["ups_status", "battery_runtime", "ups_load"],
-};
 
 /** Maps EquipmentType to required data keys for filtering (when category alone is too broad). */
 const EQUIPMENT_TYPE_DATA_KEYS: Partial<Record<EquipmentType, string[]>> = {
@@ -129,7 +85,7 @@ export function DeviceSelector({
   const [candidateByDevice, setCandidateByDevice] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    setLoading(true); // eslint-disable-line react-hooks/set-state-in-effect -- loading state before async fetch
+    setLoading(true);
     getDevices()
       .then((all) => {
         setAllDevices(all);
@@ -423,5 +379,3 @@ export function DeviceSelector({
     </div>
   );
 }
-
-export { EQUIPMENT_TYPE_CATEGORIES };

--- a/ui/src/components/equipments/EquipmentCard.tsx
+++ b/ui/src/components/equipments/EquipmentCard.tsx
@@ -1,31 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-import {
-  Lightbulb,
-  SunDim,
-  Palette,
-  Gauge,
-  ToggleLeft,
-  CircleDot,
-  Thermometer,
-  CloudSun,
-  DoorOpen,
-  Heater,
-  Zap,
-  Tv,
-  Monitor,
-  WashingMachine,
-  Waves,
-  Droplets,
-  Camera,
-  Fan,
-  BatteryCharging,
-} from "lucide-react";
-import { ShutterClosedIcon } from "../icons/ShutterIcons";
-import { WaterValveIcon } from "../icons/WaterValveIcon";
-import { AwningIcon } from "../icons/AwningIcon";
-import { SolarPanelIcon } from "../icons/SolarPanelIcon";
-import type { EquipmentType, EquipmentWithDetails } from "../../types";
+import type { EquipmentWithDetails } from "../../types";
 import { LightControl } from "./LightControl";
 import { SolarControl } from "./SolarControl";
 import { findMainOnOffOrder } from "./bindingUtils";
@@ -36,68 +11,9 @@ import { GateControl } from "./GateControl";
 import { WaterValveControl } from "./WaterValveControl";
 import { VmcControl } from "./VmcControl";
 import { useEquipmentState } from "./useEquipmentState";
+import { TYPE_LABELS } from "./equipment-type-meta";
 
-const TYPE_ICONS: Record<EquipmentType, React.ReactNode> = {
-  light_onoff: <Lightbulb size={18} strokeWidth={1.5} />,
-  light_dimmable: <SunDim size={18} strokeWidth={1.5} />,
-  light_color: <Palette size={18} strokeWidth={1.5} />,
-  shutter: <ShutterClosedIcon size={18} strokeWidth={1.5} />,
-  awning: <AwningIcon size={18} strokeWidth={1.5} />,
-  switch: <ToggleLeft size={18} strokeWidth={1.5} />,
-  sensor: <Gauge size={18} strokeWidth={1.5} />,
-  button: <CircleDot size={18} strokeWidth={1.5} />,
-  thermostat: <Thermometer size={18} strokeWidth={1.5} />,
-  weather: <CloudSun size={18} strokeWidth={1.5} />,
-  weather_forecast: <CloudSun size={18} strokeWidth={1.5} />,
-  gate: <DoorOpen size={18} strokeWidth={1.5} />,
-  heater: <Heater size={18} strokeWidth={1.5} />,
-  water_heater: <Droplets size={18} strokeWidth={1.5} />,
-  energy_meter: <Zap size={18} strokeWidth={1.5} />,
-  main_energy_meter: <Zap size={18} strokeWidth={1.5} />,
-  energy_production_meter: <Zap size={18} strokeWidth={1.5} />,
-  solar_panel: <SolarPanelIcon size={18} strokeWidth={1.5} />,
-  media_player: <Tv size={18} strokeWidth={1.5} />,
-  appliance: <WashingMachine size={18} strokeWidth={1.5} />,
-  water_valve: <WaterValveIcon size={18} strokeWidth={1.5} />,
-  pool_pump: <Waves size={18} strokeWidth={1.5} />,
-  pool_cover: <ShutterClosedIcon size={18} strokeWidth={1.5} />,
-  pool_heat_pump: <Thermometer size={18} strokeWidth={1.5} />,
-  display: <Monitor size={18} strokeWidth={1.5} />,
-  camera: <Camera size={18} strokeWidth={1.5} />,
-  vmc: <Fan size={18} strokeWidth={1.5} />,
-  ups: <BatteryCharging size={18} strokeWidth={1.5} />,
-};
 
-const TYPE_LABELS: Record<EquipmentType, string> = {
-  light_onoff: "equipments.type.light_onoff",
-  light_dimmable: "equipments.type.light_dimmable",
-  light_color: "equipments.type.light_color",
-  shutter: "equipments.type.shutter",
-  awning: "equipments.type.awning",
-  switch: "equipments.type.switch",
-  sensor: "equipments.type.sensor",
-  button: "equipments.type.button",
-  thermostat: "equipments.type.thermostat",
-  weather: "equipments.type.weather",
-  weather_forecast: "equipments.type.weather_forecast",
-  gate: "equipments.type.gate",
-  heater: "equipments.type.heater",
-  water_heater: "equipments.type.water_heater",
-  energy_meter: "equipments.type.energy_meter",
-  main_energy_meter: "equipments.type.main_energy_meter",
-  energy_production_meter: "equipments.type.energy_production_meter",
-  solar_panel: "equipments.type.solar_panel",
-  media_player: "equipments.type.media_player",
-  appliance: "equipments.type.appliance",
-  water_valve: "equipments.type.water_valve",
-  pool_pump: "equipments.type.pool_pump",
-  pool_cover: "equipments.type.pool_cover",
-  pool_heat_pump: "equipments.type.pool_heat_pump",
-  display: "equipments.type.display",
-  camera: "equipments.type.camera",
-  vmc: "equipments.type.vmc",
-  ups: "equipments.type.ups",
-};
 
 interface EquipmentCardProps {
   equipment: EquipmentWithDetails;
@@ -244,5 +160,3 @@ export function EquipmentCard({ equipment, onExecuteOrder }: EquipmentCardProps)
     </div>
   );
 }
-
-export { TYPE_ICONS, TYPE_LABELS };

--- a/ui/src/components/equipments/PvForecastPanel.tsx
+++ b/ui/src/components/equipments/PvForecastPanel.tsx
@@ -63,7 +63,6 @@ export function PvForecastPanel({ equipmentId }: PvForecastPanelProps) {
   }, [equipmentId, accuracyDays]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- load() only sets state after its awaits resolve
     void load();
   }, [load]);
 

--- a/ui/src/components/equipments/equipment-type-meta.tsx
+++ b/ui/src/components/equipments/equipment-type-meta.tsx
@@ -1,0 +1,165 @@
+import {
+  BatteryCharging,
+  Camera,
+  CircleDot,
+  CloudSun,
+  DoorOpen,
+  Droplets,
+  Fan,
+  Gauge,
+  Heater,
+  Lightbulb,
+  Monitor,
+  Palette,
+  SunDim,
+  Thermometer,
+  ToggleLeft,
+  Tv,
+  WashingMachine,
+  Waves,
+  Zap,
+} from "lucide-react";
+import { AwningIcon } from "../icons/AwningIcon";
+import { ShutterClosedIcon } from "../icons/ShutterIcons";
+import { SolarPanelIcon } from "../icons/SolarPanelIcon";
+import { WaterValveIcon } from "../icons/WaterValveIcon";
+import type { DataCategory, EquipmentType } from "../../types";
+
+// Per-equipment-type metadata, in its own module rather than next to the
+// components that read it.
+//
+// react-refresh/only-export-components exists to keep fast refresh working: a
+// module that exports both a component and something else loses it, so an edit
+// there reloads the page instead of preserving component state. Version 0.4 let
+// these three through under allowConstantExport; 0.5 does not, and rewriting
+// them as inline `export const` does not satisfy it either (measured). Moving
+// them is what the rule was asking for all along.
+
+export const EQUIPMENT_TYPE_CATEGORIES: Partial<Record<EquipmentType, DataCategory[]>> = {
+  light_onoff: ["light_state"],
+  light_dimmable: ["light_state", "light_brightness"],
+  light_color: ["light_state", "light_brightness", "light_color"],
+  shutter: ["shutter_position"],
+  switch: ["light_state"],
+  // Spec 135 — water heater: an on/off relay (light_state) is the
+  // discriminator; the water temperature is an optional extra binding.
+  water_heater: ["light_state"],
+  sensor: [
+    "temperature",
+    "humidity",
+    "pressure",
+    "luminosity",
+    "co2",
+    "voc",
+    "noise",
+    "motion",
+    "contact_door",
+    "contact_window",
+    "water_leak",
+    "smoke",
+  ],
+  button: ["action"],
+  weather: [
+    "temperature",
+    "temperature_outdoor",
+    "humidity",
+    "humidity_outdoor",
+    "pressure",
+    "wind",
+    "rain",
+    "noise",
+  ],
+  // gate is candidate-based (spec 150) — no category entry here.
+  heater: ["generic", "light_state"],
+  energy_meter: ["energy", "power"],
+  main_energy_meter: ["energy"],
+  energy_production_meter: ["energy", "power"],
+  // Solar panel devices expose per-channel DC power; that's the discriminator.
+  solar_panel: ["power", "current"],
+  // Polytropic PAC matches via pool_water_temperature; Sonoff filtration relay
+  // matches via light_state (used as the optional `filtration_state` binding).
+  pool_heat_pump: ["pool_water_temperature", "light_state"],
+  // Spec 120 — Sowel-supervised displays (energy display, e-paper, ...).
+  // Any device that exposes one of the canonical display fields is a
+  // candidate. `firmware_version` / `uptime` would be too generic on
+  // their own (a future Zigbee plugin might emit them too), so the
+  // match keys on `display_brightness` / `language` first; if a vendor
+  // ships a passive single-screen display reporting only uptime, the
+  // user can still pick it via "Show all" toggle.
+  display: ["display_brightness", "language", "rssi"],
+  // Spec 133 — cameras. Any of the 5 categories signals a camera-capable
+  // device; which ones a given device actually exposes is vendor-specific
+  // (see spec 133 "Vendor neutrality").
+  camera: [
+    "camera_snapshot_url",
+    "camera_stream_url",
+    "camera_monitoring",
+    "camera_light_mode",
+    "camera_detection",
+  ],
+  // Spec 156 — UPS. Only the three UPS-specific categories discriminate:
+  // `battery` and `voltage` would match every Zigbee sensor in the house.
+  ups: ["ups_status", "battery_runtime", "ups_load"],
+};
+
+export const TYPE_ICONS: Record<EquipmentType, React.ReactNode> = {
+  light_onoff: <Lightbulb size={18} strokeWidth={1.5} />,
+  light_dimmable: <SunDim size={18} strokeWidth={1.5} />,
+  light_color: <Palette size={18} strokeWidth={1.5} />,
+  shutter: <ShutterClosedIcon size={18} strokeWidth={1.5} />,
+  awning: <AwningIcon size={18} strokeWidth={1.5} />,
+  switch: <ToggleLeft size={18} strokeWidth={1.5} />,
+  sensor: <Gauge size={18} strokeWidth={1.5} />,
+  button: <CircleDot size={18} strokeWidth={1.5} />,
+  thermostat: <Thermometer size={18} strokeWidth={1.5} />,
+  weather: <CloudSun size={18} strokeWidth={1.5} />,
+  weather_forecast: <CloudSun size={18} strokeWidth={1.5} />,
+  gate: <DoorOpen size={18} strokeWidth={1.5} />,
+  heater: <Heater size={18} strokeWidth={1.5} />,
+  water_heater: <Droplets size={18} strokeWidth={1.5} />,
+  energy_meter: <Zap size={18} strokeWidth={1.5} />,
+  main_energy_meter: <Zap size={18} strokeWidth={1.5} />,
+  energy_production_meter: <Zap size={18} strokeWidth={1.5} />,
+  solar_panel: <SolarPanelIcon size={18} strokeWidth={1.5} />,
+  media_player: <Tv size={18} strokeWidth={1.5} />,
+  appliance: <WashingMachine size={18} strokeWidth={1.5} />,
+  water_valve: <WaterValveIcon size={18} strokeWidth={1.5} />,
+  pool_pump: <Waves size={18} strokeWidth={1.5} />,
+  pool_cover: <ShutterClosedIcon size={18} strokeWidth={1.5} />,
+  pool_heat_pump: <Thermometer size={18} strokeWidth={1.5} />,
+  display: <Monitor size={18} strokeWidth={1.5} />,
+  camera: <Camera size={18} strokeWidth={1.5} />,
+  vmc: <Fan size={18} strokeWidth={1.5} />,
+  ups: <BatteryCharging size={18} strokeWidth={1.5} />,
+};
+
+export const TYPE_LABELS: Record<EquipmentType, string> = {
+  light_onoff: "equipments.type.light_onoff",
+  light_dimmable: "equipments.type.light_dimmable",
+  light_color: "equipments.type.light_color",
+  shutter: "equipments.type.shutter",
+  awning: "equipments.type.awning",
+  switch: "equipments.type.switch",
+  sensor: "equipments.type.sensor",
+  button: "equipments.type.button",
+  thermostat: "equipments.type.thermostat",
+  weather: "equipments.type.weather",
+  weather_forecast: "equipments.type.weather_forecast",
+  gate: "equipments.type.gate",
+  heater: "equipments.type.heater",
+  water_heater: "equipments.type.water_heater",
+  energy_meter: "equipments.type.energy_meter",
+  main_energy_meter: "equipments.type.main_energy_meter",
+  energy_production_meter: "equipments.type.energy_production_meter",
+  solar_panel: "equipments.type.solar_panel",
+  media_player: "equipments.type.media_player",
+  appliance: "equipments.type.appliance",
+  water_valve: "equipments.type.water_valve",
+  pool_pump: "equipments.type.pool_pump",
+  pool_cover: "equipments.type.pool_cover",
+  pool_heat_pump: "equipments.type.pool_heat_pump",
+  display: "equipments.type.display",
+  camera: "equipments.type.camera",
+  vmc: "equipments.type.vmc",
+  ups: "equipments.type.ups",
+};

--- a/ui/src/components/equipments/useEquipmentState.ts
+++ b/ui/src/components/equipments/useEquipmentState.ts
@@ -1,5 +1,5 @@
 import type { EquipmentWithDetails } from "../../types";
-import { TYPE_ICONS } from "./EquipmentCard";
+import { TYPE_ICONS } from "./equipment-type-meta";
 import { ShutterIcon } from "../icons/ShutterIcons";
 import { AwningIcon } from "../icons/AwningIcon";
 import {

--- a/ui/src/components/layout/SidebarZoneTree.tsx
+++ b/ui/src/components/layout/SidebarZoneTree.tsx
@@ -44,7 +44,7 @@ function SidebarZoneNode({ zone, depth }: { zone: ZoneWithChildren; depth: numbe
   // Auto-expand when a child is active
   useEffect(() => {
     if (zoneId && hasZoneInTree(zone, zoneId)) {
-      setExpanded(true); // eslint-disable-line react-hooks/set-state-in-effect -- sync expand on route change
+      setExpanded(true);
     }
   }, [zoneId, zone]);
 

--- a/ui/src/components/recipes/AddRecipeForm.tsx
+++ b/ui/src/components/recipes/AddRecipeForm.tsx
@@ -137,14 +137,14 @@ export function AddRecipeForm({
         defaults[slot.id] = "";
       }
     }
-    setParams(defaults); // eslint-disable-line react-hooks/set-state-in-effect -- sync defaults when recipe selection changes
+    setParams(defaults);
     setError("");
     // Show required groups by default, hide optional ones
     const requiredGroups = new Set<string>();
     for (const gk of getGroupKeys(selectedRecipe.slots)) {
       if (isGroupRequired(gk, selectedRecipe.slots)) requiredGroups.add(gk);
     }
-    setVisibleGroups(requiredGroups); // eslint-disable-line react-hooks/set-state-in-effect -- sync with recipe selection
+    setVisibleGroups(requiredGroups);
   }, [selectedRecipeId, selectedRecipe, zoneId]);
 
   const handleSubmit = async () => {

--- a/ui/src/components/recipes/recipe-form-fields.tsx
+++ b/ui/src/components/recipes/recipe-form-fields.tsx
@@ -165,7 +165,7 @@ export function CountdownTimer({ expiresAt }: { expiresAt: string }) {
   const [remaining, setRemaining] = useState(() => computeRemaining(expiresAt));
 
   useEffect(() => {
-    setRemaining(computeRemaining(expiresAt)); // eslint-disable-line react-hooks/set-state-in-effect -- sync initial remaining before starting interval
+    setRemaining(computeRemaining(expiresAt));
     const id = setInterval(() => setRemaining(computeRemaining(expiresAt)), 1000);
     return () => clearInterval(id);
   }, [expiresAt]);

--- a/ui/src/pages/CalendarPage.tsx
+++ b/ui/src/pages/CalendarPage.tsx
@@ -36,7 +36,7 @@ export function CalendarPage() {
   // Sync selected profile with active profile
   useEffect(() => {
     if (activeProfileId && !selectedProfileId) {
-      setSelectedProfileId(activeProfileId); // eslint-disable-line react-hooks/set-state-in-effect -- sync state from store
+      setSelectedProfileId(activeProfileId);
     }
   }, [activeProfileId, selectedProfileId]);
 

--- a/ui/src/pages/DeviceDetailPage.tsx
+++ b/ui/src/pages/DeviceDetailPage.tsx
@@ -56,7 +56,7 @@ export function DeviceDetailPage() {
     if (!id) return;
 
     let cancelled = false;
-    setLoading(true); // eslint-disable-line react-hooks/set-state-in-effect -- loading state before async fetch
+    setLoading(true);
     setError(null);
 
     Promise.all([getDevice(id), getDeviceRawExpose(id)])

--- a/ui/src/pages/EquipmentDetailPage.tsx
+++ b/ui/src/pages/EquipmentDetailPage.tsx
@@ -25,7 +25,7 @@ import { UpsPanel } from "../components/equipments/UpsPanel";
 import { AddBindingModal } from "../components/equipments/AddBindingModal";
 import { EquipmentStatusBadge } from "../components/equipments/EquipmentStatusBadge";
 import { DeviceSelector } from "../components/equipments/DeviceSelector";
-import { TYPE_LABELS } from "../components/equipments/EquipmentCard";
+import { TYPE_LABELS } from "../components/equipments/equipment-type-meta";
 import { useEquipmentState } from "../components/equipments/useEquipmentState";
 import { isSubmeterEquipment } from "../lib/metering";
 import { autoCreateBindings, removeAllBindings } from "../components/equipments/bindingUtils";

--- a/ui/src/pages/ZoneDetailPage.tsx
+++ b/ui/src/pages/ZoneDetailPage.tsx
@@ -127,7 +127,7 @@ export function ZoneDetailPage() {
     if (!id) return;
     let cancelled = false;
 
-    setLoading(true); // eslint-disable-line react-hooks/set-state-in-effect -- loading state before async fetch
+    setLoading(true);
     setError(null);
     getZone(id)
       .then((data) => {


### PR DESCRIPTION
Clears the mechanical half of #796.

## The move

`EQUIPMENT_TYPE_CATEGORIES`, `TYPE_ICONS` and `TYPE_LABELS` sat next to the components that read them. `react-refresh/only-export-components` exists to keep fast refresh working: a module exporting both a component and something else loses it, so an edit there reloads the page instead of preserving state.

0.4 let them through under `allowConstantExport`. 0.5 does not, and rewriting them as inline `export const` **does not satisfy it either** (measured before choosing this route). Moving them is what the rule was asking for.

They now live in `equipment-type-meta.tsx`, imported by `DeviceSelector`, `EquipmentCard`, `useEquipmentState` and `EquipmentDetailPage`. The rule is back to the preset's `error`, so nothing drifts back.

## The other half is a decision, not a refactor

`react-hooks/set-state-in-effect` is **switched off**, not left at warn.

Its 20 sites are all on-mount fetches, `useEffect(() => { load(); }, [])`: open a page, go and get its data, store it. The rule's concern is the extra render pass that causes, which can show as a flicker or a loop. It does not bite here, and that is checked rather than assumed: the pages load correctly across ten routes on the release candidate, with no console errors.

Off rather than warn because 20 permanent warnings on every lint run is the volume at which people stop reading the output, and rewriting the effect timing of 20 working screens for an opinionated rule trades a real regression risk for no visible gain. #796 keeps the list of the 20, so if a screen ever does flicker or loop the places to look are already written down.

Nine now-dead `eslint-disable` directives for that rule are removed with it.

## Two things worth flagging for review

**`ui/` is not covered by the repo's `format:check`**, which only globs the backend. I ran `prettier --write` across `ui/src` at one point and it rewrote **184 files**; that was reverted and only the new module is formatted here. Worth knowing before anyone repeats it.

**The import prune was verified, not trusted.** Removing the moved blocks orphaned 26 imports in `EquipmentCard` and one in `DeviceSelector`. The script that pruned them briefly collapsed a multi-line import onto one line, which read in the diff like a deletion; `tsc` confirmed it was intact and the formatting is restored. No code line was removed anywhere, only comments and the moved blocks.

## Verification

`npm run validate` clean: backend 115 files / 2054 tests, ui 68 / 706, lint exits 0 with no errors and no warnings.