### PR TITLE
docs(technical): connection transitions, and what a new data point reaches

### DIFF
--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -200,13 +200,20 @@ Chaque plugin embarque un `manifest.json` avec `id`, `type` (`integration` ou `r
 ### Cycle de vie d'une intégration
 
 1. **Load** : `PluginLoader.loadAll()` parcourt la table `plugins`, importe chaque entrée activée, appelle `createPlugin(deps)`, enregistre dans `IntegrationRegistry`.
-2. **Start** : `IntegrationRegistry.startAll()` démarre les plugins séquentiellement avec de petits délais. Le `start()` de chaque plugin se connecte, découvre les devices, démarre le polling.
-3. **Runtime** : le plugin pousse les données via `deviceManager.updateDeviceData()`. Les ordres sortent via `plugin.executeOrder()`.
-4. **Stop** : `stop()` annule les timers, ferme les connexions.
-5. **Update** : Unload → `PackageManager.updateFiles()` → reload.
-6. **Uninstall** : Unload → `PackageManager.removeFiles()`.
+2. **Start** : `IntegrationRegistry.startAll()` démarre les plugins séquentiellement avec de petits délais. Le `start()` de chaque plugin se connecte, découvre les devices, démarre le polling. Le retour de `start()` ne signifie **pas** que le plugin est joignable : les connexions MQTT et les authentifications cloud se terminent ensuite, de façon asynchrone.
+3. **Connected** : le registre échantillonne le `getStatus()` de chaque plugin et émet `system.integration.connected` / `system.integration.disconnected` à chaque transition. C'est le signal du moteur lui-même, indépendant de ce qu'un plugin choisit d'émettre, et c'est lui qui rend observable le retour d'une intégration (voir [Livraison des ordres](#livraison-des-ordres-quand-une-integration-est-injoignable) ci-dessous).
+4. **Runtime** : le plugin pousse les données via `deviceManager.updateDeviceData()`. Les ordres sortent via `plugin.executeOrder()`.
+5. **Stop** : `stop()` annule les timers, ferme les connexions.
+6. **Update** : Unload → `PackageManager.updateFiles()` → reload.
+7. **Uninstall** : Unload → `PackageManager.removeFiles()`.
 
 Les réglages d'intégration sont stockés en SQLite dans `settings` sous `integration.<id>.<key>`, configurés depuis l'UI.
+
+#### Livraison des ordres quand une intégration est injoignable
+
+Un ordre envoyé vers une intégration déconnectée n'atteint jamais le fil. Plutôt que d'être jeté avec une ligne de log, il est retenu par le tracker de confirmation d'ordre (spec 141) et rejoué **une fois** quand cette intégration se connecte, dans une fenêtre courte : une commande planifiée rejouée longtemps après son créneau serait pire que celle qui a été perdue. L'appelant reçoit toujours la même erreur qu'avant.
+
+Les instances de recettes sont la raison pour laquelle cela se produisait à chaque redémarrage : elles démarrent tout à la fin du boot, derrière une attente bornée sur la connexion des intégrations, car une instance évalue et envoie des ordres dès son démarrage. L'attente est plafonnée pour qu'une intégration cloud injoignable ne bloque pas tous les automatismes, et ce qui passe malgré tout est rattrapé par la rétention décrite ci-dessus. L'API et la liste des recettes n'attendent pas ; seul l'état des instances en cours d'exécution attend.
 
 ### Écosystème actuel des plugins officiels
 

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -200,13 +200,20 @@ Each plugin ships a `manifest.json` with `id`, `type` (`integration` or `recipe`
 ### Integration lifecycle
 
 1. **Load** — `PluginLoader.loadAll()` scans the `plugins` table, imports each enabled entry, calls `createPlugin(deps)`, registers with `IntegrationRegistry`.
-2. **Start** — `IntegrationRegistry.startAll()` starts plugins sequentially with small delays. Each plugin's `start()` connects, discovers devices, begins polling.
-3. **Runtime** — Plugin pushes data via `deviceManager.updateDeviceData()`. Orders go out via `plugin.executeOrder()`.
-4. **Stop** — `stop()` cancels timers, closes connections.
-5. **Update** — Unload → `PackageManager.updateFiles()` → reload.
-6. **Uninstall** — Unload → `PackageManager.removeFiles()`.
+2. **Start** — `IntegrationRegistry.startAll()` starts plugins sequentially with small delays. Each plugin's `start()` connects, discovers devices, begins polling. `start()` returning does **not** mean the plugin is reachable: MQTT connects and cloud logins complete asynchronously afterwards.
+3. **Connected** — the registry samples every plugin's `getStatus()` and emits `system.integration.connected` / `system.integration.disconnected` on each transition. This is the engine's own signal, independent of what a plugin chooses to emit, and it is what makes an integration's recovery observable (see [Order delivery](#order-delivery-when-an-integration-is-unreachable) below).
+4. **Runtime** — Plugin pushes data via `deviceManager.updateDeviceData()`. Orders go out via `plugin.executeOrder()`.
+5. **Stop** — `stop()` cancels timers, closes connections.
+6. **Update** — Unload → `PackageManager.updateFiles()` → reload.
+7. **Uninstall** — Unload → `PackageManager.removeFiles()`.
 
 Settings for integrations are stored in SQLite `settings` under `integration.<id>.<key>`, configured from the UI.
+
+#### Order delivery when an integration is unreachable
+
+An order dispatched at a disconnected integration never reaches the wire. Rather than being dropped with a log line, it is held by the order confirmation tracker (spec 141) and re-dispatched **once** when that integration connects, within a short window: a schedule-driven command replayed long after its slot would be worse than the one that was lost. The caller still gets the same error it always did.
+
+Recipe instances are the reason this used to matter on every restart: they start at the very end of boot, behind a bounded wait on the integrations reporting connected, because an instance evaluates and dispatches as soon as it starts. The wait is capped so one unreachable cloud integration cannot hold every automation, and whatever still slips through is caught by the hold-and-replay above. The API and the recipe list do not wait; only running-instance state does.
 
 ### Current official plugin ecosystem
 

--- a/docs/technical/plugin-development.fr.md
+++ b/docs/technical/plugin-development.fr.md
@@ -190,6 +190,26 @@ Gère les devices découverts par votre plugin. Deux méthodes principales sont 
 
 Voir [Découverte de devices](#decouverte-de-devices) et [Mises à jour de données device](#mises-a-jour-de-donnees-device) pour l'usage détaillé.
 
+!!! warning "Une nouvelle donnée n'atteint pas toute seule les équipements existants"
+Ajouter une clé dans `DiscoveredDevice.data` crée bien la ligne `device_data`
+à la découverte suivante, mais la liaison automatique ne tourne qu'à la
+**création d'un équipement**. Tout équipement déjà lié à ce device conserve
+les liaisons qu'il avait : la nouvelle valeur est vivante côté device et
+invisible côté équipement.
+
+    C'est volontaire : reconstruire les liaisons automatiquement remettrait
+    celles que le propriétaire a supprimées exprès, et modifierait en silence la
+    forme d'un équipement qu'il a configuré à la main. Il récupère les nouvelles
+    valeurs depuis la section **Liaisons** de l'équipement, qui signale ce qui
+    manque et le propose sous forme de liste à cocher.
+
+    Ce que cela implique quand vous publiez une version de plugin qui ajoute des
+    données : signalez-le dans vos notes de version, et attendez-vous à ce que
+    les installations existantes aient un clic à faire par équipement. Renommer
+    une clé existante est pire qu'en ajouter une : la liaison de l'ancienne clé
+    continue de pointer vers une ligne que plus rien ne met à jour. Préférez
+    ajouter à côté et déprécier.
+
 ### `pluginDir`
 
 Chemin absolu vers le répertoire installé du plugin (par ex. `/app/plugins/weather-forecast`). Utilisez-le pour lire des fichiers locaux ou stocker des données spécifiques au plugin.

--- a/docs/technical/plugin-development.md
+++ b/docs/technical/plugin-development.md
@@ -191,6 +191,25 @@ Manage devices discovered by your plugin. Three main methods are used:
 
 See [Device Discovery](#device-discovery) and [Device Data Updates](#device-data-updates) for detailed usage.
 
+!!! warning "A new data point does not reach existing equipments on its own"
+Adding a key to `DiscoveredDevice.data` creates the `device_data` row at the
+next discovery, but auto-binding only ever runs when an **equipment is
+created**. Every equipment already bound to that device keeps the bindings
+it had, so the new value is live on the device and invisible on the
+equipment.
+
+    This is deliberate: rebuilding bindings automatically would put back the
+    ones the owner deleted on purpose, and would silently change the shape of an
+    equipment they configured by hand. The owner picks the new values up from
+    the equipment's **Bindings** section, which reports what is missing and
+    offers it as a checklist.
+
+    What this means when you publish a plugin release that adds data points: say
+    so in the release notes, and expect existing installations to need one
+    click per equipment. Renaming an existing key is worse than adding one — the
+    old key's binding keeps pointing at a row nothing updates any more, so
+    prefer adding alongside and deprecating.
+
 ---
 
 ## Device availability contract (spec 116)


### PR DESCRIPTION
Two documentation gaps left by #812 and #813.

## Integration lifecycle (`architecture.{md,fr.md}`)

The lifecycle read as if `start()` returning meant a reachable plugin. It does not: MQTT connects and cloud logins complete asynchronously afterwards, which is precisely what made #702 possible. Added the missing step: the registry samples every plugin's `getStatus()` and emits `system.integration.connected` / `.disconnected` on each transition.

Worth documenting as the engine's own signal, because it was not one before: the event types were in the union and plugins were allowed to emit them, but nothing in core ever did, so no consumer could depend on one.

A short subsection covers what now rests on it: an order dispatched at an unreachable integration is held and replayed once when it connects, and recipe instances start at the end of boot behind a bounded wait rather than into the void.

## New data points (`plugin-development.{md,fr.md}`)

The guide never told plugin authors that adding a key to `DiscoveredDevice.data` does not reach equipments already bound to that device. The row is created at discovery, but auto-binding only runs when an equipment is created, so the value is live on the device and invisible on the equipment. This is the omission #707 asked to fix.

Until #813 there was no good answer to give an author beyond "rebuild the bindings by hand and lose your aliases". There is one now, so the warning says why the behaviour is deliberate, where the owner picks the values up, and what to put in a plugin release note.

It also flags something the issue did not raise: renaming an existing key is worse than adding one, because the old key's binding keeps pointing at a row nothing updates any more. Prefer adding alongside and deprecating.

## Checks

`mkdocs build --strict` passes and both new cross-references resolve (the one anchor warning in the output is pre-existing, in `technical/data-model/recipes.md`). Prettier clean.