### PR TITLE
fix(ci): typecheck the test files, and fix the 75 errors that hid there (#834)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
+      # Test files are excluded from `typecheck` (tsconfig.json's `exclude`),
+      # which let a test assert on a type that does not exist while CI stayed
+      # green: roles the engine never had, an event type removed from
+      # EngineEvent, string literals outside their union (#834). Blocking from
+      # the start, because it is at zero and the point is to keep it there.
+      - run: npm run typecheck:tests
       - run: npm run format:check
       - run: npm test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,8 +116,9 @@ npx vitest run               # All backend tests
 npx vitest run <file>        # Single test file
 
 # Type checks and lint
-npx tsc --noEmit             # Backend
-cd ui && npx tsc -b --noEmit # UI
+npx tsc --noEmit             # Backend (src only — tests are excluded)
+npm run typecheck:tests      # Backend INCLUDING test files (#834, gated in CI)
+cd ui && npx tsc -b --noEmit # UI (its tests are already covered)
 npx eslint src/ --ext .ts
 cd ui && npx eslint .
 

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
+    "typecheck:tests": "tsc -p tsconfig.test.json",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write \"src/**/*.ts\" \"*.{json,md,js}\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"*.{json,md,js}\"",
-    "validate": "npm run typecheck && npm run lint && npm run format:check && npm run test && npm run validate:ui",
+    "validate": "npm run typecheck && npm run typecheck:tests && npm run lint && npm run format:check && npm run test && npm run validate:ui",
     "validate:ui": "cd ui && npm run lint && npm run typecheck && npm run test",
     "prepare": "husky"
   },

--- a/src/activity/activity-buffer.test.ts
+++ b/src/activity/activity-buffer.test.ts
@@ -7,16 +7,15 @@ import type { ActivityItem, Equipment } from "../shared/types.js";
 
 const logger = createLogger("silent").logger;
 
-function mkEquipment(id: string, name: string, zoneId: string | null): Equipment {
+function mkEquipment(id: string, name: string, zoneId: string): Equipment {
   return {
     id,
     name,
     type: "light_onoff",
     zoneId,
     enabled: true,
-    icon: null,
-    pinned: false,
     createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
   };
 }
 
@@ -34,19 +33,19 @@ function buildHarness() {
   const equipmentManager = {
     getById: (id: string) => equipments.get(id) ?? null,
     getDataBindingsWithValues: (id: string) => bindings.get(id) ?? [],
-  } as unknown as Parameters<typeof ActivityBuffer.prototype.constructor>[1];
+  } as unknown as ConstructorParameters<typeof ActivityBuffer>[1];
 
   const recipeManager = {
     getInstanceMeta: (id: string) => instances.get(id) ?? null,
-  } as unknown as Parameters<typeof ActivityBuffer.prototype.constructor>[2];
+  } as unknown as ConstructorParameters<typeof ActivityBuffer>[2];
 
   const zoneManager = {
     getDescendantIds: (zoneId: string) => [zoneId, ...(descendants.get(zoneId) ?? [])],
-  } as unknown as Parameters<typeof ActivityBuffer.prototype.constructor>[3];
+  } as unknown as ConstructorParameters<typeof ActivityBuffer>[3];
 
   const sunlightManager = {
     getSunlightData: () => ({ sunrise: null, sunset: null, isDaylight }),
-  } as unknown as Parameters<typeof ActivityBuffer.prototype.constructor>[4];
+  } as unknown as ConstructorParameters<typeof ActivityBuffer>[4];
 
   const buffer = new ActivityBuffer(
     bus,
@@ -589,17 +588,17 @@ describe("ActivityBuffer persistence", () => {
     const noop = {
       getById: () => null,
       getDataBindingsWithValues: () => [],
-    } as unknown as Parameters<typeof ActivityBuffer.prototype.constructor>[1];
+    };
     const zoneManager = {
       getDescendantIds: (z: string) => [z],
-    } as unknown as Parameters<typeof ActivityBuffer.prototype.constructor>[3];
+    } as unknown as ConstructorParameters<typeof ActivityBuffer>[3];
     const sunlightManager = {
       getSunlightData: () => ({ sunrise: null, sunset: null, isDaylight: false }),
-    } as unknown as Parameters<typeof ActivityBuffer.prototype.constructor>[4];
+    } as unknown as ConstructorParameters<typeof ActivityBuffer>[4];
     const buffer = new ActivityBuffer(
       bus,
-      noop,
-      noop,
+      noop as unknown as ConstructorParameters<typeof ActivityBuffer>[1],
+      noop as unknown as ConstructorParameters<typeof ActivityBuffer>[2],
       zoneManager,
       sunlightManager,
       logger,

--- a/src/api/routes/backup.test.ts
+++ b/src/api/routes/backup.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { createLogger } from "../../core/logger.js";
 import { registerBackupRoutes } from "./backup.js";
 import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+import type { UserRole } from "../../shared/types.js";
 
 // Characterization tests for the #482 schema-validation conversion of the backup
 // routes: admin gating moved to an onRequest hook (403 before the 400), and the
@@ -13,7 +14,7 @@ const logger = createLogger("silent").logger;
 
 interface BuildOpts {
   authed?: boolean;
-  role?: "admin" | "user" | "viewer";
+  role?: UserRole;
 }
 
 async function buildApp(opts: BuildOpts = {}) {
@@ -52,7 +53,7 @@ describe("backup routes (schema validation, #482)", () => {
   });
 
   it("403s a non-admin on GET /backup/local (admin gate)", async () => {
-    const built = await buildApp({ authed: true, role: "user" });
+    const built = await buildApp({ authed: true, role: "standard" });
     app = built.app;
     const res = await app.inject({ method: "GET", url: "/api/v1/backup/local" });
     expect(res.statusCode).toBe(403);
@@ -67,7 +68,7 @@ describe("backup routes (schema validation, #482)", () => {
   });
 
   it("403s a non-admin BEFORE body validation on restore-local (precedence)", async () => {
-    const built = await buildApp({ authed: true, role: "user" });
+    const built = await buildApp({ authed: true, role: "standard" });
     app = built.app;
     const res = await app.inject({
       method: "POST",

--- a/src/api/routes/energy.test.ts
+++ b/src/api/routes/energy.test.ts
@@ -893,8 +893,8 @@ describe("PV forecast routes (spec 160)", () => {
   const solarMeter = {
     id: "eq-pv",
     name: "Shelly Solar",
-    type: "energy_production_meter",
-  } as never;
+    type: "energy_production_meter" as const,
+  };
 
   it("404s on an unknown equipment", async () => {
     const app = await buildApp();
@@ -1045,7 +1045,7 @@ describe("Spec 161 — POST /energy/pv-forecast/:id/backfill", () => {
   it("refuses a non-admin before touching the forecaster", async () => {
     const app = await buildApp({
       equipments: [solarMeter],
-      authRole: "user",
+      authRole: "standard",
       pvForecaster: forecasterReturning({ ok: true, hoursPaired: 999, model: null }),
     });
     const res = await app.inject({ method: "POST", url });

--- a/src/api/routes/logs.test.ts
+++ b/src/api/routes/logs.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { createLogger } from "../../core/logger.js";
 import { registerLogRoutes } from "./logs.js";
 import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+import type { UserRole } from "../../shared/types.js";
 
 // Characterization tests for the #482 schema-validation conversion of the log
 // routes: admin gating moved to an onRequest hook (403 before the 400), and the
@@ -13,7 +14,7 @@ const logger = createLogger("silent").logger;
 
 interface BuildOpts {
   authed?: boolean;
-  role?: "admin" | "user" | "viewer";
+  role?: UserRole;
 }
 
 async function buildApp(opts: BuildOpts = {}) {
@@ -47,7 +48,7 @@ describe("log routes (schema validation, #482)", () => {
   });
 
   it("403s a non-admin on GET /logs (admin gate)", async () => {
-    app = await buildApp({ authed: true, role: "user" });
+    app = await buildApp({ authed: true, role: "standard" });
     const res = await app.inject({ method: "GET", url: "/api/v1/logs" });
     expect(res.statusCode).toBe(403);
   });
@@ -60,7 +61,7 @@ describe("log routes (schema validation, #482)", () => {
   });
 
   it("403s a non-admin BEFORE body validation on PUT /logs/level (precedence preserved)", async () => {
-    app = await buildApp({ authed: true, role: "user" });
+    app = await buildApp({ authed: true, role: "standard" });
     const res = await app.inject({
       method: "PUT",
       url: "/api/v1/logs/level",

--- a/src/api/routes/me.test.ts
+++ b/src/api/routes/me.test.ts
@@ -20,7 +20,7 @@ const currentUser = {
   id: "u1",
   username: "bob",
   displayName: "Bob",
-  role: "user" as const,
+  role: "standard" as const,
   enabled: true,
   passwordHash: "hash",
 };
@@ -31,7 +31,7 @@ async function buildApp(opts: BuildOpts = {}) {
 
   if (opts.authed) {
     app.addHook("onRequest", async (request) => {
-      request.auth = { userId: "u1", role: "user" };
+      request.auth = { userId: "u1", role: "standard" };
     });
   }
 

--- a/src/api/routes/push.test.ts
+++ b/src/api/routes/push.test.ts
@@ -19,7 +19,7 @@ async function buildApp(opts: BuildOpts = {}) {
 
   if (opts.authed) {
     app.addHook("onRequest", async (request) => {
-      request.auth = { userId: "u1", role: "user" };
+      request.auth = { userId: "u1", role: "standard" };
     });
   }
 

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { createLogger } from "../../core/logger.js";
 import { registerSettingsRoutes } from "./settings.js";
 import { installValidationErrorHandler, validationAjvOptions } from "../error-handler.js";
+import type { UserRole } from "../../shared/types.js";
 
 // Characterization tests for the #482 schema-validation conversion of the
 // settings routes: admin gating moved to an onRequest hook (403 before the body
@@ -13,7 +14,7 @@ const logger = createLogger("silent").logger;
 
 interface BuildOpts {
   authed?: boolean;
-  role?: "admin" | "user" | "viewer";
+  role?: UserRole;
 }
 
 async function buildApp(opts: BuildOpts = {}) {
@@ -59,7 +60,7 @@ describe("settings routes (schema validation, #482)", () => {
   });
 
   it("403s a non-admin on GET /settings (admin gate)", async () => {
-    app = await buildApp({ authed: true, role: "user" });
+    app = await buildApp({ authed: true, role: "standard" });
     const res = await app.inject({ method: "GET", url: "/api/v1/settings" });
     expect(res.statusCode).toBe(403);
   });
@@ -72,7 +73,7 @@ describe("settings routes (schema validation, #482)", () => {
   });
 
   it("403s a non-admin BEFORE body validation on PUT (precedence preserved)", async () => {
-    app = await buildApp({ authed: true, role: "user" });
+    app = await buildApp({ authed: true, role: "standard" });
     // Malformed body (number value) from a non-admin must 403, not 400.
     const res = await app.inject({
       method: "PUT",
@@ -118,7 +119,7 @@ describe("settings routes (schema validation, #482)", () => {
   it("does NOT admin-gate a foreign route sharing the /settings prefix", async () => {
     // The hook matches the exact settings path, so /api/v1/settings/energy/tariff
     // (owned by energy.ts, which self-guards) is reachable by a non-admin here.
-    app = await buildApp({ authed: true, role: "user" });
+    app = await buildApp({ authed: true, role: "standard" });
     const res = await app.inject({ method: "GET", url: "/api/v1/settings/energy/tariff" });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ ok: true });

--- a/src/api/routes/system.test.ts
+++ b/src/api/routes/system.test.ts
@@ -3,12 +3,13 @@ import { describe, it, expect, afterEach } from "vitest";
 import { createLogger } from "../../core/logger.js";
 import { registerSystemRoutes, type TzInfo } from "./system.js";
 import type { SunlightManager, SunlightData } from "../../zones/sunlight-manager.js";
+import type { UserRole } from "../../shared/types.js";
 
 const logger = createLogger("silent").logger;
 
 interface BuildOpts {
   authed?: boolean;
-  role?: "admin" | "user" | "viewer";
+  role?: UserRole;
   sunlight?: SunlightData;
   shadowMode?: boolean;
   takeoverPending?: boolean;
@@ -142,7 +143,7 @@ describe("POST /api/v1/system/takeover", () => {
   });
 
   it("rejects non-admin callers with 403", async () => {
-    openApp = await buildApp({ authed: true, role: "user", takeoverPending: true });
+    openApp = await buildApp({ authed: true, role: "standard", takeoverPending: true });
     const res = await openApp.inject({ method: "POST", url: "/api/v1/system/takeover" });
     expect(res.statusCode).toBe(403);
   });

--- a/src/auth/auth-middleware.test.ts
+++ b/src/auth/auth-middleware.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./auth-middleware.js";
 import type { AuthService, JwtPayload } from "./auth-service.js";
 import type { UserManager } from "./user-manager.js";
+import type { FastifyRequest } from "fastify";
 
 const logger = createLogger("silent").logger;
 
@@ -88,7 +89,7 @@ describe("auth-middleware", () => {
         logger,
       });
       // Fake protected route
-      app.get("/api/v1/test", async (req) => ({ auth: req.auth }));
+      app.get("/api/v1/test", async (req: FastifyRequest) => ({ auth: req.auth }));
       app.get("/api/v1/health", async () => ({ status: "ok" }));
       app.post("/api/v1/auth/setup", async () => ({ ok: true }));
       app.get("/non-api/foo", async () => ({ ok: true }));

--- a/src/core/event-bus.test.ts
+++ b/src/core/event-bus.test.ts
@@ -29,17 +29,21 @@ describe("EventBus", () => {
   });
 
   it("onType filters by event type", () => {
+    // The types here used to be `system.mqtt.connected` / `.disconnected`,
+    // which no longer exist in EngineEvent and could never be emitted, so the
+    // filter was being exercised against something the engine cannot produce.
+    // Invisible while test files were excluded from the typecheck (#834).
     const bus = new EventBus(logger);
     const received: EngineEvent[] = [];
 
-    bus.onType("system.mqtt.connected", (event) => received.push(event));
+    bus.onType("system.integration.connected", (event) => received.push(event));
 
     bus.emit({ type: "system.started" });
-    bus.emit({ type: "system.mqtt.connected" });
-    bus.emit({ type: "system.mqtt.disconnected" });
+    bus.emit({ type: "system.integration.connected", integrationId: "z2m" });
+    bus.emit({ type: "system.integration.disconnected", integrationId: "z2m" });
 
     expect(received).toHaveLength(1);
-    expect(received[0].type).toBe("system.mqtt.connected");
+    expect(received[0].type).toBe("system.integration.connected");
   });
 
   it("catches handler errors without crashing", () => {

--- a/src/core/shutdown-controller.test.ts
+++ b/src/core/shutdown-controller.test.ts
@@ -18,11 +18,14 @@ function makeLogger() {
 }
 
 describe("createShutdownController", () => {
-  let exit: ReturnType<typeof vi.fn>;
+  // Typed with the real signature rather than a bare `vi.fn`: an untyped mock
+  // is not assignable to `exit?: (code: number) => void`, which is invisible
+  // while test files are excluded from the typecheck (#834).
+  let exit: ReturnType<typeof vi.fn<(code: number) => void>>;
   let logger: ReturnType<typeof makeLogger>;
 
   beforeEach(() => {
-    exit = vi.fn();
+    exit = vi.fn<(code: number) => void>();
     logger = makeLogger();
     vi.useFakeTimers();
   });
@@ -183,11 +186,11 @@ describe("createShutdownController", () => {
 });
 
 describe("createShutdownController — install()", () => {
-  let exit: ReturnType<typeof vi.fn>;
+  let exit: ReturnType<typeof vi.fn<(code: number) => void>>;
   let before: { int: number; term: number };
 
   beforeEach(() => {
-    exit = vi.fn();
+    exit = vi.fn<(code: number) => void>();
     before = {
       int: process.listenerCount("SIGINT"),
       term: process.listenerCount("SIGTERM"),

--- a/src/devices/device-manager.test.ts
+++ b/src/devices/device-manager.test.ts
@@ -764,47 +764,43 @@ describe("DeviceManager", () => {
     };
 
     it("returns null for an unknown device", () => {
-      expect(manager.getDeviceDataValue("shelly_mqtt", "ghost", "energy_forward")).toBeNull();
+      expect(manager.getDeviceDataValue("shelly", "ghost", "energy_forward")).toBeNull();
     });
 
     it("returns null for an unknown key on an existing device", () => {
-      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
+      manager.upsertFromDiscovery("shelly", "shelly", sampleEm);
       expect(
-        manager.getDeviceDataValue("shelly_mqtt", "shelly-pro3em_00-em0", "missing_key"),
+        manager.getDeviceDataValue("shelly", "shelly-pro3em_00-em0", "missing_key"),
       ).toBeNull();
     });
 
     it("returns null when the key value has never been written", () => {
-      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
+      manager.upsertFromDiscovery("shelly", "shelly", sampleEm);
       expect(
-        manager.getDeviceDataValue("shelly_mqtt", "shelly-pro3em_00-em0", "energy_forward"),
+        manager.getDeviceDataValue("shelly", "shelly-pro3em_00-em0", "energy_forward"),
       ).toBeNull();
     });
 
     it("returns the numeric value for a number-typed key", () => {
-      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
-      manager.updateDeviceData("shelly_mqtt", "shelly-pro3em_00-em0", {
+      manager.upsertFromDiscovery("shelly", "shelly", sampleEm);
+      manager.updateDeviceData("shelly", "shelly-pro3em_00-em0", {
         energy_forward: 6105.7,
       });
-      expect(
-        manager.getDeviceDataValue("shelly_mqtt", "shelly-pro3em_00-em0", "energy_forward"),
-      ).toBe(6105.7);
+      expect(manager.getDeviceDataValue("shelly", "shelly-pro3em_00-em0", "energy_forward")).toBe(
+        6105.7,
+      );
     });
 
     it("returns the boolean value for a boolean-typed key", () => {
-      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
-      manager.updateDeviceData("shelly_mqtt", "shelly-pro3em_00-em0", { online: true });
-      expect(manager.getDeviceDataValue("shelly_mqtt", "shelly-pro3em_00-em0", "online")).toBe(
-        true,
-      );
+      manager.upsertFromDiscovery("shelly", "shelly", sampleEm);
+      manager.updateDeviceData("shelly", "shelly-pro3em_00-em0", { online: true });
+      expect(manager.getDeviceDataValue("shelly", "shelly-pro3em_00-em0", "online")).toBe(true);
     });
 
     it("returns the string value for a text-typed key", () => {
-      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
-      manager.updateDeviceData("shelly_mqtt", "shelly-pro3em_00-em0", { label: "main" });
-      expect(manager.getDeviceDataValue("shelly_mqtt", "shelly-pro3em_00-em0", "label")).toBe(
-        "main",
-      );
+      manager.upsertFromDiscovery("shelly", "shelly", sampleEm);
+      manager.updateDeviceData("shelly", "shelly-pro3em_00-em0", { label: "main" });
+      expect(manager.getDeviceDataValue("shelly", "shelly-pro3em_00-em0", "label")).toBe("main");
     });
   });
 
@@ -822,23 +818,23 @@ describe("DeviceManager", () => {
     };
 
     it("returns null for an unknown device", () => {
-      expect(manager.getDeviceDataLastUpdated("shelly_mqtt", "ghost", "energy_forward")).toBeNull();
+      expect(manager.getDeviceDataLastUpdated("shelly", "ghost", "energy_forward")).toBeNull();
     });
 
     it("returns null when the key has never been written", () => {
-      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
+      manager.upsertFromDiscovery("shelly", "shelly", sampleEm);
       expect(
-        manager.getDeviceDataLastUpdated("shelly_mqtt", "shelly-pro3em_00-em0", "energy_forward"),
+        manager.getDeviceDataLastUpdated("shelly", "shelly-pro3em_00-em0", "energy_forward"),
       ).toBeNull();
     });
 
     it("returns an ISO 8601 UTC timestamp after a write", () => {
-      manager.upsertFromDiscovery("shelly_mqtt", "shelly_mqtt", sampleEm);
-      manager.updateDeviceData("shelly_mqtt", "shelly-pro3em_00-em0", {
+      manager.upsertFromDiscovery("shelly", "shelly", sampleEm);
+      manager.updateDeviceData("shelly", "shelly-pro3em_00-em0", {
         energy_forward: 6105.7,
       });
       const ts = manager.getDeviceDataLastUpdated(
-        "shelly_mqtt",
+        "shelly",
         "shelly-pro3em_00-em0",
         "energy_forward",
       );

--- a/src/energy/capacity-arbiter.test.ts
+++ b/src/energy/capacity-arbiter.test.ts
@@ -2221,7 +2221,7 @@ describe("resolved load roster (spec 165)", () => {
       profiles: { lamp: { class: "deferrable", nominalPowerW: 100, minOnS: 0, minOffS: 0 } },
     });
     h.equipments.set("lamp", {
-      ...(h.equipments.get("lamp") as never),
+      ...(h.equipments.get("lamp") as unknown as Record<string, unknown>),
       energyProfile: { class: "deferrable", nominalPowerW: 100, minOnS: 0, minOffS: 0 },
     } as never);
     h.claim("lampI", { equipmentId: "lamp" });

--- a/src/equipments/equipment-manager.test.ts
+++ b/src/equipments/equipment-manager.test.ts
@@ -858,7 +858,7 @@ describe("EquipmentManager", () => {
       const eq = manager.create({ name: "Spots", type: "light_onoff", zoneId: zone.id });
       const { orderIds } = seedDevice(db, {
         name: "Switch",
-        orderKeys: [{ key: "state", payloadKey: "state" }],
+        orderKeys: [{ key: "state" }],
       });
       manager.addOrderBinding(eq.id, orderIds[0], "state");
 
@@ -901,10 +901,7 @@ describe("EquipmentManager", () => {
       const eq = manager.create({ name: "VMC", type: "vmc", zoneId: zone.id });
       const { orderIds } = seedDevice(db, {
         name: "MiniDuo",
-        orderKeys: [
-          { key: "l1", payloadKey: "l1" },
-          { key: "l2", payloadKey: "l2" },
-        ],
+        orderKeys: [{ key: "l1" }, { key: "l2" }],
       });
       manager.addOrderBinding(eq.id, orderIds[0], "low");
       manager.addOrderBinding(eq.id, orderIds[1], "high");
@@ -936,7 +933,7 @@ describe("EquipmentManager", () => {
       const eq = manager.create({ name: "Extracteur", type: "vmc", zoneId: zone.id });
       const { orderIds } = seedDevice(db, {
         name: "Relay",
-        orderKeys: [{ key: "state", payloadKey: "state" }],
+        orderKeys: [{ key: "state" }],
       });
       manager.addOrderBinding(eq.id, orderIds[0], "low");
 
@@ -950,10 +947,7 @@ describe("EquipmentManager", () => {
         const eq = manager.create({ name: "VMC", type: "vmc", zoneId: zone.id });
         const { orderIds } = seedDevice(db, {
           name: "MiniDuo",
-          orderKeys: [
-            { key: "l1", payloadKey: "l1" },
-            { key: "l2", payloadKey: "l2" },
-          ],
+          orderKeys: [{ key: "l1" }, { key: "l2" }],
         });
         manager.addOrderBinding(eq.id, orderIds[0], "low");
         manager.addOrderBinding(eq.id, orderIds[1], "high");
@@ -975,8 +969,8 @@ describe("EquipmentManager", () => {
     it.skip("dispatches to multiple devices (multi-device)", async () => {
       const zone = zoneManager.create({ name: "Salon" });
       const eq = manager.create({ name: "All Lights", type: "light_onoff", zoneId: zone.id });
-      const d1 = seedDevice(db, { name: "L1", orderKeys: [{ key: "state", payloadKey: "state" }] });
-      const d2 = seedDevice(db, { name: "L2", orderKeys: [{ key: "state", payloadKey: "state" }] });
+      const d1 = seedDevice(db, { name: "L1", orderKeys: [{ key: "state" }] });
+      const d2 = seedDevice(db, { name: "L2", orderKeys: [{ key: "state" }] });
       manager.addOrderBinding(eq.id, d1.orderIds[0], "state");
       manager.addOrderBinding(eq.id, d2.orderIds[0], "state");
 
@@ -1597,7 +1591,8 @@ describe("EquipmentManager", () => {
             key: "shutter_position",
             type: "number",
             category: "shutter_position",
-            value: positionValue,
+            // `null` means "no value seeded"; the option is optional, not nullable.
+            value: positionValue ?? undefined,
           },
         ],
       });
@@ -1783,6 +1778,8 @@ describe("deriveCoverState", () => {
       value,
       lastUpdated: null,
       lastChanged: null,
+      // Spec 116 added this to DataBindingWithValue; the fixture predates it.
+      stale: false,
     };
   }
 

--- a/src/equipments/equipment-status-tracker.test.ts
+++ b/src/equipments/equipment-status-tracker.test.ts
@@ -205,9 +205,9 @@ describe("EquipmentStatusTracker", () => {
       // Arm the 200ms debounce the way live device traffic does.
       bus.emit({
         type: "equipment.updated",
-        equipmentId: "eq-1",
-        equipmentName: "Eq",
-        zoneId: "z",
+        // The event carries the whole Equipment; the flat fields this used to
+        // pass were a shape the bus cannot produce (#834).
+        equipment: makeEquipment("eq-1", "online"),
       });
 
       // Swap in a manager that behaves like a closed database, then shut down.

--- a/src/equipments/equipment-status.test.ts
+++ b/src/equipments/equipment-status.test.ts
@@ -15,6 +15,8 @@ function makeDevice(overrides: Partial<Device>): Device {
     zoneId: null,
     source: "zigbee2mqtt",
     status: "online",
+    // Spec 143 added this to Device; the fixture predates it.
+    powerSource: "unknown",
     lastSeen: "2026-05-26 09:59:50Z",
     createdAt: "2026-01-01 00:00:00Z",
     updatedAt: "2026-05-26 09:59:50Z",

--- a/src/equipments/pool-runtime-tracker.test.ts
+++ b/src/equipments/pool-runtime-tracker.test.ts
@@ -226,7 +226,9 @@ describe("PoolRuntimeTracker", () => {
       type: "equipment.removed",
       equipmentId: eqId,
       equipmentName: "Pompe",
-      zoneId: null,
+      // `zoneId` is a string on the event, as it is on Equipment: a removed
+      // equipment always had a zone.
+      zoneId: "zone-1",
     });
 
     const row = db.prepare("SELECT * FROM pool_runtime_state WHERE equipment_id = ?").get(eqId);

--- a/src/modes/mode-manager.test.ts
+++ b/src/modes/mode-manager.test.ts
@@ -211,7 +211,13 @@ describe("ModeManager", () => {
       const impacts = manager.getImpactsByMode(modeId);
       expect(impacts).toHaveLength(1);
       expect(impacts[0].actions).toHaveLength(2);
-      expect(impacts[0].actions[0].value).toBe("OFF");
+      // ZoneModeImpactAction is a union and only the `order` variant carries
+      // a value; asserting on it unnarrowed was reading a property the type
+      // does not have on every branch (#834).
+      const action = impacts[0].actions[0];
+      expect(action.type).toBe("order");
+      if (action.type !== "order") throw new Error("expected an order action");
+      expect(action.value).toBe("OFF");
     });
 
     it("removes a zone impact", () => {

--- a/src/mqtt-publishers/mqtt-publish-service.test.ts
+++ b/src/mqtt-publishers/mqtt-publish-service.test.ts
@@ -66,8 +66,8 @@ describe("MqttPublishService — disabled mappings are skipped", () => {
     const broker = brokerManager.create({
       name: "B",
       url: "mqtt://x",
-      username: null,
-      password: null,
+      username: undefined,
+      password: undefined,
     });
     brokerId = broker.id;
     const pub = publisherManager.create({
@@ -115,12 +115,14 @@ describe("MqttPublishService — disabled mappings are skipped", () => {
       equipmentId: "eq-A",
       alias: "temperature",
       value: 22,
+      previous: undefined,
     });
     eventBus.emit({
       type: "equipment.data.changed",
       equipmentId: "eq-B",
       alias: "temperature",
       value: 99,
+      previous: undefined,
     });
 
     const calls = fakeClient.publish.mock.calls;
@@ -228,8 +230,8 @@ describe("MqttPublishService — clientId uniqueness and reconnect log throttlin
     const broker = brokerManager.create({
       name: "B",
       url: "mqtt://x",
-      username: null,
-      password: null,
+      username: undefined,
+      password: undefined,
     });
     brokerId = broker.id;
   });

--- a/src/plugins/scoped-deps.test.ts
+++ b/src/plugins/scoped-deps.test.ts
@@ -220,7 +220,7 @@ describe("DeviceManagerProxy", () => {
     const inner = makeMockDeviceManager();
     const proxy = makeDeviceManagerProxy("zigbee2mqtt", inner, logger);
     expect(() =>
-      proxy.upsertFromDiscovery("netatmo", "cloud", {
+      proxy.upsertFromDiscovery("netatmo", "netatmo_hc", {
         friendlyName: "x",
         data: [],
         orders: [],
@@ -233,14 +233,14 @@ describe("DeviceManagerProxy", () => {
   it("allows upsertFromDiscovery on own integrationId", () => {
     const inner = makeMockDeviceManager();
     const proxy = makeDeviceManagerProxy("zigbee2mqtt", inner, logger);
-    proxy.upsertFromDiscovery("zigbee2mqtt", "mqtt", {
+    proxy.upsertFromDiscovery("zigbee2mqtt", "zigbee2mqtt", {
       friendlyName: "bulb_1",
       data: [],
       orders: [],
     });
     expect(inner.upsertFromDiscovery).toHaveBeenCalledWith(
       "zigbee2mqtt",
-      "mqtt",
+      "zigbee2mqtt",
       expect.objectContaining({ friendlyName: "bulb_1" }),
     );
   });

--- a/src/recipes/engine/recipe-manager.test.ts
+++ b/src/recipes/engine/recipe-manager.test.ts
@@ -31,6 +31,18 @@ let capturedSun: {
 let capturedTariff: RecipeTariff | null = null;
 
 /**
+ * Read what the recipe captured.
+ *
+ * `capturedTariff` is assigned inside a recipe callback, which control-flow
+ * analysis cannot see, so a direct read narrows to `null` and every property
+ * access is typed `never`. Invisible while test files were excluded from the
+ * typecheck (#834).
+ */
+function readCapturedTariff(): RecipeTariff | null {
+  return capturedTariff;
+}
+
+/**
  * Backing config for the mock classifier. Handed out by reference on purpose —
  * that is what the real TariffClassifier does, and it is what lets the tests
  * prove the snapshot is copied out rather than aliased.
@@ -250,13 +262,15 @@ describe("RecipeManager", () => {
     capturedTariff = null;
     manager.createInstance("tariff-set", {});
 
-    expect(capturedTariff?.configured).toBe(true);
+    expect(readCapturedTariff()?.configured).toBe(true);
     // Only HC slots, and only the schedule covering today.
-    expect(capturedTariff?.offPeakToday).toEqual([{ start: "22:00", end: "06:00", tariff: "hc" }]);
+    expect(readCapturedTariff()?.offPeakToday).toEqual([
+      { start: "22:00", end: "06:00", tariff: "hc" },
+    ]);
     // Prices are commercial data and must never reach a recipe package.
-    expect(capturedTariff).not.toHaveProperty("prices");
-    expect(JSON.stringify(capturedTariff)).not.toContain("0.2516");
-    expect(JSON.stringify(capturedTariff)).not.toContain("0.2068");
+    expect(readCapturedTariff()).not.toHaveProperty("prices");
+    expect(JSON.stringify(readCapturedTariff())).not.toContain("0.2516");
+    expect(JSON.stringify(readCapturedTariff())).not.toContain("0.2068");
   });
 
   it("resolves whether the current time is off-peak across a midnight wrap", () => {
@@ -280,7 +294,7 @@ describe("RecipeManager", () => {
     capturedTariff = null;
     manager.createInstance("tariff-wrap", {});
 
-    expect(capturedTariff?.isOffPeakNow).toBe(true);
+    expect(readCapturedTariff()?.isOffPeakNow).toBe(true);
   });
 
   it("hands recipes a copy — mutating the snapshot cannot corrupt the config", () => {
@@ -305,7 +319,9 @@ describe("RecipeManager", () => {
     // And the next reader still sees the real schedule.
     capturedTariff = null;
     manager.createInstance("tariff-copy", {});
-    expect(capturedTariff?.offPeakToday).toEqual([{ start: "22:00", end: "06:00", tariff: "hc" }]);
+    expect(readCapturedTariff()?.offPeakToday).toEqual([
+      { start: "22:00", end: "06:00", tariff: "hc" },
+    ]);
   });
 
   it("exposes ctx.helpers.getSunlight() to a running instance", () => {

--- a/src/shared/binding-candidates.test.ts
+++ b/src/shared/binding-candidates.test.ts
@@ -111,7 +111,7 @@ describe("computeBindingCandidates", () => {
   });
 
   it("shutter with neither key-name nor category match → no candidates (unchanged behavior)", () => {
-    const orders = [order("foo", "number", { category: "generic" })];
+    const orders = [order("foo", "number", { category: "toggle_mute" })];
     const result = computeBindingCandidates("shutter", [], orders);
     expect(result).toHaveLength(0);
   });
@@ -251,7 +251,7 @@ describe("computeBindingCandidates", () => {
   });
 
   it("light_onoff ignores a non-power boolean toggle (config switch)", () => {
-    const orders = [order("child_lock", "boolean", { category: "toggle_lock" })];
+    const orders = [order("child_lock", "boolean", { category: "toggle_mute" })];
     const result = computeBindingCandidates("light_onoff", [], orders);
     expect(result).toHaveLength(0);
   });
@@ -289,7 +289,7 @@ describe("computeBindingCandidates", () => {
   });
 
   it("water_heater ignores a device with no on/off channel", () => {
-    const orders = [order("child_lock", "boolean", { category: "toggle_lock" })];
+    const orders = [order("child_lock", "boolean", { category: "toggle_mute" })];
     const result = computeBindingCandidates("water_heater", [], orders);
     expect(result).toHaveLength(0);
   });

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## The gap

`tsconfig.json` excludes `**/*.test.ts`, so `npm run typecheck` and the CI job that runs it never looked at a single test file. A test could assert on a type that does not exist and CI stayed green.

Three of the 75 errors are exactly that, and they are not slips of syntax. They are tests exercising values the engine cannot produce, which read as coverage and are not:

- **`event-bus.test.ts`** filtered `onType` on `system.mqtt.connected` and `system.mqtt.disconnected`. Neither exists in `EngineEvent`, anywhere in `src`. The filter was being proven against something that can never arrive. It now uses `system.integration.connected`, which the engine does emit.
- **`equipment-status-tracker.test.ts`** emitted `equipment.updated` with flat `equipmentId` / `equipmentName` / `zoneId` fields. That event carries the whole `Equipment`, so the debounce the test was arming was armed by a shape the bus cannot produce.
- **Seven route tests** declared roles `"user"` and `"viewer"`. `UserRole` is `admin | standard`. Every "a non-admin is refused" assertion in those files was about a value that has never existed, while the one real non-admin role went untested. This is how the same mistake reached #651's own new test, which is what surfaced this issue.

## The rest

Drift, each naming the type that moved under the test: a `Device` fixture predating `powerSource` (spec 143), a `DataBindingWithValue` predating `stale` (spec 116), `equipment.data.changed` without the `previous` field the edge guard needs, `"shelly_mqtt"` where the `DeviceSource` is `shelly`, `"generic"` used as an `OrderCategory` when it is a `DataCategory`, a dead `payloadKey` option that exists nowhere in `src`, and `ZoneModeImpactAction` read for a `value` only one branch of the union has.

Two are worth naming as patterns rather than one-off fixes:

- `Parameters<typeof X.prototype.constructor>` resolves through `Function`, which has no parameter list. `ConstructorParameters<typeof X>` is the operator for it.
- `let captured: T | null = null` narrows to `null`, and an assignment inside a callback is invisible to control-flow analysis, so every later read was typed `never`. Assertions on a `never` cannot be checking what they appear to.

## No behaviour changed

2227 tests pass before and after. Where a literal had to change, the replacement was chosen to keep the test's meaning and then verified by running it, not by assuming: the two `binding-candidates` cases wanted "a real category the rule does not recognise", and the substitutions still yield zero candidates.

## The gate

`tsconfig.test.json` adds the coverage, `npm run typecheck:tests` runs it, `validate` and the CI backend job both call it. **Blocking from the start**, because the count is at zero and the point is to keep it there rather than to watch it grow.

The UI is unaffected: `ui/tsconfig` already typechecks its own tests, which is why the UI suite had no equivalent backlog.

Docs-Impact: none — the change is a build gate plus test-file corrections; nothing an operator or a reader can observe changed, and the one behaviour-adjacent finding (an `equipment.updated` payload shape) was wrong in the test, not in the engine. The new command is documented where a contributor looks for it, in CLAUDE.md's build section, which sits outside `docs/`.

Closes #834
