### PR TITLE
fix(ui): let the updates panel finish a personal-source update (spec 172)

### DIFF
--- a/docs/user/plugins.fr.md
+++ b/docs/user/plugins.fr.md
@@ -76,6 +76,7 @@ Quand vous cliquez sur **Installer** pour un plugin personnel, Sowel télécharg
 
 - Confirmer installe exactement le contenu correspondant à cette empreinte et l'**épingle**. Si le fichier change un jour derrière la même version, Sowel le refuse.
 - Chaque **mise à jour** ultérieure réaffiche la même boîte avec la nouvelle version et la nouvelle empreinte, parce que le contenu a changé depuis votre dernière validation. Rien ne se met à jour dans votre dos.
+- La boîte s'affiche **là où vous lancez la mise à jour** : la ligne du plugin, son panneau de détail, ou le panneau de mises à jour de la barre du haut. Le badge **Perso** y figure aussi, pour que l'étape supplémentaire ne soit pas une surprise.
 
 !!! warning "Vous faites confiance au propriétaire du dépôt"
 Personne ne relit le code d'un plugin personnel. Il s'exécute avec les mêmes privilèges que Sowel lui-même. N'ajoutez que des dépôts que vous possédez ou en qui vous avez pleinement confiance -- l'empreinte garantit que _ce que_ vous installez ne change jamais silencieusement, pas que le code est sûr.

--- a/docs/user/plugins.md
+++ b/docs/user/plugins.md
@@ -76,6 +76,7 @@ When you click **Install** on a personal plugin, Sowel downloads the release, co
 
 - Confirming installs exactly the content matching that fingerprint and **pins** it. If the file ever changes behind the same version, Sowel refuses it.
 - Every later **update** shows the same dialog again with the new version and new fingerprint, because the content changed since you last approved it. Nothing updates behind your back.
+- The dialog appears **wherever you start the update**: the plugin's row, its detail panel, or the updates panel in the top bar. A personal package is marked with its **Personal** badge there too, so the extra step is no surprise.
 
 !!! warning "You are trusting the repository owner"
 Nobody reviews the code of a personal plugin. It runs with the same privileges as Sowel itself. Only add repositories you own or fully trust -- the fingerprint guarantees _what_ you install never changes silently, not that the code is safe.

--- a/specs/172-updates-sheet-personal-confirm/architecture.md
+++ b/specs/172-updates-sheet-personal-confirm/architecture.md
@@ -1,0 +1,61 @@
+# Architecture — Spec 172
+
+## What moves
+
+`PersonalConfirmModal` and its `IdentityRow`, plus the `PersonalBadge`, were private to
+`PluginsPage.tsx` (~120 lines near the bottom of a 1000-line page). They move, unchanged, to:
+
+```
+ui/src/components/plugins/PersonalConfirm.tsx
+  export interface PersonalConfirmInfo { repo, owner, version, sha256 }
+  export function PersonalConfirmModal({ info, mode, busy, onCancel, onConfirm })
+  export function PersonalBadge()
+```
+
+`PluginsPage` imports them and loses the definitions; nothing about its behaviour changes. The modal
+keeps its `createPortal` to `document.body` at `z-[60]`: it is raised above a portaled sheet on both
+surfaces now, which is exactly why it was written that way (issue #749 test asserts it).
+
+## What changes
+
+`UpdatesSheet.handlePluginUpdate` grows the branch the Plugins page has had since spec 136:
+
+```
+updatePlugin(id)
+  ├─ ok            → settle 1.5 s, refresh badge, drop the row      (unchanged)
+  ├─ 409 personal  → keep the row spinning, open the dialog          (new)
+  │                   ├─ confirm → updatePlugin(id, { confirmed: true, expectedSha256 }) → as "ok"
+  │                   └─ cancel  → clear the dialog and the spinner, nothing sent
+  └─ other error   → error line                                      (unchanged)
+```
+
+State: one more `useState`, `pending: { id, info } | null`. The row id travels with the info because
+the retry targets a package id while the dialog shows a repository.
+
+`updatePlugin(id, opts)` already takes `{ confirmed, expectedSha256 }` and already throws
+`PersonalPluginConfirmationRequiredError` — the API client needs nothing. The server needs nothing:
+`POST /plugins/:id/update` has answered this 409 since spec 136.
+
+The sheet resets `pending` when it closes, next to the `error` / `updatingId` / `plugins` resets it
+already does on `open`. The dialog lives inside the sheet's children: closing the sheet unmounts it,
+which is the intended behaviour — an update that was never confirmed was never started.
+
+## Why not the other options
+
+- **Trust the source once and stop asking.** That is the guarantee, not the friction: the fingerprint
+  is pinned per version precisely so new content cannot arrive unseen. Spec 136 is explicit.
+- **Send the user to the Plugins page with a link.** It is the current behaviour minus the error
+  code — two navigations to press a button that is already on screen.
+- **Let the panel skip personal packages** (what `UpdateAllBanner` does for the bulk button). The
+  banner acts on many packages at once and cannot show one dialog per package; the panel acts on one
+  row at a time, which is exactly the shape a fingerprint confirmation needs.
+
+## Files
+
+| File                                             | Change                                                      |
+| ------------------------------------------------ | ----------------------------------------------------------- |
+| `ui/src/components/plugins/PersonalConfirm.tsx`  | new — modal + badge, moved verbatim                         |
+| `ui/src/pages/PluginsPage.tsx`                   | imports them, definitions removed                           |
+| `ui/src/components/layout/UpdatesSheet.tsx`      | the 409 branch, the dialog, the `Personal` badge on the row |
+| `ui/src/components/layout/UpdatesSheet.test.tsx` | new — the four cases of the confirmation flow               |
+| `docs/user/plugins{,.fr}.md`                     | the dialog appears wherever the update is started           |

--- a/specs/172-updates-sheet-personal-confirm/plan.md
+++ b/specs/172-updates-sheet-personal-confirm/plan.md
@@ -1,0 +1,29 @@
+# Plan — Spec 172
+
+## Steps
+
+- [x] 1. Extract `PersonalConfirmModal`, `IdentityRow`, `PersonalBadge` and `PersonalConfirmInfo` to `components/plugins/PersonalConfirm.tsx`.
+- [x] 2. `PluginsPage` imports them; behaviour unchanged.
+- [x] 3. `UpdatesSheet`: catch the 409, hold `pending`, render the dialog, retry on confirm.
+- [x] 4. `Personal` badge on the panel rows.
+- [x] 5. Tests.
+- [x] 6. Docs (EN + FR).
+
+## Test Plan
+
+### Modules to test
+
+- `UpdatesSheet` — the whole point of the spec, and a component with no test file until now.
+- `PluginsPage` — the extraction must not change what it renders (its spec 136 test already pins the modal above the sheet).
+
+### Scenarios
+
+| Module       | Scenario                                              | Expected                                                          |
+| ------------ | ----------------------------------------------------- | ----------------------------------------------------------------- |
+| UpdatesSheet | Personal package, update clicked                      | Dialog with repo, version, truncated fingerprint; no second call  |
+| UpdatesSheet | Dialog confirmed                                      | `updatePlugin(id, { confirmed: true, expectedSha256 })`, row gone |
+| UpdatesSheet | Dialog cancelled                                      | Exactly one call in total, row still listed and updatable         |
+| UpdatesSheet | Ordinary package, update clicked                      | One bare call, no dialog                                          |
+| UpdatesSheet | Personal package listed                               | Row carries the `Personal` badge                                  |
+| UpdatesSheet | Update fails with an ordinary error                   | Error line, no dialog                                             |
+| PluginsPage  | Existing spec 136 case (modal above the detail sheet) | Still passes after the extraction                                 |

--- a/specs/172-updates-sheet-personal-confirm/spec.md
+++ b/specs/172-updates-sheet-personal-confirm/spec.md
@@ -1,0 +1,68 @@
+# Spec 172 — The updates panel can finish a personal update
+
+**Status**: implemented
+**Scope**: UI (updates sheet, plugins page)
+**Follows**: [spec 136](../136-personal-plugin-sources/spec.md), [spec 107](../107-update-row-changelog-link/spec.md)
+
+## Problem
+
+The top-bar updates panel offers an **Update** button for every outdated package. For a package installed from a **personal source**, that button cannot work: spec 136 makes the server answer `409 PersonalPluginConfirmationRequired`, carrying the version and the SHA256 fingerprint the user has to approve. The Plugins page knows how to answer that — it raises the fingerprint dialog and retries. The updates panel does not: it catches the error and prints its raw code.
+
+So the user reads `PersonalPluginConfirmationRequired` in red, and has to go to **Administration → Plugins → Installed** and update from the row instead. The panel that exists to be the one place updates happen is the one place a personal update cannot happen.
+
+The documentation already promises the opposite: _"Every later update shows the same dialog again with the new version and new fingerprint."_ It shows nothing of the sort from the top bar.
+
+## Design principle — the confirmation follows the button, not the page
+
+The fix is **not** to weaken the gate. A new release is new content; re-pinning its fingerprint is the whole point of spec 136, and a "trust this source forever" checkbox would give away the only guarantee it offers.
+
+The fix is that a confirmation belongs wherever the action is offered. Any surface that can start an update must be able to finish one.
+
+## Goal
+
+Make the updates panel handle the personal-source confirmation, with the same dialog, the same identity, and the same pinning as the Plugins page.
+
+## In scope
+
+- The updates panel catches `PersonalPluginConfirmationRequiredError` and raises the fingerprint dialog, retrying with `confirmed: true` and the fingerprint on approval.
+- `PersonalConfirmModal` (and the `Personal` badge) extracted from `PluginsPage` into a shared component, so the two surfaces cannot drift apart.
+- The rows of the panel carry the **Personal** badge, so the extra step is expected rather than surprising.
+
+## Out of scope
+
+- The confirmation itself, in any form: same dialog, same fields, same per-version re-approval.
+- Bulk update. `UpdateAllBanner` already excludes personal packages and names them; a fingerprint is a per-package decision and stays one.
+- The core (Sowel itself) update row, which has no fingerprint step.
+- Install. It happens from the store, which already has the dialog.
+
+## Functional rules
+
+1. **FR-1 — The dialog appears.** An update refused with `409 PersonalPluginConfirmationRequired` opens the fingerprint dialog in the updates panel, showing the repository, the version and the pinned fingerprint the server returned — the same three identity rows as on the Plugins page.
+
+2. **FR-2 — Approval finishes the job.** Confirming retries with `confirmed: true` and `expectedSha256`, then behaves exactly as a successful update: the row leaves the list and the badge count is refreshed.
+
+3. **FR-3 — Refusal changes nothing.** Cancelling sends no second request, leaves the package at its current version, and returns the row to its idle state so it can be retried.
+
+4. **FR-4 — One dialog, one implementation.** The Plugins page and the updates panel render the same component. A change to the wording or the identity shown lands on both.
+
+5. **FR-5 — The row says it is personal.** A package from a personal source carries the `Personal` badge in the panel, as it does in the store and on the installed list.
+
+6. **FR-6 — Other errors are unchanged.** Anything that is not the personal 409 keeps surfacing in the panel's error line.
+
+## Acceptance criteria
+
+- [x] Updating a personal package from the top-bar panel opens the fingerprint dialog instead of printing an error code.
+- [x] Confirming calls the update again with `confirmed: true` and the fingerprint from the 409, and the row disappears.
+- [x] Cancelling issues no further call and leaves the row updatable.
+- [x] A non-personal package updates in one click, with no dialog.
+- [x] The dialog renders above the panel (both are portaled) and is reachable on a phone.
+- [x] The Plugins page behaves exactly as before.
+
+## Edge cases
+
+| Case                                                | Behaviour                                                                                      |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Panel closed while the dialog is open               | Both close, nothing is sent. The update was never started.                                     |
+| Confirmed update fails (fingerprint moved, network) | The panel's error line, as for any other failure (FR-6).                                       |
+| Two personal packages behind                        | One dialog at a time: the panel already disables the other rows while one update is in flight. |
+| Personal package whose source was removed           | Server-side failure, surfaced in the error line — removing a source stops updates by design.   |

--- a/ui/src/components/layout/UpdatesSheet.test.tsx
+++ b/ui/src/components/layout/UpdatesSheet.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Spec 172 — the top-bar updates panel can finish a personal-source update.
+ *
+ * The panel offered an Update button for every outdated package, including the
+ * ones spec 136 refuses to update without a fresh fingerprint approval. The
+ * request came back 409 and the panel printed its raw code, so the only way
+ * through was the Plugins page. These pin the flow that replaced that.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "../../test-utils";
+import { UpdatesSheet } from "./UpdatesSheet";
+import { useWebSocket } from "../../store/useWebSocket";
+import * as api from "../../api";
+import type { PluginInfo } from "../../types";
+
+vi.mock("../../api", async (orig) => ({
+  ...(await orig<typeof import("../../api")>()),
+  getPlugins: vi.fn(),
+  updatePlugin: vi.fn(),
+  triggerSystemUpdate: vi.fn(),
+}));
+
+function pkg(over: Partial<PluginInfo> = {}): PluginInfo {
+  return {
+    manifest: {
+      id: "delivery-gate",
+      name: "Delivery Gate",
+      version: "0.2.0",
+      description: "",
+      icon: "Truck",
+      type: "recipe",
+      author: "adn-dev-adrien",
+      repo: "adn-dev-adrien/sowel-recipe-delivery-gate",
+    },
+    enabled: true,
+    installedAt: "2026-08-30T00:00:00.000Z",
+    latestVersion: "0.3.0",
+    ...over,
+  } as PluginInfo;
+}
+
+const FINGERPRINT = "203d1da100543f47bb63953098e3c76e3af880e5316b318c66a99d0c4e94f159";
+
+const refused = () =>
+  new api.PersonalPluginConfirmationRequiredError(
+    "adn-dev-adrien/sowel-recipe-delivery-gate",
+    "adn-dev-adrien",
+    "0.3.0",
+    FINGERPRINT,
+  );
+
+/** Render, wait for the list, and click the row's Update button. */
+async function clickUpdate() {
+  render(<UpdatesSheet open onClose={() => {}} />);
+  const button = await screen.findByRole("button", { name: "Update" });
+  await act(async () => {
+    fireEvent.click(button);
+  });
+}
+
+beforeEach(() => {
+  useWebSocket.setState({ updateAvailable: null });
+  vi.mocked(api.getPlugins).mockResolvedValue([pkg({ source: "personal" })]);
+  vi.mocked(api.updatePlugin).mockResolvedValue({ success: true });
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("UpdatesSheet — personal-source confirmation (spec 172)", () => {
+  it("asks for the fingerprint instead of printing the refusal", async () => {
+    vi.mocked(api.updatePlugin).mockRejectedValueOnce(refused());
+    await clickUpdate();
+
+    expect(screen.getByText("Personal plugin")).toBeTruthy();
+    expect(screen.getByText("adn-dev-adrien/sowel-recipe-delivery-gate")).toBeTruthy();
+    expect(screen.getByText("0.3.0")).toBeTruthy();
+    // Truncated on screen, whole value in the title attribute.
+    const shown = screen.getByText(`${FINGERPRINT.slice(0, 12)}…`);
+    expect(shown.getAttribute("title")).toBe(FINGERPRINT);
+    // The raw 409 code must not reach the user as an error.
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(api.updatePlugin).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries with the pinned fingerprint once confirmed", async () => {
+    vi.mocked(api.updatePlugin).mockRejectedValueOnce(refused());
+    await clickUpdate();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Trust and update" }));
+    });
+
+    expect(api.updatePlugin).toHaveBeenLastCalledWith("delivery-gate", {
+      confirmed: true,
+      expectedSha256: FINGERPRINT,
+    });
+    // The row leaves the list once the backend has had its settling moment.
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Update" })).toBeNull(), {
+      timeout: 3000,
+    });
+  });
+
+  it("sends nothing more when the confirmation is dismissed", async () => {
+    vi.mocked(api.updatePlugin).mockRejectedValueOnce(refused());
+    await clickUpdate();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    });
+
+    expect(api.updatePlugin).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Personal plugin")).toBeNull();
+    // And the row is still there, still updatable.
+    const retry = screen.getByRole("button", { name: "Update" });
+    expect(retry.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("marks a personal row, so the extra step is expected", async () => {
+    render(<UpdatesSheet open onClose={() => {}} />);
+    expect(await screen.findByText("Personal")).toBeTruthy();
+  });
+
+  it("updates an ordinary package in one click, with no dialog", async () => {
+    vi.mocked(api.getPlugins).mockResolvedValue([pkg()]);
+    await clickUpdate();
+
+    expect(api.updatePlugin).toHaveBeenCalledWith("delivery-gate", {});
+    expect(screen.queryByText("Personal plugin")).toBeNull();
+    expect(screen.queryByText("Personal")).toBeNull();
+  });
+
+  it("still surfaces an ordinary failure in the error line", async () => {
+    vi.mocked(api.updatePlugin).mockRejectedValueOnce(new Error("Tarball SHA256 mismatch"));
+    await clickUpdate();
+
+    expect(screen.getByRole("alert").textContent).toContain("Tarball SHA256 mismatch");
+    expect(screen.queryByText("Personal plugin")).toBeNull();
+  });
+});

--- a/ui/src/components/layout/UpdatesSheet.tsx
+++ b/ui/src/components/layout/UpdatesSheet.tsx
@@ -2,7 +2,17 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FileText, Loader2, RefreshCw } from "lucide-react";
 import { BottomSheet } from "../dashboard/BottomSheet";
-import { getPlugins, triggerSystemUpdate, updatePlugin } from "../../api";
+import {
+  getPlugins,
+  triggerSystemUpdate,
+  updatePlugin,
+  PersonalPluginConfirmationRequiredError,
+} from "../../api";
+import {
+  PersonalBadge,
+  PersonalConfirmModal,
+  type PersonalConfirmInfo,
+} from "../plugins/PersonalConfirm";
 import { useWebSocket } from "../../store/useWebSocket";
 import { refreshPluginUpdateCount } from "./usePluginUpdates";
 import type { PluginInfo, PluginManifest, PackageType } from "../../types";
@@ -42,6 +52,10 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
   const [plugins, setPlugins] = useState<PluginInfo[] | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Spec 172 — a personal-source package answers the update with a 409 asking
+  // the user to re-pin its fingerprint. The id travels with the identity: the
+  // retry targets a package id, the dialog shows a repository.
+  const [pending, setPending] = useState<{ id: string; info: PersonalConfirmInfo } | null>(null);
   // Tracks whether the sheet is currently open, so async handlers (whose
   // 1.5 s wait can outlive the close) can bail out before applying stale
   // state writes. Synced from `open` via the effect below.
@@ -53,6 +67,7 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
     let cancelled = false;
     setError(null);
     setUpdatingId(null);
+    setPending(null);
     setPlugins(null);
     getPlugins()
       .then((all) => {
@@ -69,6 +84,9 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
   }, [open]);
 
   const outdated = plugins ?? [];
+  // A row awaiting its fingerprint confirmation holds the panel too: nothing is
+  // in flight, but one dialog at a time is the whole point of it.
+  const busyId = updatingId ?? pending?.id ?? null;
   const showCore = !!coreUpdate;
   const totalCount = outdated.length + (showCore ? 1 : 0);
 
@@ -87,11 +105,15 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
     }
   }
 
-  async function handlePluginUpdate(id: string) {
+  async function handlePluginUpdate(
+    id: string,
+    opts: { confirmed?: boolean; expectedSha256?: string } = {},
+  ) {
     setError(null);
     setUpdatingId(id);
     try {
-      await updatePlugin(id);
+      await updatePlugin(id, opts);
+      setPending(null);
       // Plugin restart takes a moment — let the backend settle before refreshing the badge.
       await new Promise((r) => setTimeout(r, 1500));
       // Refresh the pill counter regardless of whether the sheet is still open —
@@ -101,6 +123,15 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
       setPlugins((prev) => (prev ?? []).filter((p) => p.manifest.id !== id));
     } catch (err) {
       if (!openRef.current) return;
+      // Spec 172 — not a failure: the server is asking the user to re-pin the
+      // fingerprint of a personal package (spec 136). Ask, then retry.
+      if (err instanceof PersonalPluginConfirmationRequiredError) {
+        setPending({
+          id,
+          info: { repo: err.repo, owner: err.owner, version: err.version, sha256: err.sha256 },
+        });
+        return;
+      }
       setError(err instanceof Error ? err.message : t("updates.error.generic"));
     } finally {
       if (openRef.current) setUpdatingId(null);
@@ -123,7 +154,7 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
           {t("updates.sheet.empty")}
         </div>
       ) : (
-        <ul className="flex flex-col gap-2" aria-busy={updatingId !== null}>
+        <ul className="flex flex-col gap-2" aria-busy={busyId !== null}>
           {showCore && coreUpdate && (
             <UpdateRow
               title="Sowel"
@@ -132,7 +163,7 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
               to={coreUpdate.latest}
               changelogHref={changelogUrl("core", undefined, coreUpdate.latest)}
               loading={updatingId === CORE_ROW_ID}
-              disabled={updatingId !== null && updatingId !== CORE_ROW_ID}
+              disabled={busyId !== null && busyId !== CORE_ROW_ID}
               onUpdate={handleCoreUpdate}
             />
           )}
@@ -146,8 +177,9 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
                 from={p.manifest.version}
                 to={to}
                 changelogHref={changelogUrl(getManifestType(p.manifest), p.manifest.repo, to)}
+                personal={p.source === "personal"}
                 loading={updatingId === p.manifest.id}
-                disabled={updatingId !== null && updatingId !== p.manifest.id}
+                disabled={busyId !== null && busyId !== p.manifest.id}
                 onUpdate={() => handlePluginUpdate(p.manifest.id)}
               />
             );
@@ -159,6 +191,23 @@ export function UpdatesSheet({ open, onClose }: UpdatesSheetProps) {
           {error}
         </div>
       )}
+      {pending && (
+        <PersonalConfirmModal
+          info={pending.info}
+          mode="update"
+          busy={updatingId === pending.id}
+          onCancel={() => {
+            setPending(null);
+            setUpdatingId(null);
+          }}
+          onConfirm={() =>
+            void handlePluginUpdate(pending.id, {
+              confirmed: true,
+              expectedSha256: pending.info.sha256,
+            })
+          }
+        />
+      )}
     </BottomSheet>
   );
 }
@@ -169,6 +218,8 @@ interface UpdateRowProps {
   from: string;
   to: string;
   changelogHref: string | null;
+  /** From a personal source (spec 136): the update will ask for a fingerprint. */
+  personal?: boolean;
   loading: boolean;
   disabled: boolean;
   onUpdate: () => void;
@@ -180,6 +231,7 @@ function UpdateRow({
   from,
   to,
   changelogHref,
+  personal,
   loading,
   disabled,
   onUpdate,
@@ -203,6 +255,9 @@ function UpdateRow({
               {badge}
             </span>
           )}
+          {/* Spec 172 — the confirmation this row is about to ask for is not a
+              surprise if the row says where the package comes from. */}
+          {personal && <PersonalBadge />}
         </div>
         <div className="text-[11px] text-text-secondary font-mono mt-0.5">
           {t("updates.sheet.versions", { from, to })}

--- a/ui/src/components/plugins/PersonalConfirm.tsx
+++ b/ui/src/components/plugins/PersonalConfirm.tsx
@@ -1,0 +1,123 @@
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import { ArrowUpCircle, Download, Loader2, ShieldAlert, UserRound } from "lucide-react";
+
+/**
+ * Spec 136 — the trust surface of a personal-source package: the fingerprint
+ * dialog and the badge that says where the package comes from.
+ *
+ * Shared rather than private to the Plugins page since spec 172: the top-bar
+ * updates panel starts the same update and hits the same 409, so it must be
+ * able to answer it with the same dialog. Two copies of a security prompt is
+ * how two prompts end up saying different things.
+ */
+
+/** Identity of a personal plugin pending TOFU confirmation (spec 136). */
+export interface PersonalConfirmInfo {
+  repo: string;
+  owner: string;
+  version: string;
+  sha256: string;
+}
+
+export function PersonalBadge() {
+  const { t } = useTranslation();
+  return (
+    <span
+      className="text-[10px] px-1.5 py-0.5 bg-primary/10 text-primary rounded-[4px] font-medium shrink-0 inline-flex items-center gap-1"
+      title={t("plugins.personal.badge.tooltip")}
+    >
+      <UserRound size={10} strokeWidth={2} />
+      {t("plugins.personal.badge")}
+    </span>
+  );
+}
+
+function IdentityRow({ label, value, title }: { label: string; value: string; title?: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span className="text-[12px] text-text-tertiary shrink-0">{label}</span>
+      <span className="text-[12px] font-mono text-text truncate" title={title ?? value}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export function PersonalConfirmModal({
+  info,
+  mode,
+  busy,
+  onCancel,
+  onConfirm,
+}: {
+  info: PersonalConfirmInfo;
+  mode: "install" | "update";
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const { t } = useTranslation();
+  const isInstall = mode === "install";
+
+  // Portaled above the detail sheet (also portaled, z-50): a security
+  // confirmation must never render behind the surface that triggered it.
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4">
+      <div className="bg-surface rounded-[14px] max-w-md w-full p-6 space-y-4 shadow-lg">
+        <div className="flex items-start gap-3">
+          <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+            <ShieldAlert size={20} className="text-primary" strokeWidth={1.5} />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-[16px] font-semibold text-text">
+              {t("plugins.personal.modal.title")}
+            </h3>
+            <p className="text-[13px] text-text-secondary mt-1">
+              {t(
+                isInstall ? "plugins.personal.modal.body" : "plugins.personal.modal.updateBody",
+                { repo: info.repo },
+              )}
+            </p>
+          </div>
+        </div>
+
+        {/* Identity of what will be installed — version + pinned fingerprint */}
+        <div className="bg-background border border-border rounded-[10px] px-4 py-3 space-y-2">
+          <IdentityRow label={t("plugins.personal.modal.repository")} value={info.repo} />
+          <IdentityRow label={t("plugins.personal.modal.version")} value={info.version} />
+          <IdentityRow
+            label={t("plugins.personal.modal.fingerprint")}
+            value={`${info.sha256.slice(0, 12)}…`}
+            title={info.sha256}
+          />
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button
+            onClick={onCancel}
+            disabled={busy}
+            className="px-4 py-2 text-[13px] font-medium text-text-secondary hover:bg-border-light rounded-[6px] transition-colors disabled:opacity-50"
+          >
+            {t("common.cancel")}
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={busy}
+            className="px-4 py-2 text-[13px] font-medium text-white bg-primary hover:bg-primary-hover rounded-[6px] transition-colors disabled:opacity-50 inline-flex items-center gap-1.5"
+          >
+            {busy ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : isInstall ? (
+              <Download size={14} />
+            ) : (
+              <ArrowUpCircle size={14} />
+            )}
+            {t(isInstall ? "plugins.personal.modal.confirm" : "plugins.personal.modal.confirmUpdate")}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/ui/src/pages/PluginsPage.tsx
+++ b/ui/src/pages/PluginsPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback } from "react";
-import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import {
   Package,
@@ -10,8 +9,6 @@ import {
   ArrowUpCircle,
   RefreshCw,
   AlertTriangle,
-  ShieldAlert,
-  UserRound,
   Users,
   FolderGit2,
   Plus,
@@ -22,6 +19,11 @@ import {
 import { refreshPluginUpdateCount } from "../components/layout/usePluginUpdates";
 import { PluginDetailSheet } from "../components/plugins/PluginDetailSheet";
 import { UpdateAllBanner } from "../components/plugins/UpdateAllBanner";
+import {
+  PersonalBadge,
+  PersonalConfirmModal,
+  type PersonalConfirmInfo,
+} from "../components/plugins/PersonalConfirm";
 import * as LucideIcons from "lucide-react";
 import {
   getPlugins,
@@ -53,14 +55,6 @@ import {
   localizedDescription as getLocalizedDescription,
   type RecipeCategoryId,
 } from "../lib/plugin-categories";
-
-/** Identity of a personal plugin pending TOFU confirmation (spec 136). */
-interface PersonalConfirmInfo {
-  repo: string;
-  owner: string;
-  version: string;
-  sha256: string;
-}
 
 type Tab = "installed" | "store";
 type CategoryFilter = "integration" | "recipe";
@@ -923,111 +917,6 @@ function StoreRow({
   );
 }
 
-// ── Personal Badge (spec 136) ────────────────────────────────
-
-function PersonalBadge() {
-  const { t } = useTranslation();
-  return (
-    <span
-      className="text-[10px] px-1.5 py-0.5 bg-primary/10 text-primary rounded-[4px] font-medium shrink-0 inline-flex items-center gap-1"
-      title={t("plugins.personal.badge.tooltip")}
-    >
-      <UserRound size={10} strokeWidth={2} />
-      {t("plugins.personal.badge")}
-    </span>
-  );
-}
-
-// ── Personal TOFU Confirm Modal (spec 136) ───────────────────
-
-function IdentityRow({ label, value, title }: { label: string; value: string; title?: string }) {
-  return (
-    <div className="flex items-baseline justify-between gap-3">
-      <span className="text-[12px] text-text-tertiary shrink-0">{label}</span>
-      <span className="text-[12px] font-mono text-text truncate" title={title ?? value}>
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function PersonalConfirmModal({
-  info,
-  mode,
-  busy,
-  onCancel,
-  onConfirm,
-}: {
-  info: PersonalConfirmInfo;
-  mode: "install" | "update";
-  busy: boolean;
-  onCancel: () => void;
-  onConfirm: () => void;
-}) {
-  const { t } = useTranslation();
-  const isInstall = mode === "install";
-
-  // Portaled above the detail sheet (also portaled, z-50): a security
-  // confirmation must never render behind the surface that triggered it.
-  return createPortal(
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4">
-      <div className="bg-surface rounded-[14px] max-w-md w-full p-6 space-y-4 shadow-lg">
-        <div className="flex items-start gap-3">
-          <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
-            <ShieldAlert size={20} className="text-primary" strokeWidth={1.5} />
-          </div>
-          <div className="min-w-0">
-            <h3 className="text-[16px] font-semibold text-text">
-              {t("plugins.personal.modal.title")}
-            </h3>
-            <p className="text-[13px] text-text-secondary mt-1">
-              {t(
-                isInstall ? "plugins.personal.modal.body" : "plugins.personal.modal.updateBody",
-                { repo: info.repo },
-              )}
-            </p>
-          </div>
-        </div>
-
-        {/* Identity of what will be installed — version + pinned fingerprint */}
-        <div className="bg-background border border-border rounded-[10px] px-4 py-3 space-y-2">
-          <IdentityRow label={t("plugins.personal.modal.repository")} value={info.repo} />
-          <IdentityRow label={t("plugins.personal.modal.version")} value={info.version} />
-          <IdentityRow
-            label={t("plugins.personal.modal.fingerprint")}
-            value={`${info.sha256.slice(0, 12)}…`}
-            title={info.sha256}
-          />
-        </div>
-
-        <div className="flex items-center justify-end gap-2 pt-2">
-          <button
-            onClick={onCancel}
-            disabled={busy}
-            className="px-4 py-2 text-[13px] font-medium text-text-secondary hover:bg-border-light rounded-[6px] transition-colors disabled:opacity-50"
-          >
-            {t("common.cancel")}
-          </button>
-          <button
-            onClick={onConfirm}
-            disabled={busy}
-            className="px-4 py-2 text-[13px] font-medium text-white bg-primary hover:bg-primary-hover rounded-[6px] transition-colors disabled:opacity-50 inline-flex items-center gap-1.5"
-          >
-            {busy ? (
-              <Loader2 size={14} className="animate-spin" />
-            ) : isInstall ? (
-              <Download size={14} />
-            ) : (
-              <ArrowUpCircle size={14} />
-            )}
-            {t(isInstall ? "plugins.personal.modal.confirm" : "plugins.personal.modal.confirmUpdate")}
-          </button>
-        </div>
-      </div>
-    </div>,
-    document.body,
-  );
-}
 
 // ── Personal Sources Section (spec 136) ──────────────────────
 


### PR DESCRIPTION
## Summary

The top-bar updates panel offers an **Update** button for every outdated package — including the ones spec 136 refuses to update without a fresh fingerprint approval. For those, the server answers `409 PersonalPluginConfirmationRequired` carrying the version and the SHA256 to re-pin. The Plugins page knows how to answer that; the panel did not, and printed the raw error code in red. The only way through was Administration → Plugins → Installed. The panel built to be the one place updates happen was the one place a personal update could not.

`docs/user/plugins.md` already promised the opposite — *"Every later update shows the same dialog again with the new version and new fingerprint."* It now holds from every surface.

**The gate does not move.** A new release is new content, and re-pinning its fingerprint per version is the guarantee spec 136 exists to give — no "trust this source forever" shortcut. What changes is only *where* the question can be answered.

Spec: [`specs/172-updates-sheet-personal-confirm/`](specs/172-updates-sheet-personal-confirm/spec.md). Reported from real use: a personal recipe published a new release, and the update button in the top bar could not install it.

## Changes

- **`components/plugins/PersonalConfirm.tsx`** (new) — `PersonalConfirmModal`, its `IdentityRow` and `PersonalBadge` moved out of `PluginsPage` verbatim. Two copies of a security prompt is how two prompts start saying different things. The `createPortal` at `z-[60]` is why it works above a portaled sheet on both surfaces.
- **`UpdatesSheet`** — catches `PersonalPluginConfirmationRequiredError`, holds `{ id, info }`, raises the same dialog, retries with `{ confirmed: true, expectedSha256 }`, then follows the existing success path (settle, refresh the badge, drop the row). Cancel sends nothing and returns the row to idle.
- A row awaiting confirmation holds the panel (`busyId = updatingId ?? pending?.id`): nothing is in flight, but one fingerprint dialog at a time is the point of it.
- Personal rows carry the **Personal** badge, so the extra step is expected rather than surprising.
- **Untouched**: the API client and the server (both have handled this since spec 136), the core update row (no fingerprint step), and bulk update — `UpdateAllBanner` already excludes personal packages and names them, a fingerprint being a per-package decision.

## Test plan

- [x] `cd ui && npx vitest run` — 950 pass, including 6 new on a component that had no test file
- [x] `npx tsc --noEmit`, `cd ui && npx tsc -b --noEmit` — clean
- [x] `npx eslint src/ --ext .ts`, `cd ui && npx eslint .` — clean
- [x] `scripts/check-docs-parity.sh` + `scripts/check-docs-impact.sh` — pass
- [x] `PluginsPage.test.tsx` still green after the extraction, including its spec 136 case asserting the modal is portaled above the detail sheet

New cases: the dialog replaces the raw refusal (repo, version, truncated hash with the full value in `title`, and no `role="alert"`); confirming retries with the pinned hash and the row leaves the list; cancelling issues no second call and leaves the row updatable; an ordinary package still updates in one bare call with no dialog; the badge renders; an ordinary failure still reaches the error line.

Reviewed by re-reading the branch diff against the spec before opening (no review agent was run on this branch).