### PR TITLE
fix(api): serve the submeter feed with a freshness verdict (#832)

### DIFF
--- a/docs/technical/api-reference.fr.md
+++ b/docs/technical/api-reference.fr.md
@@ -142,6 +142,20 @@ Toutes les routes de gestion des utilisateurs nécessitent le rôle admin.
 
 ---
 
+### Le rôle submeter (`?role=submeter`)
+
+`GET /api/v1/equipments?role=submeter` renvoie les sous-compteurs de consommation, ordonnés pinces d'abord, puis relais mesurants, puis autres charges mesurées, chaque groupe par nom : un client à capacité fixe qui tronque la liste garde ainsi les compteurs qui comptent. `?type=energy_meter` est honoré comme le même rôle, pour les firmwares plus anciens de l'afficheur d'énergie.
+
+Chaque entrée porte un champ supplémentaire, sur ce rôle uniquement :
+
+| Champ                 | Signification                                                                                                                                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `powerReadingCurrent` | `true` quand la mesure `power` peut être affichée comme une mesure en direct, `false` quand elle est plus ancienne que son budget de fraîcheur, `null` quand il n'y a pas de mesure `power` numérique à juger. |
+
+Un client doit le consulter avant de dessiner un segment. Une mesure hors budget est un reliquat, pas une mesure, et l'erreur est silencieuse : un `0 W` périmé ressemble exactement à un appareil éteint. Le budget est de deux minutes pour un compteur déclaré, dont le moteur attend déjà des remontées continues, et de dix minutes sinon, car plusieurs intégrations interrogent leur source toutes les cinq minutes et un appareil en bon état ne doit pas clignoter (issues #744 et #832).
+
+La règle vit dans `src/shared/reading-freshness.ts` et l'UI web importe la même fonction, pour que les deux surfaces ne puissent pas diverger.
+
 ## Zones
 
 | Method   | Path                                 | Description                                                                                        |

--- a/docs/technical/api-reference.fr.md
+++ b/docs/technical/api-reference.fr.md
@@ -148,13 +148,15 @@ Toutes les routes de gestion des utilisateurs nécessitent le rôle admin.
 
 Chaque entrée porte un champ supplémentaire, sur ce rôle uniquement :
 
-| Champ                 | Signification                                                                                                                                                                                                  |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `powerReadingCurrent` | `true` quand la mesure `power` peut être affichée comme une mesure en direct, `false` quand elle est plus ancienne que son budget de fraîcheur, `null` quand il n'y a pas de mesure `power` numérique à juger. |
+| Champ                 | Signification                                                                                                                                                                                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `powerReadingCurrent` | `true` quand la mesure `power` peut être affichée comme une mesure en direct, `false` quand elle ne le peut pas (mesure plus ancienne que son budget de fraîcheur, ou équipement hors-ligne), `null` quand il n'y a pas de mesure `power` numérique à juger. |
 
 Un client doit le consulter avant de dessiner un segment. Une mesure hors budget est un reliquat, pas une mesure, et l'erreur est silencieuse : un `0 W` périmé ressemble exactement à un appareil éteint. Le budget est de deux minutes pour un compteur déclaré, dont le moteur attend déjà des remontées continues, et de dix minutes sinon, car plusieurs intégrations interrogent leur source toutes les cinq minutes et un appareil en bon état ne doit pas clignoter (issues #744 et #832).
 
-La règle vit dans `src/shared/reading-freshness.ts` et l'UI web importe la même fonction, pour que les deux surfaces ne puissent pas diverger.
+Les équipements hors-ligne restent dans la liste volontairement, pour qu'un client puisse afficher une ligne « hors-ligne depuis », et ils répondent `false` : leur dernière mesure n'est pas une mesure en direct, si récente soit-elle.
+
+Le verdict vient de `classifyPowerReading` dans `src/shared/reading-freshness.ts`, et la décomposition Live de l'UI web appelle la même fonction : les deux surfaces ne peuvent pas répondre différemment à propos d'un même appareil.
 
 ## Zones
 

--- a/docs/technical/api-reference.md
+++ b/docs/technical/api-reference.md
@@ -214,6 +214,20 @@ No separate auth scheme — these routes sit behind the same JWT/API-token middl
 
 ---
 
+### The submeter role (`?role=submeter`)
+
+`GET /api/v1/equipments?role=submeter` returns the consumption submeters, ordered clamps first, then metering relays, then other metered loads, each group by name, so a fixed-capacity client truncating the list keeps the meters that matter. `?type=energy_meter` is honoured as the same role for the energy display's older firmware.
+
+Each entry carries an extra field on this role only:
+
+| Field                 | Meaning                                                                                                                                                                           |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `powerReadingCurrent` | `true` when the `power` reading may be drawn as a live measurement, `false` when it is older than its freshness budget, `null` when there is no numeric `power` reading to judge. |
+
+A client must consult it before drawing a segment. A reading past its budget is a leftover, not a measurement, and it is quiet: a stale `0 W` looks exactly like an appliance that is off. The budget is two minutes for a declared meter, which the engine already expects to report continuously, and ten minutes otherwise, because several integrations poll on a five-minute cycle and a healthy appliance must not flicker (issues #744 and #832).
+
+The rule lives in `src/shared/reading-freshness.ts` and the web UI imports the same function, so the two surfaces cannot drift apart.
+
 ## Zones
 
 | Method   | Path                                 | Description                                                                             |

--- a/docs/technical/api-reference.md
+++ b/docs/technical/api-reference.md
@@ -220,13 +220,15 @@ No separate auth scheme — these routes sit behind the same JWT/API-token middl
 
 Each entry carries an extra field on this role only:
 
-| Field                 | Meaning                                                                                                                                                                           |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `powerReadingCurrent` | `true` when the `power` reading may be drawn as a live measurement, `false` when it is older than its freshness budget, `null` when there is no numeric `power` reading to judge. |
+| Field                 | Meaning                                                                                                                                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `powerReadingCurrent` | `true` when the `power` reading may be drawn as a live measurement, `false` when it may not (the reading is older than its freshness budget, or the equipment is offline), `null` when there is no numeric `power` reading to judge. |
 
 A client must consult it before drawing a segment. A reading past its budget is a leftover, not a measurement, and it is quiet: a stale `0 W` looks exactly like an appliance that is off. The budget is two minutes for a declared meter, which the engine already expects to report continuously, and ten minutes otherwise, because several integrations poll on a five-minute cycle and a healthy appliance must not flicker (issues #744 and #832).
 
-The rule lives in `src/shared/reading-freshness.ts` and the web UI imports the same function, so the two surfaces cannot drift apart.
+Offline equipments stay in the list on purpose, so a client can render an "offline since" row, and they answer `false`: their last reading is not a live measurement however recent it is.
+
+The verdict comes from `classifyPowerReading` in `src/shared/reading-freshness.ts`, and the web UI's Live breakdown calls the same function, so the two surfaces cannot answer differently about one appliance.
 
 ## Zones
 

--- a/src/api/routes/equipments.test.ts
+++ b/src/api/routes/equipments.test.ts
@@ -12,7 +12,13 @@ interface FixtureEq {
   name: string;
   type: string;
   status?: string;
-  dataBindings?: Array<{ alias?: string; category?: string; type?: string }>;
+  dataBindings?: Array<{
+    alias?: string;
+    category?: string;
+    type?: string;
+    value?: unknown;
+    lastUpdated?: string | null;
+  }>;
 }
 function makeManager(fixture: FixtureEq[]) {
   return {
@@ -508,5 +514,99 @@ describe("PUT /api/v1/equipments/:id — solar profile (spec 160)", () => {
     });
     expect(res.statusCode).toBe(400);
     expect(received).toBeNull();
+  });
+});
+
+// ── #832 — the feed must not serve a leftover as a current measurement ──
+//
+// The energy display is this feed's consumer and cannot work a reading's age
+// out for itself without restating the rule, which is exactly how the web
+// breakdown and the arbitration card came to describe one appliance two
+// contradictory ways (#744). The verdict is computed here, from the same
+// shared rule the web UI uses.
+describe("GET /api/v1/equipments?role=submeter — reading freshness (#832)", () => {
+  let app: ReturnType<typeof Fastify>;
+  const logger = createLogger("silent").logger;
+
+  const ago = (ms: number) => new Date(Date.now() - ms).toISOString();
+  const powerAt = (value: unknown, lastUpdated: string | null) => [
+    { alias: "power", category: "power", type: "number", value, lastUpdated },
+  ];
+
+  async function build(fixture: FixtureEq[]) {
+    const a = Fastify({ logger: false, ajv: validationAjvOptions });
+    installValidationErrorHandler(a);
+    registerEquipmentRoutes(a, {
+      equipmentManager: makeManager(fixture),
+      logger,
+    } as unknown as Parameters<typeof registerEquipmentRoutes>[1]);
+    await a.ready();
+    return a;
+  }
+
+  afterEach(async () => {
+    if (app) await app.close();
+  });
+
+  async function verdicts(fixture: FixtureEq[]) {
+    app = await build(fixture);
+    const res = await app.inject({ method: "GET", url: "/api/v1/equipments?role=submeter" });
+    return Object.fromEntries(
+      (res.json() as { name: string; powerReadingCurrent: boolean | null }[]).map((e) => [
+        e.name,
+        e.powerReadingCurrent,
+      ]),
+    );
+  }
+
+  it("marks a fresh reading current and an aged one not", async () => {
+    const v = await verdicts([
+      { id: "1", name: "Piscine", type: "energy_meter", dataBindings: powerAt(1233, ago(40_000)) },
+      {
+        id: "2",
+        name: "Chauffe-eau",
+        type: "water_heater",
+        // The measured case: 560 W drawn, last reported 944 s earlier.
+        dataBindings: powerAt(0, ago(944_000)),
+      },
+    ]);
+    expect(v["Piscine"]).toBe(true);
+    expect(v["Chauffe-eau"]).toBe(false);
+  });
+
+  it("does not flag a 300 s poller, which is a supported default cadence", async () => {
+    // Four official integrations poll every 300 s. The #744 snapshot shows two
+    // such rows at 270 s with nothing wrong.
+    const v = await verdicts([
+      { id: "1", name: "Lave-linge", type: "appliance", dataBindings: powerAt(0, ago(270_000)) },
+    ]);
+    expect(v["Lave-linge"]).toBe(true);
+  });
+
+  it("holds a declared meter to the tighter window", async () => {
+    const v = await verdicts([
+      { id: "1", name: "Clamp", type: "energy_meter", dataBindings: powerAt(500, ago(270_000)) },
+    ]);
+    expect(v["Clamp"]).toBe(false);
+  });
+
+  it("reports null when there is no numeric power reading to judge", async () => {
+    // A declared meter awaiting its first report is kept in the feed on
+    // purpose (#527); "current" is not a question that applies to it.
+    const v = await verdicts([{ id: "1", name: "Neuf", type: "energy_meter", dataBindings: [] }]);
+    expect(v["Neuf"]).toBeNull();
+  });
+
+  it("leaves the rest of the payload untouched", async () => {
+    // Additive: an existing client keeps parsing exactly what it parses today.
+    app = await build([
+      { id: "1", name: "Piscine", type: "energy_meter", dataBindings: powerAt(1233, ago(40_000)) },
+    ]);
+    const res = await app.inject({ method: "GET", url: "/api/v1/equipments?role=submeter" });
+    const [eq] = res.json() as Record<string, unknown>[];
+    expect(eq.id).toBe("1");
+    expect(eq.name).toBe("Piscine");
+    expect(eq.type).toBe("energy_meter");
+    expect((eq.dataBindings as { value: number }[])[0].value).toBe(1233);
   });
 });

--- a/src/api/routes/equipments.test.ts
+++ b/src/api/routes/equipments.test.ts
@@ -536,10 +536,9 @@ describe("GET /api/v1/equipments?role=submeter — reading freshness (#832)", ()
   async function build(fixture: FixtureEq[]) {
     const a = Fastify({ logger: false, ajv: validationAjvOptions });
     installValidationErrorHandler(a);
-    registerEquipmentRoutes(a, {
-      equipmentManager: makeManager(fixture),
-      logger,
-    } as unknown as Parameters<typeof registerEquipmentRoutes>[1]);
+    // Only the manager is cast, matching the harness above: a new required
+    // field on the deps object should break the build here too.
+    registerEquipmentRoutes(a, { equipmentManager: makeManager(fixture), logger });
     await a.ready();
     return a;
   }
@@ -571,6 +570,23 @@ describe("GET /api/v1/equipments?role=submeter — reading freshness (#832)", ()
       },
     ]);
     expect(v["Piscine"]).toBe(true);
+    expect(v["Chauffe-eau"]).toBe(false);
+  });
+
+  it("does not call an offline equipment's last reading current", async () => {
+    // The feed keeps offline submeters on purpose, so the display can render
+    // an "offline since" row. Their last reading is not a live measurement
+    // either, however recent: judging on age alone made this feed disagree
+    // with the web breakdown about one appliance at one instant.
+    const v = await verdicts([
+      {
+        id: "1",
+        name: "Chauffe-eau",
+        type: "water_heater",
+        status: "offline",
+        dataBindings: powerAt(560, ago(30_000)),
+      },
+    ]);
     expect(v["Chauffe-eau"]).toBe(false);
   });
 

--- a/src/api/routes/equipments.ts
+++ b/src/api/routes/equipments.ts
@@ -3,6 +3,7 @@ import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import { EquipmentError } from "../../equipments/equipment-manager.js";
 import { isSubmeterEquipment, METERING_RELAY_TYPES } from "../../equipments/metering.js";
 import type { EnergyLoadProfile, EquipmentType, SolarProfile } from "../../shared/types.js";
+import { isReadingCurrent } from "../../shared/reading-freshness.js";
 import type { Logger } from "../../core/logger.js";
 
 interface EquipmentsDeps {
@@ -151,10 +152,29 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
           eq.status === "offline" ||
           eq.type === "energy_meter" ||
           eq.dataBindings.some((b) => b.alias === "power" && b.type === "number");
+        const now = Date.now();
         return all
           .filter((eq) => isSubmeterEquipment(eq.type, eq.dataBindings))
           .filter(hasLivePower)
-          .sort((a, b) => rank(a.type) - rank(b.type) || a.name.localeCompare(b.name));
+          .sort((a, b) => rank(a.type) - rank(b.type) || a.name.localeCompare(b.name))
+          .map((eq) => {
+            // Issue #832. This feed served whatever the plug last said, at
+            // full weight, however old: the 124-day wood-stove reading and the
+            // water heater's sixteen-minute-old 0 W shipped here unqualified,
+            // exactly as they once did to the web breakdown (#744). A client
+            // cannot work the age out for itself without restating the rule,
+            // and a restated rule is what let the two web surfaces disagree.
+            //
+            // Additive rather than a null value: the field is new, so an
+            // existing client keeps the payload it parses today, and one that
+            // reads the flag can stop drawing a leftover as a live segment.
+            const binding = eq.dataBindings.find((b) => b.alias === "power");
+            const powerReadingCurrent =
+              binding && typeof binding.value === "number"
+                ? isReadingCurrent(binding.lastUpdated, eq.type, now)
+                : null;
+            return { ...eq, powerReadingCurrent };
+          });
       }
       return type ? all.filter((eq) => eq.type === type) : all;
     },

--- a/src/api/routes/equipments.ts
+++ b/src/api/routes/equipments.ts
@@ -3,7 +3,7 @@ import type { EquipmentManager } from "../../equipments/equipment-manager.js";
 import { EquipmentError } from "../../equipments/equipment-manager.js";
 import { isSubmeterEquipment, METERING_RELAY_TYPES } from "../../equipments/metering.js";
 import type { EnergyLoadProfile, EquipmentType, SolarProfile } from "../../shared/types.js";
-import { isReadingCurrent } from "../../shared/reading-freshness.js";
+import { classifyPowerReading } from "../../shared/reading-freshness.js";
 import type { Logger } from "../../core/logger.js";
 
 interface EquipmentsDeps {
@@ -169,10 +169,20 @@ export function registerEquipmentRoutes(app: FastifyInstance, deps: EquipmentsDe
             // existing client keeps the payload it parses today, and one that
             // reads the flag can stop drawing a leftover as a live segment.
             const binding = eq.dataBindings.find((b) => b.alias === "power");
-            const powerReadingCurrent =
-              binding && typeof binding.value === "number"
-                ? isReadingCurrent(binding.lastUpdated, eq.type, now)
-                : null;
+            const verdict = classifyPowerReading({
+              status: eq.status,
+              value: binding?.value,
+              lastUpdated: binding?.lastUpdated,
+              equipmentType: eq.type,
+              now,
+            });
+            // An offline equipment is kept in the feed on purpose, so the
+            // display can render an "offline since" row. Its last reading is
+            // not a live measurement either, and answering `true` there was
+            // the same defect through a different door: the web breakdown
+            // said "offline" while this feed called the reading current, for
+            // one appliance, at one instant.
+            const powerReadingCurrent = verdict === "missing" ? null : verdict === "current";
             return { ...eq, powerReadingCurrent };
           });
       }

--- a/src/equipments/equipment-status.ts
+++ b/src/equipments/equipment-status.ts
@@ -21,19 +21,16 @@ import type {
   EquipmentStatus,
   EquipmentStatusReason,
 } from "../shared/types.js";
+import { parseReadingTime } from "../shared/reading-freshness.js";
 
 /**
  * Parse a SQLite-style ISO timestamp ("YYYY-MM-DD HH:MM:SSZ" or strict ISO 8601)
  * to epoch milliseconds. Returns null for null inputs or unparseable values.
  */
 function parseTimestamp(iso: string | null): number | null {
-  if (!iso) return null;
-  // SQLite datetime('now') returns "YYYY-MM-DD HH:MM:SS" without timezone — treat as UTC.
-  const normalized = iso.includes("T")
-    ? iso.replace("Z", "+00:00")
-    : iso.replace(" ", "T").replace("Z", "") + "Z";
-  const ms = Date.parse(normalized);
-  return Number.isFinite(ms) ? ms : null;
+  // One parser, shared with the display surfaces that ask the same question
+  // of the same timestamps (#832).
+  return parseReadingTime(iso);
 }
 
 /**

--- a/src/shared/reading-freshness.test.ts
+++ b/src/shared/reading-freshness.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  freshnessBudgetFor,
+  isReadingCurrent,
+  parseReadingTime,
+  SUBMETER_FRESHNESS_MS,
+  SUBMETER_FRESHNESS_SLOW_MS,
+} from "./reading-freshness.js";
+
+const NOW = Date.parse("2026-08-30T12:00:00Z");
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+describe("freshnessBudgetFor", () => {
+  it("gives a declared meter the engine's own electrical window", () => {
+    expect(freshnessBudgetFor("energy_meter")).toBe(SUBMETER_FRESHNESS_MS);
+    expect(freshnessBudgetFor("main_energy_meter")).toBe(SUBMETER_FRESHNESS_MS);
+    expect(SUBMETER_FRESHNESS_MS).toBe(2 * 60 * 1000);
+  });
+
+  it("gives everything else the looser one", () => {
+    // A water_heater or thermostat carrying a power channel is not a meter,
+    // and its source may legitimately be a 300 s poller.
+    for (const t of ["water_heater", "thermostat", "appliance", "switch", "media_player"]) {
+      expect(freshnessBudgetFor(t)).toBe(SUBMETER_FRESHNESS_SLOW_MS);
+    }
+  });
+
+  it("keeps the loose budget above twice the slowest supported cadence", () => {
+    // SmartThings, Legrand, Panasonic Comfort Cloud and MCZ Maestro all
+    // default to polling every 300 s. A budget below 600 s makes a healthy
+    // appliance flicker on every cycle.
+    expect(SUBMETER_FRESHNESS_SLOW_MS).toBeGreaterThanOrEqual(2 * 300 * 1000);
+  });
+});
+
+describe("parseReadingTime", () => {
+  it("accepts both timestamp spellings the API emits", () => {
+    expect(parseReadingTime("2026-05-27 08:00:00Z")).toBe(parseReadingTime("2026-05-27T08:00:00Z"));
+  });
+
+  it("returns null when there is nothing to parse", () => {
+    expect(parseReadingTime(null)).toBeNull();
+    expect(parseReadingTime(undefined)).toBeNull();
+    expect(parseReadingTime("")).toBeNull();
+    expect(parseReadingTime("not-a-date")).toBeNull();
+  });
+});
+
+describe("isReadingCurrent", () => {
+  it("accepts a reading inside the budget and refuses one past it", () => {
+    expect(isReadingCurrent(ago(60_000), "energy_meter", NOW)).toBe(true);
+    expect(isReadingCurrent(ago(SUBMETER_FRESHNESS_MS), "energy_meter", NOW)).toBe(true);
+    expect(isReadingCurrent(ago(SUBMETER_FRESHNESS_MS + 1), "energy_meter", NOW)).toBe(false);
+  });
+
+  it("does not flag a 300 s poller on a non-meter type", () => {
+    // The two rows in the #744 snapshot: Lave-linge and TV, both at 270 s,
+    // both fed by one SmartThings poll, both fine.
+    expect(isReadingCurrent(ago(270_000), "appliance", NOW)).toBe(true);
+    expect(isReadingCurrent(ago(270_000), "media_player", NOW)).toBe(true);
+  });
+
+  it("still catches the two readings #744 was about", () => {
+    // A water heater 13.5 minutes behind while drawing 560 W, and a wood stove
+    // 124 days behind, both reporting stale: false to the engine.
+    expect(isReadingCurrent(ago(944_000), "water_heater", NOW)).toBe(false);
+    expect(isReadingCurrent(ago(124 * 24 * 3600 * 1000), "thermostat", NOW)).toBe(false);
+  });
+
+  it("treats an absent or unparseable timestamp as no evidence of age", () => {
+    // Same reading as the backend: a binding that has never reported is not
+    // stale. Guessing "old" here would blank a value on first boot.
+    expect(isReadingCurrent(null, "energy_meter", NOW)).toBe(true);
+    expect(isReadingCurrent("nonsense", "energy_meter", NOW)).toBe(true);
+  });
+});

--- a/src/shared/reading-freshness.test.ts
+++ b/src/shared/reading-freshness.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  classifyPowerReading,
   freshnessBudgetFor,
   isReadingCurrent,
   parseReadingTime,
@@ -72,5 +73,55 @@ describe("isReadingCurrent", () => {
     // stale. Guessing "old" here would blank a value on first boot.
     expect(isReadingCurrent(null, "energy_meter", NOW)).toBe(true);
     expect(isReadingCurrent("nonsense", "energy_meter", NOW)).toBe(true);
+  });
+});
+
+describe("classifyPowerReading", () => {
+  const base = { equipmentType: "water_heater", now: NOW };
+
+  it("calls a fresh numeric reading current", () => {
+    expect(
+      classifyPowerReading({ ...base, status: "online", value: 560, lastUpdated: ago(30_000) }),
+    ).toBe("current");
+  });
+
+  it("calls an aged one stale", () => {
+    expect(
+      classifyPowerReading({ ...base, status: "online", value: 0, lastUpdated: ago(944_000) }),
+    ).toBe("stale");
+  });
+
+  it("reports offline BEFORE looking at the age", () => {
+    // The whole point of sharing this: the first draft of #832 judged the API
+    // feed on age alone, so an offline water heater with a 30-second-old
+    // 560 W reading shipped as "current" while the web breakdown, judging the
+    // same equipment, said "offline". One appliance, one instant, two answers.
+    expect(
+      classifyPowerReading({ ...base, status: "offline", value: 560, lastUpdated: ago(30_000) }),
+    ).toBe("offline");
+    // And it stays offline for an aged reading too: offline is the more
+    // specific fact, and "outdated" would send the reader after a reporting
+    // interval instead of a dead radio.
+    expect(
+      classifyPowerReading({ ...base, status: "offline", value: 560, lastUpdated: ago(944_000) }),
+    ).toBe("offline");
+  });
+
+  it("calls a degraded equipment by its reading, not its status", () => {
+    // Degraded is about the equipment as a whole; this particular reading is
+    // current, so it counts.
+    expect(
+      classifyPowerReading({ ...base, status: "degraded", value: 800, lastUpdated: ago(30_000) }),
+    ).toBe("current");
+  });
+
+  it("reports missing when there is no numeric reading to judge", () => {
+    expect(
+      classifyPowerReading({ ...base, status: "online", value: undefined, lastUpdated: null }),
+    ).toBe("missing");
+    // A boolean `power` is a STATE, not a measurement (SmartThings on/off).
+    expect(
+      classifyPowerReading({ ...base, status: "online", value: true, lastUpdated: ago(1_000) }),
+    ).toBe("missing");
   });
 });

--- a/src/shared/reading-freshness.ts
+++ b/src/shared/reading-freshness.ts
@@ -94,3 +94,35 @@ export function isReadingCurrent(
   if (at === null) return true;
   return now - at <= freshnessBudgetFor(equipmentType);
 }
+
+/** Why a power reading may or may not be drawn as a live measurement. */
+export type ReadingVerdict = "current" | "offline" | "stale" | "missing";
+
+/**
+ * The one classification both surfaces ask for (#832).
+ *
+ * Order matters and is not arbitrary. `offline` outranks `stale` because it is
+ * the more specific fact: an equipment whose device dropped off the network
+ * has no live reading whatever the age of the last one, and saying "outdated"
+ * there would send the reader looking at a reporting interval instead of at a
+ * dead radio. Age is only asked once the equipment is nominally present.
+ *
+ * Splitting this decision between the surfaces is what the first draft of #832
+ * did, and it immediately reproduced the defect it was fixing: the web
+ * breakdown reported `offline` while the submeter feed said the very same
+ * reading was current, for one appliance, at one instant.
+ */
+export function classifyPowerReading(opts: {
+  status: string;
+  /** The `power` binding's value, or undefined when there is no such binding. */
+  value: unknown;
+  lastUpdated: string | null | undefined;
+  equipmentType: string;
+  now?: number;
+}): ReadingVerdict {
+  if (opts.status === "offline") return "offline";
+  if (typeof opts.value !== "number") return "missing";
+  return isReadingCurrent(opts.lastUpdated, opts.equipmentType, opts.now ?? Date.now())
+    ? "current"
+    : "stale";
+}

--- a/src/shared/reading-freshness.ts
+++ b/src/shared/reading-freshness.ts
@@ -1,0 +1,96 @@
+// ============================================================
+// Reading freshness — is this measurement current, or a leftover?
+//
+// A `power` binding can carry a value of unbounded age while its equipment is
+// nominally online, and nothing in the payload says so. Issue #744 measured
+// what that looks like in production: a water heater drawing 560 W displayed
+// as 0 W, because its clamp had last reported sixteen minutes earlier, and a
+// wood stove contributing a reading 124 days old. The failure is quiet, since
+// a stale `0 W` reads as "this appliance is off", which is a perfectly
+// plausible thing for a water heater to be.
+//
+// The binding's own `stale` flag cannot answer this. `equipment-status.ts`
+// applies the electrical window only to METERING_EQUIPMENT_TYPES, on purpose:
+// a steady load stops producing updates, and a tight window would flag a
+// perfectly healthy appliance as degraded on every reporting cycle. That
+// exemption is right for equipment STATUS and leaves DISPLAY with no answer,
+// which is what this module supplies.
+//
+// It lives in shared/ because the question is asked on at least three
+// surfaces: the Live breakdown, the `?role=submeter` feed the energy display
+// consumes, and the equipment cards (issue #832). A rule restated per surface
+// is how the breakdown and the arbitration card came to describe one appliance
+// two contradictory ways in the first place.
+// ============================================================
+
+import {
+  DEFAULT_STREAMING_TIMEOUT_MS,
+  METERING_EQUIPMENT_TYPES,
+  STREAMING_TIMEOUT_MS,
+} from "./constants.js";
+
+/**
+ * How old a reading may be, on an equipment the engine itself treats as a
+ * meter, and still count as a live measurement.
+ *
+ * Taken from the engine's own per-category window rather than a number picked
+ * here, so these age out at the same moment everything else does. Two minutes
+ * for `power`.
+ */
+export const SUBMETER_FRESHNESS_MS = STREAMING_TIMEOUT_MS.power ?? DEFAULT_STREAMING_TIMEOUT_MS;
+
+/**
+ * The same budget for every other equipment type, and it has to be looser.
+ *
+ * Four official integrations (SmartThings, Legrand, Panasonic Comfort Cloud,
+ * MCZ Maestro) poll on a 300 s default, and the #744 production snapshot shows
+ * two such rows at an age of 270 s with nothing wrong. A two-minute budget
+ * would have made them read "outdated" for three minutes out of every five,
+ * their watts jumping in and out of the residual roughly once a second.
+ *
+ * Ten minutes is twice the slowest supported default cadence, so no supported
+ * source oscillates, and it is still far below both cases #744 is about: a
+ * water heater 13.5 minutes behind while drawing 560 W, and a wood stove 124
+ * days behind. It also buys margin against a viewer's browser clock running
+ * ahead of the Sowel host, which is the other thing this comparison is exposed
+ * to on the UI side.
+ */
+export const SUBMETER_FRESHNESS_SLOW_MS = 10 * 60 * 1000;
+
+/** The freshness budget that applies to an equipment of this type. */
+export function freshnessBudgetFor(equipmentType: string): number {
+  return METERING_EQUIPMENT_TYPES.has(equipmentType)
+    ? SUBMETER_FRESHNESS_MS
+    : SUBMETER_FRESHNESS_SLOW_MS;
+}
+
+/**
+ * Parse a binding timestamp. The API emits both `2026-05-27T08:00:00Z` and the
+ * SQLite-flavoured `2026-05-27 08:00:00Z`; treat them alike.
+ *
+ * Returns null when there is nothing parseable, which callers must read as "no
+ * information about age", never as "old".
+ */
+export function parseReadingTime(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const normalized = iso.includes("T") ? iso : iso.replace(" ", "T").replace("Z", "") + "Z";
+  const ms = Date.parse(normalized);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Whether a reading may be presented as a current measurement.
+ *
+ * A timestamp that is absent or unparseable counts as current: there is no
+ * evidence the value is old, and that is how the backend reads it too (a
+ * binding with `lastUpdated === null` has never reported and is not stale).
+ */
+export function isReadingCurrent(
+  lastUpdated: string | null | undefined,
+  equipmentType: string,
+  now: number = Date.now(),
+): boolean {
+  const at = parseReadingTime(lastUpdated);
+  if (at === null) return true;
+  return now - at <= freshnessBudgetFor(equipmentType);
+}

--- a/ui/src/components/energy/LiveEnergyPage.tsx
+++ b/ui/src/components/energy/LiveEnergyPage.tsx
@@ -26,6 +26,7 @@ import { PhaseBreakdown } from "./PhaseBreakdown";
 import { useWsSubscription } from "../../hooks/useWsSubscription";
 import { ArbitrationSurface } from "./ArbitrationSurface";
 import { FlowDiagram } from "../flow/FlowDiagram";
+import { formatRelative } from "../../lib/format-relative";
 
 // Sowel energy palette (matches EnergyBarChart.tsx + extends with grid colours)
 // Spec 148 — energy palette tokens (dark-mode correct), shared across energy UI.
@@ -72,19 +73,6 @@ function detectLiveStaleness(
   return { mode: allOffline ? "offline" : "stale", oldestSince };
 }
 
-function formatRelative(iso: string | null): string {
-  if (!iso) return "";
-  const normalized = iso.includes("T") ? iso : iso.replace(" ", "T").replace("Z", "") + "Z";
-  const ms = Date.parse(normalized);
-  if (!Number.isFinite(ms)) return "";
-  const seconds = Math.floor((Date.now() - ms) / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes} min`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours} h`;
-  return `${Math.floor(hours / 24)} j`;
-}
 
 /** Format a power value:
  *  - |value| < 1000 W → integer W rounded to the nearest 5 (smooth display)

--- a/ui/src/components/energy/LiveSubmeterBreakdown.tsx
+++ b/ui/src/components/energy/LiveSubmeterBreakdown.tsx
@@ -24,6 +24,7 @@ import {
   flattenZonesWithPath,
   zoneChainMap,
 } from "../../lib/zone-path";
+import { formatRelative } from "../../lib/format-relative";
 
 const HOUSE_COLOR = "#4F7BE8"; // matches HP_COLOR in LiveEnergyPage
 const OTHER_COLOR = "#A1A1AA"; // var(--n-300), neutral grey
@@ -63,21 +64,6 @@ function formatPower(value: number): { num: string; unit: "W" | "kW" } {
   return { num: (shown / 1000).toFixed(1), unit: "kW" };
 }
 
-function formatRelative(iso: string | null): string {
-  if (!iso) return "";
-  const normalized = iso.includes("T")
-    ? iso
-    : iso.replace(" ", "T").replace("Z", "") + "Z";
-  const ms = Date.parse(normalized);
-  if (!Number.isFinite(ms)) return "";
-  const seconds = Math.floor((Date.now() - ms) / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes} min`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours} h`;
-  return `${Math.floor(hours / 24)} j`;
-}
 
 export function LiveSubmeterBreakdown({ house, hasMainMeter }: Props) {
   const { t } = useTranslation();

--- a/ui/src/components/energy/submeter-helpers.test.ts
+++ b/ui/src/components/energy/submeter-helpers.test.ts
@@ -9,12 +9,17 @@ import {
   buildSubmeterRows,
   computeOther,
   displayedPower,
-  parseReadingTime,
   readSubmeterReading,
   sharePercent,
+} from "./submeter-helpers";
+// Imported from shared/ rather than re-exported through the helper: one name,
+// one module, so a signature change here cannot masquerade as compatible
+// (#832 review).
+import {
+  parseReadingTime,
   SUBMETER_FRESHNESS_MS,
   SUBMETER_FRESHNESS_SLOW_MS,
-} from "./submeter-helpers";
+} from "../../../../src/shared/reading-freshness";
 
 /**
  * Fixed clock. Every reading's age is stated by the test rather than inherited

--- a/ui/src/components/energy/submeter-helpers.ts
+++ b/ui/src/components/energy/submeter-helpers.ts
@@ -8,48 +8,24 @@ import type { EquipmentStatus, EquipmentWithDetails } from "../../types";
 import { pickSubmeterColor } from "./submeterPalette";
 import { isSubmeterEquipment } from "../../lib/metering";
 import {
-  DEFAULT_STREAMING_TIMEOUT_MS,
-  METERING_EQUIPMENT_TYPES,
-  STREAMING_TIMEOUT_MS,
-} from "../../../../src/shared/constants";
+  freshnessBudgetFor,
+  isReadingCurrent,
+  parseReadingTime,
+  SUBMETER_FRESHNESS_MS,
+  SUBMETER_FRESHNESS_SLOW_MS,
+} from "../../../../src/shared/reading-freshness";
 
-/**
- * How old a reading may be, on an equipment the engine itself treats as a
- * meter, and still count as a live measurement.
- *
- * Taken from the engine's own per-category window rather than a number picked
- * here, so those rows age out at the same moment everything else does. Two
- * minutes for `power` (issue #744).
- */
-export const SUBMETER_FRESHNESS_MS = STREAMING_TIMEOUT_MS.power ?? DEFAULT_STREAMING_TIMEOUT_MS;
-
-/**
- * The same budget for every other submeter type, and it has to be looser.
- *
- * `equipment-status.ts` applies the tight electrical window only to
- * METERING_EQUIPMENT_TYPES, and says why: a steady load stops producing
- * updates, so a two-minute window would flag a perfectly healthy appliance on
- * every reporting cycle. That reasoning applies here too. Four official
- * integrations (SmartThings, Legrand, Panasonic Comfort Cloud, MCZ Maestro)
- * poll on a 300 s default, and the issue's own production snapshot shows two
- * of those rows at an age of 270 s with nothing wrong. A two-minute budget
- * would have made them read "outdated" for three minutes out of every five.
- *
- * Ten minutes is twice the slowest supported default cadence, so no supported
- * source oscillates, and it is still far below both cases this issue is about:
- * a water heater whose reading was 13.5 minutes old while it drew 560 W, and a
- * wood stove 124 days behind. It also buys margin against a viewer's browser
- * clock running ahead of the Sowel host, which is the other thing this
- * comparison is exposed to.
- */
-export const SUBMETER_FRESHNESS_SLOW_MS = 10 * 60 * 1000;
-
-/** The budget that applies to this equipment. */
-export function freshnessBudgetFor(eq: EquipmentWithDetails): number {
-  return METERING_EQUIPMENT_TYPES.has(eq.type)
-    ? SUBMETER_FRESHNESS_MS
-    : SUBMETER_FRESHNESS_SLOW_MS;
-}
+// The freshness rule is the backend's own, imported rather than restated
+// (issue #832). It is asked on three surfaces now, and a rule restated per
+// surface is how the breakdown and the arbitration card came to describe one
+// appliance two contradictory ways in the first place (#744).
+export {
+  freshnessBudgetFor,
+  isReadingCurrent,
+  parseReadingTime,
+  SUBMETER_FRESHNESS_MS,
+  SUBMETER_FRESHNESS_SLOW_MS,
+};
 
 /** Why a submeter contributes no number to the breakdown. */
 export type SubmeterUnknown = "offline" | "stale" | "missing";
@@ -74,19 +50,6 @@ export interface SubmeterReading {
   unknown: SubmeterUnknown | null;
   /** `lastUpdated` of the reading, whether or not it aged out. */
   lastUpdated: string | null;
-}
-
-/**
- * Parse a binding timestamp. The API emits both `2026-05-27T08:00:00Z` and the
- * SQLite-flavoured `2026-05-27 08:00:00Z`; treat them alike.
- * Returns null when there is nothing parseable, which callers read as
- * "no information about age", never as "old".
- */
-export function parseReadingTime(iso: string | null | undefined): number | null {
-  if (!iso) return null;
-  const normalized = iso.includes("T") ? iso : iso.replace(" ", "T").replace("Z", "") + "Z";
-  const ms = Date.parse(normalized);
-  return Number.isFinite(ms) ? ms : null;
 }
 
 /**
@@ -121,10 +84,7 @@ export function readSubmeterReading(
   if (!binding || typeof binding.value !== "number") {
     return { power: null, unknown: "missing", lastUpdated: null };
   }
-  const at = parseReadingTime(binding.lastUpdated);
-  // No usable timestamp means no evidence the value is old, which is how the
-  // backend reads it too (a binding with lastUpdated === null is not stale).
-  if (at !== null && now - at > freshnessBudgetFor(eq)) {
+  if (!isReadingCurrent(binding.lastUpdated, eq.type, now)) {
     return { power: null, unknown: "stale", lastUpdated: binding.lastUpdated };
   }
   return { power: Math.abs(binding.value), unknown: null, lastUpdated: binding.lastUpdated };

--- a/ui/src/components/energy/submeter-helpers.ts
+++ b/ui/src/components/energy/submeter-helpers.ts
@@ -8,27 +8,12 @@ import type { EquipmentStatus, EquipmentWithDetails } from "../../types";
 import { pickSubmeterColor } from "./submeterPalette";
 import { isSubmeterEquipment } from "../../lib/metering";
 import {
-  freshnessBudgetFor,
-  isReadingCurrent,
-  parseReadingTime,
-  SUBMETER_FRESHNESS_MS,
-  SUBMETER_FRESHNESS_SLOW_MS,
+  classifyPowerReading,
+  type ReadingVerdict,
 } from "../../../../src/shared/reading-freshness";
 
-// The freshness rule is the backend's own, imported rather than restated
-// (issue #832). It is asked on three surfaces now, and a rule restated per
-// surface is how the breakdown and the arbitration card came to describe one
-// appliance two contradictory ways in the first place (#744).
-export {
-  freshnessBudgetFor,
-  isReadingCurrent,
-  parseReadingTime,
-  SUBMETER_FRESHNESS_MS,
-  SUBMETER_FRESHNESS_SLOW_MS,
-};
-
 /** Why a submeter contributes no number to the breakdown. */
-export type SubmeterUnknown = "offline" | "stale" | "missing";
+export type SubmeterUnknown = Exclude<ReadingVerdict, "current">;
 
 export interface SubmeterRow {
   id: string;
@@ -55,22 +40,21 @@ export interface SubmeterReading {
 /**
  * Read the `power` alias from a submeter equipment.
  *
- * A reading past its freshness budget is NOT returned as a number (issue
- * #744). Before this rule, the only thing that could drop a reading was
- * `status === "offline"`, so an equipment considered online contributed its
- * last known power at full weight however old it was. Measured on production:
- * a water heater drawing 560 W was displayed as 0 W because its clamp had last
+ * The verdict comes from `classifyPowerReading` in shared/, which the
+ * `?role=submeter` API feed calls too (#832). Splitting that decision between
+ * the surfaces is how this defect keeps coming back: #744 was the breakdown
+ * and the arbitration card describing one appliance two ways, and the first
+ * draft of #832 immediately reproduced it, with the feed calling an offline
+ * equipment's last reading current while this function called it offline.
+ *
+ * What the reading itself means, once classified: a value past its freshness
+ * budget is NOT returned as a number. Before that rule, the only thing that
+ * could drop a reading was `status === "offline"`, so an equipment considered
+ * online contributed its last known power at full weight however old it was. A
+ * water heater drawing 560 W was displayed as 0 W because its clamp had last
  * reported sixteen minutes earlier, and a wood stove was contributing a value
  * 124 days old. The failure is quiet, since a stale `0 W` reads as "this
  * appliance is off", which is a perfectly plausible thing for it to be.
- *
- * The binding's own `stale` flag cannot stand in for this. The backend applies
- * the electrical window only to METERING_EQUIPMENT_TYPES, on purpose, so a
- * `thermostat` or `water_heater` carrying a power channel reports
- * `stale: false` however old the value is. That exemption is right for
- * equipment status, where flagging a quiet appliance as degraded would be
- * wrong; it just leaves the display with no answer to "is this number
- * current", which is what freshnessBudgetFor supplies.
  *
  * Negative values are returned as their absolute value (clamp wired backwards,
  * same convention as the spec 091 backend integration).
@@ -79,15 +63,24 @@ export function readSubmeterReading(
   eq: EquipmentWithDetails,
   now: number = Date.now(),
 ): SubmeterReading {
-  if (eq.status === "offline") return { power: null, unknown: "offline", lastUpdated: null };
   const binding = eq.dataBindings.find((b) => b.alias === "power");
-  if (!binding || typeof binding.value !== "number") {
-    return { power: null, unknown: "missing", lastUpdated: null };
+  const verdict = classifyPowerReading({
+    status: eq.status,
+    value: binding?.value,
+    lastUpdated: binding?.lastUpdated,
+    equipmentType: eq.type,
+    now,
+  });
+  if (verdict === "current") {
+    return { power: Math.abs(binding!.value as number), unknown: null, lastUpdated: binding!.lastUpdated };
   }
-  if (!isReadingCurrent(binding.lastUpdated, eq.type, now)) {
-    return { power: null, unknown: "stale", lastUpdated: binding.lastUpdated };
-  }
-  return { power: Math.abs(binding.value), unknown: null, lastUpdated: binding.lastUpdated };
+  return {
+    power: null,
+    unknown: verdict,
+    // Only a stale row has an age worth showing; an offline one shows its own
+    // offlineSince, and a missing one has nothing to date.
+    lastUpdated: verdict === "stale" ? (binding?.lastUpdated ?? null) : null,
+  };
 }
 
 /**

--- a/ui/src/components/equipments/EnergyDataPanel.tsx
+++ b/ui/src/components/equipments/EnergyDataPanel.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import { Zap, Clock, Calendar, CalendarDays, CalendarRange } from "lucide-react";
 import type { ComputedDataEntry, EquipmentStatus, EquipmentStatusReason } from "../../types";
 import { EquipmentStatusBadge } from "./EquipmentStatusBadge";
+import { formatRelative } from "../../lib/format-relative";
 
 interface EnergyDataPanelProps {
   computedData: ComputedDataEntry[];
@@ -29,19 +30,6 @@ function formatEnergy(wh: number): { value: string; unit: string } {
   return { value: String(Math.round(wh)), unit: "Wh" };
 }
 
-function formatRelative(iso: string | null): string {
-  if (!iso) return "";
-  const normalized = iso.includes("T") ? iso : iso.replace(" ", "T").replace("Z", "") + "Z";
-  const ms = Date.parse(normalized);
-  if (!Number.isFinite(ms)) return "";
-  const seconds = Math.floor((Date.now() - ms) / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes} min`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours} h`;
-  return `${Math.floor(hours / 24)} j`;
-}
 
 export function EnergyDataPanel({ computedData, status, statusReason,
   isProduction,

--- a/ui/src/components/equipments/EquipmentStatusBadge.tsx
+++ b/ui/src/components/equipments/EquipmentStatusBadge.tsx
@@ -9,6 +9,7 @@
 import { AlertTriangle, WifiOff } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { EquipmentStatus, EquipmentStatusReason } from "../../types";
+import { formatRelative } from "../../lib/format-relative";
 
 type Size = "sm" | "md";
 
@@ -28,20 +29,6 @@ const SIZE_CLASSES: Record<Size, string> = {
 
 const ICON_SIZE: Record<Size, number> = { sm: 11, md: 13 };
 
-function formatRelative(iso: string | null): string {
-  if (!iso) return "";
-  const normalized = iso.includes("T") ? iso : iso.replace(" ", "T").replace("Z", "") + "Z";
-  const ms = Date.parse(normalized);
-  if (!Number.isFinite(ms)) return "";
-  const seconds = Math.floor((Date.now() - ms) / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes} min`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours} h`;
-  const days = Math.floor(hours / 24);
-  return `${days} j`;
-}
 
 function buildTooltip(
   status: EquipmentStatus,

--- a/ui/src/lib/format-relative.ts
+++ b/ui/src/lib/format-relative.ts
@@ -1,0 +1,26 @@
+import { parseReadingTime } from "../../../src/shared/reading-freshness";
+
+/**
+ * "how long ago", compactly: `45s`, `12 min`, `3 h`, `2 j`.
+ *
+ * One implementation for what were four byte-identical copies, in
+ * LiveSubmeterBreakdown, LiveEnergyPage, EquipmentStatusBadge and
+ * EnergyDataPanel (#832 review). Each carried its own copy of the timestamp
+ * parser too, the same one shared/ now owns, which is what made this worth
+ * lifting rather than leaving: the module arguing for one implementation of
+ * the freshness rule was sitting beside four copies of its own parser.
+ *
+ * The `j` suffix is French in every copy and is kept verbatim so the rendered
+ * text does not change. It predates this and belongs to an i18n pass, not here.
+ */
+export function formatRelative(iso: string | null): string {
+  const ms = parseReadingTime(iso);
+  if (ms === null) return "";
+  const seconds = Math.floor((Date.now() - ms) / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} h`;
+  return `${Math.floor(hours / 24)} j`;
+}


### PR DESCRIPTION
## What #744 left behind

#744 stopped the Live breakdown presenting a reading of unbounded age as a live measurement. The same readings still shipped, unqualified, to the `?role=submeter` feed the ESP32 energy display consumes: the 124-day wood stove and the water heater's sixteen-minute-old `0 W` among them. The display has no second surface to cross-check against, and it cannot work the age out for itself without restating the rule.

## The substance: one classification, two callers

`src/shared/reading-freshness.ts` now owns `classifyPowerReading`, returning `current` / `offline` / `stale` / `missing`. The API maps it to a boolean; the web UI's `readSubmeterReading` maps it to its own shape. Both call the same function.

That matters more than either call site. A rule restated per surface is precisely how the breakdown and the arbitration card came to describe one appliance in two contradictory ways, and the first draft of this PR reproduced it immediately: the verdict was computed from **age alone**, while the feed deliberately keeps offline equipments so the display can render an "offline since" row. An offline water heater with a thirty-second-old 560 W reading shipped as `powerReadingCurrent: true`, documented as "may be drawn as a live measurement", while the web UI returned `offline` for the same equipment at the same instant. Sharing the age test but splitting the decision was not enough; the whole verdict had to move.

`offline` outranks `stale` because it is the more specific fact: saying "outdated" for a dead radio sends the reader after a reporting interval instead of a dead device.

## The API change

`powerReadingCurrent` on the submeter role: `true` when the reading may be drawn as live, `false` when it may not (past its budget, or offline), `null` when there is no numeric reading to judge.

Additive rather than nulling the value, so an existing client keeps parsing exactly what it parses today. **The energy display's firmware lives in its own repository and must be changed to read the flag.** Until it is, the display shows what it shows now; what this gives it is the means to stop.

## Also lifted, because the thesis demanded it

The review pointed out that a PR arguing for one implementation was sitting beside **four byte-identical copies** of `formatRelative`, one of them in the very component that renders the "reading outdated" label, each carrying its own copy of the timestamp parser `shared/` now owns. One implementation in `ui/src/lib/format-relative`, and `equipment-status.ts` calls the shared parser too. No behaviour change; the existing suites cover all five sites.

The `freshnessBudgetFor` re-export also went: it had changed signature (equipment object to type string) while keeping its name, which is a trap even with no caller, and it made "the 136 UI tests pass, so this is retro-compatible" overstate what a passing suite proved. The UI test imports from shared directly now, and those 136 tests pass while genuinely exercising the shared classifier.

## Tests

14 on the shared rule (both budgets, the 300 s poller that must not flicker, both #744 production cases, offline outranking age, a degraded equipment judged by its reading, an absent timestamp treated as no evidence of age) and 6 on the route, including the offline case the first draft got wrong. Mutation-checked on both sides: inverting the boundary fails 3 shared, 3 route and 24 UI tests; hardcoding `true` fails 2, 2 and 11.

## Equipment cards, the third surface

Filed as #839. Power is resolved at nine independent call sites (twelve files if you count the `category === "power"` lookups an alias grep misses), and no cheap chokepoint exists: `useEquipmentState` is consumed by seven of them but resolves a power binding only for thermostats. Three of the nine are the files #325 tracks as the recurring desktop/mobile/detail drift, so its presentation resolver is the right vehicle for those; the rest sit outside its scope and need their own pass. That correction is in the issue.

Closes #832
