### PR TITLE
fix(packages): check the package id where it becomes a path

### DIFF
--- a/src/backup/backup-manager.test.ts
+++ b/src/backup/backup-manager.test.ts
@@ -216,6 +216,29 @@ describe("BackupManager", () => {
       await expect(manager.restoreFromFile("..\\windows")).rejects.toThrow(/Invalid filename/);
     });
 
+    it("rejects the shapes the old blacklist let through", async () => {
+      // "." and ".." carry no separator, so a check spelled as "contains / or
+      // \\ or .." missed the first one entirely and the name resolved to the
+      // backups directory itself.
+      // "  " is deliberately absent: a file named two spaces is odd but it
+      // cannot escape the directory, and refusing it would be a rule about
+      // taste rather than about safety.
+      for (const name of [".", "", ".."]) {
+        await expect(manager.restoreFromFile(name)).rejects.toThrow(/Invalid filename/);
+      }
+    });
+
+    it("refuses a path rather than quietly reading its last segment", async () => {
+      // Taking the basename would have turned this into a request for a real
+      // file inside data/backups. Answering a question nobody asked is worse
+      // than refusing.
+      mkdirSync(resolve(tmpDir, "backups"), { recursive: true });
+      writeFileSync(resolve(tmpDir, "backups", "real.zip"), "x");
+      await expect(manager.restoreFromFile("../backups/real.zip")).rejects.toThrow(
+        /Invalid filename/,
+      );
+    });
+
     it("rejects when file does not exist", async () => {
       mkdirSync(resolve(tmpDir, "backups"));
       await expect(manager.restoreFromFile("missing.zip")).rejects.toThrow(/not found/);

--- a/src/backup/backup-manager.ts
+++ b/src/backup/backup-manager.ts
@@ -374,13 +374,34 @@ export class BackupManager {
   }
 
   async restoreFromFile(filename: string): Promise<RestoreResult> {
-    // Reject path traversal
-    if (filename.includes("/") || filename.includes("\\") || filename.includes("..")) {
+    // The filename names a file in data/backups and nothing else. This used to
+    // be a blacklist of "/", "\\" and "..", which is the wrong shape for the
+    // job: it has to anticipate every spelling of an escape, and it accepted a
+    // bare "." or an absolute Windows path. Taking the basename removes any
+    // directory component whatever it looked like, and resolving then proving
+    // containment is what makes the guarantee independent of that reasoning.
+    const backupsDir = resolve(this.dataDir, LOCAL_BACKUPS_SUBDIR);
+    // A bare filename in data/backups, and nothing else.
+    //
+    // This was a blacklist of "/", "\\" and "..", which is the wrong shape for
+    // the job: it has to anticipate every spelling of an escape. Stating what a
+    // name may be instead covers the same cases and a few the blacklist missed,
+    // "." among them. The backslash is refused even though it is not a
+    // separator on the platforms Sowel ships on, because a name carrying one is
+    // a caller that thinks it is writing a path.
+    //
+    // Refusing rather than sanitising is deliberate: taking the basename would
+    // turn "../../etc/passwd" into a request for "passwd" inside the backups
+    // directory, answering a question nobody asked.
+    if (!/^[^/\\]+$/.test(filename) || filename === "." || filename === "..") {
       throw new Error("Invalid filename");
     }
-
-    const backupsDir = resolve(this.dataDir, LOCAL_BACKUPS_SUBDIR);
     const fullPath = resolve(backupsDir, filename);
+    // And prove it, so the guarantee does not rest on the check above being
+    // exactly right.
+    if (basename(fullPath) !== filename || !fullPath.startsWith(resolve(backupsDir) + sep)) {
+      throw new Error("Invalid filename");
+    }
     if (!existsSync(fullPath)) {
       throw new Error(`Backup file not found: ${filename}`);
     }

--- a/src/packages/package-manager.test.ts
+++ b/src/packages/package-manager.test.ts
@@ -1197,3 +1197,51 @@ describe("plugins/registry.json — recipe category guard (spec 137)", () => {
     expect(uncategorized, "recipe registry entries must declare a valid category").toEqual([]);
   });
 });
+
+/**
+ * `getPackageDir` is the single place a package id becomes a path, and the
+ * result is handed to rmSync({ recursive: true }), rename() and cpSync(), so an
+ * id that escapes the packages root would not merely read the wrong file.
+ */
+describe("getPackageDir — the package-id boundary", () => {
+  let dir: string;
+  let cwd: string;
+  let db: ReturnType<typeof createTestDb>;
+  let manager: PackageManager;
+
+  beforeEach(() => {
+    cwd = process.cwd();
+    dir = mkdtempSync(resolve(tmpdir(), "sowel-pkgdir-"));
+    mkdirSync(resolve(dir, "plugins"), { recursive: true });
+    process.chdir(dir);
+    db = createTestDb();
+    manager = new PackageManager(db, logger);
+  });
+
+  afterEach(() => {
+    db.close();
+    process.chdir(cwd);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("accepts the shapes the official registry actually uses", () => {
+    // Underscores are not decoration here: panasonic_cc, legrand_energy and
+    // netatmo_weather are all real ids, and a dash-only rule would have broken
+    // every one of them.
+    for (const id of ["zigbee2mqtt", "weather-forecast", "panasonic_cc", "legrand_energy", "a1"]) {
+      expect(manager.getPackageDir(id)).toBe(resolve(process.cwd(), "plugins", id));
+    }
+  });
+
+  it("refuses an id that would escape the packages root", () => {
+    for (const id of ["..", "../etc", "../../etc/passwd", "/etc/passwd", ".", "a/b"]) {
+      expect(() => manager.getPackageDir(id)).toThrow(/Invalid package id/);
+    }
+  });
+
+  it("refuses an empty or oddly-shaped id rather than guessing", () => {
+    for (const id of ["", " ", "-leading", "_leading", "Upper", "with space"]) {
+      expect(() => manager.getPackageDir(id)).toThrow(/Invalid package id/);
+    }
+  });
+});

--- a/src/packages/package-manager.ts
+++ b/src/packages/package-manager.ts
@@ -103,6 +103,14 @@ function semverSatisfiesGte(current: string, required: string): boolean {
 }
 
 /**
+ * What a package id may contain. Matches the ids the official registry
+ * actually uses: lowercase letters, digits, dashes and underscores, starting
+ * with an alphanumeric. Anything else cannot name a directory under the
+ * packages root, which is the only thing an id is ever used for.
+ */
+const PACKAGE_ID_FORMAT = /^[a-z0-9][a-z0-9_-]*$/;
+
+/**
  * Generic package distribution manager.
  * Handles download, install, update, uninstall, registry, and DB persistence.
  * No domain-specific logic (no createPlugin, no integrationRegistry).
@@ -170,9 +178,31 @@ export class PackageManager {
     }
   }
 
-  /** Resolve absolute path to a package directory */
+  /**
+   * Resolve the absolute path to a package directory.
+   *
+   * The single place a package id becomes a path, and therefore the single
+   * place it is checked. A package id reaches here from a manifest inside a
+   * downloaded tarball and from route parameters, and the result is handed to
+   * `rmSync({ recursive: true })`, `rename()` and `cpSync()`, so an id of
+   * `../../etc` would not merely read the wrong file.
+   *
+   * Two checks rather than one, because they fail differently. The format is
+   * what a package id actually is (the registry's own ids are lowercase,
+   * digits, dashes and underscores), and it rejects a traversal before any
+   * path is built. The containment check then proves the result, which is what
+   * makes the guarantee independent of the regex being exactly right.
+   */
   getPackageDir(packageId: string): string {
-    return resolve(this.pluginsDir, packageId);
+    if (!PACKAGE_ID_FORMAT.test(packageId)) {
+      throw new Error(`Invalid package id "${packageId}"`);
+    }
+    const dir = resolve(this.pluginsDir, packageId);
+    const root = resolve(this.pluginsDir);
+    if (!dir.startsWith(root + sep)) {
+      throw new Error(`Invalid package id "${packageId}"`);
+    }
+    return dir;
   }
 
   /** Get all installed packages (raw DB data, no runtime enrichment) */
@@ -372,7 +402,7 @@ export class PackageManager {
       }
 
       // Move to final directory
-      const pkgDir = resolve(this.pluginsDir, manifest.id);
+      const pkgDir = this.getPackageDir(manifest.id);
       if (existsSync(pkgDir)) {
         rmSync(pkgDir, { recursive: true });
       }
@@ -469,7 +499,7 @@ export class PackageManager {
         throw new Error(`Package "${manifest.id}" is already installed`);
       }
 
-      const pkgDir = resolve(this.pluginsDir, manifest.id);
+      const pkgDir = this.getPackageDir(manifest.id);
       if (existsSync(pkgDir)) {
         rmSync(pkgDir, { recursive: true });
       }
@@ -552,7 +582,7 @@ export class PackageManager {
 
       const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as PluginManifest;
 
-      const pkgDir = resolve(this.pluginsDir, manifest.id);
+      const pkgDir = this.getPackageDir(manifest.id);
       if (existsSync(pkgDir)) {
         rmSync(pkgDir, { recursive: true });
       }
@@ -618,7 +648,7 @@ export class PackageManager {
       this.validateManifest(newManifest);
 
       // Replace files
-      const pkgDir = resolve(this.pluginsDir, packageId);
+      const pkgDir = this.getPackageDir(packageId);
       if (existsSync(pkgDir)) {
         rmSync(pkgDir, { recursive: true });
       }
@@ -707,7 +737,7 @@ export class PackageManager {
         );
       }
 
-      const pkgDir = resolve(this.pluginsDir, row.id);
+      const pkgDir = this.getPackageDir(row.id);
       if (existsSync(pkgDir)) {
         rmSync(pkgDir, { recursive: true });
       }
@@ -782,7 +812,7 @@ export class PackageManager {
       throw new Error(`Package "${packageId}" is not installed`);
     }
 
-    const pkgDir = resolve(this.pluginsDir, packageId);
+    const pkgDir = this.getPackageDir(packageId);
     if (existsSync(pkgDir)) {
       rmSync(pkgDir, { recursive: true });
     }


### PR DESCRIPTION
The 16 `js/path-injection` alerts are **one defect seen from sixteen angles**: a package id reaches `resolve(pluginsDir, id)` unchecked, and the result is handed to `rmSync({ recursive: true })`, `rename()` and `cpSync()`. An id of `../../etc` would not merely read the wrong file.

`getPackageDir` was already meant to be the one place an id becomes a path, but **six call sites bypassed it** with their own inline `resolve`, including install and uninstall. They all go through it now, and it checks twice because the two checks fail differently: the format states what a package id is, and the containment check proves the result, so the guarantee does not rest on the regex being exactly right.

**The format allows underscores, and that is not a detail.** `panasonic_cc`, `legrand_energy`, `mcz_maestro` and `netatmo_weather` are real registry ids. A lowercase-and-dashes rule, which is what I would have written from memory, would have refused to load four shipped plugins. Found by running the actual registry through the pattern.

`restoreFromFile` had the same gap in blacklist form, refusing `/`, `\\` and `..`. A blacklist has to anticipate every spelling of an escape, and this one missed `.`, which resolved to the backups directory itself. It now states what a name may be and proves the resolved path, and it **refuses** a path rather than taking its basename: silently reducing `../../etc/passwd` to `passwd` would answer a question nobody asked.

Tests pin both boundaries, including the registry ids that must keep working, and fail against the unchecked version.

This should also unblock #841, whose CodeQL failure was these alerts attributed by data flow, since it changes the route that is their source.

Docs-Impact: none — a package id that could reach these paths was never a documented input; the behaviour change is that a malformed one is refused rather than resolved, and no page describes the old shape.