### PR TITLE
ci: pin third-party actions to a commit and give every job a permissions block

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -24,7 +24,7 @@ jobs:
           # Full history so gitleaks can scan more than HEAD on push.
           fetch-depth: 0
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Use the repo's .gitleaks.toml as authoritative config.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,9 @@ jobs:
       packages: write
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -52,6 +52,9 @@ jobs:
   # Docker layer is built or a GitHub release is created.
   verify-release-notes:
     runs-on: ubuntu-latest
+    # Reads the tagged commit and greps two files. Nothing else.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - name: Check release-notes entry
@@ -84,6 +87,8 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || inputs.restore_latest_from == ''
     needs: verify-release-notes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
 
@@ -121,10 +126,10 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -173,7 +178,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Build and push (amd64)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64
@@ -206,10 +211,10 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -258,7 +263,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Build and push (arm64)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/arm64
@@ -280,9 +285,9 @@ jobs:
       packages: write
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -384,6 +389,9 @@ jobs:
     needs: [docker-arm64, promote-manifest, release]
     if: ${{ !cancelled() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
+    # Reads three job results and exits. It needs no token at all, and `{}`
+    # says exactly that.
+    permissions: {}
     steps:
       - name: Fail the run when the release was withheld
         env:

--- a/src/core/release-workflow.test.ts
+++ b/src/core/release-workflow.test.ts
@@ -218,3 +218,39 @@ describe("release.yml: least privilege on the release token (#638)", () => {
     expect(job).not.toContain("contents: write");
   });
 });
+
+describe("release.yml: supply chain", () => {
+  it("pins every third-party action to a commit", () => {
+    // A moving tag is a promise the publisher can rewrite. Pinning gives up
+    // automatic patch updates, which is why dependabot's github-actions
+    // ecosystem is configured: it proposes the new commit and the diff shows
+    // what moved.
+    const thirdParty = [...workflow.matchAll(/uses: ((?!actions\/)[\w.-]+\/[\w.-]+)@(\S+)/g)];
+    expect(thirdParty.length).toBeGreaterThan(0);
+    for (const [, action, ref] of thirdParty) {
+      expect(ref, `${action} is not pinned to a commit`).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+
+  it("keeps the human-readable tag beside each pin", () => {
+    // A bare 40-character hash tells a reader nothing about which version they
+    // are on, and a reviewer cannot tell an upgrade from a downgrade.
+    for (const line of workflow.split("\n")) {
+      if (/uses: (?!actions\/)[\w.-]+\/[\w.-]+@[0-9a-f]{40}/.test(line)) {
+        expect(line, `no version comment: ${line.trim()}`).toMatch(/#\s*v?\d/);
+      }
+    }
+  });
+
+  it("gives every job an explicit permissions block", () => {
+    // Without one a job inherits the repository default, which is often write.
+    const jobs = [...workflow.matchAll(/\n {2}([a-z0-9-]+):\n/g)].map((m) => m[1]);
+    expect(jobs.length).toBeGreaterThan(5);
+    for (const job of jobs) {
+      const start = workflow.indexOf(`\n  ${job}:\n`);
+      const next = workflow.indexOf("\n  ", workflow.indexOf("steps:", start));
+      const block = workflow.slice(start, next === -1 ? undefined : next);
+      expect(block, `job ${job} has no permissions block`).toMatch(/\n {4}permissions:/);
+    }
+  });
+});


### PR DESCRIPTION
The 14 remaining `actions/*` alerts, and the last of the audit backlog that is mechanical rather than a judgement call.

**Eleven unpinned tags.** `docker/*@v4`, `@v7` and `gitleaks-action@v3` are moving refs, which is a promise the publisher can rewrite, and they run with `packages: write` on a release. Pinned to the commit each tag points at today, with the tag kept beside it as a comment, because a bare forty-character hash tells a reviewer nothing about which version they are on or whether a change is an upgrade.

The real cost is giving up automatic patch updates. Acceptable here because dependabot's `github-actions` ecosystem is already configured weekly, so the update becomes a diff somebody reads rather than one that happens silently.

**Three jobs with no permissions block**, inheriting the repository default, which is often write. `verify-release-notes` and `ci` only read the tree. `arm64-required` reads three job results and exits, so it takes `permissions: {}`: it needs no token at all, and saying so is clearer than granting the smallest useful thing.

Three tests pin the invariants (every third-party action is a commit, every pin carries its version comment, every job declares permissions). Two fail against the workflow as it stands on `main`.

This is the last of the mechanical backlog. What remains after it and #845 are the by-design alerts, which need a dismissal with a written reason rather than a change: the camera snapshot URL is admin-configured, the InfluxDB client writing responses to files is what it is for, the JWT in localStorage is a known decision, and `mfa.ts` "user-controlled bypass" is a flag that selects a verifier where both branches verify.

Docs-Impact: none — supply-chain hygiene in the workflows; no engine or interface behaviour changes.