### PR TITLE
docs(plugins): describe the detail panel and the bulk update banner (#749)

### DIFF
--- a/docs/user/plugins.fr.md
+++ b/docs/user/plugins.fr.md
@@ -10,12 +10,14 @@ Les plugins se gèrent depuis **Administration > Plugins** (admin uniquement).
 
 **Installés** liste ce qui tourne sur votre instance :
 
-- Les **intégrations** affichent leur état de connexion et le nombre d'appareils qu'elles alimentent. Depuis cette liste, vous pouvez désactiver, réactiver, mettre à jour ou désinstaller chacune.
+- Les **intégrations** affichent leur état de connexion et le nombre d'appareils qu'elles alimentent. Sélectionner une ligne ouvre son détail, d'où vous pouvez la désactiver, la réactiver, la mettre à jour ou la désinstaller.
 - Les **recettes** sont les modèles d'automatisation disponibles quand vous créez des instances de recettes.
 
 **Store** liste ce que vous pouvez installer. Les entrées viennent du catalogue officiel Sowel, plus vos propres sources personnelles (voir plus bas). Le bouton **Rafraîchir** relit le catalogue immédiatement, utile juste après l'annonce d'un nouveau plugin ou d'une nouvelle version.
 
 Quand une version plus récente d'un plugin installé est disponible, un badge de mise à jour apparaît sur sa ligne (et dans le panneau de mises à jour de la barre du haut). La mise à jour conserve tous vos réglages, appareils, liaisons d'équipements et historiques : seul le code du plugin change.
+
+Quand plusieurs plugins sont en retard, un bandeau au-dessus de la liste les met tous à jour d'un coup. Les paquets installés depuis une source personnelle y sont annoncés à part : chacun demande sa propre confirmation d'empreinte, vous les mettez donc à jour depuis leur ligne.
 
 ---
 

--- a/docs/user/plugins.md
+++ b/docs/user/plugins.md
@@ -10,12 +10,14 @@ Plugins are managed from **Administration > Plugins** (admin only).
 
 **Installed** lists what runs on your instance:
 
-- **Integrations** show their connection status and how many devices they feed. From here you can disable, re-enable, update, or uninstall each one.
+- **Integrations** show their connection status and how many devices they feed. Selecting one opens its details, where you can disable, re-enable, update or uninstall it.
 - **Recipes** are the automation templates available when you create recipe instances.
 
 **Store** lists what you can install. Entries come from the official Sowel catalogue, plus your own personal sources (see below). The **Refresh** button re-reads the catalogue immediately, useful right after a new plugin or version is announced.
 
 When a newer version of an installed plugin is available, an update badge appears on its row (and in the topbar updates sheet). Updating keeps all your settings, devices, equipment bindings and history: only the plugin code changes.
+
+When several plugins are behind, a banner above the list updates them all at once. Packages installed from a personal source are named apart in that banner: each one needs its own fingerprint confirmation, so you update those from their own row.
 
 ---
 


### PR DESCRIPTION
Follow-up to #805, which moved the per-plugin actions into a detail panel and added a bulk update banner. The user page still described the actions as living on the row.

Two paragraphs updated in both `docs/user/plugins.md` and `docs/user/plugins.fr.md`.

Refs #749