### PR TITLE
chore(registry): bump zigbee2mqtt to 2.7.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -7,11 +7,11 @@
     "icon": "Radio",
     "author": "mchacher",
     "repo": "mchacher/sowel-plugin-zigbee2mqtt",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "tags": ["zigbee", "mqtt", "z2m", "sensors", "lights", "switches"],
     "sowelVersion": ">=1.59.0",
     "owner": "mchacher",
-    "sha256": "003944b2fbe09586e850634c9cb4457e7a951d86bccfdf0c81697c1eae762189"
+    "sha256": "7d6adb7d9dda06943e871bb0882df81c759d5f874be1fd987b718d76a783bb78"
   },
   {
     "id": "lora2mqtt",


### PR DESCRIPTION
Picks up [sowel-plugin-zigbee2mqtt v2.7.0](https://github.com/mchacher/sowel-plugin-zigbee2mqtt/releases/tag/v2.7.0), which fixes cumulative Zigbee energy counters being fed to Sowel as additive Wh deltas (plugin issue #17).

Without this bump, installs of 2.7.0 fail with `ChecksumMismatchError` (spec 089).

`sha256` computed from the published asset:

```
shasum -a 256 sowel-plugin-zigbee2mqtt-2.7.0.tar.gz
7d6adb7d9dda06943e871bb0882df81c759d5f874be1fd987b718d76a783bb78
```

Two-line diff, no other entry touched.