### PR TITLE
chore(registry): bump pool-pump-schedule to 1.8.2

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "tags": ["pool", "pump", "heating", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -340,7 +340,7 @@
     },
     "sowelVersion": ">=1.52.0",
     "owner": "mchacher",
-    "sha256": "f7495b1e5eab7b1fc95ded3f4af266a8c8421edeff4f7c8612a292ecd22b324d"
+    "sha256": "2edc6bdecc47e3bc48928377263aa55f3ce839d8b1bb467aa46d9c6aa5d49d1a"
   },
   {
     "id": "freecooling",


### PR DESCRIPTION
Publishes [pool-pump-schedule v1.8.2](https://github.com/mchacher/sowel-recipe-pool-pump-schedule/releases/tag/v1.8.2) to instances.

The recipe read the core's own delivery-retry replay as a manual order and latched a dérogation against itself. On the reference installation a network outage on 2026-08-29 revoked the pool pump for `meter-stale`, the equipment came back, the core replayed the undelivered order, and the recipe sat out the rest of the afternoon with 1.9 kW of surplus available and the filtration target at 6.6/11.4 h.

The arbiter already carries this exemption (`capacity-arbiter.ts`, `source.channel !== RETRY_CHANNEL`, #420); the recipe was the last reader of the order stream without it. Fix: mchacher/sowel-recipe-pool-pump-schedule#25, closing #24 there.

sha256 verified against the published asset:
```
2edc6bdecc47e3bc48928377263aa55f3ce839d8b1bb467aa46d9c6aa5d49d1a  sowel-recipe-pool-pump-schedule-1.8.2.tar.gz
```
Computed twice: `shasum -a 256` on the downloaded asset, and `scripts/backfill-registry-sha256.mjs` with the entry's sha cleared. Registry formatting restored afterwards, so the diff is the two intended lines.