### PR TITLE
feat(zones): sum the power a zone's submeters measure

### DIFF
--- a/docs/technical/data-model/zones.md
+++ b/docs/technical/data-model/zones.md
@@ -72,6 +72,11 @@ interface ZoneAggregatedData {
   waterValvesOpen: number;
   waterValvesTotal: number;
   waterFlowTotal: number | null; // SUM of current water flow (when supported)
+  // Spec 170 — SUM of `power` over the zone subtree's consumption submeters
+  // (isSubmeterEquipment: everything metered except the grid total and the
+  // production meters). Readings past their freshness budget are dropped, not
+  // counted as 0 W. `null` = nothing current to sum, distinct from a measured 0.
+  powerTotal: number | null;
   sunrise: string | null; // From SunlightManager (computed from home location)
   sunset: string | null;
   isDaylight: boolean | null;

--- a/docs/user/zones.fr.md
+++ b/docs/user/zones.fr.md
@@ -67,6 +67,7 @@ C'est l'une des fonctionnalités les plus puissantes de Sowel. Chaque zone calcu
 | **Fenêtres ouvertes**           | Nombre de contacts de fenêtre ouverts            | 2 fenêtres ouvertes                        |
 | **Fuite d'eau**                 | OU sur tous les capteurs de fuite                | Alerte si un capteur détecte de l'eau      |
 | **Fumée**                       | OU sur tous les capteurs de fumée                | Alerte si un capteur détecte de la fumée   |
+| **Puissance**                   | Somme des sous-compteurs de consommation         | 47,6 W (arrivée d'un gîte + sa plaque)     |
 
 ### Agrégation récursive
 
@@ -86,8 +87,22 @@ Dans la vue **Accueil**, chaque zone affiche un **bandeau d'état** avec les don
 - Pastille de comptage **Lumières** (par ex. "2/5")
 - Pastille de comptage **Volets** (par ex. "1/3")
 - Pastilles **Alerte** pour portes/fenêtres ouvertes, fuites d'eau, fumée
+- Pastille **Puissance** (par ex. « 47 W », ou « 2.4 kW » au-dessus du kilowatt) dès que la zone possède au moins un compteur
 
 Sous le bandeau, les équipements sont regroupés par type (Lumières, Volets, Capteurs) avec des contrôles intégrés.
+
+### Agrégation de puissance
+
+La pastille de puissance répond à « combien tire cette partie de la maison en ce moment ». Elle somme les équipements de la zone qui mesurent une **charge** — un `energy_meter` dédié, une prise avec mesure, tout équipement qui remonte des watts — sur la zone et toutes ses descendantes. C'est ce qui permet à une seule zone de totaliser deux circuits alimentés depuis des tableaux différents, ce qu'aucun compteur seul ne sait faire.
+
+Trois règles méritent d'être connues :
+
+- **Le compteur principal et les compteurs de production ne comptent jamais.** Une zone qui contient votre compteur réseau ou votre compteur solaire ne les additionne pas : un total ne mélange donc pas ce que la maison consomme avec ce qu'elle soutire ou produit.
+- **Pas de compteur, pas de pastille — et non « 0 W ».** Une zone qui ne mesure rien n'affiche rien. Une zone dont tous les compteurs lisent zéro affiche `0 W` : c'est une mesure, et la différence compte.
+- **Une mesure qui n'arrive plus est écartée, pas comptée comme zéro.** Une pince devenue muette ne dit rien sur le fait que sa charge tourne ou non : elle sort de la somme plutôt que de la tirer vers le bas.
+
+!!! warning "Un compteur d'arrivée et ses propres sous-compteurs se comptent deux fois"
+Si une zone contient à la fois un compteur sur un circuit et un compteur sur une charge alimentée par ce circuit, la charge est comptée deux fois — une fois dans l'arrivée, une fois pour elle-même. Sowel n'a pas de hiérarchie de compteurs : gardez les deux dans des zones différentes, ou lisez le total en sachant ce qu'il recouvre. Le même recouvrement affecte déjà le résidu « Autre » de la page Énergie.
 
 ## Fil d'activité
 

--- a/docs/user/zones.md
+++ b/docs/user/zones.md
@@ -53,20 +53,21 @@ This is one of Sowel's most powerful features. Every zone automatically computes
 
 ### What gets aggregated
 
-| Data                         | Logic                                | Example                              |
-| ---------------------------- | ------------------------------------ | ------------------------------------ |
-| **Temperature**              | Average of all temperature sensors   | 21.5 C (avg of 2 Aqara sensors)      |
-| **Humidity**                 | Average of all humidity sensors      | 45%                                  |
-| **Luminosity**               | Average of all light sensors         | 320 lx                               |
-| **Motion**                   | OR across all motion sensors         | "Motion" if any PIR detects presence |
-| **Motion duration**          | Time since last motion state change  | "Calm for 15 min"                    |
-| **Lights on**                | Count of active lights               | 2 / 5 lights on                      |
-| **Shutters open**            | Count of open shutters               | 1 / 3 shutters open                  |
-| **Average shutter position** | Average position across all shutters | 65%                                  |
-| **Open doors**               | Count of open door contacts          | 1 door open                          |
-| **Open windows**             | Count of open window contacts        | 2 windows open                       |
-| **Water leak**               | OR across all water leak sensors     | Alert if any sensor detects water    |
-| **Smoke**                    | OR across all smoke sensors          | Alert if any sensor detects smoke    |
+| Data                         | Logic                                   | Example                              |
+| ---------------------------- | --------------------------------------- | ------------------------------------ |
+| **Temperature**              | Average of all temperature sensors      | 21.5 C (avg of 2 Aqara sensors)      |
+| **Humidity**                 | Average of all humidity sensors         | 45%                                  |
+| **Luminosity**               | Average of all light sensors            | 320 lx                               |
+| **Motion**                   | OR across all motion sensors            | "Motion" if any PIR detects presence |
+| **Motion duration**          | Time since last motion state change     | "Calm for 15 min"                    |
+| **Lights on**                | Count of active lights                  | 2 / 5 lights on                      |
+| **Shutters open**            | Count of open shutters                  | 1 / 3 shutters open                  |
+| **Average shutter position** | Average position across all shutters    | 65%                                  |
+| **Open doors**               | Count of open door contacts             | 1 door open                          |
+| **Open windows**             | Count of open window contacts           | 2 windows open                       |
+| **Water leak**               | OR across all water leak sensors        | Alert if any sensor detects water    |
+| **Smoke**                    | OR across all smoke sensors             | Alert if any sensor detects smoke    |
+| **Power**                    | Sum of the zone's consumption submeters | 47.6 W (a flat's feed + its hob)     |
 
 ### Recursive aggregation
 
@@ -86,8 +87,22 @@ In the **Home** view, each zone displays a **status header** with aggregated dat
 - **Lights** count pill (e.g., "2/5")
 - **Shutters** count pill (e.g., "1/3")
 - **Alert** pills for open doors/windows, water leaks, smoke
+- **Power** pill (e.g., "47 W", or "2.4 kW" above the kilowatt) when the zone has at least one meter
 
 Below the header, equipments are grouped by type (Lights, Shutters, Sensors) with inline controls.
+
+### Power aggregation
+
+The power pill answers "how much is this part of the house drawing right now". It sums the equipments a zone holds that measure a **load** — a dedicated `energy_meter`, a metering plug, any equipment reporting watts — across the zone and all its descendants. This is what lets one zone total two circuits fed from different boards, which no single meter can do.
+
+Three rules are worth knowing:
+
+- **The grid meter and production meters never count.** A zone holding your main meter or your solar meter does not add them in, so a total never mixes what the house draws with what it imports or produces.
+- **No meter means no pill, not "0 W".** A zone that measures nothing shows nothing. A zone whose meters all read zero shows `0 W` — that is a measurement, and the difference matters.
+- **A reading that stopped arriving is dropped, not counted as zero.** A clamp that went quiet says nothing about whether its load is running, so it leaves the sum rather than pulling it down.
+
+!!! warning "A feed meter and its own submeters double-count"
+If a zone holds both a meter on a circuit and a meter on a load fed by that circuit, the load is counted twice — once inside the feed, once on its own. Sowel has no meter hierarchy, so keep the two in different zones, or read the total knowing what it overlaps. The same overlap already affects the "Other" residual on the Energy page.
 
 ## Activity feed
 

--- a/specs/170-zone-power-aggregate/architecture.md
+++ b/specs/170-zone-power-aggregate/architecture.md
@@ -1,0 +1,106 @@
+# Spec 170 — Architecture
+
+## Data model
+
+One additive field on an existing public type. No SQLite change, no migration, nothing persisted: `ZoneAggregatedData` is derived on every aggregation pass.
+
+```ts
+// src/shared/types.ts — ZoneAggregatedData
+/**
+ * Spec 170 — live sum, in watts, of the consumption submeters in this zone and
+ * its descendants. `null` when nothing current was found to sum, which is not
+ * the same as a measured 0 W.
+ */
+powerTotal: number | null;
+```
+
+The internal accumulator follows the `waterFlow` pair exactly — a running sum plus a "did anything land here" flag, so the `null`/`0` distinction survives the merge:
+
+```ts
+// src/zones/zone-aggregator.ts — Accumulator
+powerSum: number;
+powerHasData: boolean;
+```
+
+## Where it plugs in
+
+The aggregator already walks a zone and its descendants, merges accumulators, and turns the result into the public shape. Three existing seams, no new pass:
+
+```
+ZoneAggregator.aggregateZone(zoneId)
+  → collect equipments of the zone + descendants
+      → status === "offline"  → unavailableByCategory, skip        (unchanged, FR-5)
+      → accumulateEquipmentPower(acc, withDetails)                 (NEW)
+      → accumulateWaterValve / accumulateBindings                  (unchanged)
+  → mergeAccumulators(children)   → powerSum += , powerHasData ||= (NEW, FR-2)
+  → toPublic(acc)                 → powerTotal = hasData ? round : null (NEW, FR-3)
+```
+
+`accumulateEquipmentPower` runs at the equipment level, not inside `accumulateBindings`, because the decision needs the equipment's **type** and **status**, not just a binding — `isSubmeterEquipment` keys off the type, and `classifyPowerReading` needs the status. That is the same reason the `display` counters and `water_valve` sit at that level.
+
+## The two shared rules it reuses
+
+Neither is restated:
+
+| Question                      | Answered by                                             | Lives in                          |
+| ----------------------------- | ------------------------------------------------------- | --------------------------------- |
+| Is this equipment a load?     | `isSubmeterEquipment(type, bindings)` (#523, blocklist) | `src/equipments/metering.ts`      |
+| Is this reading a live value? | `classifyPowerReading({...}) === "current"` (#832)      | `src/shared/reading-freshness.ts` |
+
+`classifyPowerReading` already returns `offline` for an offline equipment, so the call is correct even though the early-out means it never sees one.
+
+## Event flow
+
+Unchanged. `powerTotal` rides the existing `zone.data.changed` event and the existing WebSocket push. The change-detection helper `aggregatedDataEqual` gains one comparison so a zone whose power moved actually emits:
+
+```ts
+a.powerTotal === b.powerTotal &&
+```
+
+Without that line the field would update silently and the UI would keep the previous value until some other field moved — the failure mode `aggregatedDataEqual` exists to prevent.
+
+**Cadence note.** A power reading moves on every meter report (45 s on the reference PJ-1203A clamps, faster on some plugs), and each move now flips `aggregatedDataEqual` to false and emits `zone.data.changed`. That is the intended behaviour — it is what makes the pill live — and it is the same order of magnitude as temperature and humidity traffic, which already ride this path from every sensor in the house. High-frequency events are deduplicated per batch before reaching WebSocket clients.
+
+## API
+
+No new endpoint. `powerTotal` appears in every payload already carrying `aggregatedData`:
+
+- `GET /api/v1/zones/:id/aggregation`
+- the `zone.data.changed` WebSocket message
+
+## UI
+
+One pill, in the existing counter cluster of `ZoneAggregationPills.tsx`, rendered when `powerTotal !== null`:
+
+```tsx
+if (data.powerTotal !== null) {
+  counterPills.push({
+    key: "power",
+    icon: <Zap size={14} strokeWidth={1.5} />,
+    label: formatWatts(data.powerTotal),
+    variant: data.powerTotal > 0 ? "active" : "default",
+    ...
+  });
+}
+```
+
+`formatWatts` keeps watts below 1000 (`39 W`) and switches to kilowatts above (`2.4 kW`), so a house drawing four figures does not print six characters of noise. Unit symbols are not translated, like the `m³/h` suffix on the water-valve pill.
+
+## Files touched
+
+| File                                              | Change                                                          |
+| ------------------------------------------------- | --------------------------------------------------------------- |
+| `src/shared/types.ts`                             | `powerTotal` on `ZoneAggregatedData`                            |
+| `src/zones/zone-aggregator.ts`                    | accumulator pair, `accumulateEquipmentPower`, merge, public, eq |
+| `src/zones/zone-aggregator.test.ts`               | the scenarios of the test plan                                  |
+| `ui/src/types.ts`                                 | mirror `powerTotal`                                             |
+| `ui/src/components/home/ZoneAggregationPills.tsx` | the power pill + `formatWatts`                                  |
+| `docs/user/zones.md` / `.fr.md`                   | what the pill shows and what it deliberately excludes           |
+
+## Rejected alternatives
+
+**Sum inside `accumulateBindings`.** It receives bindings and an equipment type but no status, so freshness could not be judged there without widening the signature for one caller.
+
+**A `power` field on the zone row in SQLite.** Persisting a derived, second-resolution value invites it to go stale and disagree with the equipments it comes from. Every other aggregate is derived; this one is not special.
+
+**Reusing `energy_meter` as the only contributor.** It would miss metering plugs (`switch` + `power`), which are loads by exactly the same argument, and would introduce a second definition of "a load" alongside `isSubmeterEquipment`.

--- a/specs/170-zone-power-aggregate/plan.md
+++ b/specs/170-zone-power-aggregate/plan.md
@@ -1,0 +1,57 @@
+# Spec 170 — Implementation plan
+
+## Steps
+
+1. **Types** — `powerTotal: number | null` on `ZoneAggregatedData` (`src/shared/types.ts`), mirrored in `ui/src/types.ts`.
+2. **Aggregator** — in `src/zones/zone-aggregator.ts`:
+   - `powerSum` / `powerHasData` in `Accumulator` + `emptyAccumulator`;
+   - sum both in `mergeAccumulators`;
+   - `accumulateEquipmentPower(acc, type, status, bindings)`, called from the equipment loop after the offline early-out;
+   - `powerTotal` in the public projection, rounded to one decimal, `null` when `!powerHasData`;
+   - one comparison in `aggregatedDataEqual`.
+3. **Tests** — the scenarios below in `src/zones/zone-aggregator.test.ts`.
+4. **UI** — `formatWatts` + the power pill in `ZoneAggregationPills.tsx`.
+5. **Docs** — `docs/user/zones.md` + `.fr.md`. `docs/technical/data-model.md` names `ZoneAggregatedData` only in the event table, so it needs no change and has no `.fr.md` counterpart.
+6. **Validate** — `npx tsc --noEmit`, `npm run typecheck:tests`, `npx vitest run`, `npx eslint src/ --ext .ts`, `cd ui && npx tsc -b --noEmit && npx eslint .`, `bash scripts/check-docs-parity.sh`, `bash scripts/check-docs-impact.sh`.
+
+No database migration, no new API route, no new event type.
+
+## Test Plan
+
+### Modules to test
+
+- `src/zones/zone-aggregator.ts` — the only module with new business logic. `metering.ts` and `reading-freshness.ts` are reused unchanged and already carry their own suites.
+
+### Scenarios
+
+| Module          | Scenario                                                  | Expected                                        |
+| --------------- | --------------------------------------------------------- | ----------------------------------------------- |
+| zone-aggregator | One `energy_meter` at 39.4 W in the zone                  | `powerTotal === 39.4`                           |
+| zone-aggregator | Meter at 39.4 W + child-zone meter at 8.2 W               | `powerTotal === 47.6` (descendant roll-up)      |
+| zone-aggregator | Zone with no metered equipment                            | `powerTotal === null` (not `0`)                 |
+| zone-aggregator | Zone holding only a `main_energy_meter`                   | `powerTotal === null`                           |
+| zone-aggregator | Zone holding only an `energy_production_meter`            | `powerTotal === null`                           |
+| zone-aggregator | Metering `switch` (plug reporting `state` + `power`)      | contributes to the sum                          |
+| zone-aggregator | Submeter whose `power` is older than its freshness budget | excluded; lone submeter ⇒ `powerTotal === null` |
+| zone-aggregator | Submeter equipment `offline`                              | excluded; counted in `unavailableByCategory`    |
+| zone-aggregator | `power` binding value is `null`                           | excluded (not a number)                         |
+| zone-aggregator | `power` binding value is a boolean                        | excluded (a state, not a measurement)           |
+| zone-aggregator | Two submeters both reading exactly 0 W                    | `powerTotal === 0` (measured, not `null`)       |
+| zone-aggregator | Clamp mounted backwards reporting −250 W alongside +100 W | `powerTotal === -150` (no abs, no clamp)        |
+| zone-aggregator | Float artefact (39.4 + 8.2 + 0.04 sums to 47.63999…)      | rounded to one decimal ⇒ 47.6                   |
+| zone-aggregator | Power changes only                                        | `aggregatedDataEqual` false ⇒ event emitted     |
+
+### Retro-compat
+
+- Every existing `zone-aggregator.test.ts` scenario keeps passing: `powerTotal` is additive and no existing field changes.
+- Zones with no meters — the overwhelming majority — gain a `null` field and no pill.
+
+## Tasks
+
+- [x] 1. Types (core + UI mirror)
+- [x] 2. Aggregator (accumulator, merge, accumulate, public, equality)
+- [x] 3. Tests — 14 scenarios above
+- [x] 4. UI pill + `formatWatts`
+- [x] 5. Docs EN + FR (`docs/user/zones`)
+- [x] 6. Full validation suite green
+- [x] 7. Diff reviewed against the Phase 5 checklist (see spec notes)

--- a/specs/170-zone-power-aggregate/spec.md
+++ b/specs/170-zone-power-aggregate/spec.md
@@ -1,0 +1,86 @@
+# Spec 170 — A zone sums the power its submeters measure
+
+**Status**: implemented
+**Scope**: core (zone aggregation) + UI (zone pills)
+
+## Problem
+
+A zone already answers "how warm is it here", "is anyone here", "are the shutters open". It cannot answer **"how much is this part of the house drawing right now"**, even when every watt of the answer is already in the engine.
+
+The trigger is a guest house metered by two clamps: one on the flat's own feed, one on the cooking hob, which is fed from the main house board and therefore sits outside the first measurement. Both are `energy_meter` equipments, both are in the guest-house zone, both report `power` every 45 s. The total exists in the data and nowhere on the screen.
+
+There is no way to produce it today, and the workarounds all fail for a structural reason:
+
+- **One equipment cannot carry both.** A `dataBinding` alias is UNIQUE per equipment (SQL constraint; `addDataBinding` answers 409 `Alias "power" already exists on this equipment`). Two `power` channels on one meter is not expressible.
+- **The zone aggregate has no power field.** `ZoneAggregatedData` carries temperature, humidity, luminosity, motion, openings, lights, shutters, water valves, displays — and `waterFlowTotal`, a sum with exactly the shape this needs.
+- **Charts cannot do it.** `SavedChartConfig` is a list of `{equipmentId, alias, color}`; there is no stacking and no arithmetic between series.
+- **Recipes cannot do it.** `RecipeContext` exposes `equipmentManager`, `zoneAggregator` and `dispatchOrder` — it can read and it can act, it cannot write a measurement.
+
+So the only place the sum can live is where every other zone-level answer already lives.
+
+## Design principle — the zone sums what it already refuses to double-count
+
+The engine already owns the "is this a consumption submeter" question, in one place: `isSubmeterEquipment` (issue #523), a blocklist that enrols any equipment carrying a numeric power/energy channel except the grid total and the two production surfaces. Reusing it means the zone sum and the by-usage breakdown always agree on **what counts as a load** — the same decision, taken once.
+
+The same applies to freshness. `classifyPowerReading` (issue #832) exists precisely because a `power` binding can carry a value of unbounded age on an equipment that is nominally online, and a stale `0 W` reads as "this appliance is off". That rule was restated per surface once already, and the two surfaces then described the same appliance two contradictory ways (#744). This spec adds a third surface and restates nothing.
+
+## Goal
+
+Give every zone a live sum, in watts, of the loads its submeters measure — its own and its descendants'.
+
+## In scope
+
+- `ZoneAggregatedData.powerTotal: number | null` — watts, `null` when the zone has nothing current to sum.
+- Accumulation in `ZoneAggregator`, inheriting the existing descendant merge and the existing offline early-out.
+- A power pill on the zone header, next to the other counters.
+- Tests covering inclusion, exclusion, staleness and the descendant roll-up.
+
+## Out of scope
+
+- **Energy (Wh/kWh) per zone.** Cumulative energy is computed per equipment from InfluxDB by `EnergyAggregator`; a zone-level cumul is a different, heavier feature (bucket queries, downsampling, tariff split) and belongs in its own spec.
+- **The double-counting question.** When a zone holds both a feed meter and a submeter of a load fed by it, the sum counts that load twice — the same way the by-usage residual does today. Sowel has no meter hierarchy and no "detail, do not count" flag; introducing one is a larger design (see "Open question") and would change the existing by-usage breakdown, which this spec leaves untouched.
+- **Recording the zone total.** Nothing is written to InfluxDB; `powerTotal` is derived on every aggregation pass like every other field of `ZoneAggregatedData`.
+- **A power figure anywhere else** — Dashboard widgets, the Energy page, the mobile zone sheet.
+
+## Functional rules
+
+1. **FR-1 — What counts.** An equipment contributes when all three hold: `isSubmeterEquipment(type, dataBindings)` is true, it has a binding whose alias is `power` with a `number` value, and `classifyPowerReading` returns `current` for it. The grid meter, production meters and solar panels never contribute (`NON_SUBMETER_TYPES`), so the root zone sums the loads of the house and not the house total plus its own parts.
+
+2. **FR-2 — Descendants included.** A zone's `powerTotal` covers itself and every descendant zone, through the existing accumulator merge. The guest house totals its flat feed and the hob in its `RDC > Salle à manger` child without either being restated.
+
+3. **FR-3 — Null, not zero.** A zone with no contributing equipment reports `null`, not `0`. `0` is a measurement — every submeter reporting zero watts — and a zone with no meters at all has not measured anything. Same contract as `waterFlowTotal`.
+
+4. **FR-4 — Stale readings are dropped, not zeroed.** A submeter whose last `power` is older than its freshness budget is excluded from the sum. It is not counted as `0 W`: the load may well be running. A zone whose only submeter has gone stale therefore reports `null`.
+
+5. **FR-5 — Offline equipments are already excluded.** The aggregator's existing early-out skips an equipment whose status is `offline` and records its bindings in `unavailableByCategory`. Power inherits that behaviour unchanged, so the existing "(N unavailable)" hint covers a missing meter with no new plumbing.
+
+6. **FR-6 — Negative readings are summed as they are.** A clamp mounted backwards reports negative watts. The sum does not take an absolute value and does not clamp at zero: a negative total is a wiring fault the user needs to see, and hiding it is how a fault stays invisible. (`PowerSubmeterIntegrator` integrates `|P|` for energy, spec 091 — that is a different question: it protects a cumulative counter from running backwards.)
+
+7. **FR-7 — Rounding.** The sum is rounded to one decimal, like `waterFlowTotal` is rounded to two, so a float artefact does not make the pill flicker between `39.400000000000006` and `39.4`.
+
+## Acceptance criteria
+
+- [x] A zone holding one `energy_meter` reporting 39.4 W has `powerTotal === 39.4`.
+- [x] A zone holding a meter at 39.4 W and a child zone holding one at 8.2 W has `powerTotal === 47.6`.
+- [x] A zone holding no metered equipment has `powerTotal === null`.
+- [x] A zone holding only the `main_energy_meter` has `powerTotal === null`.
+- [x] A zone holding only an `energy_production_meter` has `powerTotal === null`.
+- [x] A metering `switch` (a plug reporting `power` alongside `state`) contributes.
+- [x] A submeter whose `power` binding is older than its freshness budget does not contribute.
+- [x] A submeter whose equipment is `offline` does not contribute and is counted in `unavailableByCategory`.
+- [x] The zone header shows a power pill when `powerTotal !== null`, and no pill when it is `null`.
+
+## Edge cases
+
+| Case                                           | Behaviour                                                              |
+| ---------------------------------------------- | ---------------------------------------------------------------------- |
+| `power` binding present but value is `null`    | Not a number → excluded (FR-1)                                         |
+| `power` binding present but value is a boolean | Excluded — a thermostat's on/off "power" is a state, not a measurement |
+| Equipment has `energy` but no `power`          | Excluded from `powerTotal`; it still counts as a submeter elsewhere    |
+| Every contributing submeter reads exactly 0 W  | `powerTotal === 0` — measured, and distinct from `null`                |
+| Zone tree deeper than two levels               | Rolled up at every level by the existing merge                         |
+| A submeter appears in two zones                | Impossible — an equipment has exactly one `zoneId`                     |
+
+## Open question (not resolved here)
+
+When a feed meter and a submeter of one of its loads share a zone, the load is counted twice — in the zone sum, and in the by-usage residual `total − Σ submeters`. The fix is a meter hierarchy (a submeter declaring its parent) or a "detail" flag excluding an equipment from enrolment. Both change the existing energy breakdown and deserve their own spec; this one deliberately reproduces today's behaviour rather than inventing a second, divergent rule.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -252,6 +252,13 @@ export interface ZoneAggregatedData {
   waterValvesOpen: number;
   waterValvesTotal: number;
   waterFlowTotal: number | null;
+  /**
+   * Spec 170 — live sum, in watts, of the consumption submeters in this zone
+   * and its descendants. `null` when nothing current was found to sum, which is
+   * NOT the same as a measured 0 W: a zone with no meters has not measured
+   * anything, and a stale reading is dropped rather than counted as zero.
+   */
+  powerTotal: number | null;
   sunrise: string | null;
   sunset: string | null;
   isDaylight: boolean | null;

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -7,7 +7,7 @@ import { EquipmentManager } from "../equipments/equipment-manager.js";
 import { DeviceManager } from "../devices/device-manager.js";
 import { EventBus } from "../core/event-bus.js";
 import { createLogger } from "../core/logger.js";
-import type { EngineEvent } from "../shared/types.js";
+import type { EngineEvent, EquipmentType } from "../shared/types.js";
 
 function createTestDb(): Database.Database {
   const db = new Database(":memory:");
@@ -115,6 +115,7 @@ describe("ZoneAggregator", () => {
         waterValvesOpen: 0,
         waterValvesTotal: 0,
         waterFlowTotal: null,
+        powerTotal: null,
         sunrise: null,
         sunset: null,
         isDaylight: null,
@@ -1088,6 +1089,218 @@ describe("ZoneAggregator", () => {
       expect(data?.temperature).toBe(21.5);
       expect(data?.lightsOn).toBe(1);
       expect(data?.lightsTotal).toBe(1);
+    });
+  });
+
+  // ============================================================
+  // Spec 170 — power aggregation
+  // ============================================================
+
+  describe("power aggregation (spec 170)", () => {
+    /** Seed a device exposing one numeric `power` channel and bind it to a new equipment. */
+    function seedMeter(
+      zoneId: string,
+      opts: {
+        name: string;
+        watts?: string | null;
+        type?: EquipmentType;
+        dataType?: string;
+        category?: string;
+      },
+    ) {
+      const dev = seedDevice(db, {
+        name: opts.name,
+        dataKeys: [
+          {
+            key: "power",
+            type: opts.dataType ?? "number",
+            category: opts.category ?? "power",
+            value: opts.watts ?? undefined,
+          },
+        ],
+      });
+      const eq = equipmentManager.create({
+        name: opts.name,
+        type: opts.type ?? "energy_meter",
+        zoneId,
+      });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "power");
+      return { dev, eq };
+    }
+
+    it("sums one submeter's live power", () => {
+      const zone = zoneManager.create({ name: "Gite" });
+      seedMeter(zone.id, { name: "Feed", watts: "39.4" });
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(39.4);
+    });
+
+    it("rolls up submeters from descendant zones", () => {
+      const parent = zoneManager.create({ name: "Gite" });
+      const child = zoneManager.create({ name: "Salle à manger", parentId: parent.id });
+      seedMeter(parent.id, { name: "Feed", watts: "39.4" });
+      seedMeter(child.id, { name: "Hob", watts: "8.2" });
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(parent.id)?.powerTotal).toBe(47.6);
+      expect(aggregator.getByZoneId(child.id)?.powerTotal).toBe(8.2);
+    });
+
+    it("reports null — not zero — for a zone with no metered equipment", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      const dev = seedDevice(db, {
+        name: "Temp",
+        dataKeys: [{ key: "temperature", type: "number", category: "temperature", value: "20" }],
+      });
+      const eq = equipmentManager.create({ name: "Sensor", type: "sensor", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "temperature");
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBeNull();
+    });
+
+    it("excludes the main energy meter", () => {
+      const zone = zoneManager.create({ name: "Domaine" });
+      seedMeter(zone.id, { name: "EDF", watts: "1200", type: "main_energy_meter" });
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBeNull();
+    });
+
+    it("excludes production meters", () => {
+      const zone = zoneManager.create({ name: "Domaine" });
+      seedMeter(zone.id, { name: "Solaire", watts: "800", type: "energy_production_meter" });
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBeNull();
+    });
+
+    it("includes a metering switch (a plug reporting power alongside state)", () => {
+      const zone = zoneManager.create({ name: "Bureau" });
+      const dev = seedDevice(db, {
+        name: "Plug",
+        dataKeys: [
+          { key: "state", type: "boolean", category: "light_state", value: "true" },
+          { key: "power", type: "number", category: "power", value: "62.5" },
+        ],
+      });
+      const eq = equipmentManager.create({ name: "Plug", type: "switch", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "state");
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[1], "power");
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(62.5);
+    });
+
+    it("drops a stale reading instead of counting it as 0 W", () => {
+      const zone = zoneManager.create({ name: "Gite" });
+      const { dev } = seedMeter(zone.id, { name: "Feed", watts: "39.4" });
+      // Older than the 2-minute power budget: the clamp stopped reporting, which
+      // says nothing about whether the load is running.
+      db.prepare("UPDATE device_data SET last_updated = ? WHERE id = ?").run(
+        new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+        dev.dataIds[0],
+      );
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBeNull();
+    });
+
+    it("excludes an offline submeter and counts it in unavailableEquipmentsByCategory", () => {
+      const zone = zoneManager.create({ name: "Gite" });
+      seedMeter(zone.id, { name: "Feed", watts: "39.4" });
+      const offline = seedMeter(zone.id, { name: "Hob", watts: "8.2" });
+      db.prepare("UPDATE devices SET status = 'offline' WHERE id = ?").run(offline.dev.deviceId);
+
+      aggregator.computeAll();
+
+      const data = aggregator.getByZoneId(zone.id);
+      expect(data?.powerTotal).toBe(39.4);
+      expect(data?.unavailableEquipmentsByCategory).toEqual({ power: 1 });
+    });
+
+    it("ignores a power binding with no value", () => {
+      const zone = zoneManager.create({ name: "Gite" });
+      seedMeter(zone.id, { name: "Feed", watts: null });
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBeNull();
+    });
+
+    it("ignores a non-numeric power channel (a state, not a measurement)", () => {
+      const zone = zoneManager.create({ name: "Salon" });
+      seedMeter(zone.id, {
+        name: "Thermostat",
+        watts: "true",
+        type: "thermostat",
+        dataType: "boolean",
+      });
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBeNull();
+    });
+
+    it("reports a measured 0 W as 0, distinct from null", () => {
+      const zone = zoneManager.create({ name: "Gite" });
+      seedMeter(zone.id, { name: "Feed", watts: "0" });
+      seedMeter(zone.id, { name: "Hob", watts: "0" });
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(0);
+    });
+
+    it("sums a backwards clamp as reported, without absolute value or clamping", () => {
+      const zone = zoneManager.create({ name: "Gite" });
+      seedMeter(zone.id, { name: "Backwards", watts: "-250" });
+      seedMeter(zone.id, { name: "Feed", watts: "100" });
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(-150);
+    });
+
+    it("rounds the sum to one decimal", () => {
+      const zone = zoneManager.create({ name: "Gite" });
+      seedMeter(zone.id, { name: "A", watts: "39.4" });
+      seedMeter(zone.id, { name: "B", watts: "8.2" });
+      seedMeter(zone.id, { name: "C", watts: "0.04" });
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(47.6);
+    });
+
+    it("emits zone.data.changed when only the power total moved", () => {
+      const zone = zoneManager.create({ name: "Gite" });
+      const { dev, eq } = seedMeter(zone.id, { name: "Feed", watts: "39.4" });
+
+      aggregator.computeAll();
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(39.4);
+
+      db.prepare("UPDATE device_data SET value = ? WHERE id = ?").run("2400", dev.dataIds[0]);
+      events.length = 0;
+
+      eventBus.emit({
+        type: "equipment.data.changed",
+        equipmentId: eq.id,
+        alias: "power",
+        value: 2400,
+        previous: 39.4,
+      });
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(2400);
+      expect(events.filter((e) => e.type === "zone.data.changed").length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -5,12 +5,15 @@ import type { EquipmentManager } from "../equipments/equipment-manager.js";
 import type { SunlightManager } from "./sunlight-manager.js";
 import type {
   DataCategory,
+  EquipmentStatus,
   EquipmentType,
   ZoneAggregatedData,
   DataBindingWithValue,
   Zone,
 } from "../shared/types.js";
 import { ROOT_ZONE_ID } from "../shared/constants.js";
+import { isSubmeterEquipment } from "../equipments/metering.js";
+import { classifyPowerReading } from "../shared/reading-freshness.js";
 
 // ============================================================
 // Internal accumulator for aggregation (tracks sums + counts)
@@ -39,6 +42,10 @@ interface Accumulator {
   waterValvesTotal: number;
   waterFlowSum: number;
   waterFlowHasData: boolean;
+  /** Spec 170 — running sum of the live `power` of this zone's submeters. */
+  powerSum: number;
+  /** Spec 170 — whether any submeter landed in `powerSum`, so 0 W stays distinct from "no meter". */
+  powerHasData: boolean;
   /** Spec 120 — displays online (EquipmentStatus === "online") vs total. */
   displaysOnline: number;
   displaysTotal: number;
@@ -70,6 +77,8 @@ function emptyAccumulator(): Accumulator {
     waterValvesTotal: 0,
     waterFlowSum: 0,
     waterFlowHasData: false,
+    powerSum: 0,
+    powerHasData: false,
     displaysOnline: 0,
     displaysTotal: 0,
     unavailableByCategory: {},
@@ -111,6 +120,8 @@ function mergeAccumulators(a: Accumulator, b: Accumulator): Accumulator {
     waterValvesTotal: a.waterValvesTotal + b.waterValvesTotal,
     waterFlowSum: a.waterFlowSum + b.waterFlowSum,
     waterFlowHasData: a.waterFlowHasData || b.waterFlowHasData,
+    powerSum: a.powerSum + b.powerSum,
+    powerHasData: a.powerHasData || b.powerHasData,
     displaysOnline: a.displaysOnline + b.displaysOnline,
     displaysTotal: a.displaysTotal + b.displaysTotal,
     unavailableByCategory: mergeUnavailable(a.unavailableByCategory, b.unavailableByCategory),
@@ -145,6 +156,7 @@ function accumulatorToPublic(acc: Accumulator): ZoneAggregatedData {
     waterValvesOpen: acc.waterValvesOpen,
     waterValvesTotal: acc.waterValvesTotal,
     waterFlowTotal: acc.waterFlowHasData ? Math.round(acc.waterFlowSum * 100) / 100 : null,
+    powerTotal: acc.powerHasData ? Math.round(acc.powerSum * 10) / 10 : null,
     sunrise: null,
     sunset: null,
     isDaylight: null,
@@ -176,6 +188,7 @@ function aggregatedDataEqual(a: ZoneAggregatedData, b: ZoneAggregatedData): bool
     a.waterValvesOpen === b.waterValvesOpen &&
     a.waterValvesTotal === b.waterValvesTotal &&
     a.waterFlowTotal === b.waterFlowTotal &&
+    a.powerTotal === b.powerTotal &&
     a.sunrise === b.sunrise &&
     a.sunset === b.sunset &&
     a.isDaylight === b.isDaylight &&
@@ -518,6 +531,7 @@ export class ZoneAggregator {
       }
 
       const bindings = withDetails.dataBindings;
+      this.accumulateEquipmentPower(acc, equipment.type, withDetails.status, bindings);
       if (equipment.type === "water_valve") {
         this.accumulateWaterValve(acc, bindings);
       } else {
@@ -526,6 +540,61 @@ export class ZoneAggregator {
     }
 
     return acc;
+  }
+
+  /**
+   * Spec 170 — add one equipment's live draw to the zone's power sum.
+   *
+   * Runs at the equipment level rather than inside `accumulateBindings` because
+   * the decision needs the equipment's TYPE and STATUS, not just a binding.
+   *
+   * Neither of the two rules below is restated here — both are the engine's
+   * single implementation, so this surface can never drift from the by-usage
+   * breakdown the way #744 saw two surfaces describe one appliance two
+   * contradictory ways:
+   *
+   *  - `isSubmeterEquipment` (#523) decides what counts as a load. It excludes
+   *    the grid total and the production meters, so the root zone sums the
+   *    house's loads instead of the house total plus its own parts.
+   *  - `classifyPowerReading` (#832) decides whether the reading is a live
+   *    measurement. A stale one is DROPPED, never counted as 0 W — a clamp that
+   *    stopped reporting says nothing about whether its load is running.
+   *
+   * Note this is deliberately stricter than the rest of the aggregation for a
+   * `degraded` equipment. Elsewhere a degraded equipment still contributes its
+   * last known value, which is right for a temperature — a room does not cool
+   * because a sensor went quiet. It is wrong for a load: the whole point of
+   * #744 is that a stale `0 W` reads as "this appliance is off", and a water
+   * heater drawing 560 W displayed as 0 W is the bug that spec exists for.
+   */
+  private accumulateEquipmentPower(
+    acc: Accumulator,
+    equipmentType: EquipmentType,
+    status: EquipmentStatus,
+    bindings: DataBindingWithValue[],
+  ): void {
+    if (!isSubmeterEquipment(equipmentType, bindings)) return;
+
+    const powerBinding = bindings.find((b) => b.alias === "power");
+    // A non-numeric `power` is a state, not a measurement (a thermostat's own
+    // on/off switch); `isSubmeterEquipment` makes the same distinction.
+    if (!powerBinding || typeof powerBinding.value !== "number") return;
+
+    const verdict = classifyPowerReading({
+      status,
+      value: powerBinding.value,
+      lastUpdated: powerBinding.lastUpdated,
+      equipmentType,
+    });
+    if (verdict !== "current") return;
+
+    // Summed as reported: no absolute value, no clamp at zero. A clamp mounted
+    // backwards reports negative watts, and a negative total is a wiring fault
+    // the user needs to see. (`PowerSubmeterIntegrator` integrates |P| for
+    // energy per spec 091 — that protects a cumulative counter, a different
+    // question.)
+    acc.powerSum += powerBinding.value;
+    acc.powerHasData = true;
   }
 
   /**

--- a/ui/src/components/home/ZoneAggregationPills.tsx
+++ b/ui/src/components/home/ZoneAggregationPills.tsx
@@ -10,6 +10,7 @@ import {
   SquareStack,
   Droplet,
   Flame,
+  Zap,
 } from "lucide-react";
 import { ShutterIcon } from "../icons/ShutterIcons";
 import { WaterValveIcon } from "../icons/WaterValveIcon";
@@ -17,6 +18,15 @@ import { ZoneSparkline } from "../history/ZoneSparkline";
 import type { ZoneAggregatedData } from "../../types";
 
 type PillVariant = "default" | "active" | "calm" | "alert";
+
+/**
+ * Spec 170 — watts below the kilowatt, kilowatts above, so a house drawing four
+ * figures does not print six characters of noise in a pill. Unit symbols are not
+ * translated, like the `m³/h` suffix on the water-valve pill.
+ */
+function formatWatts(watts: number): string {
+  return Math.abs(watts) >= 1000 ? `${(watts / 1000).toFixed(1)} kW` : `${Math.round(watts)} W`;
+}
 
 interface ZoneAggregationPillsProps {
   data: ZoneAggregatedData;
@@ -154,6 +164,20 @@ export function ZoneAggregationPills({
       icon: <WaterValveIcon size={14} strokeWidth={1.5} />,
       label: `${data.waterValvesOpen}/${data.waterValvesTotal}${flowSuffix}`,
       variant: someOpen ? "active" : "default",
+      iconTint: "text-text-tertiary",
+      valueTint: "text-text-tertiary",
+    });
+  }
+
+  // Spec 170 — the zone's live draw, summed from its submeters. Rendered only
+  // when the zone actually measures something: `null` means no meter here, and
+  // a pill reading "0 W" there would be a measurement the zone never made.
+  if (data.powerTotal !== null) {
+    counterPills.push({
+      key: "power",
+      icon: <Zap size={14} strokeWidth={1.5} />,
+      label: formatWatts(data.powerTotal),
+      variant: data.powerTotal > 0 ? "active" : "default",
       iconTint: "text-text-tertiary",
       valueTint: "text-text-tertiary",
     });

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -221,6 +221,10 @@ export interface ZoneAggregatedData {
   waterValvesOpen: number;
   waterValvesTotal: number;
   waterFlowTotal: number | null;
+  /** Spec 170 — live sum, in watts, of the consumption submeters in this zone
+   *  and its descendants. `null` when there was nothing current to sum, which
+   *  is not the same as a measured 0 W. */
+  powerTotal: number | null;
   sunrise: string | null;
   sunset: string | null;
   isDaylight: boolean | null;


### PR DESCRIPTION
## Problem

A zone answers "how warm is it here" and "is anyone here". It cannot answer **"how much is this part of the house drawing right now"** — even though every watt of the answer is already in the engine.

The case that surfaced it: a guest house metered by two clamps, one on the flat's own feed and one on the cooking hob, which is fed from the main board and therefore sits outside the first measurement. Two `energy_meter` equipments, same zone, both reporting `power`. The total exists in the data and nowhere on the screen.

Nothing available today can produce it:

- **One equipment cannot carry both** — a `dataBinding` alias is UNIQUE per equipment, so `addDataBinding` answers `409 Alias "power" already exists on this equipment`.
- **Charts cannot** — `SavedChartConfig` is a list of `{equipmentId, alias, color}`, no stacking, no arithmetic between series.
- **Recipes cannot** — `RecipeContext` can read and it can act, it cannot write a measurement.

`ZoneAggregatedData` already carries `waterFlowTotal`, a sum with exactly the shape this needs.

## What this does

Adds `ZoneAggregatedData.powerTotal: number | null`, summed over the zone **and all its descendants** through the existing accumulator merge, plus a pill on the zone header. One additive field: no migration, no new route, no new event type, nothing persisted.

## The two rules it reuses rather than restates

This is the part worth reviewing. Both questions are already answered once in the engine, and this surface asks rather than re-implements:

| Question                      | Answered by                                             |
| ----------------------------- | ------------------------------------------------------- |
| Is this equipment a load?     | `isSubmeterEquipment` (#523) — so the grid total and the production meters never land in a load total |
| Is this reading a live value? | `classifyPowerReading` (#832) |

Restating the freshness rule per surface is how the breakdown and the arbitration card came to describe one appliance two contradictory ways (#744). This adds a third surface and restates nothing.

**One deliberate divergence, flagged for review.** For a `degraded` equipment this is stricter than the rest of the aggregation. Elsewhere a degraded equipment still contributes its last known value — right for a temperature, since a room does not cool because a sensor went quiet. It is wrong for a load: a stale `0 W` reads as "this appliance is off", which is exactly the water heater drawing 560 W and displaying 0 W in #744. So a stale reading is **dropped from the sum, never counted as zero**.

## Design choices open to challenge

- **`null` rather than `0`** when a zone has no meter. `0 W` is a measurement; a zone that measures nothing has not made it. Same contract as `waterFlowTotal`.
- **Negative readings are summed as reported** — no `abs`, no clamp. A clamp mounted backwards reports negative watts and a negative total is a wiring fault the user needs to see. (`PowerSubmeterIntegrator` integrates `|P|` per spec 091 — different question: it protects a cumulative counter.)
- **Cadence.** A meter report now flips `aggregatedDataEqual` and emits `zone.data.changed`. That is what makes the pill live, and it is the same order of magnitude as the temperature/humidity traffic already on this path; high-frequency events are deduplicated per batch before the WebSocket.

## Explicitly out of scope

- **Energy (Wh) per zone** — cumulative energy is per-equipment from InfluxDB; a zone-level cumul means bucket queries, downsampling and the tariff split, and deserves its own spec.
- **Double counting.** A zone holding both a feed meter and a submeter of a load fed by it counts that load twice — exactly as the by-usage residual does today. The real fix is a meter hierarchy or a "detail, do not count" flag; both change the existing energy breakdown, so this PR reproduces today's behaviour rather than inventing a second, divergent rule. It is written up as the open question in `specs/170-zone-power-aggregate/spec.md`, and documented for users in the zones page.

## Tests

14 scenarios in `src/zones/zone-aggregator.test.ts`: descendant roll-up, grid/production exclusion, metering plug included, stale dropped, offline excluded and counted in `unavailableEquipmentsByCategory`, measured `0` vs `null`, backwards clamp, rounding, and the event emitted when only the power moved.

`npm run validate` green: 2333 backend tests, 944 UI tests, typecheck (src + tests), lint, format. Both documentation gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
