### PR TITLE
ci(registry): verify a registry bump against the published release asset (#892)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,21 @@ jobs:
         run: bash scripts/check-docs-impact.sh
       - name: Every spec folder is listed in both indexes
         run: bash scripts/check-specs-index.sh folders
+
+  registry:
+    name: Registry bump integrity
+    runs-on: ubuntu-latest
+    # Issue #892 — a registry entry pairs a version with the SHA256 of the
+    # tarball GitHub publishes for it. Nothing checked the pair, and a wrong one
+    # fails every install with ChecksumMismatchError about an hour later, once
+    # the CDN has caught up. Exits immediately on a PR that leaves the registry
+    # alone, so it costs nothing to the other 99% of pull requests.
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # need main's history for the merge-base diff
+      - name: A bumped entry matches its published release
+        env:
+          # Only to read public release assets — the workflow token is read-only.
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/check-registry-bump.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,13 @@ Every entry in `plugins/registry.json` MUST carry `sha256` (64 hex chars) and `o
 
 **Official vs community owners**: `OFFICIAL_OWNERS = ["mchacher"]` in `src/packages/registry-types.ts` is the hard-coded whitelist. Plugins from any other owner are flagged community in the UI and require an explicit user confirmation modal at install. The `OFFICIAL_OWNERS` list grows by review (not by PR — a PR adding to it must be reviewed by the Sowel maintainer).
 
-If the registry CI fails on SHA256 mismatch, the fix is always to re-run `backfill-registry-sha256.mjs`, never to remove the field or bypass the check.
+**The `Registry bump integrity` job checks this on every PR** (`scripts/check-registry-bump.sh`, issue #892). For each entry whose `version` or `sha256` changed it downloads the release asset, compares the hash, and reads the `manifest.json` inside the tarball to confirm the entry points at the release it claims. It also refuses any entry in the file missing `sha256`, `owner`, `repo`, `version` or `type`. Run it locally before pushing:
+
+```bash
+bash scripts/check-registry-bump.sh
+```
+
+If it fails on a SHA256 mismatch, the fix is always to re-run `backfill-registry-sha256.mjs`, never to remove the field or bypass the check. If it fails because the release does not exist, the bump is simply ahead of the publish: tag the plugin first.
 
 ### Release notes are mandatory (spec 108 — MANDATORY for AI agents)
 

--- a/scripts/check-registry-bump.sh
+++ b/scripts/check-registry-bump.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# Registry bump integrity gate (spec 089, issue #892).
+#
+# A `plugins/registry.json` entry says: this version of this plugin is that
+# tarball, and its SHA256 is this. Get the pair wrong and the install flow
+# refuses the download on every instance with a ChecksumMismatchError, about an
+# hour later, once the CDN has propagated the file. Nothing checked it: a
+# registry-only PR ran lint, typecheck, build and CodeQL, none of which can see
+# a stale hash.
+#
+# So this fails a PR whose registry change does not match what GitHub actually
+# publishes. It only looks at entries the PR touches, so a PR that leaves the
+# registry alone costs one `git diff` and exits.
+#
+# Checked, per changed entry:
+#   1. the release v<version> exists on <repo> and carries the expected asset
+#   2. the asset's SHA256 equals the entry's `sha256`
+#   3. the manifest.json inside the tarball declares the same id and version
+#      — the hash can be right while the entry points at the wrong release
+#
+# Plus a shape pass over the WHOLE file (sha256 is 64 hex, repo/version/owner
+# present), because spec 089 refuses to install an entry missing either field
+# and that is worth catching whether or not this PR touched it.
+#
+# Runs in CI (pull_request) and locally:
+#   bash scripts/check-registry-bump.sh
+# The download step needs `gh` authenticated (read access to public releases is
+# enough). The shape pass needs nothing.
+#
+# SOWEL_REGISTRY_ASSET_DIR reads the tarballs from a local directory instead of
+# downloading them. The test suite uses it; nothing else should.
+#
+# Uses python3 for the JSON reads (jq is not guaranteed on a contributor's Mac).
+# Portable to bash 3.2 (macOS) — no mapfile / associative arrays.
+
+set -euo pipefail
+
+REGISTRY="plugins/registry.json"
+BASE_REF="${1:-origin/main}"
+ASSET_DIR="${SOWEL_REGISTRY_ASSET_DIR:-}"
+
+if [ ! -f "${REGISTRY}" ]; then
+  echo "❌ ${REGISTRY} not found — run this from the repository root."
+  exit 1
+fi
+
+# ── Shape (whole file) ──────────────────────────────────────────────────────
+
+shape_errors="$(python3 - "${REGISTRY}" <<'PY'
+import json, re, sys
+
+try:
+    entries = json.load(open(sys.argv[1]))
+except json.JSONDecodeError as err:
+    print(f"the file is not valid JSON: {err}")
+    raise SystemExit(0)
+
+for entry in entries:
+    pid = entry.get("id") or "<entry with no id>"
+    for field in ("repo", "version", "owner", "type"):
+        if not entry.get(field):
+            print(f"{pid}: missing {field}")
+    if not re.fullmatch(r"[a-f0-9]{64}", entry.get("sha256") or ""):
+        print(f"{pid}: sha256 is not 64 hex characters")
+PY
+)"
+
+if [ -n "${shape_errors}" ]; then
+  echo "❌ ${REGISTRY} breaks the spec 089 entry contract:"
+  printf '%s\n' "${shape_errors}" | sed 's/^/   /'
+  echo
+  echo "Every entry needs repo, version, owner and a 64-hex sha256."
+  echo "Fill a missing hash with: node scripts/backfill-registry-sha256.mjs"
+  exit 1
+fi
+
+# ── Which entries does this PR change? ──────────────────────────────────────
+
+if ! git rev-parse --verify --quiet "${BASE_REF}" >/dev/null; then
+  git fetch --quiet origin main
+  BASE_REF="origin/main"
+fi
+
+BASE="$(git merge-base "${BASE_REF}" HEAD)"
+
+if [ -z "$(git diff --name-only "${BASE}" HEAD -- "${REGISTRY}" || true)" ]; then
+  echo "No registry change in this PR — bump integrity check skipped."
+  exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# A registry that did not exist at the base (or a PR that creates it) means
+# every entry is new, which is what an empty base gives us.
+git show "${BASE}:${REGISTRY}" >"${TMP}/base.json" 2>/dev/null || echo '[]' >"${TMP}/base.json"
+
+changed="$(python3 - "${TMP}/base.json" "${REGISTRY}" <<'PY'
+import json, sys
+
+base = {e.get("id"): e for e in json.load(open(sys.argv[1]))}
+head = json.load(open(sys.argv[2]))
+
+for entry in head:
+    was = base.get(entry.get("id"))
+    if was and was.get("version") == entry.get("version") and was.get("sha256") == entry.get("sha256"):
+        continue  # untouched, or only its description/tags moved
+    print("|".join([
+        entry["id"], entry["type"], entry["repo"], entry["version"], entry["sha256"],
+    ]))
+PY
+)"
+
+if [ -z "${changed}" ]; then
+  echo "Registry touched, but no version or sha256 changed — nothing to verify."
+  exit 0
+fi
+
+# ── Verify each changed entry against its published release ─────────────────
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+failed=0
+
+printf '%s\n' "${changed}" | while IFS='|' read -r id type repo version sha; do
+  [ -n "${id}" ] || continue
+
+  case "${type}" in
+    recipe) asset="sowel-recipe-${id}-${version}.tar.gz" ;;
+    *) asset="sowel-plugin-${id}-${version}.tar.gz" ;;
+  esac
+
+  if [ -n "${ASSET_DIR}" ]; then
+    file="${ASSET_DIR}/${asset}"
+    if [ ! -f "${file}" ]; then
+      echo "❌ ${id} ${version}: ${asset} not found in ${ASSET_DIR}"
+      echo "failed" >>"${TMP}/failures"
+      continue
+    fi
+  else
+    file="${TMP}/${asset}"
+    if ! gh release download "v${version}" -R "${repo}" -p "${asset}" -D "${TMP}" --clobber >/dev/null 2>&1; then
+      echo "❌ ${id} ${version}: ${repo} has no release v${version} carrying ${asset}"
+      echo "   Publish the release first: the registry is the last step, not the first."
+      echo "failed" >>"${TMP}/failures"
+      continue
+    fi
+  fi
+
+  actual="$(sha256_of "${file}")"
+  if [ "${actual}" != "${sha}" ]; then
+    echo "❌ ${id} ${version}: sha256 does not match the published asset"
+    echo "   registry: ${sha}"
+    echo "   asset:    ${actual}"
+    echo "failed" >>"${TMP}/failures"
+    continue
+  fi
+
+  manifest="$(tar -xzOf "${file}" manifest.json 2>/dev/null || true)"
+  if [ -z "${manifest}" ]; then
+    echo "❌ ${id} ${version}: no manifest.json at the root of ${asset}"
+    echo "failed" >>"${TMP}/failures"
+    continue
+  fi
+
+  mismatch="$(printf '%s' "${manifest}" | python3 -c '
+import json, sys
+
+manifest = json.load(sys.stdin)
+want_id, want_version = sys.argv[1], sys.argv[2]
+got_id = manifest.get("id")
+got_version = manifest.get("version")
+if got_id != want_id:
+    print("manifest id is %r, registry says %r" % (got_id, want_id))
+if got_version != want_version:
+    print("manifest version is %r, registry says %r" % (got_version, want_version))
+' "${id}" "${version}")"
+
+  if [ -n "${mismatch}" ]; then
+    echo "❌ ${id} ${version}: the tarball is not the release this entry claims"
+    printf '%s\n' "${mismatch}" | sed 's/^/   /'
+    echo "failed" >>"${TMP}/failures"
+    continue
+  fi
+
+  echo "✓ ${id} ${version} — asset, hash and manifest agree"
+done
+
+if [ -f "${TMP}/failures" ]; then failed=1; fi
+
+if [ "${failed}" -ne 0 ]; then
+  echo
+  echo "A wrong version/sha256 pair breaks the install on every instance once the"
+  echo "registry propagates (spec 089). Re-run the backfill after the release is"
+  echo "published: node scripts/backfill-registry-sha256.mjs"
+  exit 1
+fi
+
+echo "Every changed registry entry matches its published release."

--- a/src/tooling/check-registry-bump.test.ts
+++ b/src/tooling/check-registry-bump.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Issue #892 — scripts/check-registry-bump.sh is a shell gate, not part of the
+// TS build, but the backend suite is the only place vitest looks
+// (`src/**/*.test.ts`), so its test lives here, next to the specs-index one.
+//
+// Each case builds a throwaway git repository holding a registry, plus a
+// directory of real tarballs the script reads through SOWEL_REGISTRY_ASSET_DIR
+// instead of downloading from GitHub. Everything else — the diff against the
+// merge base, the hashing, the manifest read inside the tarball — is the real
+// script doing the real thing.
+
+const SCRIPT = resolve(import.meta.dirname, "../../scripts/check-registry-bump.sh");
+
+interface Entry {
+  id: string;
+  type: string;
+  name: string;
+  repo: string;
+  version: string;
+  owner: string;
+  sha256: string;
+}
+
+function entry(over: Partial<Entry> = {}): Entry {
+  return {
+    id: "acme",
+    type: "integration",
+    name: "Acme",
+    repo: "mchacher/sowel-plugin-acme",
+    version: "1.0.0",
+    owner: "mchacher",
+    sha256: "0".repeat(64),
+    ...over,
+  };
+}
+
+describe("scripts/check-registry-bump.sh (spec 089, issue #892)", () => {
+  let dir: string;
+  let assets: string;
+
+  function git(...args: string[]): void {
+    execFileSync("git", args, { cwd: dir, stdio: "ignore" });
+  }
+
+  /** Writes the registry and commits it, so each call is one revision. */
+  function commitRegistry(entries: Entry[], message: string): void {
+    mkdirSync(join(dir, "plugins"), { recursive: true });
+    writeFileSync(join(dir, "plugins", "registry.json"), JSON.stringify(entries, null, 2));
+    git("add", "-A");
+    git("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", message);
+  }
+
+  /**
+   * Builds the tarball a release workflow would publish and returns its SHA256,
+   * so a test can put the true hash in the registry or deliberately not.
+   */
+  function publishAsset(opts: {
+    id: string;
+    version: string;
+    type?: string;
+    manifestId?: string;
+    manifestVersion?: string;
+  }): string {
+    const prefix = opts.type === "recipe" ? "sowel-recipe" : "sowel-plugin";
+    const name = `${prefix}-${opts.id}-${opts.version}.tar.gz`;
+    const staging = mkdtempSync(join(tmpdir(), "registry-asset-"));
+    writeFileSync(
+      join(staging, "manifest.json"),
+      JSON.stringify({
+        id: opts.manifestId ?? opts.id,
+        version: opts.manifestVersion ?? opts.version,
+        type: opts.type ?? "integration",
+      }),
+    );
+    execFileSync("tar", ["czf", join(assets, name), "-C", staging, "manifest.json"]);
+    rmSync(staging, { recursive: true, force: true });
+    return createHash("sha256")
+      .update(readFileSync(join(assets, name)))
+      .digest("hex");
+  }
+
+  function run(baseRef = "HEAD~1"): { status: number; out: string } {
+    try {
+      const stdout = execFileSync("bash", [SCRIPT, baseRef], {
+        cwd: dir,
+        encoding: "utf-8",
+        env: { ...process.env, SOWEL_REGISTRY_ASSET_DIR: assets },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      return { status: 0, out: stdout };
+    } catch (err) {
+      const e = err as { status: number; stdout: string; stderr: string };
+      return { status: e.status, out: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+    }
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "registry-bump-"));
+    assets = mkdtempSync(join(tmpdir(), "registry-assets-"));
+    execFileSync("git", ["init", "-q"], { cwd: dir });
+    commitRegistry([entry({ sha256: "a".repeat(64) })], "base");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(assets, { recursive: true, force: true });
+  });
+
+  it("passes when the bumped entry matches its published asset", () => {
+    const sha = publishAsset({ id: "acme", version: "1.1.0" });
+    commitRegistry([entry({ version: "1.1.0", sha256: sha })], "bump");
+
+    const res = run();
+
+    expect(res.status).toBe(0);
+    expect(res.out).toContain("✓ acme 1.1.0");
+    expect(res.out).toContain("Every changed registry entry matches its published release");
+  });
+
+  it("fails on a hash that is not the asset's, and prints both", () => {
+    const sha = publishAsset({ id: "acme", version: "1.1.0" });
+    commitRegistry([entry({ version: "1.1.0", sha256: "b".repeat(64) })], "bump with stale hash");
+
+    const res = run();
+
+    expect(res.status).toBe(1);
+    expect(res.out).toContain("sha256 does not match the published asset");
+    expect(res.out).toContain(sha);
+    expect(res.out).toContain("backfill-registry-sha256.mjs");
+  });
+
+  it("fails when no asset exists for the declared version", () => {
+    publishAsset({ id: "acme", version: "1.0.0" });
+    commitRegistry([entry({ version: "1.1.0", sha256: "b".repeat(64) })], "bump ahead of release");
+
+    const res = run();
+
+    expect(res.status).toBe(1);
+    expect(res.out).toContain("sowel-plugin-acme-1.1.0.tar.gz");
+  });
+
+  it("fails when the hash is right but the tarball is another release", () => {
+    // The asset is genuine and the hash is its hash: only the manifest inside
+    // says otherwise, which is what pointing an entry at the wrong tag does.
+    const sha = publishAsset({ id: "acme", version: "1.1.0", manifestVersion: "1.0.9" });
+    commitRegistry([entry({ version: "1.1.0", sha256: sha })], "bump to the wrong tag");
+
+    const res = run();
+
+    expect(res.status).toBe(1);
+    expect(res.out).toContain("the tarball is not the release this entry claims");
+    expect(res.out).toContain("manifest version is '1.0.9', registry says '1.1.0'");
+  });
+
+  it("verifies a recipe entry through its own asset name", () => {
+    const sha = publishAsset({ id: "watering", version: "2.0.0", type: "recipe" });
+    commitRegistry(
+      [
+        entry({ sha256: "a".repeat(64) }),
+        entry({
+          id: "watering",
+          type: "recipe",
+          name: "Watering",
+          repo: "mchacher/sowel-recipe-watering",
+          version: "2.0.0",
+          sha256: sha,
+        }),
+      ],
+      "add a recipe",
+    );
+
+    const res = run();
+
+    expect(res.status).toBe(0);
+    expect(res.out).toContain("✓ watering 2.0.0");
+  });
+
+  it("skips when the pull request does not touch the registry", () => {
+    writeFileSync(join(dir, "README.md"), "hello\n");
+    git("add", "-A");
+    git("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "docs");
+
+    const res = run();
+
+    expect(res.status).toBe(0);
+    expect(res.out).toContain("bump integrity check skipped");
+  });
+
+  it("does not download anything when only the prose of an entry changed", () => {
+    commitRegistry([entry({ sha256: "a".repeat(64), name: "Acme Renamed" })], "rename");
+
+    const res = run();
+
+    expect(res.status).toBe(0);
+    expect(res.out).toContain("no version or sha256 changed");
+  });
+
+  it("rejects an entry that breaks the spec 089 contract, touched or not", () => {
+    commitRegistry([entry({ version: "1.1.0", sha256: "abc" })], "truncated hash");
+
+    const res = run();
+
+    expect(res.status).toBe(1);
+    expect(res.out).toContain("sha256 is not 64 hex characters");
+  });
+});


### PR DESCRIPTION
Closes #892.

## What runs

A new `Registry bump integrity` job calls `scripts/check-registry-bump.sh`. For each entry whose `version` or `sha256` changed against the merge base:

1. the release `v<version>` exists on `<repo>` and carries `sowel-plugin-<id>-<version>.tar.gz` (or `sowel-recipe-…` for a recipe);
2. the asset hashes to the declared `sha256`, and the failure prints both hashes;
3. the `manifest.json` inside the tarball declares the same id and version. The hash can be right while the entry points at the wrong release, and only the manifest catches that.

Plus a shape pass over the whole file: `sha256` is 64 hex, `repo` / `version` / `owner` / `type` present. That is the spec 089 install contract, and it is worth failing on whether or not this PR touched the entry.

A PR that does not touch `plugins/registry.json` exits after one `git diff`.

## Why now

Yesterday's six-plugin bump (#891) was verified by hand: every asset downloaded twice and hashed. That is exactly the step that gets skipped. The check is the same work, done by the runner.

`CLAUDE.md` already told agents that "if the registry CI fails on SHA256 mismatch, the fix is always to re-run `backfill-registry-sha256.mjs`" — a barrier nobody had written. That paragraph now describes what actually runs, and what each failure means (a mismatch means re-run the backfill; a missing release means the bump is ahead of the publish).

## Tests

`src/tooling/check-registry-bump.test.ts`, 8 cases, next to the specs-index one and for the same reason: the backend suite is the only place vitest looks. Each case builds a throwaway git repository and real tarballs, which the script reads through `SOWEL_REGISTRY_ASSET_DIR` instead of GitHub. The diff, the hashing and the manifest read are the real script.

Covered: a matching bump passes, a stale hash fails and prints the asset's hash, a bump ahead of the release fails, a right hash on the wrong release fails, a recipe entry resolves its own asset name, an untouched registry skips, a prose-only edit downloads nothing, a truncated hash is rejected.

Also run against the real thing: on the merged #891 commit the script verifies all six entries and passes.

`npm run lint`, `npm run typecheck`, `npm run typecheck:tests`, `npm run format:check` clean.

## One decision left to you

The job is not in the `main-protection` required checks, so today it reports without blocking. Making it required is a ruleset change, your call.