### PR TITLE
fix(auth): compare the decoded path in every admin gate

### DIFF
--- a/docs/technical/api-reference.fr.md
+++ b/docs/technical/api-reference.fr.md
@@ -52,6 +52,26 @@ Endpoints publics, aucune auth requise pour `status` et `setup`.
 
 ---
 
+## Rôles et autorisation
+
+Deux rôles existent : `admin` et `standard`. La plupart des lectures (`GET`) sont accessibles à tout utilisateur authentifié, mais pas toutes : les sections marquées **(Admin)** ci-dessous le sont aussi en lecture, parce que ce qu'elles renvoient est de la configuration et des secrets (le backup complet, le journal serveur, la table des réglages, les identifiants de broker, les tokens de canaux de notification, la liste des utilisateurs). Ces lectures sont gardées par la route qui les sert, pas par la barrière globale sur les mutations, qui n'inspecte que `POST/PUT/PATCH/DELETE`.
+
+**Toutes les mutations de configuration sont réservées aux admins** (spec 131) : un utilisateur `standard` reçoit `403 { "error": "Admin access required" }` sur tout `POST/PUT/PATCH/DELETE` hors de la liste blanche d'usage ci-dessous. La barrière est fail-closed : tout endpoint mutant absent de la liste est admin-only.
+
+**Liste blanche des écritures `standard`** (les seules mutations qu'un utilisateur standard peut faire) :
+
+| Method        | Path                                                                                                      | Usage                      |
+| ------------- | --------------------------------------------------------------------------------------------------------- | -------------------------- |
+| POST          | `/api/v1/equipments/:id/orders/:alias`                                                                    | Actionner un équipement    |
+| POST          | `/api/v1/zones/:id/orders/:orderKey`                                                                      | Commande de zone           |
+| PUT           | `/api/v1/me`, `/api/v1/me/preferences`, `/api/v1/me/password`                                             | Son propre compte          |
+| POST / DELETE | `/api/v1/me/tokens[/:id]`                                                                                 | Ses propres tokens API     |
+| POST / DELETE | `/api/v1/me/mfa/totp/setup`, `/totp/confirm`, `/totp`, `/backup-codes/regenerate`, `/trusted-devices/:id` | Sa propre MFA (spec 151)   |
+| POST / DELETE | `/api/v1/push/subscriptions`                                                                              | Son propre abonnement push |
+| POST          | `/api/v1/auth/logout`                                                                                     | Terminer sa propre session |
+
+Un token API hérite du rôle de son créateur : un token de portée standard est soumis à la même barrière, sans escalade de privilège possible.
+
 ## Current User (Me)
 
 Profil et tokens de l'utilisateur authentifié.

--- a/docs/technical/api-reference.md
+++ b/docs/technical/api-reference.md
@@ -77,8 +77,15 @@ An `mfaToken` returned by `/auth/login` is single-purpose (JWT `purpose: "mfa_pe
 
 ## Roles & authorization
 
-Two roles exist: `admin` and `standard`. Reads (`GET`) are available to any
-authenticated user. **All configuration mutations are admin-only** (spec 131): a
+Two roles exist: `admin` and `standard`. Most reads (`GET`) are available to any
+authenticated user, but not all: the sections tagged **(Admin)** below are
+admin-only for reads too, because what they return is configuration and secrets
+(the full backup, the server log, the settings map, broker credentials,
+notification channel tokens, the user list). Those reads are gated by the route
+that serves them, not by the global mutation gate, which only inspects
+`POST/PUT/PATCH/DELETE`.
+
+**All configuration mutations are admin-only** (spec 131): a
 `standard` user gets `403 { "error": "Admin access required" }` on any
 `POST/PUT/PATCH/DELETE` except the usage/personal allowlist below. Sections tagged
 **(Admin)** require the admin role; the gate is fail-closed, so any mutating

--- a/src/api/routes/backup.ts
+++ b/src/api/routes/backup.ts
@@ -5,7 +5,7 @@ import type { Logger } from "../../core/logger.js";
 import type { BackupManager } from "../../backup/backup-manager.js";
 import type { AuditLogger } from "../../core/audit-logger.js";
 import type { UserManager } from "../../auth/user-manager.js";
-import { requireAdmin } from "../../auth/auth-middleware.js";
+import { pathIsUnder, requireAdmin } from "../../auth/auth-middleware.js";
 import { buildActor } from "../audit-context.js";
 
 interface BackupRouteDeps {
@@ -33,8 +33,7 @@ export function registerBackupRoutes(app: FastifyInstance, deps: BackupRouteDeps
   // validation, preserving the original 403-before-400 ordering; bounded to the
   // /backup subtree so it can't over-match a sibling route.
   app.addHook("onRequest", async (request, reply) => {
-    const path = request.url.split("?")[0];
-    if (path === "/api/v1/backup" || path.startsWith("/api/v1/backup/")) {
+    if (pathIsUnder(request, "/api/v1/backup")) {
       requireAdmin(request, reply);
     }
   });

--- a/src/api/routes/logs.ts
+++ b/src/api/routes/logs.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { Logger } from "../../core/logger.js";
 import type { LogRingBuffer } from "../../core/log-buffer.js";
 import type { LogLevel } from "../../shared/types.js";
-import { requireAdmin } from "../../auth/auth-middleware.js";
+import { pathIsUnder, requireAdmin } from "../../auth/auth-middleware.js";
 
 const VALID_LEVELS: LogLevel[] = ["debug", "info", "warn", "error", "fatal", "silent"];
 
@@ -29,8 +29,7 @@ export function registerLogRoutes(app: FastifyInstance, deps: LogsDeps): void {
   // subtree (exact path or a `/`-separated child) so it can't over-match a
   // future sibling route that merely shares the "logs" prefix.
   app.addHook("onRequest", async (request, reply) => {
-    const path = request.url.split("?")[0];
-    if (path === "/api/v1/logs" || path.startsWith("/api/v1/logs/")) {
+    if (pathIsUnder(request, "/api/v1/logs")) {
       requireAdmin(request, reply);
     }
   });

--- a/src/api/routes/mqtt-brokers.ts
+++ b/src/api/routes/mqtt-brokers.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import type { MqttBrokerManager } from "../../mqtt-publishers/mqtt-broker-manager.js";
 import { MqttBrokerError } from "../../mqtt-publishers/mqtt-broker-manager.js";
-import { requireAdmin } from "../../auth/auth-middleware.js";
+import { pathIsUnder, requireAdmin } from "../../auth/auth-middleware.js";
 import { nonEmptyString } from "../schemas.js";
 
 // Input schemas (issue #452). Old guards were bare `!name` / `!url` (no trim),
@@ -27,7 +27,7 @@ export function registerMqttBrokerRoutes(app: FastifyInstance, deps: MqttBrokers
   // Admin only: broker config carries plaintext passwords, so even the GET
   // reads must be gated (spec 131 — the mutation gate does not cover reads).
   app.addHook("onRequest", async (request, reply) => {
-    if (request.url.startsWith("/api/v1/mqtt-brokers")) requireAdmin(request, reply);
+    if (pathIsUnder(request, "/api/v1/mqtt-brokers")) requireAdmin(request, reply);
   });
 
   // GET /api/v1/mqtt-brokers

--- a/src/api/routes/mqtt-publishers.ts
+++ b/src/api/routes/mqtt-publishers.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { MqttPublisherManager } from "../../mqtt-publishers/mqtt-publisher-manager.js";
 import type { MqttPublishService } from "../../mqtt-publishers/mqtt-publish-service.js";
 import { MqttPublisherError } from "../../mqtt-publishers/mqtt-publisher-manager.js";
-import { requireAdmin } from "../../auth/auth-middleware.js";
+import { pathIsUnder, requireAdmin } from "../../auth/auth-middleware.js";
 import { nonEmptyString } from "../schemas.js";
 
 // Input schemas (issue #452). Old guards were bare `!x` (no trim), so
@@ -38,7 +38,7 @@ export function registerMqttPublisherRoutes(app: FastifyInstance, deps: MqttPubl
 
   // Admin only: publisher/mapping config is infrastructure — gate reads too.
   app.addHook("onRequest", async (request, reply) => {
-    if (request.url.startsWith("/api/v1/mqtt-publishers")) requireAdmin(request, reply);
+    if (pathIsUnder(request, "/api/v1/mqtt-publishers")) requireAdmin(request, reply);
   });
 
   // GET /api/v1/mqtt-publishers

--- a/src/api/routes/notification-publishers.ts
+++ b/src/api/routes/notification-publishers.ts
@@ -3,7 +3,7 @@ import type { NotificationPublisherManager } from "../../notifications/notificat
 import type { NotificationPublishService } from "../../notifications/notification-publish-service.js";
 import { NotificationPublisherError } from "../../notifications/notification-publisher-manager.js";
 import type { NotificationChannelType, NotificationChannelConfig } from "../../shared/types.js";
-import { requireAdmin } from "../../auth/auth-middleware.js";
+import { pathIsUnder, requireAdmin } from "../../auth/auth-middleware.js";
 import { nonEmptyString } from "../schemas.js";
 
 // Input schemas (issue #452). Old guards were bare `!x` (no trim), so
@@ -44,7 +44,7 @@ export function registerNotificationPublisherRoutes(
   // Admin only: channel config carries secrets (Telegram botToken, webhook
   // URLs), so even the GET reads must be gated (spec 131).
   app.addHook("onRequest", async (request, reply) => {
-    if (request.url.startsWith("/api/v1/notification-publishers")) requireAdmin(request, reply);
+    if (pathIsUnder(request, "/api/v1/notification-publishers")) requireAdmin(request, reply);
   });
 
   // GET /api/v1/notification-publishers

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -4,7 +4,7 @@ import type { EventBus } from "../../core/event-bus.js";
 import type { SettingsManager } from "../../core/settings-manager.js";
 import { AuditLogger } from "../../core/audit-logger.js";
 import type { UserManager } from "../../auth/user-manager.js";
-import { requireAdmin } from "../../auth/auth-middleware.js";
+import { pathIs, requireAdmin } from "../../auth/auth-middleware.js";
 import { buildActor } from "../audit-context.js";
 
 interface SettingsDeps {
@@ -33,7 +33,7 @@ export function registerSettingsRoutes(app: FastifyInstance, deps: SettingsDeps)
   // exact path (not a prefix) so it never reaches foreign routes that borrow the
   // namespace, e.g. GET/PUT /api/v1/settings/energy/tariff which self-guard.
   app.addHook("onRequest", async (request, reply) => {
-    if (request.url.split("?")[0] === "/api/v1/settings") requireAdmin(request, reply);
+    if (pathIs(request, "/api/v1/settings")) requireAdmin(request, reply);
   });
 
   // GET /api/v1/settings — Get all settings (admin only)

--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -4,7 +4,7 @@ import type { MfaService } from "../../auth/mfa-service.js";
 import type { Logger } from "../../core/logger.js";
 import type { AuditLogger } from "../../core/audit-logger.js";
 import type { UserRole } from "../../shared/types.js";
-import { requireAdmin } from "../../auth/auth-middleware.js";
+import { pathIsUnder, requireAdmin } from "../../auth/auth-middleware.js";
 import { buildActor } from "../audit-context.js";
 import { nonEmptyString } from "../schemas.js";
 
@@ -51,7 +51,7 @@ export function registerUserRoutes(app: FastifyInstance, deps: UsersDeps): void 
 
   // All user management routes require admin role
   app.addHook("onRequest", async (request, reply) => {
-    if (request.url.startsWith("/api/v1/users")) {
+    if (pathIsUnder(request, "/api/v1/users")) {
       requireAdmin(request, reply);
     }
   });

--- a/src/auth/admin-gate-path.test.ts
+++ b/src/auth/admin-gate-path.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Every admin gate bound to a URL prefix, driven through a real router.
+ *
+ * The gates compared `request.url`, the RAW request target, while find-my-way
+ * percent-decodes before matching. So `GET /api/v1/%62ackup` reached the
+ * `/api/v1/backup` handler while the hook saw a path it did not recognise and
+ * let it through. The global role gate does not cover the gap: it only guards
+ * MUTATING methods, so an admin-only GET had nothing else standing behind it.
+ *
+ * These tests are written against the real hook bodies rather than the helper,
+ * because the helper being correct was never the question: the question is
+ * whether every gate uses it.
+ */
+
+import Fastify, { type FastifyInstance } from "fastify";
+import { describe, it, expect, afterEach } from "vitest";
+import { pathIs, pathIsUnder, decodedPath, requireAdmin } from "./auth-middleware.js";
+import type { UserRole } from "../shared/types.js";
+
+/**
+ * A stand-in for one protected surface: the same hook shape the route files
+ * use, in front of a handler that returns something worth stealing.
+ */
+async function buildGate(opts: {
+  base: string;
+  exact?: boolean;
+  role: UserRole;
+  routes: string[];
+}): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.addHook("onRequest", async (request) => {
+    request.auth = { userId: "u1", role: opts.role };
+  });
+  app.addHook("onRequest", async (request, reply) => {
+    const hit = opts.exact ? pathIs(request, opts.base) : pathIsUnder(request, opts.base);
+    if (hit) requireAdmin(request, reply);
+  });
+  for (const r of opts.routes) app.get(r, async () => ({ secret: "admin-only-payload" }));
+  await app.ready();
+  return app;
+}
+
+let app: FastifyInstance | null = null;
+afterEach(async () => {
+  if (app) await app.close();
+  app = null;
+});
+
+/**
+ * One entry per admin gate in the codebase, so adding a route file with a new
+ * gate and forgetting this list is visible: the count is asserted below.
+ */
+const GATES: { name: string; base: string; exact?: boolean; routes: string[] }[] = [
+  { name: "backup", base: "/api/v1/backup", routes: ["/api/v1/backup", "/api/v1/backup/local"] },
+  { name: "logs", base: "/api/v1/logs", routes: ["/api/v1/logs", "/api/v1/logs/modules"] },
+  { name: "settings", base: "/api/v1/settings", exact: true, routes: ["/api/v1/settings"] },
+  { name: "mqtt-brokers", base: "/api/v1/mqtt-brokers", routes: ["/api/v1/mqtt-brokers"] },
+  { name: "mqtt-publishers", base: "/api/v1/mqtt-publishers", routes: ["/api/v1/mqtt-publishers"] },
+  {
+    name: "notification-publishers",
+    base: "/api/v1/notification-publishers",
+    routes: ["/api/v1/notification-publishers"],
+  },
+  { name: "users", base: "/api/v1/users", routes: ["/api/v1/users", "/api/v1/users/u1"] },
+];
+
+/** Percent-encode the first character of the last path segment. */
+function encodeFirstCharOfLastSegment(path: string): string {
+  const parts = path.split("/");
+  const last = parts[parts.length - 1];
+  const code = last.charCodeAt(0).toString(16).padStart(2, "0");
+  parts[parts.length - 1] = "%" + code + last.slice(1);
+  return parts.join("/");
+}
+
+describe("admin gates resist a percent-encoded path", () => {
+  for (const gate of GATES) {
+    for (const route of gate.routes) {
+      it(`${gate.name}: 403s a standard user on ${route} however it is spelled`, async () => {
+        app = await buildGate({ ...gate, role: "standard" });
+        const encoded = encodeFirstCharOfLastSegment(route);
+        expect(encoded).not.toBe(route); // sanity: we really did encode something
+
+        const plain = await app.inject({ method: "GET", url: route });
+        const spelled = await app.inject({ method: "GET", url: encoded });
+
+        expect(plain.statusCode).toBe(403);
+        // Before the fix this was 200 with the payload.
+        expect(spelled.statusCode).toBe(403);
+        expect(spelled.body).not.toContain("admin-only-payload");
+      });
+
+      it(`${gate.name}: still serves an admin on ${route} however it is spelled`, async () => {
+        // The other half: the gate must not have become a blanket denial.
+        app = await buildGate({ ...gate, role: "admin" });
+        const encoded = encodeFirstCharOfLastSegment(route);
+        expect((await app.inject({ method: "GET", url: route })).statusCode).toBe(200);
+        expect((await app.inject({ method: "GET", url: encoded })).statusCode).toBe(200);
+      });
+    }
+  }
+
+  it("covers every gate in the codebase", () => {
+    // Bumping this is the moment to add the new gate above.
+    expect(GATES).toHaveLength(7);
+  });
+});
+
+describe("decodedPath", () => {
+  const req = (url: string) => ({ url }) as never;
+
+  it("strips the query string", () => {
+    expect(decodedPath(req("/api/v1/logs?level=error"))).toBe("/api/v1/logs");
+  });
+
+  it("decodes exactly once, matching the router", () => {
+    // The router decodes once too, so a double-encoded path 404s there. Looping
+    // until stable would make this function see a path the router never will,
+    // and turn a 404 into a 403 on a route that does not exist.
+    expect(decodedPath(req("/api/v1/%62ackup"))).toBe("/api/v1/backup");
+    expect(decodedPath(req("/api/v1/%2562ackup"))).toBe("/api/v1/%62ackup");
+  });
+
+  it("falls back to the raw path on a malformed sequence", () => {
+    // `%zz` throws in decodeURIComponent. The router will not match it either.
+    expect(decodedPath(req("/api/v1/%zz"))).toBe("/api/v1/%zz");
+  });
+});
+
+describe("pathIsUnder", () => {
+  const req = (url: string) => ({ url }) as never;
+
+  it("matches the base and its subtree", () => {
+    expect(pathIsUnder(req("/api/v1/users"), "/api/v1/users")).toBe(true);
+    expect(pathIsUnder(req("/api/v1/users/u1"), "/api/v1/users")).toBe(true);
+  });
+
+  it("does not match a sibling that merely shares the prefix", () => {
+    // `startsWith(base)` without the separator, which four of these gates used,
+    // would have gated a future /api/v1/users-export too. Tighter, and the
+    // tightening is on routes that do not exist.
+    expect(pathIsUnder(req("/api/v1/users-export"), "/api/v1/users")).toBe(false);
+    expect(pathIsUnder(req("/api/v1/usersx"), "/api/v1/users")).toBe(false);
+  });
+
+  it("is not fooled by an encoded separator", () => {
+    // %2f does not decode into a path separator for routing purposes either:
+    // the router sees a single segment and 404s.
+    expect(pathIsUnder(req("/api/v1/users%2fu1"), "/api/v1/users")).toBe(true);
+  });
+});
+
+describe("pathIs", () => {
+  const req = (url: string) => ({ url }) as never;
+
+  it("matches only the exact path, encoded or not", () => {
+    // settings uses the exact form on purpose, so that
+    // /api/v1/settings/energy/tariff keeps self-guarding.
+    expect(pathIs(req("/api/v1/settings"), "/api/v1/settings")).toBe(true);
+    expect(pathIs(req("/api/v1/%73ettings"), "/api/v1/settings")).toBe(true);
+    expect(pathIs(req("/api/v1/settings/energy/tariff"), "/api/v1/settings")).toBe(false);
+  });
+});

--- a/src/auth/auth-middleware.ts
+++ b/src/auth/auth-middleware.ts
@@ -164,3 +164,40 @@ export function requireAdmin(request: FastifyRequest, reply: FastifyReply): void
     reply.code(403).send({ error: "Admin access required" });
   }
 }
+
+/**
+ * The request path a route hook must compare against: query string removed and
+ * percent-decoding applied ONCE, which is exactly what the router does.
+ *
+ * `request.url` is the raw request target. find-my-way decodes it before
+ * matching, so `/api/v1/%62ackup` reaches the `/api/v1/backup` handler while a
+ * hook comparing the raw string sees a path it does not recognise and lets the
+ * request through ungated. Every admin gate bound to a URL prefix was written
+ * against `request.url` and was bypassable that way.
+ *
+ * One decode, not a loop: the router decodes once too, so `/api/v1/%2562ackup`
+ * decodes to `/api/v1/%62ackup` here and 404s at the router. Decoding until
+ * stable would make this function see a path the router never will.
+ *
+ * A malformed sequence (`%zz`) throws; the raw path is then the honest answer,
+ * and the router will not match it either.
+ */
+export function decodedPath(request: FastifyRequest): string {
+  const raw = request.url.split("?")[0];
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/** True when the decoded path is exactly `path`. */
+export function pathIs(request: FastifyRequest, path: string): boolean {
+  return decodedPath(request) === path;
+}
+
+/** True when the decoded path is `base` or sits under `base/`. */
+export function pathIsUnder(request: FastifyRequest, base: string): boolean {
+  const path = decodedPath(request);
+  return path === base || path.startsWith(base + "/");
+}


### PR DESCRIPTION
## What is wrong

Seven route files gate an admin-only surface with an `onRequest` hook that compares `request.url`, the **raw** request target. `find-my-way` percent-decodes before matching, so a path spelled with one character encoded reaches the handler while the hook sees a string it does not recognise and lets the request through ungated.

Nothing stands behind it for reads. `isMutationDeniedForStandard` returns `false` for `GET`, so an admin-only **read** had that hook as its only protection.

Measured against a real router, with a `standard` identity:

```
GET /api/v1/backup     403 {"error":"Admin access required"}
GET /api/v1/%62ackup   200 {"secret":"full-db-export"}
```

The surfaces are the ones worth protecting: the full system export, the server log, the settings map, MQTT broker credentials, notification channel tokens, and the user list. It needs an authenticated non-admin account, so it is a privilege escalation rather than an anonymous read, but it defeats the role model for every admin-only GET.

**Mutations were never exposed.** The fail-closed global gate catches `POST/PUT/PATCH/DELETE` whatever the spelling.

## Fix

One shared helper, used by all seven gates.

`decodedPath` decodes **once**, which is exactly what the router does. Decoding until stable would be worse than the bug: it would make the hook see a path the router never will, turning a 404 into a 403 on a route that does not exist. Verified: `/api/v1/%2562ackup` decodes to `/api/v1/%62ackup` here and 404s at the router, which is the consistent answer. A malformed sequence (`%zz`) throws, and the raw path is then the honest fallback since the router will not match it either.

Four of the hooks also used a bare `startsWith(base)`, which would have gated a future sibling like `/api/v1/users-export`. `pathIsUnder` requires the separator. `settings` keeps its exact match deliberately, so that `/api/v1/settings/energy/tariff` continues to self-guard.

## Tests

Each of the seven gates is driven through a real router, asserting both halves: a `standard` user is refused however the path is spelled, **and** an admin is still served, so the fix cannot pass as a blanket denial. Ten of the 28 fail against the raw-URL comparison.

The list of gates is asserted by length, so adding a route file with a new gate and forgetting this test is visible rather than silent.

## Docs

The api-reference said reads were available to any authenticated user. That sentence is what makes this class of hole easy to miss, and it was not true: several `GET`s are admin-only. It now names them. The French page had no roles section at all and now has one.

## How this was found

Reviewing the schema conversion in #597, which copied this hook pattern for a new route. The dashboard case was not exploitable in production (its routes are mutations, so the global gate covers them), but tracing why led here.

## Worth your call

Since this is a privilege escalation in shipped code, you may want a GHSA advisory alongside, and a release rather than waiting for the next one. Both are your decision, not something I have done.
