### PR TITLE
fix(equipments): stop losing orders issued before an integration connects (#702)

### DIFF
--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -98,6 +98,8 @@ describe("EquipmentManager", () => {
   let events: EngineEvent[];
   let mockPublished: { topic: string; payload: string }[];
   let deviceManager: DeviceManager;
+  // Connection status the mock integration reports (test hook for #702).
+  let pluginStatus: "connected" | "disconnected";
   // Order keys whose dispatch should throw (test hook for failure paths).
   let failOrderKeys: Set<string>;
   // Order keys whose dispatch throws exactly once, then recovers (transient
@@ -109,12 +111,13 @@ describe("EquipmentManager", () => {
     eventBus = new EventBus(logger);
     zoneManager = new ZoneManager(db, eventBus, logger);
     mockPublished = [];
+    pluginStatus = "connected";
     failOrderKeys = new Set();
     failOnceOrderKeys = new Set();
     deviceManager = new DeviceManager(db, eventBus, logger);
     const mockPlugin = {
       id: "zigbee2mqtt",
-      getStatus: () => "connected" as const,
+      getStatus: () => pluginStatus,
       executeOrder: async (_device: any, orderKey: string, value: unknown) => {
         if (failOnceOrderKeys.delete(orderKey)) {
           throw new Error(`transient dispatch failure for ${orderKey}`);
@@ -1701,6 +1704,62 @@ describe("EquipmentManager", () => {
       expect(mockPublished[0].topic).toBe("z2m/SolarRelay/set");
 
       await expect(manager.executeOrder(eq.id, "state", true)).rejects.toThrow(/not found/i);
+    });
+  });
+
+  // ============================================================
+  // Issue #702 — an order that cannot reach the wire must be reported
+  // ============================================================
+
+  describe("order at a disconnected integration (#702)", () => {
+    function seedSwitch() {
+      const zone = zoneManager.create({ name: "Piscine" });
+      const eq = manager.create({ name: "Pompe Piscine", type: "switch", zoneId: zone.id });
+      const { orderIds } = seedDevice(db, {
+        name: "PompeDev",
+        orderKeys: [{ key: "state", type: "boolean", category: "power" }],
+      });
+      manager.addOrderBinding(eq.id, orderIds[0], "state");
+      return eq;
+    }
+
+    it("emits equipment.order.failed instead of dropping the order silently", async () => {
+      const eq = seedSwitch();
+      pluginStatus = "disconnected";
+      events.length = 0;
+
+      await expect(manager.executeOrder(eq.id, "state", false)).rejects.toThrow(/not connected/);
+
+      // The throw used to skip emitOrderOutcome entirely, so the order was
+      // neither executed nor failed and nothing downstream could see it.
+      const failed = events.filter((e) => e.type === "equipment.order.failed");
+      expect(failed).toHaveLength(1);
+      expect(failed[0]).toMatchObject({
+        equipmentId: eq.id,
+        orderAlias: "state",
+        value: false,
+      });
+      // Nothing reached the wire.
+      expect(mockPublished).toHaveLength(0);
+    });
+
+    it("still throws, so recipes and API callers keep today's contract", async () => {
+      const eq = seedSwitch();
+      pluginStatus = "disconnected";
+
+      await expect(manager.executeOrder(eq.id, "state", true)).rejects.toThrow(
+        "Integration zigbee2mqtt not connected",
+      );
+    });
+
+    it("emits order.executed as usual once the integration is connected", async () => {
+      const eq = seedSwitch();
+      events.length = 0;
+
+      await manager.executeOrder(eq.id, "state", true);
+
+      expect(events.filter((e) => e.type === "equipment.order.failed")).toHaveLength(0);
+      expect(events.filter((e) => e.type === "equipment.order.executed")).toHaveLength(1);
     });
   });
 });

--- a/src/equipments/equipment-manager.ts
+++ b/src/equipments/equipment-manager.ts
@@ -880,11 +880,32 @@ export class EquipmentManager {
     // Dispatch to every bound device order via its integration plugin.
     let successes = 0;
     let lastError: string | undefined;
-    for (const binding of bindings) {
-      const outcome = await this.dispatchToBinding(binding, resolvedValue, equipment, alias);
-      if (!outcome) continue; // device missing — binding skipped
-      if (outcome.error !== undefined) lastError = outcome.error;
-      if (outcome.dispatched) successes++;
+    try {
+      for (const binding of bindings) {
+        const outcome = await this.dispatchToBinding(binding, resolvedValue, equipment, alias);
+        if (!outcome) continue; // device missing — binding skipped
+        if (outcome.error !== undefined) lastError = outcome.error;
+        if (outcome.dispatched) successes++;
+      }
+    } catch (err) {
+      // Issue #702 — a missing or disconnected integration aborts the order
+      // from inside dispatchToBinding. Until now that throw skipped
+      // emitOrderOutcome entirely, so the order was neither `executed` nor
+      // `failed`: the order confirmation tracker (spec 141) never saw it, and
+      // the command was dropped with nothing but a log line. Emit the outcome
+      // first so the tracker can hold the order and replay it when the
+      // integration comes back, then rethrow — callers (recipes, modes, zone
+      // bulk, API) keep the exact contract they have today.
+      this.emitOrderOutcome({
+        equipment,
+        alias,
+        resolvedValue,
+        successes,
+        targets: bindings.length,
+        lastError: err instanceof Error ? err.message : String(err),
+        source,
+      });
+      throw err;
     }
 
     this.emitOrderOutcome({

--- a/src/equipments/order-confirmation-tracker.test.ts
+++ b/src/equipments/order-confirmation-tracker.test.ts
@@ -88,8 +88,14 @@ describe("OrderConfirmationTracker", () => {
   } as unknown as DeviceManager;
 
   let pollingIntervalMs: number | null = null;
+  let integrationStatus: "connected" | "disconnected" = "connected";
+  let noteUnreachableCalls: string[] = [];
   const integrationRegistry = {
+    noteUnreachable: (id: string) => {
+      noteUnreachableCalls.push(id);
+    },
     getById: () => ({
+      getStatus: () => integrationStatus,
       getPollingInfo: () =>
         pollingIntervalMs === null
           ? null
@@ -146,6 +152,8 @@ describe("OrderConfirmationTracker", () => {
     bindingValue = "OFF";
     executeOrderCalls = [];
     pollingIntervalMs = null;
+    integrationStatus = "connected";
+    noteUnreachableCalls = [];
     eventBus.on((event) => {
       emitted.push(event);
     });
@@ -382,5 +390,212 @@ describe("OrderConfirmationTracker", () => {
     vi.advanceTimersByTime(60_000);
 
     expect(alarmsRaised().length).toBe(0);
+  });
+
+  // ============================================================
+  // Issue #702 — orders that never reached the wire
+  // ============================================================
+
+  describe("orders lost to a disconnected integration (#702)", () => {
+    function emitOrderFailed(value: unknown, source?: unknown): void {
+      eventBus.emit({
+        type: "equipment.order.failed",
+        equipmentId: "eq-1",
+        orderAlias: "state",
+        value,
+        error: "Integration int-1 not connected",
+        ...(source !== undefined ? { source } : {}),
+      } as EngineEvent);
+    }
+
+    function emitIntegrationConnected(integrationId = "int-1"): void {
+      integrationStatus = "connected";
+      eventBus.emit({ type: "system.integration.connected", integrationId });
+    }
+
+    it("holds an order its integration could not carry, and replays it on connect", () => {
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON");
+
+      expect(executeOrderCalls).toHaveLength(0);
+
+      emitIntegrationConnected();
+
+      expect(executeOrderCalls).toEqual([{ equipmentId: "eq-1", alias: "state", value: "ON" }]);
+    });
+
+    it("heals a boot-window loss silently, with no alarm and no push", () => {
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON");
+
+      // The integration is back within the grace window, which is the ordinary
+      // restart. Alarming on the failure itself would push a failure and a
+      // recovery notification per held order on every reboot.
+      vi.advanceTimersByTime(5_000);
+      expect(alarmsRaised()).toHaveLength(0);
+      expect(unconfirmedEvents()).toHaveLength(0);
+
+      emitIntegrationConnected();
+      emitData("ON");
+      vi.advanceTimersByTime(120_000);
+
+      expect(executeOrderCalls).toHaveLength(1);
+      expect(alarmsRaised()).toHaveLength(0);
+    });
+
+    it("surfaces the loss once the integration stays away", () => {
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON");
+
+      vi.advanceTimersByTime(60_001);
+
+      expect(unconfirmedEvents()).toHaveLength(1);
+      expect(unconfirmedEvents()[0]).toMatchObject({ reason: "integration_disconnected" });
+      expect(alarmsRaised()).toHaveLength(1);
+    });
+
+    it("replays once only, however many times the integration reconnects", () => {
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON");
+
+      emitIntegrationConnected();
+      emitIntegrationConnected();
+      emitIntegrationConnected();
+
+      expect(executeOrderCalls).toHaveLength(1);
+    });
+
+    it("does not replay an order when a different integration connects", () => {
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON");
+
+      emitIntegrationConnected("some-other-integration");
+
+      expect(executeOrderCalls).toHaveLength(0);
+    });
+
+    it("does not replay a command whose window has passed", () => {
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON");
+
+      // A schedule-driven OFF replayed long after its slot would be worse than
+      // the command that was lost, so the replay window is short.
+      vi.advanceTimersByTime(300_001);
+      emitIntegrationConnected();
+
+      expect(executeOrderCalls).toHaveLength(0);
+      // The alarm stays raised: the order genuinely never landed.
+      expect(alarmsResolved()).toHaveLength(0);
+    });
+
+    it("applies the same short window to the device-online trigger", () => {
+      // Both triggers must agree on the window. The device path used to carry
+      // a one hour TTL, which silently overrode this one: an integration
+      // reconnect correctly declined the replay, and the device coming online
+      // a moment later did it anyway.
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON");
+
+      vi.advanceTimersByTime(300_001);
+      emitDeviceStatus("online");
+
+      expect(executeOrderCalls).toHaveLength(0);
+    });
+
+    it("still replays on device-online when the connect event was missed", () => {
+      // A plugin that drops and recovers between two status sweeps emits no
+      // connected event, so the device path is the remaining way out.
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON");
+
+      integrationStatus = "connected";
+      emitDeviceStatus("online");
+
+      expect(executeOrderCalls).toHaveLength(1);
+    });
+
+    it("releases a stateless order's inherited alarm instead of orphaning it", () => {
+      // An alarmed order superseded by one nothing can confirm: the entry is
+      // dropped after its replay, so the alarm has to be resolved here or it
+      // stands until the next restart.
+      emitOrder("ON");
+      vi.advanceTimersByTime(60_000);
+      expect(alarmsRaised()).toHaveLength(1);
+
+      (equipmentManager.getDataBindingsWithValues as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+        [],
+      );
+      integrationStatus = "disconnected";
+      emitOrderFailed("WAKE");
+
+      expect(alarmsResolved()).toHaveLength(1);
+    });
+
+    it("marks the integration unreachable so a flap still produces a transition", () => {
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON");
+
+      expect(noteUnreachableCalls).toEqual(["int-1"]);
+    });
+
+    it("resolves the alarm when the replayed order is finally observed", () => {
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON");
+      vi.advanceTimersByTime(60_001);
+      expect(alarmsRaised()).toHaveLength(1);
+
+      emitIntegrationConnected();
+      emitData("ON");
+
+      expect(alarmsResolved()).toHaveLength(1);
+    });
+
+    it("does not enrol its own replay when that fails again", () => {
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON");
+      emitIntegrationConnected();
+      expect(executeOrderCalls).toHaveLength(1);
+
+      // The replay lands while the integration has dropped again.
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON", { kind: "external", channel: RETRY_CHANNEL });
+      emitIntegrationConnected();
+
+      // Still one: a replay that fails must not start the cycle over.
+      expect(executeOrderCalls).toHaveLength(1);
+    });
+
+    it("ignores a failure raised by an integration that was connected", () => {
+      // A plugin that threw while reachable is a different problem, with no
+      // reconnect signal to hang a replay on.
+      integrationStatus = "connected";
+      emitOrderFailed("ON");
+
+      expect(unconfirmedEvents()).toHaveLength(0);
+      expect(alarmsRaised()).toHaveLength(0);
+    });
+
+    it("ignores an order the equipment already satisfies", () => {
+      bindingValue = "ON";
+      integrationStatus = "disconnected";
+      emitOrderFailed("ON");
+
+      expect(alarmsRaised()).toHaveLength(0);
+      expect(unconfirmedEvents()).toHaveLength(0);
+    });
+
+    it("replays a stateless order without raising an alarm nothing could resolve", () => {
+      (equipmentManager.getDataBindingsWithValues as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+        [],
+      );
+      integrationStatus = "disconnected";
+      emitOrderFailed("WAKE");
+
+      expect(alarmsRaised()).toHaveLength(0);
+
+      emitIntegrationConnected();
+
+      expect(executeOrderCalls).toEqual([{ equipmentId: "eq-1", alias: "state", value: "WAKE" }]);
+    });
   });
 });

--- a/src/equipments/order-confirmation-tracker.ts
+++ b/src/equipments/order-confirmation-tracker.ts
@@ -27,6 +27,23 @@ const CONFIRMATION_TIMEOUT_MS = 30_000;
 /** Maximum age of an unconfirmed order eligible for the reconnect re-dispatch. */
 const REDISPATCH_TTL_MS = 3_600_000;
 /**
+ * Maximum age of a never-dispatched order eligible for the replay that follows
+ * its integration reconnecting (issue #702). Much tighter than the device
+ * reconnect TTL above: this one exists for the boot window and for a short
+ * integration outage, and a schedule-driven command replayed long after its
+ * slot has passed would be worse than the command that was lost.
+ */
+const DISCONNECTED_REDISPATCH_TTL_MS = 300_000;
+/**
+ * Grace given to a held order before it is surfaced as unconfirmed. The
+ * integration is expected back within seconds (a boot, an MQTT reconnect), and
+ * the replay then resolves the whole thing silently. Alarming on the failure
+ * itself would push a failure and a recovery notification per held order on an
+ * ordinary restart. Same reasoning as STATUS_SETTLE_MS above: a signal read
+ * during the settling window is not yet evidence.
+ */
+const DISCONNECTED_ALARM_GRACE_MS = 60_000;
+/**
  * Settle window after start during which a device's persisted "offline" is not
  * evidence on its own. Statuses survive a restart in SQLite and integrations
  * restore the real one asynchronously — Zigbee2MQTT replays its retained
@@ -53,7 +70,27 @@ interface PendingOrder {
   retried: boolean;
   /** Every target device was believed offline when the order was dispatched. */
   offlineAtDispatch: boolean;
+  /**
+   * How old this order may get and still be replayed. Two triggers can replay
+   * it (a device coming online, its integration connecting) and they must agree
+   * on the window, or the tighter one is bypassed by the other.
+   */
+  redispatchTtlMs: number;
+  /**
+   * The order never reached the wire: its integration was missing or
+   * disconnected (issue #702). Such an order is replayed when that integration
+   * connects, not when a device comes back online.
+   */
+  neverDispatched: boolean;
+  /**
+   * Whether equipment state can ever confirm this order. False for stateless
+   * orders (scenes, a display wake) — they are still replayed when they were
+   * never dispatched, but they raise no alarm, because nothing could resolve it.
+   */
+  confirmable: boolean;
   deviceIds: string[];
+  /** Integrations behind the order bindings — the replay trigger for #702. */
+  integrationIds: string[];
   source?: OrderSource | undefined;
 }
 
@@ -131,6 +168,28 @@ export class OrderConfirmationTracker {
           this.logger.error({ err }, "Reconnect re-dispatch failed");
         }
       }),
+      // Issue #702 — an order whose integration was unreachable never reached
+      // the wire. It is held here and replayed once that integration connects.
+      this.eventBus.onType("equipment.order.failed", (event) => {
+        try {
+          this.handleOrderFailed(
+            event.equipmentId,
+            event.orderAlias,
+            event.value,
+            event.error,
+            event.source,
+          );
+        } catch (err) {
+          this.logger.error({ err }, "Failed order tracking failed");
+        }
+      }),
+      this.eventBus.onType("system.integration.connected", (event) => {
+        try {
+          this.handleIntegrationConnected(event.integrationId);
+        } catch (err) {
+          this.logger.error({ err }, "Integration reconnect re-dispatch failed");
+        }
+      }),
     );
     this.logger.info("Order confirmation tracker started");
   }
@@ -184,10 +243,7 @@ export class OrderConfirmationTracker {
       return;
     }
 
-    const deviceIds = this.equipmentManager
-      .getOrderBindingsWithDetails(equipmentId)
-      .filter((b) => b.alias === alias)
-      .map((b) => b.deviceId);
+    const { deviceIds, integrationIds } = this.targetsFor(equipmentId, alias);
 
     const entry: PendingOrder = {
       equipmentId,
@@ -200,7 +256,11 @@ export class OrderConfirmationTracker {
       alarmRaised: previous?.alarmRaised ?? false,
       retried: false,
       offlineAtDispatch: this.allTargetsOffline(deviceIds),
+      redispatchTtlMs: REDISPATCH_TTL_MS,
+      neverDispatched: false,
+      confirmable: true,
       deviceIds,
+      integrationIds,
       source,
     };
 
@@ -222,6 +282,30 @@ export class OrderConfirmationTracker {
     }
 
     this.armTimer(entry);
+  }
+
+  /**
+   * The devices behind an order alias, and the integrations that own them.
+   * The integrations are what #702 keys its replay on: at boot a device
+   * persisted as online never emits a status change, so the integration
+   * connecting is the only signal that the wire is live again.
+   */
+  private targetsFor(
+    equipmentId: string,
+    alias: string,
+  ): { deviceIds: string[]; integrationIds: string[] } {
+    const deviceIds = this.equipmentManager
+      .getOrderBindingsWithDetails(equipmentId)
+      .filter((b) => b.alias === alias)
+      .map((b) => b.deviceId);
+    const integrationIds = [
+      ...new Set(
+        deviceIds
+          .map((id) => this.deviceManager.getById(id)?.integrationId)
+          .filter((id): id is string => id !== undefined),
+      ),
+    ];
+    return { deviceIds, integrationIds };
   }
 
   /** Whether every device behind the order bindings is currently offline. */
@@ -272,7 +356,10 @@ export class OrderConfirmationTracker {
     }, entry.timeoutMs);
   }
 
-  private markUnconfirmed(entry: PendingOrder, reason: "timeout" | "device_offline"): void {
+  private markUnconfirmed(
+    entry: PendingOrder,
+    reason: "timeout" | "device_offline" | "integration_disconnected",
+  ): void {
     if (entry.timer) {
       clearTimeout(entry.timer);
       entry.timer = null;
@@ -300,12 +387,17 @@ export class OrderConfirmationTracker {
       ...(entry.source !== undefined ? { source: entry.source } : {}),
     });
 
-    if (!entry.alarmRaised) {
+    // A stateless order (a scene, a display wake) has nothing that could ever
+    // report the ordered value, so an alarm on it could never resolve. It is
+    // still tracked and replayed — it just stays out of the alarm surface.
+    if (!entry.alarmRaised && entry.confirmable) {
       entry.alarmRaised = true;
       const detail =
         reason === "device_offline"
           ? "device offline"
-          : `no state change within ${Math.round(entry.timeoutMs / 1000)}s`;
+          : reason === "integration_disconnected"
+            ? "integration unreachable"
+            : `no state change within ${Math.round(entry.timeoutMs / 1000)}s`;
       this.eventBus.emit({
         type: "system.alarm.raised",
         alarmId: this.alarmId(entry),
@@ -348,17 +440,162 @@ export class OrderConfirmationTracker {
     return `order-unconfirmed:${entry.equipmentId}:${entry.alias}`;
   }
 
+  // ── Undispatched orders (issue #702) ─────────────────────────
+
+  /**
+   * An order that failed before reaching the wire because its integration was
+   * missing or disconnected. Until #702 this threw out of `executeOrder`
+   * without emitting anything, so the command was dropped with only a log line
+   * behind it: the recipe's own state advanced as if it had acted, and nothing
+   * brought the device back in line until the next trigger.
+   *
+   * The order is held here and replayed once when that integration connects.
+   * Only the undispatched class is held: a failure raised by a plugin that was
+   * connected is a different problem with no reconnect signal to hang a replay
+   * on, and is left alone.
+   */
+  private handleOrderFailed(
+    equipmentId: string,
+    alias: string,
+    value: unknown,
+    error: string,
+    source?: OrderSource,
+  ): void {
+    // Our own replay failing again must not enrol the order a second time.
+    // The existing entry already carries retried=true, so the single-replay
+    // guarantee holds.
+    if (source?.kind === "external" && source.channel === RETRY_CHANNEL) return;
+
+    const { deviceIds, integrationIds } = this.targetsFor(equipmentId, alias);
+    const unreachable = integrationIds.filter(
+      (id) => this.integrationRegistry.getById(id)?.getStatus() !== "connected",
+    );
+    if (unreachable.length === 0) return;
+
+    const key = `${equipmentId}:${alias}`;
+    const previous = this.pending.get(key);
+    if (previous) {
+      if (previous.timer) clearTimeout(previous.timer);
+      this.pending.delete(key);
+    }
+
+    const bindings = this.equipmentManager.getDataBindingsWithValues(equipmentId);
+    const mirror = bindings.find((b) => b.alias === alias);
+    const confirmable = mirror !== undefined && isConfirmableValue(value, mirror.enumValues);
+
+    // Already in the ordered state: the command being lost changes nothing.
+    if (confirmable && mirror && valuesMatch(value, mirror.value)) {
+      if (previous?.alarmRaised) this.resolveAlarm(previous, "state finally confirmed");
+      return;
+    }
+
+    // A carried-over alarm needs something that can still resolve it. A
+    // stateless order cannot, so it is released here rather than left standing
+    // until the next restart — same rule the executed path applies to an
+    // exempt order superseding an alarmed one.
+    if (!confirmable && previous?.alarmRaised) {
+      this.resolveAlarm(previous, "superseded by an exempt order");
+    }
+
+    const entry: PendingOrder = {
+      equipmentId,
+      alias,
+      value,
+      orderedAt: Date.now(),
+      timer: null,
+      timeoutMs: this.confirmationTimeoutFor(deviceIds),
+      unconfirmed: false,
+      alarmRaised: confirmable ? (previous?.alarmRaised ?? false) : false,
+      retried: false,
+      offlineAtDispatch: false,
+      redispatchTtlMs: DISCONNECTED_REDISPATCH_TTL_MS,
+      neverDispatched: true,
+      confirmable,
+      deviceIds,
+      integrationIds,
+      source,
+    };
+    this.pending.set(key, entry);
+
+    this.logger.warn(
+      { equipmentId, alias, value, error, integrationIds: unreachable },
+      "Order could not be dispatched — holding it until the integration connects",
+    );
+
+    // Make sure the next status sweep sees a transition even if the plugin
+    // recovers between two samples: without this, a brief flap emits no
+    // connected event and the order would be held with nothing to release it.
+    for (const id of unreachable) this.integrationRegistry.noteUnreachable(id);
+
+    // No watchdog on the ordered value: nothing was sent, so there is no effect
+    // to wait for. What is timed instead is how long the order stays held —
+    // the alarm is for an integration that does not come back.
+    entry.timer = setTimeout(() => {
+      entry.timer = null;
+      this.markUnconfirmed(entry, "integration_disconnected");
+    }, DISCONNECTED_ALARM_GRACE_MS);
+  }
+
+  /**
+   * An integration is reachable again: replay every order that was lost
+   * because it was not. At boot this is the only usable signal — a device
+   * persisted as online never emits a status change when its integration
+   * finally connects, so `handleDeviceOnline` would never fire.
+   */
+  private handleIntegrationConnected(integrationId: string): void {
+    for (const [key, entry] of [...this.pending.entries()]) {
+      if (entry.retried || !entry.neverDispatched) continue;
+      if (!entry.integrationIds.includes(integrationId)) continue;
+      // Too old to be replayed safely. The entry is kept rather than dropped:
+      // if it raised an alarm, a later state report still has to resolve it.
+      if (Date.now() - entry.orderedAt > entry.redispatchTtlMs) continue;
+
+      entry.retried = true;
+      const name = this.equipmentManager.getById(entry.equipmentId)?.name ?? entry.equipmentId;
+      this.logger.warn(
+        {
+          equipmentId: entry.equipmentId,
+          equipmentName: name,
+          alias: entry.alias,
+          value: entry.value,
+          integrationId,
+        },
+        "Integration connected — re-dispatching the order it could not deliver",
+      );
+      void this.equipmentManager
+        .executeOrder(entry.equipmentId, entry.alias, entry.value, {
+          kind: "external",
+          channel: RETRY_CHANNEL,
+        })
+        .catch((err: unknown) => {
+          this.logger.error(
+            { err, equipmentId: entry.equipmentId, alias: entry.alias },
+            "Re-dispatch after integration connect failed",
+          );
+        });
+      // Nothing can ever confirm a stateless order, so it is released as soon
+      // as it has been replayed rather than lingering forever.
+      if (!entry.confirmable) {
+        if (entry.timer) clearTimeout(entry.timer);
+        this.pending.delete(key);
+      }
+    }
+  }
+
   // ── Reconnect re-dispatch ────────────────────────────────────
 
   private handleDeviceOnline(deviceId: string): void {
     for (const entry of this.pending.values()) {
       if (entry.retried) continue;
-      // Unconfirmed, or still inside its watchdog after being dispatched at a
-      // device believed offline: either way the command may never have landed,
-      // and this reconnect is the moment to re-assert it.
-      if (!entry.unconfirmed && !entry.offlineAtDispatch) continue;
+      // Unconfirmed, still inside its watchdog after being dispatched at a
+      // device believed offline, or never dispatched at all: either way the
+      // command may never have landed, and this reconnect is the moment to
+      // re-assert it. A held order is eligible here as well as on its
+      // integration connecting, because that event can be missed when a plugin
+      // drops and recovers between two status sweeps.
+      if (!entry.unconfirmed && !entry.offlineAtDispatch && !entry.neverDispatched) continue;
       if (!entry.deviceIds.includes(deviceId)) continue;
-      if (Date.now() - entry.orderedAt > REDISPATCH_TTL_MS) continue;
+      if (Date.now() - entry.orderedAt > entry.redispatchTtlMs) continue;
 
       entry.retried = true;
       const name = this.equipmentManager.getById(entry.equipmentId)?.name ?? entry.equipmentId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,16 @@ import { createShutdownController } from "./core/shutdown-controller.js";
 
 /** Half the shutdown budget, so the steps after stopAll() always get a share. */
 const INTEGRATION_STOP_TIMEOUT_MS = 4000;
+/**
+ * Issue #702 — how long recipe instances wait for the integrations they drive
+ * to report "connected" before starting anyway. Recipes used to go live while
+ * `startAll()` was still connecting, so their first orders were dispatched at
+ * integrations that could not carry them and were dropped. The wait is bounded
+ * so one unreachable cloud integration cannot hold every automation: whatever
+ * still slips through is caught by the order confirmation tracker, which
+ * replays it when the integration connects.
+ */
+const RECIPE_START_READINESS_TIMEOUT_MS = 30_000;
 import { CapacityArbiter } from "./energy/capacity-arbiter.js";
 import { ArbiterJournalStore } from "./energy/arbiter-journal-store.js";
 import { ArbiterSurplusStore } from "./energy/arbiter-surplus-store.js";
@@ -626,11 +636,9 @@ async function main() {
   // 17. Emit system started event (triggers zone aggregation compute)
   eventBus.emit({ type: "system.started" });
 
-  // 17. Initialize recipe manager (restore persisted instances — after aggregation is ready)
-  // Spec 124 — skip in shadow mode (no recipe should re-arm on a
-  // shadow). The runtime gate on startInstance is the second line
-  // of defence for runtime UI actions.
-  await runUnlessShadow("recipeManager.init()", () => recipeManager.init());
+  // 17. Recipe instances are NOT restored here. They start at the very end of
+  // boot, once the integrations they drive can actually carry an order — see
+  // "21. Restore recipe instances" below (issue #702).
 
   // 17b. Start pool runtime tracker (subscribes to equipment.data.changed)
   poolRuntimeTracker.start();
@@ -723,9 +731,22 @@ async function main() {
     logger.error({ err }, "Failed to start integrations");
   });
 
+  // 20b. Watch every plugin's connection status so the engine emits
+  // system.integration.{connected,disconnected} itself (issue #702). The event
+  // type existed and plugins were allowed to emit it, but nothing in core did,
+  // so nothing could depend on it. The order confirmation tracker now does.
+  integrationRegistry.startStatusWatch(eventBus);
+
   // Graceful shutdown — each step is isolated so one failure doesn't block the rest
+  let shuttingDown = false;
   const shutdown = async () => {
+    shuttingDown = true;
     logger.info("Shutting down...");
+    try {
+      integrationRegistry.stopStatusWatch();
+    } catch (err) {
+      logger.error({ err }, "Error stopping integration status watch");
+    }
     try {
       capacityArbiter.stop();
     } catch (err) {
@@ -897,6 +918,35 @@ async function main() {
   // controller owns the exit, so `shutdown` no longer calls process.exit
   // itself — that is what lets it be awaited to completion.
   shutdownController.setGraceful(shutdown, logger);
+
+  // 21. Restore recipe instances (spec 124 — never on a shadow).
+  //
+  // Last step of boot, and deliberately after the shutdown handler is wired:
+  // an instance evaluates as soon as it starts and dispatches orders straight
+  // away, so starting it before its integration is reachable guaranteed a lost
+  // command on every single restart (issue #702).
+  //
+  // The server has been listening since step 15 and the recipe packages were
+  // loaded at step 14b, so recipes stay listed and editable throughout. What
+  // does wait is running-instance state: a recipe action posted during this
+  // window is rejected with "Instance not running" until init() has run.
+  await runUnlessShadow("recipeManager.init()", async () => {
+    const { pending } = await integrationRegistry.waitForConnections(
+      RECIPE_START_READINESS_TIMEOUT_MS,
+    );
+    if (pending.length > 0) {
+      logger.warn(
+        { integrations: pending, timeoutMs: RECIPE_START_READINESS_TIMEOUT_MS },
+        "Starting recipes before every integration is connected — orders to these will be held and replayed",
+      );
+    }
+    // The wait is long enough that a shutdown can land inside it.
+    if (shuttingDown) {
+      logger.info("Shutdown started during the readiness wait — not restoring recipe instances");
+      return;
+    }
+    recipeManager.init();
+  });
 }
 
 main().catch((err) => {

--- a/src/integrations/integration-registry.test.ts
+++ b/src/integrations/integration-registry.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { IntegrationRegistry } from "./integration-registry.js";
 import type { IntegrationPlugin } from "./integration-registry.js";
+import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
+import type { EngineEvent, IntegrationStatus } from "../shared/types.js";
 
 const logger = createLogger("silent").logger;
 
@@ -52,6 +54,200 @@ describe("IntegrationRegistry", () => {
       await expect(registry.dispatchOrder("unknown", device, "state", "ON")).rejects.toThrow(
         /not found/i,
       );
+    });
+  });
+
+  // ============================================================
+  // Issue #702 — connection transitions and readiness
+  // ============================================================
+
+  describe("status watch", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    function setup(initial: IntegrationStatus) {
+      vi.useFakeTimers();
+      const registry = new IntegrationRegistry(logger);
+      const eventBus = new EventBus(logger);
+      const emitted: EngineEvent[] = [];
+      eventBus.on((e) => emitted.push(e));
+      let status = initial;
+      registry.register(createMockPlugin({ id: "z2m", getStatus: () => status }));
+      return {
+        registry,
+        eventBus,
+        emitted,
+        set: (s: IntegrationStatus) => {
+          status = s;
+        },
+      };
+    }
+
+    it("emits system.integration.connected when a plugin finishes connecting", () => {
+      const { registry, eventBus, emitted, set } = setup("disconnected");
+      registry.startStatusWatch(eventBus);
+
+      set("connected");
+      vi.advanceTimersByTime(2000);
+
+      expect(emitted).toEqual([{ type: "system.integration.connected", integrationId: "z2m" }]);
+      registry.stopStatusWatch();
+    });
+
+    it("does not report the status it found at boot as a transition", () => {
+      const { registry, eventBus, emitted } = setup("connected");
+      registry.startStatusWatch(eventBus);
+
+      vi.advanceTimersByTime(10_000);
+
+      expect(emitted).toHaveLength(0);
+      registry.stopStatusWatch();
+    });
+
+    it("emits disconnected when a connected plugin drops", () => {
+      const { registry, eventBus, emitted, set } = setup("connected");
+      registry.startStatusWatch(eventBus);
+
+      set("error");
+      vi.advanceTimersByTime(2000);
+
+      expect(emitted).toEqual([{ type: "system.integration.disconnected", integrationId: "z2m" }]);
+      registry.stopStatusWatch();
+    });
+
+    it("reports each transition once, not on every sweep", () => {
+      const { registry, eventBus, emitted, set } = setup("disconnected");
+      registry.startStatusWatch(eventBus);
+
+      set("connected");
+      vi.advanceTimersByTime(20_000);
+
+      expect(emitted).toHaveLength(1);
+      registry.stopStatusWatch();
+    });
+
+    it("survives a plugin whose getStatus throws", () => {
+      vi.useFakeTimers();
+      const registry = new IntegrationRegistry(logger);
+      const eventBus = new EventBus(logger);
+      registry.register(
+        createMockPlugin({
+          id: "broken",
+          getStatus: () => {
+            throw new Error("boom");
+          },
+        }),
+      );
+      registry.startStatusWatch(eventBus);
+
+      expect(() => vi.advanceTimersByTime(4000)).not.toThrow();
+      registry.stopStatusWatch();
+    });
+
+    it("reports recovery after a flap the sampler could not see", () => {
+      const { registry, eventBus, emitted, set } = setup("connected");
+      registry.startStatusWatch(eventBus);
+
+      // The plugin dropped and recovered between two samples. Both samples read
+      // "connected", so nothing would be emitted and an order held during the
+      // flap would never be released.
+      registry.noteUnreachable("z2m");
+      set("connected");
+      vi.advanceTimersByTime(2000);
+
+      expect(emitted).toEqual([{ type: "system.integration.connected", integrationId: "z2m" }]);
+      registry.stopStatusWatch();
+    });
+
+    it("ignores noteUnreachable for an integration it does not know", () => {
+      const { registry, eventBus, emitted } = setup("connected");
+      registry.startStatusWatch(eventBus);
+
+      expect(() => registry.noteUnreachable("ghost")).not.toThrow();
+      vi.advanceTimersByTime(4000);
+
+      expect(emitted).toHaveLength(0);
+      registry.stopStatusWatch();
+    });
+
+    it("stops sweeping once stopped", () => {
+      const { registry, eventBus, emitted, set } = setup("disconnected");
+      registry.startStatusWatch(eventBus);
+      registry.stopStatusWatch();
+
+      set("connected");
+      vi.advanceTimersByTime(10_000);
+
+      expect(emitted).toHaveLength(0);
+    });
+  });
+
+  describe("waitForConnections", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("resolves as soon as every configured integration is connected", async () => {
+      const registry = new IntegrationRegistry(logger);
+      registry.register(createMockPlugin({ id: "a", getStatus: () => "connected" }));
+      registry.register(createMockPlugin({ id: "b", getStatus: () => "connected" }));
+
+      await expect(registry.waitForConnections(5000)).resolves.toEqual({ pending: [] });
+    });
+
+    it("ignores integrations the user has not configured", async () => {
+      const registry = new IntegrationRegistry(logger);
+      registry.register(createMockPlugin({ id: "a", getStatus: () => "connected" }));
+      registry.register(
+        createMockPlugin({
+          id: "unused",
+          isConfigured: () => false,
+          getStatus: () => "not_configured",
+        }),
+      );
+
+      await expect(registry.waitForConnections(5000)).resolves.toEqual({ pending: [] });
+    });
+
+    it("does not wait on an integration that needs the user to finish setup", async () => {
+      const registry = new IntegrationRegistry(logger);
+      registry.register(createMockPlugin({ id: "a", getStatus: () => "connected" }));
+      // Configured, but reporting not_configured: an OAuth flow it cannot
+      // complete on its own. Waiting the full timeout on it delays every boot.
+      registry.register(
+        createMockPlugin({
+          id: "oauth",
+          isConfigured: () => true,
+          getStatus: () => "not_configured",
+        }),
+      );
+
+      await expect(registry.waitForConnections(5000)).resolves.toEqual({ pending: [] });
+    });
+
+    it("gives up after the timeout and names what is still missing", async () => {
+      const registry = new IntegrationRegistry(logger);
+      registry.register(createMockPlugin({ id: "a", getStatus: () => "connected" }));
+      registry.register(createMockPlugin({ id: "cloud", getStatus: () => "disconnected" }));
+
+      // One unreachable cloud integration must not hold the engine forever.
+      const result = await registry.waitForConnections(600);
+
+      expect(result).toEqual({ pending: ["cloud"] });
+    });
+
+    it("resolves once a slow integration catches up", async () => {
+      const registry = new IntegrationRegistry(logger);
+      let status: IntegrationStatus = "disconnected";
+      registry.register(createMockPlugin({ id: "slow", getStatus: () => status }));
+
+      const pending = registry.waitForConnections(5000);
+      setTimeout(() => {
+        status = "connected";
+      }, 300);
+
+      await expect(pending).resolves.toEqual({ pending: [] });
     });
   });
 });

--- a/src/integrations/integration-registry.ts
+++ b/src/integrations/integration-registry.ts
@@ -1,4 +1,5 @@
 import type { Logger } from "../core/logger.js";
+import type { EventBus } from "../core/event-bus.js";
 import type {
   IntegrationInfo,
   IntegrationStatus,
@@ -70,12 +71,145 @@ export interface IntegrationPlugin {
 // IntegrationRegistry
 // ============================================================
 
+/**
+ * Interval at which every plugin's connection status is sampled to derive
+ * `system.integration.{connected,disconnected}`. `getStatus()` is an in-memory
+ * read on every plugin, so sampling is cheap.
+ */
+const STATUS_POLL_MS = 2_000;
+
+/** Interval at which `waitForConnections` re-checks the configured plugins. */
+const READINESS_POLL_MS = 250;
+
 export class IntegrationRegistry {
   private plugins: Map<string, IntegrationPlugin> = new Map();
   private logger: Logger;
+  /** Last sampled status per plugin id — the baseline for transition detection. */
+  private lastStatus: Map<string, IntegrationStatus> = new Map();
+  private statusTimer: NodeJS.Timeout | null = null;
 
   constructor(logger: Logger) {
     this.logger = logger.child({ module: "integration-registry" });
+  }
+
+  /**
+   * Read a plugin's status without letting a throwing plugin break the sweep.
+   * `wrapPluginMethods` (spec 111) already degrades `getStatus` for loaded
+   * plugins; this covers everything else that reaches the registry.
+   */
+  private safeStatus(plugin: IntegrationPlugin): IntegrationStatus {
+    try {
+      return plugin.getStatus();
+    } catch {
+      // Deliberately silent: this runs on every sweep, and `wrapPluginMethods`
+      // (spec 111) already logs the throw once with the plugin's context. The
+      // transition to "error" is what gets reported, not each failed read.
+      return "error";
+    }
+  }
+
+  /**
+   * Issue #702 — derive connection transitions from the plugins themselves.
+   *
+   * `system.integration.connected` exists in the event union and plugins are
+   * allowed to emit it, but nothing in core ever did, so no consumer could rely
+   * on it. Sampling `getStatus()` here makes the signal dependable regardless
+   * of what a given plugin chooses to emit, which is what lets the order
+   * confirmation tracker replay an order that could not be dispatched.
+   *
+   * The first sweep only seeds the baseline: a status observed at boot is not a
+   * transition.
+   */
+  startStatusWatch(eventBus: EventBus): void {
+    if (this.statusTimer) return;
+    for (const plugin of this.plugins.values()) {
+      this.lastStatus.set(plugin.id, this.safeStatus(plugin));
+    }
+    this.statusTimer = setInterval(() => {
+      try {
+        this.sampleStatus(eventBus);
+      } catch (err) {
+        this.logger.error({ err }, "Integration status sweep failed");
+      }
+    }, STATUS_POLL_MS);
+    this.statusTimer.unref?.();
+  }
+
+  /**
+   * Record that an integration was found unreachable outside the sampling
+   * loop, so the next sweep reports its recovery as a transition.
+   *
+   * A plugin that drops and recovers between two samples looks unchanged to
+   * `sampleStatus`, and no `system.integration.connected` is emitted. That is
+   * invisible to most consumers but not to the order confirmation tracker: an
+   * order held during such a flap would never be released (issue #702).
+   */
+  noteUnreachable(integrationId: string): void {
+    if (!this.plugins.has(integrationId)) return;
+    if (this.lastStatus.get(integrationId) === "connected") {
+      this.lastStatus.set(integrationId, "disconnected");
+    }
+  }
+
+  stopStatusWatch(): void {
+    if (this.statusTimer) clearInterval(this.statusTimer);
+    this.statusTimer = null;
+    this.lastStatus.clear();
+  }
+
+  private sampleStatus(eventBus: EventBus): void {
+    for (const plugin of this.plugins.values()) {
+      const current = this.safeStatus(plugin);
+      const previous = this.lastStatus.get(plugin.id);
+      this.lastStatus.set(plugin.id, current);
+      // A plugin registered since the last sweep (runtime install) is seeded,
+      // not reported: we never saw what it transitioned from.
+      if (previous === undefined || previous === current) continue;
+      if (current === "connected") {
+        this.logger.info({ integrationId: plugin.id }, "Integration connected");
+        eventBus.emit({ type: "system.integration.connected", integrationId: plugin.id });
+      } else if (previous === "connected") {
+        this.logger.warn({ integrationId: plugin.id, status: current }, "Integration disconnected");
+        eventBus.emit({ type: "system.integration.disconnected", integrationId: plugin.id });
+      }
+    }
+    for (const id of [...this.lastStatus.keys()]) {
+      if (!this.plugins.has(id)) this.lastStatus.delete(id);
+    }
+  }
+
+  /**
+   * Issue #702 — resolve once every configured plugin reports "connected", or
+   * when `timeoutMs` elapses, whichever comes first. Returns the ids still not
+   * connected so the caller can say so.
+   *
+   * `start()` resolving does not mean a plugin is reachable: MQTT connects and
+   * cloud logins complete asynchronously afterwards. Polling the status the
+   * plugins actually report is the only honest readiness signal, and the
+   * timeout keeps one unreachable cloud integration from holding the engine.
+   */
+  async waitForConnections(timeoutMs: number): Promise<{ pending: string[] }> {
+    const deadline = Date.now() + timeoutMs;
+    // Snapshot once: isConfigured() reads settings, and re-reading them on
+    // every 250 ms iteration is thousands of prepared statements over the wait.
+    const watched = this.getAll().filter((p) => p.isConfigured());
+    for (;;) {
+      const pending = watched
+        .filter((p) => {
+          const status = this.safeStatus(p);
+          // "not_configured" from a plugin that claims to be configured means
+          // it is waiting on the user (an OAuth flow it cannot complete on its
+          // own). Waiting the full timeout on it would delay every boot.
+          return status !== "connected" && status !== "not_configured";
+        })
+        .map((p) => p.id);
+      if (pending.length === 0) return { pending };
+      if (Date.now() >= deadline) return { pending };
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, READINESS_POLL_MS);
+        t.unref?.();
+      });
+    }
   }
 
   register(plugin: IntegrationPlugin): void {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1353,7 +1353,9 @@ export type EngineEvent =
       equipmentId: string;
       orderAlias: string;
       value: unknown;
-      reason: "timeout" | "device_offline";
+      // "integration_disconnected" (issue #702): the order never reached the
+      // wire at all, the integration was unreachable when it was dispatched.
+      reason: "timeout" | "device_offline" | "integration_disconnected";
       source?: OrderSource;
     }
   | {


### PR DESCRIPTION
## Root cause

Recipe instances went live roughly 200 lines of boot before `integrationRegistry.startAll()` had connected anything, so their first orders were dispatched at integrations that could not carry them. Each one hit the guard in `EquipmentManager.dispatchToBinding`:

```ts
if (integration.getStatus() !== "connected")
  throw new EquipmentError(`Integration ${id} not connected`, 503);
```

That throw propagates out of `executeOrder` **before** `emitOrderOutcome()` runs, so neither `equipment.order.executed` nor `equipment.order.failed` was ever emitted. The spec 141 order confirmation tracker, which exists precisely to model "the order did not land", never saw these orders at all: no watchdog, no alarm, no reconnect replay. The command was dropped with a log line behind it while the recipe advanced its state as if it had acted.

Investigating showed the boot window is one symptom of a wider hole: the same throw fires on any mid-day disconnect (an MQTT drop, a cloud integration dropping out), with the same silent loss. A fix scoped to boot would have left that open.

## What changed

**Prevention.** `recipeManager.init()` moves from mid-boot to the end of `main()`, behind a bounded wait on the integrations reporting connected (30 s cap). This removes the guaranteed case, the one that fired on every single restart. Only running-instance state waits: the server has been listening since step 15 and the recipe packages were loaded at step 14b, so recipes stay listed and editable throughout. The cap means one unreachable cloud integration cannot hold every automation.

**Healing.** `executeOrder` now emits the order outcome before rethrowing, so the tracker sees the failure. An order whose target integration was unreachable is held and replayed exactly once when that integration connects, within a 5 minute window. The window is deliberately much tighter than spec 141's 1 hour device-reconnect TTL: a schedule-driven `OFF` replayed long after its slot has passed would be worse than the command that was lost. Callers still get the same throw they get today, so no installed recipe package changes behaviour.

**The missing signal.** The replay needs to know when an integration comes back, and no usable signal existed. `system.integration.connected` was in the event union and plugins were allowed to emit it, but nothing in core ever did, so no consumer could depend on it. `device.status_changed` does not cover the boot case either: a device persisted as online never emits a change when its integration finally connects. The registry now derives the transition by sampling plugin status every 2 s and emits both events itself.

**Noise control.** A held order stays silent for a 60 s grace period before being surfaced as unconfirmed. The integration is normally back within seconds and the replay resolves everything quietly. Alarming on the failure itself would have pushed a failure and a recovery notification per held order on an ordinary restart. This follows the module's existing `STATUS_SETTLE_MS` principle: a signal read during the settling window is not yet evidence.

## Review findings folded in

An independent review pass caught five real defects in the first draft, all fixed here:

- An inherited alarm was orphaned when a stateless order's entry was dropped after its replay, leaving a warning and its push standing until restart.
- The 5 minute replay window was not actually enforced: `handleDeviceOnline` still applied the 1 hour TTL to held orders, and since both triggers usually fire on a reconnect, the tight window was bypassed in the common case. The TTL is now per entry.
- The alarm fired with no grace, which is the noise control described above.
- A plugin dropping and recovering between two status samples emitted no transition, so an order held during the flap would never be released. `noteUnreachable` now forces the next sweep to see it, and the device-online path is a second way out.
- `waitForConnections` re-read settings every 250 ms and waited the full timeout on integrations blocked on user action (OAuth), delaying every boot.

## Behaviour change worth knowing

Recipes used to start before any integration data existed. They now start about 250 ms after a plugin reports connected, which is roughly when Zigbee2MQTT's retained state burst begins. A recipe that arms purely on an edge, rather than reading current state at start, could miss that first burst and wait one reporting interval after a restart. Reading initial state is strictly better than before (previously there was no data at all), and recipes are external packages, so this is documented rather than worked around.

## Tests

- `order-confirmation-tracker.test.ts` — held and replayed on connect, replayed once only, not replayed by another integration, both triggers honour the short window, device-online as fallback when the connect event was missed, silent healing inside the grace, surfacing after it, alarm resolution, no replay loop when the replay itself fails, stateless orders replayed without an unresolvable alarm, inherited alarm released rather than orphaned, `noteUnreachable` called.
- `equipment-manager.test.ts` — `equipment.order.failed` emitted instead of the order vanishing, the throw contract preserved, normal path unaffected.
- `integration-registry.test.ts` — transitions emitted once, boot status not reported as a transition, flap recovery, a throwing `getStatus` tolerated, watch stops cleanly, readiness resolves/times out/ignores unconfigured and user-blocked integrations.

16 of the new tests were verified to fail against the unpatched source. `npm run validate` is clean: 2097 backend tests, 786 UI tests, lint, typecheck, format.

Closes #702
