### PR TITLE
fix(packages): check the repo reference where it becomes a URL

### DIFF
--- a/src/packages/package-manager.test.ts
+++ b/src/packages/package-manager.test.ts
@@ -26,6 +26,7 @@ import { createHash } from "node:crypto";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { PackageManager } from "./package-manager.js";
+import { PersonalSourceManager } from "./personal-sources.js";
 import { applyMigrations } from "../test-helpers/migrations.js";
 import {
   ChecksumMismatchError,
@@ -1242,6 +1243,46 @@ describe("getPackageDir — the package-id boundary", () => {
   it("refuses an empty or oddly-shaped id rather than guessing", () => {
     for (const id of ["", " ", "-leading", "_leading", "Upper", "with space"]) {
       expect(() => manager.getPackageDir(id)).toThrow(/Invalid package id/);
+    }
+  });
+});
+
+/**
+ * `repo` reaches the path of an authenticated outbound request to GitHub, so
+ * its shape decides where that request goes.
+ */
+describe("latestReleaseUrl — the repo-to-URL boundary", () => {
+  it("builds the release URL for a well-formed reference", () => {
+    expect(PersonalSourceManager.latestReleaseUrl("mchacher/sowel-plugin-x")).toBe(
+      "https://api.github.com/repos/mchacher/sowel-plugin-x/releases/latest",
+    );
+  });
+
+  it("refuses a reference that would point the request elsewhere", () => {
+    for (const repo of [
+      "../../orgs/evil",
+      "evil.com/x",
+      "a/b/../../../etc",
+      "user@evil.com/x",
+      "a/b?x=1",
+      "a/b#frag",
+      "//evil.com/x",
+      "",
+    ]) {
+      expect(() => PersonalSourceManager.latestReleaseUrl(repo)).toThrow(/Invalid repository/);
+    }
+  });
+
+  it("agrees with isValidRepo, so there is one definition of the shape", () => {
+    for (const repo of ["a/b", "mchacher/sowel", "../x", "no-slash", "a/b/c"]) {
+      const valid = PersonalSourceManager.isValidRepo(repo);
+      let built = true;
+      try {
+        PersonalSourceManager.latestReleaseUrl(repo);
+      } catch {
+        built = false;
+      }
+      expect(built).toBe(valid);
     }
   });
 });

--- a/src/packages/package-manager.ts
+++ b/src/packages/package-manager.ts
@@ -1015,7 +1015,12 @@ export class PackageManager {
     repo: string,
     tmpDir: string,
   ): Promise<{ tarballPath: string; sha256: string; version: string }> {
-    const apiUrl = `https://api.github.com/repos/${repo}/releases/latest`;
+    // Built through the one checked constructor rather than interpolated here:
+    // `repo` reaches the path of an authenticated outbound request, and a value
+    // carrying a traversal or an `@` points it at another host. The install
+    // route validates the shape too, but a schema is not a barrier anything
+    // downstream can see, and this method is also reached from the store.
+    const apiUrl = PersonalSourceManager.latestReleaseUrl(repo);
     const releaseRes = await fetch(apiUrl, {
       headers: { Accept: "application/vnd.github+json" },
     });

--- a/src/packages/personal-sources.ts
+++ b/src/packages/personal-sources.ts
@@ -60,6 +60,23 @@ export class PersonalSourceManager {
     return REPO_FORMAT.test(repo);
   }
 
+  /**
+   * The GitHub API URL for a repository's latest release.
+   *
+   * The one place a repo reference becomes a URL, and therefore the one place
+   * it is checked. `repo` is interpolated into the path of an authenticated
+   * outbound request, so a value like `../../orgs/x` or one carrying a `@`
+   * points the request somewhere else entirely. Callers hold a repo they
+   * believe is valid; this makes that belief a check rather than an assumption,
+   * on the request itself where it matters.
+   */
+  static latestReleaseUrl(repo: string): string {
+    if (!REPO_FORMAT.test(repo)) {
+      throw new Error(`Invalid repository format "${repo}" (expected owner/repo)`);
+    }
+    return `https://api.github.com/repos/${repo}/releases/latest`;
+  }
+
   /** All sources, enriched with the cached latest release version (no network). */
   list(): PluginSource[] {
     const rows = this.stmts.getAll.all() as SourceRow[];
@@ -145,7 +162,7 @@ export class PersonalSourceManager {
    */
   async fetchLatestRelease(repo: string): Promise<PersonalRelease | undefined> {
     try {
-      const res = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, {
+      const res = await fetch(PersonalSourceManager.latestReleaseUrl(repo), {
         headers: { Accept: "application/vnd.github+json" },
         signal: AbortSignal.timeout(10_000),
       });


### PR DESCRIPTION
The last two alerts of the audit backlog that are a real boundary rather than a judgement call, and the same defect as the path one seen from the network side.

`repo` was interpolated straight into `https://api.github.com/repos/${repo}/releases/latest`, in two places, with nothing between the value and an authenticated outbound request. A reference carrying a traversal, an `@` or a query string points that request at another path or another host.

`latestReleaseUrl` is now the one place a repo reference becomes a URL, and it checks the shape there against the same `REPO_FORMAT` that `isValidRepo` uses, so there is still one definition of what a repo reference is. A test asserts the two agree, so they cannot drift apart.

The install route already validates the shape (added on the #597 branch), but a schema is not a barrier anything downstream can see, and `downloadTarball` is also reached from the registry store rather than only from that route. **The check belongs on the request**, which is the same lesson as #845: put it where the value becomes dangerous, not where it arrives.

## Where the backlog stands

72 open alerts at the start of the day. After #844 (scope), #845 (paths) and this one, what is left needs a **dismissal with a written reason**, not a change:

- `camera.ts` SSRF: the snapshot URL is admin-configured.
- `influx-client.ts` file-access-to-http, six of them: writing a query response to a file is what the client is for.
- `useAuth.ts` clear-text storage: the JWT in localStorage is a known decision.
- `mfa.ts` user-controlled bypass: the flag *selects* a verifier and both branches verify.
- `useWebSocket.ts` remote-property-injection, two: a computed key in an object literal defines an own property, verified.
- `package-manager.test.ts` incomplete-url-substring-sanitization, three: a test asserting on a URL substring.

Those are yours to dismiss, since a dismissal is a statement about intent rather than a code change.

Docs-Impact: none — a malformed repo reference is refused where it used to be sent to GitHub; no page documents the old shape.