### PR TITLE
fix(backup): keep the instance marker out of backups and restores (#790)

### DIFF
--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -355,17 +355,19 @@ Les backups capturent l'état complet du système dans une seule archive ZIP et 
 
 Un ZIP de backup contient :
 
-| Entrée                    | Contenu                                                                                                          |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `sowel-backup.json`       | Export SQLite en JSON, structuré par table (format version 2)                                                    |
-| `influx-raw.lp`           | Données InfluxDB brutes en line protocol (7 derniers jours)                                                      |
-| `influx-hourly.lp`        | Données horaires downsamplées (90 derniers jours)                                                                |
-| `influx-daily.lp`         | Données journalières downsamplées (5 dernières années)                                                           |
-| `influx-energy-hourly.lp` | Sommes énergétiques horaires (2 dernières années)                                                                |
-| `influx-energy-daily.lp`  | Sommes énergétiques journalières (10 dernières années)                                                           |
-| `data/*`                  | Tous les fichiers non DB de `data/` (secrets de tokens, etc.), scannés dynamiquement, hors `.db`, `.pid`, `.log` |
+| Entrée                    | Contenu                                                                                                                                          |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `sowel-backup.json`       | Export SQLite en JSON, structuré par table (format version 2)                                                                                    |
+| `influx-raw.lp`           | Données InfluxDB brutes en line protocol (7 derniers jours)                                                                                      |
+| `influx-hourly.lp`        | Données horaires downsamplées (90 derniers jours)                                                                                                |
+| `influx-daily.lp`         | Données journalières downsamplées (5 dernières années)                                                                                           |
+| `influx-energy-hourly.lp` | Sommes énergétiques horaires (2 dernières années)                                                                                                |
+| `influx-energy-daily.lp`  | Sommes énergétiques journalières (10 dernières années)                                                                                           |
+| `data/*`                  | Tous les fichiers non DB de `data/` (secrets de tokens, etc.), scannés dynamiquement, hors `.db`, `.pid`, `.log` et hors marqueur `.instance-id` |
 
 L'export JSON SQLite couvre une liste sélectionnée de tables (constante `BACKUP_TABLES` dans `backup-manager.ts`) dans l'ordre des dépendances (parents d'abord pour la restauration).
+
+Le marqueur `.instance-id` est exclu volontairement, dans les deux sens : il décrit le déploiement en cours d'exécution, et une archive qui l'embarquerait donnerait à l'instance qui restaure l'identité de la machine d'où viennent les données, désarmant le garde-fou de restauration de l'issue #401. Voir la section « Restaurer un backup d'un autre déploiement » de [deployment.fr.md](deployment.fr.md).
 
 ### Backups locaux (data/backups/)
 

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -460,17 +460,19 @@ Backups capture the full system state as a single ZIP archive and restore it ato
 
 A backup ZIP contains:
 
-| Entry                     | Content                                                                                                          |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `sowel-backup.json`       | SQLite export as JSON, structured per table (version 2 format)                                                   |
-| `influx-raw.lp`           | Raw InfluxDB data as line protocol (last 7 days)                                                                 |
-| `influx-hourly.lp`        | Downsampled hourly data (last 90 days)                                                                           |
-| `influx-daily.lp`         | Downsampled daily data (last 5 years)                                                                            |
-| `influx-energy-hourly.lp` | Energy hourly sums (last 2 years)                                                                                |
-| `influx-energy-daily.lp`  | Energy daily sums (last 10 years)                                                                                |
-| `data/*`                  | All non-DB files from `data/` (token secrets, etc.) — dynamically scanned, excluding `.db`, `.pid`, `.log` files |
+| Entry                     | Content                                                                                                                                       |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sowel-backup.json`       | SQLite export as JSON, structured per table (version 2 format)                                                                                |
+| `influx-raw.lp`           | Raw InfluxDB data as line protocol (last 7 days)                                                                                              |
+| `influx-hourly.lp`        | Downsampled hourly data (last 90 days)                                                                                                        |
+| `influx-daily.lp`         | Downsampled daily data (last 5 years)                                                                                                         |
+| `influx-energy-hourly.lp` | Energy hourly sums (last 2 years)                                                                                                             |
+| `influx-energy-daily.lp`  | Energy daily sums (last 10 years)                                                                                                             |
+| `data/*`                  | All non-DB files from `data/` (token secrets, etc.), dynamically scanned, excluding `.db`, `.pid`, `.log` files and the `.instance-id` marker |
 
 The SQLite JSON export covers a curated list of tables (`BACKUP_TABLES` constant in `backup-manager.ts`) in dependency order (parents first for restore).
+
+The `.instance-id` marker is excluded on purpose, in both directions: it describes the deployment currently running, and an archive that carried it would hand a restoring instance the identity of the machine the data came from, disarming the #401 restored-data guardrail. See the "Restoring a backup from another deployment" section of [deployment.md](deployment.md).
 
 ### Local backups (data/backups/)
 

--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -229,6 +229,8 @@ L'identifiant d'instance stocké dans la table settings voyage dans les backups.
 
 L'autre moitié de la comparaison est le fichier marqueur `.instance-id` situé à côté de la base, qui décrit le déploiement en cours d'exécution. Ce fichier n'est délibérément **jamais** embarqué dans un backup ni réécrit par une restauration : une instance conserve donc sa propre identité quelle que soit l'archive qu'on lui donne. Restaurer une archive de production sur une seconde machine déclenche donc bien le bandeau, et c'est précisément l'objectif : la restauration est la façon dont des données de production arrivent normalement là où elles n'ont rien à faire. Les versions antérieures embarquaient le marqueur dans l'archive, ce qui faisait venir les deux moitiés de la comparaison du même déploiement et empêchait silencieusement le garde-fou de se déclencher lors d'une restauration (issue #790).
 
+Une instance démarrée avec `SOWEL_SHADOW_MODE=1` est par construction une copie volontaire des données de production : elle a donc toujours une reprise en attente, et le bandeau y est supprimé. Les gates du mode shadow la maintiennent déjà inerte, et confirmer graverait l'identité d'origine dans le marqueur du shadow, supprimant la seconde ligne de défense pour le jour où la variable d'environnement sera oubliée.
+
 ### Contenu de l'archive
 
 Voir la section "Backup et restauration" dans [architecture.md](architecture.md) pour le format complet.

--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -227,6 +227,8 @@ docker compose restart sowel
 
 L'identifiant d'instance stocké dans la table settings voyage dans les backups. Quand une base restaurée porte l'identifiant d'un autre déploiement (backup de prod ouvert sur une machine de dev, migration vers un nouveau matériel), le moteur démarre **inerte** : intégrations sortantes, recettes, publishers et notifications restent désactivés, et un bandeau rouge s'affiche dans l'UI. Un admin confirme la reprise depuis ce bandeau (le moteur redémarre alors armé), ou vous pouvez pré-confirmer avec `SOWEL_TAKEOVER=1` dans l'environnement. Cela empêche une copie des données de production de se connecter vers l'extérieur et de perturber le déploiement d'origine (collisions de clientId MQTT, courses sur les refresh tokens OAuth).
 
+L'autre moitié de la comparaison est le fichier marqueur `.instance-id` situé à côté de la base, qui décrit le déploiement en cours d'exécution. Ce fichier n'est délibérément **jamais** embarqué dans un backup ni réécrit par une restauration : une instance conserve donc sa propre identité quelle que soit l'archive qu'on lui donne. Restaurer une archive de production sur une seconde machine déclenche donc bien le bandeau, et c'est précisément l'objectif : la restauration est la façon dont des données de production arrivent normalement là où elles n'ont rien à faire. Les versions antérieures embarquaient le marqueur dans l'archive, ce qui faisait venir les deux moitiés de la comparaison du même déploiement et empêchait silencieusement le garde-fou de se déclencher lors d'une restauration (issue #790).
+
 ### Contenu de l'archive
 
 Voir la section "Backup et restauration" dans [architecture.md](architecture.md) pour le format complet.

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -233,6 +233,8 @@ docker compose restart sowel
 
 The instance id stored in the settings table travels inside backups. When a restored database carries another deployment's id (a prod backup opened on a dev machine, a migration to new hardware), the engine starts **inert**: outbound integrations, recipes, publishers, and notifications stay disabled, and a red banner appears in the UI. An admin confirms the takeover from that banner (the engine then restarts armed), or you can pre-confirm with `SOWEL_TAKEOVER=1` in the environment. This prevents a copy of production data from dialing out and fighting the original deployment (MQTT client id collisions, OAuth refresh-token races).
 
+The other half of the comparison is the `.instance-id` marker file next to the database, which describes the deployment currently running. That file is deliberately **never** carried by a backup and never written by a restore, so an instance keeps its own identity whatever archive you feed it. Restoring a production archive onto a second machine therefore trips the banner, which is the point: the restore path is how production data normally arrives somewhere it does not belong. Earlier versions carried the marker inside the archive, which made both halves of the comparison come from the same deployment and left the guardrail silently unable to fire on a restore (issue #790).
+
 ### Archive contents
 
 See the "Backup & Restore" section in [architecture.md](architecture.md) for the full format.

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -235,6 +235,8 @@ The instance id stored in the settings table travels inside backups. When a rest
 
 The other half of the comparison is the `.instance-id` marker file next to the database, which describes the deployment currently running. That file is deliberately **never** carried by a backup and never written by a restore, so an instance keeps its own identity whatever archive you feed it. Restoring a production archive onto a second machine therefore trips the banner, which is the point: the restore path is how production data normally arrives somewhere it does not belong. Earlier versions carried the marker inside the archive, which made both halves of the comparison come from the same deployment and left the guardrail silently unable to fire on a restore (issue #790).
 
+An instance started with `SOWEL_SHADOW_MODE=1` is a deliberate copy of production data, so it always has a pending takeover and the banner is suppressed there. The shadow gates already hold it inert, and confirming would stamp the origin's identity onto the shadow's marker, removing the second line of defence for the day the environment variable is forgotten.
+
 ### Archive contents
 
 See the "Backup & Restore" section in [architecture.md](architecture.md) for the full format.

--- a/src/backup/backup-manager.test.ts
+++ b/src/backup/backup-manager.test.ts
@@ -461,6 +461,35 @@ describe("BackupManager", () => {
       expect(identity.instanceId).toBe(ORIGIN_ID);
     });
 
+    it("leaves the guardrail disarmed when an instance restores its own backup", async () => {
+      // The common case, and the one this exclusion could plausibly break: the
+      // marker is skipped, but the settings row carries this instance's own id,
+      // so the two halves still agree and nothing is prompted.
+      writeFileSync(resolve(tmpDir, INSTANCE_MARKER_FILE), LOCAL_ID + "\n");
+
+      const zip = new AdmZip();
+      const tables = Object.fromEntries(BACKUP_TABLES.map((t) => [t, [] as unknown[]]));
+      tables.settings = [
+        { key: INSTANCE_ID_SETTING, value: LOCAL_ID, updated_at: "2026-08-01T00:00:00.000Z" },
+      ];
+      zip.addFile(
+        "sowel-backup.json",
+        Buffer.from(JSON.stringify({ version: 2, exportedAt: new Date().toISOString(), tables })),
+      );
+      zip.addFile(`data/${INSTANCE_MARKER_FILE}`, Buffer.from(LOCAL_ID + "\n"));
+
+      await manager.restoreFromBuffer(zip.toBuffer());
+
+      expect(localMarker()).toBe(LOCAL_ID);
+      const identity = resolveInstanceIdentity({
+        settingsManager: new SettingsManager(db),
+        dataDir: tmpDir,
+        takeoverConfirmed: false,
+        logger,
+      });
+      expect(identity.takeoverPending).toBe(false);
+    });
+
     it("does not create a marker on an instance that has none yet", async () => {
       // A restore onto a pristine data dir must leave the identity to be minted
       // on the next boot, not adopt the origin's.

--- a/src/backup/backup-manager.test.ts
+++ b/src/backup/backup-manager.test.ts
@@ -6,6 +6,12 @@ import { tmpdir } from "node:os";
 import AdmZip from "adm-zip";
 import { BACKUP_TABLES, BackupManager, BackupSizeCapExceededError } from "./backup-manager.js";
 import { createLogger } from "../core/logger.js";
+import {
+  INSTANCE_ID_SETTING,
+  INSTANCE_MARKER_FILE,
+  resolveInstanceIdentity,
+} from "../core/instance-identity.js";
+import { SettingsManager } from "../core/settings-manager.js";
 import { applyMigrations } from "../test-helpers/migrations.js";
 import type { InfluxClient } from "../core/influx-client.js";
 
@@ -164,6 +170,25 @@ describe("BackupManager", () => {
       // without a test noticing.
       const entry = zip.getEntries().find((e) => e.entryName === "sowel-backup.json");
       expect(entry?.header.method).toBe(8);
+    });
+
+    // #790 — the instance marker is the local half of the #401 guardrail.
+    // Shipping it inside the archive makes both halves of the comparison come
+    // from the same deployment, so the guardrail can never fire.
+    it("never carries the instance marker into the archive (#790)", async () => {
+      writeFileSync(
+        resolve(tmpDir, INSTANCE_MARKER_FILE),
+        "55c68282-8cae-4a4a-b86c-46ae9347fa46\n",
+      );
+      // A neighbouring data file proves the scan is still picking files up, so
+      // an assertion passing because nothing was scanned at all would be caught.
+      writeFileSync(resolve(tmpDir, "tokens.json"), '{"ok":true}');
+
+      const result = await manager.exportToFile("identity.zip");
+      const names = new AdmZip(result.path).getEntries().map((e) => e.entryName);
+
+      expect(names).toContain("data/tokens.json");
+      expect(names).not.toContain(`data/${INSTANCE_MARKER_FILE}`);
     });
 
     it("multiple exports create multiple files", async () => {
@@ -372,6 +397,78 @@ describe("BackupManager", () => {
 
       expect(existsSync(resolve(tmpDir, "legit.json"))).toBe(true);
       expect(readFileSync(resolve(tmpDir, "legit.json"), "utf-8")).toBe('{"ok": true}');
+    });
+  });
+
+  // ── #790 — the restore must not hand this deployment a foreign identity ──
+  //
+  // The #401 guardrail compares the instance id carried in the settings table
+  // (which travels inside backups by design) with the `.instance-id` marker
+  // beside the database (which describes THIS deployment). Restoring the marker
+  // too made both halves come from the same source, so `takeoverPending` could
+  // never become true and a prod backup restored on a second machine came up
+  // fully armed against the origin instance.
+  describe("restoreFromBuffer — #401 guardrail survives a restore (#790)", () => {
+    const ORIGIN_ID = "55c68282-8cae-4a4a-b86c-46ae9347fa46";
+    const LOCAL_ID = "23972d52-8cff-43ce-b9c8-1ed459ae27d9";
+
+    /** Archive as an instance predating #790 would have produced it. */
+    function buildArchiveCarryingOriginIdentity(): Buffer {
+      const zip = new AdmZip();
+      const tables = Object.fromEntries(BACKUP_TABLES.map((t) => [t, [] as unknown[]]));
+      tables.settings = [
+        { key: INSTANCE_ID_SETTING, value: ORIGIN_ID, updated_at: "2026-08-01T00:00:00.000Z" },
+      ];
+      zip.addFile(
+        "sowel-backup.json",
+        Buffer.from(JSON.stringify({ version: 2, exportedAt: new Date().toISOString(), tables })),
+      );
+      zip.addFile(`data/${INSTANCE_MARKER_FILE}`, Buffer.from(ORIGIN_ID + "\n"));
+      return zip.toBuffer();
+    }
+
+    function localMarker(): string | null {
+      const p = resolve(tmpDir, INSTANCE_MARKER_FILE);
+      return existsSync(p) ? readFileSync(p, "utf-8").trim() : null;
+    }
+
+    it("leaves the local instance marker untouched", async () => {
+      writeFileSync(resolve(tmpDir, INSTANCE_MARKER_FILE), LOCAL_ID + "\n");
+
+      await manager.restoreFromBuffer(buildArchiveCarryingOriginIdentity());
+
+      expect(localMarker()).toBe(LOCAL_ID);
+    });
+
+    it("arms the takeover guardrail on the next boot", async () => {
+      writeFileSync(resolve(tmpDir, INSTANCE_MARKER_FILE), LOCAL_ID + "\n");
+
+      await manager.restoreFromBuffer(buildArchiveCarryingOriginIdentity());
+
+      // The settings table now carries the origin deployment's id — that half
+      // is meant to travel. What must not travel is the marker.
+      const settingsManager = new SettingsManager(db);
+      expect(settingsManager.get(INSTANCE_ID_SETTING)).toBe(ORIGIN_ID);
+
+      const identity = resolveInstanceIdentity({
+        settingsManager,
+        dataDir: tmpDir,
+        takeoverConfirmed: false,
+        logger,
+      });
+
+      expect(identity.takeoverPending).toBe(true);
+      expect(identity.instanceId).toBe(ORIGIN_ID);
+    });
+
+    it("does not create a marker on an instance that has none yet", async () => {
+      // A restore onto a pristine data dir must leave the identity to be minted
+      // on the next boot, not adopt the origin's.
+      expect(localMarker()).toBeNull();
+
+      await manager.restoreFromBuffer(buildArchiveCarryingOriginIdentity());
+
+      expect(localMarker()).toBeNull();
     });
   });
 });

--- a/src/backup/backup-manager.ts
+++ b/src/backup/backup-manager.ts
@@ -120,9 +120,10 @@ const DELETE_ORDER = ["recipe_log", ...[...BACKUP_TABLES].reverse()];
 // instance id of the deployment that produced the data, and this marker carries
 // the identity of THIS deployment. The guardrail fires when the two disagree, so
 // a marker that travels inside the archive makes both halves come from the same
-// source and `takeoverPending` structurally false. Excluding it here covers both
-// directions at once: `scanDataFiles` keeps it out of new archives, and the
-// restore loop skips it in archives already in the wild.
+// source and `takeoverPending` structurally false. Listing it here is what keeps
+// it out of new archives (`scanDataFiles`) and is the backstop on restore; the
+// restore loop names it explicitly one step earlier so that an archive produced
+// before this fix leaves a log line rather than being skipped in silence.
 const DATA_FILES_EXCLUDE = new Set([
   "sowel.db",
   "sowel.db-wal",

--- a/src/backup/backup-manager.ts
+++ b/src/backup/backup-manager.ts
@@ -14,6 +14,7 @@ import AdmZip from "adm-zip";
 import type Database from "better-sqlite3";
 import type { Logger } from "../core/logger.js";
 import type { InfluxClient } from "../core/influx-client.js";
+import { INSTANCE_MARKER_FILE } from "../core/instance-identity.js";
 
 export interface BackupManagerDeps {
   db: Database.Database;
@@ -112,8 +113,23 @@ export const BACKUP_TABLES = [
 // Reverse order for deletion (children first) + tables not exported but must be cleared
 const DELETE_ORDER = ["recipe_log", ...[...BACKUP_TABLES].reverse()];
 
-// Exclude these files from data/ backup (managed separately or transient)
-const DATA_FILES_EXCLUDE = new Set(["sowel.db", "sowel.db-wal", "sowel.db-shm", "sowel.pid"]);
+// Exclude these files from data/ backup (managed separately or transient).
+//
+// `.instance-id` is here for a different reason than the rest (#790). It is the
+// local half of the #401 restored-data guardrail: the settings table carries the
+// instance id of the deployment that produced the data, and this marker carries
+// the identity of THIS deployment. The guardrail fires when the two disagree, so
+// a marker that travels inside the archive makes both halves come from the same
+// source and `takeoverPending` structurally false. Excluding it here covers both
+// directions at once: `scanDataFiles` keeps it out of new archives, and the
+// restore loop skips it in archives already in the wild.
+const DATA_FILES_EXCLUDE = new Set([
+  "sowel.db",
+  "sowel.db-wal",
+  "sowel.db-shm",
+  "sowel.pid",
+  INSTANCE_MARKER_FILE,
+]);
 const DATA_FILES_EXCLUDE_EXT = new Set([".db", ".pid", ".log"]);
 
 // Local backups subdirectory inside dataDir
@@ -500,7 +516,19 @@ export class BackupManager {
       }
 
       const filename = entry.entryName.slice("data/".length);
-      if (!filename || DATA_FILES_EXCLUDE.has(filename)) continue;
+      if (!filename) continue;
+      if (filename === INSTANCE_MARKER_FILE) {
+        // Archives produced before #790 carry the origin deployment's marker.
+        // Writing it back would hand this instance the identity of the machine
+        // the data came from, which is exactly what the #401 guardrail exists
+        // to notice. Keep our own marker.
+        this.logger.info(
+          { entry: entry.entryName },
+          "Backup restore: instance marker in archive ignored — this deployment keeps its own identity (#790)",
+        );
+        continue;
+      }
+      if (DATA_FILES_EXCLUDE.has(filename)) continue;
 
       // Path confinement: resolve + verify the result stays under dataDir.
       // Defeats `data/../../etc/passwd` and absolute-name games.

--- a/src/core/instance-identity.test.ts
+++ b/src/core/instance-identity.test.ts
@@ -6,6 +6,7 @@ import { createLogger } from "./logger.js";
 import {
   resolveInstanceIdentity,
   confirmTakeover,
+  shouldPromptTakeover,
   INSTANCE_ID_SETTING,
   INSTANCE_MARKER_FILE,
 } from "./instance-identity.js";
@@ -131,5 +132,25 @@ describe("resolveInstanceIdentity", () => {
       logger,
     });
     expect(identity.takeoverPending).toBe(false);
+  });
+});
+
+// #790 — restoring a prod backup onto a shadow instance is the documented
+// workflow (`scripts/shadow-deploy.sh seed`), and now that the marker no longer
+// travels, every shadow has a pending takeover for the whole of its life.
+// Prompting there is worse than useless: confirming stamps the origin id onto
+// the shadow's marker and disarms the guardrail for good.
+describe("shouldPromptTakeover", () => {
+  it("prompts on a normal instance whose data came from elsewhere", () => {
+    expect(shouldPromptTakeover({ takeoverPending: true, shadowModeFromEnv: false })).toBe(true);
+  });
+
+  it("stays silent on a deliberate shadow run", () => {
+    expect(shouldPromptTakeover({ takeoverPending: true, shadowModeFromEnv: true })).toBe(false);
+  });
+
+  it("stays silent when nothing is pending, shadow or not", () => {
+    expect(shouldPromptTakeover({ takeoverPending: false, shadowModeFromEnv: false })).toBe(false);
+    expect(shouldPromptTakeover({ takeoverPending: false, shadowModeFromEnv: true })).toBe(false);
   });
 });

--- a/src/core/instance-identity.ts
+++ b/src/core/instance-identity.ts
@@ -95,6 +95,25 @@ export function resolveInstanceIdentity(opts: {
   return { instanceId: dbId, takeoverPending: true };
 }
 
+/**
+ * Whether the UI should surface the takeover prompt.
+ *
+ * A deliberate shadow run (`SOWEL_SHADOW_MODE=1`) is a copy of production data
+ * by definition, so `takeoverPending` is true there by design and the prompt is
+ * pure noise. Worse, it is a trap: confirming writes the ORIGIN deployment's id
+ * into the shadow's marker, so the day the env var falls off the command line
+ * the guardrail no longer catches the very run it was built to catch. The spec
+ * 124 gates already hold the instance inert, so the prompt adds no protection
+ * a shadow does not already have.
+ */
+export function shouldPromptTakeover(opts: {
+  takeoverPending: boolean;
+  /** Shadow mode as requested by the environment, BEFORE a pending takeover forces it on. */
+  shadowModeFromEnv: boolean;
+}): boolean {
+  return opts.takeoverPending && !opts.shadowModeFromEnv;
+}
+
 /** Adopt the current database as this deployment's own (UI confirm path). */
 export function confirmTakeover(opts: {
   settingsManager: SettingsManager;

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,11 @@ import { UserManager } from "./auth/user-manager.js";
 import { AuthService } from "./auth/auth-service.js";
 import { MfaService } from "./auth/mfa-service.js";
 import { SettingsManager } from "./core/settings-manager.js";
-import { resolveInstanceIdentity, confirmTakeover } from "./core/instance-identity.js";
+import {
+  resolveInstanceIdentity,
+  confirmTakeover,
+  shouldPromptTakeover,
+} from "./core/instance-identity.js";
 import { ModeManager } from "./modes/mode-manager.js";
 import { CalendarManager } from "./modes/calendar-manager.js";
 import { ButtonActionManager } from "./buttons/button-action-manager.js";
@@ -229,6 +233,10 @@ async function main() {
   // stored instance id disagrees with the local marker, force the spec 124
   // shadow gates for this boot; the admin confirms the takeover in the UI
   // (or via SOWEL_TAKEOVER=1) and restarts to arm the instance.
+  // Read before the block below mutates it: a pending takeover forces shadow
+  // mode on, so `config.shadowMode` no longer tells us whether the operator
+  // asked for a shadow run. `shouldPromptTakeover` needs the operator's intent.
+  const shadowModeFromEnv = config.shadowMode;
   const identity = resolveInstanceIdentity({
     settingsManager,
     dataDir: config.dataDir,
@@ -598,7 +606,10 @@ async function main() {
     logger,
     corsOrigins: config.cors.origins,
     shadowMode: config.shadowMode,
-    takeoverPending: identity.takeoverPending,
+    takeoverPending: shouldPromptTakeover({
+      takeoverPending: identity.takeoverPending,
+      shadowModeFromEnv,
+    }),
     confirmTakeover: () => {
       confirmTakeover({ settingsManager, dataDir: config.dataDir, logger });
     },


### PR DESCRIPTION
## Root cause

The #401 restored-data guardrail compares two values: the instance id stored in the `settings` table, which travels inside backups by design, and the `.instance-id` marker file beside the database, which is meant to describe **this** deployment. When they disagree, the engine starts inert until an admin confirms the takeover.

The marker was in neither exclusion list. `DATA_FILES_EXCLUDE` does not name it, and `DATA_FILES_EXCLUDE_EXT` never sees it because `scanDataFiles` derives the extension with `slice(lastIndexOf("."))`, which on a leading-dot filename returns the whole name. So the export copied it into the archive and the restore wrote it back. Both halves of the comparison then came from the same deployment and `takeoverPending` was structurally always `false`.

Restoring a production archive onto a second machine therefore produced a fully armed instance sharing the origin's MQTT clientId, OAuth grants and notification channels: the 2026-08-10 incident the guardrail was built to prevent.

## Fix

`INSTANCE_MARKER_FILE` joins `DATA_FILES_EXCLUDE`, which covers both directions in one edit: the export scan skips it, and the restore loop skips it in archives already in the wild. The restore names it explicitly one step earlier so a pre-fix archive leaves a log line instead of being skipped in silence.

A second commit handles what the agent review surfaced: with the marker no longer travelling, `scripts/shadow-deploy.sh seed` leaves every shadow instance with a permanently pending takeover, and the red banner beside the amber SHADOW MODE one invites the operator to confirm it. Confirming stamps the **origin** deployment's id onto the shadow's marker, so the day `SOWEL_SHADOW_MODE` falls off the command line the guardrail no longer catches the very run it exists to catch. `shouldPromptTakeover` suppresses the prompt when shadow mode was requested by the environment; the spec 124 gates already hold a shadow inert, so nothing is lost.

## Behaviour change

Disaster recovery onto a fresh volume now trips the takeover banner and needs one admin click, or `SOWEL_TAKEOVER=1`. That is what #401 was built to do, and the deployment guide already names "a migration to new hardware" as a case that trips it.

Restoring your own backup on the same instance is unaffected: the marker is skipped but the settings row carries this instance's own id, so the two halves still agree. Pinned by a test, since that is the case this change could plausibly have regressed.

## Tests

Five new, four of which fail without the one-line exclusion (verified by reverting only `backup-manager.ts` and re-running):

- export never emits `data/.instance-id`, with a neighbouring `tokens.json` proving the scan still runs so the assertion cannot pass vacuously
- restore leaves an existing local marker untouched
- restore onto a pristine data dir creates no marker
- end to end: after restoring an archive carrying a foreign identity, `resolveInstanceIdentity` returns `takeoverPending: true`, going through the real function rather than re-asserting the exclusion
- negative case: an instance restoring its own backup still boots with the guardrail disarmed

Plus three unit tests on `shouldPromptTakeover`. Full backend suite: 2105 passed.

## Docs

`deployment.{md,fr.md}` gain the marker's role and the shadow-mode suppression. `architecture.{md,fr.md}` had drifted: the archive-format table still listed only the `.db`/`.pid`/`.log` exclusions, and the new deployment paragraph points readers straight at it.

## Deferred

The export and restore derive a file's extension differently (`slice(lastIndexOf("."))` vs `extname()`), so any `data/.<name>` entry bypasses the spec 089 C2 extension whitelist and two entries in `ALLOWED_RESTORE_EXTENSIONS` are dead. `.instance-id` was the visible symptom; the general case is filed as #829.

Closes #790
