### PR TITLE
fix(docs): stop publishing the legacy tree, and fail on broken anchors

### DIFF
--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -533,7 +533,7 @@ Conventions :
 
 ---
 
-## Gestion des fuseaux horaires (spec 061)
+## Gestion des fuseaux horaires (spec 061) { #timezone-handling }
 
 La logique backend de Sowel dépend fortement de l'heure locale : créneaux cron du calendrier (`croner`), classification tarifaire HP/HC énergie, frontières de jour énergétique, affichage des levers/couchers de soleil, notifications. Tout utilise les méthodes natives `Date` qui dépendent de `process.env.TZ`.
 

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -635,7 +635,7 @@ Conventions:
 
 ---
 
-## Timezone handling (spec 061)
+## Timezone handling (spec 061) { #timezone-handling }
 
 Sowel backend logic depends heavily on local time: calendar cron slots (`croner`), energy HP/HC tariff classification, energy day boundaries, sunrise/sunset display, notifications. All use native `Date` methods that depend on `process.env.TZ`.
 

--- a/docs/technical/data-model/recipes.md
+++ b/docs/technical/data-model/recipes.md
@@ -2,7 +2,7 @@
 
 > **Orchestration**: reusable automation templates distributed as plugins. Users instantiate a recipe by filling in its typed slots; the engine runs the resulting `RecipeInstance`.
 >
-> See also: [Plugin](../data-model.md#3-plugin) in the data-model index for how recipes are distributed and loaded.
+> See also: [the data model index](../data-model.md) in the data-model index for how recipes are distributed and loaded.
 
 ## Recipe
 

--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -420,7 +420,7 @@ Si vous restaurez sur une machine fraîche, InfluxDB peut ne pas encore avoir de
 
 ### Logique horaire cassée (volets à la mauvaise heure, HP/HC erroné)
 
-Le conteneur démarre par défaut en UTC. Définissez `TZ=Europe/Paris` (ou votre fuseau) dans `docker-compose.yml` puis redémarrez. Voir [architecture.md § Gestion des fuseaux horaires](architecture.md#gestion-des-fuseaux-horaires-spec-061) et la spec 061 sur [github.com/mchacher/sowel/tree/main/specs/061-timezone-from-home-location](https://github.com/mchacher/sowel/tree/main/specs/061-timezone-from-home-location).
+Le conteneur démarre par défaut en UTC. Définissez `TZ=Europe/Paris` (ou votre fuseau) dans `docker-compose.yml` puis redémarrez. Voir [architecture.md § Gestion des fuseaux horaires](architecture.md#timezone-handling) et la spec 061 sur [github.com/mchacher/sowel/tree/main/specs/061-timezone-from-home-location](https://github.com/mchacher/sowel/tree/main/specs/061-timezone-from-home-location).
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,18 @@ markdown_extensions:
 exclude_docs: |
   audit/
   planning/
+  _legacy/
+  mockups/
+  fixtures/
+  sowel-spec.md
+
+# Broken internal links and anchors are INFO by default, which is how two of
+# them survived in the published site. Promote them so `mkdocs build --strict`
+# actually fails (spec 167).
+validation:
+  links:
+    anchors: warn
+    not_found: warn
 
 plugins:
   - search


### PR DESCRIPTION
Audit PR 1. First of seven from `docs/audit/2026-08-29-documentation.md`.

## What was published that should not have been

`docs/_legacy/` (8 files), `sowel-spec.md`, `fixtures/` and `mockups/` were built, indexed and in `sitemap.xml`. CLAUDE.md tells readers not to rely on `sowel-spec.md`, and none of the eight `_legacy` pages carries any warning at all, so a search for "plugin development" or "data model" on docs.sowel.org could land on the superseded copy.

Measured on the built site: **127 of 1674 search entries came from content the project already considers dead**. The index is now 1547 and none of it is legacy; the sitemap has zero legacy URLs. Nothing in the published docs linked to any of it, only the `_legacy` pages and the audit files (both excluded) did. An audit in May 2026 already flagged `sowel-spec.md`.

## Broken anchors were invisible by design

They are emitted at INFO, so `mkdocs build --strict` passed with two of them live. A `validation:` block promotes anchors and not-found to `warn`, which `--strict` turns into a failure. Both known ones are fixed with it:

- `## Timezone handling (spec 061)` gets an explicit `{ #timezone-handling }` in **both** languages, rather than the link chasing the `(spec 061)` suffix into the slug. The French deployment link is realigned onto the same stable id.
- `data-model/recipes.md` drops a fragment that resolves on the EN data model hub but not on the French monolith, whose section 3 is Zone. That French page is dealt with in audit PR 4.

`mkdocs build --strict` passes.

Docs-Parity: docs/technical/deployment.md — only the French link needed realigning; the English one already pointed at #timezone-handling, which is what made the anchor worth pinning