### PR TITLE
feat(ci): documentation currency gates (spec 167)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+<!--
+Describe the root cause (for a fix) or the design (for a feature), and list the
+tests added. Reference the issue with `Closes #NNN` so the merge closes it.
+-->
+
+<!--
+DOCUMENTATION TRAILERS (spec 167)
+=================================
+
+Two CI checks read the lines below. Delete this block if neither applies.
+
+`Docs-Impact:` — needed when a `feat`/`fix` PR touches src/ or ui/src/ and
+updates no page under docs/. State why nothing a reader can observe changed.
+A bare "none" does not pass; the sentence is the point.
+
+  Docs-Impact: none — internal refactor of the retry loop, no documented
+  behaviour changes
+
+`Docs-Parity:` — needed when you change one side of an EN/FR page pair without
+the other. Name the untouched file and say why.
+
+  Docs-Parity: docs/technical/api-reference.fr.md — typo fix in the EN copy only
+
+Both run locally, before you push:
+
+  bash scripts/check-docs-impact.sh
+  bash scripts/check-docs-parity.sh
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,24 @@ jobs:
           fetch-depth: 0 # need main's history for the merge-base diff
       - name: Every new spec folder has spec.md + architecture.md + plan.md
         run: bash scripts/check-specs-complete.sh
+
+  docs-currency:
+    name: Documentation currency
+    runs-on: ubuntu-latest
+    # Spec 167 — the only documentation artefact with a gate (release notes,
+    # spec 108) is the only one that never drifted. These two generalise it to
+    # the rest of docs/, at the moment the author still has the context: in the
+    # PR, not at the tag where sixteen commits have to be reconstructed.
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # need main's history for the merge-base diff
+      - name: EN/FR pages move together
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: bash scripts/check-docs-parity.sh
+      - name: A feat/fix states its documentation impact
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: bash scripts/check-docs-impact.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,49 @@ The `verify-release-notes` job in `.github/workflows/release.yml` greps the tagg
 
 **Do NOT bypass this check** by editing the workflow or skipping the grep — it is the contract that keeps `docs.sowel.org/release-notes` aligned with what is actually shipped.
 
+### Documentation currency (spec 167 — MANDATORY for AI agents)
+
+Two CI checks run on every pull request. Both run locally, and running them before pushing is
+cheaper than reading a red check:
+
+```bash
+bash scripts/check-docs-parity.sh
+bash scripts/check-docs-impact.sh
+```
+
+**EN/FR parity.** Most pages under `docs/` exist as a pair, `x.md` and `x.fr.md`. Touch one and
+you must touch the other. If that is genuinely not wanted, name the untouched file and say why:
+
+```
+Docs-Parity: docs/technical/api-reference.fr.md — typo fix in the EN copy only
+```
+
+The check is silent when the counterpart does not exist, so creating a page in one language is
+allowed and translating it is a separate decision.
+
+**Documentation impact.** A `feat` or `fix` pull request that touches `src/` or `ui/src/` must
+either change something under `docs/`, or carry:
+
+```
+Docs-Impact: none — <why nothing a reader can observe changed>
+```
+
+**The reason is required.** A bare `Docs-Impact: none` fails on purpose: a checkbox gets ticked
+without thought, a sentence does not. `chore`, `refactor`, `test`, `docs`, `style`, `ci`,
+`build` and `perf` are not gated at all.
+
+The check also prints the pages your change probably affects, from the map in
+`scripts/docs-impact-map.sh`. That part never fails a build — it is there to turn "did you think
+about the docs" into "this page needs a look". When you find drift in an area the map misses,
+add a row; it is data, not logic.
+
+**Why this exists.** The 2026-08-29 audit (`docs/audit/2026-08-29-documentation.md`) found three
+months of drift, including a plugin guide teaching an `executeOrder` signature that migration
+004 removed. In the same repository, `docs/release-notes.md` and `.fr.md` carry 158 version
+anchors, identical in both files, with no divergence at all — because spec 108 fails the release
+workflow on a missing anchor. Same authors, same pace; the difference is the gate. Do not weaken
+these checks to get a pull request through: update the page, or write the sentence.
+
 ### Plugin soft isolation (spec 111)
 
 Every integration plugin runs with scoped Proxies on its `PluginDeps`. There is no opt-out: the isolation is unconditional since v1.11.0. The contract is enforced by `src/plugins/scoped-deps.ts`:

--- a/docs/audit/2026-08-29-documentation.md
+++ b/docs/audit/2026-08-29-documentation.md
@@ -1,0 +1,583 @@
+# Documentation audit — 2026-08-29 (state: v1.62.0)
+
+Full review of `docs/` against `src/`, `ui/src/`, `migrations/`, `plugins/registry.json`,
+`scripts/`, `.github/workflows/` and `git log`. Nothing was changed: this is the work list.
+
+**This file is the brief for the remediation work.** It is written to be picked up by a
+session that has no memory of the review, so every finding carries the doc location, the
+contradicting source location, and what the truth is.
+
+`docs/audit/` is in `mkdocs.yml`'s `exclude_docs`, so this page is not published.
+
+---
+
+## How to read the confidence markers
+
+| Marker  | Meaning                                                                                                                                              |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **[V]** | Verified by hand during the review session. Act on it directly.                                                                                      |
+| **[R]** | Reported by the review agent with a cited source line, not independently re-checked. Re-verify the specific claim before editing, it costs one grep. |
+| **[?]** | Flagged as suspicious but explicitly unconfirmed (usually a measurement). Needs a decision, not a grep.                                              |
+
+Do not skip re-verification on **[R]** items. The agent was accurate on everything spot-checked,
+but the whole point of this exercise is that confidently-wrong documentation is the expensive
+kind, and replacing one wrong statement with another wrong statement is the worst outcome.
+
+---
+
+## Ordering: do these in this order
+
+| #   | PR                                         | Size | Why here                                                |
+| --- | ------------------------------------------ | ---- | ------------------------------------------------------- |
+| 1   | Stop publishing the legacy tree            | XS   | Free, and stops serving wrong content immediately       |
+| 2   | Correct the plugin author contract         | L    | **Highest value.** Widest blast radius, outside readers |
+| 3   | Activity feed is persistent                | S    | Tiny, corrects a user-facing falsehood                  |
+| 4   | Resolve the French data model              | M    | Removes a phantom product                               |
+| 5   | Correct `architecture.md` against the code | M    |                                                         |
+| 6   | API + data-model reference                 | L    |                                                         |
+| 7   | User guide catches up with v1.53–v1.62     | L    | Splittable                                              |
+
+PRs 2, 5 and 6 touch disjoint files and can run in parallel. Screenshots are **not** in any
+PR: see the last section.
+
+---
+
+## PR 1 — `fix(docs): stop publishing the legacy tree` (XS)
+
+**[V]** `mkdocs.yml:68-70` `exclude_docs` lists only `audit/` and `planning/`. So
+`docs/_legacy/` (8 files), `docs/sowel-spec.md`, `docs/fixtures/` and `docs/mockups/` are
+built, indexed and in `sitemap.xml` under `https://docs.sowel.org/_legacy/…`.
+
+**[R]** Measured on the built site: 429 of 1981 search-index entries (22 %) come from
+`_legacy/` and `sowel-spec.md`. Someone searching "plugin development", "equipment types" or
+"data model" can land on the superseded page. Only `sowel-spec.md` carries a "LEGACY
+DOCUMENT" banner; none of the eight `_legacy/*.md` files does.
+
+Do:
+
+1. Add `_legacy/`, `mockups/`, `fixtures/` to `exclude_docs`.
+2. Add a `validation:` block promoting `links.anchors` and `links.not_found` to `warn`, so
+   `mkdocs build --strict` fails on them instead of printing INFO. **[V]** Today the build
+   passes with two broken anchors precisely because there is no `validation:` block.
+3. Fix the two known anchors:
+   - **[V]** `technical/deployment.md` → `architecture.md#timezone-handling`. The heading is
+     `## Timezone handling (spec 061)`, so the slug is `timezone-handling-spec-061`. Give the
+     heading an explicit `{ #timezone-handling }` rather than changing the link.
+   - **[V]** `technical/data-model/recipes.md` → `../data-model.md#3-plugin`. FR only: EN
+     section 3 is "Plugin", the FR monolith's section 3 is "Zone". PR 4 fixes this properly;
+     point at the EN hub in the meantime.
+
+**[R]** Independent check over the rendered HTML of all 89 pages found **exactly these two**
+link/anchor problems and no others. No missing images.
+
+---
+
+## PR 2 — `fix(docs): correct the plugin author contract` (L) ← do this one if only one gets done
+
+Single file: `docs/technical/plugin-development.md` (and `.fr.md` where the section exists).
+
+A plugin author who follows this guide end to end ships a plugin that installs, connects,
+discovers devices, and then **silently fails to actuate anything**. It is also the document
+most likely to be read by someone outside the project.
+
+### 2a. `executeOrder`'s signature is wrong in six places **[V]**
+
+```
+doc  (:354, :533, :638, :898, :908, :1247)
+  executeOrder(device: Device, dispatchConfig: Record<string, unknown>, value: unknown)
+
+code (src/integrations/integration-registry.ts:41, call site :269)
+  executeOrder(device: Device, orderKey: string, value: unknown)
+```
+
+Confirmed against a real shipped plugin: `sowel-plugin-smartthings/dist/index.js:444` is
+`async executeOrder(device, orderKey, value)`.
+
+The doc's worked example at `:913` does `const action = dispatchConfig.action as string` on a
+value that is now a plain string, falls to `default:`, and logs "Unknown order action".
+
+### 2b. `dispatchConfig` does not exist **[V]**
+
+`grep -rn dispatchConfig src ui/src` → **0 hits**. Same grep on the doc → **12 hits**.
+`migrations/004_drop_dispatch_config.sql:1` says verbatim: "Legacy columns dispatch_config,
+mqtt_set_topic, payload_key are no longer used."
+
+Remove it from the `DiscoveredDevice.orders[]` shape at `:804`, and delete the MQTT
+best-practice block at `:934` that is built on it (`topicSuffix`, "use `dispatchConfig.topic`
+as a fallback").
+
+### 2c. The field that actually routes orders is undocumented **[R]**
+
+`DiscoveredDevice.orders[].category` (`src/devices/device-manager.ts:64`, persisted `:297`/`:312`,
+column from `migrations/003_device_order_category.sql`) is absent from the shape at `:800-811`.
+`specs/110-category-first-binding-resolution/spec.md` states the contract: callers resolve
+bindings by category, alias is cosmetic.
+
+### 2d. The manifest table omits a required field **[R]**
+
+`:98-107` lists 8 fields then asserts at `:109`: "Fields that do NOT exist in the manifest:
+`entry`, `integrationId`, `license`, `repository`." But `src/shared/types.ts:1565` declares
+`repo: string` and `package-manager.ts:1179` throws `"Package manifest missing 'repo'"`. The
+near-miss with `repository` reads as confirmation that no repo field exists. Both full example
+manifests (`:75-93`, `:719-743`) omit it. `type` and `category` (spec 137) also missing.
+
+### 2e. The install flow does three things it does not do **[R]**
+
+`:1044`, `:1055-1064`, `:1074` claim Sowel falls back to the GitHub source tarball, runs
+`npm install --production`, and attempts `npx tsc`. In `src/packages/package-manager.ts` the
+only `execFile` in the whole file is `:1087` `execFile("tar", …)`. No npm, no tsc. `:1005-1009`
+**throws** when no `sowel-*.tar.gz` asset exists, there is no fallback. Combined with `:1031`'s
+instruction to exclude `node_modules/`, an author with runtime dependencies ships an artifact
+that fails at dynamic import.
+
+### 2f. Plugins are not imported from `dist/index.js` **[R]**
+
+`:35`, `:59`. `src/plugins/plugin-loader.ts:311-313` copies `dist/` to
+`plugins/<id>/.hot/<Date.now()>/` on **every** load and imports from there. A plugin resolving
+sibling files via `import.meta.url` lands in a directory that gets pruned. Explain why
+`deps.pluginDir` exists, and warn that `.hot/` appears inside the plugin's own directory.
+
+### 2g. Smaller corrections in the same file **[R]**
+
+- `:854-858`, `:488-492` — `updateDeviceData` has a 4th param `sourceTimestamp?`
+  (`scoped-deps.ts:189-198`).
+- `:779`, `:658`, `:302` — `source` documented as a free string "typically your plugin ID";
+  `device-manager.ts:181` takes `DeviceSource`, a closed 9-literal union. `:302` tells a
+  non-Zigbee plugin to claim `"zigbee2mqtt"`.
+- `:343-377`, `:523-540` — `IntegrationPlugin` omits `getOAuthUrl?` and `handleOAuthCallback?`
+  (`integration-registry.ts:60,67`), the methods that make the OAuth button appear.
+- `:843` — "Stale data/order entries … cleaned up automatically" is false;
+  `device-manager.ts:~266` deliberately keeps rows currently bound to an equipment.
+
+### 2h. Additions this file needs
+
+- **Spec 141 is not mentioned anywhere, and `getPollingInfo()` became safety-critical.** `:377`
+  still marks it optional and cosmetic. `src/equipments/order-confirmation-tracker.ts:339-341`
+  uses it to widen `CONFIRMATION_TIMEOUT_MS = 30_000` to `2 × intervalMs`. **A polling plugin
+  that omits it raises a system alarm and pushes a phone notification ~30 s after every order
+  it executes**, because the mirror binding cannot move before the next poll. Also: since spec
+  141, `executeOrder` can be re-invoked spontaneously on device reconnect
+  (`order-confirmation-tracker.ts:566,613`), so plugins must be idempotent. Undocumented.
+- **Spec 111 gaps** — the existing section `:259-334` is good and was verified accurate. What is
+  missing: `setMany` **throws** if any key in the batch is foreign (`scoped-deps.ts:75-86`) while
+  the table at `:180` lists it with no caveat; `getMqttConfig`/`getZ2mConfig` throw for every
+  plugin except the hard-coded id `"zigbee2mqtt"` (`:98-112`); `markRemoved` /
+  `removeStaleDevices` / `migrateIntegrationId` are ownership-gated (`:208-234`) and
+  `removeStaleDevices` is never introduced; `SLOW_CALL_MS = 1000` floods logs with "Slow plugin
+  call" (`:46,286`); `wrapPluginMethods` returns a **new 14-key literal** (`:305-334`),
+  discarding extra methods and class identity, which makes `:261`'s "bit-for-bit identical"
+  true for the interface and false for everything else. Omitting any of the six
+  unconditionally-bound methods kills load with an opaque `Cannot read properties of undefined
+(reading 'bind')` — belongs in Troubleshooting.
+- **Spec 089 gaps** — `:1119-1147` covers sha256, the registry loop, the backfill script and
+  `OFFICIAL_OWNERS`. Missing: `RegistryEntryInvalidError` (a _missing_ hash fails before
+  download, a different path from a mismatch); `SymlinkInTarballError`
+  (`registry-types.ts:123-133`); the `sowel-*.tar.gz` asset-name filter is **enforced**
+  (`package-manager.ts:1002-1004`), not a convention as `:1209` implies; the `sowelVersion`
+  compatibility gate (`package-manager.ts:215,232`); and
+  `CommunityPluginConfirmationRequiredError` — `:1145` frames the community tier as "a modal",
+  but the API path throws (`package-manager.ts:350-353`), which every non-`mchacher` author
+  hits on their first install.
+- **Spec 137 plugin categories** — zero author-facing documentation anywhere. Not in the
+  manifest table, the registry entry table (`:1105-1117`), or `recipe-development.md:31`.
+  `RECIPE_CATEGORIES` is a closed enum (`src/packages/registry-types.ts:19-26`);
+  `PluginManifest.category` (`types.ts:1568`) exists so personal-source recipes can
+  self-declare. All 16 registry recipes carry one. Without it an author lands in "Other" at the
+  bottom of the store, with no error to diagnose.
+- **Spec 150 inbound normalization** — the doc covers outbound `valueOn`/`valueOff` at `:815`
+  but never states what the core coerces on the way in. That is the exact question of an author
+  debugging `"ON"` vs `true`.
+
+---
+
+## PR 3 — `fix(docs): the activity feed is persistent since spec 147` (S)
+
+**[V]** `src/activity/activity-store.ts:16` `ACTIVITY_RETENTION_DAYS = 7`.
+`src/activity/activity-buffer.ts:62-70` reloads from SQLite on boot. Table is `activity_log`
+(`migrations/019_activity_arbiter_history.sql:8`). Retention is **7 days** and the feed
+**survives a restart**. Only the 2000-item cap is still correct.
+
+Three files say otherwise:
+
+- **[V]** `technical/architecture.md:570` "keeps the last **24 hours** … in a single in-memory
+  ring buffer"; `:585` "Buffer is lost on container restart, same as the logs ring buffer."
+- **[R]** `user/zones.md:136` "last 24 hours … in memory … reset when the container restarts."
+- **[R]** `technical/api-reference.md:475` "in-memory ring buffer (24h retention … reset on
+  restart)."
+
+A user told "reset on restart" will not think to look for yesterday's evidence. Small,
+self-contained, high value per line changed.
+
+---
+
+## PR 4 — `fix(docs): resolve the French data model` (M)
+
+**[V]** `docs/technical/data-model.fr.md` is not a stale translation, it documents a different
+product. The EN page was rewritten and split into five sub-pages on 2026-05-10 (`62160621`);
+the FR page is still the 2026-02-19 monolith (831 lines vs EN's 359).
+
+Phantom content confirmed:
+
+- **[V]** `:158-223` a whole `## 4. Equipment Group` section with a TS interface and a
+  `CREATE TABLE equipment_groups`. `grep -rn "equipment_group\|EquipmentGroup" src migrations`
+  → **0 hits** (the FR doc has 5).
+- **[R]** `:792-800` four `/api/v1/zones/:zoneId/groups` + `/api/v1/groups/:id` routes and
+  `:823` `POST /api/v1/groups/:id/orders/:orderKey`. No `/groups` path is registered anywhere.
+- **[R]** `:444-489` `## 9. Computed Data (V0.5)` and the `computed_data` / `internal_rules`
+  tables at `:572-780` — none exist.
+- **[R]** `:572-780` presents itself as the complete schema with 17 tables; the real schema has 46. Missing: `modes`, `plugins`, `plugin_sources`, `audit_log`, `activity_log`,
+  `dashboard_widgets`, `calendar_*`, `arbiter_*`, `pv_*`, `user_mfa_*`, `mqtt_*`,
+  `notification_*`.
+- **[R]** `:824-831` closes with a `## 14. Roadmap d'implémentation` mapping entities to
+  V0.1/V0.2/V0.3/V0.5.
+
+**Decision needed, and the recommendation is to delete.** `git rm docs/technical/data-model.fr.md`
+and let the i18n fallback serve the correct EN hub. Deleting is a net improvement on day one: it
+removes a phantom entity, a phantom table, six phantom routes and a V0.x roadmap, and it fixes
+the `#3-plugin` anchor from PR 1. Translating the five sub-pages can follow separately if wanted.
+
+Same PR: `docs/specs-index.fr.md` stops at spec **136**; specs 137–166 are missing. Either bring
+it current or replace it with a pointer to the EN index.
+
+---
+
+## PR 5 — `fix(docs): correct architecture.md against the code` (M)
+
+### Project structure tree **[R]**, verified partially **[V]** with `ls src/`
+
+| Line       | Claim                                                        | Truth                                                                                            |
+| ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `:128`     | `src/ai/` LLM integration                                    | does not exist                                                                                   |
+| `:130`     | `src/users/`                                                 | does not exist; it is `src/auth/user-manager.ts`                                                 |
+| `:143`     | root `recipes/` built-in JSON templates                      | does not exist; recipes are code packages                                                        |
+| `:115`     | `src/integrations/` "plugins (zigbee2mqtt, panasonic-cc, …)" | contains only `integration-registry.ts` + test. Contradicts `:155` "Nothing is built-in anymore" |
+| `:139-140` | UI `scenarios/` dir and a Scenarios page                     | neither exists; the real dir is `ui/src/components/recipes/`                                     |
+
+Missing from the tree: `src/packages/` (referenced by the same file at `:161`), `src/activity/`,
+`src/backup/`, `src/weather/`, `src/test-helpers/`.
+
+**[R]** `:49-50` elevates **Scenario** to a first-class domain concept. There is no `Scenario`
+type, route, page or component.
+
+**`CLAUDE.md` repeats several of these** and must be fixed in the same PR: `src/users/` at
+`:84`, "React 18" at `:56` (real: `^19.2.8`), and the design tokens below.
+
+### Facts that are wrong **[R]**
+
+| Line       | Claim                                                                 | Truth                                                                                                                                                                                                                                                             |
+| ---------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:546-552` | `scripts/release.sh` bumps versions, runs `npm run validate`, commits | `release.sh:12` says the opposite, `:57-62` asserts versions already match and exits 1 otherwise, `:84-85` only tags and pushes. No `validate` in the file                                                                                                        |
+| `:542`     | "Docker build is amd64-only"                                          | `release.yml:174` `docker-arm64` job, `:225` `platforms: linux/arm64`, `:236-241` `promote-manifest`. Dual-arch, and the doc even rationalises the reversed decision                                                                                              |
+| `:93`      | `equipment.data.changed \| equipmentId, key, value`                   | field is `alias` (`types.ts:1329`); WS dedup uses `event.alias` (`websocket.ts:193`)                                                                                                                                                                              |
+| `:95`      | `zone.data.changed \| zoneId, key, value`                             | `{ zoneId, aggregatedData }` (`types.ts:1321`); no per-key zone event exists                                                                                                                                                                                      |
+| `:102`     | `recipe.state_changed`                                                | no such member; it is `recipe.instance.state.changed` (`types.ts:1374`)                                                                                                                                                                                           |
+| `:686`     | `CORS_ORIGINS` default `*`                                            | `config.ts:114` default is `http://localhost:3000,http://localhost:5173`. **`:402` of the same file states it correctly** — self-contradiction. Also in `contributing.md:242`                                                                                     |
+| `:688`     | `INFLUX_TOKEN` auto-generated, persisted to `data/.influx-token`      | `config.ts:75-91` a hardcoded `DEFAULT_INFLUX_TOKEN` matching `docker-compose.yml:62`; the file is read if present, never written. (`JWT_SECRET` at `:682` _is_ generated — that row is fine)                                                                     |
+| `:38`      | PM2 as production process manager                                     | no `pm2` anywhere; `CMD ["node","dist/index.js"]` under `gosu`, Docker restart policy is the supervisor                                                                                                                                                           |
+| `:518`     | self-update helper uses `AutoRemove: true`                            | `update-manager.ts:416-419` `AutoRemove: false`, deliberately, so `docker logs sowel-updater` survives                                                                                                                                                            |
+| `:658`     | restart runs `docker compose up -d sowel`                             | `update-manager.ts:461` needs `--force-recreate`; the code comment at `:435-440` explains the doc's command silently no-ops                                                                                                                                       |
+| `:284`     | "InfluxDB is mandatory"                                               | `src/index.ts:336-345` catches and warns; the engine boots without it, only history/energy degrade                                                                                                                                                                |
+| `:203`     | `startAll()` starts plugins "sequentially with small delays"          | `integration-registry.ts:272-293` awaits back-to-back with no delay; the 10 s `STAGGER_MS` is a `pollOffset` passed to pollers                                                                                                                                    |
+| `:229`     | `netatmo-security \| mchacher/sowel-plugin-netatmo-security`          | not in `plugins/registry.json`; the camera integration is `netatmo_camera` owned by `alpitux`. The table lists 17 packages, the registry has 33 including third-party owners, so "official plugin ecosystem" no longer describes it. Regenerate from the registry |
+
+### Design system and stack **[R]**
+
+`:434-437` and `CLAUDE.md:254-255`: accent `#D4963F` hover `#BB8232`, primary hover `#13405A` /
+light `#E6F0F6`, radii 6/10/14. Real values: `design-system/tokens.css:13,16`
+(`--p-600:#144159`, `--p-50:#EEF5F8`, `--a-500:#F2C035`, `--a-600:#D4A41C`) and
+`ui/src/index.css:56-58` (`6px / 8px / 12px`). Only the primary base `#1A4F6E`, the fonts and
+the 28 px data size survive.
+
+`:26-30` "React 18+", Vite, Tailwind. Real (`ui/package.json`): React `^19.2.8`, Vite `^8.2.2`,
+Tailwind `^4.2.0` — **v4 means there is no `tailwind.config.js` at all**, which no doc mentions.
+
+### Fold in `contributing.md` **[R]**
+
+- `:141` "Roles: admin > standard > viewer" — `types.ts:1172` `UserRole = "admin" | "standard"`,
+  two roles.
+- `:143-147` an "Expression Engine" section describing `expr-eval` and
+  `OR/AND/NOT/AVG/MIN/MAX/SUM/IF/THRESHOLD`. No `src/expressions/`, `expr-eval` not in
+  `package.json`. It is an unbuilt design note sitting in "Coding Conventions" — delete it.
+- `:27` "`npm run dev` is ts-node + nodemon" → `tsx watch`.
+- `:63` `npm test -- --grep` is a Mocha flag; vitest uses `-t`.
+- `:119` cites `033_plugins.sql`; migrations stop at `028`.
+- Missing: `npm run validate` (the real gate) and the `.husky/pre-commit` gitleaks scan that
+  will block a first-time contributor's commit. Env table omits `SOWEL_SHADOW_MODE` (which
+  makes `loadPlugin` a no-op for every path, `plugin-loader.ts:258-264`, i.e. "why do no
+  plugins load"), `SOWEL_TAKEOVER` and `TZ`.
+- `:136-141` Authentication predates MFA (151), admin-only RBAC (131) and the audit log (113).
+
+### `deep-dives/surplus-arbiter.md` **[R]**
+
+`:26` "A load with no power measurement stays solid green: Sowel does not display what it does
+not know." Spec 166 (`345d46a1`, #746) added `claim.reportNeed()`: a never-measured load with
+`need = false` now renders `granted-idle`. `:54`'s feature-history line still reads "specs 140,
+148, 158" though the article already describes 164 and 165.
+
+---
+
+## PR 6 — `docs(api): bring the API and data-model reference current` (L)
+
+### Six documented routes return 404 **[R]** (`docs/technical/data-model.md`)
+
+| Line          | Documented                            | Real                                               |
+| ------------- | ------------------------------------- | -------------------------------------------------- |
+| `:338`        | `PUT /modes/:id/zones/:zoneId/impact` | `PUT /modes/:id/impacts/:zoneId`                   |
+| `:340`        | `POST /recipes/:recipeId/instances`   | `POST /recipe-instances`                           |
+| `:341`        | `GET /recipes/instances/:id`          | shape does not exist; `/recipe-instances/*`        |
+| `:345`,`:346` | `GET\|POST /button-actions`           | `GET\|POST /equipments/:id/action-bindings`        |
+| `:327`        | `DELETE /plugins/:id`                 | `POST /plugins/:id/uninstall` (`plugins.ts:322`)   |
+| `:328`        | `GET /history`                        | no bare route; `/history/:equipmentId/:alias` etc. |
+
+### Arbiter read model documents the deprecated half **[R]**
+
+`api-reference.md:325` documents `ArbiterPublicState` as
+`{ enabled, state, availableSurplusW, productionDetected, grants, pending, suspensions, journal, surplusSeries }`.
+`types.ts:950-1024` additionally has `loads: ArbiterLoadInfo[]`, `dormant`, `engageMarginW`,
+`idle`, `priority` — and `:983-993` marks `grants`/`pending`/`suspensions` `@deprecated …
+superseded by loads`. The `ArbiterLoadState` union
+(`granted | granted-idle | pending | unmanaged | suspended | idle`, `types.ts:900`) appears in
+no doc at all.
+
+### Missing event union members **[R]**
+
+`data-model.md:206-286` omits 8: `equipment.status.changed` (`types.ts:1362`),
+`equipment.order.unconfirmed` (`:1352`, spec 141), `activity.added` (`:1440`),
+`energy.capacity.granted|revoked|denied|released` (`:1443-1462`), `energy.arbiter.status`
+(`:1464`).
+
+### Enum and schema drift **[R]**
+
+- `data-model/equipments.md:14-39` — `EquipmentType` missing `solar_panel`, `display`, `camera`
+  (`types.ts:297,305,307`). `api-reference.md:185` documents `camera`, so the two pages
+  contradict each other.
+- `data-model/devices.md:94-154` — `DataCategory` missing `temperature_device`, `solar_state`,
+  five `camera_*`, three `ups_*`, the spec-120 display categories. `OrderCategory` missing
+  `solar_toggle`, three camera orders, three display orders.
+- `data-model/equipments.md:41-52,86-97` — missing `requireConfirmation` (`migrations/018`),
+  `invertDirection` (`migrations/024`), `solarProfile` (`migrations/026`).
+- `data-model/equipments.md:159-166` — `data_bindings` missing `category_override`
+  (`migrations/023`).
+- `data-model/devices.md:182-194` — `device_data` missing `value_on` / `value_off`
+  (`migrations/028`, the newest migration).
+- `data-model/recipes.md:18` — slot `type` union missing `"select"`, plus `options` and
+  `hiddenWhen` (`types.ts:507-527`).
+- `api-reference.md:467` — button effect types missing `zone_order` (`types.ts:1132`);
+  `data-model/modes.md:80` lists it, so the two disagree.
+- `api-reference.md:153` — `PUT /equipments/:id` body omits `energyProfile`,
+  `requireConfirmation`, `invertDirection`, `solarProfile` (`equipments.ts:216-229`) — the only
+  way to configure arbitration, shutter inversion and PV forecast.
+- `api-reference.md:566` — WS topic list missing `energy` (`websocket.ts:80,92`); no mention
+  that `mqtt-publishers` and `logs` are silently dropped for non-admins (`websocket.ts:104`).
+- `api-reference.md:593` — "Each push is a single event (not batched)" for `activity` is false;
+  it goes through the 200 ms batch flush (`websocket.ts:250-257`). Only `log.entry` is sent
+  individually (`:271`).
+- `api-reference.md:140` — `GET /devices/suggest` "suggest compatible devices for an equipment
+  type": `devices.ts:74-119` has a single `if (eqType === "gate")` branch, every other type
+  returns `[]`.
+- `api-reference.md:150` — `?type=energy_meter` is not a plain type filter
+  (`equipments.ts:142-160` takes a submeter-eligibility branch); the undocumented `?role=submeter`
+  shares it.
+- `data-model.md:190` — "Notification Publishers → Telegram/**webhook**"; `channelType` is
+  `telegram | web-push`.
+- `data-model/equipments.md:283-288` — "Current providers in the codebase" lists 4; there are 7
+  (`WeatherTempExtremesTracker`, `VmcSpeedTracker`, `PvForecaster`, `WeatherAggregator`).
+
+### A promise the schema forbids **[R]**
+
+`data-model/equipments.md:198-206`: "An Equipment can have multiple OrderBindings sharing the
+same alias but pointing to different Devices." `migrations/001_initial.sql:91` still declares
+`UNIQUE(equipment_id, alias)` and no later migration relaxes it. The manager loops over N rows
+(`equipment-manager.ts:848-890`) so the capability exists in code but is unreachable through the
+DB. The page flags this in an **HTML comment** at `:208`, invisible in the rendered page where
+only the false claim shows.
+
+### Undocumented route surface **[R]**
+
+All of `/api/v1/system/*` (8 routes), `GET /api/v1/audit`, `/backup/local` +
+`/backup/restore-local`, `GET /energy/arbiter/timeline` (spec 148), the four PV endpoints
+(160/161/162), and `/plugins/:id/oauth/url|callback`.
+
+### `recipe-development.md` **[R]**
+
+- `:215-222` points authors at `equipmentManager.executeOrder`, but
+  `src/recipes/engine/recipe.ts:27-35` says: "Prefer this over `equipmentManager.executeOrder`
+  to populate the Activity feed". No `dispatchOrder` row, no `logger` row, and no mention of the
+  `{ success, error }` return that is a recipe's only way to learn an order failed.
+- Recipe actions (`RecipeActionDef` / `onAction`, `types.ts:556-561,591,603`), the mode-impact
+  hook, are absent end to end.
+- `:90` slot union missing `"text" | "data-key" | "select"`, while the same page's table at
+  `:151` documents a `select` row and `:153` a paragraph on it.
+- `:166` uses `override readonly i18n: … = {` — class-member syntax inside an object-literal
+  `createRecipe()`. A syntax error as written.
+
+### `docs/specs-index.md` **[R]**
+
+Missing 34 rows: `063-066, 075-080, 089, 094-102, 104, 106-110, 146, 147, 148, 149, 151, 152,
+154, 155`. Several are cited by number elsewhere (`architecture.md:184` "specs 089 + 136",
+`:568` "spec 101", `api-reference.md:381` "spec 089") so the index's own promise fails.
+Separately it still marks specs **139–166 as "Unreleased"** although they shipped through
+v1.62.0.
+
+### `dependency-management.md` **[R]**
+
+`:43-47` "Linters, formatters and the TypeScript compiler ship as individual PRs".
+`.github/dependabot.yml:50` (`backend-toolchain`) and `:84` (`ui-toolchain`) group them. The
+doc's list at `:40-41` names three groups; there are five. `:184-187` reasons about
+`better-sqlite3 11.10.0` prebuilds and Node 23 ABI; `package.json` is on `^13.0.3` and
+`.nvmrc`/`Dockerfile` on Node 24.
+
+---
+
+## PR 7 — `docs(user): cover what shipped in v1.53–v1.62` (L, splittable)
+
+The systematic asymmetry: recent equipment and safety features land in
+`data-model/equipments.md` and never reach `user/equipments.md`. The technical layer is
+maintained, the user layer is not.
+
+Ordered by how likely someone is to be stuck.
+
+1. **Shutter and gate invert direction (specs 154, 155) — zero hits in the whole docs tree**
+   **[R]** (`grep -rni "invert" docs/` returns only "inverter"). This is the fix for "my awning
+   commands are backwards" (#614) and "my garage relay triggers on OFF" (#627).
+   `user/equipments.md:57-64` still asserts the fixed convention ("RF-up = retract = position
+   0") as unchangeable, and `:78-87` tells gate owners to "configure the pulse behavior on the
+   device itself" — exactly the advice spec 155 replaced. A user with reversed hardware
+   concludes Sowel cannot drive their motor.
+2. **PV production forecast (160), backfill (161), new Production page (163)** — no user
+   documentation. Only coverage is one sentence in `deep-dives/pv-health.md:27`, i.e. the
+   feature is documented as a prerequisite of another feature. No mention of the
+   `weather-forecast` ≥ 2.3.0 requirement, the 45-day window, or why "Relearn from my history"
+   is manual.
+3. **`user/energy.md` describes a Production page that was replaced.** `:86-90` lists the
+   sidebar and `:140-152` describes Production as a two-colour history chart with a totals row.
+   Spec 163 (#721) made it the PV monitoring home (`ProductionPage.tsx` renders the
+   forecast/accuracy and health panels). The page was last touched 2026-08-20, before that
+   shipped. **`deep-dives/energy-tour.md:30-36` describes the new page correctly, so the "In
+   Depth" article is more accurate than the User Guide — backwards.**
+4. **UPS (156) and VMC (153) absent from the user equipment catalogue** while
+   `user/equipments.md:47` bills it as "closed … Every equipment in your home is one of these".
+   Both are fully documented technically, so this is user-guide-only. Spec 157's rebuilt
+   three-card UPS panel is undocumented everywhere.
+5. **Order delivery confirmation (141), user side** — zero hits. The alarm and push a user
+   receives when an order's effect is not observed has nowhere to be looked up.
+6. **Low battery alerts (143)**, **gate action confirmation (146)**, **spec 166's need/gap
+   columns** (#809, the newest user-visible change; `user/energy.md:181` still lists three
+   parts), **weather multi-model confidence (159)** (the pill is on screen, unexplained),
+   **RBAC roles (131)** (zero hits while `getting-started.md:82` invites you to add users).
+7. `user/index.md` + `.fr.md` "Guide sections" grid lists 8 of the 11 pages: **Devices**,
+   **Recipes** and **Plugins** are missing though all three are in the nav.
+   `technical/index.md:29-35` likewise omits **Dependency Management**.
+8. `user/recipes.md` missing 6 recipes (Schedule On/Off, Smart Cooling, VMC Humidity, Water
+   Heater on Solar, Runtime Guard, Presence Display).
+9. **`user/modes.md` duplicate heading** `### Calendar scheduling` (`:85`) and
+   `## Calendar scheduling` (`:89`) → `#calendar-scheduling` and `#calendar-scheduling_1`. Any
+   external link to the section is a coin flip.
+10. **`user/remote-access.md` is a developer page in the user guide**, and the oldest page in
+    the tree (2026-03-22). `:144-157` tells the reader to `cd ui && npm run build && cp -r dist
+../ui-dist`; for the documented Docker deployment `ui-dist/` is baked into the image
+    (`Dockerfile:55`) and the command does nothing. `:161-165` presents `localhost:5173` as a
+    normal usage mode. `:167-175` recommends Cloudflare Access "for an additional layer of
+    authentication" without mentioning Sowel has shipped TOTP MFA since v1.51.0.
+11. **`deep-dives/pv-health.md`** never mentions the reference build-up state added by
+    `297c44b1` (v1.58.1).
+
+---
+
+## EN/FR divergence (fold into the PRs above)
+
+All gaps are EN-only; there are no FR-only pages.
+
+**Untranslated pages** (the FR site silently serves English via i18n fallback):
+
+| Page                                                                        | Verdict                                                                                                                                                                                |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `user/devices.md` (133 l.), `user/recipes.md` (129 l.)                      | Oversight. Every other `user/` page has a `.fr.md`, and `nav_translations` already maps `Recipes: Recettes`, so the FR nav promises a French page and serves English                   |
+| `technical/data-model/{devices,equipments,zones,modes,recipes}.md` (930 l.) | Oversight. The 2026-05-10 split never reached French. `equipments.md` carries the UPS section, so **UPS is documented nowhere in French**                                              |
+| `technical/dependency-management.md` (241 l.)                               | Plausibly deliberate: the only nav entry with no `nav_translations` mapping. But `contributing.fr.md` lacks the link line `contributing.md:83` has, so a French reader hits a dead end |
+
+**Diverged pairs, worst first** **[R]**:
+
+1. `data-model.md` ↔ `.fr.md` — two different products. See PR 4.
+2. `api-reference.md` ↔ `.fr.md` (622/43 vs 514/38) — five surfaces absent in FR: MFA (`:56`),
+   Roles & authorization (`:78`), Equipment status spec 116 (`:157`), Camera media proxy
+   (`:183`), Web Push (`:447`). FR has zero hits for `mfa|totp|viewer`, and its `## Energy` has
+   no claims endpoints.
+3. `recipe-development.md` ↔ `.fr.md` — the entire capacity-claim helper is absent. EN
+   `:261-322` documents `energy` / `claimCapacity`; FR has **no occurrence** of `energy`,
+   `claim`, `surplus`, `arbiter` or `arbitre`. A French recipe author cannot discover the API.
+4. `architecture.md` ↔ `.fr.md` — EN-only: `## Energy Capacity Arbiter (spec 140)` +
+   `### Daily metrics (spec 158)` (~62 lines) and four auth subsections. Worse, FR is
+   _behaviourally_ stale: it says the auth middleware "tente d'abord le décodage JWT, puis le
+   lookup de token d'API" where EN correctly describes the spec-105 auth-by-default `onRequest`
+   hook and `PUBLIC_ROUTES`.
+5. `specs-index.fr.md` — highest row 136; ~30 specs and 15 releases behind.
+6. `plugin-development.md` ↔ `.fr.md` — EN-only `## Device availability contract (spec 116)`
+   (`:215-258`) and `#### Security: SHA256 integrity & community plugins (spec 089)` (`:1119`).
+7. `deployment.md` ↔ `.fr.md` — EN-only `### Container user (spec 105)` (`:80-84`): the non-root
+   `sowel` uid 1000, the `gosu` drop, and the volume-ownership consequence of overriding
+   `user:`. This bites a French operator doing a manual upgrade.
+8. `user/equipments.md` ↔ `.fr.md` — EN `:163-170` documents the metering plug; FR `:251` says
+   only "Simple interrupteur on/off ou prise connectée". Structurally FR is _richer_ elsewhere
+   (per-type `####` headings vs EN tables) — style divergence, not an error.
+9. `user/energy.md` ↔ `.fr.md` — EN `:166` documents the per-equipment **Shutdown delay (min)**
+   arbiter field; FR's list has no délai d'arrêt.
+
+**In sync, verified:** `release-notes.md` / `.fr.md` — 158 version anchors, identical in both,
+`v1-0-0` through `v1-62-0`, no diff. The `verify-release-notes` CI gate is doing its job. Also
+in sync: all three `deep-dives/*`, `user/host-setup`, `user/plugins`, `user/dashboard`,
+`user/getting-started`, `user/index`, `user/modes`, `user/remote-access`, `user/zones`,
+`technical/index`, `technical/contributing`, both `index.md`.
+
+---
+
+## Screenshots — a separate session, not a PR
+
+Needs a seeded local instance and the fixture pipeline
+(see the `sowel-docs` skill and `reference_screenshot_workflow` in memory: anonymized FR/EN via
+`build-fixtures.py`, shot on a **local** docker instance, never prod).
+
+- **Definitively stale** (May 15–16, ~25 UI commits since): all 12 `energy-*.png`, all 18
+  `getting-started-*.png`, plus `activity-*`, `calendar-*`, `dashboard-*`, `devices-*`,
+  `equipments-*`, `modes-*`. Worst is `energy-production-day-{en,fr}.png` — it shows the page
+  spec 163 replaced. `energy-live-*.png` predates spec 132's three-phase breakdown and the whole
+  arbiter surface rebuild.
+- **Nearly current but already behind:** `arbiter-live-*.png`, `arbiter-settings-*.png`,
+  `arbiter-energy-profile-*.png` predate `074bbb11` (#809, 2026-08-29) which added the need and
+  gap columns to the exact table they show.
+- **Freshest:** `pv-*.png`, `energy-tour-*.png`.
+- **`user/plugins.md` has no screenshots at all** — the page was rewritten 2026-08-29 for the
+  v1.62.0 list rebuild, so this is a gap rather than a stale image.
+- **Ten orphan images** on disk from 2026-03-23, referenced by nothing:
+  `manual-equipments-{diagram,full,hero,ui-preview}.png`, `manual-sidebar.png`,
+  `sidebar-{admin-expanded,autocollapse,current,maison-expanded,modes-expanded}.png`.
+
+---
+
+## Areas checked and found accurate
+
+Recorded so no effort is spent re-reviewing them: the SQLite section; the whole InfluxDB
+pipeline (bucket names, retentions, task names, flux ranges); the Energy Capacity Arbiter and
+spec-158 metrics sections of `architecture.md`; the auth / MFA / WebSocket-auth /
+security-headers sections; trust tiers and personal sources (spec 136, the strongest section in
+the repo); Backup & Restore; Logging; Timezone; self-update detection; the spec-116 availability
+contract; the documented half of the spec-111 isolation section; `api-reference.md`'s Roles &
+authorization allowlist (matches `STANDARD_WRITE_ALLOWLIST` entry for entry); camera proxy
+semantics; the arbiter metrics payload; ~120 REST endpoints verified at the documented path and
+method; `deep-dives/pv-health.md` against `specs/162-pv-health/spec.md` line by line.
+
+---
+
+## Working rules for the remediation session
+
+- Branch per PR, `docs/<slug>`, never commit to `main`. PR and wait for approval before merging.
+- Every claim written into the docs must be checked against the source **at the time of
+  writing**, not against this file. This file is a work list, not a source of truth, and it
+  ages from the moment it was written (2026-08-29, v1.62.0).
+- Re-run `mkdocs build --strict` after each PR. **Never** `mkdocs serve` — the maintainer owns
+  the dev server on port 8000.
+- Keep EN and FR in step for anything touched, or note explicitly why not.
+- No em-dashes or en-dashes in user-facing copy, EN or FR.
+- `npm run validate` does not cover `docs/`, but `npx prettier --check "docs/**/*.md"` does, and
+  two files (`docs/sowel-spec.md`, `docs/specs-index.md`) are already unformatted on `main` —
+  do not reformat them as a side effect.

--- a/scripts/check-docs-impact.sh
+++ b/scripts/check-docs-impact.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Behaviour-change documentation gate (spec 167, R2).
+#
+# A `feat` or `fix` that touches src/ or ui/src/ changes something a reader can
+# observe. Either the documentation moved with it, or somebody has to say why
+# not — in a sentence, not a checkbox. The 2026-08-29 audit measured what the
+# absence of this costs: the technical layer stayed maintained while the user
+# guide silently lost six shipped equipment features.
+#
+# NOT gated: chore, refactor, test, docs, style, ci, build, perf. They change
+# nothing a reader can observe, and gating them produces edits made to satisfy
+# a gate, which is worse than no edit because it looks like maintenance.
+#
+# Waiving: put a trailer in the PR body. The reason is the load-bearing part and
+# is required — a bare `Docs-Impact: none` fails.
+#
+#   Docs-Impact: none — internal refactor of the retry loop, no documented behaviour changes
+#
+# Runs in CI (pull_request, with PR_TITLE and PR_BODY set) and locally:
+#   bash scripts/check-docs-impact.sh
+# Locally PR_TITLE falls back to the last commit subject and PR_BODY is empty,
+# so the local run is the strict case.
+#
+# Portable to bash 3.2 (macOS) — no mapfile / associative arrays.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/docs-impact-map.sh
+. "${SCRIPT_DIR}/docs-impact-map.sh"
+
+BASE_REF="${1:-origin/main}"
+PR_BODY="${PR_BODY:-}"
+PR_TITLE="${PR_TITLE:-$(git log -1 --pretty=%s)}"
+
+if ! git rev-parse --verify --quiet "${BASE_REF}" >/dev/null; then
+  git fetch --quiet origin main
+  BASE_REF="origin/main"
+fi
+
+BASE="$(git merge-base "${BASE_REF}" HEAD)"
+changed="$(git diff --name-only "${BASE}" HEAD || true)"
+
+# ── Does this PR claim to change observable behaviour? ────────────────
+if ! printf '%s' "${PR_TITLE}" | grep -qE '^(feat|fix)(\([^)]*\))?!?:'; then
+  echo "Not a feat/fix title (${PR_TITLE}) — documentation impact check skipped."
+  exit 0
+fi
+
+if ! printf '%s\n' "${changed}" | grep -qE '^(src/|ui/src/)'; then
+  echo "No src/ or ui/src/ change — documentation impact check skipped."
+  exit 0
+fi
+
+# ── Surface the likely pages either way (advisory, never fails) ───────
+hints="$(docs_impact_hints "${changed}")"
+if [ -n "${hints}" ]; then
+  echo "Documentation pages likely affected by this change:"
+  echo "${hints}"
+  echo
+fi
+
+# ── Satisfied by a documentation change ───────────────────────────────
+if printf '%s\n' "${changed}" | grep -q '^docs/'; then
+  echo "Documentation changed alongside the code ✓"
+  exit 0
+fi
+
+# ── Or by a trailer carrying an actual reason ──────────────────────────
+# Accept `-`, `--` or `—` as the separator, any case, flexible spacing. A gate
+# that fails on punctuation teaches people to distrust it.
+reason="$(
+  printf '%s\n' "${PR_BODY}" \
+    | grep -iE '^[[:space:]]*docs-impact:' \
+    | head -1 \
+    | sed -E 's/^[[:space:]]*[Dd][Oo][Cc][Ss]-[Ii][Mm][Pp][Aa][Cc][Tt]:[[:space:]]*//' \
+    | sed -E 's/^(none|aucun|aucune|n\/a)[[:space:]]*(—|--|-|:)?[[:space:]]*//I' \
+    | sed -E 's/[[:space:]]*$//' \
+    || true
+)"
+
+if [ -n "${reason}" ]; then
+  echo "No documentation change, waived by Docs-Impact ✓"
+  echo "  reason: ${reason}"
+  exit 0
+fi
+
+echo "❌ This ${PR_TITLE%%:*} touches src/ or ui/src/ but no documentation page."
+echo
+echo "Either update the relevant page, or state why none is needed with a"
+echo "trailer in the PR body:"
+echo
+echo "  Docs-Impact: none — <why no reader-visible behaviour changed>"
+echo
+echo "The reason is required: a bare 'Docs-Impact: none' does not pass."
+exit 1

--- a/scripts/check-docs-parity.sh
+++ b/scripts/check-docs-parity.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# EN/FR documentation parity gate (spec 167, R1).
+#
+# Most pages under docs/ exist as a pair: `x.md` and `x.fr.md`. Nothing checked
+# that a change to one reached the other, and the 2026-08-29 audit found the
+# result: five API surfaces documented in English only, the whole capacity-claim
+# chapter missing from the French recipe guide, and a French architecture page
+# describing an auth middleware that had been replaced.
+#
+# This check fails a PR that touches one side of a pair without the other. It is
+# silent when the counterpart does not exist (a page with no translation, or a
+# page being created), because demanding a translation at creation time pushes
+# authors to write neither.
+#
+# Waiving: put a trailer in the PR body naming the file and a reason.
+#
+#   Docs-Parity: docs/technical/api-reference.fr.md — typo fix in the EN copy only
+#
+# Runs in CI (pull_request, with PR_BODY set) and locally:
+#   bash scripts/check-docs-parity.sh
+# Locally PR_BODY is empty, so the local run is the strict case: it never passes
+# on a trailer the runner would have seen.
+#
+# Portable to bash 3.2 (macOS) — no mapfile / associative arrays.
+
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+PR_BODY="${PR_BODY:-}"
+
+if ! git rev-parse --verify --quiet "${BASE_REF}" >/dev/null; then
+  git fetch --quiet origin main
+  BASE_REF="origin/main"
+fi
+
+BASE="$(git merge-base "${BASE_REF}" HEAD)"
+
+changed="$(git diff --name-only "${BASE}" HEAD -- 'docs/*.md' 'docs/**/*.md' || true)"
+
+if [ -z "${changed}" ]; then
+  echo "No documentation page touched — parity check skipped."
+  exit 0
+fi
+
+# Is $1 present in the changed set?
+is_changed() {
+  printf '%s\n' "${changed}" | grep -qxF "$1"
+}
+
+# Does the PR body waive the missing counterpart $1?
+is_waived() {
+  [ -n "${PR_BODY}" ] || return 1
+  printf '%s\n' "${PR_BODY}" \
+    | tr '[:upper:]' '[:lower:]' \
+    | grep -q "docs-parity:.*$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+}
+
+failed=0
+for f in ${changed}; do
+  case "${f}" in
+    *.fr.md) counterpart="${f%.fr.md}.md" ;;
+    *.md) counterpart="${f%.md}.fr.md" ;;
+    *) continue ;;
+  esac
+
+  # No counterpart in the tree: a page with no translation, or one being
+  # created. Not a divergence.
+  [ -f "${counterpart}" ] || continue
+
+  is_changed "${counterpart}" && continue
+
+  if is_waived "${counterpart}"; then
+    echo "~ ${f} changed without ${counterpart} (waived by Docs-Parity)"
+    continue
+  fi
+
+  echo "❌ ${f} changed but ${counterpart} did not"
+  failed=1
+done
+
+if [ "${failed}" -ne 0 ]; then
+  echo
+  echo "Documentation pages come in EN/FR pairs. Update both, or state why not"
+  echo "with a trailer in the PR body:"
+  echo
+  echo "  Docs-Parity: <the untouched file> — <reason>"
+  exit 1
+fi
+
+echo "EN/FR parity holds for every page touched."

--- a/scripts/docs-impact-map.sh
+++ b/scripts/docs-impact-map.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Source area → likely documentation page (spec 167, R3).
+#
+# ADVISORY ONLY. This never fails a build, and that is deliberate. A blocking
+# check built on an inexhaustive mapping is exactly where an escape hatch
+# becomes the default path: the false positives train the author to reach for
+# it, and the gate stops meaning anything. Heuristics inform, mechanics enforce.
+#
+# Its job is to turn "did you think about the documentation" into "this page
+# probably needs a look", which is harder to dismiss and easier to act on.
+#
+# The map below is data. Extending it is a one-line change and carries no risk
+# of failing a build, so add a row whenever drift shows up somewhere new.
+#
+# Sourced by check-docs-impact.sh; also runnable on its own:
+#   bash scripts/docs-impact-map.sh
+#
+# Portable to bash 3.2 (macOS) — no mapfile / associative arrays.
+
+set -euo pipefail
+
+# One row per line: "<source prefix>|<comma-separated likely pages>"
+# Longest-prefix wins is NOT implemented on purpose — a file matching several
+# rows should surface all of them.
+DOCS_IMPACT_MAP='
+ui/src/components/equipments/|docs/user/equipments.md
+ui/src/components/energy/|docs/user/energy.md, docs/deep-dives/energy-tour.md, docs/deep-dives/surplus-arbiter.md
+ui/src/components/plugins/|docs/user/plugins.md
+ui/src/components/dashboard/|docs/user/dashboard.md
+ui/src/pages/|docs/user/
+src/shared/types.ts|docs/technical/data-model.md, docs/technical/api-reference.md
+src/api/routes/|docs/technical/api-reference.md
+src/api/websocket.ts|docs/technical/api-reference.md
+src/shared/plugin-api.ts|docs/technical/plugin-development.md
+src/plugins/|docs/technical/plugin-development.md
+src/packages/|docs/technical/plugin-development.md
+src/recipes/|docs/technical/recipe-development.md
+src/energy/|docs/deep-dives/surplus-arbiter.md, docs/user/energy.md
+src/devices/|docs/technical/data-model/devices.md
+src/equipments/|docs/technical/data-model/equipments.md
+src/zones/|docs/technical/data-model/zones.md
+src/modes/|docs/technical/data-model/modes.md
+src/auth/|docs/technical/api-reference.md
+migrations/|docs/technical/data-model/
+Dockerfile|docs/technical/deployment.md
+docker-compose.yml|docs/technical/deployment.md
+.github/dependabot.yml|docs/technical/dependency-management.md
+'
+
+# Print the likely pages for the given changed files, one annotation per match.
+# Never exits non-zero.
+docs_impact_hints() {
+  local changed="$1"
+  local hinted=""
+
+  printf '%s\n' "${DOCS_IMPACT_MAP}" | while IFS='|' read -r prefix pages; do
+    [ -n "${prefix}" ] || continue
+    if printf '%s\n' "${changed}" | grep -q "^${prefix}"; then
+      echo "  ${prefix} → ${pages}"
+    fi
+  done
+}
+
+# Standalone invocation: hint against the working diff.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  BASE_REF="${1:-origin/main}"
+  if ! git rev-parse --verify --quiet "${BASE_REF}" >/dev/null; then
+    git fetch --quiet origin main
+    BASE_REF="origin/main"
+  fi
+  BASE="$(git merge-base "${BASE_REF}" HEAD)"
+  changed="$(git diff --name-only "${BASE}" HEAD || true)"
+  hints="$(docs_impact_hints "${changed}")"
+  if [ -n "${hints}" ]; then
+    echo "Documentation pages likely affected by this change:"
+    echo "${hints}"
+  else
+    echo "No mapped source area touched."
+  fi
+fi

--- a/specs/167-documentation-currency/architecture.md
+++ b/specs/167-documentation-currency/architecture.md
@@ -1,0 +1,130 @@
+# Spec 167 — Architecture
+
+## Where the enforcement lives today
+
+One gate, one file. `.github/workflows/release.yml:53-76` (`verify-release-notes`) greps
+`{ #vX-Y-Z }` in `docs/release-notes.md` and `.fr.md` at the tagged commit and fails the
+workflow before the build jobs it gates. `.github/workflows/ci.yml:67-74`
+(`Specs completeness`) runs `scripts/check-specs-complete.sh` on pull requests, but it checks
+the presence of three files in a new spec folder, not documentation currency.
+
+Nothing else in the repository has an opinion about whether documentation still matches the
+code.
+
+## The change
+
+Three scripts and one workflow job, following the shape `check-specs-complete.sh` already
+established: bash, portable to 3.2 (macOS ships it), no `mapfile`, no associative arrays,
+takes an optional base ref, runs identically in CI and locally.
+
+```
+scripts/
+  check-docs-parity.sh      R1  blocking   pull_request
+  check-docs-impact.sh      R2  blocking   pull_request
+  docs-impact-map.sh        R3  advisory   pull_request  (sourced by check-docs-impact.sh)
+  check-specs-index.sh      R4  blocking   tag
+```
+
+### R1 — `check-docs-parity.sh`
+
+For every `docs/**/*.md` in the diff against the merge base, derive its counterpart
+(`x.md` <-> `x.fr.md`) and, when that counterpart exists in the tree, require it in the diff
+too. A missing counterpart is waived by a `Docs-Parity:` trailer naming it.
+
+The counterpart is derived rather than looked up in a list, so a new page pair is covered the
+day it is created.
+
+### R2 — `check-docs-impact.sh`
+
+Fires only when both conditions hold:
+
+- the pull request title matches `^(feat|fix)(\(.+\))?!?:`
+- the diff touches `src/` or `ui/src/`
+
+Then requires either a path under `docs/` in the diff, or a `Docs-Impact:` trailer whose reason
+is non-empty. The reason is checked for content, not just presence: a bare `Docs-Impact: none`
+fails, because the requirement is that a sentence was written.
+
+### R3 — `docs-impact-map.sh`
+
+A table of `source-prefix -> doc-page` pairs, emitted as a GitHub annotation. Deliberately
+partial and deliberately non-blocking. Initial map, drawn from where the audit found the drift:
+
+| Source prefix                                  | Likely page                                                       |
+| ---------------------------------------------- | ----------------------------------------------------------------- |
+| `ui/src/components/equipments/`                | `docs/user/equipments.md`                                         |
+| `ui/src/components/energy/`                    | `docs/user/energy.md`, `docs/deep-dives/energy-tour.md`           |
+| `ui/src/pages/`                                | `docs/user/`                                                      |
+| `src/shared/types.ts`                          | `docs/technical/data-model.md`, `docs/technical/api-reference.md` |
+| `src/api/routes/`                              | `docs/technical/api-reference.md`                                 |
+| `src/shared/plugin-api.ts`, `src/plugins/`     | `docs/technical/plugin-development.md`                            |
+| `src/recipes/`                                 | `docs/technical/recipe-development.md`                            |
+| `src/packages/`                                | `docs/technical/plugin-development.md` (registry + trust tiers)   |
+| `migrations/`                                  | `docs/technical/data-model/`                                      |
+| `src/energy/`                                  | `docs/deep-dives/surplus-arbiter.md`                              |
+| `docker-compose.yml`, `Dockerfile`, `scripts/` | `docs/technical/deployment.md`                                    |
+
+The map is data, not logic, so extending it is a one-line change and carries no risk of failing
+a build.
+
+### R4 — `check-specs-index.sh`
+
+Two assertions against `docs/specs-index.md`:
+
+1. every `specs/NNN-*/` folder has a row whose number matches
+2. no spec number that appears in a `### vX.Y.Z` block of `docs/release-notes.md` is still
+   marked `Unreleased` in the index
+
+Runs in `verify-release-notes`, which already exists, already runs at tag time, and already
+gates every build job. Adding it there rather than creating a job keeps the failure in the place
+maintainers already look when a release stops.
+
+**This one lands red.** The index is currently 34 rows short and marks specs 139-166 as
+unreleased. Acceptance criterion 8 requires green on `main`, so the index is corrected in the
+same pull request as the script. That correction is the point of the check, not a cost of it.
+
+## Reading the pull request body
+
+Trailers come from `github.event.pull_request.body`, passed to the scripts as an environment
+variable. No token, no `gh` call, works from a fork. Locally the variable is simply empty, which
+means a local run is the strict case: it will not silently pass because of a trailer the runner
+would have seen.
+
+Matching is case-insensitive, tolerant of whitespace, and accepts `-`, `--` or `—` as the
+separator. A gate failing on punctuation would teach people to distrust it.
+
+## Files touched
+
+| File                                        | Change                                                                   |
+| ------------------------------------------- | ------------------------------------------------------------------------ |
+| `scripts/check-docs-parity.sh`              | new                                                                      |
+| `scripts/check-docs-impact.sh`              | new                                                                      |
+| `scripts/docs-impact-map.sh`                | new                                                                      |
+| `scripts/check-specs-index.sh`              | new                                                                      |
+| `.github/workflows/ci.yml`                  | one job, `Documentation currency`, running the two pull-request scripts  |
+| `.github/workflows/release.yml`             | one step added to `verify-release-notes`                                 |
+| `.github/pull_request_template.md`          | the two trailers, commented, with a one-line explanation                 |
+| `CLAUDE.md`                                 | a `Documentation currency (spec 167 — MANDATORY for AI agents)` section  |
+| `docs/specs-index.md`                       | 34 missing rows, 28 stale statuses (required for the gate to land green) |
+| `docs/technical/contributing.md` + `.fr.md` | the contract, for humans                                                 |
+
+## Why not the alternatives
+
+**A label instead of a trailer.** Labels are invisible in the merge commit and in `git log`, and
+an agent cannot set one without an extra API call. A trailer is in the body, is reviewed with the
+change, and survives in history where the release sweep can grep it.
+
+**A blocking path map.** Covered in the spec: the false positives are what break the gate's
+credibility.
+
+**Everything at release time.** The knowledge is at the pull request. A release-time sweep of
+sixteen commits reconstructs from memory what the author knew an hour after writing the code.
+R4 keeps only what is genuinely release-scoped.
+
+**A docs coverage metric.** Measures pages, not truth. A page can be long, current in structure
+and wrong in every claim, which is exactly what the audit found.
+
+## Out of scope
+
+Checking that documentation is _correct_ (no gate can), translation quality, screenshot decay,
+and any gate on `chore` / `refactor` / `test` / `docs` pull requests.

--- a/specs/167-documentation-currency/plan.md
+++ b/specs/167-documentation-currency/plan.md
@@ -1,0 +1,100 @@
+# Spec 167 — Plan
+
+## Tasks
+
+### 1. Scripts
+
+- `scripts/check-docs-parity.sh` — R1. Diff against merge base, derive `.md` <-> `.fr.md`
+  counterparts, require both when the counterpart exists, waive on `Docs-Parity:`.
+- `scripts/docs-impact-map.sh` — R3. The source-prefix to doc-page table, emitted as GitHub
+  annotations. Sourced by the impact check; never exits non-zero.
+- `scripts/check-docs-impact.sh` — R2. Gate on `feat`/`fix` title plus a `src/` or `ui/src/`
+  change; require a `docs/` change or a `Docs-Impact:` trailer with a non-empty reason. Emits
+  the map's annotations on the way through.
+- `scripts/check-specs-index.sh` — R4. Every `specs/NNN-*/` has a row; no spec cited in a
+  published release-notes block is still `Unreleased`.
+
+All four: bash 3.2, `set -euo pipefail`, optional base-ref argument defaulting to `origin/main`,
+usable with no arguments locally, header comment in the style of `check-specs-complete.sh`.
+
+### 2. Wiring
+
+- `.github/workflows/ci.yml` — a `Documentation currency` job running the parity and impact
+  checks, with `PR_BODY: ${{ github.event.pull_request.body }}` and
+  `fetch-depth: 0` for the merge-base diff.
+- `.github/workflows/release.yml` — one step in `verify-release-notes` calling
+  `check-specs-index.sh`.
+- `.github/pull_request_template.md` — both trailers as commented lines with a one-line
+  explanation of when to use them.
+
+### 3. Shipping order — R4 travels separately
+
+The parity and impact checks are diff-scoped, so they cannot fail on existing content and land
+green immediately. `check-specs-index.sh` cannot: the index is 34 rows short and marks specs
+139-166 as unreleased, so the script fails on `main` the day it is written.
+
+Correcting the index is data entry across 34 rows plus 28 statuses cross-checked against
+`docs/release-notes.md`, and the 2026-08-29 audit already schedules exactly that work in its
+PR 6. Bundling it here would make one pull request out of two unrelated reviews.
+
+So:
+
+- **PR A (this one)** — R1, R2, R3, R5, R6. The pull-request gates, live straight away, in time
+  for the seven audit remediation PRs to run under them.
+- **PR B (with audit PR 6)** — `check-specs-index.sh`, wired into `verify-release-notes`, landing
+  in the same pull request as the index correction that makes it pass.
+
+Confirm before wiring that the two PR-time scripts pass against `main` as it stands.
+
+### 4. Write the rule where agents read it
+
+- `CLAUDE.md` — a `Documentation currency (spec 167 — MANDATORY for AI agents)` section, in the
+  register of the existing spec 089 and spec 108 sections: what the two trailers are, when each
+  applies, and that the checks run locally.
+- `docs/technical/contributing.md` + `.fr.md` — the same contract for humans. Note this page is
+  itself on the audit's correction list (PR 5), so keep the addition self-contained to avoid a
+  conflict.
+
+## Test Plan
+
+No unit-test framework covers shell scripts here, and mocking a pull request event would test
+the mock. The scripts are verified against real git history, which is what they read.
+
+### Verification matrix
+
+Each row is a real commit or a scratch branch, checked with the script run directly.
+
+| Case                                                                               | Expectation                                                       |
+| ---------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `main` as it stands, all four scripts                                              | parity/impact/specs-complete pass; specs-index fails until task 3 |
+| Commit `8a4ffbd8` (`feat(equipments)`, touches `src/` + `ui/src/` + `docs/`)       | impact passes on the `docs/` change                               |
+| Commit `0fc42635` (docs only, EN+FR pairs)                                         | parity passes                                                     |
+| Scratch: edit `docs/technical/api-reference.md` only                               | parity fails, names `api-reference.fr.md`                         |
+| ... plus `Docs-Parity: docs/technical/api-reference.fr.md — <reason>` in `PR_BODY` | passes                                                            |
+| Scratch: `feat(ui):` title, edit `ui/src/` only                                    | impact fails                                                      |
+| ... plus `Docs-Impact: none — <reason>`                                            | passes                                                            |
+| ... plus a bare `Docs-Impact: none`                                                | still fails, the reason is required                               |
+| Scratch: `chore(deps):` title, edit `package.json`                                 | not gated                                                         |
+| Scratch: `refactor(ui):` title, edit `ui/src/`                                     | not gated                                                         |
+| Scratch: edit `docs/technical/dependency-management.md` (no `.fr.md`)              | parity silent                                                     |
+| Scratch: create `docs/user/foo.md` alone                                           | parity silent, counterpart does not exist                         |
+| Trailer written `docs-impact: none - reason`                                       | accepted, matching is case and punctuation tolerant               |
+| Empty `PR_BODY` (local run)                                                        | strict: no trailer can waive anything                             |
+| Scratch: `specs/168-x/` with no index row                                          | specs-index fails                                                 |
+| Scratch: spec 166 marked `Unreleased` while cited in the v1.60.0 block             | specs-index fails                                                 |
+
+### Live verification
+
+The pull request carrying this spec is itself the first subject: it touches `docs/` and
+`specs/`, no `src/`, so R2 must stay silent and R1 must be satisfied by the `specs-index.md`
+edit needing no French counterpart. Then the seven documentation remediation pull requests from
+the audit run under the new gates, which is the real test: if the parity check is going to be
+annoying, seven consecutive documentation pull requests will show it immediately.
+
+### Retro-compat
+
+- No runtime code, no migration, no API, no UI. Nothing ships in the Docker image.
+- The new CI job is additive; existing required checks are untouched.
+- `verify-release-notes` gains a step. If `check-specs-index.sh` is wrong, a release is blocked,
+  which is the same failure mode spec 108 already accepts, and the recovery is the same: fix,
+  amend, re-tag.

--- a/specs/167-documentation-currency/spec.md
+++ b/specs/167-documentation-currency/spec.md
@@ -1,0 +1,133 @@
+# Spec 167 — Documentation currency gates
+
+## Context
+
+The 2026-08-29 documentation audit (`docs/audit/2026-08-29-documentation.md`) found roughly
+three months of drift: a plugin guide teaching an `executeOrder` signature that migration 004
+removed, a French data model documenting an entity that never existed, an activity feed
+described as volatile a year after it was made persistent, and a user guide with no mention of
+six shipped equipment features.
+
+The same audit contains the answer. **The only documentation artefact with a CI gate is the
+only one that did not drift.** `docs/release-notes.md` and `.fr.md` carry 158 version anchors,
+identical in both files, `v1-0-0` through `v1-62-0`, with no divergence at all. Spec 108 makes
+the release workflow fail on a missing anchor before a single Docker layer is built. Meanwhile
+`docs/specs-index.md` lost 34 rows and still marks 28 shipped specs as "Unreleased", and the
+EN/FR pairs diverged on five API surfaces.
+
+Same repository, same authors, same pace. The difference is enforcement.
+
+This spec generalises the spec 108 mechanism from one file to the documentation as a whole,
+and places most of it at pull-request time rather than at release time. The reason is where the
+knowledge is: at the tag there are sixteen commits and no memory of which needed documentation;
+in the pull request the author has just written the code and knows exactly.
+
+The repository is worked almost entirely through AI agents. That changes the usual objection to
+process gates, which is human fatigue leading to a token edit and an escape hatch taken by
+default. It also changes what the gate must be: an agent reads `CLAUDE.md` at session start and
+complies proactively, so the rule belongs there and the CI job is the backstop, exactly as
+specs 089 and 108 are written.
+
+## Requirements
+
+### R1 — EN/FR parity is enforced per pull request
+
+A pull request that modifies `docs/<path>.md` where `docs/<path>.fr.md` exists (or the reverse)
+must modify both, or carry a `Docs-Parity:` trailer naming the file and a reason.
+
+This is the cheapest check with the highest return: it alone would have prevented the MFA, roles,
+equipment-status, camera-proxy and web-push sections being English-only in the API reference,
+and the entire capacity-claim chapter being absent from the French recipe guide.
+
+### R2 — A behaviour change states its documentation impact
+
+A pull request whose title is a `feat(...)` or `fix(...)` conventional commit and which modifies
+`src/` or `ui/src/` must either modify something under `docs/`, or carry a
+`Docs-Impact: none — <reason>` trailer.
+
+The reason is the load-bearing part. A checkbox is ticked without thought; a sentence that has
+to be written is not. The trailer is deliberately not a label, so it lives in the pull request
+body where it is reviewed alongside the change and survives in the merge commit.
+
+### R3 — The pull request is told which pages are likely affected
+
+A path map from source areas to documentation pages produces an advisory annotation naming the
+pages that probably need a look. It never fails the build.
+
+The split is deliberate: **heuristics inform, mechanics enforce.** A blocking check built on an
+inexhaustive mapping is precisely where an escape hatch becomes the default path, because the
+false positives train the author to reach for it. The map's job is to turn "did you think about
+documentation" into "this page probably needs a look", which is far harder to dismiss and far
+more actionable.
+
+### R4 — Release-scoped artefacts are verified at the tag
+
+Two checks join the existing `verify-release-notes` job, because they concern artefacts that are
+release-scoped by nature and cannot be evaluated per pull request:
+
+- every `specs/NNN-*/` folder has a row in `docs/specs-index.md`
+- no spec whose number appears in a published release-notes entry is still marked "Unreleased"
+  in the index
+
+These would have caught the 34 missing rows and the 28 stale statuses.
+
+### R5 — The rule is written where agents read it
+
+A `CLAUDE.md` section states the contract before the gate is hit, in the register specs 089 and
+108 already use. The CI job is enforcement; `CLAUDE.md` is the instruction. An agent that only
+learns the rule from a red check has already written the pull request the wrong way.
+
+### R6 — Every check runs locally
+
+Each script runs standalone against `origin/main`, as `scripts/check-specs-complete.sh` does,
+so an agent can verify before pushing rather than discovering the failure in CI.
+
+## Explicitly NOT in scope
+
+- **Requiring a documentation change on every pull request.** A `chore`, a `refactor`, a test or
+  a dependency bump changes nothing a reader can observe. Gating them produces edits made to
+  satisfy a gate, which is worse than no edit because it looks like maintenance.
+- **Blocking on the path map.** See R3.
+- **Checking that the documentation is correct.** No gate can do this. R2 catches omission by
+  forgetting; it cannot catch omission by not knowing, which is what produced the worst finding
+  in the audit: a new equipment type does not tell you that `user/equipments.md:47` claims the
+  catalogue is closed. That class is caught by periodic review, not by CI.
+- **Screenshots.** Staleness there is a function of time and UI churn, not of any single pull
+  request. Noted in the audit as its own session.
+- **Translation quality.** R1 checks that the French file was touched, not that the French is
+  good.
+
+## Acceptance criteria
+
+1. A pull request touching `docs/technical/api-reference.md` alone fails, and names the missing
+   `.fr.md`.
+2. The same pull request passes with `Docs-Parity: docs/technical/api-reference.fr.md — <reason>`.
+3. A `feat(ui): ...` pull request touching only `ui/src/` fails; it passes with a documentation
+   change, or with `Docs-Impact: none — <reason>`.
+4. A `chore(deps): ...` pull request touching `package.json` is not gated.
+5. A `refactor(ui): ...` pull request touching `ui/src/` is not gated.
+6. A pull request touching `ui/src/components/equipments/` is annotated with
+   `docs/user/equipments.md` and does not fail on that account.
+7. Tagging a version whose `specs/` contains a folder absent from `docs/specs-index.md` fails
+   `verify-release-notes`, before any image is built.
+8. Every script exits 0 on `main` as it stands today, so the gates land green rather than
+   requiring a cleanup first.
+9. Each script runs locally with no arguments.
+
+## Edge cases
+
+- **A file with no translation.** `docs/technical/dependency-management.md` has no `.fr.md`.
+  R1 only fires when the counterpart exists, so it stays silent rather than demanding a new
+  translation.
+- **A new page added in one language.** Creating `docs/user/foo.md` with no `.fr.md` does not
+  fire R1, since the counterpart does not exist. Deliberate: forcing a translation at creation
+  time would push authors to write neither.
+- **A revert.** Carries the original title, so a `feat` revert is gated. Acceptable: a revert of
+  a user-visible feature does have documentation impact.
+- **The release pull request.** Title is `release: vX.Y.Z`, not `feat`/`fix`, so R2 does not
+  fire. It touches both release-notes files, so R1 is satisfied.
+- **A pull request touching only `docs/`.** R2 does not apply (no `src/` change); R1 does.
+- **A merge from a fork.** The pull request body is available on the `pull_request` event, so
+  trailers are readable without a token.
+- **Case and spacing in trailers.** Matched case-insensitively with flexible whitespace, and
+  both `—` and `-` accepted as the separator, so a gate is never failed on punctuation.


### PR DESCRIPTION
Spec 167. Also lands `docs/audit/2026-08-29-documentation.md`, the work list this comes from.

## The argument

The audit found roughly three months of drift. The same audit contains the answer:

**The only documentation artefact with a CI gate is the only one that did not drift.** `docs/release-notes.md` and `.fr.md` carry 158 version anchors, identical in both files, `v1-0-0` through `v1-62-0`, no divergence at all, because spec 108 fails the release workflow on a missing anchor before a single Docker layer is built. Meanwhile `docs/specs-index.md` lost 34 rows and marks 28 shipped specs "Unreleased", and the EN/FR pairs diverged on five API surfaces.

Same repository, same authors, same pace. The difference is the gate.

## Why the pull request and not the tag

At the tag there are sixteen commits and no memory of which needed documentation. In the pull request the author has just written the code and knows exactly. Only what is genuinely release-scoped stays at the tag, and that half ships separately (see below).

## What is enforced

**EN/FR parity.** Touch `x.md` and you touch `x.fr.md`, or you name the file and say why. Silent when the counterpart does not exist, so creating a page in one language stays allowed. This one check alone would have prevented MFA, roles, equipment status, the camera proxy and web push being English-only in the API reference, and the entire capacity-claim chapter being absent from the French recipe guide.

**Documentation impact.** A `feat` or `fix` touching `src/` or `ui/src/` either changes something under `docs/` or carries `Docs-Impact: none — <reason>`. **The reason is required and a bare `none` fails**: a checkbox is ticked without thought, a sentence is not. `chore`, `refactor`, `test`, `docs`, `style`, `ci`, `build` and `perf` are not gated, because gating them produces edits made to satisfy a gate, which is worse than no edit since it looks like maintenance.

## What is deliberately advisory

`scripts/docs-impact-map.sh` prints the pages a change probably affects and **never fails a build**. A blocking check built on an inexhaustive map is precisely where an escape hatch becomes the default path: the false positives train you to reach for it and the gate stops meaning anything. Heuristics inform, mechanics enforce. The map is data, so adding a row is a one-line change with no risk.

## Why the rule is also in CLAUDE.md

This repository is worked through agents, and an agent reads `CLAUDE.md` at session start. One that only learns the rule from a red check has already written the pull request the wrong way. The CI job is the backstop; `CLAUDE.md` is the instruction, in the register specs 089 and 108 already use.

## The honest limit

R2 catches omission by forgetting. It cannot catch omission by not knowing, which produced the audit's worst finding: adding an equipment type does not tell you that `user/equipments.md:47` claims the catalogue is closed. That class needs periodic review, not CI, and the spec says so rather than implying the gates are complete.

## Verification

No test framework covers shell, and mocking a PR event would test the mock, so the scripts were run against real git history:

| Case | Result |
| ---- | ------ |
| EN page touched alone | fails, names the `.fr.md` |
| ... with a matching `Docs-Parity:` trailer | passes |
| ... with a trailer naming a *different* file | still fails |
| ... trailer in lower case with `-` instead of `—` | passes |
| `feat(ui):` touching `ui/src/` only | fails |
| ... with `Docs-Impact: none — <reason>` | passes |
| ... with a bare `Docs-Impact: none` | still fails |
| `chore(deps):` / `refactor(ui):` | not gated |
| Real commit `8a4ffbd8` (feat, src+ui+docs) | passes on the docs change |
| Real commit `0fc42635` (docs EN+FR) | parity passes |
| Mapped area touched | hints printed, non-blocking |
| `main` as it stands | both pass, so the gates land green |

This pull request is its own first subject: it touches `docs/` and `specs/` and no `src/`, so the impact check stays silent and parity is satisfied.

## Shipping in two parts

The release-time half (`specs-index.md` has a row per spec folder; no spec cited in a published release block still reads `Unreleased`) **fails on `main` today**: the index is 34 rows short with 28 stale statuses. Correcting it is data entry already scheduled as PR 6 of the audit, so the script ships with that correction rather than making one pull request out of two unrelated reviews. `specs/167-documentation-currency/plan.md` records the split.

No runtime code, no migration, no API, no UI. Nothing ships in the Docker image.
