### PR TITLE
fix(docs): the Live arbitration panel has no allocation bar

### DIFF
--- a/docs/user/energy.fr.md
+++ b/docs/user/energy.fr.md
@@ -179,8 +179,7 @@ Allez dans **Réglages > Administration > Énergie**, activez l'**Arbitre de sur
 
 La page **Énergie > En direct** gagne un panneau d'arbitrage du surplus en trois parties :
 
-- une **barre d'allocation** montrant où va la production en ce moment (maison, chaque charge accordée, surplus libre), et une ligne nommant toute charge en attente et pourquoi ;
-- un **tableau des charges**, une ligne par charge flexible, avec ce qu'il lui faut pour démarrer, ce qu'elle tire réellement, et l'**écart** qui manque encore quand elle attend. Le besoin est rempli sur chaque ligne, pas seulement celles en attente : ce qu'il faut à une charge pour démarrer reste vrai qu'elle tourne, attende ou soit à l'arrêt ;
+- un **tableau des charges**, une ligne par charge flexible : son état, l'**écart** qui manque encore avant qu'elle puisse démarrer, ce qu'elle tire actuellement, l'import réseau qu'elle tolère, et ce dont elle a **besoin**. Le besoin est rempli sur chaque ligne, pas seulement celles en attente : ce qu'il faut à une charge pour démarrer reste vrai qu'elle tourne, attende ou soit à l'arrêt ;
 - une **frise du jour** avec un couloir par charge pilotable — vert là où elle a tenu le surplus, un repère rouge (avec la raison au survol) là où elle s'est effacée ;
 - un **journal des décisions** en langage clair, pour que rien de ce que fait l'arbitre ne soit un mystère.
 

--- a/docs/user/energy.md
+++ b/docs/user/energy.md
@@ -180,8 +180,7 @@ Go to **Settings > Administration > Energy**, enable **Surplus arbiter**, and or
 
 The **Energy > Live** page gains a surplus-arbitration panel with three parts:
 
-- an **allocation bar** showing where the production is going right now (household, each granted load, free surplus), and a line naming any load that is waiting and why;
-- a **load table**, one row per flexible load, with what it needs to start, what it actually draws, and the **gap** still missing when it is waiting. The need is filled on every row, not just the waiting ones: what a load takes to start is true whether it runs, waits or sits idle;
+- a **roster**, one row per flexible load: its state, the **gap** still missing before it can start, what it currently draws, how much grid import it tolerates, and what it **needs**. The need is filled on every row, not only on waiting ones, because what a load takes to start is true whether it runs, waits or sits idle;
 - a **day timeline** with one lane per flexible load — green where it held the surplus, a red marker (with the reason on hover) where it was stepped back;
 - a **decision journal** in plain language, so nothing the arbiter does is a mystery.
 


### PR DESCRIPTION
**My mistake, and a duplicated effort.** Flagging both rather than quietly patching over them.

#825 added a roster bullet to a list that still described an **allocation bar**, leaving the user guide claiming three parts and listing four, the first of which does not exist.

`ui/src/components/energy/ArbitrationSurface.tsx` renders a `<table>`, `<ArbiterTimeline />` and the journal. `grep -ci "bar"` on it returns **0**. Spec 165 replaced the allocation bar with the roster; the guide never caught up and I did not check before adding to the list. The six columns here are read from the component's own header keys (`equipment`, `state`, `gap`, `load`, `tolerates`, `need`), not from memory.

## This overlaps #810

[#810](https://github.com/mchacher/sowel/pull/810) has been open since this morning with the same correction and a **fuller** treatment: the four columns explained one by one, the need arithmetic (`load + engage margin - tolerated import`), and the words the gap uses when nothing is missing. I did not see it before starting the audit's PR 7 and duplicated part of its work.

This PR is the **minimum to stop `main` being wrong**. #810 is the better version of that section and its content is not reproduced here. It will now conflict on `docs/user/energy.{md,fr.md}`; whether to rebase it over this or close this in its favour is your call, and I have not touched it.

Two process notes for the audit brief: the review agent did not surface #810 either, and nothing in the workflow makes an agent check open PRs for overlap before starting a documentation pass.

`mkdocs build --strict` clean, EN/FR moved together.