### PR TITLE
fix(docs): the activity feed is persistent since spec 147

### DIFF
--- a/docs/technical/api-reference.fr.md
+++ b/docs/technical/api-reference.fr.md
@@ -373,7 +373,7 @@ Mappe les appuis sur des boutons physiques (boutons Zigbee, etc.) à des actions
 
 ## Activité
 
-Événements moteur récents pour le panneau d'activité de la vue Zone. Lit depuis le ring buffer en mémoire (rétention 24 h, plafonné à 2000 entrées, remis à zéro au redémarrage). Voir [Zones — Fil d'activité](../user/zones.md#fil-dactivite) pour la description côté utilisateur.
+Événements moteur récents pour le panneau d'activité de la vue Zone. Rétention de 7 jours, plafonnée à 2000 entrées, persistée en SQLite et rechargée au démarrage. Voir [Zones — Fil d'activité](../user/zones.md#fil-dactivite) pour la description côté utilisateur.
 
 | Method | Path               | Description                                                                                                                       |
 | ------ | ------------------ | --------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/technical/api-reference.md
+++ b/docs/technical/api-reference.md
@@ -472,7 +472,7 @@ Map physical button presses (Zigbee buttons, etc.) to actions (mode activation, 
 
 ## Activity
 
-Recent engine events for the zone-view activity panel. Reads from the in-memory ring buffer (24h retention, capped at 2000 entries, reset on restart). See [Zones — Activity feed](../user/zones.md#activity-feed) for the user-facing description.
+Recent engine events for the zone-view activity panel. 7-day retention, capped at 2000 entries, persisted in SQLite and reloaded on boot. See [Zones — Activity feed](../user/zones.md#activity-feed) for the user-facing description.
 
 | Method | Path               | Description                                                                                                                  |
 | ------ | ------------------ | ---------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -465,7 +465,7 @@ L'image runtime fait environ 950 Mo non compressée (environ 210 Mo de contenu).
 
 ## Activity Buffer (spec 101)
 
-`src/activity/activity-buffer.ts` garde les **dernières 24 heures** d'événements moteur (filtrés et enrichis pour la vue zone) dans un ring buffer en mémoire unique (plafonné à 2000 items). Il alimente le panneau **Activité** dans la vue zone ([guide utilisateur](../user/zones.md#fil-dactivite)).
+`src/activity/activity-buffer.ts` garde les **7 derniers jours** d'événements moteur (filtrés et enrichis pour la vue zone, plafonnés à 2000 items en mémoire), persistés dans la table `activity_log` et rechargés au démarrage. Il alimente le panneau **Activité** dans la vue zone ([guide utilisateur](../user/zones.md#fil-dactivite)).
 
 ### Flux d'événements
 
@@ -480,7 +480,7 @@ L'image runtime fait environ 950 Mo non compressée (environ 210 Mo de contenu).
 
 ### Empreinte mémoire
 
-À environ 400 octets par item, 2000 items représentent environ 800 Ko, soit moins de 0,3 % du RSS d'un conteneur Sowel typique. Le buffer est perdu au redémarrage du conteneur, comme le ring buffer des logs.
+À environ 400 octets par item, 2000 items représentent environ 800 Ko, soit moins de 0,3 % du RSS d'un conteneur Sowel typique. Contrairement au ring buffer des logs, le fil **survit au redémarrage** : il est adossé à SQLite (spec 147).
 
 ---
 

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -567,7 +567,7 @@ Runtime image is ~950 MB uncompressed (~210 MB content). The Python 3.13 require
 
 ## Activity Buffer (spec 101)
 
-`src/activity/activity-buffer.ts` keeps the last **24 hours** of zone-scoped engine events in a single in-memory ring buffer (capped at 2000 items). It powers the **Activity** panel in the zone view ([user guide](../user/zones.md#activity-feed)).
+`src/activity/activity-buffer.ts` keeps the last **7 days** of zone-scoped engine events (capped at 2000 items in memory), persisted to the `activity_log` table and reloaded on boot. It powers the **Activity** panel in the zone view ([user guide](../user/zones.md#activity-feed)).
 
 ### Event flow
 
@@ -582,7 +582,7 @@ Runtime image is ~950 MB uncompressed (~210 MB content). The Python 3.13 require
 
 ### Memory footprint
 
-At ~400 bytes per item, 2000 items = ~800 KB — under 0.3 % of a typical Sowel container's RSS. Buffer is lost on container restart, same as the logs ring buffer.
+At ~400 bytes per item, 2000 items = ~800 KB — under 0.3 % of a typical Sowel container's RSS. Unlike the logs ring buffer, the feed **survives a restart**: it is backed by SQLite (spec 147).
 
 ---
 

--- a/docs/user/zones.fr.md
+++ b/docs/user/zones.fr.md
@@ -133,7 +133,7 @@ La pastille en haut à droite affiche `● live` quand l'application est connect
 
 ### Fenêtre mémoire
 
-Le moteur Sowel garde les **dernières 24 heures** d'événements en mémoire (avec un plafond à 2000 entrées). Le tampon est remis à zéro au redémarrage du conteneur, comme le ring buffer des logs. Pour une investigation plus profonde ou plus ancienne, utilisez la page Journaux.
+Le moteur Sowel garde les **7 derniers jours** d'événements (avec un plafond à 2000 entrées) et **les conserve au redémarrage**. Pour remonter plus loin, utilisez la page Journaux.
 
 ## Ordres de zone
 

--- a/docs/user/zones.md
+++ b/docs/user/zones.md
@@ -133,7 +133,7 @@ The pill in the top right shows `● live` when the app is connected to Sowel vi
 
 ### Memory window
 
-The Sowel engine keeps the last **24 hours** of events in memory (capped at 2000 entries). The buffer is reset when the container restarts, the same way the logs ring buffer works. For deeper or older investigation, use the Logs page.
+The Sowel engine keeps the last **7 days** of events (capped at 2000 entries) and **keeps them across a restart**. For anything older, use the Logs page.
 
 ## Zone orders
 


### PR DESCRIPTION
Audit PR 3. Small and self-contained: three pages, one fact, both languages.

## The fact

| | Documented | Actual |
| --- | --- | --- |
| Retention | 24 hours | **7 days** (`activity-store.ts:16` `ACTIVITY_RETENTION_DAYS = 7`) |
| Survives restart | no, "reset on restart" | **yes** (`activity-buffer.ts:65` reloads from SQLite on boot) |
| Storage | in-memory ring buffer only | `activity_log` table, `migrations/019` |
| 2000-item cap | yes | yes, still true |

Spec 147 made it persistent; three pages never caught up: `technical/architecture.md` (twice), `user/zones.md`, and `technical/api-reference.md`, plus all three French counterparts.

## Why it is worth its own PR

This is the page a user reads when something happened overnight and they want to know what. Being told the feed is reset on restart is an instruction not to look, at exactly the moment the evidence is there.

`mkdocs build --strict` clean, EN/FR moved together.