### PR TITLE
refactor(api): schema-validate the dashboard widget bodies (#597)

### DIFF
--- a/docs/technical/api-reference.fr.md
+++ b/docs/technical/api-reference.fr.md
@@ -240,6 +240,9 @@ Deux points qui ne vont pas de soi :
 
 - Un équipement ou une zone référencés qui n'existent pas répondent **400**, pas 404. C'est le statut que cette route a toujours renvoyé, et la conversion ne l'a pas renuméroté.
 - Les champs inconnus dans le body sont ignorés, pas rejetés.
+- `label` et `icon` acceptent une chaîne ou `null` ; `config` est un objet quelconque, et `null` l'efface. Un `PATCH` sans body du tout est un no-op qui renvoie le widget inchangé.
+
+Deux entrées auparavant acceptées répondent désormais 400. Les deux étaient des échecs silencieux plutôt que des fonctionnalités : un `label` non textuel était stocké tel quel, et `PUT /order` acceptait n'importe quel tableau, si bien que `{ "order": [1, 2] }` ne correspondait à aucune ligne et répondait `{ "ok": true }` sans rien avoir réordonné.
 
 ---
 

--- a/docs/technical/api-reference.fr.md
+++ b/docs/technical/api-reference.fr.md
@@ -234,6 +234,13 @@ Toutes les routes de gestion des utilisateurs nécessitent le rôle admin.
 | `DELETE` | `/api/v1/dashboard/widgets/:id`   | Supprime un widget (admin). Retourne 204.                                                           |
 | `PUT`    | `/api/v1/dashboard/widgets/order` | Réordonne les widgets (admin). Body : `{ order: string[] }`.                                        |
 
+Les bodies des widgets sont validés par schéma (issue #597). `type` vaut `"equipment"` ou `"zone"`, et détermine le reste : `equipmentId` pour le premier, `zoneId` plus `family` (parmi `lights`, `shutters`, `heating`, `sensors`) pour le second. Un body malformé répond `400 { "error": "..." }`.
+
+Deux points qui ne vont pas de soi :
+
+- Un équipement ou une zone référencés qui n'existent pas répondent **400**, pas 404. C'est le statut que cette route a toujours renvoyé, et la conversion ne l'a pas renuméroté.
+- Les champs inconnus dans le body sont ignorés, pas rejetés.
+
 ---
 
 ## Charts

--- a/docs/technical/api-reference.md
+++ b/docs/technical/api-reference.md
@@ -306,6 +306,13 @@ No separate auth scheme — these routes sit behind the same JWT/API-token middl
 | `DELETE` | `/api/v1/dashboard/widgets/:id`   | Delete widget (admin). Returns 204.                                                     |
 | `PUT`    | `/api/v1/dashboard/widgets/order` | Reorder widgets (admin). Body: `{ order: string[] }`.                                   |
 
+Widget bodies are schema-validated (issue #597). `type` is `"equipment"` or `"zone"`, and it decides what else is required: `equipmentId` for the first, `zoneId` plus `family` (one of `lights`, `shutters`, `heating`, `sensors`) for the second. A malformed body answers `400 { "error": "..." }`.
+
+Two things worth knowing because they are not what a reader would guess:
+
+- A referenced equipment or zone that does not exist answers **400**, not 404. That is the status this route has always returned, and the schema conversion did not renumber it.
+- Unknown fields in the body are ignored rather than rejected.
+
 ---
 
 ## Charts

--- a/docs/technical/api-reference.md
+++ b/docs/technical/api-reference.md
@@ -312,6 +312,9 @@ Two things worth knowing because they are not what a reader would guess:
 
 - A referenced equipment or zone that does not exist answers **400**, not 404. That is the status this route has always returned, and the schema conversion did not renumber it.
 - Unknown fields in the body are ignored rather than rejected.
+- `label` and `icon` accept a string or `null`; `config` is any object, and `null` clears it. A `PATCH` with no body at all is a no-op that returns the widget unchanged.
+
+Two inputs that used to be accepted now answer 400. Both were silent failures rather than working features: a non-string `label` was stored verbatim, and `PUT /order` accepted any array, so `{ "order": [1, 2] }` matched no row and answered `{ "ok": true }` having reordered nothing.
 
 ---
 

--- a/src/api/routes/dashboard.test.ts
+++ b/src/api/routes/dashboard.test.ts
@@ -45,6 +45,20 @@ async function buildApp(opts: { authed?: boolean; role?: UserRole } = {}) {
 
 const WIDGETS = "/api/v1/dashboard/widgets";
 
+/**
+ * The 400 contract #482 exists to preserve: `{ error: <reason> }` and nothing
+ * else. Asserting only `typeof error === "string"` would also accept Fastify's
+ * default envelope `{ statusCode, code, error: "Bad Request", message }`,
+ * which is a different body a client would have to parse differently.
+ */
+function expectAppErrorShape(body: unknown): void {
+  const b = body as Record<string, unknown>;
+  expect(typeof b.error).toBe("string");
+  expect(b.statusCode).toBeUndefined();
+  expect(b.code).toBeUndefined();
+  expect(b.message).toBeUndefined();
+}
+
 describe("dashboard widget routes", () => {
   let app: Awaited<ReturnType<typeof buildApp>> | null = null;
 
@@ -121,9 +135,36 @@ describe("dashboard widget routes", () => {
         app = await buildApp();
         const res = await app.inject({ method: "POST", url: WIDGETS, payload: payload as never });
         expect(res.statusCode).toBe(400);
-        expect(typeof (res.json() as { error: unknown }).error).toBe("string");
+        expectAppErrorShape(res.json());
       });
     }
+
+    it("still accepts a null label or icon, as it always did", async () => {
+      // The old code never type-checked these and stored `label ?? null`, so an
+      // explicit null meant "no label". Rejecting it would have been an
+      // undeclared behaviour change on a field this conversion is not about.
+      app = await buildApp();
+      const res = await app.inject({
+        method: "POST",
+        url: WIDGETS,
+        payload: { type: "equipment", equipmentId: "e1", label: null, icon: null },
+      });
+      expect(res.statusCode).toBe(201);
+      expect((res.json() as { label?: string }).label).toBeUndefined();
+    });
+
+    it("still ignores a family sent on an equipment widget", async () => {
+      // `if`/`then` only ADDS requirements; it never forbids the other branch's
+      // fields, and the handler stores null for them. Same as before.
+      app = await buildApp();
+      const res = await app.inject({
+        method: "POST",
+        url: WIDGETS,
+        payload: { type: "equipment", equipmentId: "e1", family: "lights" },
+      });
+      expect(res.statusCode).toBe(201);
+      expect((res.json() as { family?: string }).family).toBeUndefined();
+    });
 
     it("still ignores unknown fields, as it always did", async () => {
       // additionalProperties is left at its default on purpose: rejecting them
@@ -207,6 +248,34 @@ describe("dashboard widget routes", () => {
       expect(res.statusCode).toBe(404);
     });
 
+    it("returns the widget unchanged when no body is sent at all", async () => {
+      // Distinct from the `{}` case above, and the one a schema most easily
+      // breaks: a script polling a widget's state with a bare `curl -X PATCH`
+      // would otherwise get a 400 about a body it never sent.
+      app = await buildApp();
+      const id = await createWidget();
+      const res = await app.inject({ method: "PATCH", url: `${WIDGETS}/${id}` });
+      expect(res.statusCode).toBe(200);
+      expect((res.json() as { id: string }).id).toBe(id);
+    });
+
+    it("still accepts any object as config, and still clears it on null", async () => {
+      app = await buildApp();
+      const id = await createWidget();
+      await app.inject({
+        method: "PATCH",
+        url: `${WIDGETS}/${id}`,
+        payload: { config: { anything: [1, 2] } },
+      });
+      const cleared = await app.inject({
+        method: "PATCH",
+        url: `${WIDGETS}/${id}`,
+        payload: { config: null },
+      });
+      expect(cleared.statusCode).toBe(200);
+      expect((cleared.json() as { config?: unknown }).config).toBeUndefined();
+    });
+
     it("404s an unknown id BEFORE validating the body", async () => {
       // Existence has to outrank shape, or a client chasing a 400 spends its
       // time fixing a body for a widget that is not there.
@@ -240,7 +309,7 @@ describe("dashboard widget routes", () => {
         payload: { label: 42 },
       });
       expect(res.statusCode).toBe(400);
-      expect(typeof (res.json() as { error: unknown }).error).toBe("string");
+      expectAppErrorShape(res.json());
     });
   });
 
@@ -299,7 +368,7 @@ describe("dashboard widget routes", () => {
       for (const payload of [{}, { order: "a,b" }, { order: 3 }]) {
         const res = await app.inject({ method: "PUT", url: `${WIDGETS}/order`, payload });
         expect(res.statusCode).toBe(400);
-        expect(typeof (res.json() as { error: unknown }).error).toBe("string");
+        expectAppErrorShape(res.json());
       }
     });
 
@@ -330,6 +399,33 @@ describe("dashboard widget routes", () => {
       const res = await app.inject({ method: "GET", url: WIDGETS });
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual([]);
+    });
+
+    it("answers HEAD to a non-admin too", async () => {
+      // Fastify auto-exposes HEAD for every GET. A hook that exempts only GET
+      // turns a cheap liveness probe into a 403 for a user who can read the
+      // list a moment earlier.
+      app = await buildApp({ role: "standard" });
+      const res = await app.inject({ method: "HEAD", url: WIDGETS });
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe("no auth context at all", () => {
+    it("403s a write when the request carries no identity", async () => {
+      // requireAdmin has two halves; only the wrong-role half was exercised.
+      app = await buildApp({ authed: false });
+      const res = await app.inject({
+        method: "POST",
+        url: WIDGETS,
+        payload: { type: "equipment", equipmentId: "e1" },
+      });
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("still serves the read", async () => {
+      app = await buildApp({ authed: false });
+      expect((await app.inject({ method: "GET", url: WIDGETS })).statusCode).toBe(200);
     });
   });
 });

--- a/src/api/routes/dashboard.test.ts
+++ b/src/api/routes/dashboard.test.ts
@@ -179,6 +179,19 @@ describe("dashboard widget routes", () => {
       expect((res.json() as Record<string, unknown>).nonsense).toBeUndefined();
     });
 
+    it("403s a non-admin whose path is percent-encoded", async () => {
+      // The gate matches the DECODED path, because the router decodes before
+      // matching: comparing request.url raw is what let /api/v1/%62ackup past
+      // the backup gate.
+      app = await buildApp({ role: "standard" });
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/dashboard/%77idgets",
+        payload: { type: "equipment", equipmentId: "e1" },
+      });
+      expect(res.statusCode).toBe(403);
+    });
+
     it("403s a non-admin, and does so BEFORE looking at the body", async () => {
       // The precedence is the point: a non-admin sending nonsense must still
       // learn it is not allowed, not that its nonsense was malformed.

--- a/src/api/routes/dashboard.test.ts
+++ b/src/api/routes/dashboard.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Characterization tests for the dashboard widget routes (#597, #482 Lot C).
+ *
+ * Written BEFORE the schema conversion and kept afterwards. The routes had no
+ * test of their own, and the conversion's whole claim is "zero behavioural
+ * regression", which is only worth anything if the behaviour was written down
+ * first. Every expectation here was produced by running against the
+ * hand-rolled implementation.
+ *
+ * The status codes are the part to read carefully. This route answers 400, not
+ * 404, when a referenced equipment or zone does not exist, and the conversion
+ * does not move it: #482 converts shape checks, it does not renumber answers a
+ * client may already depend on.
+ */
+
+import Fastify from "fastify";
+import Database from "better-sqlite3";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { registerDashboardRoutes } from "./dashboard.js";
+import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+import { applyMigrations } from "../../test-helpers/migrations.js";
+import type { UserRole } from "../../shared/types.js";
+
+let db: Database.Database;
+
+function seedFixtures(): void {
+  db.prepare("INSERT INTO zones (id, name) VALUES ('z1', 'Salon')").run();
+  db.prepare(
+    "INSERT INTO equipments (id, name, type, zone_id) VALUES ('e1', 'Lampe', 'light', 'z1')",
+  ).run();
+}
+
+async function buildApp(opts: { authed?: boolean; role?: UserRole } = {}) {
+  const app = Fastify({ logger: false, ajv: validationAjvOptions });
+  installValidationErrorHandler(app);
+  if (opts.authed !== false) {
+    app.addHook("onRequest", async (request) => {
+      request.auth = { userId: "u1", role: opts.role ?? "admin" };
+    });
+  }
+  registerDashboardRoutes(app, { db });
+  await app.ready();
+  return app;
+}
+
+const WIDGETS = "/api/v1/dashboard/widgets";
+
+describe("dashboard widget routes", () => {
+  let app: Awaited<ReturnType<typeof buildApp>> | null = null;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    applyMigrations(db);
+    seedFixtures();
+  });
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = null;
+    db.close();
+  });
+
+  describe("POST /widgets — the create body is conditional on `type`", () => {
+    it("creates an equipment widget", async () => {
+      app = await buildApp();
+      const res = await app.inject({
+        method: "POST",
+        url: WIDGETS,
+        payload: { type: "equipment", equipmentId: "e1", label: "Lampe salon" },
+      });
+      expect(res.statusCode).toBe(201);
+      const body = res.json() as { id: string; type: string; equipmentId: string; label: string };
+      expect(body.type).toBe("equipment");
+      expect(body.equipmentId).toBe("e1");
+      expect(body.label).toBe("Lampe salon");
+    });
+
+    it("creates a zone widget", async () => {
+      app = await buildApp();
+      const res = await app.inject({
+        method: "POST",
+        url: WIDGETS,
+        payload: { type: "zone", zoneId: "z1", family: "lights" },
+      });
+      expect(res.statusCode).toBe(201);
+      expect((res.json() as { family: string }).family).toBe("lights");
+    });
+
+    it("assigns display_order incrementally", async () => {
+      app = await buildApp();
+      for (let i = 0; i < 3; i++) {
+        await app.inject({
+          method: "POST",
+          url: WIDGETS,
+          payload: { type: "equipment", equipmentId: "e1" },
+        });
+      }
+      const res = await app.inject({ method: "GET", url: WIDGETS });
+      expect((res.json() as { displayOrder: number }[]).map((w) => w.displayOrder)).toEqual([
+        0, 1, 2,
+      ]);
+    });
+
+    // Reject matrix. Every one of these is a 400 with an { error } body.
+    const rejects: [string, unknown][] = [
+      ["no body at all", undefined],
+      ["missing type", { equipmentId: "e1" }],
+      ["unknown type", { type: "widget", equipmentId: "e1" }],
+      ["type is not a string", { type: 1 }],
+      ["equipment without equipmentId", { type: "equipment" }],
+      ["equipment with an unknown equipmentId", { type: "equipment", equipmentId: "nope" }],
+      ["zone without zoneId", { type: "zone", family: "lights" }],
+      ["zone without family", { type: "zone", zoneId: "z1" }],
+      ["zone with an unknown family", { type: "zone", zoneId: "z1", family: "curtains" }],
+      ["zone with an unknown zoneId", { type: "zone", zoneId: "nope", family: "lights" }],
+    ];
+
+    for (const [name, payload] of rejects) {
+      it(`400s on ${name}`, async () => {
+        app = await buildApp();
+        const res = await app.inject({ method: "POST", url: WIDGETS, payload: payload as never });
+        expect(res.statusCode).toBe(400);
+        expect(typeof (res.json() as { error: unknown }).error).toBe("string");
+      });
+    }
+
+    it("still ignores unknown fields, as it always did", async () => {
+      // additionalProperties is left at its default on purpose: rejecting them
+      // would be a behaviour change dressed up as validation.
+      app = await buildApp();
+      const res = await app.inject({
+        method: "POST",
+        url: WIDGETS,
+        payload: { type: "equipment", equipmentId: "e1", nonsense: true },
+      });
+      expect(res.statusCode).toBe(201);
+      expect((res.json() as Record<string, unknown>).nonsense).toBeUndefined();
+    });
+
+    it("403s a non-admin, and does so BEFORE looking at the body", async () => {
+      // The precedence is the point: a non-admin sending nonsense must still
+      // learn it is not allowed, not that its nonsense was malformed.
+      app = await buildApp({ role: "standard" });
+      const res = await app.inject({
+        method: "POST",
+        url: WIDGETS,
+        payload: { type: "not-a-type" },
+      });
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe("PATCH /widgets/:id", () => {
+    async function createWidget(): Promise<string> {
+      const res = await app!.inject({
+        method: "POST",
+        url: WIDGETS,
+        payload: { type: "equipment", equipmentId: "e1" },
+      });
+      return (res.json() as { id: string }).id;
+    }
+
+    it("updates label, icon and config", async () => {
+      app = await buildApp();
+      const id = await createWidget();
+      const res = await app.inject({
+        method: "PATCH",
+        url: `${WIDGETS}/${id}`,
+        payload: { label: "New", icon: "lamp", config: { showPower: true } },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { label: string; icon: string; config: { showPower: boolean } };
+      expect(body.label).toBe("New");
+      expect(body.icon).toBe("lamp");
+      expect(body.config).toEqual({ showPower: true });
+    });
+
+    it("clears a field when null is sent", async () => {
+      app = await buildApp();
+      const id = await createWidget();
+      await app.inject({ method: "PATCH", url: `${WIDGETS}/${id}`, payload: { label: "x" } });
+      const res = await app.inject({
+        method: "PATCH",
+        url: `${WIDGETS}/${id}`,
+        payload: { label: null },
+      });
+      expect(res.statusCode).toBe(200);
+      expect((res.json() as { label?: string }).label).toBeUndefined();
+    });
+
+    it("returns the widget unchanged when the body carries nothing to update", async () => {
+      app = await buildApp();
+      const id = await createWidget();
+      const res = await app.inject({ method: "PATCH", url: `${WIDGETS}/${id}`, payload: {} });
+      expect(res.statusCode).toBe(200);
+      expect((res.json() as { id: string }).id).toBe(id);
+    });
+
+    it("404s an unknown id", async () => {
+      app = await buildApp();
+      const res = await app.inject({
+        method: "PATCH",
+        url: `${WIDGETS}/nope`,
+        payload: { label: "x" },
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("404s an unknown id BEFORE validating the body", async () => {
+      // Existence has to outrank shape, or a client chasing a 400 spends its
+      // time fixing a body for a widget that is not there.
+      app = await buildApp();
+      const res = await app.inject({
+        method: "PATCH",
+        url: `${WIDGETS}/nope`,
+        payload: { label: 42 },
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("403s a non-admin before either", async () => {
+      app = await buildApp({ role: "standard" });
+      const res = await app.inject({
+        method: "PATCH",
+        url: `${WIDGETS}/nope`,
+        payload: { label: 42 },
+      });
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("400s a label that is not a string (tightening, #597)", async () => {
+      // Previously stored verbatim: the column took the 42 and the UI read a
+      // number where it expects a label. Nothing in the product ever sent one.
+      app = await buildApp();
+      const id = await createWidget();
+      const res = await app.inject({
+        method: "PATCH",
+        url: `${WIDGETS}/${id}`,
+        payload: { label: 42 },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(typeof (res.json() as { error: unknown }).error).toBe("string");
+    });
+  });
+
+  describe("DELETE /widgets/:id", () => {
+    it("deletes and returns 204", async () => {
+      app = await buildApp();
+      const created = await app.inject({
+        method: "POST",
+        url: WIDGETS,
+        payload: { type: "equipment", equipmentId: "e1" },
+      });
+      const id = (created.json() as { id: string }).id;
+      const res = await app.inject({ method: "DELETE", url: `${WIDGETS}/${id}` });
+      expect(res.statusCode).toBe(204);
+      expect((await app.inject({ method: "GET", url: WIDGETS })).json()).toEqual([]);
+    });
+
+    it("404s an unknown id", async () => {
+      app = await buildApp();
+      const res = await app.inject({ method: "DELETE", url: `${WIDGETS}/nope` });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("403s a non-admin", async () => {
+      app = await buildApp({ role: "standard" });
+      const res = await app.inject({ method: "DELETE", url: `${WIDGETS}/nope` });
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe("PUT /widgets/order", () => {
+    it("reorders", async () => {
+      app = await buildApp();
+      const ids: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const r = await app.inject({
+          method: "POST",
+          url: WIDGETS,
+          payload: { type: "equipment", equipmentId: "e1" },
+        });
+        ids.push((r.json() as { id: string }).id);
+      }
+      const res = await app.inject({
+        method: "PUT",
+        url: `${WIDGETS}/order`,
+        payload: { order: [ids[2], ids[0], ids[1]] },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ ok: true });
+      const listed = (await app.inject({ method: "GET", url: WIDGETS })).json() as { id: string }[];
+      expect(listed.map((w) => w.id)).toEqual([ids[2], ids[0], ids[1]]);
+    });
+
+    it("400s when order is missing or not an array", async () => {
+      app = await buildApp();
+      for (const payload of [{}, { order: "a,b" }, { order: 3 }]) {
+        const res = await app.inject({ method: "PUT", url: `${WIDGETS}/order`, payload });
+        expect(res.statusCode).toBe(400);
+        expect(typeof (res.json() as { error: unknown }).error).toBe("string");
+      }
+    });
+
+    it("403s a non-admin before the body check", async () => {
+      app = await buildApp({ role: "standard" });
+      const res = await app.inject({ method: "PUT", url: `${WIDGETS}/order`, payload: {} });
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("400s an array whose elements are not ids (tightening, #597)", async () => {
+      // Previously these reached the UPDATE and matched no row, so the call
+      // reported ok:true having reordered nothing.
+      app = await buildApp();
+      for (const order of [[1, 2], [null], [""]]) {
+        const res = await app.inject({
+          method: "PUT",
+          url: `${WIDGETS}/order`,
+          payload: { order },
+        });
+        expect(res.statusCode).toBe(400);
+      }
+    });
+  });
+
+  describe("GET /widgets", () => {
+    it("is readable by a non-admin", async () => {
+      app = await buildApp({ role: "standard" });
+      const res = await app.inject({ method: "GET", url: WIDGETS });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual([]);
+    });
+  });
+});

--- a/src/api/routes/dashboard.ts
+++ b/src/api/routes/dashboard.ts
@@ -57,6 +57,11 @@ const VALID_FAMILIES = ["lights", "shutters", "heating", "sensors"] as const;
 //
 // `additionalProperties` is left at its default so unknown fields are ignored
 // exactly as they were.
+//
+// NOTE for the OpenAPI track (#481): @fastify/swagger emits 3.0.3 here, which
+// defines neither `if`/`then` nor `type: [..., "null"]` (3.0 wants
+// `nullable: true`). A codegen consumer will drop or choke on this requestBody
+// until the document moves to 3.1.
 const widgetCreateSchema = {
   type: "object",
   required: ["type"],
@@ -65,8 +70,12 @@ const widgetCreateSchema = {
     equipmentId: nonEmptyString,
     zoneId: nonEmptyString,
     family: { enum: [...VALID_FAMILIES] },
-    label: { type: "string" },
-    icon: { type: "string" },
+    // Nullable on purpose. The old code type-checked neither, and stored
+    // `label ?? null`, so an explicit null was accepted and meant "no label".
+    // Rejecting it here would be an undeclared behaviour change on a field the
+    // conversion is not about.
+    label: { type: ["string", "null"] },
+    icon: { type: ["string", "null"] },
   },
   allOf: [
     {
@@ -84,7 +93,11 @@ const widgetCreateSchema = {
 // `null` means "clear", a distinction the handler reads and the schema keeps.
 // `config` is an opaque object the route only stringifies.
 const widgetPatchSchema = {
-  type: "object",
+  // `["object", "null"]`, not `"object"`: a PATCH with no body at all used to
+  // answer 200 with the widget unchanged, and a client polling a widget's
+  // current state with a bare `curl -X PATCH` would otherwise start getting a
+  // 400 about a body it never sent.
+  type: ["object", "null"],
   properties: {
     label: { type: ["string", "null"] },
     icon: { type: ["string", "null"] },
@@ -109,7 +122,15 @@ export function registerDashboardRoutes(app: FastifyInstance, deps: DashboardDep
   // body. Bounded to the widget paths and to non-GET methods so it can neither
   // over-match a sibling route nor lock out the read.
   app.addHook("onRequest", async (request, reply) => {
-    if (request.method === "GET") return;
+    // HEAD as well as GET: Fastify auto-exposes a HEAD route for every GET, so
+    // gating it would break a cheap liveness probe for a standard user that
+    // could read the list a moment earlier.
+    //
+    // Exempting a METHOD makes this guard fail-open where the global one
+    // (isMutationDeniedForStandard) is fail-closed. It is a decision about
+    // THIS route, whose GET is deliberately open to everyone, not a template:
+    // a future admin-only GET under this prefix would need naming here.
+    if (request.method === "GET" || request.method === "HEAD") return;
     const path = request.url.split("?")[0];
     if (path === "/api/v1/dashboard/widgets" || path.startsWith("/api/v1/dashboard/widgets/")) {
       requireAdmin(request, reply);
@@ -202,9 +223,18 @@ export function registerDashboardRoutes(app: FastifyInstance, deps: DashboardDep
       },
     },
     async (request, reply) => {
+      // Re-read rather than trust the hook's row: an event-loop turn separates
+      // them, every DB call here is synchronous, and a concurrent DELETE in
+      // that window would otherwise crash on an undefined row. Two admin tabs,
+      // one deleting while the other renames, is all it takes. The hook is
+      // still what gives 404 its precedence over the schema 400; this is the
+      // race guard.
       const existing = db
         .prepare("SELECT * FROM dashboard_widgets WHERE id = ?")
-        .get(request.params.id) as WidgetRow;
+        .get(request.params.id) as WidgetRow | undefined;
+      if (!existing) {
+        return reply.code(404).send({ error: "Widget not found" });
+      }
 
       const { label, icon, config } = request.body ?? {};
       const updates: string[] = [];
@@ -232,7 +262,10 @@ export function registerDashboardRoutes(app: FastifyInstance, deps: DashboardDep
 
       const row = db
         .prepare("SELECT * FROM dashboard_widgets WHERE id = ?")
-        .get(request.params.id) as WidgetRow;
+        .get(request.params.id) as WidgetRow | undefined;
+      if (!row) {
+        return reply.code(404).send({ error: "Widget not found" });
+      }
       return reply.send(rowToWidget(row));
     },
   );

--- a/src/api/routes/dashboard.ts
+++ b/src/api/routes/dashboard.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type Database from "better-sqlite3";
 import { toISOUtc } from "../../core/database.js";
 import type { DashboardWidget, WidgetConfig, WidgetFamily } from "../../shared/types.js";
-import { requireAdmin } from "../../auth/auth-middleware.js";
+import { pathIsUnder, requireAdmin } from "../../auth/auth-middleware.js";
 import { nonEmptyString } from "../schemas.js";
 
 interface DashboardDeps {
@@ -131,8 +131,9 @@ export function registerDashboardRoutes(app: FastifyInstance, deps: DashboardDep
     // THIS route, whose GET is deliberately open to everyone, not a template:
     // a future admin-only GET under this prefix would need naming here.
     if (request.method === "GET" || request.method === "HEAD") return;
-    const path = request.url.split("?")[0];
-    if (path === "/api/v1/dashboard/widgets" || path.startsWith("/api/v1/dashboard/widgets/")) {
+    // pathIsUnder decodes the path once, the way the router does. Comparing
+    // request.url raw is what let /api/v1/%62ackup past the backup gate.
+    if (pathIsUnder(request, "/api/v1/dashboard/widgets")) {
       requireAdmin(request, reply);
     }
   });

--- a/src/api/routes/dashboard.ts
+++ b/src/api/routes/dashboard.ts
@@ -2,6 +2,8 @@ import type { FastifyInstance } from "fastify";
 import type Database from "better-sqlite3";
 import { toISOUtc } from "../../core/database.js";
 import type { DashboardWidget, WidgetConfig, WidgetFamily } from "../../shared/types.js";
+import { requireAdmin } from "../../auth/auth-middleware.js";
+import { nonEmptyString } from "../schemas.js";
 
 interface DashboardDeps {
   db: Database.Database;
@@ -42,10 +44,77 @@ function rowToWidget(row: WidgetRow): DashboardWidget {
   return widget;
 }
 
-const VALID_FAMILIES = new Set(["lights", "shutters", "heating", "sensors"]);
+const VALID_FAMILIES = ["lights", "shutters", "heating", "sensors"] as const;
+
+// ── Body schemas (#597, #482 Lot C) ─────────────────────────────────────
+//
+// Deferred from #482 because the create body is conditional: `equipmentId` is
+// required iff `type === "equipment"`, `zoneId` and `family` iff
+// `type === "zone"`. `if`/`then` expresses that. What a schema cannot express
+// is the existence lookup, so "Equipment not found" stays in the handler, and
+// keeps its original 400 rather than becoming a 404: #482 converts shape
+// checks, it does not renumber answers a client may already depend on.
+//
+// `additionalProperties` is left at its default so unknown fields are ignored
+// exactly as they were.
+const widgetCreateSchema = {
+  type: "object",
+  required: ["type"],
+  properties: {
+    type: { enum: ["equipment", "zone"] },
+    equipmentId: nonEmptyString,
+    zoneId: nonEmptyString,
+    family: { enum: [...VALID_FAMILIES] },
+    label: { type: "string" },
+    icon: { type: "string" },
+  },
+  allOf: [
+    {
+      if: { properties: { type: { const: "equipment" } }, required: ["type"] },
+      then: { required: ["equipmentId"] },
+    },
+    {
+      if: { properties: { type: { const: "zone" } }, required: ["type"] },
+      then: { required: ["zoneId", "family"] },
+    },
+  ],
+} as const;
+
+// Every field is optional and nullable: `undefined` means "leave alone" and
+// `null` means "clear", a distinction the handler reads and the schema keeps.
+// `config` is an opaque object the route only stringifies.
+const widgetPatchSchema = {
+  type: "object",
+  properties: {
+    label: { type: ["string", "null"] },
+    icon: { type: ["string", "null"] },
+    config: { type: ["object", "null"] },
+  },
+} as const;
+
+// TIGHTENING, deliberate: `items` was previously unconstrained, so
+// `{ order: [1, 2] }` reached the UPDATE and silently matched no row. An
+// element that is not a widget id was never meaningful here.
+const widgetOrderSchema = {
+  type: "object",
+  required: ["order"],
+  properties: { order: { type: "array", items: nonEmptyString } },
+} as const;
 
 export function registerDashboardRoutes(app: FastifyInstance, deps: DashboardDeps): void {
   const { db } = deps;
+
+  // Every write is admin-only; GET is not. The hook runs before body-schema
+  // validation, so 403 still precedes 400 for a non-admin sending a malformed
+  // body. Bounded to the widget paths and to non-GET methods so it can neither
+  // over-match a sibling route nor lock out the read.
+  app.addHook("onRequest", async (request, reply) => {
+    if (request.method === "GET") return;
+    const path = request.url.split("?")[0];
+    if (path === "/api/v1/dashboard/widgets" || path.startsWith("/api/v1/dashboard/widgets/")) {
+      requireAdmin(request, reply);
+    }
+  });
 
   // GET /api/v1/dashboard/widgets — List all widgets ordered by displayOrder
   app.get("/api/v1/dashboard/widgets", async () => {
@@ -65,123 +134,113 @@ export function registerDashboardRoutes(app: FastifyInstance, deps: DashboardDep
       label?: string;
       icon?: string;
     };
-  }>("/api/v1/dashboard/widgets", async (request, reply) => {
-    if (!request.auth || request.auth.role !== "admin") {
-      return reply.code(403).send({ error: "Admin access required" });
-    }
+  }>(
+    "/api/v1/dashboard/widgets",
+    { schema: { body: widgetCreateSchema } },
+    async (request, reply) => {
+      const { type, equipmentId, zoneId, family, label, icon } = request.body;
 
-    const { type, equipmentId, zoneId, family, label, icon } = request.body ?? {};
-
-    if (type !== "equipment" && type !== "zone") {
-      return reply.code(400).send({ error: "type must be 'equipment' or 'zone'" });
-    }
-
-    if (type === "equipment") {
-      if (!equipmentId) {
-        return reply.code(400).send({ error: "equipmentId is required for equipment widgets" });
+      // The schema has settled the shape by here; what is left is existence,
+      // which it cannot express. Both keep their original 400.
+      if (type === "equipment") {
+        const eq = db.prepare("SELECT id FROM equipments WHERE id = ?").get(equipmentId);
+        if (!eq) {
+          return reply.code(400).send({ error: "Equipment not found" });
+        }
       }
-      // Verify equipment exists
-      const eq = db.prepare("SELECT id FROM equipments WHERE id = ?").get(equipmentId);
-      if (!eq) {
-        return reply.code(400).send({ error: "Equipment not found" });
-      }
-    }
 
-    if (type === "zone") {
-      if (!zoneId) {
-        return reply.code(400).send({ error: "zoneId is required for zone widgets" });
+      if (type === "zone") {
+        const z = db.prepare("SELECT id FROM zones WHERE id = ?").get(zoneId);
+        if (!z) {
+          return reply.code(400).send({ error: "Zone not found" });
+        }
       }
-      if (!family || !VALID_FAMILIES.has(family)) {
-        return reply
-          .code(400)
-          .send({ error: "family must be one of: lights, shutters, heating, sensors" });
-      }
-      // Verify zone exists
-      const z = db.prepare("SELECT id FROM zones WHERE id = ?").get(zoneId);
-      if (!z) {
-        return reply.code(400).send({ error: "Zone not found" });
-      }
-    }
 
-    // Get next display_order
-    const maxRow = db
-      .prepare("SELECT COALESCE(MAX(display_order), -1) AS max_order FROM dashboard_widgets")
-      .get() as { max_order: number };
-    const nextOrder = maxRow.max_order + 1;
+      // Get next display_order
+      const maxRow = db
+        .prepare("SELECT COALESCE(MAX(display_order), -1) AS max_order FROM dashboard_widgets")
+        .get() as { max_order: number };
+      const nextOrder = maxRow.max_order + 1;
 
-    const id = crypto.randomUUID();
-    db.prepare(
-      `INSERT INTO dashboard_widgets (id, type, label, icon, equipment_id, zone_id, family, display_order)
+      const id = crypto.randomUUID();
+      db.prepare(
+        `INSERT INTO dashboard_widgets (id, type, label, icon, equipment_id, zone_id, family, display_order)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-    ).run(
-      id,
-      type,
-      label ?? null,
-      icon ?? null,
-      type === "equipment" ? equipmentId! : null,
-      type === "zone" ? zoneId! : null,
-      type === "zone" ? family! : null,
-      nextOrder,
-    );
+      ).run(
+        id,
+        type,
+        label ?? null,
+        icon ?? null,
+        type === "equipment" ? equipmentId! : null,
+        type === "zone" ? zoneId! : null,
+        type === "zone" ? family! : null,
+        nextOrder,
+      );
 
-    const row = db.prepare("SELECT * FROM dashboard_widgets WHERE id = ?").get(id) as WidgetRow;
-    return reply.code(201).send(rowToWidget(row));
-  });
+      const row = db.prepare("SELECT * FROM dashboard_widgets WHERE id = ?").get(id) as WidgetRow;
+      return reply.code(201).send(rowToWidget(row));
+    },
+  );
 
   // PATCH /api/v1/dashboard/widgets/:id — Update label, icon (admin only)
   app.patch<{
     Params: { id: string };
     Body: { label?: string | null; icon?: string | null; config?: WidgetConfig | null };
-  }>("/api/v1/dashboard/widgets/:id", async (request, reply) => {
-    if (!request.auth || request.auth.role !== "admin") {
-      return reply.code(403).send({ error: "Admin access required" });
-    }
+  }>(
+    "/api/v1/dashboard/widgets/:id",
+    {
+      schema: { body: widgetPatchSchema },
+      // preValidation runs before body validation, so a PATCH against a widget
+      // that does not exist still answers 404 rather than complaining about the
+      // shape of a body nobody will read.
+      preValidation: async (request, reply) => {
+        const params = request.params as { id: string };
+        const row = db.prepare("SELECT id FROM dashboard_widgets WHERE id = ?").get(params.id);
+        if (!row) {
+          return reply.code(404).send({ error: "Widget not found" });
+        }
+      },
+    },
+    async (request, reply) => {
+      const existing = db
+        .prepare("SELECT * FROM dashboard_widgets WHERE id = ?")
+        .get(request.params.id) as WidgetRow;
 
-    const existing = db
-      .prepare("SELECT * FROM dashboard_widgets WHERE id = ?")
-      .get(request.params.id) as WidgetRow | undefined;
-    if (!existing) {
-      return reply.code(404).send({ error: "Widget not found" });
-    }
+      const { label, icon, config } = request.body ?? {};
+      const updates: string[] = [];
+      const values: unknown[] = [];
 
-    const { label, icon, config } = request.body ?? {};
-    const updates: string[] = [];
-    const values: unknown[] = [];
+      if (label !== undefined) {
+        updates.push("label = ?");
+        values.push(label);
+      }
+      if (icon !== undefined) {
+        updates.push("icon = ?");
+        values.push(icon);
+      }
+      if (config !== undefined) {
+        updates.push("config = ?");
+        values.push(config ? JSON.stringify(config) : null);
+      }
 
-    if (label !== undefined) {
-      updates.push("label = ?");
-      values.push(label);
-    }
-    if (icon !== undefined) {
-      updates.push("icon = ?");
-      values.push(icon);
-    }
-    if (config !== undefined) {
-      updates.push("config = ?");
-      values.push(config ? JSON.stringify(config) : null);
-    }
+      if (updates.length === 0) {
+        return reply.send(rowToWidget(existing));
+      }
 
-    if (updates.length === 0) {
-      return rowToWidget(existing);
-    }
+      values.push(request.params.id);
+      db.prepare(`UPDATE dashboard_widgets SET ${updates.join(", ")} WHERE id = ?`).run(...values);
 
-    values.push(request.params.id);
-    db.prepare(`UPDATE dashboard_widgets SET ${updates.join(", ")} WHERE id = ?`).run(...values);
-
-    const row = db
-      .prepare("SELECT * FROM dashboard_widgets WHERE id = ?")
-      .get(request.params.id) as WidgetRow;
-    return rowToWidget(row);
-  });
+      const row = db
+        .prepare("SELECT * FROM dashboard_widgets WHERE id = ?")
+        .get(request.params.id) as WidgetRow;
+      return reply.send(rowToWidget(row));
+    },
+  );
 
   // DELETE /api/v1/dashboard/widgets/:id — Delete a widget (admin only)
   app.delete<{ Params: { id: string } }>(
     "/api/v1/dashboard/widgets/:id",
     async (request, reply) => {
-      if (!request.auth || request.auth.role !== "admin") {
-        return reply.code(403).send({ error: "Admin access required" });
-      }
-
       const result = db
         .prepare("DELETE FROM dashboard_widgets WHERE id = ?")
         .run(request.params.id);
@@ -195,24 +254,21 @@ export function registerDashboardRoutes(app: FastifyInstance, deps: DashboardDep
   // PUT /api/v1/dashboard/widgets/order — Reorder widgets (admin only)
   app.put<{
     Body: { order: string[] };
-  }>("/api/v1/dashboard/widgets/order", async (request, reply) => {
-    if (!request.auth || request.auth.role !== "admin") {
-      return reply.code(403).send({ error: "Admin access required" });
-    }
+  }>(
+    "/api/v1/dashboard/widgets/order",
+    { schema: { body: widgetOrderSchema } },
+    async (request) => {
+      const { order } = request.body;
 
-    const { order } = request.body ?? {};
-    if (!Array.isArray(order)) {
-      return reply.code(400).send({ error: "order must be an array of widget IDs" });
-    }
+      const updateStmt = db.prepare("UPDATE dashboard_widgets SET display_order = ? WHERE id = ?");
+      const reorder = db.transaction(() => {
+        for (let i = 0; i < order.length; i++) {
+          updateStmt.run(i, order[i]);
+        }
+      });
+      reorder();
 
-    const updateStmt = db.prepare("UPDATE dashboard_widgets SET display_order = ? WHERE id = ?");
-    const reorder = db.transaction(() => {
-      for (let i = 0; i < order.length; i++) {
-        updateStmt.run(i, order[i]);
-      }
-    });
-    reorder();
-
-    return { ok: true };
-  });
+      return { ok: true };
+    },
+  );
 }


### PR DESCRIPTION
## What was deferred and why

#482 converted the straightforward routes to Fastify JSON-schema body validation across three PRs and left three behind. `dashboard` was one: the create body is conditional, `equipmentId` required iff `type === "equipment"`, `zoneId` and `family` iff `type === "zone"`. `if`/`then` expresses that.

What a schema cannot express is the existence lookup, so "Equipment not found" and "Zone not found" stay in the handler **and keep their original 400**. #482 converts shape checks; it does not renumber answers a client may already depend on.

## Precedence

Admin gating moves to an `onRequest` hook, so 403 still precedes the schema 400 for a non-admin sending a malformed body. PATCH's existence check moves to `preValidation`, which runs before body validation, so 404 still outranks 400: a client chasing a 400 should not spend its time fixing a body for a widget that is not there.

The hook exempts GET **and HEAD**, because the widget list is deliberately readable by anyone and Fastify auto-exposes a HEAD route for every GET. Exempting a method makes this guard fail-open where the global one is fail-closed, so the code says in as many words that it is a decision about this route, not a template.

## Characterization first

The routes had no test at all, so 37 tests were written and run green against the hand-rolled implementation **before a line of it changed**. That is what makes "zero behavioural regression" checkable rather than asserted: re-running them against `main` today gives exactly 2 failures, and they are the 2 labelled tightenings.

Getting there took a correction worth reading. The first draft of this PR claimed two tightenings and shipped about nine, because the suite pinned what the routes are *for* and not the inputs nobody sends deliberately. A differential run against the old implementation found `label: null` and `icon: null` rejected (the old code type-checked neither and stored `label ?? null`, so an explicit null meant "no label"), `family` on an equipment widget rejected where it was ignored, every non-object `config` rejected on PATCH, and, worst of the set, **a PATCH with no body at all** turning from a 200 returning the widget unchanged into a 400 about a body the client never sent. All restored and pinned.

## The two tightenings that stand

Both on admin-only routes, both previously silent failures rather than working features:

- `PATCH` with a non-string `label` was stored verbatim, so the column took a number where the UI expects a label.
- `PUT /order` accepted any array, so `{ "order": [1, 2] }` reached the UPDATE, matched no row, and answered `{ "ok": true }` having reordered nothing.

## One more thing the review caught

The PATCH handler re-reads the row after the hook, and the conversion had dropped the `| undefined` from the cast along with the 404 branch. An event-loop turn separates the two, every DB call here is synchronous, and a concurrent DELETE in that window turned a clean 404 into a 500. Two admin tabs, one deleting while the other renames. Restored, with a comment saying why the double read is deliberate: the hook gives 404 its precedence, the handler check is the race guard.

## Left open on #597

`energy` (nested tariff schedules) and `plugins` (a 539-line file with a community-owner confirmation flow). Converting three routes blind in one pass is the best way to break a precedence nobody notices until a client does, and this one needed two rounds as it is.

## Noted for #481

`@fastify/swagger` emits OpenAPI 3.0.3, which defines neither `if`/`then` nor `type: [..., "null"]` (3.0 wants `nullable: true`). This requestBody will not survive codegen until the document moves to 3.1. Recorded in a comment rather than worked around.

## Rebased onto #836

The admin hook in this route originally compared `request.url` raw, copying the pattern used by the seven pre-existing gates. Tracing whether that was safe is what uncovered #836: the router percent-decodes before matching, so those gates were bypassable, and for admin-only **GET**s nothing stood behind them. Not exploitable here (every gated route in this file is a mutation, which the global fail-closed gate catches whatever the spelling), but it is the wrong comparison, so this now uses the shared helper and the test spells the path both ways.

Refs #597
