### PR TITLE
fix(ui): fit the gate slide-to-confirm to a thumb (#858)

### DIFF
--- a/ui/src/components/dashboard/ConfirmActionSheet.tsx
+++ b/ui/src/components/dashboard/ConfirmActionSheet.tsx
@@ -45,7 +45,13 @@ export function ConfirmActionSheet({
       onClose={onClose}
       title={t("controls.gate.confirmSheetTitle", { name: equipment.name })}
     >
-      <div className="flex flex-col gap-5 pt-1">
+      {/* The slide has to sit in the thumb's arc, not on the phone's chin, and
+          the height above the bottom edge is bought with content rather than
+          with empty space: cancel is a real button instead of a text link, and
+          the stack breathes. Growing the sheet or floating it were both tried
+          and both read as a hole in the layout (#858). Cancel is deliberately
+          narrower and lighter than the slide: primary action, secondary exit. */}
+      <div className="flex flex-col gap-6 pt-2 pb-8">
         {subtitleParts.length > 0 && (
           <p className="text-[12px] text-text-tertiary text-center -mt-1">
             {subtitleParts.join(" · ")}
@@ -58,7 +64,7 @@ export function ConfirmActionSheet({
         />
         <button
           onClick={onClose}
-          className="w-full text-center text-[13px] text-text-tertiary hover:text-text-secondary py-1.5 cursor-pointer"
+          className="w-[150px] mx-auto mt-4 text-center text-[13px] text-text-secondary border border-border rounded-[9px] py-2 hover:bg-border-light cursor-pointer"
         >
           {t("common.cancel")}
         </button>

--- a/ui/src/components/dashboard/SlideToConfirm.test.tsx
+++ b/ui/src/components/dashboard/SlideToConfirm.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Issue #858 — the slide-to-confirm control had to fit a thumb.
+ *
+ * Full width on a 393 px phone meant a 295 px sweep starting in the
+ * bottom-left corner. These pin the two things that fix rests on: the track is
+ * capped, and the label never sits under the knob at either end of the travel.
+ *
+ * The threshold tests are the spec 146 guarantee (#320) that the cap must not
+ * have weakened: a partial drag still actuates nothing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { fireEvent, render, screen } from "../../test-utils";
+import { SlideToConfirm } from "./SlideToConfirm";
+
+/**
+ * jsdom lays nothing out, so the track reports the width we give it here.
+ * Kept equal to the CSS cap on purpose: the stub stands in for the capped
+ * track, and the cap assertion below reads the same number.
+ */
+const TRACK_WIDTH = 260;
+const KNOB_SPAN = 58; // knob 50 + 4 px padding either side
+const TRAVEL = TRACK_WIDTH - KNOB_SPAN;
+
+let widthSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  widthSpy = vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(TRACK_WIDTH);
+});
+afterEach(() => widthSpy.mockRestore());
+
+function setup(onConfirm = vi.fn()) {
+  const { container } = render(
+    <SlideToConfirm label="Slide to open" confirmedLabel="Actuated" onConfirm={onConfirm} />,
+  );
+  const knob = screen.getByRole("button", { name: "Slide to open" });
+  const track = container.firstElementChild as HTMLElement;
+  return { onConfirm, knob, track };
+}
+
+/** Drag the knob by `dx` px without releasing. */
+function drag(knob: HTMLElement, dx: number) {
+  fireEvent.pointerDown(knob, { pointerId: 1, clientX: 0 });
+  fireEvent.pointerMove(knob, { pointerId: 1, clientX: dx });
+}
+
+describe("SlideToConfirm", () => {
+  it("caps the track instead of filling its parent (#858)", () => {
+    const { track } = setup();
+    // The cap is the fix: without it the track inherits the sheet's full width.
+    expect(track.className).toMatch(new RegExp(`max-w-\\[${TRACK_WIDTH}px\\]`));
+    expect(track.className).toMatch(/mx-auto/);
+  });
+
+  it("keeps the label clear of the knob at rest", () => {
+    setup();
+    const label = screen.getByText("Slide to open");
+    // Centred across the whole track, at this width the text would start
+    // underneath the knob.
+    expect(label.style.left).toBe(`${KNOB_SPAN}px`);
+    expect(label.style.right).toBe("0px");
+  });
+
+  it("moves the label to the other side once the slide is done", () => {
+    const { knob } = setup();
+    drag(knob, TRAVEL);
+
+    const label = screen.getByText("Actuated");
+    expect(label.style.left).toBe("0px");
+    expect(label.style.right).toBe(`${KNOB_SPAN}px`);
+  });
+
+  it("actuates when the knob reaches the end of the capped track", () => {
+    const { onConfirm, knob } = setup();
+    drag(knob, TRAVEL);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("actuates once, not on every further move", () => {
+    const { onConfirm, knob } = setup();
+    drag(knob, TRAVEL);
+    fireEvent.pointerMove(knob, { pointerId: 1, clientX: TRAVEL + 40 });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not actuate on a partial drag, and snaps back on release", () => {
+    const { onConfirm, knob } = setup();
+    drag(knob, TRAVEL - 20);
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(knob.style.left).toBe(`${4 + TRAVEL - 20}px`);
+
+    fireEvent.pointerUp(knob, { pointerId: 1 });
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(knob.style.left).toBe("4px");
+  });
+
+  it("never actuates on a track too narrow to have any travel", () => {
+    widthSpy.mockReturnValue(0);
+    const { onConfirm, knob } = setup();
+    drag(knob, 200);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/dashboard/SlideToConfirm.tsx
+++ b/ui/src/components/dashboard/SlideToConfirm.tsx
@@ -3,12 +3,24 @@ import { ChevronsRight, Check } from "lucide-react";
 
 const KNOB = 50; // px
 const PAD = 4; // px inset around the knob
+/** Space the knob occupies at either end, label areas have to clear it. */
+const KNOB_SPAN = KNOB + PAD * 2; // px
 
 /**
  * Spec 146 — slide-to-confirm control (issue #320). A deliberate horizontal
  * drag of the knob to the end fires `onConfirm`; releasing before the end snaps
  * back and does nothing, so a stray touch cannot actuate. Pointer events unify
  * mouse and touch; `setPointerCapture` keeps the drag tracking off-element.
+ *
+ * The track is capped rather than filling its parent (#858). Full width, on a
+ * 393 px phone, meant a 295 px sweep starting in the bottom-left corner — the
+ * point farthest from the thumb of the hand holding the phone, on a control
+ * whose entire purpose is to be used one-handed in front of a gate. Capped at
+ * 260 px and centred, the knob starts at x=72 instead of x=20 and the sweep is
+ * 202 px, tuned by hand on a phone rather than picked from a round number.
+ *
+ * `maxOffset()` reads the rendered width, so the threshold, the progress fill
+ * and the knob all follow the cap without knowing about it.
  */
 export function SlideToConfirm({
   label,
@@ -29,7 +41,7 @@ export function SlideToConfirm({
 
   const maxOffset = () => {
     const w = trackRef.current?.clientWidth ?? 0;
-    return Math.max(0, w - KNOB - PAD * 2);
+    return Math.max(0, w - KNOB_SPAN);
   };
 
   const finish = () => {
@@ -71,7 +83,7 @@ export function SlideToConfirm({
   return (
     <div
       ref={trackRef}
-      className={`relative h-[58px] rounded-[12px] border overflow-hidden select-none touch-none ${
+      className={`relative mx-auto w-full max-w-[260px] h-[58px] rounded-[12px] border overflow-hidden select-none touch-none ${
         done ? "border-success/40" : "border-border"
       } bg-border-light`}
     >
@@ -80,11 +92,14 @@ export function SlideToConfirm({
         className={`absolute inset-y-0 left-0 rounded-[12px] ${done ? "bg-success/20" : "bg-warning/15"}`}
         style={{ width: `${KNOB + x}px`, transition }}
       />
-      {/* label */}
+      {/* Label, in whichever half the knob is not occupying: to its right at
+          rest, to its left once the slide is done. On a capped track a label
+          centred across the whole width would start under the knob. */}
       <div
-        className={`absolute inset-0 flex items-center justify-center gap-2 text-[13px] font-medium pointer-events-none ${
+        className={`absolute inset-y-0 flex items-center justify-center gap-2 px-2 text-[13px] font-medium whitespace-nowrap pointer-events-none ${
           done ? "text-success" : "text-text-secondary"
         }`}
+        style={done ? { left: 0, right: `${KNOB_SPAN}px` } : { left: `${KNOB_SPAN}px`, right: 0 }}
       >
         {done ? confirmedLabel : label}
         {!done && <ChevronsRight size={16} strokeWidth={2} className="text-warning" />}


### PR DESCRIPTION
## The report

The spec 146 confirmation slide is "trop large pour glisser avec le pouce", and it should sit nearer the middle of the screen.

## Root cause

`SlideToConfirm` capped nothing, so its track filled the sheet's content box. On a 393 px phone that is a 353 px track, a 50 px knob and **295 px of travel**, starting in the bottom-left corner of the screen and ending in the bottom-right one. One-handed, that corner is the farthest point from the thumb's pivot, and the sweep crosses the whole screen at the very bottom edge — on a control whose entire purpose is to be used one-handed standing in front of a gate.

## The fix

Tuned on a phone viewport against real data rather than picked from round numbers, measured at 393x852:

| | before | after |
| --- | --- | --- |
| track width | 353 px | 260 px |
| travel | 295 px | 202 px |
| knob start | x = 20 | x = 72 |
| height above the bottom edge | 88 px | 134 px |

The height is bought with content, not with empty space. Growing the sheet and floating it off the bottom were both tried on the device and both read as a hole in the layout. Instead the cancel becomes a real button rather than a text link, deliberately narrower (150 px) and lighter than the slide, so the stack fills the height it occupies and the primary action stays the wider of the two.

Travel is derived from the rendered width (`maxOffset()`), so the confirm threshold, the progress fill and the knob all followed the cap with no other change. What did not follow is the label: centred across the whole track, at this width it started underneath the knob at rest. It now takes whichever half the knob is not occupying — to its right at rest, to its left once confirmed.

## Tests

`ui/src/components/dashboard/SlideToConfirm.test.tsx`, 7 cases: the cap itself, the label clear of the knob at both ends of the travel, confirmation on reaching the end, confirmation firing once and not on every further move, a partial drag snapping back with nothing actuated, and a degenerate zero-width track never auto-confirming. Three of them fail against the pre-fix component; the other four are the spec 146 guarantees (#320) that the cap had to leave intact.

Empirically verified on the shadow instance with the real Porte Garage widget at 393x852: a 90 px drag snaps back and actuates nothing, a full drag confirms and shows the green state.

Full suite green: UI 907, typecheck and lint clean.

## Out of scope

Changing the gesture. Press-and-hold would remove the travel entirely, but the slide is what was validated with the reporter in #320 and shipped by spec 146.

Closes #858

Docs-Impact: none — the control looks and reads the same, the gesture and the guarantee behind it are unchanged, and no documentation page describes or pictures the slider's dimensions.
