### PR TITLE
fix(self-update): give up on a helper that never returns (#884)

### DIFF
--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -406,8 +406,12 @@ nettoyer, la tentative suivante supprime elle-même le helper resté en place. L
 seul cas qu'elle refuse est un helper de la tentative précédente **encore en
 cours** : le supprimer couperait un `docker compose up -d` en deux, donc la mise
 à jour s'arrête sur `Helper "sowel-updater" from a previous attempt is still
-running`. Attendez-le, ou, une fois ses logs lus et le blocage confirmé,
-`docker rm -f sowel-updater`.
+running`. Les deux helpers comptent, un updater bloque un restart et
+réciproquement, puisqu'ils pilotent le même projet compose. Attendez-le, ou
+supprimez-le à la main une fois ses logs lus (`docker rm -f sowel-updater`).
+Passé la fenêtre de quinze minutes, la tentative suivante le supprime d'elle-même :
+un helper orphelin laissé par un redémarrage de conteneur ne bloque pas les
+mises à jour indéfiniment.
 
 ```bash
 cd /opt/sowel

--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -396,8 +396,18 @@ du serveur pour les autres rôles, qui ne voient donc que le résultat. Sowel
 continue de servir la version précédente, et le backup pré-update qu'il a pris
 est toujours dans `data/backups/`.
 
+Un helper qui se bloque au lieu de sortir est traité lui aussi : au bout de
+quinze minutes le moteur l'abandonne, libère la mise à jour et le signale.
+L'abandonner ne le tue pas, donc s'il était seulement lent il peut encore mener
+le swap à son terme.
+
 Récupération : corrigez la cause et recliquez sur Update. Il n'y a rien à
-nettoyer, la tentative suivante supprime elle-même le helper resté en place.
+nettoyer, la tentative suivante supprime elle-même le helper resté en place. Le
+seul cas qu'elle refuse est un helper de la tentative précédente **encore en
+cours** : le supprimer couperait un `docker compose up -d` en deux, donc la mise
+à jour s'arrête sur `Helper "sowel-updater" from a previous attempt is still
+running`. Attendez-le, ou, une fois ses logs lus et le blocage confirmé,
+`docker rm -f sowel-updater`.
 
 ```bash
 cd /opt/sowel
@@ -408,7 +418,7 @@ docker compose pull && docker compose up -d   # ou mise à jour à la main
 Investigation :
 
 - `docker logs sowel-updater` : le conteneur helper est délibérément conservé après sa sortie (`AutoRemove: false`), précisément pour ça
-- Les logs propres de Sowel : `Update helper spawned` est la dernière ligne avant un swap réussi, et `Helper finished without restarting Sowel` marque l'échec
+- Les logs propres de Sowel : `Update helper spawned` est la dernière ligne avant un swap réussi. `Helper finished without restarting Sowel` marque un helper qui est sorti, `Helper did not return within the watchdog window` un helper qui n'a jamais répondu
 - Si Sowel n'est jamais revenu du tout, `docker ps -a` indique si son conteneur est en Exited
 
 ### Base de données corrompue

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -398,8 +398,17 @@ the WebSocket layer redacts free-form server strings for other roles, so they
 get the outcome alone. Sowel keeps serving the previous
 version, and the pre-update backup it took is still in `data/backups/`.
 
+A helper that hangs instead of exiting is caught too: after fifteen minutes the
+engine gives up on it, releases the update and says so. Giving up does not kill
+the helper, so if it was merely slow it may still complete the swap on its own.
+
 Recovery: fix the cause and click Update again. There is nothing to clean up —
-the next attempt removes the leftover helper itself.
+the next attempt removes the leftover helper itself. The one case it refuses is
+a helper from the previous attempt that is **still running**: removing it could
+cut a `docker compose up -d` in half, so the update stops with
+`Helper "sowel-updater" from a previous attempt is still running`. Wait for it,
+or, once you have read its logs and know it is stuck, `docker rm -f
+sowel-updater`.
 
 ```bash
 cd /opt/sowel
@@ -410,7 +419,7 @@ docker compose pull && docker compose up -d   # or upgrade by hand
 Investigation:
 
 - `docker logs sowel-updater` — the helper container is deliberately kept after it exits (`AutoRemove: false`) for exactly this
-- Sowel's own logs: `Update helper spawned` is the last line before a successful swap, and `Helper finished without restarting Sowel` marks the failure
+- Sowel's own logs: `Update helper spawned` is the last line before a successful swap. `Helper finished without restarting Sowel` marks a helper that exited, `Helper did not return within the watchdog window` one that never answered at all
 - If Sowel never came back at all, `docker ps -a` shows whether its container is Exited
 
 ### Database corrupted

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -406,9 +406,12 @@ Recovery: fix the cause and click Update again. There is nothing to clean up —
 the next attempt removes the leftover helper itself. The one case it refuses is
 a helper from the previous attempt that is **still running**: removing it could
 cut a `docker compose up -d` in half, so the update stops with
-`Helper "sowel-updater" from a previous attempt is still running`. Wait for it,
-or, once you have read its logs and know it is stuck, `docker rm -f
-sowel-updater`.
+`Helper "sowel-updater" from a previous attempt is still running`. Either helper
+counts, an updater blocks a restart and the reverse, since both drive the same
+compose project. Wait for it, or remove it by hand once its logs show it is
+stuck (`docker rm -f sowel-updater`). Past the fifteen-minute window the next
+attempt clears it itself, so a helper orphaned by a container restart does not
+block updates forever.
 
 ```bash
 cd /opt/sowel

--- a/src/core/update-manager.test.ts
+++ b/src/core/update-manager.test.ts
@@ -547,7 +547,9 @@ describe("UpdateManager — helper watchdog", () => {
   function hangingHelper() {
     return {
       wait: vi.fn(() => new Promise<never>(() => {})),
-      logs: vi.fn(async () => frame(1, "[sowel-updater] pulling ghcr.io/mchacher/sowel:1.66.0...\n")),
+      logs: vi.fn(async () =>
+        frame(1, "[sowel-updater] pulling ghcr.io/mchacher/sowel:1.66.0...\n"),
+      ),
     };
   }
 

--- a/src/core/update-manager.test.ts
+++ b/src/core/update-manager.test.ts
@@ -400,6 +400,7 @@ function makeHelperStub(opts: { statusCode?: number; waitError?: Error; logs?: B
 type ManagerInternals = {
   updating: boolean;
   watchHelper: (helper: unknown, name: string, operation: "update" | "restart") => void;
+  removeLeftoverHelper: (docker: unknown, name: string) => Promise<void>;
 };
 
 type UpdateErrorEvent = { error: string; operation: "update" | "restart" };
@@ -510,5 +511,132 @@ describe("UpdateManager — helper supervision", () => {
 
     expect(await errorPromise).toBeNull();
     expect(manager.isUpdating()).toBe(false);
+  });
+});
+
+// ── Watchdog (#884) ──────────────────────────────────────────
+//
+// Watching for the exit only catches a helper that dies. One that hangs kept
+// `updating` set for the life of the process, which is the same frozen overlay
+// and the same 409 the exit path was fixed for.
+
+const WATCHDOG_MS = 15 * 60 * 1000;
+
+describe("UpdateManager — helper watchdog", () => {
+  let eventBus: EventBus;
+  let manager: UpdateManager;
+  let internals: ManagerInternals;
+  let errors: string[];
+
+  beforeEach(() => {
+    eventBus = new EventBus(logger);
+    manager = new UpdateManager(eventBus, makeBackupStub(), logger);
+    internals = manager as unknown as ManagerInternals;
+    errors = [];
+    eventBus.on((event) => {
+      if (event.type === "system.update.error") errors.push(event.error);
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** A helper whose wait() never settles — the daemon is answering nothing. */
+  function hangingHelper() {
+    return {
+      wait: vi.fn(() => new Promise<never>(() => {})),
+      logs: vi.fn(async () => frame(1, "[sowel-updater] pulling ghcr.io/mchacher/sowel:1.66.0...\n")),
+    };
+  }
+
+  it("gives up on a helper that never returns, and says what it was doing", async () => {
+    internals.updating = true;
+    internals.watchHelper(hangingHelper(), "sowel-updater", "update");
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_MS);
+
+    expect(manager.isUpdating()).toBe(false);
+    expect(errors[0]).toContain("has not returned");
+    // The tail still comes from the helper, which is where the stall shows.
+    expect(errors[0]).toContain("pulling ghcr.io/mchacher/sowel:1.66.0");
+  });
+
+  it("holds the flag while the helper is merely slow", async () => {
+    internals.updating = true;
+    internals.watchHelper(hangingHelper(), "sowel-updater", "update");
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_MS - 1000);
+
+    // A pull on a slow link is not a failure — a second trigger stays out.
+    expect(manager.isUpdating()).toBe(true);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("does not fire the watchdog once the helper has exited", async () => {
+    internals.updating = true;
+    internals.watchHelper(makeHelperStub({ statusCode: 1 }), "sowel-updater", "update");
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(errors).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_MS * 2);
+    expect(errors).toHaveLength(1);
+  });
+});
+
+// ── Leftover helper (#884) ───────────────────────────────────
+//
+// The watchdog gives up on a helper without killing it, so the next attempt can
+// meet one that is still working. Forcing it out would cut a swap in half.
+
+describe("UpdateManager — leftover helper", () => {
+  let internals: ManagerInternals;
+
+  beforeEach(() => {
+    const manager = new UpdateManager(new EventBus(logger), makeBackupStub(), logger);
+    internals = manager as unknown as ManagerInternals;
+  });
+
+  function dockerWith(container: unknown) {
+    return { getContainer: vi.fn(() => container) };
+  }
+
+  it("refuses to force-remove a helper that is still running", async () => {
+    const remove = vi.fn();
+    const docker = dockerWith({
+      inspect: vi.fn(async () => ({ State: { Running: true } })),
+      remove,
+    });
+
+    await expect(internals.removeLeftoverHelper(docker, "sowel-updater")).rejects.toThrow(
+      /still running/,
+    );
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it("removes the container a previous run left behind", async () => {
+    const remove = vi.fn(async () => undefined);
+    const docker = dockerWith({
+      inspect: vi.fn(async () => ({ State: { Running: false } })),
+      remove,
+    });
+
+    await internals.removeLeftoverHelper(docker, "sowel-updater");
+    expect(remove).toHaveBeenCalledWith({ force: true });
+  });
+
+  it("is a no-op when no helper is there", async () => {
+    const remove = vi.fn();
+    const docker = dockerWith({
+      inspect: vi.fn(async () => {
+        throw new Error("no such container");
+      }),
+      remove,
+    });
+
+    await expect(internals.removeLeftoverHelper(docker, "sowel-updater")).resolves.toBeUndefined();
+    expect(remove).not.toHaveBeenCalled();
   });
 });

--- a/src/core/update-manager.test.ts
+++ b/src/core/update-manager.test.ts
@@ -574,12 +574,32 @@ describe("UpdateManager — helper watchdog", () => {
     expect(errors).toHaveLength(0);
   });
 
+  it("reports without the tail when the daemon never hands the logs over", async () => {
+    // A hung wait() is usually a hung daemon, and the same daemon serves the
+    // logs. Waiting on it forever here would pin the flag three lines after the
+    // watchdog released it.
+    const helper = {
+      wait: vi.fn(async () => ({ StatusCode: 1 })),
+      logs: vi.fn(() => new Promise<never>(() => {})),
+    };
+    internals.updating = true;
+    internals.watchHelper(helper, "sowel-updater", "update");
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(manager.isUpdating()).toBe(false);
+    expect(errors[0]).toContain("code 1");
+  });
+
   it("does not fire the watchdog once the helper has exited", async () => {
     internals.updating = true;
     internals.watchHelper(makeHelperStub({ statusCode: 1 }), "sowel-updater", "update");
 
     await vi.advanceTimersByTimeAsync(0);
     expect(errors).toHaveLength(1);
+
+    // The watchdog timer is cleared, not merely outvoted by the emit guard.
+    expect(vi.getTimerCount()).toBe(0);
 
     await vi.advanceTimersByTimeAsync(WATCHDOG_MS * 2);
     expect(errors).toHaveLength(1);
@@ -599,44 +619,88 @@ describe("UpdateManager — leftover helper", () => {
     internals = manager as unknown as ManagerInternals;
   });
 
-  function dockerWith(container: unknown) {
-    return { getContainer: vi.fn(() => container) };
+  const ABSENT = Symbol("absent");
+
+  /** State of one helper container, or ABSENT when there is none. */
+  type HelperState = typeof ABSENT | { Running: boolean; StartedAt?: string };
+
+  function dockerWith(states: Record<string, HelperState>) {
+    const removals: string[] = [];
+    const docker = {
+      getContainer: (name: string) => ({
+        inspect: async () => {
+          const state = states[name] ?? ABSENT;
+          if (state === ABSENT) throw new Error("no such container");
+          return { State: state };
+        },
+        remove: async () => {
+          removals.push(name);
+        },
+      }),
+    };
+    return { docker, removals };
   }
 
+  const minutesAgo = (m: number) => new Date(Date.now() - m * 60_000).toISOString();
+
   it("refuses to force-remove a helper that is still running", async () => {
-    const remove = vi.fn();
-    const docker = dockerWith({
-      inspect: vi.fn(async () => ({ State: { Running: true } })),
-      remove,
+    const { docker, removals } = dockerWith({
+      "sowel-updater": { Running: true, StartedAt: minutesAgo(2) },
     });
 
     await expect(internals.removeLeftoverHelper(docker, "sowel-updater")).rejects.toThrow(
       /still running/,
     );
-    expect(remove).not.toHaveBeenCalled();
+    expect(removals).toEqual([]);
   });
 
-  it("removes the container a previous run left behind", async () => {
-    const remove = vi.fn(async () => undefined);
-    const docker = dockerWith({
-      inspect: vi.fn(async () => ({ State: { Running: false } })),
-      remove,
+  // An updater still swapping and a restarter spawned beside it would race for
+  // the same compose project, which is the same damage by another route.
+  it("refuses when the helper still running is the other one", async () => {
+    const { docker, removals } = dockerWith({
+      "sowel-updater": { Running: true, StartedAt: minutesAgo(2) },
+    });
+
+    await expect(internals.removeLeftoverHelper(docker, "sowel-restarter")).rejects.toThrow(
+      /sowel-updater/,
+    );
+    expect(removals).toEqual([]);
+  });
+
+  // Otherwise a `docker restart sowel` would leave an orphan blocking every
+  // future in-app update until someone removed it by hand.
+  it("clears a runner older than the watchdog window", async () => {
+    const { docker, removals } = dockerWith({
+      "sowel-updater": { Running: true, StartedAt: minutesAgo(30) },
     });
 
     await internals.removeLeftoverHelper(docker, "sowel-updater");
-    expect(remove).toHaveBeenCalledWith({ force: true });
+    expect(removals).toEqual(["sowel-updater"]);
+  });
+
+  it("removes the container a previous run left behind", async () => {
+    const { docker, removals } = dockerWith({ "sowel-updater": { Running: false } });
+
+    await internals.removeLeftoverHelper(docker, "sowel-updater");
+    expect(removals).toEqual(["sowel-updater"]);
+  });
+
+  // A stopped helper under the other name blocks nothing, and its logs may be
+  // the only record of what went wrong.
+  it("leaves a stopped helper under the other name alone", async () => {
+    const { docker, removals } = dockerWith({
+      "sowel-updater": { Running: false },
+      "sowel-restarter": { Running: false },
+    });
+
+    await internals.removeLeftoverHelper(docker, "sowel-restarter");
+    expect(removals).toEqual(["sowel-restarter"]);
   });
 
   it("is a no-op when no helper is there", async () => {
-    const remove = vi.fn();
-    const docker = dockerWith({
-      inspect: vi.fn(async () => {
-        throw new Error("no such container");
-      }),
-      remove,
-    });
+    const { docker, removals } = dockerWith({});
 
     await expect(internals.removeLeftoverHelper(docker, "sowel-updater")).resolves.toBeUndefined();
-    expect(remove).not.toHaveBeenCalled();
+    expect(removals).toEqual([]);
   });
 });

--- a/src/core/update-manager.ts
+++ b/src/core/update-manager.ts
@@ -17,6 +17,19 @@ const BACKUP_KEEP_COUNT = 3;
 const HELPER_LOG_TAIL_LINES = 5;
 /** Cap on the quoted tail, so a runaway helper cannot flood the event bus. */
 const HELPER_LOG_TAIL_MAX_CHARS = 400;
+/**
+ * How long to wait for a helper before deciding it will never hand back.
+ *
+ * Watching for the exit only catches a helper that dies. One that hangs, a
+ * `docker pull` against a registry that accepts the connection and then answers
+ * nothing, leaves `wait()` pending for the life of the process, which is the
+ * pinned flag and the frozen overlay all over again (#884). Fifteen minutes is
+ * far past a normal pull on a slow link, so reaching it means something is
+ * wrong rather than slow.
+ */
+const HELPER_WATCHDOG_MS = 15 * 60 * 1000;
+/** Resolution of the watchdog race, kept distinct from any daemon payload. */
+const HELPER_TIMED_OUT = Symbol("helper-watchdog");
 
 type DockerContainer = InstanceType<typeof import("dockerode").Container>;
 /**
@@ -420,14 +433,7 @@ export class UpdateManager {
     const { default: Docker } = await import("dockerode");
     const docker = new Docker({ socketPath: DOCKER_SOCKET_PATH });
 
-    // Remove any leftover helper from a previous failed run
-    try {
-      const existing = docker.getContainer(args.name);
-      await existing.remove({ force: true });
-      this.logger.debug({ name: args.name }, "Removed leftover helper container");
-    } catch {
-      // Not present — that's fine
-    }
+    await this.removeLeftoverHelper(docker, args.name);
 
     // Pull the helper image (cached after first time)
     try {
@@ -474,6 +480,46 @@ export class UpdateManager {
   }
 
   /**
+   * Clear the helper container a previous attempt left behind.
+   *
+   * The helper is deliberately kept after it exits (`AutoRemove: false`) so its
+   * logs stay readable, so a stopped one is expected here and simply removed.
+   *
+   * A *running* one is a different animal: since #884 the watchdog gives up on
+   * a helper that has not returned, and giving up does not kill it. Forcing it
+   * out here would cut a `docker compose up -d` in half and leave the stack
+   * half-recreated, so refuse instead and say what to do about it. The throw
+   * lands in the caller's catch, which releases `updating` and reports it.
+   */
+  private async removeLeftoverHelper(
+    docker: { getContainer: (name: string) => DockerContainer },
+    name: string,
+  ): Promise<void> {
+    const existing = docker.getContainer(name);
+    let state: { State?: { Running?: boolean } };
+    try {
+      state = await existing.inspect();
+    } catch {
+      return; // Not present — that's fine, nothing to clear
+    }
+
+    if (state.State?.Running) {
+      throw new Error(
+        `Helper "${name}" from a previous attempt is still running. Wait for it to finish, or remove it with: docker rm -f ${name}`,
+      );
+    }
+
+    try {
+      await existing.remove({ force: true });
+      this.logger.debug({ name }, "Removed leftover helper container");
+    } catch (err) {
+      // Raced with someone else removing it. Creating the new one will tell us
+      // soon enough if it really is still there.
+      this.logger.debug({ err, name }, "Leftover helper container already gone");
+    }
+  }
+
+  /**
    * Watch a helper we just started, and release `updating` if it dies without
    * taking us with it.
    *
@@ -489,20 +535,38 @@ export class UpdateManager {
    * ghcr.io) pinned an instance that way for hours, with the real cause
    * readable only in `docker logs sowel-updater`. So we quote that tail into
    * the error the admin actually sees.
+   *
+   * A helper that hangs never reaches any of that, so the wait is also raced
+   * against a watchdog (#884). Giving up on it does not kill it: it may still
+   * be working, and the next attempt refuses to force-remove a helper that is
+   * still running rather than cutting a swap in half.
    */
   private watchHelper(helper: DockerContainer, name: string, operation: HelperOperation): void {
     void (async () => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
       let outcome: string;
+      let timedOut = false;
       try {
-        const result = (await helper.wait()) as { StatusCode?: number } | undefined;
-        const code = result?.StatusCode ?? -1;
-        outcome = `Helper "${name}" exited with code ${code} without restarting Sowel`;
+        const result = await Promise.race([
+          helper.wait() as Promise<{ StatusCode?: number } | undefined>,
+          new Promise<typeof HELPER_TIMED_OUT>((resolveRace) => {
+            timer = setTimeout(() => resolveRace(HELPER_TIMED_OUT), HELPER_WATCHDOG_MS);
+          }),
+        ]);
+        if (result === HELPER_TIMED_OUT) {
+          timedOut = true;
+          outcome = `Helper "${name}" has not returned after ${HELPER_WATCHDOG_MS / 60_000} minutes, giving up on it`;
+        } else {
+          outcome = `Helper "${name}" exited with code ${result?.StatusCode ?? -1} without restarting Sowel`;
+        }
       } catch (err) {
         // The daemon went away, or the container was removed under us. An
         // unknown outcome still beats a flag pinned for the life of the process.
         outcome = `Helper "${name}" could not be watched: ${
           err instanceof Error ? err.message : String(err)
         }`;
+      } finally {
+        clearTimeout(timer);
       }
 
       // A failure on our own side may have released the flag already; and a
@@ -514,7 +578,11 @@ export class UpdateManager {
       this.updating = false;
       this.logger.error(
         { helper: name, operation, tail },
-        "Helper finished without restarting Sowel",
+        // Two distinct lines on purpose: troubleshooting greps for them, and
+        // "finished" would be a lie about a helper that is still running.
+        timedOut
+          ? "Helper did not return within the watchdog window"
+          : "Helper finished without restarting Sowel",
       );
       this.eventBus.emit({ type: "system.update.error", error, operation });
     })();

--- a/src/core/update-manager.ts
+++ b/src/core/update-manager.ts
@@ -9,6 +9,8 @@ const DOCKER_SOCKET_PATH = "/var/run/docker.sock";
 const HELPER_IMAGE = "docker:25-cli";
 const HELPER_NAME = "sowel-updater";
 const RESTART_HELPER_NAME = "sowel-restarter";
+/** Every helper we spawn. Only one may be running at a time, see below. */
+const HELPER_NAMES = [HELPER_NAME, RESTART_HELPER_NAME] as const;
 const COMPOSE_LABEL_WORKING_DIR = "com.docker.compose.project.working_dir";
 const COMPOSE_LABEL_PROJECT = "com.docker.compose.project";
 const COMPOSE_LABEL_SERVICE = "com.docker.compose.service";
@@ -30,6 +32,15 @@ const HELPER_LOG_TAIL_MAX_CHARS = 400;
 const HELPER_WATCHDOG_MS = 15 * 60 * 1000;
 /** Resolution of the watchdog race, kept distinct from any daemon payload. */
 const HELPER_TIMED_OUT = Symbol("helper-watchdog");
+/**
+ * Bound on the log read that explains a failure.
+ *
+ * A hung `wait()` is usually a hung daemon, and the same daemon serves the logs
+ * endpoint. Waiting on it forever here would pin `updating` three lines after
+ * the watchdog released it, which is the bug all over again. Report without the
+ * tail rather than not at all.
+ */
+const HELPER_LOG_READ_TIMEOUT_MS = 10_000;
 
 type DockerContainer = InstanceType<typeof import("dockerode").Container>;
 /**
@@ -480,42 +491,65 @@ export class UpdateManager {
   }
 
   /**
-   * Clear the helper container a previous attempt left behind.
+   * Clear the ground before spawning a helper.
    *
-   * The helper is deliberately kept after it exits (`AutoRemove: false`) so its
-   * logs stay readable, so a stopped one is expected here and simply removed.
+   * A helper is deliberately kept after it exits (`AutoRemove: false`) so its
+   * logs stay readable, so a stopped one under our own name is expected here
+   * and simply removed. One under the *other* name is left alone: it blocks
+   * nothing, and its logs may still be the record of what went wrong.
    *
-   * A *running* one is a different animal: since #884 the watchdog gives up on
-   * a helper that has not returned, and giving up does not kill it. Forcing it
-   * out here would cut a `docker compose up -d` in half and leave the stack
-   * half-recreated, so refuse instead and say what to do about it. The throw
-   * lands in the caller's catch, which releases `updating` and reports it.
+   * A *running* one is the case that matters. The watchdog gives up on a helper
+   * without killing it, so one may still be doing real work; forcing it out
+   * mid `docker compose up -d` would leave the stack half-recreated. Both names
+   * are checked, not just the one we are about to reuse: an updater still
+   * running and a restarter spawned beside it would race for the same compose
+   * project, which is the same damage by another route.
+   *
+   * The exception is a runner older than the watchdog window. We have already
+   * declared that one lost and told the admin so; refusing forever would mean a
+   * `docker restart sowel` (the documented recovery) leaves an orphan that
+   * blocks every future in-app update until someone removes it by hand.
+   *
+   * The throw lands in the caller's catch, which releases `updating` and
+   * reports the refusal like any other failure.
    */
   private async removeLeftoverHelper(
     docker: { getContainer: (name: string) => DockerContainer },
     name: string,
   ): Promise<void> {
-    const existing = docker.getContainer(name);
-    let state: { State?: { Running?: boolean } };
-    try {
-      state = await existing.inspect();
-    } catch {
-      return; // Not present — that's fine, nothing to clear
-    }
+    for (const candidate of HELPER_NAMES) {
+      const existing = docker.getContainer(candidate);
+      let state: { State?: { Running?: boolean; StartedAt?: string } };
+      try {
+        state = await existing.inspect();
+      } catch {
+        continue; // Not present under that name — nothing to clear
+      }
 
-    if (state.State?.Running) {
-      throw new Error(
-        `Helper "${name}" from a previous attempt is still running. Wait for it to finish, or remove it with: docker rm -f ${name}`,
-      );
-    }
+      if (state.State?.Running) {
+        const startedAt = Date.parse(state.State.StartedAt ?? "");
+        const ageMs = Number.isNaN(startedAt) ? 0 : Date.now() - startedAt;
+        if (ageMs < HELPER_WATCHDOG_MS) {
+          throw new Error(
+            `Helper "${candidate}" from a previous attempt is still running. Wait for it to finish, or remove it with: docker rm -f ${candidate}`,
+          );
+        }
+        this.logger.warn(
+          { name: candidate, ageMs },
+          "Removing a helper we had already given up on",
+        );
+      } else if (candidate !== name) {
+        continue; // Stopped, and not the name we need — keep it for its logs
+      }
 
-    try {
-      await existing.remove({ force: true });
-      this.logger.debug({ name }, "Removed leftover helper container");
-    } catch (err) {
-      // Raced with someone else removing it. Creating the new one will tell us
-      // soon enough if it really is still there.
-      this.logger.debug({ err, name }, "Leftover helper container already gone");
+      try {
+        await existing.remove({ force: true });
+        this.logger.debug({ name: candidate }, "Removed leftover helper container");
+      } catch (err) {
+        // Raced with someone else removing it. Creating the new one will tell
+        // us soon enough if it really is still there.
+        this.logger.debug({ err, name: candidate }, "Leftover helper container already gone");
+      }
     }
   }
 
@@ -590,15 +624,22 @@ export class UpdateManager {
 
   /**
    * Last few lines the helper printed, for the failure message. Best effort:
-   * an unreadable log must not mask the failure it was meant to explain.
+   * an unreadable log — or one the daemon never hands over — must not mask the
+   * failure it was meant to explain, nor hold the flag the caller is about to
+   * release.
    */
   private async readHelperTail(helper: DockerContainer): Promise<string> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      const raw = (await helper.logs({
-        stdout: true,
-        stderr: true,
-        tail: 20,
-      })) as unknown as Buffer;
+      const raw = (await Promise.race([
+        helper.logs({ stdout: true, stderr: true, tail: 20 }),
+        new Promise<never>((_, rejectRead) => {
+          timer = setTimeout(
+            () => rejectRead(new Error("timed out reading helper logs")),
+            HELPER_LOG_READ_TIMEOUT_MS,
+          );
+        }),
+      ])) as unknown as Buffer;
 
       return demuxDockerLogs(Buffer.from(raw))
         .split("\n")
@@ -609,6 +650,8 @@ export class UpdateManager {
         .slice(0, HELPER_LOG_TAIL_MAX_CHARS);
     } catch {
       return "";
+    } finally {
+      clearTimeout(timer);
     }
   }
 


### PR DESCRIPTION
#880 taught the engine to notice a helper that dies. This one covers the helper that never answers at all.

## Root cause

`watchHelper` had exactly two exits, `helper.wait()` resolving and `helper.wait()` rejecting. Neither happens when the helper hangs: a `docker pull` against a registry that accepts the connection and then goes silent, a compose call waiting on a lock, a wedged daemon. `updating` then stays set for the life of the process, which is the frozen overlay and the 409 on every later update and restart that #880 was opened for, reached by a slower road.

The 2026-09-02 incident produced an exit (`i/o timeout`, the daemon giving up), which is the only reason it was visible.

## What changed

**The wait is raced against a fifteen-minute watchdog**, far past a normal pull on a slow link. On expiry the flag is released, the helper's last output is quoted into the failure, and the event carries its `operation` like any other. The timeout logs `Helper did not return within the watchdog window`, deliberately distinct from `Helper finished without restarting Sowel`: troubleshooting greps for these, and "finished" would be a lie about a helper that is still running.

**Giving up does not kill the helper**, which is the other half. `runHelperContainer` used to clear the ground with `remove({ force: true })` on whatever carried the helper name. After a watchdog expiry that container may still be doing real work, so forcing it out mid `docker compose up -d` would leave the stack half-recreated. It is now removed only once it has actually exited, and the check covers **both** helper names, since an updater still swapping and a restarter spawned beside it drive the same compose project.

**With one exception**: a runner older than the watchdog window. That one we have already declared lost and told the admin about. Refusing it forever would mean a `docker restart sowel`, the documented recovery for the old bug, leaves an orphan that blocks every in-app update until someone removes it by hand.

**The tail read is bounded too** (second commit, from the review). The watchdog bounded `wait()` and the very next line awaited `helper.logs()` with no bound. A hung `wait()` is usually a hung daemon, and the same daemon serves the logs, so the flag would have been re-pinned three lines after being released. Ten seconds, then report without the tail.

## Tests

- watchdog fires, releases the flag and quotes the tail
- a helper that is merely slow is not declared dead before the window
- once the helper has exited the timer is cleared, asserted on `getTimerCount()` rather than on the emit guard that would hide it
- a hung log read still releases the flag and reports
- leftover removal: refuses a running helper, refuses it under the other name too, clears one older than the window, removes a stopped one, leaves a stopped helper under the other name alone, no-ops when there is none

Seven of the new tests fail without the corresponding fix. Full backend suite green (2429), types and lint clean, EN and FR deployment docs updated.

## Deliberately not done

`watchHelper` carries no generation token, so a watchdog from attempt 1 cannot tell its own flag from attempt 2's. Nothing can release `updating` between arming the timer and the caller returning (the event bus swallows handler throws), so the misfire is unreachable today. The real answer is turning `updating` from a bare boolean into a record of the current operation (owner, start time, token), which would also make the guard exact and let a leftover be judged by age. That is a refactor, not a line in this fix.

One deviation from the issue text: it suggested logging the expiry at `warn`, the code logs `error`. The consequence is a failed update, and the event emitted alongside is an error.

Closes #884