### PR TITLE
fix(zones): count the meters that report demand_5min, and give freshness a clock

### DIFF
--- a/docs/technical/data-model/zones.md
+++ b/docs/technical/data-model/zones.md
@@ -72,10 +72,13 @@ interface ZoneAggregatedData {
   waterValvesOpen: number;
   waterValvesTotal: number;
   waterFlowTotal: number | null; // SUM of current water flow (when supported)
-  // Spec 170 — SUM of `power` over the zone subtree's consumption submeters
-  // (isSubmeterEquipment: everything metered except the grid total and the
-  // production meters). Readings past their freshness budget are dropped, not
-  // counted as 0 W. `null` = nothing current to sum, distinct from a measured 0.
+  // Spec 170 — SUM, in whole watts, of the live power over the zone subtree's
+  // consumption submeters (isSubmeterEquipment: everything metered except the
+  // grid total and the production meters). Reads `power`, falling back to
+  // `demand_5min` for a meter that has no `power` channel. Readings past their
+  // freshness budget are dropped, not counted as 0 W, re-judged on a 60 s tick
+  // so a meter that goes quiet clears itself. `null` = nothing current to sum,
+  // distinct from a measured 0.
   powerTotal: number | null;
   sunrise: string | null; // From SunlightManager (computed from home location)
   sunset: string | null;

--- a/docs/user/zones.fr.md
+++ b/docs/user/zones.fr.md
@@ -67,7 +67,7 @@ C'est l'une des fonctionnalités les plus puissantes de Sowel. Chaque zone calcu
 | **Fenêtres ouvertes**           | Nombre de contacts de fenêtre ouverts            | 2 fenêtres ouvertes                        |
 | **Fuite d'eau**                 | OU sur tous les capteurs de fuite                | Alerte si un capteur détecte de l'eau      |
 | **Fumée**                       | OU sur tous les capteurs de fumée                | Alerte si un capteur détecte de la fumée   |
-| **Puissance**                   | Somme des sous-compteurs de consommation         | 47,6 W (arrivée d'un gîte + sa plaque)     |
+| **Puissance**                   | Somme des sous-compteurs de consommation         | 48 W (arrivée d'un gîte + sa plaque)       |
 
 ### Agrégation récursive
 
@@ -93,16 +93,16 @@ Sous le bandeau, les équipements sont regroupés par type (Lumières, Volets, C
 
 ### Agrégation de puissance
 
-La pastille de puissance répond à « combien tire cette partie de la maison en ce moment ». Elle somme les équipements de la zone qui mesurent une **charge** — un `energy_meter` dédié, une prise avec mesure, tout équipement qui remonte des watts — sur la zone et toutes ses descendantes. C'est ce qui permet à une seule zone de totaliser deux circuits alimentés depuis des tableaux différents, ce qu'aucun compteur seul ne sait faire.
+La pastille de puissance répond à « combien tire cette partie de la maison en ce moment ». Elle somme les équipements de la zone qui mesurent une **charge** (un `energy_meter` dédié, une prise avec mesure, tout équipement qui remonte des watts) sur la zone et toutes ses descendantes. C'est ce qui permet à une seule zone de totaliser deux circuits alimentés depuis des tableaux différents, ce qu'aucun compteur seul ne sait faire.
 
 Trois règles méritent d'être connues :
 
 - **Le compteur principal et les compteurs de production ne comptent jamais.** Une zone qui contient votre compteur réseau ou votre compteur solaire ne les additionne pas : un total ne mélange donc pas ce que la maison consomme avec ce qu'elle soutire ou produit.
-- **Pas de compteur, pas de pastille — et non « 0 W ».** Une zone qui ne mesure rien n'affiche rien. Une zone dont tous les compteurs lisent zéro affiche `0 W` : c'est une mesure, et la différence compte.
-- **Une mesure qui n'arrive plus est écartée, pas comptée comme zéro.** Une pince devenue muette ne dit rien sur le fait que sa charge tourne ou non : elle sort de la somme plutôt que de la tirer vers le bas.
+- **Pas de compteur, pas de pastille, et non « 0 W ».** Une zone qui ne mesure rien n'affiche rien. Une zone dont tous les compteurs lisent zéro affiche `0 W` : c'est une mesure, et la différence compte.
+- **Une mesure qui n'arrive plus est écartée, pas comptée comme zéro.** Une pince devenue muette ne dit rien sur le fait que sa charge tourne ou non : elle sort de la somme plutôt que de la tirer vers le bas. Sowel revérifie chaque minute, donc un compteur qui meurt disparaît du total même dans une zone silencieuse.
 
 !!! warning "Un compteur d'arrivée et ses propres sous-compteurs se comptent deux fois"
-Si une zone contient à la fois un compteur sur un circuit et un compteur sur une charge alimentée par ce circuit, la charge est comptée deux fois — une fois dans l'arrivée, une fois pour elle-même. Sowel n'a pas de hiérarchie de compteurs : gardez les deux dans des zones différentes, ou lisez le total en sachant ce qu'il recouvre. Le même recouvrement affecte déjà le résidu « Autre » de la page Énergie.
+Si une zone contient à la fois un compteur sur un circuit et un compteur sur une charge alimentée par ce circuit, la charge est comptée deux fois : une fois dans l'arrivée, une fois pour elle-même. Sowel n'a pas de hiérarchie de compteurs : gardez les deux dans des zones différentes, ou lisez le total en sachant ce qu'il recouvre. Le même recouvrement affecte déjà le résidu « Autre » de la page Énergie.
 
 ## Fil d'activité
 

--- a/docs/user/zones.md
+++ b/docs/user/zones.md
@@ -67,7 +67,7 @@ This is one of Sowel's most powerful features. Every zone automatically computes
 | **Open windows**             | Count of open window contacts           | 2 windows open                       |
 | **Water leak**               | OR across all water leak sensors        | Alert if any sensor detects water    |
 | **Smoke**                    | OR across all smoke sensors             | Alert if any sensor detects smoke    |
-| **Power**                    | Sum of the zone's consumption submeters | 47.6 W (a flat's feed + its hob)     |
+| **Power**                    | Sum of the zone's consumption submeters | 48 W (a flat's feed + its hob)       |
 
 ### Recursive aggregation
 
@@ -93,16 +93,16 @@ Below the header, equipments are grouped by type (Lights, Shutters, Sensors) wit
 
 ### Power aggregation
 
-The power pill answers "how much is this part of the house drawing right now". It sums the equipments a zone holds that measure a **load** — a dedicated `energy_meter`, a metering plug, any equipment reporting watts — across the zone and all its descendants. This is what lets one zone total two circuits fed from different boards, which no single meter can do.
+The power pill answers "how much is this part of the house drawing right now". It sums the equipments a zone holds that measure a **load** (a dedicated `energy_meter`, a metering plug, any equipment reporting watts) across the zone and all its descendants. This is what lets one zone total two circuits fed from different boards, which no single meter can do.
 
 Three rules are worth knowing:
 
 - **The grid meter and production meters never count.** A zone holding your main meter or your solar meter does not add them in, so a total never mixes what the house draws with what it imports or produces.
-- **No meter means no pill, not "0 W".** A zone that measures nothing shows nothing. A zone whose meters all read zero shows `0 W` — that is a measurement, and the difference matters.
-- **A reading that stopped arriving is dropped, not counted as zero.** A clamp that went quiet says nothing about whether its load is running, so it leaves the sum rather than pulling it down.
+- **No meter means no pill, not "0 W".** A zone that measures nothing shows nothing. A zone whose meters all read zero shows `0 W`, which is a measurement, and the difference matters.
+- **A reading that stopped arriving is dropped, not counted as zero.** A clamp that went quiet says nothing about whether its load is running, so it leaves the sum rather than pulling it down. Sowel re-checks this every minute, so a meter that dies clears itself from the total even in a quiet zone.
 
 !!! warning "A feed meter and its own submeters double-count"
-If a zone holds both a meter on a circuit and a meter on a load fed by that circuit, the load is counted twice — once inside the feed, once on its own. Sowel has no meter hierarchy, so keep the two in different zones, or read the total knowing what it overlaps. The same overlap already affects the "Other" residual on the Energy page.
+If a zone holds both a meter on a circuit and a meter on a load fed by that circuit, the load is counted twice: once inside the feed, once on its own. Sowel has no meter hierarchy, so keep the two in different zones, or read the total knowing what it overlaps. The same overlap already affects the "Other" residual on the Energy page.
 
 ## Activity feed
 

--- a/specs/170-zone-power-aggregate/architecture.md
+++ b/specs/170-zone-power-aggregate/architecture.md
@@ -38,14 +38,42 @@ ZoneAggregator.aggregateZone(zoneId)
 
 `accumulateEquipmentPower` runs at the equipment level, not inside `accumulateBindings`, because the decision needs the equipment's **type** and **status**, not just a binding — `isSubmeterEquipment` keys off the type, and `classifyPowerReading` needs the status. That is the same reason the `display` counters and `water_valve` sit at that level.
 
+## Review follow-up (#866 review, merged as a second pass)
+
+Three points found on review of the first implementation, and what was done about them:
+
+**The `power` alias is not the only live power channel.** A Legrand NLPC meter has no `power`
+binding at all: its live channel is `demand_5min`, which is why `pickLivePowerW` on the equipment
+tiles falls back to it. Looking up `power` alone therefore did not read a stale value, it read
+nothing, and the meter dropped out of the total while its own card kept printing live watts. The
+accumulator now walks `LIVE_POWER_ALIASES` (`power`, then `demand_5min`) and passes the matching
+budget through `powerBudgetFor`, the same rule the tiles ask (#839) — hoisted into
+`shared/reading-freshness.ts` so there is still one implementation, not two.
+
+**The freshness rule had no clock.** `powerTotal` drops a reading past its budget, but the
+aggregator only recomputes when an equipment reports, and a clamp that went quiet reports nothing.
+`equipment.status.changed` does not close the gap either: `equipment-status.ts` applies the
+electrical window only to `METERING_EQUIPMENT_TYPES`, so a metering plug stays `online` however
+old its watts are. In the case this spec is written for — a guest house whose zone holds two
+meters and nothing else — the total would have stayed frozen indefinitely. A 60 s wallclock tick
+now recomputes the chains of the zones that actually carry power readings; the cached
+`powerHasData` flag is both the trigger and the stop condition.
+
+**Rounding.** Tenths of a watt are never displayed (whole watts below the kilowatt, one decimal of
+a kilowatt above), and they guarantee that sub-watt jitter on an idle plug flips
+`aggregatedDataEqual` and emits `zone.data.changed` up the whole ancestor chain. The sum is now
+rounded to whole watts, which also means the number the API and MQTT publish is the number the
+pill shows.
+
 ## The two shared rules it reuses
 
 Neither is restated:
 
-| Question                      | Answered by                                             | Lives in                          |
-| ----------------------------- | ------------------------------------------------------- | --------------------------------- |
-| Is this equipment a load?     | `isSubmeterEquipment(type, bindings)` (#523, blocklist) | `src/equipments/metering.ts`      |
-| Is this reading a live value? | `classifyPowerReading({...}) === "current"` (#832)      | `src/shared/reading-freshness.ts` |
+| Question                        | Answered by                                             | Lives in                          |
+| ------------------------------- | ------------------------------------------------------- | --------------------------------- |
+| Is this equipment a load?       | `isSubmeterEquipment(type, bindings)` (#523, blocklist) | `src/equipments/metering.ts`      |
+| Is this reading a live value?   | `classifyPowerReading({...}) === "current"` (#832)      | `src/shared/reading-freshness.ts` |
+| Which budget does it answer to? | `powerBudgetFor(type, alias)` (#839)                    | `src/shared/reading-freshness.ts` |
 
 `classifyPowerReading` already returns `offline` for an offline equipment, so the call is correct even though the early-out means it never sees one.
 

--- a/src/shared/reading-freshness.ts
+++ b/src/shared/reading-freshness.ts
@@ -57,11 +57,53 @@ export const SUBMETER_FRESHNESS_MS = STREAMING_TIMEOUT_MS.power ?? DEFAULT_STREA
  */
 export const SUBMETER_FRESHNESS_SLOW_MS = 10 * 60 * 1000;
 
+/**
+ * The aliases that can carry a live power reading, in the order a surface
+ * should prefer them.
+ *
+ * `demand_5min` is not a second-class `power`: a Legrand NLPC meter has no
+ * `power` channel at all, so a surface that looks up `power` alone does not
+ * read a stale value, it reads nothing and silently omits the meter. That is
+ * why `pickLivePowerW` falls back on it, and why anything summing meters must
+ * do the same or under-report a supported meter shape (#866 review).
+ */
+export const LIVE_POWER_ALIASES = ["power", "demand_5min"] as const;
+
 /** The freshness budget that applies to an equipment of this type. */
 export function freshnessBudgetFor(equipmentType: string): number {
   return METERING_EQUIPMENT_TYPES.has(equipmentType)
     ? SUBMETER_FRESHNESS_MS
     : SUBMETER_FRESHNESS_SLOW_MS;
+}
+
+/**
+ * The freshness budget for one power reading, when the binding's own cadence
+ * outranks the window its equipment type implies (#839).
+ *
+ * `METERING_EQUIPMENT_TYPES` earns the tight two-minute window because the
+ * engine expects a declared meter to report continuously. Two sources in that
+ * set do not, and applying it to them calls a healthy device outdated for most
+ * of every reporting cycle:
+ *
+ * - `demand_5min`: a Legrand NLPC reports a power already averaged over five
+ *   minutes, so the reading cannot be fresher than five minutes by
+ *   construction.
+ * - `solar_panel`: the one solar integration in the registry (apsystems)
+ *   delivers on a Tasmota `tele/<root>/SENSOR` topic, whose default
+ *   `TelePeriod` is 300 s.
+ *
+ * The ten-minute slow budget is twice the slowest of those cadences, so neither
+ * oscillates, and it still catches what #744 is about (a reading 124 days old).
+ *
+ * This lives here rather than on one surface because both the equipment tiles
+ * (#839) and the zone power total (spec 170) have to ask it, and a rule
+ * restated per surface is how two surfaces came to describe one appliance two
+ * contradictory ways in the first place.
+ */
+export function powerBudgetFor(equipmentType: string, bindingAlias?: string | null): number {
+  if (bindingAlias === "demand_5min") return SUBMETER_FRESHNESS_SLOW_MS;
+  if (equipmentType === "solar_panel") return SUBMETER_FRESHNESS_SLOW_MS;
+  return freshnessBudgetFor(equipmentType);
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -253,10 +253,12 @@ export interface ZoneAggregatedData {
   waterValvesTotal: number;
   waterFlowTotal: number | null;
   /**
-   * Spec 170 — live sum, in watts, of the consumption submeters in this zone
-   * and its descendants. `null` when nothing current was found to sum, which is
-   * NOT the same as a measured 0 W: a zone with no meters has not measured
-   * anything, and a stale reading is dropped rather than counted as zero.
+   * Spec 170 — live sum, in whole watts, of the consumption submeters in this
+   * zone and its descendants. `null` when nothing current was found to sum,
+   * which is NOT the same as a measured 0 W: a zone with no meters has not
+   * measured anything, and a stale reading is dropped rather than counted as
+   * zero (re-judged on a wallclock tick, so a meter that goes quiet clears
+   * itself from the sum).
    */
   powerTotal: number | null;
   sunrise: string | null;

--- a/src/zones/zone-aggregator.test.ts
+++ b/src/zones/zone-aggregator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Database from "better-sqlite3";
 import { ZoneManager } from "./zone-manager.js";
 import { applyMigrations } from "../test-helpers/migrations.js";
@@ -83,6 +83,7 @@ describe("ZoneAggregator", () => {
   });
 
   afterEach(() => {
+    aggregator.destroy();
     db.close();
   });
 
@@ -1106,13 +1107,16 @@ describe("ZoneAggregator", () => {
         type?: EquipmentType;
         dataType?: string;
         category?: string;
+        /** The binding alias, for a meter whose live channel is not `power`. */
+        alias?: string;
       },
     ) {
+      const alias = opts.alias ?? "power";
       const dev = seedDevice(db, {
         name: opts.name,
         dataKeys: [
           {
-            key: "power",
+            key: alias,
             type: opts.dataType ?? "number",
             category: opts.category ?? "power",
             value: opts.watts ?? undefined,
@@ -1124,7 +1128,7 @@ describe("ZoneAggregator", () => {
         type: opts.type ?? "energy_meter",
         zoneId,
       });
-      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "power");
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], alias);
       return { dev, eq };
     }
 
@@ -1134,7 +1138,7 @@ describe("ZoneAggregator", () => {
 
       aggregator.computeAll();
 
-      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(39.4);
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(39);
     });
 
     it("rolls up submeters from descendant zones", () => {
@@ -1145,8 +1149,8 @@ describe("ZoneAggregator", () => {
 
       aggregator.computeAll();
 
-      expect(aggregator.getByZoneId(parent.id)?.powerTotal).toBe(47.6);
-      expect(aggregator.getByZoneId(child.id)?.powerTotal).toBe(8.2);
+      expect(aggregator.getByZoneId(parent.id)?.powerTotal).toBe(48);
+      expect(aggregator.getByZoneId(child.id)?.powerTotal).toBe(8);
     });
 
     it("reports null — not zero — for a zone with no metered equipment", () => {
@@ -1196,7 +1200,7 @@ describe("ZoneAggregator", () => {
 
       aggregator.computeAll();
 
-      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(62.5);
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(63);
     });
 
     it("drops a stale reading instead of counting it as 0 W", () => {
@@ -1223,7 +1227,7 @@ describe("ZoneAggregator", () => {
       aggregator.computeAll();
 
       const data = aggregator.getByZoneId(zone.id);
-      expect(data?.powerTotal).toBe(39.4);
+      expect(data?.powerTotal).toBe(39);
       expect(data?.unavailableEquipmentsByCategory).toEqual({ power: 1 });
     });
 
@@ -1270,7 +1274,7 @@ describe("ZoneAggregator", () => {
       expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(-150);
     });
 
-    it("rounds the sum to one decimal", () => {
+    it("rounds the sum to whole watts", () => {
       const zone = zoneManager.create({ name: "Gite" });
       seedMeter(zone.id, { name: "A", watts: "39.4" });
       seedMeter(zone.id, { name: "B", watts: "8.2" });
@@ -1278,7 +1282,7 @@ describe("ZoneAggregator", () => {
 
       aggregator.computeAll();
 
-      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(47.6);
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(48);
     });
 
     it("emits zone.data.changed when only the power total moved", () => {
@@ -1286,7 +1290,7 @@ describe("ZoneAggregator", () => {
       const { dev, eq } = seedMeter(zone.id, { name: "Feed", watts: "39.4" });
 
       aggregator.computeAll();
-      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(39.4);
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(39);
 
       db.prepare("UPDATE device_data SET value = ? WHERE id = ?").run("2400", dev.dataIds[0]);
       events.length = 0;
@@ -1301,6 +1305,78 @@ describe("ZoneAggregator", () => {
 
       expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(2400);
       expect(events.filter((e) => e.type === "zone.data.changed").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("counts a meter whose only live channel is demand_5min", () => {
+      const zone = zoneManager.create({ name: "Gite" });
+      const { dev } = seedMeter(zone.id, { name: "NLPC", watts: "850", alias: "demand_5min" });
+      // Six minutes old: past the two-minute meter window, inside the budget a
+      // five-minute average answers to (#839). Under the meter window this
+      // healthy meter would drop out of the total for most of every cycle.
+      db.prepare("UPDATE device_data SET last_updated = ? WHERE id = ?").run(
+        new Date(Date.now() - 6 * 60 * 1000).toISOString(),
+        dev.dataIds[0],
+      );
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(850);
+    });
+
+    it("still drops a demand_5min reading past the slow budget", () => {
+      const zone = zoneManager.create({ name: "Gite" });
+      const { dev } = seedMeter(zone.id, { name: "NLPC", watts: "850", alias: "demand_5min" });
+      db.prepare("UPDATE device_data SET last_updated = ? WHERE id = ?").run(
+        new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+        dev.dataIds[0],
+      );
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBeNull();
+    });
+
+    it("prefers `power` over `demand_5min` when an equipment carries both", () => {
+      const zone = zoneManager.create({ name: "Gite" });
+      const dev = seedDevice(db, {
+        name: "Meter",
+        dataKeys: [
+          { key: "power", type: "number", category: "power", value: "120" },
+          { key: "demand_5min", type: "number", category: "power", value: "300" },
+        ],
+      });
+      const eq = equipmentManager.create({ name: "Meter", type: "energy_meter", zoneId: zone.id });
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[0], "power");
+      equipmentManager.addDataBinding(eq.id, dev.dataIds[1], "demand_5min");
+
+      aggregator.computeAll();
+
+      expect(aggregator.getByZoneId(zone.id)?.powerTotal).toBe(120);
+    });
+
+    it("drops a reading that ages out with no event, on its own tick", () => {
+      vi.useFakeTimers();
+      const ticking = new ZoneAggregator(zoneManager, equipmentManager, eventBus, logger);
+      try {
+        const zone = zoneManager.create({ name: "Gite" });
+        const { dev } = seedMeter(zone.id, { name: "Feed", watts: "39.4" });
+        ticking.computeAll();
+        expect(ticking.getByZoneId(zone.id)?.powerTotal).toBe(39);
+
+        // The clamp goes quiet. Nothing reports, so nothing recomputes the zone
+        // except the wallclock tick: without it the pill keeps printing 39 W
+        // for as long as the zone stays quiet.
+        db.prepare("UPDATE device_data SET last_updated = ? WHERE id = ?").run(
+          new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+          dev.dataIds[0],
+        );
+        vi.advanceTimersByTime(60_000);
+
+        expect(ticking.getByZoneId(zone.id)?.powerTotal).toBeNull();
+      } finally {
+        ticking.destroy();
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/src/zones/zone-aggregator.ts
+++ b/src/zones/zone-aggregator.ts
@@ -13,7 +13,11 @@ import type {
 } from "../shared/types.js";
 import { ROOT_ZONE_ID } from "../shared/constants.js";
 import { isSubmeterEquipment } from "../equipments/metering.js";
-import { classifyPowerReading } from "../shared/reading-freshness.js";
+import {
+  LIVE_POWER_ALIASES,
+  classifyPowerReading,
+  powerBudgetFor,
+} from "../shared/reading-freshness.js";
 
 // ============================================================
 // Internal accumulator for aggregation (tracks sums + counts)
@@ -156,7 +160,13 @@ function accumulatorToPublic(acc: Accumulator): ZoneAggregatedData {
     waterValvesOpen: acc.waterValvesOpen,
     waterValvesTotal: acc.waterValvesTotal,
     waterFlowTotal: acc.waterFlowHasData ? Math.round(acc.waterFlowSum * 100) / 100 : null,
-    powerTotal: acc.powerHasData ? Math.round(acc.powerSum * 10) / 10 : null,
+    // Whole watts, not tenths. The pill prints an integer below the kilowatt
+    // and one decimal of a kilowatt above it, so a tenth of a watt is never
+    // displayed — it only guarantees that sub-watt jitter on an idle plug
+    // flips `aggregatedDataEqual` and emits `zone.data.changed` up the whole
+    // ancestor chain. Rounding here also means the number the API and MQTT
+    // publish is the number the pill shows.
+    powerTotal: acc.powerHasData ? Math.round(acc.powerSum) : null,
     sunrise: null,
     sunset: null,
     isDaylight: null,
@@ -245,6 +255,25 @@ function isContactOpen(value: unknown): boolean {
 // Zone Aggregator
 // ============================================================
 
+/**
+ * Wallclock cadence for re-judging the freshness of a zone's power readings.
+ *
+ * `powerTotal` drops a reading past its budget (spec 170), but the aggregator
+ * only recomputes when an equipment reports, and a clamp that went quiet
+ * reports nothing by definition. Without a clock the sum keeps a reading that
+ * has since aged out for as long as the zone stays quiet, which in the case
+ * spec 170 is written for — a guest house whose zone holds two meters and
+ * nothing else — is forever.
+ *
+ * `equipment.status.changed` is not enough on its own: `equipment-status.ts`
+ * applies the electrical window only to METERING_EQUIPMENT_TYPES, so a metering
+ * plug stays `online` however old its watts are and never emits a transition.
+ *
+ * One minute matches EquipmentStatusTracker's own tick, and only zones that
+ * actually contribute power are recomputed.
+ */
+const POWER_FRESHNESS_TICK_MS = 60_000;
+
 export class ZoneAggregator {
   private logger: Logger;
   private eventBus: EventBus;
@@ -252,6 +281,7 @@ export class ZoneAggregator {
   private equipmentManager: EquipmentManager;
   private sunlightManager: SunlightManager | null = null;
   private unsubscribe: (() => void) | null = null;
+  private freshnessTimer: ReturnType<typeof setInterval> | null = null;
 
   // Cache: per-zone accumulators and public data
   private directCache = new Map<string, Accumulator>();
@@ -270,6 +300,31 @@ export class ZoneAggregator {
     this.logger = logger.child({ module: "zone-aggregator" });
 
     this.setupEventListeners();
+    this.startFreshnessTimer();
+  }
+
+  /**
+   * Re-judge the freshness of the zones that carry power readings, on a
+   * wallclock tick (see POWER_FRESHNESS_TICK_MS).
+   *
+   * Only zones whose own equipments landed in the power sum are walked: the
+   * cached flag is the trigger AND the stop condition, since a zone whose last
+   * reading ages out recomputes once, clears the flag, and goes quiet again.
+   */
+  private startFreshnessTimer(): void {
+    this.freshnessTimer = setInterval(() => {
+      try {
+        const zoneIds = [...this.directCache.entries()]
+          .filter(([, acc]) => acc.powerHasData)
+          .map(([zoneId]) => zoneId);
+        for (const zoneId of zoneIds) {
+          this.recomputeZoneChain(zoneId, "power freshness tick");
+        }
+      } catch (err) {
+        this.logger.error({ err }, "Error in zone aggregator freshness tick");
+      }
+    }, POWER_FRESHNESS_TICK_MS);
+    if (typeof this.freshnessTimer.unref === "function") this.freshnessTimer.unref();
   }
 
   setSunlightManager(sunlightManager: SunlightManager): void {
@@ -279,6 +334,10 @@ export class ZoneAggregator {
   destroy(): void {
     this.unsubscribe?.();
     this.unsubscribe = null;
+    if (this.freshnessTimer) {
+      clearInterval(this.freshnessTimer);
+      this.freshnessTimer = null;
+    }
   }
 
   // ============================================================
@@ -575,9 +634,18 @@ export class ZoneAggregator {
   ): void {
     if (!isSubmeterEquipment(equipmentType, bindings)) return;
 
-    const powerBinding = bindings.find((b) => b.alias === "power");
-    // A non-numeric `power` is a state, not a measurement (a thermostat's own
-    // on/off switch); `isSubmeterEquipment` makes the same distinction.
+    // `power` first, `demand_5min` as the fallback, the same order the
+    // equipment tiles use (`pickLivePowerW`). A Legrand NLPC has no `power`
+    // channel at all: looking up `power` alone does not read a stale value, it
+    // reads nothing, and the meter drops out of the total while its own card
+    // still prints live watts.
+    let powerBinding: DataBindingWithValue | undefined;
+    for (const alias of LIVE_POWER_ALIASES) {
+      // A non-numeric reading is a state, not a measurement (a thermostat's own
+      // on/off switch); `isSubmeterEquipment` makes the same distinction.
+      powerBinding = bindings.find((b) => b.alias === alias && typeof b.value === "number");
+      if (powerBinding) break;
+    }
     if (!powerBinding || typeof powerBinding.value !== "number") return;
 
     const verdict = classifyPowerReading({
@@ -585,6 +653,10 @@ export class ZoneAggregator {
       value: powerBinding.value,
       lastUpdated: powerBinding.lastUpdated,
       equipmentType,
+      // A `demand_5min` reading is averaged over five minutes and cannot be
+      // fresher than that; under the meter window it would read outdated for
+      // most of every cycle (#839).
+      budgetMs: powerBudgetFor(equipmentType, powerBinding.alias),
     });
     if (verdict !== "current") return;
 

--- a/ui/src/lib/power-reading.ts
+++ b/ui/src/lib/power-reading.ts
@@ -1,6 +1,6 @@
 import {
   classifyPowerReading,
-  SUBMETER_FRESHNESS_SLOW_MS,
+  powerBudgetFor,
   type ReadingVerdict,
 } from "../../../src/shared/reading-freshness";
 import type { DataBindingWithValue, EquipmentWithDetails } from "../types";
@@ -48,33 +48,16 @@ export interface PowerReading {
  * The freshness budget a reading answers to, when its own cadence outranks the
  * window its equipment type implies.
  *
- * `METERING_EQUIPMENT_TYPES` earns the tight two-minute window because the
- * engine expects a declared meter to report continuously. Two sources in that
- * set do not, and applying it to them would call a perfectly healthy device
- * outdated for most of every reporting cycle — the exact oscillation the
- * shared module documents and avoids for slow pollers:
- *
- * - `demand_5min`: a Legrand NLPC reports a power already averaged over five
- *   minutes, so the reading cannot be fresher than five minutes by
- *   construction.
- * - `solar_panel`: the one solar integration in the registry (apsystems)
- *   delivers on a Tasmota `tele/<root>/SENSOR` topic, whose default
- *   `TelePeriod` is 300 s. Under the meter window a panel in full sun would
- *   blank for roughly three minutes out of every five.
- *
- * The ten-minute slow budget is twice the slowest of those cadences, so
- * neither oscillates, and it still catches the failure this issue is about
- * (#744 measured a reading 124 days old).
- *
- * Returning undefined means "no override": the type's own budget applies.
+ * The rule itself is `powerBudgetFor` in shared/: the zone power total asks the
+ * same question of the same bindings (spec 170), and a budget restated per
+ * surface is how one meter ends up live on its card and outdated in a total.
+ * This wrapper only adapts the shapes the tiles hold.
  */
 function budgetFor(
   equipment: EquipmentWithDetails,
   binding: DataBindingWithValue | undefined,
-): number | undefined {
-  if (binding?.alias === "demand_5min") return SUBMETER_FRESHNESS_SLOW_MS;
-  if (equipment.type === "solar_panel") return SUBMETER_FRESHNESS_SLOW_MS;
-  return undefined;
+): number {
+  return powerBudgetFor(equipment.type, binding?.alias);
 }
 
 /**

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -221,9 +221,9 @@ export interface ZoneAggregatedData {
   waterValvesOpen: number;
   waterValvesTotal: number;
   waterFlowTotal: number | null;
-  /** Spec 170 — live sum, in watts, of the consumption submeters in this zone
-   *  and its descendants. `null` when there was nothing current to sum, which
-   *  is not the same as a measured 0 W. */
+  /** Spec 170 — live sum, in whole watts, of the consumption submeters in this
+   *  zone and its descendants. `null` when there was nothing current to sum,
+   *  which is not the same as a measured 0 W. */
   powerTotal: number | null;
   sunrise: string | null;
   sunset: string | null;


### PR DESCRIPTION
Follow-up to #866 (spec 170), from its review. Three findings, one fix each.

## 1. A meter reporting `demand_5min` was silently missing from the total

The accumulator looked up `bindings.find(b => b.alias === "power")` and gave up when it found nothing. A Legrand NLPC meter has no `power` channel at all, which is exactly why `pickLivePowerW` on the equipment tiles falls back to `demand_5min`. So this was not a stale value being read, it was nothing being read: the meter dropped out of the zone total while its own card kept printing live watts. That is the "one appliance, two surfaces, two answers" shape #744 is about.

Second half of the same defect: the budget override merged the day before in #865 was not passed. A five-minute average cannot be fresher than five minutes, so under the two-minute meter window it would have been judged `stale` for most of every cycle even once found.

The accumulator now walks `LIVE_POWER_ALIASES` (`power`, then `demand_5min`) and asks `powerBudgetFor` for the matching budget. That budget rule moves from `ui/src/lib/power-reading.ts` into `src/shared/reading-freshness.ts`, and the tiles now ask it there: one implementation, two callers, which is the point of the shared module.

## 2. The freshness rule had no clock

`powerTotal` drops a reading past its budget, but the aggregator only recomputes on `equipment.data.changed`, and a clamp that went quiet emits nothing by definition. `equipment.status.changed` would not have closed it either: `equipment-status.ts` applies the electrical window only to `METERING_EQUIPMENT_TYPES`, so a metering plug stays `online` however old its watts are and never emits a transition.

Effect, in the exact case spec 170 is written for: a guest house whose zone holds two meters and nothing else. Both clamps go quiet, nothing else in that zone ever reports, and the pill keeps printing the last total forever. The rule only self-healed in busy zones.

A 60 s wallclock tick (the same cadence `EquipmentStatusTracker` uses) now recomputes the chains of the zones that actually carry power readings. The cached `powerHasData` flag is both the trigger and the stop condition: a zone recomputes once, clears the flag, and goes quiet again.

## 3. Rounding to a tenth of a watt was pure event churn

The pill prints whole watts below the kilowatt and one decimal of a kilowatt above, so a tenth of a watt was never displayed. It only guaranteed that sub-watt jitter on an idle plug flipped `aggregatedDataEqual` and emitted `zone.data.changed` up the entire ancestor chain, up to the root, on every meter report in the house. Rounded to whole watts, which also makes the number the API and MQTT publish the number the pill shows.

No functional risk downstream, verified rather than assumed: the WebSocket deduplicates per zone per batch, MQTT has its `onChangeOnly` cache, notifications deduplicate at 1 s and compare against `lastValue`.

## Docs

The user page examples matched neither the rounding nor the French decimal separator (`47,6 W` for a pill that prints `48 W`), and the freshness bullet now says the check is periodic, which it finally is. Spec 170's architecture note records the three findings and their resolution.

## Tests

Four added to `zone-aggregator.test.ts`: a `demand_5min`-only meter counted at six minutes of age (stale under the meter window, current under the budget it answers to), the same meter dropped at thirty, `power` preferred when an equipment carries both, and a reading that ages out with no event dropped on the tick. Seven existing expectations updated for whole watts.

`npm run validate` green: 2337 backend tests, 944 UI tests, typecheck and lint both sides. Both documentation gates pass locally.

Docs-Impact: covered — docs/user/zones.{md,fr.md} and docs/technical/data-model/zones.md updated with the alias fallback, the periodic freshness check, and the corrected examples.