### PR TITLE
docs(energy): describe the arbitration roster as it now reads (#807)

### DIFF
--- a/docs/user/energy.fr.md
+++ b/docs/user/energy.fr.md
@@ -179,9 +179,22 @@ Allez dans **Réglages > Administration > Énergie**, activez l'**Arbitre de sur
 
 La page **Énergie > En direct** gagne un panneau d'arbitrage du surplus en trois parties :
 
-- un **tableau des charges**, une ligne par charge flexible : son état, l'**écart** qui manque encore avant qu'elle puisse démarrer, ce qu'elle tire actuellement, l'import réseau qu'elle tolère, et ce dont elle a **besoin**. Le besoin est rempli sur chaque ligne, pas seulement celles en attente : ce qu'il faut à une charge pour démarrer reste vrai qu'elle tourne, attende ou soit à l'arrêt ;
-- une **frise du jour** avec un couloir par charge pilotable — vert là où elle a tenu le surplus, un repère rouge (avec la raison au survol) là où elle s'est effacée ;
+- un **tableau** listant chaque charge pilotable dans votre ordre de priorité, avec son état et ses chiffres ;
+- une **frise** avec un couloir par charge pilotable : vert là où elle a tenu le surplus, un repère rouge (avec la raison au survol) là où elle s'est effacée ;
 - un **journal des décisions** en langage clair, pour que rien de ce que fait l'arbitre ne soit un mystère.
+
+Le tableau répond aux deux questions que vous vous posez vraiment devant lui : qui a le surplus, et qu'est-ce qui retient la suivante.
+
+| Colonne    | Ce qu'elle dit                                                                                                                                                                                                                                                                                                    |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Manque** | Ce qui manque encore à une charge en attente, en watts. Quand rien ne manque, elle le dit avec un mot plutôt qu'un chiffre : _couvert_ pour une charge qui a déjà le surplus, _non demandé_ pour une charge qu'aucune automatisation n'a réclamée, ou la raison qui la retient (temporisation, anti-cycle court). |
+| **Charge** | Ce que la charge consomme : mesuré quand elle tourne, sa puissance nominale au repos.                                                                                                                                                                                                                             |
+| **Tolère** | L'import réseau qu'elle accepte, tel que réglé dans sa gestion d'énergie.                                                                                                                                                                                                                                         |
+| **Besoin** | Le surplus qu'il faut pour la démarrer : **charge + marge d'engagement - tolérance**. La marge est rappelée sous le tableau, vous pouvez donc vérifier le calcul sur n'importe quelle ligne. Une charge qui tolère plus d'import qu'elle ne consomme n'a besoin d'aucun surplus et affiche 0 W.                   |
+
+Le numéro devant chaque nom est son rang dans votre liste de priorité. Sur un écran étroit, le tableau garde l'équipement, son état et le manque, et laisse tomber le reste.
+
+La nuit, l'arbitre se met en veille : il n'y a pas de surplus à distribuer, chaque charge est _au repos_, et le panneau indique la reprise.
 
 ### Vous avez toujours le dernier mot
 

--- a/docs/user/energy.md
+++ b/docs/user/energy.md
@@ -180,9 +180,22 @@ Go to **Settings > Administration > Energy**, enable **Surplus arbiter**, and or
 
 The **Energy > Live** page gains a surplus-arbitration panel with three parts:
 
-- a **roster**, one row per flexible load: its state, the **gap** still missing before it can start, what it currently draws, how much grid import it tolerates, and what it **needs**. The need is filled on every row, not only on waiting ones, because what a load takes to start is true whether it runs, waits or sits idle;
-- a **day timeline** with one lane per flexible load — green where it held the surplus, a red marker (with the reason on hover) where it was stepped back;
+- a **roster** listing every flexible load in your priority order, with its state and its figures;
+- a **timeline** with one lane per flexible load: green where it held the surplus, a red marker (with the reason on hover) where it was stepped back;
 - a **decision journal** in plain language, so nothing the arbiter does is a mystery.
+
+The roster answers the two questions you actually have in front of it: who has the surplus, and what is holding up the next one.
+
+| Column        | What it says                                                                                                                                                                                                                                                            |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Gap**       | What a waiting load is still short of, in watts. When nothing is missing it says so in words instead: _covered_ for a load that already has the surplus, _not requested_ for one no automation has asked for, or the reason it is held back (confirming, cooling down). |
+| **Load**      | What the load draws: measured while it runs, its rating while it rests.                                                                                                                                                                                                 |
+| **Tolerates** | The grid import it accepts, from its energy management settings.                                                                                                                                                                                                        |
+| **Need**      | The surplus it takes to start it: **load + engage margin - tolerated import**. The margin is stated under the table, so you can check the arithmetic on any row. A load tolerating more import than it draws needs no surplus at all and reads 0 W.                     |
+
+The number in front of each name is its rank in your priority list. On a narrow screen the table keeps the equipment, its state and the gap, and drops the rest.
+
+At night the arbiter goes dormant: there is no surplus to hand out, every load reads _at rest_, and the panel says when it resumes.
 
 ### You always win
 


### PR DESCRIPTION
The **Energy > Live** section of the user guide still described an *allocation bar* that spec 165 replaced with a roster table, and said nothing about the columns. #809 filled the need on every row and added the gap column, so the paragraph was both stale and silent on the two figures a reader is looking at.

What the section now covers:

- the three parts as they actually are: roster, timeline, journal;
- a table of the four columns, saying what each one means;
- the arithmetic behind the need, `load + engage margin - tolerated import`, and the fact that the margin is stated under the table so any row can be checked;
- the words the gap uses when nothing is missing, and why they are words rather than a dash;
- the 0 W case for a load tolerating more import than it draws;
- the priority rank in front of each name, what a narrow screen keeps, and the dormant night state.

English and French kept in step. No behaviour change, docs only.