### PR TITLE
release: v1.68.0

### DIFF
--- a/docs/release-notes.fr.md
+++ b/docs/release-notes.fr.md
@@ -11,6 +11,17 @@ Cette page résume toutes les versions publiées, de la plus récente à la plus
 
 ---
 
+## 1.68.x : L'alias qui voulait dire deux choses
+
+### v1.68.0 — 2026-09-05 { #v1-68-0 }
+
+La v1.67.1 a appris au chien de garde des ordres que `power` veut dire deux choses sur un thermostat sous-compté : le booléen envoyé au device cloud et la puissance lue par la pince sur son alimentation. Cette version l'apprend au reste du produit, car le chien de garde n'était que la première victime. L'interface elle-même comparait ce wattage à `true` depuis des mois et concluait, à chaque rendu, qu'une pompe à chaleur en marche était éteinte.
+
+- Correctif (ui) : **le marche/arrêt d'un thermostat se lit sur son propre état, jamais sur la pince** (spec 176, #904). Sur un thermostat sous-compté, chaque surface dérivait la bascule de `power === true`, et `2974 === true` est faux : la carte affichait toujours OFF pendant que l'unité tournait à 2974 W, chaque appui renvoyait ON — cinq ordres ON en 90 secondes mesurés en production, d'un utilisateur qui essayait d'arrêter la machine — et l'éteindre réellement exigeait un double appui dans la fenêtre optimiste, la carte effaçant par ailleurs tout son état optimiste au moindre changement de donnée alors que la pince pousse un wattage toutes les quelques secondes. Le booléen du device se lie désormais sous `state`, le même alias marche/arrêt que tous les équipements à relais, aucun mot nouveau dans le modèle de données ; l'alias n'était simplement jamais proposé aux thermostats, la liste d'auto-liaison datant d'avant les catégories de la spec 077. La liaison est marquée `appliance_state` au lieu d'hériter de la catégorie `power` du device, et cette ligne est ce qui garde le moteur d'énergie honnête : sans elle, un thermostat sous-compté porte deux liaisons de catégorie power et l'arbitre, l'intégrateur de sous-comptage et le panneau énergie prennent chacun la première ligne venue. Toute lecture marche/arrêt passe désormais par un résolveur unique — l'alias `state` d'abord, un `power` booléen hérité ensuite, un wattage jamais — et la bascule optimiste s'efface par alias, quand son propre miroir re-rapporte ou après 90 secondes, au lieu de disparaître à la première mesure venue. Les thermostats existants ne changent pas ; un thermostat sous-compté gagne son état le jour où son propriétaire ajoute la liaison que le panneau des liaisons manquantes propose désormais. Deux bugs latents sont morts au passage : un thermostat fraîchement lié perdait silencieusement ses points d'alimentation, de consigne et de sonde extérieure, et son ordre d'alimentation atterrissait sous un alias qu'aucune surface thermostat ne pilote. Version compagnon : panasonic_cc 2.3.2 ajoute un poll de rattrapage 45 s après un ordre, Comfort Cloud rapportant couramment encore l'état d'avant l'ordre au premier poll, la vérité suivante étant à cinq minutes.
+- Maintenance (deps) : les groupes hebdomadaires d'outillage — mises à jour minor/patch backend et UI, typescript-eslint 8.69, codeql-action v4 (#896, #897, #898, #899, #900).
+
+---
+
 ## 1.67.x : L'horloge sur laquelle une mesure est jugée
 
 ### v1.67.1 — 2026-09-04 { #v1-67-1 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,17 @@ This page summarises every published version, newest first. For the full diff be
 
 ---
 
+## 1.68.x: The alias that meant two things
+
+### v1.68.0 — 2026-09-05 { #v1-68-0 }
+
+v1.67.1 taught the order watchdog that `power` means two things on a submetered thermostat: the boolean sent to the cloud device and the wattage read from the clamp on its supply. This release teaches the rest of the product, because the watchdog was only the first victim. The interface itself had been comparing that wattage to `true` for months and concluding, on every render, that a running heat pump was off.
+
+- Fix (ui): **a thermostat's on/off is read from its own state, never from the clamp** (spec 176, #904). On a submetered thermostat every surface derived the toggle from `power === true`, and `2974 === true` is false: the card always showed OFF while the unit ran at 2974 W, every tap sent ON again — five ON orders in 90 seconds measured on production, from a user trying to stop the thing — and actually turning it off took a double-tap race inside the optimistic window, because the card also wiped its whole optimistic state on any data change while the clamp pushes a wattage every few seconds. The device's boolean now binds under `state`, the same on/off alias every relay-style equipment already uses, no new word in the data model; the alias was simply never offered to thermostats because the auto-binding whitelist predated the spec 077 categories. The binding is tagged `appliance_state` rather than inheriting the device's `power` category, and that one line is what keeps the energy engine honest: without it a submetered thermostat carries two category=power bindings and the arbiter, the submeter integrator and the energy panel each pick whichever row comes first. Every on/off read now goes through one resolver — the `state` alias first, a legacy boolean `power` second, a wattage never — and the optimistic toggle is cleared per alias, when its own mirror re-reports or after 90 seconds, instead of by whichever reading arrives next. Existing thermostats change nothing; a submetered one gains its state the day its owner adds the binding the missing-bindings panel now offers. Two latent bugs died on the way: a freshly bound thermostat silently lost its power, setpoint and outdoor-probe points, and its power order landed under an alias no thermostat surface drives. Companion release: panasonic_cc 2.3.2 adds a follow-up poll 45 s after an order, because Comfort Cloud routinely still reports the pre-order state at the first poll and the next truth was five minutes away.
+- Maintenance (deps): the weekly toolchain groups — backend and UI minor/patch updates, typescript-eslint 8.69, codeql-action v4 (#896, #897, #898, #899, #900).
+
+---
+
 ## 1.67.x: The clock a reading is judged on
 
 ### v1.67.1 — 2026-09-04 { #v1-67-1 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sowel",
-  "version": "1.67.0",
+  "version": "1.68.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sowel",
-      "version": "1.67.0",
+      "version": "1.68.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cors": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sowel",
-  "version": "1.67.1",
+  "version": "1.68.0",
   "description": "Sowel — Home automation engine powered by MQTT",
   "author": "Marc Chachereau <marc.chachereau@gmail.com>",
   "license": "AGPL-3.0-only",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "1.67.0",
+  "version": "1.68.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "1.67.0",
+      "version": "1.68.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.67.1",
+  "version": "1.68.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump + release notes (EN/FR) for v1.68.0.

Covers everything since v1.67.1:
- #904 — thermostat run state under the `state` alias (spec 176), companion of panasonic_cc 2.3.2
- #896-#900 — weekly toolchain groups

Tag will be pushed on the merged commit via scripts/release.sh.