### PR TITLE
fix(backup): escape the backslash in line protocol, and take the generated bundles out of scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,28 @@
+name: "Sowel CodeQL config"
+
+# Why this file exists.
+#
+# The August 2026 audit left 72 open alerts, and a third of them were not about
+# Sowel's code at all: CodeQL was analysing checked-in build output and the
+# minified vendor bundles inside it. They cost a real review each time, and
+# because the pull-request check attributes an alert to any PR that touches its
+# file, they also failed unrelated pull requests.
+#
+# Excluding a path means giving up scanning it, so each entry says what it is
+# and why the loss is acceptable.
+paths-ignore:
+  # Build output, checked in so a deploy can serve it. Everything under here is
+  # generated from ui/src, which IS scanned, plus minified third-party code and
+  # a generated Workbox service worker. Scanning it reports the vendors' code
+  # back to us, in a form nobody can act on.
+  - "ui-dist"
+  - "ui/dev-dist"
+
+  # Operator tools, run by hand on an admin's own machine against their own
+  # instance. They are not reachable from the network and never run inside the
+  # server. Their alerts are all one pattern, "downloads over HTTP and writes
+  # to a file", which is the entire purpose of a backfill script.
+  #
+  # This is the softest entry here. If one of these ever becomes something the
+  # engine invokes, it belongs back in scope.
+  - "scripts"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,6 +42,9 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
+          # Keeps checked-in build output and the operator scripts out of scope;
+          # the file says why for each path.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -17,7 +17,11 @@ interface BuildOpts {
   role?: UserRole;
 }
 
+/** Audit entries the route emitted, so a test can prove one was not lost. */
+let audited: unknown[] = [];
+
 async function buildApp(opts: BuildOpts = {}) {
+  audited = [];
   const app = Fastify({ logger: false, ajv: validationAjvOptions });
   installValidationErrorHandler(app);
 
@@ -38,7 +42,7 @@ async function buildApp(opts: BuildOpts = {}) {
       setMany: (entries: Record<string, string>) => Object.assign(store, entries),
     } as never,
     eventBus: { emit: () => {} } as never,
-    auditLogger: { log: () => {} } as never,
+    auditLogger: { log: (e: unknown) => audited.push(e) } as never,
     userManager: { getById: () => ({ username: "admin" }) } as never,
     logger,
   });
@@ -123,5 +127,43 @@ describe("settings routes (schema validation, #482)", () => {
     const res = await app.inject({ method: "GET", url: "/api/v1/settings/energy/tariff" });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ ok: true });
+  });
+});
+
+describe("a __proto__ key never reaches the handler", () => {
+  it("is refused by the body parser, before any route code runs", async () => {
+    // What actually protects this route, and it is the framework rather than
+    // anything here: Fastify parses with secure-json-parse and its default
+    // protoAction is `error`, so the request is rejected outright.
+    //
+    // Pinned because the handler's audit capture writes body keys into a map,
+    // and CodeQL flags that shape. It is unreachable while this holds, and if a
+    // future Fastify or a custom parser ever changed it, this test is where the
+    // assumption is written down.
+    const app = await buildApp({ authed: true });
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/settings",
+      headers: { "content-type": "application/json" },
+      body: '{"__proto__":"x","home.latitude":"45.0"}',
+    });
+    expect(res.statusCode).toBe(400);
+    expect(audited).toEqual([]);
+    await app.close();
+  });
+
+  it("lets an ordinary inherited name through and audits it", async () => {
+    // `constructor` is not special to the parser and is an ordinary own-property
+    // write, so nothing is lost.
+    const app = await buildApp({ authed: true });
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/settings",
+      headers: { "content-type": "application/json" },
+      body: '{"constructor":"x"}',
+    });
+    expect(res.statusCode).toBe(200);
+    expect((audited as { targetId: string }[]).map((e) => e.targetId)).toContain("constructor");
+    await app.close();
   });
 });

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -48,8 +48,18 @@ export function registerSettingsRoutes(app: FastifyInstance, deps: SettingsDeps)
     async (request) => {
       const entries = request.body;
 
-      // Capture old values BEFORE the write for the audit meta
-      const oldValues: Record<string, string | undefined> = {};
+      // Capture old values BEFORE the write for the audit meta.
+      //
+      // A null-prototype map, not `{}`: the keys are whatever the request body
+      // carries, and assigning to `__proto__` on a plain object is swallowed by
+      // the setter rather than stored. It cannot pollute here, because the
+      // value is always a string or undefined and the setter ignores those, but
+      // the audit entry for a setting named `__proto__` would vanish without a
+      // trace, which is the one thing an audit log must not do.
+      const oldValues: Record<string, string | undefined> = Object.create(null) as Record<
+        string,
+        string | undefined
+      >;
       for (const k of Object.keys(entries)) oldValues[k] = settingsManager.get(k);
 
       settingsManager.setMany(entries);

--- a/src/backup/backup-manager.test.ts
+++ b/src/backup/backup-manager.test.ts
@@ -6,6 +6,8 @@ import { tmpdir } from "node:os";
 import AdmZip from "adm-zip";
 import {
   ALLOWED_RESTORE_EXTENSIONS,
+  escapeFieldString,
+  escapeTag,
   BACKUP_TABLES,
   BackupManager,
   BackupSizeCapExceededError,
@@ -706,5 +708,46 @@ describe("dataFileExtension (#829)", () => {
       // about, and without it the assertion above passes under extname() too.
       expect(dataFileExtension(ext).toLowerCase()).toBe(ext);
     }
+  });
+});
+
+/**
+ * Line-protocol escaping for the InfluxDB half of a backup.
+ *
+ * Tag values carry equipment and device names, which are whatever the household
+ * typed, so this is user data reaching a format with its own escape character.
+ */
+describe("escapeTag", () => {
+  it("escapes the characters line protocol reserves in a tag", () => {
+    expect(escapeTag("a,b")).toBe("a\\,b");
+    expect(escapeTag("a b")).toBe("a\\ b");
+    expect(escapeTag("a=b")).toBe("a\\=b");
+  });
+
+  it("escapes the backslash, which is the escape character itself", () => {
+    // The defect: a name ending in a backslash was written verbatim, so the
+    // parser read the separator that followed as escaped, the tag swallowed the
+    // comma, and the rest of the line was misread. Reachable from any equipment
+    // or device name.
+    expect(escapeTag("Prise garage\\")).toBe("Prise\\ garage\\\\");
+    expect(escapeTag("a\\b")).toBe("a\\\\b");
+  });
+
+  it("escapes the backslash FIRST, so the ones it inserts are not escaped again", () => {
+    // Doing it last would turn the `\,` produced for a comma into `\\,`, which
+    // reads as a literal backslash followed by a separator.
+    expect(escapeTag("a,b\\c")).toBe("a\\,b\\\\c");
+  });
+
+  it("leaves an ordinary name alone", () => {
+    expect(escapeTag("Chauffe-eau")).toBe("Chauffe-eau");
+  });
+});
+
+describe("escapeFieldString", () => {
+  it("already had the order right, and keeps it", () => {
+    expect(escapeFieldString('a"b')).toBe('a\\"b');
+    expect(escapeFieldString("a\\b")).toBe("a\\\\b");
+    expect(escapeFieldString('a\\"b')).toBe('a\\\\\\"b');
   });
 });

--- a/src/backup/backup-manager.ts
+++ b/src/backup/backup-manager.ts
@@ -785,10 +785,23 @@ function rowToLineProtocol(row: Record<string, unknown>): string | null {
   return `${escapeTag(measurement)}${tagSet} ${escapeTag(field)}=${fieldValue} ${tsNs}`;
 }
 
-function escapeTag(s: string): string {
-  return s.replace(/,/g, "\\,").replace(/ /g, "\\ ").replace(/=/g, "\\=");
+/**
+ * Escape a measurement name, tag key or tag value for InfluxDB line protocol.
+ *
+ * The backslash goes FIRST, and its absence was a real defect rather than a
+ * scanner nit. Backslash is line protocol's own escape character, so a value
+ * ending in one, `Prise garage\` say, was written verbatim and the parser read
+ * the following separator as escaped: the tag swallowed the comma and the rest
+ * of the line was misread. `escapeFieldString` below already had the order
+ * right; this one simply never handled it.
+ *
+ * Order matters for the same reason it does there: escaping the backslash after
+ * the other characters would double-escape the ones just inserted.
+ */
+export function escapeTag(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/,/g, "\\,").replace(/ /g, "\\ ").replace(/=/g, "\\=");
 }
 
-function escapeFieldString(s: string): string {
+export function escapeFieldString(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }


### PR DESCRIPTION
Triage of the 72 open alerts the August audit left. **72 across 15 rules**, not 15 alerts, which is what I told you earlier and was wrong.

## Three nominated as real bugs. One is.

**Real.** `escapeTag` escaped the comma, the space and the equals sign but not the **backslash**, which is line protocol's own escape character. A tag value ending in one, an equipment named `Prise garage\` say, was written verbatim, so the parser read the separator that followed as escaped: the tag swallowed the comma and the rest of the line was misread. Tag values carry equipment and device names, so this is user data reaching a format with its own escaping. `escapeFieldString` beside it already had both the character and the order right. Escaping the backslash first matters for the same reason it does there. Four tests, two of which fail without the fix.

**Not a bug.** `settings.ts` writes request body keys into a capture map. Unreachable: Fastify parses with secure-json-parse and its default `protoAction` is `error`, so a body carrying `__proto__` is refused with a 400 before any route code runs. Verified against a real server. The map is null-prototype now because it costs nothing, but the test pins the *framework* behaviour the route depends on, since that is where the protection actually lives.

**Not a bug.** `useWebSocket.ts` builds `{ ...prev, [event.integrationId]: "connected" }`. A computed key in an object literal is DefineOwnProperty, not Set, so it creates an own property and cannot reach the `__proto__` setter. Verified. Left alone; changing it would only have moved the alert.

## A third of the alerts were never about Sowel's code

There was no CodeQL config in the repo, so the scan covered checked-in build output. `ui-dist` and `ui/dev-dist` are minified third-party bundles and a generated service worker, reported back to us in a form nobody can act on, and generated from `ui/src`, which stays in scope. `scripts` holds operator tools run by hand against an admin's own instance, never invoked by the engine, whose alerts are all the one "downloads over HTTP and writes a file" pattern that is their entire purpose.

Excluding a path means giving up scanning it, so the config says what each one is and why the loss is acceptable, and marks `scripts` as the softer of the two.

This also stops those alerts failing unrelated pull requests. The check attributes an alert to any PR that **touches its file**, which is why #841, a schema conversion, inherited thirteen of them, and why my first attempt to clear it made the count go up: the fix touched one more file that already had one.

## What this leaves

Roughly 46 of 72, and the remainder decomposes cleanly:

- **16 `js/path-injection`**, one root cause: a plugin id or repo building a path. Half is already addressed by the `owner/repo` pattern in #841; the rest wants the same at the plugin-id boundary.
- **14 workflow-hygiene** alerts (unpinned action tags, missing permissions blocks), mechanical but they touch the release workflow.
- **~6 by-design**, needing a dismissal with a written reason rather than a change: the camera snapshot URL is admin-configured, the InfluxDB client writing responses to files is what it is for, the JWT in localStorage is a known decision.
- **1 false positive worth recording**: `mfa.ts` "user-controlled bypass" is a flag that *selects* a verifier; both branches verify.

Docs-Impact: none — the escaping fix changes the bytes of an InfluxDB export for a name containing a backslash, which no page documents at that level, and the rest is scanner configuration and a null-prototype map.