### PR TITLE
fix(ui): stop presenting a stale submeter reading as a live one (#744)

### DIFF
--- a/docs/deep-dives/energy-tour.fr.md
+++ b/docs/deep-dives/energy-tour.fr.md
@@ -16,7 +16,7 @@ En dessous, la décomposition de la consommation dit où partent les watts, en d
 
 ![La décomposition de la consommation en direct, par charge](../screenshots/energy-tour-breakdown-fr.png)
 
-Une charge dont la prise n'a rien envoyé depuis plus de deux minutes affiche **mesure ancienne**, sans chiffre ni pourcentage, plutôt que la dernière valeur reçue. Ce détail compte plus qu'il n'en a l'air : un `0 W` périmé ressemble exactement à un appareil éteint, et rien à l'écran ne dirait que le chiffre date d'un quart d'heure. Il compte surtout pendant le surplus, car le total de la maison est alors une petite différence entre deux grands nombres : une mesure oubliée peut l'écraser (issue #744).
+Une charge dont la prise se tait depuis trop longtemps affiche **mesure ancienne**, sans chiffre ni pourcentage, plutôt que la dernière valeur reçue. « Trop longtemps », c'est deux minutes pour un compteur déclaré, dont le moteur attend déjà des remontées continues, et dix minutes pour le reste, car plusieurs intégrations interrogent leur source toutes les cinq minutes et un appareil en bon état ne doit pas clignoter à chaque cycle. Ce détail compte plus qu'il n'en a l'air : un `0 W` périmé ressemble exactement à un appareil éteint, et rien à l'écran ne dirait que le chiffre date d'un quart d'heure. Il compte surtout pendant le surplus, car le total de la maison est alors une petite différence entre deux grands nombres : une mesure oubliée peut l'écraser (issue #744).
 
 ### Dans le temps : la page Consommation
 

--- a/docs/deep-dives/energy-tour.fr.md
+++ b/docs/deep-dives/energy-tour.fr.md
@@ -16,6 +16,8 @@ En dessous, la décomposition de la consommation dit où partent les watts, en d
 
 ![La décomposition de la consommation en direct, par charge](../screenshots/energy-tour-breakdown-fr.png)
 
+Une charge dont la prise n'a rien envoyé depuis plus de deux minutes affiche **mesure ancienne**, sans chiffre ni pourcentage, plutôt que la dernière valeur reçue. Ce détail compte plus qu'il n'en a l'air : un `0 W` périmé ressemble exactement à un appareil éteint, et rien à l'écran ne dirait que le chiffre date d'un quart d'heure. Il compte surtout pendant le surplus, car le total de la maison est alors une petite différence entre deux grands nombres : une mesure oubliée peut l'écraser (issue #744).
+
 ### Dans le temps : la page Consommation
 
 Jour, semaine, mois ou année, avec une barre par heure ou par jour. Deux choses font de cette page plus qu'un graphique :

--- a/docs/deep-dives/energy-tour.md
+++ b/docs/deep-dives/energy-tour.md
@@ -16,6 +16,8 @@ Below it, the consumption breakdown says where the watts are going, live, per me
 
 ![The live consumption breakdown per load](../screenshots/energy-tour-breakdown-en.png)
 
+A load whose plug has not reported for more than two minutes reads **reading outdated**, with no figure and no share, rather than showing the last value it sent. That matters more than it sounds. A stale `0 W` looks exactly like an appliance that is off, and nothing on screen would tell you the number was a quarter of an hour old. It also matters most during surplus, because the house total is then a small difference between two large numbers, so a leftover reading can dwarf it (issue #744).
+
 ### Over time: the Consumption page
 
 Day, week, month or year, with one bar per hour or per day. Two things make this page more than a chart:

--- a/docs/deep-dives/energy-tour.md
+++ b/docs/deep-dives/energy-tour.md
@@ -16,7 +16,7 @@ Below it, the consumption breakdown says where the watts are going, live, per me
 
 ![The live consumption breakdown per load](../screenshots/energy-tour-breakdown-en.png)
 
-A load whose plug has not reported for more than two minutes reads **reading outdated**, with no figure and no share, rather than showing the last value it sent. That matters more than it sounds. A stale `0 W` looks exactly like an appliance that is off, and nothing on screen would tell you the number was a quarter of an hour old. It also matters most during surplus, because the house total is then a small difference between two large numbers, so a leftover reading can dwarf it (issue #744).
+A load whose plug has gone quiet for too long reads **reading outdated**, with no figure and no share, rather than showing the last value it sent. "Too long" is two minutes for a declared meter, which the engine already expects to report continuously, and ten minutes for anything else, because several integrations poll on a five-minute cycle and a healthy appliance must not flicker in and out on every poll. That matters more than it sounds. A stale `0 W` looks exactly like an appliance that is off, and nothing on screen would tell you the number was a quarter of an hour old. It also matters most during surplus, because the house total is then a small difference between two large numbers, so a leftover reading can dwarf it (issue #744).
 
 ### Over time: the Consumption page
 

--- a/src/api/routes/equipments.ts
+++ b/src/api/routes/equipments.ts
@@ -123,7 +123,7 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
   // cumulative `energy` (Wh) channel — e.g. a SmartThings appliance whose sole
   // `power` binding is a boolean on/off state, not watts — has no live watts to
   // draw and would otherwise render as a "no measurement" row on the display.
-  // Mirror the web UI fix (#560, ui submeter-helpers `readSubmeterPower`): keep
+  // Mirror the web UI fix (#560, ui submeter-helpers `readSubmeterReading`): keep
   // a submeter only when it can contribute a live segment or is meaningful as a
   // legend row. See #590.  Kept when the equipment:
   //   - is offline — an "offline since X" row is meaningful, not noise; OR

--- a/ui/src/components/energy/LiveSubmeterBreakdown.test.tsx
+++ b/ui/src/components/energy/LiveSubmeterBreakdown.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Issue #744 — the consumption breakdown must not present a stale reading as a
+ * live one.
+ *
+ * These render the whole Live page, because the defect is exactly a mismatch
+ * between two of its parts: the whole is rebuilt from the grid and solar meters
+ * on every message, while each part carried whatever its own plug last said.
+ * Testing the helper alone would not show that.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, within } from "../../test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { LiveEnergyPage } from "./LiveEnergyPage";
+import { useEquipments } from "../../store/useEquipments";
+import type { EquipmentWithDetails } from "../../types";
+
+vi.mock("../../hooks/useWsSubscription", () => ({ useWsSubscription: () => {} }));
+
+const NOW = Date.parse("2026-08-14T12:00:00Z");
+
+function meter(
+  id: string,
+  type: EquipmentWithDetails["type"],
+  power: number,
+  ageMs = 20_000,
+): EquipmentWithDetails {
+  return {
+    id,
+    name: id,
+    type,
+    zoneId: "z",
+    enabled: true,
+    status: "online",
+    dataBindings: [
+      {
+        id: `${id}-p`,
+        alias: "power",
+        category: "power",
+        type: "number",
+        value: power,
+        lastUpdated: new Date(NOW - ageMs).toISOString(),
+        // The backend applies the 2-minute power window only to metering
+        // equipment types, so a water_heater's power binding reports fresh
+        // however old it is. That is the flag the card must not rely on.
+        stale: false,
+      },
+    ],
+    orderBindings: [],
+  } as unknown as EquipmentWithDetails;
+}
+
+function seed(equipments: EquipmentWithDetails[]): void {
+  useEquipments.setState({ equipments, fetchEquipments: async () => {} } as never);
+}
+
+/** The legend row for a submeter, as the reader sees it. */
+function row(name: string): HTMLElement {
+  const label = screen.getByText(name);
+  const el = label.closest("div.grid");
+  if (!el) throw new Error(`no legend row for ${name}`);
+  return el as HTMLElement;
+}
+
+describe("Live consumption breakdown — stale parts (#744)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    seed([]);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("shows a stale submeter as unknown rather than as its last number", () => {
+    // Measured on production during export: the water heater was drawing 560 W
+    // and the card said 0 W, because its clamp had last reported 16 minutes
+    // earlier. A stale 0 W reads as "this appliance is off", which is why
+    // nobody questioned it.
+    seed([
+      meter("Grid", "main_energy_meter", -1077),
+      meter("Solar", "energy_production_meter", 2710),
+      meter("Piscine", "energy_meter", 1233, 40_000),
+      meter("Chauffe-eau", "water_heater", 0, 16 * 60 * 1000),
+    ]);
+    render(<LiveEnergyPage />, { wrapper: MemoryRouter });
+
+    const stale = row("Chauffe-eau");
+    expect(within(stale).getByText("—")).toBeTruthy();
+    expect(within(stale).getByText(/reading outdated/)).toBeTruthy();
+    expect(stale.textContent).not.toMatch(/\b0 W\b/);
+
+    // The fresh one is untouched.
+    expect(within(row("Piscine")).getByText(/1\.2/)).toBeTruthy();
+  });
+
+  it("never renders a part at more than 100% of the whole", () => {
+    // The reported screenshot: a 35 W house against a 275 W pool reading left
+    // over from before the pump stopped, printed as 776 %.
+    seed([
+      meter("Grid", "main_energy_meter", -2675),
+      meter("Solar", "energy_production_meter", 2710),
+      meter("Piscine", "energy_meter", 275, 30 * 60 * 1000),
+    ]);
+    const { container } = render(<LiveEnergyPage />, { wrapper: MemoryRouter });
+
+    expect(container.textContent).not.toMatch(/776\s*%/);
+    for (const m of container.textContent?.matchAll(/(\d+)\s*%/g) ?? []) {
+      expect(Number(m[1])).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("keeps the donut inside one circle when the parts overshoot", () => {
+    // A fresh overshoot is still possible (two meters read microseconds apart,
+    // clamp error), and the arcs must not wrap over themselves when it happens.
+    seed([
+      meter("Grid", "main_energy_meter", 100),
+      meter("Piscine", "energy_meter", 900),
+      meter("PAC", "energy_meter", 900),
+    ]);
+    const { container } = render(<LiveEnergyPage />, { wrapper: MemoryRouter });
+
+    const circles = [...container.querySelectorAll("circle[stroke-dasharray]")];
+    expect(circles.length).toBeGreaterThan(0);
+    const circumference = 2 * Math.PI * 78;
+    const drawn = circles.reduce((acc, c) => {
+      const [len] = (c.getAttribute("stroke-dasharray") ?? "0 0").split(" ");
+      return acc + Number(len);
+    }, 0);
+    // Sum of the painted arc lengths never exceeds the ring itself.
+    expect(drawn).toBeLessThanOrEqual(circumference + 0.01);
+  });
+
+  it("agrees with its own centre label", () => {
+    // The centre rounds to the nearest 5 W while the shares used to divide by
+    // the unrounded total, so the two figures on screen contradicted each other.
+    seed([
+      meter("Grid", "main_energy_meter", 33.5),
+      meter("PAC", "energy_meter", 10),
+    ]);
+    render(<LiveEnergyPage />, { wrapper: MemoryRouter });
+
+    // The flow diagram above shows the same house figure, so scope to the card.
+    const card = screen.getByText("Consumption breakdown").closest(".bg-surface");
+    if (!card) throw new Error("breakdown card not found");
+    expect(within(card as HTMLElement).getByText("35")).toBeTruthy(); // donut centre
+    expect(within(row("PAC")).getByText("29%")).toBeTruthy(); // 10 of 35
+  });
+});

--- a/ui/src/components/energy/LiveSubmeterBreakdown.test.tsx
+++ b/ui/src/components/energy/LiveSubmeterBreakdown.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, within } from "../../test-utils";
+import { act, render, screen, within } from "../../test-utils";
 import { MemoryRouter } from "react-router-dom";
 import { LiveEnergyPage } from "./LiveEnergyPage";
 import { useEquipments } from "../../store/useEquipments";
@@ -92,9 +92,9 @@ describe("Live consumption breakdown — stale parts (#744)", () => {
     expect(within(row("Piscine")).getByText(/1\.2/)).toBeTruthy();
   });
 
-  it("never renders a part at more than 100% of the whole", () => {
+  it("shows no share at all for the stale part that used to print 776%", () => {
     // The reported screenshot: a 35 W house against a 275 W pool reading left
-    // over from before the pump stopped, printed as 776 %.
+    // over from before the pump stopped.
     seed([
       meter("Grid", "main_energy_meter", -2675),
       meter("Solar", "energy_production_meter", 2710),
@@ -103,6 +103,22 @@ describe("Live consumption breakdown — stale parts (#744)", () => {
     const { container } = render(<LiveEnergyPage />, { wrapper: MemoryRouter });
 
     expect(container.textContent).not.toMatch(/776\s*%/);
+    expect(within(row("Piscine")).getByText(/reading outdated/)).toBeTruthy();
+    expect(within(row("Piscine")).queryByText(/%/)).toBeNull();
+  });
+
+  it("never renders a part at more than 100% when the parts genuinely overshoot", () => {
+    // Every reading here is FRESH, so the clamp is what is under test rather
+    // than the freshness rule. Two 900 W loads in a 100 W house is what a
+    // clamp error or two meters read microseconds apart can produce.
+    seed([
+      meter("Grid", "main_energy_meter", 100),
+      meter("Piscine", "energy_meter", 900),
+      meter("PAC", "energy_meter", 900),
+    ]);
+    const { container } = render(<LiveEnergyPage />, { wrapper: MemoryRouter });
+
+    expect(within(row("Piscine")).getByText("100%")).toBeTruthy();
     for (const m of container.textContent?.matchAll(/(\d+)\s*%/g) ?? []) {
       expect(Number(m[1])).toBeLessThanOrEqual(100);
     }
@@ -120,13 +136,46 @@ describe("Live consumption breakdown — stale parts (#744)", () => {
 
     const circles = [...container.querySelectorAll("circle[stroke-dasharray]")];
     expect(circles.length).toBeGreaterThan(0);
-    const circumference = 2 * Math.PI * 78;
+    // RADIUS in LiveSubmeterBreakdown.tsx. Getting this wrong by even a few
+    // units turns the assertion into a tolerance for the overrun it exists to
+    // catch.
+    const circumference = 2 * Math.PI * 72;
     const drawn = circles.reduce((acc, c) => {
       const [len] = (c.getAttribute("stroke-dasharray") ?? "0 0").split(" ");
       return acc + Number(len);
     }, 0);
     // Sum of the painted arc lengths never exceeds the ring itself.
     expect(drawn).toBeLessThanOrEqual(circumference + 0.01);
+  });
+
+  it("ages a row out on the wall clock, with no equipment event", () => {
+    // Before the tick, a row only aged out when something else re-rendered the
+    // page. A home whose only sources poll every 300 s would recompute at the
+    // poll, with the reading 0 s old, and the rule would never apply at all.
+    seed([
+      meter("Grid", "main_energy_meter", 1000),
+      meter("Piscine", "energy_meter", 900, 30_000),
+    ]);
+    render(<LiveEnergyPage />, { wrapper: MemoryRouter });
+    expect(within(row("Piscine")).queryByText(/reading outdated/)).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(3 * 60 * 1000);
+    });
+
+    expect(within(row("Piscine")).getByText(/reading outdated/)).toBeTruthy();
+  });
+
+  it("says where a stale load's watts went", () => {
+    // The row contributes nothing, but its consumption is still in the house
+    // total, so it lands in the residual. Both facts are true and nothing on
+    // screen used to connect them.
+    seed([
+      meter("Grid", "main_energy_meter", 1000),
+      meter("Chauffe-eau", "water_heater", 560, 20 * 60 * 1000),
+    ]);
+    const { container } = render(<LiveEnergyPage />, { wrapper: MemoryRouter });
+    expect(container.textContent).toMatch(/is not counted, so its consumption shows up in Other/);
   });
 
   it("agrees with its own centre label", () => {

--- a/ui/src/components/energy/LiveSubmeterBreakdown.tsx
+++ b/ui/src/components/energy/LiveSubmeterBreakdown.tsx
@@ -14,6 +14,7 @@ import { useZones } from "../../store/useZones";
 import {
   buildSubmeterRows,
   computeOther,
+  sharePercent,
   type SubmeterRow,
 } from "./submeter-helpers";
 import { isSubmeterEquipment } from "../../lib/metering";
@@ -129,7 +130,7 @@ export function LiveSubmeterBreakdown({ house, hasMainMeter }: Props) {
                 {formatPower(other).num} {formatPower(other).unit}
               </span>
               <span className="font-mono font-semibold text-text-tertiary min-w-[40px] text-right">
-                {total > 0 ? `${Math.round((other / total) * 100)}%` : "—"}
+                {sharePercent(other, total) !== null ? `${sharePercent(other, total)}%` : "—"}
               </span>
             </div>
           )}
@@ -158,14 +159,25 @@ function buildSegments(
   total: number,
 ): DonutSegment[] {
   if (total <= 0) return [];
+  // The parts are held to one circle. Before #744 the fractions were drawn
+  // unclamped, so a part larger than the whole produced arcs that wrapped over
+  // themselves: two plausible-looking wedges bearing no relation to the numbers
+  // beneath them. A ring that stops at full is at least readable as "we cannot
+  // account for this", which is what the footnote then says.
   const segments: DonutSegment[] = [];
+  let remaining = 1;
+  const push = (id: string, color: string, value: number) => {
+    if (remaining <= 0) return;
+    const fraction = Math.min(value / total, remaining);
+    if (fraction <= 0) return;
+    segments.push({ id, color, fraction });
+    remaining -= fraction;
+  };
   for (const r of rows) {
     if (r.power === null || r.power <= 0) continue;
-    segments.push({ id: r.id, color: r.color, fraction: r.power / total });
+    push(r.id, r.color, r.power);
   }
-  if (other > 0) {
-    segments.push({ id: "__other__", color: OTHER_COLOR, fraction: other / total });
-  }
+  if (other > 0) push("__other__", OTHER_COLOR, other);
   return segments;
 }
 
@@ -259,16 +271,14 @@ function LegendRow({
   t: (key: string, opts?: Record<string, unknown>) => string;
 }) {
   const isOffline = row.status === "offline";
-  const pct =
-    row.power !== null && total > 0
-      ? Math.round((row.power / total) * 100)
-      : null;
+  const isStale = row.unknown === "stale";
+  const pct = row.power !== null ? sharePercent(row.power, total) : null;
   const power = row.power !== null ? formatPower(row.power) : null;
 
   return (
     <div
       className={`grid grid-cols-[10px_1fr_auto_auto] gap-x-3 items-center text-[13px] ${
-        isOffline ? "opacity-60" : ""
+        isOffline || isStale ? "opacity-60" : ""
       }`}
     >
       <span
@@ -281,6 +291,14 @@ function LegendRow({
           <span className="text-[11px] text-text-tertiary">
             {t("energy.live.breakdown.offline")}
             {row.offlineSince && ` · ${formatRelative(row.offlineSince)}`}
+          </span>
+        )}
+        {/* Not "0 W": the row says the reading is old rather than presenting a
+            number the household has no reason to doubt (#744). */}
+        {!isOffline && isStale && (
+          <span className="text-[11px] text-text-tertiary">
+            {t("energy.live.breakdown.stale")}
+            {row.staleSince && ` · ${formatRelative(row.staleSince)}`}
           </span>
         )}
       </div>
@@ -304,12 +322,23 @@ function buildAriaLabel(
   const p = formatPower(total);
   const parts = [`${p.num} ${p.unit}`];
   for (const r of rows) {
-    if (r.power === null) continue;
-    const pct = total > 0 ? Math.round((r.power / total) * 100) : 0;
-    parts.push(`${r.name} ${pct}%`);
+    if (r.power === null) {
+      // A screen reader gets the same answer the sighted reader does: this row
+      // has no current measurement, rather than a silently omitted one (#744).
+      const why =
+        r.status === "offline"
+          ? t("energy.live.breakdown.offline")
+          : r.unknown === "stale"
+            ? t("energy.live.breakdown.stale")
+            : null;
+      if (why) parts.push(`${r.name} ${why}`);
+      continue;
+    }
+    parts.push(`${r.name} ${sharePercent(r.power, total) ?? 0}%`);
   }
-  if (hasMainMeter && other > 0 && total > 0) {
-    parts.push(`${t("energy.live.breakdown.other")} ${Math.round((other / total) * 100)}%`);
+  if (hasMainMeter && other > 0) {
+    const pct = sharePercent(other, total);
+    if (pct !== null) parts.push(`${t("energy.live.breakdown.other")} ${pct}%`);
   }
   return parts.join(", ");
 }

--- a/ui/src/components/energy/LiveSubmeterBreakdown.tsx
+++ b/ui/src/components/energy/LiveSubmeterBreakdown.tsx
@@ -7,13 +7,14 @@
  * parent page subscribes to.
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useEquipments } from "../../store/useEquipments";
 import { useZones } from "../../store/useZones";
 import {
   buildSubmeterRows,
   computeOther,
+  displayedPower,
   sharePercent,
   type SubmeterRow,
 } from "./submeter-helpers";
@@ -34,6 +35,16 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 const IDLE_THRESHOLD_W = 5;
 /** Show the overshoot footnote only when Σ exceeds house by > 5%. */
 const OVERSHOOT_RATIO = 0.05;
+/**
+ * How often the card re-checks reading ages against the wall clock (#744).
+ *
+ * Without it a row only ages out when some unrelated equipment event happens
+ * to re-render the page. In a home whose only sources poll every 300 s the
+ * recompute would land at the poll, with the reading 0 s old, so the rule
+ * would silently never apply; in a home with a 1 Hz main meter it would apply
+ * continuously. Same code, opposite behaviour, decided by unrelated hardware.
+ */
+const STALENESS_TICK_MS = 30_000;
 
 interface Props {
   /** House consumption in W (grid + solar). Null when both are unknown. */
@@ -43,10 +54,13 @@ interface Props {
 }
 
 function formatPower(value: number): { num: string; unit: "W" | "kW" } {
+  // One rounding, shared with sharePercent's denominator, so the figures on
+  // screen cannot contradict each other (#744).
+  const shown = displayedPower(value);
   if (value < 1000) {
-    return { num: String(Math.round(value / 5) * 5), unit: "W" };
+    return { num: String(shown), unit: "W" };
   }
-  return { num: (value / 1000).toFixed(1), unit: "kW" };
+  return { num: (shown / 1000).toFixed(1), unit: "kW" };
 }
 
 function formatRelative(iso: string | null): string {
@@ -72,13 +86,19 @@ export function LiveSubmeterBreakdown({ house, hasMainMeter }: Props) {
 
   // Homonym submeters get a `name — zone` label (spec 139); the qualifier
   // only appears when two submeters actually share a name.
+  const [clock, setClock] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setClock(Date.now()), STALENESS_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
   const rows = useMemo(() => {
     const labels = equipmentLabelMap(
       equipments.filter((eq) => isSubmeterEquipment(eq)),
       zoneChainMap(flattenZonesWithPath(zoneTree)),
     );
-    return buildSubmeterRows(equipments, labels);
-  }, [equipments, zoneTree]);
+    return buildSubmeterRows(equipments, labels, clock);
+  }, [equipments, zoneTree, clock]);
   if (rows.length === 0) return null;
 
   const submeterSum = rows.reduce((acc, r) => acc + (r.power ?? 0), 0);
@@ -88,6 +108,7 @@ export function LiveSubmeterBreakdown({ house, hasMainMeter }: Props) {
   const other = hasMainMeter ? computeOther(total, rows) : 0;
   const overshoot =
     hasMainMeter && submeterSum > total * (1 + OVERSHOOT_RATIO);
+  const hasStale = rows.some((r) => r.unknown === "stale");
 
   const isIdle = total < IDLE_THRESHOLD_W;
   const segments = isIdle
@@ -140,6 +161,16 @@ export function LiveSubmeterBreakdown({ house, hasMainMeter }: Props) {
       {overshoot && (
         <p className="mt-3 text-[12px] text-warning italic">
           {t("energy.live.breakdown.overshoot")}
+        </p>
+      )}
+
+      {/* A load with no recent reading contributes nothing, so its watts are
+          still in the house total and land in the residual. Both facts are
+          true and nothing on screen connected them, which reads as an
+          unmetered load appearing from nowhere (#744). */}
+      {hasStale && (
+        <p className="mt-3 text-[12px] text-text-tertiary italic">
+          {t("energy.live.breakdown.staleNote")}
         </p>
       )}
     </div>

--- a/ui/src/components/energy/submeter-helpers.test.ts
+++ b/ui/src/components/energy/submeter-helpers.test.ts
@@ -8,8 +8,20 @@ import { pickSubmeterColor, SUBMETER_PALETTE } from "./submeterPalette";
 import {
   buildSubmeterRows,
   computeOther,
-  readSubmeterPower,
+  displayedPower,
+  parseReadingTime,
+  readSubmeterReading,
+  sharePercent,
+  SUBMETER_FRESHNESS_MS,
 } from "./submeter-helpers";
+
+/**
+ * Fixed clock. Every reading's age is stated by the test rather than inherited
+ * from whenever the suite happens to run, which matters now that age is what
+ * decides whether a value is shown at all (#744).
+ */
+const NOW = Date.parse("2026-05-27T08:00:00Z");
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
 
 function makeBinding(
   partial: Partial<DataBindingWithValue> & { alias: string },
@@ -24,8 +36,8 @@ function makeBinding(
     type: "number",
     category: "power",
     value: 0,
-    lastUpdated: "2026-05-27 08:00:00Z",
-    lastChanged: "2026-05-27 08:00:00Z",
+    lastUpdated: ago(5_000),
+    lastChanged: ago(5_000),
     stale: false,
     ...partial,
   };
@@ -39,11 +51,24 @@ function makeEquipment(
     status?: EquipmentStatus;
     power?: number | null;
     offlineSince?: string | null;
+    /** Age of the power reading. Defaults to a few seconds, i.e. fresh. */
+    readingAgeMs?: number;
+    /** Force `lastUpdated` outright, including to null or to something unparseable. */
+    lastUpdated?: string | null;
   } = {},
 ): EquipmentWithDetails {
   const bindings: DataBindingWithValue[] = [];
   if (opts.power !== undefined && opts.power !== null) {
-    bindings.push(makeBinding({ alias: "power", value: opts.power }));
+    bindings.push(
+      makeBinding({
+        alias: "power",
+        value: opts.power,
+        lastUpdated:
+          opts.lastUpdated !== undefined
+            ? opts.lastUpdated
+            : ago(opts.readingAgeMs ?? 5_000),
+      }),
+    );
   }
   return {
     id,
@@ -67,6 +92,12 @@ function makeEquipment(
   };
 }
 
+/** buildSubmeterRows, pinned to the fixed clock. */
+const buildRows = (
+  eqs: EquipmentWithDetails[],
+  labels?: Map<string, string>,
+): ReturnType<typeof buildSubmeterRows> => buildSubmeterRows(eqs, labels, NOW);
+
 describe("pickSubmeterColor", () => {
   it("returns the palette color at the given index", () => {
     expect(pickSubmeterColor(0)).toBe(SUBMETER_PALETTE[0]);
@@ -80,36 +111,120 @@ describe("pickSubmeterColor", () => {
   });
 });
 
-describe("readSubmeterPower", () => {
+describe("readSubmeterReading", () => {
   it("returns the power binding value for an online equipment", () => {
     const eq = makeEquipment("a", "PAC", { power: 1200 });
-    expect(readSubmeterPower(eq)).toBe(1200);
+    expect(readSubmeterReading(eq, NOW).power).toBe(1200);
   });
 
   it("returns the absolute value when power is negative (clamp wired backwards)", () => {
     const eq = makeEquipment("a", "PAC", { power: -50 });
-    expect(readSubmeterPower(eq)).toBe(50);
+    expect(readSubmeterReading(eq, NOW).power).toBe(50);
   });
 
   it("returns null when no power binding exists", () => {
     const eq = makeEquipment("a", "PAC", { power: null });
-    expect(readSubmeterPower(eq)).toBeNull();
+    expect(readSubmeterReading(eq, NOW).power).toBeNull();
   });
 
   it("returns null when the equipment is offline, even with a power binding", () => {
     const eq = makeEquipment("a", "PAC", { power: 500, status: "offline" });
-    expect(readSubmeterPower(eq)).toBeNull();
+    expect(readSubmeterReading(eq, NOW).power).toBeNull();
   });
 
-  it("returns the power for a degraded equipment (stale value still counts)", () => {
+  it("returns the power for a degraded equipment whose reading is still fresh", () => {
+    // Degraded is about the equipment as a whole; this particular reading is
+    // current, so it counts.
     const eq = makeEquipment("a", "Piscine", { power: 800, status: "degraded" });
-    expect(readSubmeterPower(eq)).toBe(800);
+    expect(readSubmeterReading(eq, NOW).power).toBe(800);
+  });
+});
+
+// ── #744 — a part must not be older than the whole it is a part of ──
+//
+// The card's total is rebuilt from the grid and solar meters every ~25 s while
+// each part carried whatever its own plug last said. On production a water
+// heater drawing 560 W was displayed as 0 W because its clamp had last reported
+// sixteen minutes earlier, and the reading was folded into a live total at full
+// weight. During export the total is a small difference of two large numbers,
+// so a stale part can dwarf it: 275 W against a 35 W house read as 776 %.
+describe("readSubmeterReading — freshness (#744)", () => {
+  it("refuses a reading older than the engine's own power window", () => {
+    const eq = makeEquipment("a", "Chauffe-eau", {
+      power: 560,
+      readingAgeMs: SUBMETER_FRESHNESS_MS + 1_000,
+    });
+    const reading = readSubmeterReading(eq, NOW);
+    expect(reading.power).toBeNull();
+    expect(reading.unknown).toBe("stale");
+    expect(reading.lastUpdated).not.toBeNull();
+  });
+
+  it("accepts a reading right at the edge of the window", () => {
+    const eq = makeEquipment("a", "Chauffe-eau", {
+      power: 560,
+      readingAgeMs: SUBMETER_FRESHNESS_MS,
+    });
+    expect(readSubmeterReading(eq, NOW).power).toBe(560);
+  });
+
+  it("refuses a stale zero, which is the quiet case", () => {
+    // A stale 0 W reads as "this appliance is off", a perfectly plausible thing
+    // for a water heater to be, so nothing on screen invites doubt.
+    const eq = makeEquipment("a", "Chauffe-eau", {
+      power: 0,
+      readingAgeMs: 16 * 60 * 1000,
+    });
+    expect(readSubmeterReading(eq, NOW).unknown).toBe("stale");
+  });
+
+  it("does not trust the binding's own stale flag", () => {
+    // The backend applies the 2-minute power window only to metering equipment
+    // types, so a thermostat or water_heater carrying a power channel reports
+    // stale: false however old the value is. The 124-day-old wood stove
+    // reading on production had stale: false.
+    const eq = makeEquipment("a", "Poele", {
+      type: "thermostat",
+      power: 0,
+      readingAgeMs: 124 * 24 * 60 * 60 * 1000,
+    });
+    expect(eq.dataBindings[0].stale).toBe(false);
+    expect(readSubmeterReading(eq, NOW).unknown).toBe("stale");
+  });
+
+  it("treats an absent timestamp as no evidence of age, not as old", () => {
+    // Same reading as the backend: a binding with lastUpdated === null has
+    // never reported, and is not therefore stale.
+    const eq = makeEquipment("a", "PAC", { power: 300, lastUpdated: null });
+    expect(readSubmeterReading(eq, NOW).power).toBe(300);
+  });
+
+  it("treats an unparseable timestamp the same way", () => {
+    const eq = makeEquipment("a", "PAC", { power: 300, lastUpdated: "not-a-date" });
+    expect(readSubmeterReading(eq, NOW).power).toBe(300);
+  });
+
+  it("accepts the SQLite-flavoured timestamp the API also emits", () => {
+    expect(parseReadingTime("2026-05-27 08:00:00Z")).toBe(
+      parseReadingTime("2026-05-27T08:00:00Z"),
+    );
+    expect(parseReadingTime(null)).toBeNull();
+    expect(parseReadingTime("nope")).toBeNull();
+  });
+
+  it("reports offline before stale, since offline is the more specific fact", () => {
+    const eq = makeEquipment("a", "Piscine", {
+      power: 275,
+      status: "offline",
+      readingAgeMs: 60 * 60 * 1000,
+    });
+    expect(readSubmeterReading(eq, NOW).unknown).toBe("offline");
   });
 });
 
 describe("buildSubmeterRows", () => {
   it("filters main/production meters out", () => {
-    const rows = buildSubmeterRows([
+    const rows = buildRows([
       makeEquipment("a", "PAC", { power: 100 }),
       makeEquipment("b", "Shelly Grid", { type: "main_energy_meter", power: 200 }),
       makeEquipment("c", "Shelly Solar", { type: "energy_production_meter", power: 300 }),
@@ -118,7 +233,7 @@ describe("buildSubmeterRows", () => {
   });
 
   it("includes metering switches, excludes bare relays (spec 129)", () => {
-    const rows = buildSubmeterRows([
+    const rows = buildRows([
       makeEquipment("a", "PAC", { power: 100 }),
       makeEquipment("b", "Prise Bureau", { type: "switch", power: 40 }),
       makeEquipment("c", "Relais nu", { type: "switch", power: null }),
@@ -130,7 +245,7 @@ describe("buildSubmeterRows", () => {
   it("assigns colors by sorted-id index (stable across power reorders)", () => {
     const a = makeEquipment("aaa-id", "Z-last", { power: 100 });
     const b = makeEquipment("bbb-id", "A-first", { power: 9999 });
-    const rows = buildSubmeterRows([b, a]);
+    const rows = buildRows([b, a]);
     const rowA = rows.find((r) => r.id === "aaa-id");
     const rowB = rows.find((r) => r.id === "bbb-id");
     expect(rowA?.color).toBe(SUBMETER_PALETTE[0]);
@@ -138,7 +253,7 @@ describe("buildSubmeterRows", () => {
   });
 
   it("sorts rows by power descending for display", () => {
-    const rows = buildSubmeterRows([
+    const rows = buildRows([
       makeEquipment("a", "Low", { power: 50 }),
       makeEquipment("b", "High", { power: 2000 }),
       makeEquipment("c", "Mid", { power: 500 }),
@@ -147,7 +262,7 @@ describe("buildSubmeterRows", () => {
   });
 
   it("places offline (null-power) rows last", () => {
-    const rows = buildSubmeterRows([
+    const rows = buildRows([
       makeEquipment("a", "Online1", { power: 100 }),
       makeEquipment("b", "OfflineOne", { power: 500, status: "offline" }),
       makeEquipment("c", "Online2", { power: 50 }),
@@ -157,7 +272,7 @@ describe("buildSubmeterRows", () => {
   });
 
   it("drops online submeters with no power measurement (#560)", () => {
-    const rows = buildSubmeterRows([
+    const rows = buildRows([
       makeEquipment("a", "PAC", { power: 100 }),
       makeEquipment("b", "Lave-linge", { power: null }),
     ]);
@@ -166,7 +281,7 @@ describe("buildSubmeterRows", () => {
   });
 
   it("keeps offline submeters even without a power value (#560)", () => {
-    const rows = buildSubmeterRows([
+    const rows = buildRows([
       makeEquipment("a", "PAC", { power: 100 }),
       makeEquipment("b", "Piscine", { power: null, status: "offline" }),
     ]);
@@ -178,19 +293,87 @@ describe("buildSubmeterRows", () => {
     const inputs = Array.from({ length: 9 }, (_, i) =>
       makeEquipment(`id-${i}`, `S${i}`, { power: 100 - i }),
     );
-    const rows = buildSubmeterRows(inputs);
+    const rows = buildRows(inputs);
     const ninth = rows.find((r) => r.id === "id-8");
     expect(ninth?.color).toBe(SUBMETER_PALETTE[0]);
   });
 
   it("returns an empty array when no submeters exist", () => {
-    expect(buildSubmeterRows([])).toEqual([]);
+    expect(buildRows([])).toEqual([]);
+  });
+
+  it("keeps a submeter whose reading aged out, with no number (#744)", () => {
+    const rows = buildRows([
+      makeEquipment("a", "PAC", { power: 100 }),
+      makeEquipment("b", "Chauffe-eau", { power: 560, readingAgeMs: 16 * 60 * 1000 }),
+    ]);
+    // It stays, because "we do not know" is information. What it does not do
+    // is contribute 560 W to a total measured 25 seconds ago.
+    expect(rows.map((r) => r.name)).toEqual(["PAC", "Chauffe-eau"]);
+    const stale = rows[1];
+    expect(stale.power).toBeNull();
+    expect(stale.unknown).toBe("stale");
+    expect(stale.staleSince).not.toBeNull();
+  });
+
+  it("still drops a submeter that was never bound (#560)", () => {
+    const rows = buildRows([
+      makeEquipment("a", "PAC", { power: 100 }),
+      makeEquipment("b", "Lave-linge", { power: null }),
+    ]);
+    expect(rows.map((r) => r.name)).toEqual(["PAC"]);
+  });
+
+  it("sorts stale rows after every row that has a number", () => {
+    const rows = buildRows([
+      makeEquipment("a", "Stale", { power: 9999, readingAgeMs: 60 * 60 * 1000 }),
+      makeEquipment("b", "Small", { power: 5 }),
+    ]);
+    expect(rows.map((r) => r.name)).toEqual(["Small", "Stale"]);
+  });
+
+  it("keeps a stale reading out of the residual (#744)", () => {
+    // This is the arithmetic the household actually sees: before the fix the
+    // 560 W leftover was subtracted from the house total as if it were current.
+    const rows = buildRows([
+      makeEquipment("a", "PAC", { power: 1200 }),
+      makeEquipment("b", "Chauffe-eau", { power: 560, readingAgeMs: 16 * 60 * 1000 }),
+    ]);
+    expect(computeOther(2000, rows)).toBe(800);
+  });
+});
+
+describe("displayedPower and sharePercent (#744)", () => {
+  it("rounds the way formatPower does, so shares match what is on screen", () => {
+    // The shape of the reported case: the centre label rounds to the nearest
+    // 5 W while the share divided by the raw total, so the two numbers on
+    // screen disagreed. Here the raw share is 30 % and the label says 35 W;
+    // the reader can only check 10/35, so that is what the row shows.
+    expect(displayedPower(33.5)).toBe(35);
+    expect(displayedPower(10)).toBe(10);
+    expect(Math.round((10 / 33.5) * 100)).toBe(30); // what it used to print
+    expect(sharePercent(10, 33.5)).toBe(29); // what the label supports
+  });
+
+  it("rounds kilowatts to the displayed decimal", () => {
+    expect(displayedPower(1632.9)).toBe(1600);
+    expect(displayedPower(999)).toBe(1000);
+  });
+
+  it("never reports a part larger than the whole", () => {
+    // 776 % was what the card actually rendered. A breakdown cannot have one.
+    expect(sharePercent(275, 35)).toBe(100);
+  });
+
+  it("returns null rather than dividing by nothing", () => {
+    expect(sharePercent(100, 0)).toBeNull();
+    expect(sharePercent(100, 2)).toBeNull(); // rounds down to a zero whole
   });
 });
 
 describe("computeOther", () => {
   it("returns house minus the sum of submeter powers", () => {
-    const rows = buildSubmeterRows([
+    const rows = buildRows([
       makeEquipment("a", "PAC", { power: 1200 }),
       makeEquipment("b", "Pool", { power: 800 }),
       makeEquipment("c", "EV", { power: 570 }),
@@ -199,7 +382,7 @@ describe("computeOther", () => {
   });
 
   it("clamps to 0 when the submeters overshoot the house total", () => {
-    const rows = buildSubmeterRows([
+    const rows = buildRows([
       makeEquipment("a", "PAC", { power: 2000 }),
       makeEquipment("b", "Pool", { power: 1500 }),
     ]);
@@ -211,14 +394,14 @@ describe("computeOther", () => {
   });
 
   it("returns 0 when submeter sum equals the house value", () => {
-    const rows = buildSubmeterRows([
+    const rows = buildRows([
       makeEquipment("a", "PAC", { power: 1000 }),
     ]);
     expect(computeOther(1000, rows)).toBe(0);
   });
 
   it("ignores null-power rows in the sum", () => {
-    const rows = buildSubmeterRows([
+    const rows = buildRows([
       makeEquipment("a", "PAC", { power: 1200 }),
       makeEquipment("b", "Pool", { power: null, status: "offline" }),
     ]);

--- a/ui/src/components/energy/submeter-helpers.test.ts
+++ b/ui/src/components/energy/submeter-helpers.test.ts
@@ -13,6 +13,7 @@ import {
   readSubmeterReading,
   sharePercent,
   SUBMETER_FRESHNESS_MS,
+  SUBMETER_FRESHNESS_SLOW_MS,
 } from "./submeter-helpers";
 
 /**
@@ -149,9 +150,10 @@ describe("readSubmeterReading", () => {
 // weight. During export the total is a small difference of two large numbers,
 // so a stale part can dwarf it: 275 W against a 35 W house read as 776 %.
 describe("readSubmeterReading — freshness (#744)", () => {
-  it("refuses a reading older than the engine's own power window", () => {
-    const eq = makeEquipment("a", "Chauffe-eau", {
-      power: 560,
+  it("refuses a reading older than the engine's own power window, on a meter", () => {
+    const eq = makeEquipment("a", "Piscine", {
+      type: "energy_meter",
+      power: 1233,
       readingAgeMs: SUBMETER_FRESHNESS_MS + 1_000,
     });
     const reading = readSubmeterReading(eq, NOW);
@@ -161,11 +163,37 @@ describe("readSubmeterReading — freshness (#744)", () => {
   });
 
   it("accepts a reading right at the edge of the window", () => {
-    const eq = makeEquipment("a", "Chauffe-eau", {
-      power: 560,
+    const eq = makeEquipment("a", "Piscine", {
+      type: "energy_meter",
+      power: 1233,
       readingAgeMs: SUBMETER_FRESHNESS_MS,
     });
-    expect(readSubmeterReading(eq, NOW).power).toBe(560);
+    expect(readSubmeterReading(eq, NOW).power).toBe(1233);
+  });
+
+  it("gives a non-meter type the looser budget, so a 300 s poller never flickers", () => {
+    // SmartThings, Legrand, Panasonic Comfort Cloud and MCZ Maestro all default
+    // to a 300 s poll. The issue's own production snapshot shows two such rows
+    // at an age of 270 s with nothing wrong; under the tight window they would
+    // have read "outdated" for three minutes out of every five.
+    const eq = makeEquipment("a", "Lave-linge", {
+      type: "appliance",
+      power: 0,
+      readingAgeMs: 270 * 1000,
+    });
+    expect(readSubmeterReading(eq, NOW).unknown).toBeNull();
+    expect(SUBMETER_FRESHNESS_SLOW_MS).toBeGreaterThanOrEqual(2 * 300 * 1000);
+  });
+
+  it("still refuses the reported case: a 560 W water heater 13.5 minutes behind", () => {
+    // The measurement that closed the root-cause question. Whatever the budget,
+    // this one has to be caught.
+    const eq = makeEquipment("a", "Chauffe-eau", {
+      type: "water_heater",
+      power: 0,
+      readingAgeMs: 944 * 1000,
+    });
+    expect(readSubmeterReading(eq, NOW).unknown).toBe("stale");
   });
 
   it("refuses a stale zero, which is the quiet case", () => {
@@ -173,7 +201,7 @@ describe("readSubmeterReading — freshness (#744)", () => {
     // for a water heater to be, so nothing on screen invites doubt.
     const eq = makeEquipment("a", "Chauffe-eau", {
       power: 0,
-      readingAgeMs: 16 * 60 * 1000,
+      readingAgeMs: SUBMETER_FRESHNESS_SLOW_MS + 60_000,
     });
     expect(readSubmeterReading(eq, NOW).unknown).toBe("stale");
   });
@@ -305,7 +333,11 @@ describe("buildSubmeterRows", () => {
   it("keeps a submeter whose reading aged out, with no number (#744)", () => {
     const rows = buildRows([
       makeEquipment("a", "PAC", { power: 100 }),
-      makeEquipment("b", "Chauffe-eau", { power: 560, readingAgeMs: 16 * 60 * 1000 }),
+      makeEquipment("b", "Chauffe-eau", {
+        type: "water_heater",
+        power: 560,
+        readingAgeMs: 16 * 60 * 1000,
+      }),
     ]);
     // It stays, because "we do not know" is information. What it does not do
     // is contribute 560 W to a total measured 25 seconds ago.
@@ -337,7 +369,11 @@ describe("buildSubmeterRows", () => {
     // 560 W leftover was subtracted from the house total as if it were current.
     const rows = buildRows([
       makeEquipment("a", "PAC", { power: 1200 }),
-      makeEquipment("b", "Chauffe-eau", { power: 560, readingAgeMs: 16 * 60 * 1000 }),
+      makeEquipment("b", "Chauffe-eau", {
+        type: "water_heater",
+        power: 560,
+        readingAgeMs: 16 * 60 * 1000,
+      }),
     ]);
     expect(computeOther(2000, rows)).toBe(800);
   });
@@ -358,6 +394,14 @@ describe("displayedPower and sharePercent (#744)", () => {
   it("rounds kilowatts to the displayed decimal", () => {
     expect(displayedPower(1632.9)).toBe(1600);
     expect(displayedPower(999)).toBe(1000);
+  });
+
+  it("rounds a half-step the way toFixed(1) does, not the way Math.round does", () => {
+    // The binary double nearest 1.15 sits just below the half, so toFixed(1)
+    // gives "1.1" while Math.round(1150 / 100) * 100 gives 1200. A 575 W part
+    // in a 1150 W house printed 48 % under a label reading 1.1 kW.
+    expect(displayedPower(1150)).toBe(1100);
+    expect(sharePercent(575, 1150)).toBe(52);
   });
 
   it("never reports a part larger than the whole", () => {

--- a/ui/src/components/energy/submeter-helpers.ts
+++ b/ui/src/components/energy/submeter-helpers.ts
@@ -7,30 +7,93 @@
 import type { EquipmentStatus, EquipmentWithDetails } from "../../types";
 import { pickSubmeterColor } from "./submeterPalette";
 import { isSubmeterEquipment } from "../../lib/metering";
+import {
+  DEFAULT_STREAMING_TIMEOUT_MS,
+  STREAMING_TIMEOUT_MS,
+} from "../../../../src/shared/constants";
+
+/**
+ * How old a `power` reading may be and still count as a live measurement.
+ *
+ * Taken from the engine's own per-category window rather than a number picked
+ * here, so the breakdown ages a reading out at the same moment everything else
+ * does. Two minutes for `power` (issue #744).
+ */
+export const SUBMETER_FRESHNESS_MS = STREAMING_TIMEOUT_MS.power ?? DEFAULT_STREAMING_TIMEOUT_MS;
+
+/** Why a submeter contributes no number to the breakdown. */
+export type SubmeterUnknown = "offline" | "stale" | "missing";
 
 export interface SubmeterRow {
   id: string;
   name: string;
-  /** Instantaneous power in W. Null when binding is missing or equipment offline. */
+  /** Instantaneous power in W. Null when there is no current measurement. */
   power: number | null;
+  /** Set when `power` is null: what is missing, so the row can say so. */
+  unknown: SubmeterUnknown | null;
   status: EquipmentStatus;
   /** ISO timestamp from spec 116 statusReason, if available. */
   offlineSince: string | null;
+  /** ISO timestamp of the reading that aged out, when `unknown === "stale"`. */
+  staleSince: string | null;
   color: string;
+}
+
+export interface SubmeterReading {
+  power: number | null;
+  unknown: SubmeterUnknown | null;
+  /** `lastUpdated` of the reading, whether or not it aged out. */
+  lastUpdated: string | null;
+}
+
+/**
+ * Parse a binding timestamp. The API emits both `2026-05-27T08:00:00Z` and the
+ * SQLite-flavoured `2026-05-27 08:00:00Z`; treat them alike.
+ * Returns null when there is nothing parseable, which callers read as
+ * "no information about age", never as "old".
+ */
+export function parseReadingTime(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const normalized = iso.includes("T") ? iso : iso.replace(" ", "T").replace("Z", "") + "Z";
+  const ms = Date.parse(normalized);
+  return Number.isFinite(ms) ? ms : null;
 }
 
 /**
  * Read the `power` alias from a submeter equipment.
- * Returns null when the equipment is fully offline, when no `power` binding
- * exists, or when the value is non-numeric. Negative values are returned as
- * their absolute value (clamp wired backwards — same convention as spec 091
- * backend integration).
+ *
+ * A reading older than SUBMETER_FRESHNESS_MS is NOT returned as a number
+ * (issue #744). Before this rule, the only thing that could drop a reading was
+ * `status === "offline"`, so an equipment considered online contributed its
+ * last known power at full weight however old it was. Measured on production:
+ * a water heater drawing 560 W was displayed as 0 W because its clamp had last
+ * reported sixteen minutes earlier, and a wood stove was contributing a value
+ * 124 days old. The failure is quiet, since a stale `0 W` reads as "this
+ * appliance is off", which is a perfectly plausible thing for it to be.
+ *
+ * The binding's own `stale` flag cannot be used for this: the backend applies
+ * the `power` window only to METERING_EQUIPMENT_TYPES, so a `thermostat` or a
+ * `water_heater` carrying a power channel reports `stale: false` forever.
+ *
+ * Negative values are returned as their absolute value (clamp wired backwards,
+ * same convention as the spec 091 backend integration).
  */
-export function readSubmeterPower(eq: EquipmentWithDetails): number | null {
-  if (eq.status === "offline") return null;
+export function readSubmeterReading(
+  eq: EquipmentWithDetails,
+  now: number = Date.now(),
+): SubmeterReading {
+  if (eq.status === "offline") return { power: null, unknown: "offline", lastUpdated: null };
   const binding = eq.dataBindings.find((b) => b.alias === "power");
-  if (!binding || typeof binding.value !== "number") return null;
-  return Math.abs(binding.value);
+  if (!binding || typeof binding.value !== "number") {
+    return { power: null, unknown: "missing", lastUpdated: null };
+  }
+  const at = parseReadingTime(binding.lastUpdated);
+  // No usable timestamp means no evidence the value is old, which is how the
+  // backend reads it too (a binding with lastUpdated === null is not stale).
+  if (at !== null && now - at > SUBMETER_FRESHNESS_MS) {
+    return { power: null, unknown: "stale", lastUpdated: binding.lastUpdated };
+  }
+  return { power: Math.abs(binding.value), unknown: null, lastUpdated: binding.lastUpdated };
 }
 
 /**
@@ -40,12 +103,14 @@ export function readSubmeterPower(eq: EquipmentWithDetails): number | null {
  *   2. Sort by `id` ascending and assign a palette color by index — this is
  *      the SAME indexing rule the backend uses for the historical By-usage
  *      chart, so a given equipment gets the same color in both views.
- *   3. Drop rows that carry no power measurement at all (null power while the
- *      equipment is *online*): a declared submeter with no `power` binding
- *      contributes nothing and is pure noise in the legend (#560). Offline
- *      rows keep their null power — they are meaningful and stay.
- *   4. Re-sort the rows for display: by power descending, then null-power
- *      (offline) last.
+ *   3. Drop rows that carry no power measurement at all: a declared submeter
+ *      with no `power` binding contributes nothing and is pure noise in the
+ *      legend (#560). Offline rows and rows whose reading aged out both stay:
+ *      "we do not know" is information, and hiding a stale row would put the
+ *      household back where #744 found it, reading a plausible number that
+ *      happens to be wrong.
+ *   4. Re-sort the rows for display: by power descending, then the rows with
+ *      no number (offline, stale) last.
  *
  * `labels` optionally overrides display names by equipment id (spec 139 —
  * `name — zone` for homonym submeters); sorting uses the displayed name.
@@ -53,22 +118,28 @@ export function readSubmeterPower(eq: EquipmentWithDetails): number | null {
 export function buildSubmeterRows(
   equipments: EquipmentWithDetails[],
   labels?: Map<string, string>,
+  now: number = Date.now(),
 ): SubmeterRow[] {
   const byId = [...equipments]
     .filter((eq) => isSubmeterEquipment(eq))
     .sort((a, b) => a.id.localeCompare(b.id));
 
   const rows: SubmeterRow[] = byId
-    .map((eq, idx) => ({
-      id: eq.id,
-      name: labels?.get(eq.id) ?? eq.name,
-      power: readSubmeterPower(eq),
-      status: eq.status,
-      offlineSince: eq.statusReason?.offlineSince ?? null,
-      color: pickSubmeterColor(idx),
-    }))
-    // No measurement and not offline → nothing to show (#560).
-    .filter((row) => row.power !== null || row.status === "offline");
+    .map((eq, idx) => {
+      const reading = readSubmeterReading(eq, now);
+      return {
+        id: eq.id,
+        name: labels?.get(eq.id) ?? eq.name,
+        power: reading.power,
+        unknown: reading.unknown,
+        status: eq.status,
+        offlineSince: eq.statusReason?.offlineSince ?? null,
+        staleSince: reading.unknown === "stale" ? reading.lastUpdated : null,
+        color: pickSubmeterColor(idx),
+      };
+    })
+    // Never bound, so nothing to say about it (#560).
+    .filter((row) => row.unknown !== "missing");
 
   rows.sort((a, b) => {
     const aNull = a.power === null;
@@ -80,6 +151,35 @@ export function buildSubmeterRows(
   });
 
   return rows;
+}
+
+/**
+ * The numeric value `formatPower` actually puts on screen: watts rounded to
+ * the nearest 5 below a kilowatt, and to one decimal of a kilowatt above.
+ *
+ * Shares are computed from this rather than from the raw reading so that the
+ * figures on screen agree with each other. Dividing raw values while
+ * displaying rounded ones is how a PAC at 10 W of a 32.4 W house came to read
+ * "31 % of 35 W" (#744): both numbers were defensible and they contradicted
+ * each other, which is worse than either being slightly off.
+ */
+export function displayedPower(value: number): number {
+  return value < 1000 ? Math.round(value / 5) * 5 : Math.round(value / 100) * 100;
+}
+
+/**
+ * A part's share of the whole, in whole percent, as the reader sees both.
+ *
+ * Clamped to 100. A breakdown cannot have a part larger than the whole, so
+ * when the arithmetic says otherwise the honest output is the boundary, not
+ * "776 %" (#744). The clamp is a guard, not the fix: it is the freshness rule
+ * in `readSubmeterReading` that stops the two sides being measured at
+ * different moments in the first place.
+ */
+export function sharePercent(part: number, whole: number): number | null {
+  const w = displayedPower(whole);
+  if (w <= 0) return null;
+  return Math.min(100, Math.round((displayedPower(part) / w) * 100));
 }
 
 /**

--- a/ui/src/components/energy/submeter-helpers.ts
+++ b/ui/src/components/energy/submeter-helpers.ts
@@ -9,17 +9,47 @@ import { pickSubmeterColor } from "./submeterPalette";
 import { isSubmeterEquipment } from "../../lib/metering";
 import {
   DEFAULT_STREAMING_TIMEOUT_MS,
+  METERING_EQUIPMENT_TYPES,
   STREAMING_TIMEOUT_MS,
 } from "../../../../src/shared/constants";
 
 /**
- * How old a `power` reading may be and still count as a live measurement.
+ * How old a reading may be, on an equipment the engine itself treats as a
+ * meter, and still count as a live measurement.
  *
  * Taken from the engine's own per-category window rather than a number picked
- * here, so the breakdown ages a reading out at the same moment everything else
- * does. Two minutes for `power` (issue #744).
+ * here, so those rows age out at the same moment everything else does. Two
+ * minutes for `power` (issue #744).
  */
 export const SUBMETER_FRESHNESS_MS = STREAMING_TIMEOUT_MS.power ?? DEFAULT_STREAMING_TIMEOUT_MS;
+
+/**
+ * The same budget for every other submeter type, and it has to be looser.
+ *
+ * `equipment-status.ts` applies the tight electrical window only to
+ * METERING_EQUIPMENT_TYPES, and says why: a steady load stops producing
+ * updates, so a two-minute window would flag a perfectly healthy appliance on
+ * every reporting cycle. That reasoning applies here too. Four official
+ * integrations (SmartThings, Legrand, Panasonic Comfort Cloud, MCZ Maestro)
+ * poll on a 300 s default, and the issue's own production snapshot shows two
+ * of those rows at an age of 270 s with nothing wrong. A two-minute budget
+ * would have made them read "outdated" for three minutes out of every five.
+ *
+ * Ten minutes is twice the slowest supported default cadence, so no supported
+ * source oscillates, and it is still far below both cases this issue is about:
+ * a water heater whose reading was 13.5 minutes old while it drew 560 W, and a
+ * wood stove 124 days behind. It also buys margin against a viewer's browser
+ * clock running ahead of the Sowel host, which is the other thing this
+ * comparison is exposed to.
+ */
+export const SUBMETER_FRESHNESS_SLOW_MS = 10 * 60 * 1000;
+
+/** The budget that applies to this equipment. */
+export function freshnessBudgetFor(eq: EquipmentWithDetails): number {
+  return METERING_EQUIPMENT_TYPES.has(eq.type)
+    ? SUBMETER_FRESHNESS_MS
+    : SUBMETER_FRESHNESS_SLOW_MS;
+}
 
 /** Why a submeter contributes no number to the breakdown. */
 export type SubmeterUnknown = "offline" | "stale" | "missing";
@@ -62,8 +92,8 @@ export function parseReadingTime(iso: string | null | undefined): number | null 
 /**
  * Read the `power` alias from a submeter equipment.
  *
- * A reading older than SUBMETER_FRESHNESS_MS is NOT returned as a number
- * (issue #744). Before this rule, the only thing that could drop a reading was
+ * A reading past its freshness budget is NOT returned as a number (issue
+ * #744). Before this rule, the only thing that could drop a reading was
  * `status === "offline"`, so an equipment considered online contributed its
  * last known power at full weight however old it was. Measured on production:
  * a water heater drawing 560 W was displayed as 0 W because its clamp had last
@@ -71,9 +101,13 @@ export function parseReadingTime(iso: string | null | undefined): number | null 
  * 124 days old. The failure is quiet, since a stale `0 W` reads as "this
  * appliance is off", which is a perfectly plausible thing for it to be.
  *
- * The binding's own `stale` flag cannot be used for this: the backend applies
- * the `power` window only to METERING_EQUIPMENT_TYPES, so a `thermostat` or a
- * `water_heater` carrying a power channel reports `stale: false` forever.
+ * The binding's own `stale` flag cannot stand in for this. The backend applies
+ * the electrical window only to METERING_EQUIPMENT_TYPES, on purpose, so a
+ * `thermostat` or `water_heater` carrying a power channel reports
+ * `stale: false` however old the value is. That exemption is right for
+ * equipment status, where flagging a quiet appliance as degraded would be
+ * wrong; it just leaves the display with no answer to "is this number
+ * current", which is what freshnessBudgetFor supplies.
  *
  * Negative values are returned as their absolute value (clamp wired backwards,
  * same convention as the spec 091 backend integration).
@@ -90,7 +124,7 @@ export function readSubmeterReading(
   const at = parseReadingTime(binding.lastUpdated);
   // No usable timestamp means no evidence the value is old, which is how the
   // backend reads it too (a binding with lastUpdated === null is not stale).
-  if (at !== null && now - at > SUBMETER_FRESHNESS_MS) {
+  if (at !== null && now - at > freshnessBudgetFor(eq)) {
     return { power: null, unknown: "stale", lastUpdated: binding.lastUpdated };
   }
   return { power: Math.abs(binding.value), unknown: null, lastUpdated: binding.lastUpdated };
@@ -164,7 +198,12 @@ export function buildSubmeterRows(
  * each other, which is worse than either being slightly off.
  */
 export function displayedPower(value: number): number {
-  return value < 1000 ? Math.round(value / 5) * 5 : Math.round(value / 100) * 100;
+  if (value < 1000) return Math.round(value / 5) * 5;
+  // NOT Math.round(value / 100) * 100: toFixed(1) rounds 1.15 down, because
+  // the binary double nearest 1.15 is below the half. The two disagreed on
+  // every X50 W step, so a 575 W part in a 1150 W house printed 48 % under a
+  // label reading 1.1 kW.
+  return Number((value / 1000).toFixed(1)) * 1000;
 }
 
 /**

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1132,6 +1132,7 @@
   "energy.live.breakdown.other": "Other",
   "energy.live.breakdown.offline": "offline",
   "energy.live.breakdown.stale": "reading outdated",
+  "energy.live.breakdown.staleNote": "A load with no recent reading is not counted, so its consumption shows up in Other.",
   "energy.live.breakdown.houseIdle": "House idle",
   "energy.live.breakdown.overshoot": "Σ submeters ≥ house total",
   "energy.live.phases.title": "Phase breakdown",

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1131,6 +1131,7 @@
   "energy.live.breakdown.title": "Consumption breakdown",
   "energy.live.breakdown.other": "Other",
   "energy.live.breakdown.offline": "offline",
+  "energy.live.breakdown.stale": "reading outdated",
   "energy.live.breakdown.houseIdle": "House idle",
   "energy.live.breakdown.overshoot": "Σ submeters ≥ house total",
   "energy.live.phases.title": "Phase breakdown",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1131,6 +1131,7 @@
   "energy.live.breakdown.title": "Décomposition consommation",
   "energy.live.breakdown.other": "Autre",
   "energy.live.breakdown.offline": "hors-ligne",
+  "energy.live.breakdown.stale": "mesure ancienne",
   "energy.live.breakdown.houseIdle": "Maison à l'arrêt",
   "energy.live.breakdown.overshoot": "Σ sous-compteurs ≥ total maison",
   "energy.live.phases.title": "Répartition par phase",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1132,6 +1132,7 @@
   "energy.live.breakdown.other": "Autre",
   "energy.live.breakdown.offline": "hors-ligne",
   "energy.live.breakdown.stale": "mesure ancienne",
+  "energy.live.breakdown.staleNote": "Une charge sans mesure récente n'est pas comptée : sa consommation se retrouve dans Autre.",
   "energy.live.breakdown.houseIdle": "Maison à l'arrêt",
   "energy.live.breakdown.overshoot": "Σ sous-compteurs ≥ total maison",
   "energy.live.phases.title": "Répartition par phase",


### PR DESCRIPTION
## Root cause

The card mixed readings of wildly different ages into one instantaneous picture. Its **whole** is rebuilt from the grid and solar meters on every message, roughly every 25 s. Each **part** was whatever that submeter's plug last said, at full weight, however old: `readSubmeterPower` dropped a reading on exactly one condition, `status === "offline"`.

Measured on production, and this is what closed the question: a water heater drawing **560 W was displayed as 0 W**, because its clamp had last reported sixteen minutes earlier. The arbitration surface rendered directly below on the same page had it right (`granted, watts = 567`) because it was reading something current. Two components of one page describing one appliance in two contradictory ways.

The failure is quiet, which is the worst part. A stale `0 W` reads as "this appliance is off", a perfectly plausible thing for a water heater to be, and nothing on screen suggested the figure was a quarter of an hour old.

The binding's own `stale` flag cannot carry this. The backend applies the electrical window only to `METERING_EQUIPMENT_TYPES`, on purpose, so a `thermostat` or `water_heater` with a power channel reports `stale: false` however old the value is. The 124-day-old wood stove reading on the same page had `stale: false`.

The 776 % and the self-overlapping donut arcs from the original report are symptoms of the same thing: during export the house total is a small difference of two large numbers, so it is at its most sensitive exactly when a stale part is at its most visible.

## Fix

`readSubmeterReading` ages a reading out and the row says **"reading outdated"** with the age instead of printing a number. It stays in the legend: "we do not know" is information, and hiding it would put the household back where this started.

The budget is split, and getting this wrong was the review's blocking finding on the first commit. Two minutes for `METERING_EQUIPMENT_TYPES`, where the engine already treats a frozen reading as a fault. **Ten minutes elsewhere**, because SmartThings, Legrand, Panasonic Comfort Cloud and MCZ Maestro all default to a 300 s poll, and the issue's own snapshot shows two such rows at an age of 270 s with nothing wrong. A flat two-minute budget would have made them oscillate every poll cycle, roughly once a second, with their watts jumping into the grey residual and back. Ten minutes is twice the slowest supported cadence and still catches both production cases (944 s, and 124 days).

Ages are re-checked on a 30 s tick. Without it a row only aged out when an unrelated equipment event re-rendered the page, so a home whose only sources poll every 300 s would recompute at the poll, with the reading 0 s old, and the rule would silently never apply.

Guards kept for the symptoms, since a fresh overshoot remains possible: shares clamp to 100 % and the arcs are held to one circle. Shares are also computed from the values actually displayed, so a 10 W load in a house whose centre label reads 35 W prints 29 % instead of the 30 % it got from dividing the raw total. `formatPower` now derives from the same rounding, after the review found the two disagreed on every X50 W half-step (a 575 W part in a 1150 W house printed 48 % under a label reading 1.1 kW).

A stale row contributes nothing but its watts are still in the house total, so they land in the residual. The card now says so rather than leaving a reader to conclude an unmetered load appeared.

## Tests

23 helper tests and 7 component tests driving the whole Live page, because the defect is a mismatch between two of its parts and testing the helper alone would not show it. They reproduce the production export scenario, the reported screenshot, and the 300 s poller that must not flicker.

All 7 component tests fail against the code on main. Mutation-checked by the review: unclamping `buildSegments`, dropping `Math.min(100, ...)`, and reverting `sharePercent` to raw division each fail a test.

## Docs

The energy tour describes what an outdated reading looks like, what "too long" means for each kind of source, and why it matters most during surplus.

## Deferred

`GET /api/v1/equipments?role=submeter` (the ESP32 energy display's feed) applies no age test at all, and equipment cards print power untagged whatever its age. The same quiet failure is still readable on both, filed as #832 with a note that the rule should be shared rather than re-implemented per surface.

Closes #744
