### PR TITLE
ci(release): gate the GitHub Release on the multi-arch manifest (#764, #638)

### DIFF
--- a/.claude/skills/sowel-release/SKILL.md
+++ b/.claude/skills/sowel-release/SKILL.md
@@ -102,8 +102,9 @@ After pushing the tag, GitHub Actions will:
 
 1. Verify release notes anchors (fails fast if missing — recovery: add the entries, amend, `git tag -f v<version> && git push --force origin v<version>`)
 2. Run CI checks (typecheck, lint, tests)
-3. Build Docker images (amd64 + arm64) and push `ghcr.io/mchacher/sowel:<version>` and `:latest`
-4. Create the GitHub Release with changelog
+3. Build Docker images (amd64 + arm64) in parallel and push `ghcr.io/mchacher/sowel:<version>` and `:<version>-arm64`
+4. Promote the two into one multi-arch `:<version>`, then point `:latest` at it
+5. Create the GitHub Release with changelog
 
 ```bash
 gh run list --limit 3
@@ -111,6 +112,8 @@ gh run view <run-id> --log-failed   # if it fails
 ```
 
 Do NOT poll in a fire-and-forget background loop; check directly, then act.
+
+**If the arm64 build fails** (#764): steps 4 and 5 are skipped on purpose, so `:latest` and the GitHub Release are withheld and no instance is told about a version half the fleet cannot pull. The `arm64-required` job turns the run red so this never reads as a success. Recover with **Re-run all jobs** on that run. Do NOT dispatch the workflow on the tag: the dispatch path resolves the version from `test_tag`, so it builds test images and publishes nothing under the tag's own version.
 
 > **CHECK**: GitHub Actions workflow completed successfully.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           FROM: ${{ inputs.restore_latest_from }}
         run: |
-          docker buildx imagetools create --tag ${REPO}:latest ${REPO}:${FROM}
+          docker buildx imagetools create --tag "${REPO}:latest" "${REPO}:${FROM}"
 
   # ── Verify release-notes entry exists (spec 108) ─────────
   # Greps both EN and FR release-notes pages for the version anchor that
@@ -137,12 +137,23 @@ jobs:
           TEST_TAG: ${{ inputs.test_tag }}
         run: |
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "version=${TEST_TAG}" >> $GITHUB_OUTPUT
-            echo "is_release=false" >> $GITHUB_OUTPUT
+            VERSION="${TEST_TAG}"
+            IS_RELEASE=false
           else
-            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
-            echo "is_release=true" >> $GITHUB_OUTPUT
+            VERSION="${GITHUB_REF_NAME#v}"
+            IS_RELEASE=true
           fi
+          # A version reaches an unquoted `${REPO}:${V}` in imagetools and the
+          # `tags:` list of build-push-action, and is written to GITHUB_OUTPUT
+          # a line at a time. A newline in it would inject a second output key;
+          # a space would word-split into extra CLI arguments. Neither is a
+          # legitimate image tag, so refuse rather than sanitise.
+          if [[ ! "$VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "::error::Refusing version '${VERSION}': not a valid image tag"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "is_release=${IS_RELEASE}" >> $GITHUB_OUTPUT
 
       # :latest is deliberately NOT pushed here (#764). This job produces an
       # amd64-only manifest, so pushing :latest before promote-manifest merges
@@ -181,7 +192,10 @@ jobs:
   # the GitHub Release job are both gated on this job succeeding (#764). An
   # arm64 failure therefore leaves :V pushed as amd64-only and withholds both
   # :latest and the Release, so no instance is told about a version half the
-  # fleet cannot pull. Re-running the workflow on the same tag completes it.
+  # fleet cannot pull, and the `arm64-required` job turns the run red so the
+  # omission is not silent. Recover with "Re-run all jobs" on that run, NOT by
+  # dispatching the workflow on the tag: the dispatch path builds :<test_tag>
+  # images and publishes nothing under the tag's own version.
   docker-arm64:
     needs: ci
     runs-on: ubuntu-24.04-arm
@@ -208,12 +222,23 @@ jobs:
           TEST_TAG: ${{ inputs.test_tag }}
         run: |
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "version=${TEST_TAG}" >> $GITHUB_OUTPUT
-            echo "is_release=false" >> $GITHUB_OUTPUT
+            VERSION="${TEST_TAG}"
+            IS_RELEASE=false
           else
-            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
-            echo "is_release=true" >> $GITHUB_OUTPUT
+            VERSION="${GITHUB_REF_NAME#v}"
+            IS_RELEASE=true
           fi
+          # A version reaches an unquoted `${REPO}:${V}` in imagetools and the
+          # `tags:` list of build-push-action, and is written to GITHUB_OUTPUT
+          # a line at a time. A newline in it would inject a second output key;
+          # a space would word-split into extra CLI arguments. Neither is a
+          # legitimate image tag, so refuse rather than sanitise.
+          if [[ ! "$VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "::error::Refusing version '${VERSION}': not a valid image tag"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "is_release=${IS_RELEASE}" >> $GITHUB_OUTPUT
 
       - name: Compute image tags
         id: tags
@@ -269,25 +294,36 @@ jobs:
           TEST_TAG: ${{ inputs.test_tag }}
         run: |
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "version=${TEST_TAG}" >> $GITHUB_OUTPUT
-            echo "is_release=false" >> $GITHUB_OUTPUT
+            VERSION="${TEST_TAG}"
+            IS_RELEASE=false
           else
-            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
-            echo "is_release=true" >> $GITHUB_OUTPUT
+            VERSION="${GITHUB_REF_NAME#v}"
+            IS_RELEASE=true
           fi
+          # A version reaches an unquoted `${REPO}:${V}` in imagetools and the
+          # `tags:` list of build-push-action, and is written to GITHUB_OUTPUT
+          # a line at a time. A newline in it would inject a second output key;
+          # a space would word-split into extra CLI arguments. Neither is a
+          # legitimate image tag, so refuse rather than sanitise.
+          if [[ ! "$VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "::error::Refusing version '${VERSION}': not a valid image tag"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "is_release=${IS_RELEASE}" >> $GITHUB_OUTPUT
       - name: Promote tags to multi-arch manifest
         env:
           REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           V: ${{ steps.version.outputs.version }}
           IS_RELEASE: ${{ steps.version.outputs.is_release }}
         run: |
-          docker buildx imagetools create --tag ${REPO}:${V} ${REPO}:${V} ${REPO}:${V}-arm64
+          docker buildx imagetools create --tag "${REPO}:${V}" "${REPO}:${V}" "${REPO}:${V}-arm64"
           if [[ "$IS_RELEASE" == "true" ]]; then
             # :V is multi-arch as of the line above, so :latest is a copy of it
             # rather than a second merge of the two per-arch tags. This is the
             # only step that publishes :latest, so the tag is never transiently
             # single-arch (#764).
-            docker buildx imagetools create --tag ${REPO}:latest ${REPO}:${V}
+            docker buildx imagetools create --tag "${REPO}:latest" "${REPO}:${V}"
           fi
 
   # ── Create GitHub Release (after multi-arch manifest is published) ──
@@ -304,9 +340,20 @@ jobs:
   # exactly the failure the gate exists to prevent, silently and on a green
   # run. amd64 images remain pullable by tag or digest either way; what an
   # arm64 failure withholds is the update announcement.
+  #
+  # `github.event_name == 'push'` is load-bearing, not decoration. The "Run
+  # workflow" dropdown accepts a TAG as its ref, and on that path every
+  # "Resolve version" step takes the workflow_dispatch branch: only
+  # :<test_tag> images are built, nothing is published under the tag's own
+  # version. Without this term `startsWith(github.ref, 'refs/tags/v')` still
+  # holds, so the job would create a GitHub Release for a version that has no
+  # images anywhere, and UpdateChecker would announce it to the whole fleet.
+  #
+  # `!cancelled()` rather than `always()`: cancelling a run after
+  # promote-manifest succeeded should not still publish the Release.
   release:
     needs: [docker, docker-arm64, promote-manifest]
-    if: always() && needs.docker.result == 'success' && needs.promote-manifest.result == 'success' && startsWith(github.ref, 'refs/tags/v')
+    if: ${{ !cancelled() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && needs.docker.result == 'success' && needs.promote-manifest.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -320,6 +367,36 @@ jobs:
           gh release create "$V" \
             --title "Sowel ${V#v}" \
             --generate-notes
+
+  # ── Make an arm64 failure loud ────────────────────────────
+  # `continue-on-error` on docker-arm64 buys ordering: amd64 finishes and its
+  # image is published while arm64 is still building, and a broken arm64 build
+  # does not abort a job that has already succeeded. What it must not buy is
+  # silence. Without this job an arm64 failure produces a GREEN run in which
+  # `release` is merely grey, and GitHub notifies on red runs, not on skipped
+  # jobs: the maintainer tags v1.58.0, sees green, moves on, and nobody ever
+  # receives 1.58.0 while :latest stays on the previous version.
+  #
+  # Kept as a separate terminal job rather than dropping continue-on-error so
+  # the amd64 image still reaches GHCR on a mixed run and can be pulled by
+  # digest while the arm64 build is repaired.
+  arm64-required:
+    needs: [docker-arm64, promote-manifest, release]
+    if: ${{ !cancelled() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail the run when the release was withheld
+        env:
+          ARM64: ${{ needs.docker-arm64.result }}
+          PROMOTE: ${{ needs.promote-manifest.result }}
+          RELEASE: ${{ needs.release.result }}
+        run: |
+          if [[ "$ARM64" == "success" && "$PROMOTE" == "success" && "$RELEASE" == "success" ]]; then
+            echo "arm64 built, manifest promoted, Release published."
+            exit 0
+          fi
+          echo "::error::Release withheld (arm64=${ARM64}, promote-manifest=${PROMOTE}, release=${RELEASE}). The amd64 image is on GHCR under its version tag, but :latest and the GitHub Release were not published, so no instance is told about a version half the fleet cannot pull. Fix the arm64 build and use Re-run all jobs on this run."
+          exit 1
 
   # ── GHCR retention policy ─────────────────────────────────
   # After a successful release, prune old container versions on GHCR so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Check release-notes entry
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "Skipping release-notes check on workflow_dispatch event"
             exit 0
           fi
@@ -113,7 +115,7 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
     steps:
       - uses: actions/checkout@v7
@@ -130,29 +132,32 @@ jobs:
 
       - name: Resolve version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TEST_TAG: ${{ inputs.test_tag }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "version=${{ inputs.test_tag }}" >> $GITHUB_OUTPUT
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "version=${TEST_TAG}" >> $GITHUB_OUTPUT
             echo "is_release=false" >> $GITHUB_OUTPUT
           else
             echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
             echo "is_release=true" >> $GITHUB_OUTPUT
           fi
 
+      # :latest is deliberately NOT pushed here (#764). This job produces an
+      # amd64-only manifest, so pushing :latest before promote-manifest merges
+      # the two architectures leaves a window, short but real on every healthy
+      # release, in which an arm64 host pulling :latest gets no matching
+      # manifest. promote-manifest points :latest at the merged :V instead.
       - name: Compute image tags
         id: tags
         env:
           REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           V: ${{ steps.version.outputs.version }}
-          IS_RELEASE: ${{ steps.version.outputs.is_release }}
         run: |
-          tags="${REPO}:${V}"
-          if [[ "$IS_RELEASE" == "true" ]]; then
-            tags="${tags}"$'\n'"${REPO}:latest"
-          fi
           {
             echo 'list<<EOF'
-            echo "$tags"
+            echo "${REPO}:${V}"
             echo 'EOF'
           } >> $GITHUB_OUTPUT
 
@@ -171,8 +176,12 @@ jobs:
   # No QEMU emulation — build time drops from ~12 min to ~2 min and runs
   # in parallel with the amd64 job. Once both archs are pushed, the
   # multi-arch manifest is promoted in this job's last step.
-  # Failure here does NOT fail the release — amd64 image stays valid,
-  # the main tags just remain amd64-only until the next release.
+  # continue-on-error keeps an arm64 failure from failing the workflow, but
+  # it does not make the release proceed without arm64: promote-manifest and
+  # the GitHub Release job are both gated on this job succeeding (#764). An
+  # arm64 failure therefore leaves :V pushed as amd64-only and withholds both
+  # :latest and the Release, so no instance is told about a version half the
+  # fleet cannot pull. Re-running the workflow on the same tag completes it.
   docker-arm64:
     needs: ci
     runs-on: ubuntu-24.04-arm
@@ -194,9 +203,12 @@ jobs:
 
       - name: Resolve version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TEST_TAG: ${{ inputs.test_tag }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "version=${{ inputs.test_tag }}" >> $GITHUB_OUTPUT
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "version=${TEST_TAG}" >> $GITHUB_OUTPUT
             echo "is_release=false" >> $GITHUB_OUTPUT
           else
             echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
@@ -252,9 +264,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Resolve version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TEST_TAG: ${{ inputs.test_tag }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "version=${{ inputs.test_tag }}" >> $GITHUB_OUTPUT
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "version=${TEST_TAG}" >> $GITHUB_OUTPUT
             echo "is_release=false" >> $GITHUB_OUTPUT
           else
             echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
@@ -268,20 +283,30 @@ jobs:
         run: |
           docker buildx imagetools create --tag ${REPO}:${V} ${REPO}:${V} ${REPO}:${V}-arm64
           if [[ "$IS_RELEASE" == "true" ]]; then
-            docker buildx imagetools create --tag ${REPO}:latest ${REPO}:latest ${REPO}:latest-arm64
+            # :V is multi-arch as of the line above, so :latest is a copy of it
+            # rather than a second merge of the two per-arch tags. This is the
+            # only step that publishes :latest, so the tag is never transiently
+            # single-arch (#764).
+            docker buildx imagetools create --tag ${REPO}:latest ${REPO}:${V}
           fi
 
   # ── Create GitHub Release (after multi-arch manifest is published) ──
-  # Gated behind promote-manifest so the Release is not visible until
-  # the multi-arch manifest exists. Otherwise arm64 instances (Pi) would
-  # see "update available" while `docker pull` still fails for them.
-  # If arm64 fails (continue-on-error), promote-manifest is skipped, and
-  # this job still runs because of `always() && needs.docker.result ==
-  # 'success'` — the main tag stays amd64-only and arm64 users correctly
-  # see no update.
+  # Gated behind promote-manifest so the Release is not visible until the
+  # multi-arch manifest exists. UpdateChecker polls the GitHub Release
+  # (`/releases/latest` in src/core/version-checker.ts), not the GHCR
+  # manifest, so a Release published while :V is still amd64-only tells
+  # every Raspberry Pi an update is available and then fails their
+  # `docker pull` with no matching manifest.
+  #
+  # arm64 is continue-on-error, so an arm64 failure skips promote-manifest
+  # and must skip this job too (#764). Before that condition was added the
+  # release job only checked `docker`, so it published anyway and produced
+  # exactly the failure the gate exists to prevent, silently and on a green
+  # run. amd64 images remain pullable by tag or digest either way; what an
+  # arm64 failure withholds is the update announcement.
   release:
     needs: [docker, docker-arm64, promote-manifest]
-    if: always() && needs.docker.result == 'success' && startsWith(github.ref, 'refs/tags/v')
+    if: always() && needs.docker.result == 'success' && needs.promote-manifest.result == 'success' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -436,13 +436,15 @@ Pourquoi un helper ? Appeler `dockerode.stop()` sur le conteneur en cours depuis
 
 1. **job verify-release-notes** : fait échouer le workflow avant tout build si le commit taggé n'a pas d'ancre de release notes (spec 108)
 2. **job ci** : typecheck, lint, tests (backend + UI)
-3. **jobs docker** : build `linux/amd64` et `linux/arm64` avec Buildx en parallèle, chacun poussant son propre tag (`:<version>` et `:<version>-arm64`)
+3. **jobs docker** : build `linux/amd64` et `linux/arm64` avec Buildx en parallèle, chacun poussant son propre tag (`:<version>`, et `:<version>-arm64` plus `:latest-arm64` pour le job arm64)
 4. **job promote-manifest** : fusionne les deux en un `:<version>` multi-architecture, puis fait pointer `:latest` dessus
 5. **job release** : crée la GitHub Release avec des notes auto-générées
+6. **job arm64-required** : fait échouer le run quand la release a été retenue, pour qu'un échec arm64 ne soit pas juste un job grisé sur un run vert
+7. **job prune-ghcr** : conserve les 30 versions GHCR les plus récentes après une release réussie, sans jamais toucher aux tags flottants `:latest`
 
 Le build Docker est **multi-architecture** : amd64 et arm64 sont construits dans des jobs parallèles puis fusionnés en un seul manifeste, de sorte que `docker pull` résout la bonne image.
 
-L'ordre des trois dernières étapes est une exigence de correction, pas de confort. `UpdateChecker` interroge la GitHub Release et non le manifeste GHCR : une Release publiée alors que `:<version>` est encore amd64-only annoncerait une mise à jour à tous les Raspberry Pi puis ferait échouer leur `docker pull`. `promote-manifest` et `release` sont donc conditionnés à la réussite du build arm64, et `:latest` n'est publié que par `promote-manifest`, jamais par le job amd64. Un échec arm64 laisse `:<version>` poussé en amd64-only et retient à la fois `:latest` et la Release : rien n'annonce une version que la moitié du parc ne peut pas récupérer, et relancer le workflow sur le même tag termine l'opération.
+L'ordre des trois dernières étapes est une exigence de correction, pas de confort. `UpdateChecker` interroge la GitHub Release et non le manifeste GHCR : une Release publiée alors que `:<version>` est encore amd64-only annoncerait une mise à jour à tous les Raspberry Pi puis ferait échouer leur `docker pull`. `promote-manifest` et `release` sont donc conditionnés à la réussite du build arm64, et `:latest` n'est publié que par `promote-manifest`, jamais par le job amd64. Un échec arm64 laisse `:<version>` poussé en amd64-only et retient à la fois `:latest` et la Release : rien n'annonce une version que la moitié du parc ne peut pas récupérer. La récupération passe par **Re-run all jobs** sur ce run, jamais par un dispatch du workflow sur le tag : le chemin dispatch résout la version depuis `test_tag`, donc il construit des images de test et ne publie rien sous la version du tag.
 
 ### Script de release
 

--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -434,20 +434,26 @@ Pourquoi un helper ? Appeler `dockerode.stop()` sur le conteneur en cours depuis
 
 `.github/workflows/release.yml` se déclenche sur les tags poussés correspondant à `v*`. Il exécute :
 
-1. **job ci** : typecheck, lint, tests (backend + UI)
-2. **job docker** : build l'image `linux/amd64` avec Buildx, pousse vers `ghcr.io/mchacher/sowel:<version>` et `:latest`, puis crée une GitHub Release avec des notes auto-générées
+1. **job verify-release-notes** : fait échouer le workflow avant tout build si le commit taggé n'a pas d'ancre de release notes (spec 108)
+2. **job ci** : typecheck, lint, tests (backend + UI)
+3. **jobs docker** : build `linux/amd64` et `linux/arm64` avec Buildx en parallèle, chacun poussant son propre tag (`:<version>` et `:<version>-arm64`)
+4. **job promote-manifest** : fusionne les deux en un `:<version>` multi-architecture, puis fait pointer `:latest` dessus
+5. **job release** : crée la GitHub Release avec des notes auto-générées
 
-Le build Docker est **amd64-only** (spec simplifiée en avril 2026 pour des builds environ 3x plus rapides ; arm64 abandonné car aucun utilisateur ne tourne sur des hôtes Linux Apple Silicon en production).
+Le build Docker est **multi-architecture** : amd64 et arm64 sont construits dans des jobs parallèles puis fusionnés en un seul manifeste, de sorte que `docker pull` résout la bonne image.
+
+L'ordre des trois dernières étapes est une exigence de correction, pas de confort. `UpdateChecker` interroge la GitHub Release et non le manifeste GHCR : une Release publiée alors que `:<version>` est encore amd64-only annoncerait une mise à jour à tous les Raspberry Pi puis ferait échouer leur `docker pull`. `promote-manifest` et `release` sont donc conditionnés à la réussite du build arm64, et `:latest` n'est publié que par `promote-manifest`, jamais par le job amd64. Un échec arm64 laisse `:<version>` poussé en amd64-only et retient à la fois `:latest` et la Release : rien n'annonce une version que la moitié du parc ne peut pas récupérer, et relancer le workflow sur le même tag termine l'opération.
 
 ### Script de release
 
 `scripts/release.sh <version>` :
 
 1. Valide le format semver et un working tree propre
-2. Bump les versions de `package.json` + `ui/package.json`
-3. Lance la validation complète (`npm run validate`)
-4. Commit `release: vX.Y.Z`, tag `vX.Y.Z`, push vers origin
-5. GitHub Actions prend le relais
+2. **Vérifie** que `package.json` et `ui/package.json` sont déjà à cette version, et sort sinon. Il ne les bump pas : c'est une PR normale qui le fait, et elle est mergée avant le tag
+3. Tag `vX.Y.Z` et pousse le tag vers origin
+4. GitHub Actions prend le relais
+
+Il ne lance aucune validation de son côté et ne commite pas. La protection de branche impose que le bump de version et les release notes passent d'abord par une PR.
 
 Une skill Claude Code emballe ça dans `.claude/skills/sowel-release/SKILL.md`.
 

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -539,10 +539,15 @@ Why a helper? Calling `dockerode.stop()` on the current container from within th
 
 `.github/workflows/release.yml` triggers on pushed tags matching `v*`. It runs:
 
-1. **ci job** — typecheck, lint, tests (backend + UI)
-2. **docker jobs** — build `linux/amd64` and `linux/arm64` with Buildx, push to `ghcr.io/mchacher/sowel:<version>`, then a `promote-manifest` job merges them into one multi-architecture `:latest`, and a GitHub Release is created with auto-generated notes
+1. **verify-release-notes job**: fails the workflow before any layer is built if the tagged commit has no release-notes anchor (spec 108)
+2. **ci job**: typecheck, lint, tests (backend + UI)
+3. **docker jobs**: build `linux/amd64` and `linux/arm64` with Buildx in parallel, each pushing its own tag (`:<version>` and `:<version>-arm64`)
+4. **promote-manifest job**: merges the two into one multi-architecture `:<version>`, then points `:latest` at it
+5. **release job**: creates the GitHub Release with auto-generated notes
 
 The Docker build is **multi-architecture**: amd64 and arm64 are built in parallel jobs and merged into a single manifest, so `docker pull` resolves the right one.
+
+The ordering of the last three steps is a correctness requirement, not a convenience. `UpdateChecker` polls the GitHub Release rather than the GHCR manifest, so a Release published while `:<version>` is still amd64-only would announce an update to every Raspberry Pi and then fail their `docker pull`. Both `promote-manifest` and `release` are therefore gated on the arm64 build succeeding, and `:latest` is published only by `promote-manifest`, never by the amd64 job. An arm64 failure leaves `:<version>` pushed as amd64-only and withholds both `:latest` and the Release: nothing announces a version half the fleet cannot pull, and re-running the workflow on the same tag completes it.
 
 ### Release script
 

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -541,13 +541,15 @@ Why a helper? Calling `dockerode.stop()` on the current container from within th
 
 1. **verify-release-notes job**: fails the workflow before any layer is built if the tagged commit has no release-notes anchor (spec 108)
 2. **ci job**: typecheck, lint, tests (backend + UI)
-3. **docker jobs**: build `linux/amd64` and `linux/arm64` with Buildx in parallel, each pushing its own tag (`:<version>` and `:<version>-arm64`)
+3. **docker jobs**: build `linux/amd64` and `linux/arm64` with Buildx in parallel, each pushing its own tag (`:<version>`, and `:<version>-arm64` plus `:latest-arm64` for the arm64 job)
 4. **promote-manifest job**: merges the two into one multi-architecture `:<version>`, then points `:latest` at it
 5. **release job**: creates the GitHub Release with auto-generated notes
+6. **arm64-required job**: fails the run when the release was withheld, so an arm64 failure is not merely a grey job on a green run
+7. **prune-ghcr job**: keeps the 30 newest GHCR versions after a successful release, never touching the floating `:latest` tags
 
 The Docker build is **multi-architecture**: amd64 and arm64 are built in parallel jobs and merged into a single manifest, so `docker pull` resolves the right one.
 
-The ordering of the last three steps is a correctness requirement, not a convenience. `UpdateChecker` polls the GitHub Release rather than the GHCR manifest, so a Release published while `:<version>` is still amd64-only would announce an update to every Raspberry Pi and then fail their `docker pull`. Both `promote-manifest` and `release` are therefore gated on the arm64 build succeeding, and `:latest` is published only by `promote-manifest`, never by the amd64 job. An arm64 failure leaves `:<version>` pushed as amd64-only and withholds both `:latest` and the Release: nothing announces a version half the fleet cannot pull, and re-running the workflow on the same tag completes it.
+The ordering of the last three steps is a correctness requirement, not a convenience. `UpdateChecker` polls the GitHub Release rather than the GHCR manifest, so a Release published while `:<version>` is still amd64-only would announce an update to every Raspberry Pi and then fail their `docker pull`. Both `promote-manifest` and `release` are therefore gated on the arm64 build succeeding, and `:latest` is published only by `promote-manifest`, never by the amd64 job. An arm64 failure leaves `:<version>` pushed as amd64-only and withholds both `:latest` and the Release, so nothing announces a version half the fleet cannot pull. Recover with **Re-run all jobs** on that run, never by dispatching the workflow on the tag: the dispatch path resolves the version from `test_tag`, so it builds test images and publishes nothing under the tag's own version.
 
 ### Release script
 

--- a/src/core/release-workflow.test.ts
+++ b/src/core/release-workflow.test.ts
@@ -22,17 +22,26 @@ const WORKFLOW_PATH = resolve(import.meta.dirname, "../../.github/workflows/rele
 const workflow = readFileSync(WORKFLOW_PATH, "utf-8");
 
 /**
- * Every `run:` script body in the file, with the step it belongs to.
- * YAML block scalars are found by indentation: the body is the run of lines
- * indented deeper than the `run:` key itself.
+ * Every `run:` line in the file, whether it introduces a block scalar or a
+ * one-liner, and whether or not it is the first key of a compact sequence
+ * entry (`- run: npm ci`). Block bodies are found by indentation: the body is
+ * the run of lines indented deeper than the `run:` key itself.
+ *
+ * The compact-sequence form is the one that matters. An earlier version of
+ * this parser anchored on `^\s*run:`, which cannot match a leading `-`, so it
+ * silently skipped `- run: npm ci` and would have kept passing had someone
+ * later written `- run: echo "${{ inputs.test_tag }}"`. A scanner that misses
+ * a shape is worse than no scanner, because it reads as coverage.
  */
-function runBlocks(): { line: number; body: string }[] {
-  const lines = workflow.split("\n");
+function runLines(source = workflow): { line: number; body: string }[] {
+  const lines = source.split("\n");
   const blocks: { line: number; body: string }[] = [];
   for (let i = 0; i < lines.length; i++) {
-    const m = /^(\s*)run: (\||>)-?\s*$/.exec(lines[i]);
-    if (m) {
-      const indent = m[1].length;
+    // `- run:` counts the dash and its spacing as indentation, which is what
+    // YAML itself does for the keys of a compact sequence entry.
+    const block = /^(\s*(?:-\s+)?)run: [|>][+-]?\d*\s*$/.exec(lines[i]);
+    if (block) {
+      const indent = block[1].length;
       const body: string[] = [];
       let j = i + 1;
       for (; j < lines.length; j++) {
@@ -49,14 +58,18 @@ function runBlocks(): { line: number; body: string }[] {
       i = j - 1;
       continue;
     }
-    // Single-line form: `run: some command`
-    const single = /^\s*run: (?!\||>)(.+)$/.exec(lines[i]);
+    const single = /^\s*(?:-\s+)?run: (?![|>])(.+)$/.exec(lines[i]);
     if (single) blocks.push({ line: i + 1, body: single[1] });
   }
   return blocks;
 }
 
-describe("release.yml — the GitHub Release is gated on a multi-arch manifest (#764)", () => {
+/** Every line that opens a `run:` script, however it is written. */
+function countRunKeys(source = workflow): number {
+  return source.split("\n").filter((l) => /^\s*(?:-\s+)?run:/.test(l)).length;
+}
+
+describe("release.yml: the GitHub Release is gated on a multi-arch manifest (#764)", () => {
   function jobCondition(job: string): string {
     // The `if:` on the job itself, i.e. the first `if:` after the job key at
     // job indentation (4 spaces for keys inside a job).
@@ -74,6 +87,27 @@ describe("release.yml — the GitHub Release is gated on a multi-arch manifest (
     // which is exactly the #764 defect: promote-manifest is skipped by its own
     // arm64 gate while the Release goes out regardless.
     expect(cond).toContain("needs.promote-manifest.result == 'success'");
+  });
+
+  it("does not publish a Release for a tag that was merely dispatched", () => {
+    // The "Run workflow" dropdown accepts a tag as its ref. On that path every
+    // Resolve version step takes the workflow_dispatch branch and builds only
+    // :<test_tag>, so a Release created under the tag's own version would name
+    // a version that has no images anywhere, and UpdateChecker would announce
+    // it to the fleet.
+    expect(jobCondition("release")).toContain("github.event_name == 'push'");
+  });
+
+  it("turns the run red when the release was withheld", () => {
+    // continue-on-error on the arm64 build means an arm64 failure otherwise
+    // produces a green run with a merely grey release job, and GitHub notifies
+    // on red runs, not on skipped ones.
+    expect(workflow).toContain("  arm64-required:");
+    const start = workflow.indexOf("  arm64-required:");
+    const job = workflow.slice(start, workflow.indexOf("  prune-ghcr:"));
+    expect(job).toContain("needs.docker-arm64.result");
+    expect(job).toContain("exit 1");
+    expect(jobCondition("arm64-required")).toContain("github.event_name == 'push'");
   });
 
   it("keeps promote-manifest itself gated on both architectures", () => {
@@ -95,33 +129,86 @@ describe("release.yml — the GitHub Release is gated on a multi-arch manifest (
     );
     expect(buildJobs.length).toBeGreaterThan(0);
     expect(buildJobs).toContain("packages: write"); // sanity: we sliced the right region
-    // `:latest-arm64` is fine: it is a per-arch convenience tag, not the tag
-    // docker-compose.yml pulls. The negative lookahead keeps it out of scope.
-    expect(buildJobs).not.toMatch(/REPO\}:latest(?![-\w])/);
-    expect(buildJobs).toMatch(/REPO\}:latest-arm64/); // sanity: the lookahead is doing work
+    // `:latest-arm64` is out of scope: it is a per-arch convenience tag, not
+    // the tag docker-compose.yml pulls. The lookahead is exercised against a
+    // fixture rather than against the live file, so removing that now-unused
+    // push (nothing consumes it since :latest stopped being merged from the
+    // per-arch tags) does not have to come back through this test.
+    const latestTag = /REPO\}:latest(?![-\w])/;
+    expect('docker buildx imagetools create --tag "${REPO}:latest-arm64"').not.toMatch(latestTag);
+    expect('tags="${REPO}:latest"').toMatch(latestTag);
+    expect(buildJobs).not.toMatch(latestTag);
   });
 });
 
-describe("release.yml — no workflow expression is interpolated into a shell script (#638)", () => {
+describe("release.yml: no workflow expression is interpolated into a shell script (#638)", () => {
   it("routes every ${{ }} value through env: instead of the run: body", () => {
     // `${{ inputs.test_tag }}` expanded straight into `run:` is a command
     // injection: the value is substituted before the shell ever sees it, so
     // quoting in the script cannot help. Only actors with workflow-dispatch
     // rights can set it, which bounds the severity but not the shape.
-    const offenders = runBlocks()
+    const offenders = runLines()
       .filter((b) => b.body.includes("${{"))
       .map((b) => `line ${b.line}`);
     expect(offenders).toEqual([]);
   });
 
-  it("finds the run blocks it claims to scan", () => {
-    // A parser that silently matched nothing would make the assertion above
-    // pass forever. Pin a lower bound instead of trusting it.
-    expect(runBlocks().length).toBeGreaterThanOrEqual(6);
+  it("scans every run: in the file, so the assertion above cannot pass by blindness", () => {
+    // Self-calibrating rather than a hand-set lower bound: a shape the parser
+    // cannot see still shows up as a `run:` line, so the two counts diverge.
+    expect(runLines().length).toBe(countRunKeys());
+    expect(countRunKeys()).toBeGreaterThan(6); // sanity: we read the real file
+  });
+
+  it("sees the shapes a hand-rolled YAML scanner usually misses", () => {
+    const fixture = [
+      "jobs:",
+      "  a:",
+      "    steps:",
+      "      - run: echo ${{ inputs.compact_oneliner }}",
+      "      - run: |",
+      "          echo ${{ inputs.compact_block }}",
+      "      - name: keyed",
+      "        run: |2",
+      "          echo ${{ inputs.indent_indicator }}",
+      "      - name: chomped",
+      "        run: |+",
+      "          echo ${{ inputs.keep_chomping }}",
+      "      - name: folded",
+      "        run: >-",
+      "          echo ${{ inputs.folded }}",
+      "",
+    ].join("\n");
+
+    const found = runLines(fixture);
+    expect(found).toHaveLength(countRunKeys(fixture));
+    expect(found).toHaveLength(5);
+    // Every one of them carries an interpolation, so a parser that saw them
+    // all reports five offenders and a parser with a hole reports fewer.
+    expect(found.filter((b) => b.body.includes("${{"))).toHaveLength(5);
   });
 });
 
-describe("release.yml — least privilege on the release token (#638)", () => {
+describe("release.yml: a resolved version is always a valid image tag", () => {
+  it("refuses a version carrying a newline or a space", () => {
+    // The value reaches an unquoted ${REPO}:${V} and is written to
+    // GITHUB_OUTPUT one line at a time, so a newline in a dispatched test_tag
+    // injects a second output key and a space word-splits into extra CLI
+    // arguments. Routing through env: stops the shell from re-evaluating the
+    // value; it does not stop either of those.
+    const guards = workflow.match(/\^\[A-Za-z0-9\]\[A-Za-z0-9\._-\]\*\$/g) ?? [];
+    // One per "Resolve version" step: docker, docker-arm64, promote-manifest.
+    expect(guards).toHaveLength(3);
+    const rejects = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+    expect(rejects.test("1.62.0")).toBe(true);
+    expect(rejects.test("ci-test")).toBe(true);
+    expect(rejects.test("ci-test\nis_release=true")).toBe(false);
+    expect(rejects.test("ci test")).toBe(false);
+    expect(rejects.test("-leading-dash")).toBe(false);
+  });
+});
+
+describe("release.yml: least privilege on the release token (#638)", () => {
   it("gives the amd64 docker job packages:write but not contents:write", () => {
     const start = workflow.indexOf("  docker:\n");
     expect(start).toBeGreaterThan(-1);

--- a/src/core/release-workflow.test.ts
+++ b/src/core/release-workflow.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Invariants of `.github/workflows/release.yml` that the running engine depends
+ * on. They live beside `version-checker.ts` on purpose: the updater polls the
+ * GitHub Release rather than the GHCR manifest, so what the workflow publishes
+ * and in what order is part of this module's contract, not a detail of CI.
+ *
+ * Issue #764 is what these guard. The `release` job condition was missing the
+ * `promote-manifest` check for months, so an arm64 build failure still created
+ * a Release, every Raspberry Pi was told an update was available, and every
+ * `docker pull` then failed with no matching manifest. Nothing went red. A
+ * workflow file has no type checker and no test runner of its own, so a
+ * condition can be loosened in a one-line edit and nothing notices until a
+ * release goes out wrong. Assertions on the text are the cheapest thing that
+ * would have caught it.
+ */
+
+const WORKFLOW_PATH = resolve(import.meta.dirname, "../../.github/workflows/release.yml");
+const workflow = readFileSync(WORKFLOW_PATH, "utf-8");
+
+/**
+ * Every `run:` script body in the file, with the step it belongs to.
+ * YAML block scalars are found by indentation: the body is the run of lines
+ * indented deeper than the `run:` key itself.
+ */
+function runBlocks(): { line: number; body: string }[] {
+  const lines = workflow.split("\n");
+  const blocks: { line: number; body: string }[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^(\s*)run: (\||>)-?\s*$/.exec(lines[i]);
+    if (m) {
+      const indent = m[1].length;
+      const body: string[] = [];
+      let j = i + 1;
+      for (; j < lines.length; j++) {
+        const l = lines[j];
+        if (l.trim() === "") {
+          body.push(l);
+          continue;
+        }
+        const lead = l.length - l.trimStart().length;
+        if (lead <= indent) break;
+        body.push(l);
+      }
+      blocks.push({ line: i + 1, body: body.join("\n") });
+      i = j - 1;
+      continue;
+    }
+    // Single-line form: `run: some command`
+    const single = /^\s*run: (?!\||>)(.+)$/.exec(lines[i]);
+    if (single) blocks.push({ line: i + 1, body: single[1] });
+  }
+  return blocks;
+}
+
+describe("release.yml — the GitHub Release is gated on a multi-arch manifest (#764)", () => {
+  function jobCondition(job: string): string {
+    // The `if:` on the job itself, i.e. the first `if:` after the job key at
+    // job indentation (4 spaces for keys inside a job).
+    const start = workflow.indexOf(`\n  ${job}:\n`);
+    expect(start, `job ${job} not found`).toBeGreaterThan(-1);
+    const rest = workflow.slice(start + 1);
+    const m = /\n {4}if: (.+)/.exec(rest.slice(0, rest.indexOf("\n    steps:")));
+    expect(m, `job ${job} has no if: condition`).not.toBeNull();
+    return m![1];
+  }
+
+  it("does not publish the Release when the arm64 build failed", () => {
+    const cond = jobCondition("release");
+    // Without this term the job runs on `always() && docker == success` alone,
+    // which is exactly the #764 defect: promote-manifest is skipped by its own
+    // arm64 gate while the Release goes out regardless.
+    expect(cond).toContain("needs.promote-manifest.result == 'success'");
+  });
+
+  it("keeps promote-manifest itself gated on both architectures", () => {
+    const cond = jobCondition("promote-manifest");
+    expect(cond).toContain("needs.docker.result == 'success'");
+    expect(cond).toContain("needs.docker-arm64.result == 'success'");
+  });
+
+  it("publishes :latest only from promote-manifest, never from a single-arch job", () => {
+    // A per-arch job pushing :latest leaves the tag single-arch until the
+    // manifest is promoted. Short, but it is a real window on every healthy
+    // release, and an arm64 host pulling inside it gets no matching manifest.
+    // Scoped to the two per-arch build jobs. The `restore-latest` job also
+    // writes :latest, but that is the manual recovery path and it repoints the
+    // tag at an already-published multi-arch version.
+    const buildJobs = workflow.slice(
+      workflow.indexOf("  docker:\n"),
+      workflow.indexOf("  promote-manifest:"),
+    );
+    expect(buildJobs.length).toBeGreaterThan(0);
+    expect(buildJobs).toContain("packages: write"); // sanity: we sliced the right region
+    // `:latest-arm64` is fine: it is a per-arch convenience tag, not the tag
+    // docker-compose.yml pulls. The negative lookahead keeps it out of scope.
+    expect(buildJobs).not.toMatch(/REPO\}:latest(?![-\w])/);
+    expect(buildJobs).toMatch(/REPO\}:latest-arm64/); // sanity: the lookahead is doing work
+  });
+});
+
+describe("release.yml — no workflow expression is interpolated into a shell script (#638)", () => {
+  it("routes every ${{ }} value through env: instead of the run: body", () => {
+    // `${{ inputs.test_tag }}` expanded straight into `run:` is a command
+    // injection: the value is substituted before the shell ever sees it, so
+    // quoting in the script cannot help. Only actors with workflow-dispatch
+    // rights can set it, which bounds the severity but not the shape.
+    const offenders = runBlocks()
+      .filter((b) => b.body.includes("${{"))
+      .map((b) => `line ${b.line}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it("finds the run blocks it claims to scan", () => {
+    // A parser that silently matched nothing would make the assertion above
+    // pass forever. Pin a lower bound instead of trusting it.
+    expect(runBlocks().length).toBeGreaterThanOrEqual(6);
+  });
+});
+
+describe("release.yml — least privilege on the release token (#638)", () => {
+  it("gives the amd64 docker job packages:write but not contents:write", () => {
+    const start = workflow.indexOf("  docker:\n");
+    expect(start).toBeGreaterThan(-1);
+    const job = workflow.slice(start, workflow.indexOf("  docker-arm64:"));
+    expect(job).toContain("packages: write");
+    // The job pushes images; it creates no tag, release or commit.
+    expect(job).not.toContain("contents: write");
+  });
+});


### PR DESCRIPTION
## #764: the Release was published without a manifest arm64 could pull

`docker-arm64` is `continue-on-error`, so an arm64 failure skips `promote-manifest` by its own gate. The `release` job declared `promote-manifest` in `needs` but its condition only checked `docker`, so it created the GitHub Release anyway. `version-checker.ts` polls `/releases/latest`, not the GHCR manifest, so every Raspberry Pi would have been told an update was available and every `docker pull` would then have failed. The run stayed green, and the comment above the job described the opposite behaviour.

It was worse than the issue states. The amd64 job also pushed **`:latest`**, and `docker-compose.yml` pins `:latest` (spec 104's update helper rewrites compose back to it). So an arm64 failure did not merely show a phantom update: it repointed `:latest` at an amd64-only manifest, and the next `docker compose pull` on every Pi would have failed outright.

Three changes:

- the `release` condition now requires `promote-manifest` to have succeeded
- `:latest` moves out of the amd64 job into `promote-manifest`, pointed at the already-merged `:<version>`. Pushing it from a single-arch job left the tag amd64-only between the two steps, which is a real window on **every** healthy release, not only a failing one
- the two comments that documented behaviour the workflow did not have are corrected

## Two holes the review found on top of that

**A dispatched tag would publish a Release for a version with no images.** GitHub's "Run workflow" dropdown accepts a tag as its ref. On that path every "Resolve version" step takes the `workflow_dispatch` branch, so only `:<test_tag>` images are built, yet `startsWith(github.ref, 'refs/tags/v')` still held and `gh release create` ran with `github.ref_name`. Pre-existing, and the recovery advice this branch first added ("re-run the workflow on the same tag") pointed an operator straight at it. The condition now requires a push, and the guidance says **Re-run all jobs**.

**A withheld release was silent.** With `continue-on-error` retained, an arm64 failure produced a green run in which `release` was merely grey, and GitHub notifies on red runs, not on skipped jobs: tag v1.58.0, see green, move on, and nobody ever receives it. The new `arm64-required` job fails the run when the release was withheld. `continue-on-error` stays so the amd64 image still reaches GHCR and is pullable by digest while the arm64 build is repaired.

## Behaviour change, deliberate

An arm64 failure now withholds `:latest` and the GitHub Release entirely rather than shipping an amd64-only update to half the fleet, and turns the run red. `:<version>` is still pushed for anyone pulling by tag or digest.

## #638: workflow token and interpolation hardening

`ci.yml` already carried `permissions: contents: read` on main, so what remained:

- `${{ inputs.test_tag }}` was expanded straight into three `run:` bodies. It goes through `env:` now, as does the one remaining `${{ github.event_name }}` in a run block, which makes "no workflow expression reaches a shell script" a property of the whole file rather than a habit
- routing through `env:` stops the shell re-evaluating the value but not a **newline** (which injects a second `GITHUB_OUTPUT` key; the dispatch REST API accepts multi-line input values even though the UI field is single-line) nor a **space** (which word-splits into extra `imagetools` arguments). Each "Resolve version" step now refuses a version that is not a valid image tag, and the `imagetools` arguments are quoted
- the amd64 `docker` job drops `contents: write`; it pushes packages and writes nothing to the repo

## Tests

A workflow file has no type checker and no test runner of its own, which is how a missing condition survived for months. `src/core/release-workflow.test.ts` asserts ten invariants against the workflow text, beside `version-checker.ts` because the updater's contract is what the ordering protects. **Seven fail against the workflow as it stands on main**, one per defect.

The `run:` scanner is hand-rolled, so it is pinned twice: its block count is compared against the count of `run:` keys in the file, and it is run against a fixture carrying all five YAML shapes (compact one-liner, compact block, indent indicator, chomping, folded). The first version of it anchored on `^\s*run:` and was already silently skipping `- run: npm ci`.

## Docs

The release-pipeline section of `architecture.{md,fr.md}` now lists all seven jobs and states why the ordering is a correctness requirement. The French page was separately drifted: it claimed the build was amd64-only and described a `release.sh` that bumps versions and commits, neither of which is true. Both were flagged in the 2026-08-29 documentation audit. The `sowel-release` skill gains the arm64-failure troubleshooting line.

Closes #764
Closes #638
