### PR TITLE
fix(equipments): observe an order where it was actually sent (#901)

### DIFF
--- a/docs/technical/architecture.fr.md
+++ b/docs/technical/architecture.fr.md
@@ -268,6 +268,12 @@ Des buckets downsamplés supplémentaires (`sowel-hourly`, `sowel-daily`) existe
 
 InfluxDB est obligatoire : Sowel se connecte au démarrage et auto-crée les buckets, les tâches de downsampling, et les tâches d'agrégation énergétique.
 
+#### Où l'effet d'un ordre est observé
+
+Un `executeOrder` qui réussit signifie que l'ordre a atteint l'intégration, pas que l'appareil a agi : le tracker guette donc l'apparition de la valeur ordonnée et alerte si elle ne vient pas. La lecture qu'il surveille est résolue dans cet ordre : une liaison de donnée portant l'alias de l'ordre **sur l'appareil même auquel l'ordre a été envoyé** ; à défaut, la liaison sur un autre appareil, si son type peut rapporter la valeur ordonnée ; à défaut, la donnée propre de l'appareil ciblé sous la clé de l'ordre, là où un thermostat cloud publie un état que personne n'a lié. Quand aucune des trois n'existe, l'ordre reste suivi et rejoué, mais il sort de la surface d'alarme : une alarme que rien ne peut résoudre est du bruit.
+
+La règle du milieu existe parce qu'un alias n'est pas un vocabulaire. Sur un appareil sous-compté, `power` désigne à la fois le booléen envoyé à l'appareil et la puissance lue par une pince, et comparer les deux ne peut jamais être vrai (issue #901).
+
 #### Les deltas d'énergie sont cumulés, jamais échantillonnés
 
 Un binding `energy` porte un **delta additif** (Wh depuis le tick précédent), pas une mesure. La déduplication qui protège les autres catégories (deadband, intervalle minimum de 30 s) détruirait silencieusement de l'énergie : les compteurs ont des cadences très différentes — un Shelly EM émet un tick par minute, un Tuya PJ-1203A en émet ~30, dont un seul porte le saut de compteur de 10 Wh.

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -219,6 +219,12 @@ An order dispatched at a disconnected integration never reaches the wire. Rather
 
 Recipe instances are the reason this used to matter on every restart: they start at the very end of boot, behind a bounded wait on the integrations reporting connected, because an instance evaluates and dispatches as soon as it starts. The wait is capped so one unreachable cloud integration cannot hold every automation, and whatever still slips through is caught by the hold-and-replay above. The API and the recipe list do not wait; only running-instance state does.
 
+#### Where an order's effect is observed
+
+`executeOrder` succeeding means the order reached the integration, not that the device acted, so the tracker watches for the ordered value to appear and alarms when it does not. Which reading it watches is resolved in this order: a data binding carrying the order's alias **on the very device the order was sent to**; failing that, the binding on another device, when its type could report the ordered value; failing that, the ordered device's own data under the order key, which is where a cloud thermostat publishes a state nobody bound. When none of the three exists, the order is still tracked and replayed, but it stays out of the alarm surface, because an alarm nothing can resolve is noise.
+
+The middle rule exists because an alias is not a vocabulary. On a submetered appliance `power` is both the boolean sent to the device and the wattage read from a clamp, and comparing the two can only ever be false (issue #901).
+
 ### Current official plugin ecosystem
 
 | Plugin                  | Repo                                          | Type        |

--- a/src/equipments/order-confirmation-tracker.test.ts
+++ b/src/equipments/order-confirmation-tracker.test.ts
@@ -6,6 +6,7 @@ import {
   RETRY_CHANNEL,
   valuesMatch,
   isConfirmableValue,
+  mirrorCanReport,
 } from "./order-confirmation-tracker.js";
 import type { EquipmentManager } from "./equipment-manager.js";
 import type { DeviceManager } from "../devices/device-manager.js";
@@ -52,6 +53,23 @@ describe("isConfirmableValue", () => {
     expect(isConfirmableValue("CLOSE", ["OPEN", "CLOSED"])).toBe(false);
     expect(isConfirmableValue("STOP", ["OPEN", "CLOSED"])).toBe(false);
     expect(isConfirmableValue("SMART", undefined)).toBe(false);
+  });
+});
+
+describe("mirrorCanReport", () => {
+  it("refuses a wattage as the mirror of a boolean order, and the reverse", () => {
+    expect(mirrorCanReport(true, "number")).toBe(false);
+    expect(mirrorCanReport("OFF", "number")).toBe(false);
+    expect(mirrorCanReport(25, "boolean")).toBe(false);
+  });
+
+  it("keeps every mirror that could actually report the value", () => {
+    expect(mirrorCanReport(true, "boolean")).toBe(true);
+    // An ON/OFF enum is a real mirror for a boolean order, and stays one.
+    expect(mirrorCanReport(true, "enum")).toBe(true);
+    expect(mirrorCanReport(25, "number")).toBe(true);
+    expect(mirrorCanReport("SMART", "enum")).toBe(true);
+    expect(mirrorCanReport(true, undefined)).toBe(true);
   });
 });
 
@@ -597,5 +615,154 @@ describe("OrderConfirmationTracker", () => {
 
       expect(executeOrderCalls).toEqual([{ equipmentId: "eq-1", alias: "state", value: "WAKE" }]);
     });
+  });
+});
+
+// ============================================================
+// Issue #901 — the alias is not a vocabulary
+//
+// A submetered thermostat: the `power` order is a boolean sent to the cloud
+// device, while the `power` data binding is the wattage read from a clamp on
+// the same appliance. Measured on production before this fix: 15 power orders,
+// 15 alarms, and every one of them a false positive.
+// ============================================================
+
+describe("OrderConfirmationTracker — submetered thermostat (issue #901)", () => {
+  let eventBus: EventBus;
+  let tracker: OrderConfirmationTracker;
+  let emitted: EngineEvent[];
+  /** What the Panasonic device itself publishes under `power`, or null. */
+  let devicePower: boolean | null;
+  /** Bindings of the equipment: the clamp wattage, plus optionally the device state. */
+  let bindings: Record<string, unknown>[];
+
+  const equipmentManager = {
+    getById: (id: string) => ({ id, name: "PAC" }),
+    getDataBindingsWithValues: vi.fn(() => bindings),
+    getOrderBindingsWithDetails: vi.fn(() => [
+      { alias: "power", deviceId: "dev-pac", key: "power" },
+    ]),
+    executeOrder: vi.fn(async () => ({ success: true })),
+  } as unknown as EquipmentManager;
+
+  const deviceManager = {
+    getById: (id: string) => ({
+      id,
+      status: "online",
+      integrationId: "panasonic_cc",
+      sourceDeviceId: `src-${id}`,
+    }),
+    getDeviceDataValue: (_integrationId: string, sourceDeviceId: string, key: string) =>
+      sourceDeviceId === "src-dev-pac" && key === "power" ? devicePower : null,
+  } as unknown as DeviceManager;
+
+  const integrationRegistry = {
+    noteUnreachable: () => {},
+    getById: () => ({
+      getStatus: () => "connected",
+      // The real plugin polls every 300 s, so the watchdog is 600 s.
+      getPollingInfo: () => ({ lastPollAt: "2026-09-04T00:00:00Z", intervalMs: 300_000 }),
+    }),
+  } as unknown as IntegrationRegistry;
+
+  function emitOrder(value: unknown): void {
+    eventBus.emit({
+      type: "equipment.order.executed",
+      equipmentId: "eq-pac",
+      orderAlias: "power",
+      value,
+    } as EngineEvent);
+  }
+
+  /** The Panasonic device reporting its own state, one poll later. */
+  function emitDevicePower(value: boolean): void {
+    devicePower = value;
+    eventBus.emit({
+      type: "device.data.updated",
+      deviceId: "dev-pac",
+      deviceName: "PAC",
+      dataId: "dd-1",
+      key: "power",
+      value,
+      previous: !value,
+      timestamp: "2026-09-04T10:36:00Z",
+    } as EngineEvent);
+  }
+
+  function alarmsRaised(): EngineEvent[] {
+    return emitted.filter((e) => e.type === "system.alarm.raised");
+  }
+  function unconfirmedEvents(): EngineEvent[] {
+    return emitted.filter((e) => e.type === "equipment.order.unconfirmed");
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    eventBus = new EventBus(logger);
+    emitted = [];
+    devicePower = false;
+    bindings = [{ alias: "power", value: 646, type: "number", deviceId: "dev-clamp" }];
+    eventBus.on((event) => {
+      emitted.push(event);
+    });
+    tracker = new OrderConfirmationTracker(
+      eventBus,
+      equipmentManager,
+      deviceManager,
+      integrationRegistry,
+      logger,
+    );
+    tracker.init();
+  });
+
+  afterEach(() => {
+    tracker.destroy();
+    vi.useRealTimers();
+  });
+
+  it("confirms from the ordered device's own state when a wattage holds the alias", () => {
+    emitOrder(true);
+    vi.advanceTimersByTime(120_000);
+    emitDevicePower(true);
+    vi.advanceTimersByTime(600_000);
+
+    expect(unconfirmedEvents().length).toBe(0);
+    expect(alarmsRaised().length).toBe(0);
+  });
+
+  it("still alarms when the ordered device reports the opposite state", () => {
+    emitOrder(true);
+    // The device answers, and says it did not switch: that is a real failure.
+    emitDevicePower(false);
+    vi.advanceTimersByTime(601_000);
+
+    expect(unconfirmedEvents().length).toBe(1);
+    expect(alarmsRaised().length).toBe(1);
+  });
+
+  it("stays out of the alarm surface when nothing could report the value", () => {
+    // The cloud device publishes no state under the order key either.
+    devicePower = null;
+    emitOrder(true);
+    vi.advanceTimersByTime(601_000);
+
+    expect(unconfirmedEvents().length).toBe(0);
+    expect(alarmsRaised().length).toBe(0);
+  });
+
+  it("prefers a binding on the ordered device over one on another device", () => {
+    bindings = [
+      { alias: "power", value: 646, type: "number", deviceId: "dev-clamp" },
+      { alias: "power", value: true, type: "boolean", deviceId: "dev-pac" },
+    ];
+
+    // Already in the ordered state, seen through the right binding: nothing to
+    // watch. Against the clamp, `true` versus `646` would have armed a
+    // watchdog that could only expire.
+    emitOrder(true);
+    vi.advanceTimersByTime(601_000);
+
+    expect(unconfirmedEvents().length).toBe(0);
+    expect(alarmsRaised().length).toBe(0);
   });
 });

--- a/src/equipments/order-confirmation-tracker.ts
+++ b/src/equipments/order-confirmation-tracker.ts
@@ -3,7 +3,7 @@ import type { EventBus } from "../core/event-bus.js";
 import type { EquipmentManager } from "./equipment-manager.js";
 import type { DeviceManager } from "../devices/device-manager.js";
 import type { IntegrationRegistry } from "../integrations/integration-registry.js";
-import type { OrderSource } from "../shared/types.js";
+import type { DataBindingWithValue, DataType, OrderSource } from "../shared/types.js";
 
 // ============================================================
 // Spec 141 — order delivery confirmation
@@ -91,6 +91,12 @@ interface PendingOrder {
   deviceIds: string[];
   /** Integrations behind the order bindings — the replay trigger for #702. */
   integrationIds: string[];
+  /**
+   * Set when the confirmation is read from the ordered device's own data
+   * rather than from an equipment binding, because no binding on this
+   * equipment could mirror the order (issue #901).
+   */
+  deviceMirror?: { deviceId: string; key: string };
   source?: OrderSource | undefined;
 }
 
@@ -125,6 +131,22 @@ export function isConfirmableValue(ordered: unknown, enumValues?: string[]): boo
   return false;
 }
 
+/**
+ * Whether a mirror could ever report the ordered value. An alias is not a
+ * vocabulary: on a submetered thermostat `power` is a boolean order to the
+ * cloud device and a wattage read from a clamp, so comparing them can only
+ * ever be false and the watchdog would alarm on every order (issue #901).
+ * Narrow on purpose: boolean against number, both ways, and nothing else.
+ * A boolean ordered against an ON/OFF enum is a real mirror, and stays one.
+ */
+export function mirrorCanReport(ordered: unknown, mirrorType: DataType | undefined): boolean {
+  if (mirrorType === undefined) return true;
+  const normalized = normalizeValue(ordered);
+  if (typeof normalized === "boolean") return mirrorType !== "number";
+  if (typeof normalized === "number") return mirrorType !== "boolean";
+  return true;
+}
+
 export class OrderConfirmationTracker {
   private readonly logger: Logger;
   private readonly pending: Map<string, PendingOrder> = new Map();
@@ -156,6 +178,15 @@ export class OrderConfirmationTracker {
       this.eventBus.onType("equipment.data.changed", (event) => {
         try {
           this.handleDataChanged(event.equipmentId, event.alias, event.value);
+        } catch (err) {
+          this.logger.error({ err }, "Confirmation check failed");
+        }
+      }),
+      // A device-level mirror is not bound to the equipment, so no
+      // equipment.data.changed will ever carry it (issue #901).
+      this.eventBus.onType("device.data.updated", (event) => {
+        try {
+          this.handleDeviceDataUpdated(event.deviceId, event.key, event.value);
         } catch (err) {
           this.logger.error({ err }, "Confirmation check failed");
         }
@@ -233,17 +264,17 @@ export class OrderConfirmationTracker {
       this.pending.delete(key);
     }
 
+    const { deviceIds, integrationIds, targets } = this.targetsFor(equipmentId, alias);
     const bindings = this.equipmentManager.getDataBindingsWithValues(equipmentId);
-    const mirror = bindings.find((b) => b.alias === alias);
-    // No observable effect (scenes, stateless orders) or a cross-vocabulary
-    // enum (cover CLOSE vs state CLOSED) — exempt. A carried-over alarm has
-    // nothing left to confirm it, so it is released here.
-    if (!mirror || !isConfirmableValue(value, mirror.enumValues)) {
+    const { mirror, deviceMirror } = this.resolveMirror(bindings, alias, value, deviceIds, targets);
+    // No observable effect (scenes, stateless orders), a cross-vocabulary enum
+    // (cover CLOSE vs state CLOSED), or nothing that could ever report this
+    // value — exempt. A carried-over alarm has nothing left to confirm it, so
+    // it is released here.
+    if ((!mirror && !deviceMirror) || !isConfirmableValue(value, mirror?.enumValues)) {
       if (previous?.alarmRaised) this.resolveAlarm(previous, "superseded by an exempt order");
       return;
     }
-
-    const { deviceIds, integrationIds } = this.targetsFor(equipmentId, alias);
 
     const entry: PendingOrder = {
       equipmentId,
@@ -261,12 +292,14 @@ export class OrderConfirmationTracker {
       confirmable: true,
       deviceIds,
       integrationIds,
+      ...(deviceMirror !== undefined ? { deviceMirror } : {}),
       source,
     };
 
     // Already in the ordered state (e.g. OFF ordered while already OFF):
     // nothing will change, confirm immediately.
-    if (valuesMatch(value, mirror.value)) {
+    const current = mirror ? mirror.value : this.readDeviceValue(deviceMirror);
+    if (valuesMatch(value, current)) {
       if (entry.alarmRaised) this.resolveAlarm(entry, "state finally confirmed");
       return;
     }
@@ -285,6 +318,67 @@ export class OrderConfirmationTracker {
   }
 
   /**
+   * Where the effect of this order will be observed.
+   *
+   * The mirror used to be "any data binding carrying the order's alias", which
+   * assumes an alias means one thing per equipment. It does not: on a
+   * submetered thermostat `power` is both the boolean sent to the cloud device
+   * and the wattage read from a clamp, and the tracker then compared `true` to
+   * `646` on every order and alarmed 15 times out of 15 (issue #901).
+   *
+   * Order of preference:
+   *   1. a binding on the very device the order was sent to;
+   *   2. the established cross-device binding, when it could report the value;
+   *   3. the ordered device's own data under the order key, which is where a
+   *      cloud thermostat publishes the state nobody bound;
+   *   4. nothing, and the order is tracked without an alarm.
+   */
+  private resolveMirror(
+    bindings: DataBindingWithValue[],
+    alias: string,
+    value: unknown,
+    deviceIds: string[],
+    targets: { deviceId: string; key: string }[],
+  ): { mirror?: DataBindingWithValue; deviceMirror?: { deviceId: string; key: string } } {
+    const candidates = bindings.filter((b) => b.alias === alias);
+
+    const onTarget = candidates.find((b) => deviceIds.includes(b.deviceId));
+    if (onTarget) return { mirror: onTarget };
+
+    const crossDevice = candidates.find((b) => mirrorCanReport(value, b.type));
+    if (crossDevice) return { mirror: crossDevice };
+
+    for (const target of targets) {
+      const device = this.deviceManager.getById(target.deviceId);
+      if (!device) continue;
+      const current = this.deviceManager.getDeviceDataValue(
+        device.integrationId,
+        device.sourceDeviceId,
+        target.key,
+      );
+      // A key the device has never reported tells us nothing about whether it
+      // could: better no watchdog than one that can only expire.
+      if (current === null) continue;
+      if (!mirrorCanReport(value, typeof current === "number" ? "number" : "boolean")) continue;
+      return { deviceMirror: { deviceId: target.deviceId, key: target.key } };
+    }
+
+    return {};
+  }
+
+  /** Current value of a device-level mirror, for the already-in-state check. */
+  private readDeviceValue(mirror: { deviceId: string; key: string } | undefined): unknown {
+    if (!mirror) return undefined;
+    const device = this.deviceManager.getById(mirror.deviceId);
+    if (!device) return undefined;
+    return this.deviceManager.getDeviceDataValue(
+      device.integrationId,
+      device.sourceDeviceId,
+      mirror.key,
+    );
+  }
+
+  /**
    * The devices behind an order alias, and the integrations that own them.
    * The integrations are what #702 keys its replay on: at boot a device
    * persisted as online never emits a status change, so the integration
@@ -293,11 +387,16 @@ export class OrderConfirmationTracker {
   private targetsFor(
     equipmentId: string,
     alias: string,
-  ): { deviceIds: string[]; integrationIds: string[] } {
-    const deviceIds = this.equipmentManager
+  ): {
+    deviceIds: string[];
+    integrationIds: string[];
+    targets: { deviceId: string; key: string }[];
+  } {
+    const targets = this.equipmentManager
       .getOrderBindingsWithDetails(equipmentId)
       .filter((b) => b.alias === alias)
-      .map((b) => b.deviceId);
+      .map((b) => ({ deviceId: b.deviceId, key: b.key }));
+    const deviceIds = targets.map((t) => t.deviceId);
     const integrationIds = [
       ...new Set(
         deviceIds
@@ -305,7 +404,7 @@ export class OrderConfirmationTracker {
           .filter((id): id is string => id !== undefined),
       ),
     ];
-    return { deviceIds, integrationIds };
+    return { deviceIds, integrationIds, targets };
   }
 
   /** Whether every device behind the order bindings is currently offline. */
@@ -412,18 +511,34 @@ export class OrderConfirmationTracker {
 
   private handleDataChanged(equipmentId: string, alias: string, value: unknown): void {
     const entry = this.pending.get(`${equipmentId}:${alias}`);
-    if (!entry) return;
+    if (!entry || entry.deviceMirror) return;
+    this.confirm(entry, value);
+  }
+
+  /**
+   * The ordered device reporting its own state, for an order whose effect no
+   * equipment binding could mirror (issue #901).
+   */
+  private handleDeviceDataUpdated(deviceId: string, key: string, value: unknown): void {
+    for (const entry of this.pending.values()) {
+      if (entry.deviceMirror?.deviceId !== deviceId) continue;
+      if (entry.deviceMirror.key !== key) continue;
+      this.confirm(entry, value);
+    }
+  }
+
+  private confirm(entry: PendingOrder, value: unknown): void {
     if (!valuesMatch(entry.value, value)) return;
 
     if (entry.timer) clearTimeout(entry.timer);
     if (entry.alarmRaised) {
       this.resolveAlarm(entry, "state finally confirmed");
       this.logger.info(
-        { equipmentId, alias, value },
+        { equipmentId: entry.equipmentId, alias: entry.alias, value },
         "Unconfirmed order finally confirmed by equipment state",
       );
     }
-    this.pending.delete(`${equipmentId}:${alias}`);
+    this.pending.delete(`${entry.equipmentId}:${entry.alias}`);
   }
 
   private resolveAlarm(entry: PendingOrder, why: string): void {


### PR DESCRIPTION
Closes #901.

## The bug, measured on production

15 days of logs: the `PAC` equipment dispatched **15 `power` orders and raised 15 alarms**, all `reason: "timeout"`, all false. The Panasonic device obeyed every one of them and reported `power: true` minutes later. `setpoint` on the same equipment, same period: 50 orders, 1 unconfirmed.

The tracker resolved the mirror by alias alone, which assumes an alias means one thing per equipment:

```ts
const mirror = bindings.find((b) => b.alias === alias);
```

On a submetered appliance it means two. Order `power` goes to the cloud device as a boolean; data `power` is the wattage read from a Legrand clamp, 646 W at the time of the investigation. `Object.is(true, 646)` is false and no poll will change that. `isConfirmableValue` could not catch it either: it judges the ordered value, which is a perfectly confirmable boolean, never the mirror it will be compared against.

This is not fixable in configuration. `power` is the alias the metering pipeline reads for live wattage (`LIVE_POWER_ALIASES`), so the clamp must publish under it, and the Panasonic on/off order is called `power` too.

## The fix

The mirror is resolved in order of preference:

1. a data binding carrying the alias **on the very device the order was sent to**;
2. the cross-device binding, when its type could report the ordered value (the established pattern: a relay ordered on one device, its state read from another);
3. the ordered device's **own data** under the order key, which is where a cloud thermostat publishes the state nobody bound. This is what makes the production PAC actually confirm rather than merely stop alarming;
4. nothing: the order is still tracked and replayed, but stays out of the alarm surface, exactly as stateless orders already did.

`mirrorCanReport` is deliberately narrow: boolean against number, both ways. A boolean ordered against an `ON`/`OFF` enum is a real mirror and stays one.

A device-level mirror is not carried by `equipment.data.changed`, so the tracker also listens to `device.data.updated` now.

## Tests

Six new cases. Three of the four behavioural ones fail against the previous behaviour, verified by restoring the old `candidates[0]` line; the fourth is the guard that a device genuinely reporting the opposite state still alarms.

- confirms from the ordered device's own state when a wattage holds the alias
- still alarms when the ordered device reports the opposite state
- stays out of the alarm surface when nothing could report the value
- prefers a binding on the ordered device over one on another device
- `mirrorCanReport` unit cases, including the enum mirror that must survive

`npm run validate` green: 2482 backend tests, 1043 UI tests, lint, both typechecks, format.

## Docs

`docs/technical/architecture.md` and its French counterpart gain a short "Where an order's effect is observed" section next to the existing delivery-replay one.