### PR TITLE
fix(ui): give the Live page one heading shape, and the flow diagram a heading (#818)

### DIFF
--- a/ui/src/components/energy/ArbitrationSurface.tsx
+++ b/ui/src/components/energy/ArbitrationSurface.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import type { ArbiterLoadInfo, ArbiterLoadState } from "../../types";
 import { useTranslation } from "react-i18next";
 import { Scale, Moon } from "lucide-react";
+import { SectionHeader } from "./SectionHeader";
 import { ArbiterTimeline } from "./ArbiterTimeline";
 import { surplusStickerColor, loadStateColor, displayState } from "./arbiterColors";
 import { useArbiter } from "../../store/useArbiter";
@@ -154,35 +155,35 @@ export function ArbitrationSurface() {
 
   return (
     <div className="bg-surface border border-border rounded-[10px] p-4 mt-4">
-      <div className="flex items-start gap-2 mb-4">
-        <Scale size={18} strokeWidth={1.5} className="text-text-secondary mt-0.5" />
-        <div>
-          <h2 className="text-[15px] font-semibold text-text">{t("arbiter.surfaceTitle")}</h2>
-          <p className="text-[12px] text-text-secondary">{t("arbiter.surfaceHint")}</p>
-        </div>
-        <span
-          className="ml-auto flex items-center gap-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-full whitespace-nowrap"
-          style={{
-            color: stickerColor,
-            background: `color-mix(in srgb, ${stickerColor} 12%, transparent)`,
-          }}
-          title={state.state === "degraded" ? t("arbiter.degradedReason") : undefined}
-        >
-          {dormant ? (
-            <>
-              <Moon size={11} strokeWidth={2} />
-              {t("arbiter.state.dormant")}
-            </>
-          ) : (
-            <>
-              {t(`arbiter.state.${state.state}`)}
-              {available !== null && (
-                <span className="font-mono">{(available / 1000).toFixed(1)} kW</span>
-              )}
-            </>
-          )}
-        </span>
-      </div>
+      <SectionHeader
+        icon={Scale}
+        title={t("arbiter.surfaceTitle")}
+        hint={t("arbiter.surfaceHint")}
+        aside={
+          <span
+            className="ml-auto flex items-center gap-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-full whitespace-nowrap"
+            style={{
+              color: stickerColor,
+              background: `color-mix(in srgb, ${stickerColor} 12%, transparent)`,
+            }}
+            title={state.state === "degraded" ? t("arbiter.degradedReason") : undefined}
+          >
+            {dormant ? (
+              <>
+                <Moon size={11} strokeWidth={2} />
+                {t("arbiter.state.dormant")}
+              </>
+            ) : (
+              <>
+                {t(`arbiter.state.${state.state}`)}
+                {available !== null && (
+                  <span className="font-mono">{(available / 1000).toFixed(1)} kW</span>
+                )}
+              </>
+            )}
+          </span>
+        }
+      />
       {state.state === "degraded" && (
         <p className="text-[12px] text-warning mb-2">{t("arbiter.degradedReason")}</p>
       )}

--- a/ui/src/components/energy/LiveEnergyPage.tsx
+++ b/ui/src/components/energy/LiveEnergyPage.tsx
@@ -15,7 +15,8 @@
 
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Clock, WifiOff } from "lucide-react";
+import { Clock, Waypoints, WifiOff } from "lucide-react";
+import { SectionHeader } from "./SectionHeader";
 import { SolarPanelIcon } from "../icons/SolarPanelIcon";
 import { GridPylonIcon } from "../icons/GridPylonIcon";
 import { useEquipments } from "../../store/useEquipments";
@@ -30,10 +31,10 @@ import { formatRelative } from "../../lib/format-relative";
 
 // Sowel energy palette (matches EnergyBarChart.tsx + extends with grid colours)
 // Spec 148 — energy palette tokens (dark-mode correct), shared across energy UI.
-const HP_COLOR = "var(--color-energy-hp)";       // House consumption (vivid blue, focal)
-const GRID_COLOR = "var(--color-energy-grid)";   // Grid import (slate blue)
+const HP_COLOR = "var(--color-energy-hp)"; // House consumption (vivid blue, focal)
+const GRID_COLOR = "var(--color-energy-grid)"; // Grid import (slate blue)
 const GRID_OFF_COLOR = "var(--color-text-tertiary)"; // Grid passive (neutral, on export)
-const AUTO_COLOR = "var(--color-solar-auto)";    // Solar / autoconso (green)
+const AUTO_COLOR = "var(--color-solar-auto)"; // Solar / autoconso (green)
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -61,9 +62,7 @@ function detectLiveStaleness(
   contributors: EquipmentWithDetails[],
 ): { mode: "stale" | "offline"; oldestSince: string | null } | null {
   if (contributors.length === 0) return null;
-  const anyDegraded = contributors.some(
-    (e) => e.status === "degraded" || e.status === "offline",
-  );
+  const anyDegraded = contributors.some((e) => e.status === "degraded" || e.status === "offline");
   if (!anyDegraded) return null;
   const allOffline = contributors.every((e) => e.status === "offline");
   const sinces = contributors
@@ -72,7 +71,6 @@ function detectLiveStaleness(
   const oldestSince = sinces.length > 0 ? sinces.reduce((a, b) => (a < b ? a : b)) : null;
   return { mode: allOffline ? "offline" : "stale", oldestSince };
 }
-
 
 /** Format a power value:
  *  - |value| < 1000 W → integer W rounded to the nearest 5 (smooth display)
@@ -143,9 +141,7 @@ export function LiveEnergyPage() {
           )}
           <span className="font-medium">
             {t(
-              staleness.mode === "offline"
-                ? "energy.live.metersOffline"
-                : "energy.live.dataStale",
+              staleness.mode === "offline" ? "energy.live.metersOffline" : "energy.live.dataStale",
               { when: formatRelative(staleness.oldestSince) },
             )}
           </span>
@@ -207,12 +203,7 @@ function LiveDiagram({
   //   balanced (|grid| < 5W) + production         → "Autonome"
   //   importing + solar producing & solar ≥ grid  → "Appoint réseau"   (solar is the main)
   //   importing + solar producing & solar <  grid → "Appoint solaire"  (grid is the main)
-  type Status =
-    | "grid_only"
-    | "self"
-    | "mixed_solar_lead"
-    | "mixed_grid_lead"
-    | "export";
+  type Status = "grid_only" | "self" | "mixed_solar_lead" | "mixed_grid_lead" | "export";
   let status: Status;
   if (solar < 5) status = "grid_only";
   else if (grid < -5) status = "export";
@@ -247,6 +238,7 @@ function LiveDiagram({
 
   return (
     <div className="bg-surface border border-border rounded-[10px] p-4 sm:p-6">
+      <SectionHeader icon={Waypoints} title={t("energy.live.diagram.title")} />
       <FlowDiagram
         tag={{ text: t(`energy.live.status.${status}`), color: statusColor }}
         links={[
@@ -280,7 +272,15 @@ function LiveDiagram({
             value: houseValue.num,
             unit: houseValue.unit,
             icon: (
-              <svg className="w-11 h-11 sm:w-14 sm:h-14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+              <svg
+                className="w-11 h-11 sm:w-14 sm:h-14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
                 <path d="M12 3 L20 11 Q21 12 20 13 L20 19 Q20 20 19 20 L5 20 Q4 20 4 19 L4 13 Q3 12 4 11 Z" />
                 {/* Lightning bolt inside the house body — flash-1-svgrepo-com.svg
                  * scaled and centered. vector-effect keeps the stroke crisp despite

--- a/ui/src/components/energy/LiveSubmeterBreakdown.tsx
+++ b/ui/src/components/energy/LiveSubmeterBreakdown.tsx
@@ -19,12 +19,10 @@ import {
   type SubmeterRow,
 } from "./submeter-helpers";
 import { isSubmeterEquipment } from "../../lib/metering";
-import {
-  equipmentLabelMap,
-  flattenZonesWithPath,
-  zoneChainMap,
-} from "../../lib/zone-path";
+import { equipmentLabelMap, flattenZonesWithPath, zoneChainMap } from "../../lib/zone-path";
 import { formatRelative } from "../../lib/format-relative";
+import { ChartPie } from "lucide-react";
+import { SectionHeader } from "./SectionHeader";
 
 const HOUSE_COLOR = "#4F7BE8"; // matches HP_COLOR in LiveEnergyPage
 const OTHER_COLOR = "#A1A1AA"; // var(--n-300), neutral grey
@@ -64,7 +62,6 @@ function formatPower(value: number): { num: string; unit: "W" | "kW" } {
   return { num: (shown / 1000).toFixed(1), unit: "kW" };
 }
 
-
 export function LiveSubmeterBreakdown({ house, hasMainMeter }: Props) {
   const { t } = useTranslation();
   const equipments = useEquipments((s) => s.equipments);
@@ -92,24 +89,17 @@ export function LiveSubmeterBreakdown({ house, hasMainMeter }: Props) {
   // (no residual segment, consistent with spec 091 acceptance criterion).
   const total = hasMainMeter ? Math.max(0, house ?? 0) : submeterSum;
   const other = hasMainMeter ? computeOther(total, rows) : 0;
-  const overshoot =
-    hasMainMeter && submeterSum > total * (1 + OVERSHOOT_RATIO);
+  const overshoot = hasMainMeter && submeterSum > total * (1 + OVERSHOOT_RATIO);
   const hasStale = rows.some((r) => r.unknown === "stale");
 
   const isIdle = total < IDLE_THRESHOLD_W;
-  const segments = isIdle
-    ? []
-    : buildSegments(rows, other, total);
+  const segments = isIdle ? [] : buildSegments(rows, other, total);
 
   const t_total = formatPower(total);
 
   return (
     <div className="bg-surface border border-border rounded-[10px] p-4 sm:p-6 mt-4">
-      <div className="flex items-baseline justify-between mb-4">
-        <h2 className="text-[14px] font-semibold text-text">
-          {t("energy.live.breakdown.title")}
-        </h2>
-      </div>
+      <SectionHeader icon={ChartPie} title={t("energy.live.breakdown.title")} />
 
       <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 max-w-[600px]">
         <Donut
@@ -130,9 +120,7 @@ export function LiveSubmeterBreakdown({ house, hasMainMeter }: Props) {
                 className="w-[10px] h-[10px] rounded-[2px] border border-border"
                 style={{ background: OTHER_COLOR }}
               />
-              <span className="text-text-secondary">
-                {t("energy.live.breakdown.other")}
-              </span>
+              <span className="text-text-secondary">{t("energy.live.breakdown.other")}</span>
               <span className="font-mono font-medium text-text-secondary min-w-[64px] text-right">
                 {formatPower(other).num} {formatPower(other).unit}
               </span>
@@ -170,11 +158,7 @@ interface DonutSegment {
   fraction: number;
 }
 
-function buildSegments(
-  rows: SubmeterRow[],
-  other: number,
-  total: number,
-): DonutSegment[] {
+function buildSegments(rows: SubmeterRow[], other: number, total: number): DonutSegment[] {
   if (total <= 0) return [];
   // The parts are held to one circle. Before #744 the fractions were drawn
   // unclamped, so a part larger than the whole produced arcs that wrapped over
@@ -252,9 +236,7 @@ function Donut({
       </svg>
       <div className="absolute inset-0 flex flex-col items-center justify-center text-center pointer-events-none">
         {idle ? (
-          <span className="text-[13px] font-semibold text-text-tertiary px-3">
-            {totalLabel}
-          </span>
+          <span className="text-[13px] font-semibold text-text-tertiary px-3">{totalLabel}</span>
         ) : (
           <>
             <span className="text-[10px] font-semibold uppercase tracking-widest text-text-tertiary">
@@ -266,9 +248,7 @@ function Donut({
             >
               <span>{totalLabel}</span>
               {totalUnit && (
-                <span className="text-[12px] text-text-tertiary font-semibold">
-                  {totalUnit}
-                </span>
+                <span className="text-[12px] text-text-tertiary font-semibold">{totalUnit}</span>
               )}
             </span>
           </>
@@ -298,10 +278,7 @@ function LegendRow({
         isOffline || isStale ? "opacity-60" : ""
       }`}
     >
-      <span
-        className="w-[10px] h-[10px] rounded-[2px]"
-        style={{ background: row.color }}
-      />
+      <span className="w-[10px] h-[10px] rounded-[2px]" style={{ background: row.color }} />
       <div className="flex flex-col min-w-0">
         <span className="font-medium text-text truncate">{row.name}</span>
         {isOffline && (

--- a/ui/src/components/energy/PhaseBreakdown.tsx
+++ b/ui/src/components/energy/PhaseBreakdown.tsx
@@ -12,6 +12,8 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { EquipmentWithDetails } from "../../types";
 import { extractPhases, formatPhasePower } from "./phase-helpers";
+import { Columns3 } from "lucide-react";
+import { SectionHeader } from "./SectionHeader";
 
 const PHASE_COLORS = ["#4F7BE8", "#6BCB77", "#F2A93B", "#E8677D"];
 
@@ -29,9 +31,7 @@ export function PhaseBreakdown({ gridEquipments }: Props) {
 
   return (
     <div className="bg-surface border border-border rounded-[10px] p-4 sm:p-6 mt-4">
-      <h2 className="text-[14px] font-semibold text-text mb-4">
-        {t("energy.live.phases.title")}
-      </h2>
+      <SectionHeader icon={Columns3} title={t("energy.live.phases.title")} />
       <div className="flex flex-col gap-3 max-w-[600px]">
         {phases.map((p, i) => {
           const f = formatPhasePower(p.power);

--- a/ui/src/components/energy/SectionHeader.test.tsx
+++ b/ui/src/components/energy/SectionHeader.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Issue #818 — the four cards on the Live page must present one heading shape.
+ *
+ * The drift they had is easy to reintroduce, because each section renders its
+ * own card: two headings at 14px with no icon, one at 15px with an icon, and
+ * the flow diagram with none at all. These tests assert the four are the same
+ * component rather than four copies that happen to agree today.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "../../test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { LiveEnergyPage } from "./LiveEnergyPage";
+import { useEquipments } from "../../store/useEquipments";
+import type { EquipmentWithDetails } from "../../types";
+
+vi.mock("../../hooks/useWsSubscription", () => ({ useWsSubscription: () => {} }));
+
+function meter(
+  id: string,
+  type: EquipmentWithDetails["type"],
+  power: number,
+  extra: Record<string, unknown> = {},
+): EquipmentWithDetails {
+  return {
+    id,
+    name: id,
+    type,
+    zoneId: "z",
+    enabled: true,
+    status: "online",
+    dataBindings: [
+      {
+        id: `${id}-p`,
+        alias: "power",
+        category: "power",
+        type: "number",
+        value: power,
+        lastUpdated: new Date().toISOString(),
+        stale: false,
+        ...extra,
+      },
+    ],
+    orderBindings: [],
+  } as unknown as EquipmentWithDetails;
+}
+
+describe("Live page section headings (#818)", () => {
+  it("gives the flow diagram a heading, where it had none", () => {
+    useEquipments.setState({
+      equipments: [meter("Grid", "main_energy_meter", 1000)],
+      fetchEquipments: async () => {},
+    } as never);
+    render(<LiveEnergyPage />, { wrapper: MemoryRouter });
+    expect(screen.getByText("Live flows")).toBeTruthy();
+  });
+
+  it("renders every section heading at the same size, with an icon", () => {
+    useEquipments.setState({
+      equipments: [meter("Grid", "main_energy_meter", 1000), meter("Piscine", "energy_meter", 400)],
+      fetchEquipments: async () => {},
+    } as never);
+    const { container } = render(<LiveEnergyPage />, { wrapper: MemoryRouter });
+
+    const headings = [...container.querySelectorAll("h2")];
+    expect(headings.length).toBeGreaterThanOrEqual(2);
+
+    for (const h of headings) {
+      // One size for all of them. 14px and 15px used to coexist.
+      expect(h.className, `"${h.textContent}" is not the shared size`).toContain("text-[15px]");
+      // And each sits beside an icon, which only the arbitration card had.
+      const header = h.closest("div")?.parentElement;
+      expect(header?.querySelector("svg"), `"${h.textContent}" has no icon`).toBeTruthy();
+    }
+  });
+
+  it("keeps the consumption breakdown labelled", () => {
+    useEquipments.setState({
+      equipments: [meter("Grid", "main_energy_meter", 1000), meter("Piscine", "energy_meter", 400)],
+      fetchEquipments: async () => {},
+    } as never);
+    render(<LiveEnergyPage />, { wrapper: MemoryRouter });
+    const heading = screen.getByText("Consumption breakdown");
+    expect(within(heading.closest("div")!.parentElement!).queryByRole("img")).toBeDefined();
+  });
+});

--- a/ui/src/components/energy/SectionHeader.tsx
+++ b/ui/src/components/energy/SectionHeader.tsx
@@ -1,0 +1,37 @@
+import type { LucideIcon } from "lucide-react";
+
+/**
+ * The heading every card on the Live page shares (issue #818).
+ *
+ * The four sections had drifted: two headings at 14px with no icon, one at
+ * 15px with an icon and a hint, and the flow diagram with no heading at all,
+ * so the eye had nothing to anchor on and the first card was unlabelled. The
+ * arbitration card was the one that read best, so its shape is the one kept.
+ *
+ * A component rather than a copied block, because four copies of a heading is
+ * how they came to differ in the first place.
+ */
+export function SectionHeader({
+  icon: Icon,
+  title,
+  hint,
+  aside,
+}: {
+  icon: LucideIcon;
+  title: string;
+  /** Optional second line, for a section whose purpose is not obvious. */
+  hint?: string;
+  /** Optional right-aligned slot, e.g. the arbiter's state sticker. */
+  aside?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start gap-2 mb-4">
+      <Icon size={18} strokeWidth={1.5} className="text-text-secondary mt-0.5" />
+      <div className="min-w-0">
+        <h2 className="text-[15px] font-semibold text-text">{title}</h2>
+        {hint && <p className="text-[12px] text-text-secondary">{hint}</p>}
+      </div>
+      {aside}
+    </div>
+  );
+}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1128,6 +1128,7 @@
   "energy.live.status.mixed_grid_lead": "Solar-assisted",
   "energy.live.status.self": "Self-sufficient",
   "energy.live.status.export": "Solar surplus",
+  "energy.live.diagram.title": "Live flows",
   "energy.live.breakdown.title": "Consumption breakdown",
   "energy.live.breakdown.other": "Other",
   "energy.live.breakdown.offline": "offline",

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -1128,6 +1128,7 @@
   "energy.live.status.mixed_grid_lead": "Appoint solaire",
   "energy.live.status.self": "Autonome",
   "energy.live.status.export": "Excédent solaire",
+  "energy.live.diagram.title": "Flux en direct",
   "energy.live.breakdown.title": "Décomposition consommation",
   "energy.live.breakdown.other": "Autre",
   "energy.live.breakdown.offline": "hors-ligne",


### PR DESCRIPTION
Four cards, three different headings and one missing.

| Section | Before |
| --- | --- |
| Flow diagram | **no heading at all**, and it is the first thing on the page |
| Phase breakdown | 14px, no icon |
| Consumption breakdown | 14px, no icon |
| Surplus arbitration | 15px, icon, hint |

The arbitration card was the one that read best, so its shape is the one kept, extracted as `SectionHeader` and used by all four. A component rather than a copied block, because four copies of a heading is exactly how they came to differ.

Icons chosen to say what the section is rather than to decorate: waypoints for the flows, three columns for the phase split, a pie for the consumption donut, and the scales the arbitration card already had.

The diagram's title is new (`energy.live.diagram.title`, "Live flows" / "Flux en direct"); the other three keep their existing strings, so nothing already translated moves.

Three component tests drive the real page: every heading at one size, each beside an icon, and the diagram labelled. Two fail against `main`.

Docs-Impact: none — no prose changes, because the energy tour describes what each section shows rather than how it is titled, and no sentence there becomes wrong. The two screenshots on that page are now cosmetically dated (the cards gained icons and the diagram a title); refreshing them needs the anonymised fixture pipeline, which is a separate pass and not something to bundle into a heading change.