### PR TITLE
fix(ws): redact free-form system strings for non-admins, pin the role wiring (#651)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ The Proxy does NOT protect against direct `require("better-sqlite3")`, `process.
 - Passwords: bcrypt cost 12. JWT HS256 via `jsonwebtoken`.
 - Access token TTL 15 min, refresh token TTL 30 days
 - API tokens: `swl_` prefix, SHA-256 hash stored, `crypto.randomBytes(32)`
-- Roles: `admin` > `user` > `viewer`
+- Roles: `admin` > `standard` (`UserRole` in `src/shared/types.ts`)
 
 ### Frontend
 

--- a/docs/technical/api-reference.fr.md
+++ b/docs/technical/api-reference.fr.md
@@ -480,6 +480,16 @@ Les événements sont batchés toutes les 200 ms et envoyés sous forme de table
 ]
 ```
 
+### Filtrage par rôle (audit de sécurité S01)
+
+Deux choses liées au rôle d'un client sont appliquées à la livraison, et pas seulement au moment de l'abonnement.
+
+**Flux réservés aux admins.** Les topics `mqtt-publishers` et `logs` sont silencieusement retirés de la demande d'abonnement d'un non-admin, et les événements `notification-publisher.*` ne lui sont jamais livrés bien qu'ils soient routés vers le topic partagé `system`, parce qu'ils transportent la configuration du canal du publisher (un token de bot Telegram, par exemple).
+
+**Chaînes libres.** `system.error`, `system.update.error` et `system.update.progress` transportent du texte destiné à l'opérateur, assemblé au point d'appel plutôt que contraint par un schéma. Leur champ message est masqué et remplacé par `"[redacted]"` pour les clients non-admin. L'événement lui-même est toujours livré et ses champs structurés (`step`, par exemple) sont conservés : un client non-admin qui assiste à une mise à jour voit toujours l'overlay, ce qu'il cesse de recevoir est une chaîne que l'UI n'affichait pas. Aucun secret n'y circule aujourd'hui ; ce masquage existe pour que cela ne dépende plus de la vigilance de chaque auteur futur (issue #651).
+
+**Ce qui n'est délibérément pas masqué.** `system.alarm.raised` et `.resolved` transportent eux aussi du texte libre, et c'est le plus exposé du lot : `equipment-manager.ts` y interpole une erreur de driver brute, et n'importe quel plugin tiers peut émettre ce type. Mais cette chaîne est _affichée_ : elle sert de texte de repli pour les alarmes dont l'UI n'a pas de clé i18n, donc la masquer viderait le bandeau d'incidents pour tout client non-admin, et ne fermerait rien puisque `activity-buffer.ts` recopie le même texte dans `activity.added`, sur un topic ouvert à tous les rôles. Considérez le texte d'alarme comme visible par tout client authentifié. Le vrai correctif est la migration vers `messageKey` / `messageParams`, pour que l'erreur de driver cesse d'être la charge utile.
+
 ### Flux d'activité
 
 Quand on est abonné au topic `activity`, le serveur pousse chaque nouvel item au fil de l'eau. Chaque envoi est un événement unitaire (non batché), avec le même format que les items retournés par `GET /api/v1/activity` :

--- a/docs/technical/api-reference.md
+++ b/docs/technical/api-reference.md
@@ -588,6 +588,16 @@ Events are batched every 200ms and sent as a JSON array. High-frequency data eve
 
 The `equipment.status.changed` event (spec 116) is emitted by the EquipmentStatusTracker on every transition between `online` / `degraded` / `offline`. Deduplicated per equipment ID per batch.
 
+### Role filtering (security audit S01)
+
+Two things about a client's role are enforced at delivery, not merely at subscription time.
+
+**Admin-only streams.** The `mqtt-publishers` and `logs` topics are silently dropped from a non-admin's subscription request, and `notification-publisher.*` events are never delivered to a non-admin even though they route to the shared `system` topic, because they carry the publisher's channel configuration (a Telegram bot token, for instance).
+
+**Free-form strings.** `system.error`, `system.update.error` and `system.update.progress` carry operator-facing prose assembled at the call site rather than values a schema constrains. Their message field is replaced with `"[redacted]"` for non-admin clients. The event itself is still delivered, and its structured fields (`step`, for instance) survive, so a non-admin client watching an update in progress still sees the overlay: what it stops receiving is a string the UI never rendered. No secret flows there today; the redaction exists so that keeping it that way does not depend on every future author remembering (issue #651).
+
+**What is deliberately not redacted.** `system.alarm.raised` and `.resolved` carry free-form text too, and it is the most exposed of the lot: `equipment-manager.ts` interpolates a raw driver error into it, and any third-party plugin may emit the type. But that string is _rendered_: it is the fallback text for alarms the UI has no i18n key for, so redacting it would blank the header issue banner for every non-admin client, and it would close nothing, because `activity-buffer.ts` mirrors the same prose into `activity.added` on a topic every role may subscribe to. Treat alarm text as visible to every authenticated client. The real fix is the migration to `messageKey` / `messageParams`, so the driver error stops being the payload.
+
 ### Activity Stream
 
 When subscribed to the `activity` topic, the server pushes new items as they are produced. Each push is a single event (not batched), shape identical to the items returned by `GET /api/v1/activity`:

--- a/src/api/websocket-role-wiring.test.ts
+++ b/src/api/websocket-role-wiring.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Issue #651 — assert the connection-level role wiring, not just the helpers.
+ *
+ * The 30 tests in `websocket.test.ts` cover the pure functions
+ * (`isAdminOnlyEvent`, `resolveSubscribedTopics`, `canReceiveEvent`), and they
+ * would all still pass if `verifyApiToken().role` never reached
+ * `ClientState.role`. Nothing asserted the wiring between them, which is the
+ * one line whose failure would silently hand every non-admin an admin's feed.
+ *
+ * So this drives a real server over a real socket: connect with a viewer's API
+ * token, subscribe to everything including the admin-only topics, and watch
+ * what actually arrives.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import websocketPlugin from "@fastify/websocket";
+import WebSocket from "ws";
+import { registerWebSocket, REDACTED_FOR_ROLE } from "./websocket.js";
+import { EventBus } from "../core/event-bus.js";
+import { createLogger } from "../core/logger.js";
+import type { AuthService } from "../auth/auth-service.js";
+import type { LogRingBuffer } from "../core/log-buffer.js";
+import type { EngineEvent, LogEntry, UserRole } from "../shared/types.js";
+
+const logger = createLogger("silent").logger;
+
+/**
+ * What actually comes down the socket: engine events, plus the frames the
+ * server sends outside the event bus (the greeting, and `log.entry` from the
+ * ring-buffer stream).
+ */
+type Frame = EngineEvent | { type: string; [k: string]: unknown };
+
+/**
+ * `UserRole` is `admin | standard`. There is no viewer.
+ *
+ * Both connection branches are stubbed, because both are load-bearing and only
+ * one of them is what the browser uses. A `swl_`/`wch_`/`cbl_` token goes
+ * through `verifyApiToken` and is how scripts and the energy display connect;
+ * anything else is a JWT through `verifyAccessToken`, which is how every
+ * logged-in UI session connects, since a browser cannot set headers on a
+ * WebSocket and has to smuggle the token through `bearer.<token>`.
+ */
+const API_TOKENS: Record<string, UserRole> = {
+  swl_admin: "admin",
+  swl_standard: "standard",
+};
+
+/** JWTs here are just opaque non-`swl_` strings; only the mapped role matters. */
+const JWTS: Record<string, UserRole> = {
+  "jwt.admin.sig": "admin",
+  "jwt.standard.sig": "standard",
+};
+
+const authService = {
+  verifyApiToken: (token: string) => {
+    const role = API_TOKENS[token];
+    return role ? { userId: "u-" + role, role } : null;
+  },
+  verifyAccessToken: (token: string) => {
+    const role = JWTS[token];
+    if (!role) throw new Error("invalid token");
+    return { userId: "u-" + role, role };
+  },
+} as unknown as AuthService;
+
+/** A real fan-out, so the log-stream gate can actually be driven. */
+const logListeners = new Set<(entry: LogEntry) => void>();
+const logBuffer = {
+  subscribe: (listener: (entry: LogEntry) => void) => {
+    logListeners.add(listener);
+    return () => logListeners.delete(listener);
+  },
+} as unknown as LogRingBuffer;
+
+function emitLog(entry: Partial<LogEntry>): void {
+  for (const listener of logListeners) listener(entry as LogEntry);
+}
+
+let app: FastifyInstance;
+let eventBus: EventBus;
+let port: number;
+
+beforeAll(async () => {
+  eventBus = new EventBus(logger);
+  app = Fastify({ logger: false });
+  await app.register(websocketPlugin);
+  registerWebSocket(app, {
+    eventBus,
+    authService,
+    logBuffer,
+    logger,
+    corsOrigins: [],
+  });
+  await app.listen({ port: 0, host: "127.0.0.1" });
+  const addr = app.server.address();
+  if (!addr || typeof addr === "string") throw new Error("no port");
+  port = addr.port;
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+/** Connect, subscribe to every topic, and collect what the server sends. */
+async function connect(token: string): Promise<{
+  received: Frame[];
+  close: () => void;
+}> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, [`bearer.${token}`]);
+  const received: Frame[] = [];
+  ws.on("message", (raw) => {
+    const parsed = JSON.parse(String(raw)) as Frame | Frame[];
+    if (Array.isArray(parsed)) received.push(...parsed);
+    else received.push(parsed);
+  });
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", () => resolve());
+    ws.once("error", reject);
+  });
+  ws.send(
+    JSON.stringify({
+      type: "subscribe",
+      topics: ["system", "devices", "mqtt-publishers", "logs", "energy"],
+    }),
+  );
+  // The subscribe is processed before any event emitted after this point.
+  await new Promise((r) => setTimeout(r, 30));
+  return { received, close: () => ws.close() };
+}
+
+/** Poll until `predicate` holds or the deadline passes. */
+async function until(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+/**
+ * Emit, then wait for a client that IS entitled to the events to have received
+ * them. Waiting on a fixed delay past the 200 ms batch interval works until a
+ * loaded runner misses it, and then the failure surfaces on a positive
+ * assertion, which reads as an authorization regression rather than a timeout.
+ * Waiting on the witness makes the negative assertions meaningful by
+ * construction: what a client did not get, it did not get by the time a peer
+ * had everything.
+ */
+async function emitAndAwait(events: EngineEvent[], witness: { received: Frame[] }): Promise<void> {
+  for (const e of events) eventBus.emit(e);
+  const wanted = events.map((e) => e.type);
+  await until(() => wanted.every((t) => witness.received.some((r) => r.type === t)));
+  // One more batch period: a client that should NOT receive an event would be
+  // flushed in the same tick as the witness, never a later one.
+  await new Promise((r) => setTimeout(r, 220));
+}
+
+const ev = (type: string, extra: Record<string, unknown> = {}): EngineEvent =>
+  ({ type, ...extra }) as unknown as EngineEvent;
+
+describe("WebSocket role wiring, end to end (#651)", () => {
+  it("does not deliver admin-only topics to a standard client that asked for them", async () => {
+    const standard = await connect("swl_standard");
+    const admin = await connect("swl_admin");
+
+    await emitAndAwait(
+      [
+        ev("mqtt-publisher.created", { publisherId: "p1" }),
+        ev("notification-publisher.updated", { publisherId: "n1" }),
+        ev("device.status_changed", { deviceId: "d1" }),
+      ],
+      admin,
+    );
+
+    const standardTypes = standard.received.map((e) => e.type);
+    const adminTypes = admin.received.map((e) => e.type);
+
+    // The admin proves the events really were emitted and routed, so the
+    // standard client's empty result cannot be an artefact of nothing sent.
+    expect(adminTypes).toContain("mqtt-publisher.created");
+    expect(adminTypes).toContain("notification-publisher.updated");
+
+    expect(standardTypes).not.toContain("mqtt-publisher.created");
+    expect(standardTypes).not.toContain("notification-publisher.updated");
+    // Not a blanket block: it still gets what its role allows.
+    expect(standardTypes).toContain("device.status_changed");
+
+    standard.close();
+    admin.close();
+  });
+
+  it("gates a browser session the same way, and that is the JWT branch", async () => {
+    // The branch every logged-in UI session takes: a browser cannot set headers
+    // on a WebSocket, so it sends the JWT as `bearer.<token>` and the server
+    // reads the role through verifyAccessToken. Covering only the swl_ branch
+    // left a hardcoded role here invisible to the whole suite.
+    const standard = await connect("jwt.standard.sig");
+    const admin = await connect("jwt.admin.sig");
+
+    await emitAndAwait(
+      [
+        ev("mqtt-publisher.created", { publisherId: "p2" }),
+        ev("device.status_changed", { deviceId: "d2" }),
+      ],
+      admin,
+    );
+
+    expect(admin.received.map((e) => e.type)).toContain("mqtt-publisher.created");
+    expect(standard.received.map((e) => e.type)).not.toContain("mqtt-publisher.created");
+    // Positive control on the standard client itself: it is connected and
+    // receiving, so the assertion above is about the gate, not about silence.
+    expect(standard.received.map((e) => e.type)).toContain("device.status_changed");
+
+    standard.close();
+    admin.close();
+  });
+
+  it("refuses the log stream to a standard client even if it reaches the subscribe", async () => {
+    // resolveSubscribedTopics drops `logs` for a non-admin, so this is belt and
+    // braces. It is worth the line: deleting that role check is a one-line edit
+    // and the full server log is what sits behind it.
+    const standard = await connect("swl_standard");
+    const admin = await connect("swl_admin");
+
+    emitLog({ level: "error", msg: "db connect failed for user:p4ss@host" });
+    await until(() => admin.received.some((e) => e.type === "log.entry"));
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(admin.received.map((e) => e.type)).toContain("log.entry");
+    expect(standard.received.map((e) => e.type)).not.toContain("log.entry");
+    expect(JSON.stringify(standard.received)).not.toContain("p4ss");
+
+    standard.close();
+    admin.close();
+  });
+
+  it("strips free-form system strings for a non-admin and keeps them for an admin", async () => {
+    const standard = await connect("swl_standard");
+    const admin = await connect("swl_admin");
+
+    const secret = "postgres://sowel:hunter2@db.internal:5432";
+    await emitAndAwait(
+      [
+        ev("system.update.error", { error: `pull failed: ${secret}` }),
+        ev("system.update.progress", { step: "pull", message: `pulling from ${secret}` }),
+      ],
+      admin,
+    );
+
+    const standardJson = JSON.stringify(standard.received);
+    expect(standardJson).not.toContain("hunter2");
+    expect(standardJson).toContain(REDACTED_FOR_ROLE);
+    // The event itself still arrives: the UI raises its overlay on the type.
+    expect(standard.received.map((e) => e.type)).toContain("system.update.progress");
+    // `step` is a fixed vocabulary, not free-form, so it survives.
+    expect(standard.received.some((e) => (e as { step?: string }).step === "pull")).toBe(true);
+
+    expect(JSON.stringify(admin.received)).toContain("hunter2");
+
+    standard.close();
+    admin.close();
+  });
+
+  it("refuses a connection with no credentials at all", async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    const code = await new Promise<number>((resolve) => {
+      ws.on("close", (c) => resolve(c));
+      ws.on("error", () => {});
+    });
+    expect(code).toBe(4001);
+  });
+
+  it("refuses a token the auth service does not recognise", async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, ["bearer.swl_nope"]);
+    const code = await new Promise<number>((resolve) => {
+      ws.on("close", (c) => resolve(c));
+      ws.on("error", () => {});
+    });
+    expect(code).toBe(4001);
+  });
+});

--- a/src/api/websocket.test.ts
+++ b/src/api/websocket.test.ts
@@ -5,6 +5,8 @@ import {
   isAdminOnlyEvent,
   resolveSubscribedTopics,
   canReceiveEvent,
+  redactForRole,
+  REDACTED_FOR_ROLE,
 } from "./websocket.js";
 import type { EngineEvent } from "../shared/types.js";
 
@@ -202,5 +204,60 @@ describe("websocket role authorization (S01)", () => {
         }),
       ).toBe(true);
     });
+  });
+});
+
+// Issue #651 — free-form strings on the shared `system` topic.
+describe("redactForRole", () => {
+  const withError = (type: string, error: string): EngineEvent =>
+    ({ type, error }) as unknown as EngineEvent;
+
+  it("leaves every event untouched for an admin", () => {
+    const event = withError("system.update.error", "pull failed: s3cr3t");
+    expect(redactForRole(event, "admin")).toBe(event); // same reference, no copy
+  });
+
+  it("strips the free-form field for a non-admin", () => {
+    const event = withError("system.error", "connect ECONNREFUSED user:p4ss@host");
+    for (const role of ["standard"] as const) {
+      const out = redactForRole(event, role) as { error: string };
+      expect(out.error).toBe(REDACTED_FOR_ROLE);
+    }
+  });
+
+  it("keeps the structured fields beside it", () => {
+    const event = {
+      type: "system.update.progress",
+      step: "pull",
+      message: "pulling from registry.example/private",
+    } as unknown as EngineEvent;
+    const out = redactForRole(event, "standard") as { step: string; message: string; type: string };
+    // `step` is a fixed vocabulary the UI switches on; only `message` is prose.
+    expect(out.step).toBe("pull");
+    expect(out.type).toBe("system.update.progress");
+    expect(out.message).toBe(REDACTED_FOR_ROLE);
+  });
+
+  it("does not mutate the event other clients are still holding", () => {
+    // One emit fans out to every client, so redacting in place would strip the
+    // string from the admin's copy too, depending on iteration order.
+    const event = withError("system.update.error", "boom: s3cr3t");
+    redactForRole(event, "standard");
+    expect((event as unknown as { error: string }).error).toBe("boom: s3cr3t");
+  });
+
+  it("passes through an event with no free-form field, by reference", () => {
+    const event = ev("device.status_changed");
+    expect(redactForRole(event, "standard")).toBe(event);
+  });
+
+  it("leaves system.update.available alone: versions and a URL, no prose", () => {
+    const event = {
+      type: "system.update.available",
+      current: "1.62.0",
+      latest: "1.63.0",
+      releaseUrl: "https://github.com/mchacher/sowel/releases/tag/v1.63.0",
+    } as unknown as EngineEvent;
+    expect(redactForRole(event, "standard")).toBe(event);
   });
 });

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -172,6 +172,65 @@ export function resolveSubscribedTopics(requested: string[], role: UserRole): Se
   return result;
 }
 
+/**
+ * Free-form message fields on events that route to the shared `system` topic,
+ * which every authenticated client subscribes to by default.
+ *
+ * These carry operator-facing strings assembled at the call site, not values a
+ * schema constrains, so nothing structural stops a future one interpolating a
+ * connection string, a token, or a path. No secret flows there today; the
+ * point is that keeping it that way currently depends on every author
+ * remembering, and a reviewer noticing (security audit S01, issue #651).
+ *
+ * Redacting rather than withholding the whole event is deliberate. The UI
+ * reads only the TYPE of the update events, to raise and clear its overlay, so
+ * a non-admin watching an update in progress still sees the overlay; what it
+ * stops receiving is a string it never rendered.
+ *
+ * `system.alarm.raised` / `.resolved` are deliberately NOT here, and the
+ * omission is the interesting one. Their `message` is the closest thing in the
+ * codebase to what this guards against: `equipment-manager.ts` interpolates a
+ * raw driver error into it, and `ALLOWED_EMIT_TYPES` lets any third-party
+ * plugin emit the type. But that string is *rendered*: `alarm-message.ts`
+ * keeps it as the fallback text for alarms the UI has no i18n key for, so
+ * redacting it would blank the header issue banner for every non-admin. Nor
+ * would it close anything on its own, since `activity-buffer.ts` mirrors the
+ * same prose into `activity.added`, on a topic every role may subscribe to.
+ * The fix there is the migration `alarm-message.ts` already started: move
+ * alarms to `messageKey` / `messageParams` so the driver error stops being the
+ * payload. Until then, treat alarm text as visible to every authenticated
+ * client.
+ *
+ * TOP-LEVEL SCALAR FIELDS ONLY. `redactForRole` shallow-copies, so a nested
+ * field (`activity.added.item.message.params`, the obvious next candidate)
+ * would be mutated in place and stripped from every other client's copy too.
+ * Adding one means deep-copying first.
+ */
+const FREE_FORM_SYSTEM_FIELDS = new Map<EngineEvent["type"], readonly string[]>([
+  ["system.error", ["error"]],
+  ["system.update.progress", ["message"]],
+  ["system.update.error", ["error"]],
+]);
+
+/** Placeholder substituted for a free-form string sent to a non-admin client. */
+export const REDACTED_FOR_ROLE = "[redacted]";
+
+/**
+ * Strip free-form strings from an event bound for a non-admin client.
+ * Returns the event untouched for admins and for every type not listed above,
+ * so this costs one map lookup on the hot path.
+ */
+export function redactForRole(event: EngineEvent, role: UserRole): EngineEvent {
+  if (role === "admin") return event;
+  const fields = FREE_FORM_SYSTEM_FIELDS.get(event.type);
+  if (!fields) return event;
+  const copy: Record<string, unknown> = { ...event };
+  for (const field of fields) {
+    if (field in copy) copy[field] = REDACTED_FOR_ROLE;
+  }
+  return copy as EngineEvent;
+}
+
 /** True when a client with the given role and subscriptions should receive the event. */
 export function canReceiveEvent(
   event: EngineEvent,
@@ -252,13 +311,24 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
 
     for (const [, state] of clients) {
       if (canReceiveEvent(event, state)) {
-        state.pending.push(event);
+        state.pending.push(redactForRole(event, state.role));
       }
     }
   });
 
   /** Subscribe a client to log streaming via ring buffer */
   function subscribeToLogs(state: ClientState): void {
+    // Second gate. Reaching here already requires `logs` in state.topics, which
+    // resolveSubscribedTopics only grants to an admin, so this is unreachable
+    // today. It is here because every other privileged delivery has two
+    // independent checks (the subscription AND canReceiveEvent) while this one
+    // had a single line standing between a non-admin and the full server log,
+    // secrets included. Deleting the role check in resolveSubscribedTopics is a
+    // one-line edit; it should not be enough on its own.
+    if (state.role !== "admin") {
+      logger.warn({ role: state.role }, "Refused log stream for a non-admin client");
+      return;
+    }
     // Unsubscribe previous if any
     if (state.logUnsubscribe) {
       state.logUnsubscribe();


### PR DESCRIPTION
## 1. Free-form strings on the shared `system` topic

`system.error`, `system.update.error` and `system.update.progress` carry operator-facing prose assembled at the call site, and they route to the `system` topic that every authenticated client subscribes to by default. No secret flows there today. The point the issue makes is that keeping it that way rests entirely on every future author remembering, and a reviewer noticing.

`redactForRole` replaces the message field with `"[redacted]"` for non-admin clients, at enqueue time, per client.

Redacting rather than withholding the event is deliberate: the UI switches on the **type** of the update events to raise and clear its overlay and never renders the string, so a non-admin watching an admin-triggered update still sees the overlay. Structured fields beside it (`step`) survive.

**`system.alarm.raised` is deliberately excluded**, and that is now stated rather than silent. Its `message` is the most exposed free-form string in the codebase: `equipment-manager.ts` interpolates a raw driver error into it, and `ALLOWED_EMIT_TYPES` lets any third-party plugin emit the type. But it is *rendered*: `alarm-message.ts` keeps it as the fallback text for alarms with no i18n key, so redacting it would blank the header issue banner for every non-admin. And it would close nothing, because `activity-buffer.ts` mirrors the same prose into `activity.added` on a topic every role may subscribe to. The real fix is the `messageKey` / `messageParams` migration `alarm-message.ts` already began. Both docs pages now say so, because a security section claiming free-form strings are handled would otherwise overstate the guarantee.

## 2. The role wiring itself

The 30 existing tests cover the pure helpers and would all still pass if `verifyApiToken().role` never reached `ClientState.role`, which is the one line whose failure hands every non-admin an admin's feed. The new test drives a real Fastify server over a real socket, with an admin connected alongside so an empty result cannot pass as an artefact of nothing being emitted.

## What the review of the first draft caught

Worth reading, because two of these were in the safety net itself:

- **The tests used the roles `"viewer"` and `"user"`.** `UserRole` is `admin | standard`; neither exists. They passed because `tsconfig.json` excludes `**/*.test.ts` from the typecheck, so every assertion was about values the engine cannot produce while the one real role went untested. `CLAUDE.md` carried the same stale claim, which is presumably where it came from, and is corrected here. The systemic cause is filed as #834, with the 75 pre-existing errors a test-inclusive typecheck surfaces.
- **Only the `swl_` branch was covered.** Hardcoding the role in the `verifyAccessToken` branch passed all 340 tests. That is the branch every browser session takes, since a WebSocket cannot carry headers and the UI smuggles its JWT through `bearer.<token>`. Now stubbed and tested.
- **One test asserted only absences**, with no positive control, so it stayed green even with nothing delivered at all.
- **`subscribeToLogs` had one gate where every event delivery has two.** Unreachable today, but deleting the role check in `resolveSubscribedTopics` is a one-line edit and the full server log sits behind it. Now symmetric.
- **Fixed 250 ms sleeps against a 200 ms batch interval.** A slow runner would have failed on a *positive* assertion, reading as an authorization regression and sending a reviewer after the wrong bug. The tests now wait for an entitled peer to have received the events, which also makes the negative assertions meaningful by construction.

## Mutation checks

| Mutation | Result |
| --- | --- |
| role hardcoded in the `swl_` branch | 3 wiring tests fail |
| role hardcoded in the JWT branch | 1 wiring test fails (passed everything before) |
| `redactForRole` neutered | wiring + unit fail |
| redact in place instead of copying | wiring + unit fail |
| `canReceiveEvent` returns true | wiring fails |
| `resolveSubscribedTopics` ignores role | wiring stays green, **correctly**: the second gate holds. The pre-existing unit test still fails. |

Closes #651
