### PR TITLE
fix(ui): hold the forecast panel to five columns (#851 review)

### DIFF
--- a/ui/src/components/dashboard/ForecastDetailContent.test.tsx
+++ b/ui/src/components/dashboard/ForecastDetailContent.test.tsx
@@ -62,6 +62,25 @@ function fiveDays(withConfidence = true): DataBindingWithValue[] {
   return out;
 }
 
+/**
+ * A plugin publishing further out than the sheet is laid out for. `j(\d+)` has
+ * no upper bound in the parser, so nothing but the sheet stops a seven day feed
+ * from squeezing every column.
+ */
+function sevenDays(): DataBindingWithValue[] {
+  const out = fiveDays();
+  for (const n of [6, 7]) {
+    out.push(binding(`j${n}_condition`, "cloudy"));
+    out.push(binding(`j${n}_temp_max`, 31));
+    out.push(binding(`j${n}_temp_min`, 19));
+    out.push(binding(`j${n}_rain_prob`, 0));
+    out.push(binding(`j${n}_wind_gusts`, 25));
+    out.push(binding(`j${n}_confidence`, "low"));
+    out.push(binding(`j${n}_temp_max_spread`, 5.4));
+  }
+  return out;
+}
+
 /** One column per published day. */
 const columns = (c: HTMLElement) => [...c.querySelectorAll("div.flex-1")];
 
@@ -145,6 +164,24 @@ describe("ForecastDetailContent (spec 168)", () => {
   it("says so rather than rendering an empty list when nothing is bound", () => {
     render(<ForecastDetailContent equipment={equipmentWith([])} />);
     expect(screen.getByText("No forecast available")).toBeTruthy();
+  });
+
+  it("keeps five columns when the plugin publishes seven days", () => {
+    // The paddings, the type sizes and the pill slot are tuned for five across
+    // a 390px phone. At seven each column falls to about 46px and the pill
+    // wraps out of the slot held for it, so the sheet clamps rather than trust
+    // the feed. `ForecastStrip` held this bound before it was deleted.
+    const { container } = render(<ForecastDetailContent equipment={equipmentWith(sevenDays())} />);
+    expect(columns(container)).toHaveLength(5);
+    expect(pills(container)).toHaveLength(5);
+  });
+
+  it("clamps from the near end, so the days kept are the ones nearest today", () => {
+    // Day 6 and 7 are the ones to lose: a forecast is least sure furthest out.
+    const { container } = render(<ForecastDetailContent equipment={equipmentWith(sevenDays())} />);
+    // The j6/j7 maximum (31) never renders; the j5 one (30) does.
+    expect(container.textContent).toContain("30");
+    expect(container.textContent).not.toContain("31");
   });
 
   it("does not scroll horizontally, which is the reason the columns shrink", () => {

--- a/ui/src/components/dashboard/ForecastDetailContent.tsx
+++ b/ui/src/components/dashboard/ForecastDetailContent.tsx
@@ -13,6 +13,18 @@ import {
 } from "../equipments/weatherForecastUtils";
 
 /**
+ * The sheet is laid out for five columns and no more: the paddings, the type
+ * sizes and the pill's reserved slot are all tuned for five across a 390px
+ * phone. A plugin is free to publish further out, so the count is clamped here
+ * rather than trusted from the feed — at seven days each column falls to about
+ * 46px and the confidence pill wraps out of the slot held for it.
+ *
+ * The deleted `ForecastStrip` carried the same bound as `STRIP_DAYS` and took
+ * it with it; this is that invariant, kept next to the layout that needs it.
+ */
+const SHEET_DAYS = 5;
+
+/**
  * The forecast behind the dashboard tile (spec 168, option C2).
  *
  * The same card anatomy as the equipment page, narrowed so the five days fit
@@ -42,7 +54,7 @@ export function ForecastDetailContent({ equipment }: { equipment: EquipmentWithD
   return (
     <div>
       <div className="flex items-stretch gap-1.5 sm:gap-3">
-        {days.map((day) => (
+        {days.slice(0, SHEET_DAYS).map((day) => (
           <ForecastDayColumn key={day.dayIndex} day={day} locale={locale} />
         ))}
       </div>

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -114,8 +114,8 @@ export function MobileWidgetCard({
         </span>
       )}
 
-      {/* Spec 168 — the forecast tile carries its five-day strip on the phone
-          too, which is the surface this dashboard is mostly read on. */}
+      {/* Spec 168 — the forecast tile qualifies tomorrow on the phone too,
+          which is the surface this dashboard is mostly read on. */}
       {footer}
     </button>
   );

--- a/ui/src/components/dashboard/getMobileClickAction.test.tsx
+++ b/ui/src/components/dashboard/getMobileClickAction.test.tsx
@@ -178,8 +178,8 @@ describe("getMobileClickAction", () => {
     });
   });
 
-  // Spec 168 — the forecast tile now has somewhere to go: the strip shows five
-  // days at a glance, the sheet shows each of them with its confidence.
+  // Spec 168 — the forecast tile now has somewhere to go: the tile qualifies
+  // tomorrow, the sheet shows the five days with their confidence.
   describe("weather forecast (spec 168)", () => {
     const forecast = () =>
       makeSwitch({

--- a/ui/src/components/dashboard/mobile-click-action.ts
+++ b/ui/src/components/dashboard/mobile-click-action.ts
@@ -88,8 +88,8 @@ export function getMobileClickAction(
   }
 
   // Sensor / weather → open detail sheet to see all data.
-  // Spec 168 adds the forecast: the tile shows tomorrow and a five-day strip,
-  // the sheet shows every day with its confidence.
+  // Spec 168 adds the forecast: the tile qualifies tomorrow, the sheet shows
+  // the five days as columns, each with its confidence.
   if (type === "sensor" || type === "weather" || type === "weather_forecast") {
     return onOpenDetail;
   }

--- a/ui/src/components/equipments/weatherForecastUtils.test.ts
+++ b/ui/src/components/equipments/weatherForecastUtils.test.ts
@@ -5,8 +5,6 @@ import {
   parseForecastDays,
   parseModelUsed,
   CONFIDENCE_STYLES,
-  CONFIDENCE_BAR,
-  CONFIDENCE_BAR_UNKNOWN,
   type ForecastConfidence,
 } from "./weatherForecastUtils";
 
@@ -151,23 +149,17 @@ describe("modelLabel", () => {
 
 // Spec 168 — the tile, the sheet and the equipment page render the same three
 // bands, so the bands live here and nowhere else.
-describe("confidence colour maps", () => {
+describe("confidence colour map", () => {
   const levels: ForecastConfidence[] = ["high", "medium", "low"];
 
-  it("gives every level a pill style and a bar colour", () => {
+  it("gives every level a pill style", () => {
     for (const level of levels) {
       expect(CONFIDENCE_STYLES[level]).toBeTruthy();
-      expect(CONFIDENCE_BAR[level]).toBeTruthy();
     }
   });
 
   it("keeps the three bands distinguishable from each other", () => {
     // A traffic light where two lamps share a colour is not a traffic light.
-    expect(new Set(levels.map((l) => CONFIDENCE_BAR[l])).size).toBe(3);
     expect(new Set(levels.map((l) => CONFIDENCE_STYLES[l])).size).toBe(3);
-  });
-
-  it("keeps the unknown bar out of the three, so no verdict never reads as one", () => {
-    expect(levels.map((l) => CONFIDENCE_BAR[l])).not.toContain(CONFIDENCE_BAR_UNKNOWN);
   });
 });

--- a/ui/src/components/equipments/weatherForecastUtils.ts
+++ b/ui/src/components/equipments/weatherForecastUtils.ts
@@ -52,20 +52,6 @@ export const CONFIDENCE_STYLES: Record<ForecastConfidence, string> = {
   low: "border-error text-error bg-error/10",
 };
 
-/**
- * The same three bands as a solid bar, for the tile's five-day strip where
- * there is no room for a word. A day the plugin cannot qualify falls back to
- * the neutral border colour rather than borrowing a confidence colour, so an
- * absent verdict never reads as a good one.
- */
-export const CONFIDENCE_BAR: Record<ForecastConfidence, string> = {
-  high: "bg-success",
-  medium: "bg-warning",
-  low: "bg-error",
-};
-
-export const CONFIDENCE_BAR_UNKNOWN = "bg-border";
-
 const CONFIDENCE_VALUES: readonly string[] = ["high", "medium", "low"];
 
 export interface ForecastDay {


### PR DESCRIPTION
Three findings from the code review of #851, in descending order of consequence.

## The panel trusted the feed for its column count

`ForecastDetailContent` mapped **every** published day into a `flex-1` column, but its paddings, type sizes and the `min-h-[30px]` slot reserved for the confidence pill are all tuned for exactly five columns across a 390px phone. `parseForecastDays` matches `j(\d+)` with no upper bound, so a plugin publishing `j1..j7` produced seven columns of roughly 46px each, and the pill wrapped out of the slot held for it — breaking the "five columns end on one line" criterion the sheet was built around.

The deleted `ForecastStrip` carried this bound as `STRIP_DAYS` and took it with it. It returns as `SHEET_DAYS`, kept next to the layout that depends on it, clamping from the near end: a forecast is least sure furthest out, so days 6 and 7 are the ones to lose.

No plugin publishes past `j5` today, so nothing is visibly different right now. That is the point — the invariant is enforced rather than merely observed.

## Dead confidence bars

`CONFIDENCE_BAR` and `CONFIDENCE_BAR_UNKNOWN` have had no consumer since `ForecastStrip` was deleted. Three assertions in `weatherForecastUtils.test.ts` still exercised them, so three tests were guarding nothing shipped, and their doc comment still described the five-day strip. Both constants and the assertions that outlived them are gone; the pill-style coverage stays.

## Three stale comments

`MobileWidgetCard.tsx`, `mobile-click-action.ts` and `getMobileClickAction.test.tsx` still promised a five-day strip on the tile. They now describe what the tile does: qualify tomorrow, with the five days behind the tap.

## Test plan

- [x] Two new cases in `ForecastDetailContent.test.tsx`: seven published days still render five columns and five pills, and the days kept are the near ones (the `j6`/`j7` maximum never renders).
- [x] **Both fail without the clamp** — verified by reverting the `slice` and re-running: `2 failed | 10 passed`.
- [x] Full UI suite green: 864 passed, against 863 on `main` (+2 new, -1 removed with the dead constants).
- [x] `tsc -b --noEmit` and `eslint .` clean on `ui/`.

Docs-Impact: none — `docs/user/dashboard` already describes a five-day panel, which is what the code now guarantees rather than what it merely happened to produce with the reference plugin.