### PR TITLE
fix(backup): give export and restore one rule for a dotfile's extension (#829)

### DIFF
--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -355,21 +355,23 @@ Les backups capturent l'état complet du système dans une seule archive ZIP et 
 
 Un ZIP de backup contient :
 
-| Entrée                    | Contenu                                                                                                                                          |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `sowel-backup.json`       | Export SQLite en JSON, structuré par table (format version 2)                                                                                    |
-| `influx-raw.lp`           | Données InfluxDB brutes en line protocol (7 derniers jours)                                                                                      |
-| `influx-hourly.lp`        | Données horaires downsamplées (90 derniers jours)                                                                                                |
-| `influx-daily.lp`         | Données journalières downsamplées (5 dernières années)                                                                                           |
-| `influx-energy-hourly.lp` | Sommes énergétiques horaires (2 dernières années)                                                                                                |
-| `influx-energy-daily.lp`  | Sommes énergétiques journalières (10 dernières années)                                                                                           |
-| `data/*`                  | Tous les fichiers non DB de `data/` (secrets de tokens, etc.), scannés dynamiquement, hors `.db`, `.pid`, `.log` et hors marqueur `.instance-id` |
+| Entrée                    | Contenu                                                                                                                                                                                                                   |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sowel-backup.json`       | Export SQLite en JSON, structuré par table (format version 2)                                                                                                                                                             |
+| `influx-raw.lp`           | Données InfluxDB brutes en line protocol (7 derniers jours)                                                                                                                                                               |
+| `influx-hourly.lp`        | Données horaires downsamplées (90 derniers jours)                                                                                                                                                                         |
+| `influx-daily.lp`         | Données journalières downsamplées (5 dernières années)                                                                                                                                                                    |
+| `influx-energy-hourly.lp` | Sommes énergétiques horaires (2 dernières années)                                                                                                                                                                         |
+| `influx-energy-daily.lp`  | Sommes énergétiques journalières (10 dernières années)                                                                                                                                                                    |
+| `data/*`                  | Tous les fichiers non DB de `data/` (secrets de tokens, etc.), scannés dynamiquement au regard de la liste blanche de restauration, hors `.db`, `.pid`, `.log` et hors marqueurs locaux `.instance-id` / `.shadow-target` |
 
 L'export JSON SQLite couvre une liste sélectionnée de tables (constante `BACKUP_TABLES` dans `backup-manager.ts`) dans l'ordre des dépendances (parents d'abord pour la restauration).
 
 Le marqueur `.instance-id` est exclu volontairement, dans les deux sens : il décrit le déploiement en cours d'exécution, et une archive qui l'embarquerait donnerait à l'instance qui restaure l'identité de la machine d'où viennent les données, désarmant le garde-fou de restauration de l'issue #401. Voir la section « Restaurer un backup d'un autre déploiement » de [deployment.fr.md](deployment.fr.md).
 
-À la restauration, les entrées `data/` passent par une liste blanche d'extensions (spec 089 C2) : tout ce qui n'est pas une extension de données ou d'image connue est refusé, pour qu'une archive ne puisse pas glisser un script ou un module natif dans le répertoire de données. Un nom de fichier commençant par un point compte comme sa propre extension, c'est ainsi que `.jwt-secret` et `.influx-token` figurent dans cette liste et que tout autre fichier caché est refusé (issue #829).
+À la restauration, les entrées `data/` passent par une liste blanche d'extensions (spec 089 C2) : tout ce qui n'est pas une extension de données ou d'image connue est refusé, pour qu'une archive ne puisse pas glisser un script ou un module natif dans le répertoire de données. Un nom de fichier commençant par un point compte comme sa propre extension, c'est ainsi que `.jwt-secret` et `.influx-token` figurent dans cette liste et que tout autre fichier caché est refusé. Un nom sans aucune extension est refusé également (issue #829).
+
+Le scan d'export applique la même liste blanche, si bien qu'une archive ne peut jamais contenir une entrée que sa propre restauration écarterait. C'est cette propriété que suppose la note de risque de la spec 089 ; sans elle, un fichier pouvait être archivé puis disparaître silencieusement à la restauration. Ce qui est laissé de côté est nommé dans le log d'export, et une restauration renvoie `filesSkipped` à côté de `filesRestored`, pour qu'une restauration partielle soit visible plutôt que muette.
 
 ### Backups locaux (data/backups/)
 

--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -369,6 +369,8 @@ L'export JSON SQLite couvre une liste sélectionnée de tables (constante `BACKU
 
 Le marqueur `.instance-id` est exclu volontairement, dans les deux sens : il décrit le déploiement en cours d'exécution, et une archive qui l'embarquerait donnerait à l'instance qui restaure l'identité de la machine d'où viennent les données, désarmant le garde-fou de restauration de l'issue #401. Voir la section « Restaurer un backup d'un autre déploiement » de [deployment.fr.md](deployment.fr.md).
 
+À la restauration, les entrées `data/` passent par une liste blanche d'extensions (spec 089 C2) : tout ce qui n'est pas une extension de données ou d'image connue est refusé, pour qu'une archive ne puisse pas glisser un script ou un module natif dans le répertoire de données. Un nom de fichier commençant par un point compte comme sa propre extension, c'est ainsi que `.jwt-secret` et `.influx-token` figurent dans cette liste et que tout autre fichier caché est refusé (issue #829).
+
 ### Backups locaux (data/backups/)
 
 Distinct de l'export manuel, `BackupManager.exportToFile()` écrit les backups dans `data/backups/sowel-backup-<name>.zip` sur le volume persistant. Utilisé par :

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -474,6 +474,8 @@ The SQLite JSON export covers a curated list of tables (`BACKUP_TABLES` constant
 
 The `.instance-id` marker is excluded on purpose, in both directions: it describes the deployment currently running, and an archive that carried it would hand a restoring instance the identity of the machine the data came from, disarming the #401 restored-data guardrail. See the "Restoring a backup from another deployment" section of [deployment.md](deployment.md).
 
+On restore, `data/` entries face an extension whitelist (spec 089 C2): anything that is not a known data or image extension is refused, so an archive cannot smuggle a script or a native module into the data directory. A leading-dot filename counts as its own extension, which is how `.jwt-secret` and `.influx-token` are named in that whitelist and how any other dotfile is refused (issue #829).
+
 ### Local backups (data/backups/)
 
 Separate from manual export, `BackupManager.exportToFile()` writes backups to `data/backups/sowel-backup-<name>.zip` on the persistent volume. Used by:

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -460,21 +460,23 @@ Backups capture the full system state as a single ZIP archive and restore it ato
 
 A backup ZIP contains:
 
-| Entry                     | Content                                                                                                                                       |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sowel-backup.json`       | SQLite export as JSON, structured per table (version 2 format)                                                                                |
-| `influx-raw.lp`           | Raw InfluxDB data as line protocol (last 7 days)                                                                                              |
-| `influx-hourly.lp`        | Downsampled hourly data (last 90 days)                                                                                                        |
-| `influx-daily.lp`         | Downsampled daily data (last 5 years)                                                                                                         |
-| `influx-energy-hourly.lp` | Energy hourly sums (last 2 years)                                                                                                             |
-| `influx-energy-daily.lp`  | Energy daily sums (last 10 years)                                                                                                             |
-| `data/*`                  | All non-DB files from `data/` (token secrets, etc.), dynamically scanned, excluding `.db`, `.pid`, `.log` files and the `.instance-id` marker |
+| Entry                     | Content                                                                                                                                                                                               |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sowel-backup.json`       | SQLite export as JSON, structured per table (version 2 format)                                                                                                                                        |
+| `influx-raw.lp`           | Raw InfluxDB data as line protocol (last 7 days)                                                                                                                                                      |
+| `influx-hourly.lp`        | Downsampled hourly data (last 90 days)                                                                                                                                                                |
+| `influx-daily.lp`         | Downsampled daily data (last 5 years)                                                                                                                                                                 |
+| `influx-energy-hourly.lp` | Energy hourly sums (last 2 years)                                                                                                                                                                     |
+| `influx-energy-daily.lp`  | Energy daily sums (last 10 years)                                                                                                                                                                     |
+| `data/*`                  | All non-DB files from `data/` (token secrets, etc.), dynamically scanned against the restore whitelist, excluding `.db`, `.pid`, `.log` files and the `.instance-id` / `.shadow-target` local markers |
 
 The SQLite JSON export covers a curated list of tables (`BACKUP_TABLES` constant in `backup-manager.ts`) in dependency order (parents first for restore).
 
 The `.instance-id` marker is excluded on purpose, in both directions: it describes the deployment currently running, and an archive that carried it would hand a restoring instance the identity of the machine the data came from, disarming the #401 restored-data guardrail. See the "Restoring a backup from another deployment" section of [deployment.md](deployment.md).
 
-On restore, `data/` entries face an extension whitelist (spec 089 C2): anything that is not a known data or image extension is refused, so an archive cannot smuggle a script or a native module into the data directory. A leading-dot filename counts as its own extension, which is how `.jwt-secret` and `.influx-token` are named in that whitelist and how any other dotfile is refused (issue #829).
+On restore, `data/` entries face an extension whitelist (spec 089 C2): anything that is not a known data or image extension is refused, so an archive cannot smuggle a script or a native module into the data directory. A leading-dot filename counts as its own extension, which is how `.jwt-secret` and `.influx-token` are named in that whitelist and how any other dotfile is refused. A name with no extension at all is refused too (issue #829).
+
+The export scan applies the same whitelist, so an archive can never contain an entry its own restore would drop. That property is what the spec 089 risk note rests on, and without it a file could be archived and then silently vanish on restore. Anything left out is named in the export log, and a restore reports `filesSkipped` alongside `filesRestored` so a partial restore is visible rather than quiet.
 
 ### Local backups (data/backups/)
 

--- a/src/backup/backup-manager.test.ts
+++ b/src/backup/backup-manager.test.ts
@@ -4,7 +4,13 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
 import AdmZip from "adm-zip";
-import { BACKUP_TABLES, BackupManager, BackupSizeCapExceededError } from "./backup-manager.js";
+import {
+  ALLOWED_RESTORE_EXTENSIONS,
+  BACKUP_TABLES,
+  BackupManager,
+  BackupSizeCapExceededError,
+  dataFileExtension,
+} from "./backup-manager.js";
 import { createLogger } from "../core/logger.js";
 import {
   INSTANCE_ID_SETTING,
@@ -400,6 +406,72 @@ describe("BackupManager", () => {
     });
   });
 
+  // ── #829 — the dotfile-shaped hole in the spec 089 C2 whitelist ──
+  //
+  // The export derived an extension with slice(lastIndexOf(".")) and the
+  // restore with extname(), which returns "" for a leading-dot basename. The
+  // restore's `if (ext && ...)` guard then short-circuited and let any
+  // `data/.<name>` entry through, at any depth. The `.jwt-secret` and
+  // `.influx-token` entries in the whitelist could never match and were dead:
+  // what actually let those files land was the hole itself.
+  describe("restoreFromBuffer — dotfile entries face the whitelist (#829)", () => {
+    function buildZipWith(entries: { name: string; data: Buffer }[]): Buffer {
+      const zip = new AdmZip();
+      const tables = Object.fromEntries(BACKUP_TABLES.map((t) => [t, [] as unknown[]]));
+      zip.addFile(
+        "sowel-backup.json",
+        Buffer.from(JSON.stringify({ version: 2, exportedAt: new Date().toISOString(), tables })),
+      );
+      for (const e of entries) zip.addFile(e.name, e.data);
+      return zip.toBuffer();
+    }
+
+    it("refuses an unexpected top-level dotfile", async () => {
+      await manager.restoreFromBuffer(
+        buildZipWith([{ name: "data/.whatever", data: Buffer.from("x") }]),
+      );
+      expect(existsSync(resolve(tmpDir, ".whatever"))).toBe(false);
+    });
+
+    it("refuses one nested under a subdirectory", async () => {
+      // The old extname() path returned "" whatever the depth, so nesting was
+      // not even an evasion: it was the same hole.
+      await manager.restoreFromBuffer(
+        buildZipWith([{ name: "data/plugins/x/.whatever", data: Buffer.from("x") }]),
+      );
+      expect(existsSync(resolve(tmpDir, "plugins", "x", ".whatever"))).toBe(false);
+    });
+
+    it("still restores the two dotfiles the whitelist names", async () => {
+      // The other half. These are real: config.ts reads data/.jwt-secret and
+      // data/.influx-token, so a restore that dropped them would lose the JWT
+      // signing secret and log every session out.
+      await manager.restoreFromBuffer(
+        buildZipWith([
+          { name: "data/.jwt-secret", data: Buffer.from("s3cr3t") },
+          { name: "data/.influx-token", data: Buffer.from("t0k3n") },
+        ]),
+      );
+      expect(readFileSync(resolve(tmpDir, ".jwt-secret"), "utf-8")).toBe("s3cr3t");
+      expect(readFileSync(resolve(tmpDir, ".influx-token"), "utf-8")).toBe("t0k3n");
+    });
+
+    it("still refuses a banned extension on a nested entry", async () => {
+      // Deriving from the basename must not have loosened the ordinary case.
+      await manager.restoreFromBuffer(
+        buildZipWith([{ name: "data/plugins/x/evil.so", data: Buffer.from("x") }]),
+      );
+      expect(existsSync(resolve(tmpDir, "plugins", "x", "evil.so"))).toBe(false);
+    });
+
+    it("still restores a nested entry with an allowed extension", async () => {
+      await manager.restoreFromBuffer(
+        buildZipWith([{ name: "data/plugins/x/config.json", data: Buffer.from("{}") }]),
+      );
+      expect(existsSync(resolve(tmpDir, "plugins", "x", "config.json"))).toBe(true);
+    });
+  });
+
   // ── #790 — the restore must not hand this deployment a foreign identity ──
   //
   // The #401 guardrail compares the instance id carried in the settings table
@@ -535,5 +607,40 @@ describe("BACKUP_TABLES covers everything a restore would cascade away", () => {
 
   it("has no duplicates", () => {
     expect(new Set(BACKUP_TABLES).size).toBe(BACKUP_TABLES.length);
+  });
+});
+
+describe("dataFileExtension (#829)", () => {
+  it("treats a leading-dot basename as its own extension", () => {
+    expect(dataFileExtension(".jwt-secret")).toBe(".jwt-secret");
+    expect(dataFileExtension(".influx-token")).toBe(".influx-token");
+    expect(dataFileExtension(".instance-id")).toBe(".instance-id");
+  });
+
+  it("judges a nested file by its basename", () => {
+    expect(dataFileExtension("plugins/x/.whatever")).toBe(".whatever");
+    expect(dataFileExtension("plugins/x/config.json")).toBe(".json");
+  });
+
+  it("behaves ordinarily otherwise", () => {
+    expect(dataFileExtension("config.json")).toBe(".json");
+    expect(dataFileExtension("archive.tar.gz")).toBe(".gz");
+    expect(dataFileExtension("noextension")).toBe("");
+  });
+
+  it("preserves case, which the two call sites handle differently", () => {
+    // The restore lowercases at its call site, as it always did; the export's
+    // exclusion list is case-sensitive, as it always was. Folding case here
+    // would silently change which files are left out of a backup.
+    expect(dataFileExtension("FOO.LOG")).toBe(".LOG");
+  });
+
+  it("leaves no unreachable entry in the restore whitelist", () => {
+    // An extension the derivation cannot produce is not a permission, it is a
+    // comment that reads like one. `.jwt-secret` and `.influx-token` were
+    // exactly that until this fix.
+    for (const ext of ALLOWED_RESTORE_EXTENSIONS) {
+      expect(dataFileExtension("file" + ext).toLowerCase()).toBe(ext);
+    }
   });
 });

--- a/src/backup/backup-manager.test.ts
+++ b/src/backup/backup-manager.test.ts
@@ -470,6 +470,67 @@ describe("BackupManager", () => {
       );
       expect(existsSync(resolve(tmpDir, "plugins", "x", "config.json"))).toBe(true);
     });
+
+    it("refuses an entry with no extension at all", async () => {
+      // Same short-circuit, same hole: `data/plain` used to land while
+      // `data/plain.sh` was refused. The whitelist now means what it says.
+      const res = await manager.restoreFromBuffer(
+        buildZipWith([{ name: "data/plain", data: Buffer.from("x") }]),
+      );
+      expect(existsSync(resolve(tmpDir, "plain"))).toBe(false);
+      expect(res.filesSkipped).toBe(1);
+    });
+
+    it("counts every refusal so a partial restore is not silent", async () => {
+      const res = await manager.restoreFromBuffer(
+        buildZipWith([
+          { name: "data/.env", data: Buffer.from("x") },
+          { name: "data/evil.so", data: Buffer.from("x") },
+          { name: "data/keep.json", data: Buffer.from("{}") },
+        ]),
+      );
+      expect(res.filesRestored).toBe(1);
+      expect(res.filesSkipped).toBe(2);
+    });
+  });
+
+  // ── #829 review — the export must not archive what the restore refuses ──
+  //
+  // Spec 089 was accepted on the note that "no legitimate backup should be
+  // rejected: we control the export format". Tightening the restore without
+  // tightening the export made that false, and silently: Sowel's own
+  // shadow-deploy script writes data/.shadow-target, which used to round-trip.
+  describe("exportToFile — the export is held to the restore's whitelist", () => {
+    it("leaves out a file the restore would refuse, and says which", async () => {
+      writeFileSync(resolve(tmpDir, "keep.json"), "{}");
+      writeFileSync(resolve(tmpDir, ".shadow-target"), "prod");
+      writeFileSync(resolve(tmpDir, "sowel.db.bak.1777715864"), "stale");
+
+      const result = await manager.exportToFile("scan.zip");
+      const names = new AdmZip(result.path).getEntries().map((e) => e.entryName);
+
+      expect(names).toContain("data/keep.json");
+      expect(names).not.toContain("data/.shadow-target");
+      expect(names).not.toContain("data/sowel.db.bak.1777715864");
+    });
+
+    it("round-trips everything it did archive", async () => {
+      // The property that matters: whatever comes out of an export goes back
+      // in. Before this, an archive could contain entries its own restore
+      // dropped with nothing but a log line.
+      writeFileSync(resolve(tmpDir, ".jwt-secret"), "s3cr3t");
+      writeFileSync(resolve(tmpDir, "tokens.json"), "{}");
+      const result = await manager.exportToFile("roundtrip.zip");
+      const archive = new AdmZip(result.path);
+
+      const res = await manager.restoreFromBuffer(archive.toBuffer());
+
+      expect(res.filesSkipped).toBe(0);
+      const archived = archive
+        .getEntries()
+        .filter((e) => e.entryName.startsWith("data/") && !e.isDirectory).length;
+      expect(res.filesRestored).toBe(archived);
+    });
   });
 
   // ── #790 — the restore must not hand this deployment a foreign identity ──
@@ -641,6 +702,9 @@ describe("dataFileExtension (#829)", () => {
     // exactly that until this fix.
     for (const ext of ALLOWED_RESTORE_EXTENSIONS) {
       expect(dataFileExtension("file" + ext).toLowerCase()).toBe(ext);
+      // Bare, with no prefix: this is the leading-dot shape the whole bug is
+      // about, and without it the assertion above passes under extname() too.
+      expect(dataFileExtension(ext).toLowerCase()).toBe(ext);
     }
   });
 });

--- a/src/backup/backup-manager.ts
+++ b/src/backup/backup-manager.ts
@@ -7,7 +7,7 @@ import {
   statSync,
   unlinkSync,
 } from "node:fs";
-import { resolve, dirname, extname, sep } from "node:path";
+import { resolve, dirname, basename, sep } from "node:path";
 import { ZipArchive } from "archiver";
 import type { Archiver } from "archiver";
 import AdmZip from "adm-zip";
@@ -25,10 +25,36 @@ export interface BackupManagerDeps {
   maxRestoreBytes?: number;
 }
 
+/**
+ * The extension of a data file, as BOTH the export scan and the restore
+ * whitelist must agree it is (#829).
+ *
+ * A leading-dot basename is its own extension: `.jwt-secret` is not "a file
+ * named .jwt-secret with no extension", it is the secret file, and
+ * `ALLOWED_RESTORE_EXTENSIONS` has always been written that way. `extname()`
+ * disagrees and returns "" for that shape, which is what left a dotfile-sized
+ * hole in the spec 089 C2 whitelist: the restore's `if (ext && ...)` guard
+ * short-circuited on the empty string and let any `data/.<name>` entry
+ * through, at any depth. The `.jwt-secret` and `.influx-token` entries in the
+ * whitelist were dead code; what actually let those files land was the hole.
+ *
+ * Derived from the BASENAME, so a nested `plugins/x/.whatever` is judged the
+ * same way a top-level `.whatever` is. Case is preserved; the restore
+ * lowercases at its call site, as it always did, while the export's exclusion
+ * list is case-sensitive, as it always was.
+ */
+export function dataFileExtension(name: string): string {
+  const base = basename(name);
+  const dot = base.lastIndexOf(".");
+  return dot < 0 ? "" : base.slice(dot);
+}
+
 // ── Spec 089 C2: backup restore hardening ─────────────────────────────
 // Extensions allowed in `data/` entries of a restore archive. Anything
-// else (executables, native modules, scripts) is rejected.
-const ALLOWED_RESTORE_EXTENSIONS = new Set([
+// else (executables, native modules, scripts) is rejected. Every entry here
+// must be producible by `dataFileExtension`, which a test asserts: an entry
+// that cannot match is not a permission, it is a comment that reads like one.
+export const ALLOWED_RESTORE_EXTENSIONS = new Set([
   ".json",
   ".png",
   ".jpg",
@@ -543,7 +569,7 @@ export class BackupManager {
       }
 
       // Extension whitelist: reject .sh, .so, .node, etc.
-      const ext = extname(filename).toLowerCase();
+      const ext = dataFileExtension(filename).toLowerCase();
       if (ext && !ALLOWED_RESTORE_EXTENSIONS.has(ext)) {
         this.logger.warn(
           { entry: entry.entryName, ext },
@@ -661,8 +687,7 @@ function scanDataFiles(dataDir: string): string[] {
   for (const entry of readdirSync(dataDir, { withFileTypes: true })) {
     if (!entry.isFile()) continue;
     if (DATA_FILES_EXCLUDE.has(entry.name)) continue;
-    const ext = entry.name.includes(".") ? entry.name.slice(entry.name.lastIndexOf(".")) : "";
-    if (DATA_FILES_EXCLUDE_EXT.has(ext)) continue;
+    if (DATA_FILES_EXCLUDE_EXT.has(dataFileExtension(entry.name))) continue;
     files.push(entry.name);
   }
   return files;

--- a/src/backup/backup-manager.ts
+++ b/src/backup/backup-manager.ts
@@ -156,6 +156,11 @@ const DATA_FILES_EXCLUDE = new Set([
   "sowel.db-shm",
   "sowel.pid",
   INSTANCE_MARKER_FILE,
+  // Same reason as the marker above: `scripts/shadow-deploy.sh` writes which
+  // host this shadow points at. It describes THIS deployment, so carrying it
+  // into an archive would tell a restoring instance to target the machine the
+  // data came from.
+  ".shadow-target",
 ]);
 const DATA_FILES_EXCLUDE_EXT = new Set([".db", ".pid", ".log"]);
 
@@ -194,6 +199,13 @@ export interface RestoreResult {
   restoredAt: string;
   influxPointsRestored: number;
   filesRestored: number;
+  /**
+   * Data-file entries the restore refused: an unlisted extension, a symlink, a
+   * path escaping the data directory. Counted rather than left to a log line
+   * so a caller can say "3 entries skipped" instead of a silent partial
+   * restore (#829 review).
+   */
+  filesSkipped: number;
   restartRequired: true;
 }
 
@@ -293,7 +305,15 @@ export class BackupManager {
     }
 
     // 4. Append data files (tokens, JWT secret — dynamically scanned)
-    const dataFiles = scanDataFiles(this.dataDir);
+    const { files: dataFiles, skipped } = scanDataFiles(this.dataDir);
+    if (skipped.length > 0) {
+      // Named, not counted: a file left out of a backup is the kind of thing
+      // an operator wants to see before they need it.
+      this.logger.info(
+        { skipped },
+        "Backup export: data files left out, extension not in the restore whitelist",
+      );
+    }
     for (const filename of dataFiles) {
       const filePath = resolve(this.dataDir, filename);
       if (existsSync(filePath)) {
@@ -527,6 +547,7 @@ export class BackupManager {
     //    Spec 089 C2: hardened against path traversal, symlink injection,
     //    arbitrary extensions, and zip bombs.
     let filesRestored = 0;
+    let filesSkipped = 0;
     let restoreBytes = 0;
     const dataDirAbs = resolve(this.dataDir);
     for (const entry of zip.getEntries()) {
@@ -535,6 +556,7 @@ export class BackupManager {
 
       // Refuse symlink entries outright.
       if (isSymlinkEntry(entry)) {
+        filesSkipped++;
         this.logger.warn(
           { entry: entry.entryName },
           "Backup restore: symlink entry refused (spec 089 C2)",
@@ -561,6 +583,7 @@ export class BackupManager {
       // Defeats `data/../../etc/passwd` and absolute-name games.
       const filePath = resolve(this.dataDir, filename);
       if (filePath !== dataDirAbs && !filePath.startsWith(dataDirAbs + sep)) {
+        filesSkipped++;
         this.logger.warn(
           { entry: entry.entryName, resolved: filePath },
           "Backup restore: path traversal refused (spec 089 C2)",
@@ -569,8 +592,16 @@ export class BackupManager {
       }
 
       // Extension whitelist: reject .sh, .so, .node, etc.
+      //
+      // The `ext &&` short-circuit is gone with the dotfile hole it belonged
+      // to (#829): a name with no dot at all skipped the whitelist by the same
+      // mechanism a dotfile did, so `data/plain` landed while `data/plain.sh`
+      // was refused. Now that the export is held to this same list, nothing
+      // Sowel produces can be extensionless, so refusing it costs nothing and
+      // makes the whitelist mean what it says.
       const ext = dataFileExtension(filename).toLowerCase();
-      if (ext && !ALLOWED_RESTORE_EXTENSIONS.has(ext)) {
+      if (!ALLOWED_RESTORE_EXTENSIONS.has(ext)) {
+        filesSkipped++;
         this.logger.warn(
           { entry: entry.entryName, ext },
           "Backup restore: extension not allowed (spec 089 C2)",
@@ -605,7 +636,7 @@ export class BackupManager {
     }
 
     this.logger.info(
-      { exportedAt: payload.exportedAt, influxPointsRestored, filesRestored },
+      { exportedAt: payload.exportedAt, influxPointsRestored, filesRestored, filesSkipped },
       "Backup restore completed — restart server to reload",
     );
 
@@ -614,6 +645,7 @@ export class BackupManager {
       restoredAt: new Date().toISOString(),
       influxPointsRestored,
       filesRestored,
+      filesSkipped,
       restartRequired: true,
     };
   }
@@ -681,16 +713,28 @@ export class BackupManager {
 // ============================================================
 
 /** Scan data/ directory for files to include in backup (tokens, secrets, etc.) */
-function scanDataFiles(dataDir: string): string[] {
-  if (!existsSync(dataDir)) return [];
+function scanDataFiles(dataDir: string): { files: string[]; skipped: string[] } {
+  if (!existsSync(dataDir)) return { files: [], skipped: [] };
   const files: string[] = [];
+  const skipped: string[] = [];
   for (const entry of readdirSync(dataDir, { withFileTypes: true })) {
     if (!entry.isFile()) continue;
     if (DATA_FILES_EXCLUDE.has(entry.name)) continue;
-    if (DATA_FILES_EXCLUDE_EXT.has(dataFileExtension(entry.name))) continue;
+    const ext = dataFileExtension(entry.name);
+    if (DATA_FILES_EXCLUDE_EXT.has(ext)) continue;
+    // The export is held to the SAME whitelist the restore applies, so an
+    // archive cannot contain an entry its own restore would refuse. Spec 089
+    // was accepted on the note that "no legitimate backup should be rejected",
+    // and without this the scan happily archives, say, `data/.shadow-target`
+    // or a stray `sowel.db.bak.1777715864`, which the restore then drops with
+    // nothing but a log line (#829 review).
+    if (!ALLOWED_RESTORE_EXTENSIONS.has(ext.toLowerCase())) {
+      skipped.push(entry.name);
+      continue;
+    }
     files.push(entry.name);
   }
-  return files;
+  return { files, skipped };
 }
 
 /**

--- a/ui/src/api/system.ts
+++ b/ui/src/api/system.ts
@@ -77,6 +77,8 @@ export async function restoreLocalBackup(filename: string): Promise<{
   restoredAt: string;
   influxPointsRestored: number;
   filesRestored: number;
+  /** Entries the restore refused: unlisted extension, symlink, path escape. */
+  filesSkipped: number;
   restartRequired: boolean;
 }> {
   return fetchJSON(`${API_BASE}/backup/restore-local`, {


### PR DESCRIPTION
## The divergence

The export derived a file's extension by hand with `slice(lastIndexOf("."))`, so `.jwt-secret` yielded `".jwt-secret"`. The restore used `extname()`, which returns `""` for a leading-dot basename, and its guard reads `if (ext && !ALLOWED.has(ext))`. The empty string short-circuited, so **every `data/.<name>` entry skipped the spec 089 C2 whitelist entirely**, at any depth.

Two consequences, both closed here:

- The `".jwt-secret"` and `".influx-token"` entries in `ALLOWED_RESTORE_EXTENSIONS` were dead code. `extname()` cannot produce them, so they never matched anything; what actually let those files land was the hole, not the permission.
- The invariant the whitelist states, "only these extensions may land in `data/`", was not the invariant the code enforced.

Not an escalation on its own (restore is admin-only, path confinement and the symlink refusal still hold, and `.sh` / `.node` were always rejected), but `.instance-id` in #790 was a symptom of this, and excluding that one file by name did not close the general case.

## Fix

`dataFileExtension` is now the single derivation, taken from the **basename** so a nested `plugins/x/.whatever` is judged like a top-level one. It preserves case, because the two call sites have always handled case differently: the restore lowercases, the export's exclusion list does not. Folding case in the helper would have silently changed which files a backup leaves out.

## What the review caught, and it mattered

**Tightening the restore alone reversed the asymmetry rather than closing it.** `scanDataFiles` has no whitelist, so the export kept archiving files the restore now drops, with nothing but a `logger.warn`. Not hypothetical: `scripts/shadow-deploy.sh` writes `data/.shadow-target`, it is in this repo's data dir, and it round-tripped before this branch. It also invalidated the note spec 089 was accepted on, that *"no legitimate backup should be rejected: we control the export format"*.

So the export now applies the same whitelist and **names** what it leaves out. `.shadow-target` also joins `DATA_FILES_EXCLUDE` outright, for the same reason `.instance-id` is there: it says which host this deployment points at, so it should not travel even if its extension were listed.

Two more:

- A name with **no dot at all** skipped the whitelist by the same short-circuit a dotfile did, so `data/plain` landed while `data/plain.sh` was refused. The first draft of the documentation asserted the opposite. Now that the export cannot produce an extensionless entry, refusing one costs nothing and makes the whitelist mean what it says.
- Every refusal is counted into `filesSkipped` on the restore result, so a partial restore is visible to the caller instead of living in a log line.

## Tests

44 in the file. The restore refuses an unexpected dotfile at the top level and nested, refuses an extensionless entry, still restores the two dotfiles the whitelist names (`config.ts` reads both, so dropping `.jwt-secret` would log every session out), and still applies the ordinary rules to nested entries.

Two that pin the properties rather than the mechanics:

- **Round trip**: everything an export archives, its restore restores, with `filesSkipped === 0`. That is the property the previous commit broke.
- **No unreachable whitelist entry**: every entry must be producible by the derivation. The first version asserted `dataFileExtension("file" + ext)`, and the prefix removed the leading-dot shape the whole bug is about, so it passed under both mutations. It now also asserts the bare extension and fails under both.

Mutation-checked: reverting the helper to `extname()` semantics, and separately making a leading dot yield `""`, each fail four tests.

Closes #829
