### PR TITLE
fix(ui): custom widget icons follow their equipment, and the timed tile stops clipping its button

### DIFF
--- a/docs/user/dashboard.fr.md
+++ b/docs/user/dashboard.fr.md
@@ -82,6 +82,8 @@ Chaque widget peut avoir une étiquette et une icône personnalisées qui rempla
 
 Le sélecteur d'icônes propose d'abord les icônes dessinées qui correspondent au type d'équipement, puis toutes les autres sous **Autres icônes** — une prise qui pilote un compresseur d'air ou une imprimante 3D peut donc porter la machine plutôt qu'une prise.
 
+Une icône choisie suit l'équipement exactement comme celle qu'elle remplace : allumez le compresseur et son dessin s'allume, fermez le portail et le dessin choisi se ferme. Les vignettes du sélecteur sont des aperçus figés — une tuile, elle, montre toujours l'état courant.
+
 ### Configuration des widgets de capteur
 
 Pour les widgets d'équipements capteurs, vous pouvez choisir quelles liaisons de données afficher. Par défaut, toutes les liaisons sont affichées. Si un capteur remonte température, humidité et pression mais que seule la température vous intéresse, vous pouvez masquer les autres.

--- a/docs/user/dashboard.md
+++ b/docs/user/dashboard.md
@@ -82,6 +82,8 @@ Each widget can have a custom label and icon that override the default equipment
 
 The icon picker offers the drawn icons that match the equipment type first, then every other one under **Other icons** — so a plug driving an air compressor or a 3D printer can wear that machine rather than a socket.
 
+A chosen icon follows the equipment exactly like the default one it replaces: switch the compressor on and its drawing lights up, close the gate and the picked drawing closes. The picker's thumbnails are static previews — what a tile shows is always the current state.
+
 ### Sensor widget configuration
 
 For sensor equipment widgets, you can choose which data bindings to display. By default, all bindings are shown. If a sensor reports temperature, humidity, and pressure but you only care about temperature, you can hide the others.

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -41,7 +41,6 @@ import { resolvePowerReading } from "../../lib/power-reading";
 import { pickLivePowerBinding } from "../../lib/energy-meter-display";
 import { thermostatPowerStateBinding } from "../../lib/thermostat-state";
 import { formatRelative } from "../../lib/format-relative";
-import { createElement, type ReactNode } from "react";
 import {
   LightBulbIcon,
   ShutterWidgetIcon,
@@ -60,17 +59,9 @@ import {
 import { WeatherForecastWidget } from "./WeatherForecastWidget";
 import { WidgetCard } from "./WidgetCard";
 import { TimedEquipmentWidget } from "./TimedEquipmentWidget";
-import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
+import { renderWidgetStateIcon, shutterLevel } from "./widget-icons";
 import { resolveWidgetPresentation } from "./presentation/resolveWidgetPresentation";
 import { PresentationWidget } from "./presentation/PresentationWidget";
-
-/** Render the widget's custom icon (widget.icon -> CUSTOM_ICON_REGISTRY) when set,
- *  otherwise the equipment-type default. Mirrors the mobile card so a custom icon
- *  shows the same on phone and desktop (issue #318). */
-function resolveWidgetIcon(iconKey: string | undefined, fallback: ReactNode): ReactNode {
-  const custom = iconKey ? CUSTOM_ICON_REGISTRY[iconKey] : undefined;
-  return custom ? createElement(custom.component, custom.previewProps) : fallback;
-}
 
 interface EquipmentWidgetProps {
   widget: DashboardWidget;
@@ -358,7 +349,7 @@ function LightEquipmentWidget({
       {/* Zone 2: Picto + État horizontal */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
-        {resolveWidgetIcon(iconKey, <LightBulbIcon on={isOn} />)}
+        {renderWidgetStateIcon(iconKey, <LightBulbIcon on={isOn} />)}
         <div className="flex items-center gap-2 pl-2">
           {isDimmable && brightness !== null ? (
             <>
@@ -491,7 +482,7 @@ function WaterHeaterEquipmentWidget({
     >
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
-        {resolveWidgetIcon(iconKey, <WaterHeaterIcon on={isOn} />)}
+        {renderWidgetStateIcon(iconKey, <WaterHeaterIcon on={isOn} />)}
         <div className="flex flex-col items-start gap-1 pl-2">
           <span
             className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
@@ -576,7 +567,7 @@ function VmcEquipmentWidget({
     <WidgetCard label={label} sublabel={sublabel}>
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
-        {resolveWidgetIcon(
+        {renderWidgetStateIcon(
           iconKey,
           <Fan
             size={44}
@@ -675,7 +666,7 @@ function ShutterEquipmentWidget({
       {/* Zone 2: Picto + État horizontal */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
-        {resolveWidgetIcon(
+        {renderWidgetStateIcon(
           iconKey,
           isAwning ? (
             <AwningWidgetIcon deployed={position !== null && position > 0} />
@@ -818,7 +809,7 @@ function ThermostatEquipmentWidget({
       {/* Zone 2: Picto + temp + power */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
-        {resolveWidgetIcon(iconKey, <ThermometerIcon warm={isOn} level={thermometerLevel} />)}
+        {renderWidgetStateIcon(iconKey, <ThermometerIcon warm={isOn} level={thermometerLevel} />)}
         <div className="flex flex-col items-start gap-2 pl-2">
           {insideTemp !== null ? (
             <div className="flex items-baseline gap-0.5">
@@ -1045,7 +1036,7 @@ function HeaterEquipmentWidget({
       {/* Zone 2: Picto + État horizontal */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
-        {resolveWidgetIcon(iconKey, <HeaterWidgetIcon comfort={isComfort} />)}
+        {renderWidgetStateIcon(iconKey, <HeaterWidgetIcon comfort={isComfort} />)}
         <div className="pl-2">
           <span
             className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
@@ -1103,12 +1094,7 @@ function SensorEquipmentWidget({
 }) {
   const { sensorBindings, batteryBindings, batteryAlert } = useEquipmentState(equipment);
 
-  const customEntry = iconKey ? CUSTOM_ICON_REGISTRY[iconKey] : undefined;
-  const sensorIcon = customEntry ? (
-    createElement(customEntry.component, customEntry.previewProps)
-  ) : (
-    <MultiSensorIcon />
-  );
+  const sensorIcon = renderWidgetStateIcon(iconKey, <MultiSensorIcon />);
 
   // Filter and order bindings according to visibleBindings config
   const filteredBindings =
@@ -1592,7 +1578,7 @@ function WaterValveEquipmentWidget({
     >
       <div className="grid grid-cols-[1fr_auto_1fr] items-center h-[104px] my-auto">
         <div />
-        {resolveWidgetIcon(iconKey, <WaterValveWidgetIcon open={isOpen} />)}
+        {renderWidgetStateIcon(iconKey, <WaterValveWidgetIcon open={isOpen} />)}
         <div className="flex items-center gap-2 pl-2">
           <span
             className={`text-[12px] font-medium px-2.5 py-0.5 rounded-full ${
@@ -1708,7 +1694,7 @@ function PoolCoverEquipmentWidget({
          * viewBox and the dashboard slot reads it slightly low. Mobile
          * containers center it correctly without this offset. */}
         <div className="-mt-3">
-          {resolveWidgetIcon(iconKey, <PoolCoverIcon position={position} />)}
+          {renderWidgetStateIcon(iconKey, <PoolCoverIcon position={position} />)}
         </div>
         <div className="pl-2">
           {position === null ? (

--- a/ui/src/components/dashboard/MobileWidgetCard.tsx
+++ b/ui/src/components/dashboard/MobileWidgetCard.tsx
@@ -1,4 +1,3 @@
-import { createElement } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import type { DashboardWidget, EquipmentWithDetails } from "../../types";
@@ -25,7 +24,7 @@ import {
   EnergyMeterIcon,
 } from "./WidgetIcons";
 import { resolveWidgetPresentation } from "./presentation/resolveWidgetPresentation";
-import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
+import { renderWidgetStateIcon, shutterLevel } from "./widget-icons";
 import { SolarPanelIcon } from "../icons/SolarPanelIcon";
 import { solarWidgetState } from "./solarWidget";
 import { resolvePowerReading } from "../../lib/power-reading";
@@ -156,9 +155,6 @@ function useMobileState(
     };
   }
 
-  // Custom icon from registry
-  const customEntry = widget.icon ? CUSTOM_ICON_REGISTRY[widget.icon] : undefined;
-
   if (isLight) {
     const brightness = equipment.dataBindings.find(
       (b) => b.alias === "brightness" || b.category === "light_brightness",
@@ -169,11 +165,7 @@ function useMobileState(
         : null;
     const isDimmable = equipment.type === "light_dimmable" || equipment.type === "light_color";
     return {
-      icon: customEntry ? (
-        createElement(customEntry.component, customEntry.previewProps)
-      ) : (
-        <LightBulbIcon on={isOn} />
-      ),
+      icon: renderWidgetStateIcon(widget.icon, <LightBulbIcon on={isOn} />),
       stateLines: [isDimmable && pct !== null ? `${pct}%` : isOn ? "ON" : "OFF"],
     };
   }
@@ -191,11 +183,7 @@ function useMobileState(
             ? `${position}%`
             : null;
     return {
-      icon: customEntry ? (
-        createElement(customEntry.component, customEntry.previewProps)
-      ) : (
-        <ShutterWidgetIcon level={level} />
-      ),
+      icon: renderWidgetStateIcon(widget.icon, <ShutterWidgetIcon level={level} />),
       stateLines: text ? [text] : [],
     };
   }
@@ -212,10 +200,9 @@ function useMobileState(
             ? `${position}%`
             : null;
     return {
-      icon: customEntry ? (
-        createElement(customEntry.component, customEntry.previewProps)
-      ) : (
-        <AwningWidgetIcon deployed={position !== null && position > 0} />
+      icon: renderWidgetStateIcon(
+        widget.icon,
+        <AwningWidgetIcon deployed={position !== null && position > 0} />,
       ),
       stateLines: text ? [text] : [],
     };
@@ -237,11 +224,7 @@ function useMobileState(
     const minBound = isPoolHeatPump ? 10 : 16;
     const level = spVal !== null ? (spVal - minBound) / (30 - minBound) : undefined;
     return {
-      icon: customEntry ? (
-        createElement(customEntry.component, customEntry.previewProps)
-      ) : (
-        <ThermometerIcon warm={isOn} level={level} />
-      ),
+      icon: renderWidgetStateIcon(widget.icon, <ThermometerIcon warm={isOn} level={level} />),
       stateLines: tempVal !== null ? [`${tempVal.toFixed(1)}°C`] : [],
     };
   }
@@ -274,11 +257,7 @@ function useMobileState(
       : false;
     const isComfort = !relayOn;
     return {
-      icon: customEntry ? (
-        createElement(customEntry.component, customEntry.previewProps)
-      ) : (
-        <HeaterWidgetIcon comfort={isComfort} />
-      ),
+      icon: renderWidgetStateIcon(widget.icon, <HeaterWidgetIcon comfort={isComfort} />),
       stateLines: [isComfort ? t("controls.heater.comfort") : t("controls.heater.eco")],
     };
   }
@@ -352,11 +331,7 @@ function useMobileState(
   }
 
   if (isSensor) {
-    const sensorIcon = customEntry ? (
-      createElement(customEntry.component, customEntry.previewProps)
-    ) : (
-      <MultiSensorIcon />
-    );
+    const sensorIcon = renderWidgetStateIcon(widget.icon, <MultiSensorIcon />);
     const allSensorBindings = getSensorBindings(equipment.dataBindings);
     const visibleBindings = widget.config?.visibleBindings;
     const sensorBindings =
@@ -476,11 +451,7 @@ function useMobileState(
       ? channelState.value === true || String(channelState.value).toUpperCase() === "ON"
       : false;
     return {
-      icon: customEntry ? (
-        createElement(customEntry.component, customEntry.previewProps)
-      ) : (
-        <WaterHeaterIcon on={heaterOn} />
-      ),
+      icon: renderWidgetStateIcon(widget.icon, <WaterHeaterIcon on={heaterOn} />),
       stateLines: [
         heaterOn ? "ON" : "OFF",
         ...(tempValue !== null ? [`${tempValue.toFixed(1)}°C`] : []),
@@ -490,11 +461,7 @@ function useMobileState(
 
   if (isWaterValve) {
     return {
-      icon: customEntry ? (
-        createElement(customEntry.component, customEntry.previewProps)
-      ) : (
-        <WaterValveWidgetIcon open={isOn} />
-      ),
+      icon: renderWidgetStateIcon(widget.icon, <WaterValveWidgetIcon open={isOn} />),
       stateLines: [isOn ? t("water.open") : t("water.closed")],
     };
   }
@@ -524,10 +491,9 @@ function useMobileState(
         ? `${String(charge)} %`
         : "";
     return {
-      icon: customEntry ? (
-        createElement(customEntry.component, customEntry.previewProps)
-      ) : (
-        <BatteryCharging size={96} strokeWidth={1.2} className={tone} />
+      icon: renderWidgetStateIcon(
+        widget.icon,
+        <BatteryCharging size={96} strokeWidth={1.2} className={tone} />,
       ),
       stateLines: [
         status ? t(upsStatusKey(status)) : (raw ?? t(upsStatusKey(null))),
@@ -546,10 +512,13 @@ function useMobileState(
           ? t("equipments.vmc.v1")
           : t("equipments.vmc.off");
     return {
-      icon: customEntry ? (
-        createElement(customEntry.component, customEntry.previewProps)
-      ) : (
-        <Fan size={96} strokeWidth={1.2} className={running ? "text-primary" : "text-text-tertiary"} />
+      icon: renderWidgetStateIcon(
+        widget.icon,
+        <Fan
+          size={96}
+          strokeWidth={1.2}
+          className={running ? "text-primary" : "text-text-tertiary"}
+        />,
       ),
       stateLines: [label],
     };
@@ -569,11 +538,7 @@ function useMobileState(
             ? `${position}%`
             : null;
     return {
-      icon: customEntry ? (
-        createElement(customEntry.component, customEntry.previewProps)
-      ) : (
-        <PoolCoverIcon position={position} />
-      ),
+      icon: renderWidgetStateIcon(widget.icon, <PoolCoverIcon position={position} />),
       stateLines: text ? [text] : [],
     };
   }

--- a/ui/src/components/dashboard/TimedEquipmentWidget.test.tsx
+++ b/ui/src/components/dashboard/TimedEquipmentWidget.test.tsx
@@ -116,6 +116,24 @@ describe("TimedEquipmentWidget", () => {
     expect(api.armTimedCommand).not.toHaveBeenCalled();
   });
 
+  it("never lets the controls be the row that gives ground", () => {
+    // There is no layout engine here, so what is pinned is the rule the fix
+    // rests on. Measured in a browser at 390 px: the arm button used to hang
+    // 14 px below the card's edge, and `overflow-hidden` cut it in half.
+    // The illustration is the flexible row and the only one hidden on a
+    // phone; the state and the controls never shrink.
+    const { container } = render(<TimedEquipmentWidget label="Portail" equipment={gate()} />);
+
+    const illustration = container.querySelector(".flex-1");
+    expect(illustration?.className).toContain("min-h-0");
+    expect(container.querySelector("svg")?.getAttribute("class")).toContain("hidden sm:block");
+
+    const arm = screen.getByTitle(/Lancer|Run for/i);
+    expect(arm.parentElement?.className).toContain("shrink-0");
+    const pill = container.querySelector(".rounded-full");
+    expect(pill?.parentElement?.className).toContain("shrink-0");
+  });
+
   it("is inert in edit mode, where the tile is a drag target", async () => {
     render(<TimedEquipmentWidget label="Portail" equipment={gate()} editMode />);
 

--- a/ui/src/components/dashboard/TimedEquipmentWidget.tsx
+++ b/ui/src/components/dashboard/TimedEquipmentWidget.tsx
@@ -73,21 +73,33 @@ export function TimedEquipmentWidget({
       }
       onClick={!running && !editMode && !inert ? arm : undefined}
     >
-      <div className="flex-1 flex items-center justify-center">
+      {/* Four things do not fit in the shell's 160 px on a phone. Of title,
+          state and controls, the title is truncated, the state is the answer
+          and the controls are the point — so the illustration is what goes,
+          and only at that width. Its row stays: flexible (`flex-1 min-h-0`),
+          it absorbs the slack on a 240 px desktop tile and collapses to a
+          gap on a phone, while the state and the controls never shrink.
+          Before this the icon held its 40 px, the stack overflowed, and the
+          shell's `overflow-hidden` cut the arm button in half. */}
+      <div className="flex-1 min-h-0 flex items-center justify-center overflow-hidden">
         {busy ? (
-          <Loader2 size={32} className="animate-spin text-text-tertiary" />
+          <Loader2 size={32} className="hidden sm:block animate-spin text-text-tertiary" />
         ) : (
-          <TimerReset size={40} strokeWidth={1.5} className="text-text-tertiary" />
+          <TimerReset
+            size={40}
+            strokeWidth={1.5}
+            className="hidden sm:block text-text-tertiary"
+          />
         )}
       </div>
 
-      <div className="flex justify-center mt-auto pt-1">
+      <div className="shrink-0 flex justify-center pt-1">
         {running ? (
           <span className="text-[12px] font-medium px-2.5 py-0.5 rounded-full bg-active/10 text-active-text">
             <TimedCountdown action={running} />
           </span>
         ) : (
-          <span className="text-[12px] font-medium px-2.5 py-0.5 rounded-full bg-border-light text-text-tertiary">
+          <span className="text-[12px] font-medium px-2.5 py-0.5 rounded-full bg-border-light text-text-tertiary text-center">
             {inert
               ? t("dashboard.timed.unavailable")
               : error
@@ -97,7 +109,7 @@ export function TimedEquipmentWidget({
         )}
       </div>
 
-      <div className="flex justify-center gap-3 mt-auto pt-1">
+      <div className="shrink-0 flex justify-center gap-3 pt-1">
         <button
           onClick={arm}
           disabled={busy || editMode || inert}

--- a/ui/src/components/dashboard/WidgetDetailSheet.tsx
+++ b/ui/src/components/dashboard/WidgetDetailSheet.tsx
@@ -51,7 +51,7 @@ import {
   GarageDoorIcon,
   PoolCoverIcon,
 } from "./WidgetIcons";
-import { CUSTOM_ICON_REGISTRY, shutterLevel } from "./widget-icons";
+import { CUSTOM_ICON_REGISTRY, customIconProps, shutterLevel } from "./widget-icons";
 import { BottomSheet } from "./BottomSheet";
 import { EQUIPMENT_ZONE_SEPARATOR } from "../../lib/zone-path";
 import { ForecastDetailContent } from "./ForecastDetailContent";
@@ -70,19 +70,50 @@ interface EquipmentDetailProps {
 }
 
 export function EquipmentDetailSheet({ widget, equipment, equipmentZone, onExecuteOrder, onClose }: EquipmentDetailProps) {
-  const { isLight, isShutter, isAwning, isThermostat, isHeater, isSensor, isGate, isPoolHeatPump } = useEquipmentState(equipment);
+  const {
+    isLight,
+    isShutter,
+    isAwning,
+    isThermostat,
+    isHeater,
+    isSensor,
+    isGate,
+    isPoolHeatPump,
+    isShutterFamily,
+    shutterIsOpen,
+    isOn,
+    gateIsOpen,
+    shutterPosition,
+  } = useEquipmentState(equipment);
   // A full-width sheet header has room for the joined form, unlike the cards.
   const label = widget.label
     || (equipmentZone ? `${equipment.name}${EQUIPMENT_ZONE_SEPARATOR}${equipmentZone}` : equipment.name);
   const execOrder = (alias: string, value: unknown) => onExecuteOrder(equipment.id, alias, value);
 
-  // Get icon
+  // Sheet header icon — the hand-picked drawing only, rendered from the
+  // equipment's live state like the tile it was opened from. Reading
+  // `previewProps` here froze the sheet on the picker's thumbnail.
   const customEntry = widget.icon ? CUSTOM_ICON_REGISTRY[widget.icon] : undefined;
+  const customIcon = customEntry ? (
+    <div className="scale-[0.35]">
+      {createElement(
+        customEntry.component,
+        customIconProps(customEntry, {
+          // "Is this thing doing something" — each family reads it from the
+          // state the hook already resolved. A heater is fil pilote: its relay
+          // OPEN is comfort, which is the state its drawing calls warm.
+          on: isHeater ? !isOn : isGate ? gateIsOpen : isShutterFamily ? shutterIsOpen : isOn,
+          position: shutterPosition ?? undefined,
+          level: shutterPosition !== null ? shutterLevel(shutterPosition) : undefined,
+        }),
+      )}
+    </div>
+  ) : undefined;
 
   if (isLight && (equipment.type === "light_dimmable" || equipment.type === "light_color")) {
     return (
       <BottomSheet open onClose={onClose} title={label}
-        icon={customEntry ? <div className="scale-[0.35]">{createElement(customEntry.component, customEntry.previewProps)}</div> : undefined}
+        icon={customIcon}
       >
         <LightDetailContent equipment={equipment} onExecuteOrder={execOrder} />
       </BottomSheet>
@@ -95,7 +126,7 @@ export function EquipmentDetailSheet({ widget, equipment, equipmentZone, onExecu
   if (equipment.type === "weather_forecast") {
     return (
       <BottomSheet open onClose={onClose} title={label}
-        icon={customEntry ? <div className="scale-[0.35]">{createElement(customEntry.component, customEntry.previewProps)}</div> : undefined}
+        icon={customIcon}
       >
         <ForecastDetailContent equipment={equipment} />
       </BottomSheet>
@@ -105,7 +136,7 @@ export function EquipmentDetailSheet({ widget, equipment, equipmentZone, onExecu
   if (isShutter || isAwning || equipment.type === "pool_cover") {
     return (
       <BottomSheet open onClose={onClose} title={label}
-        icon={customEntry ? <div className="scale-[0.35]">{createElement(customEntry.component, customEntry.previewProps)}</div> : undefined}
+        icon={customIcon}
       >
         <ShutterDetailContent equipment={equipment} onExecuteOrder={execOrder} />
       </BottomSheet>
@@ -115,7 +146,7 @@ export function EquipmentDetailSheet({ widget, equipment, equipmentZone, onExecu
   if (isThermostat || isPoolHeatPump) {
     return (
       <BottomSheet open onClose={onClose} title={label}
-        icon={customEntry ? <div className="scale-[0.35]">{createElement(customEntry.component, customEntry.previewProps)}</div> : undefined}
+        icon={customIcon}
       >
         <ThermostatDetailContent equipment={equipment} onExecuteOrder={execOrder} />
       </BottomSheet>
@@ -125,7 +156,7 @@ export function EquipmentDetailSheet({ widget, equipment, equipmentZone, onExecu
   if (isHeater) {
     return (
       <BottomSheet open onClose={onClose} title={label}
-        icon={customEntry ? <div className="scale-[0.35]">{createElement(customEntry.component, customEntry.previewProps)}</div> : undefined}
+        icon={customIcon}
       >
         <HeaterDetailContent equipment={equipment} onExecuteOrder={execOrder} />
       </BottomSheet>
@@ -135,7 +166,7 @@ export function EquipmentDetailSheet({ widget, equipment, equipmentZone, onExecu
   if (isGate) {
     return (
       <BottomSheet open onClose={onClose} title={label}
-        icon={customEntry ? <div className="scale-[0.35]">{createElement(customEntry.component, customEntry.previewProps)}</div> : undefined}
+        icon={customIcon}
       >
         <GateDetailContent equipment={equipment} onExecuteOrder={execOrder} iconKey={widget.icon} />
       </BottomSheet>
@@ -145,7 +176,7 @@ export function EquipmentDetailSheet({ widget, equipment, equipmentZone, onExecu
   if (equipment.type === "weather") {
     return (
       <BottomSheet open onClose={onClose} title={label}
-        icon={customEntry ? <div className="scale-[0.35]">{createElement(customEntry.component, customEntry.previewProps)}</div> : undefined}
+        icon={customIcon}
       >
         <WeatherDetailContent equipment={equipment} />
       </BottomSheet>
@@ -155,7 +186,7 @@ export function EquipmentDetailSheet({ widget, equipment, equipmentZone, onExecu
   if (equipment.type === "vmc") {
     return (
       <BottomSheet open onClose={onClose} title={label}
-        icon={customEntry ? <div className="scale-[0.35]">{createElement(customEntry.component, customEntry.previewProps)}</div> : undefined}
+        icon={customIcon}
       >
         <div className="p-4">
           <VmcControl equipment={equipment} onExecuteOrder={execOrder} />
@@ -167,7 +198,7 @@ export function EquipmentDetailSheet({ widget, equipment, equipmentZone, onExecu
   if (isSensor) {
     return (
       <BottomSheet open onClose={onClose} title={label}
-        icon={customEntry ? <div className="scale-[0.35]">{createElement(customEntry.component, customEntry.previewProps)}</div> : undefined}
+        icon={customIcon}
       >
         <SensorDetailContent equipment={equipment} visibleBindings={widget.config?.visibleBindings} />
       </BottomSheet>

--- a/ui/src/components/dashboard/WidgetIcons.test.tsx
+++ b/ui/src/components/dashboard/WidgetIcons.test.tsx
@@ -9,8 +9,15 @@
 import { describe, it, expect } from "vitest";
 import { createElement } from "react";
 import { render } from "../../test-utils";
-import { AirCompressorIcon, Printer3DIcon } from "./WidgetIcons";
-import { CUSTOM_ICON_REGISTRY } from "./widget-icons";
+import {
+  AirCompressorIcon,
+  GateWidgetIcon,
+  LightBulbIcon,
+  PlugWidgetIcon,
+  PoolCoverIcon,
+  Printer3DIcon,
+} from "./WidgetIcons";
+import { CUSTOM_ICON_REGISTRY, customIconProps, renderWidgetStateIcon } from "./widget-icons";
 
 function svgOf(node: React.ReactElement): SVGSVGElement {
   const { container } = render(node);
@@ -63,9 +70,9 @@ describe("CUSTOM_ICON_REGISTRY", () => {
     expect(CUSTOM_ICON_REGISTRY.printer_3d.types).toContain("switch");
   });
 
-  it("hands the printer a state its component understands, not a stale prop", () => {
-    // previewProps are frozen into every surface that renders a hand-picked
-    // icon, so a key the component ignores shows up as a silently wrong state.
+  it("hands the picker thumbnail a state its component understands", () => {
+    // previewProps drive the picker's grid and nothing else. A key the
+    // component ignores would show the icon frozen in the wrong state there.
     const { container } = render(
       createElement(
         CUSTOM_ICON_REGISTRY.printer_3d.component,
@@ -78,5 +85,58 @@ describe("CUSTOM_ICON_REGISTRY", () => {
   it("draws the compressor at rest until something tells it otherwise", () => {
     const svg = svgOf(<AirCompressorIcon on={false} />);
     expect(svg.getAttribute("class")).toContain("text-primary");
+  });
+});
+
+/**
+ * The defect this pins: a hand-picked icon used to be rendered from its
+ * previewProps on every live surface, so a compressor stayed at rest and a
+ * plug stayed lit whatever the relay was doing. The drawing must inherit the
+ * state props of the type icon it replaces.
+ */
+describe("renderWidgetStateIcon", () => {
+  it("leaves the type icon alone when no icon was picked", () => {
+    const typeIcon = <LightBulbIcon on={true} />;
+    expect(renderWidgetStateIcon(undefined, typeIcon)).toBe(typeIcon);
+    expect(renderWidgetStateIcon("no_such_icon", typeIcon)).toBe(typeIcon);
+  });
+
+  it("swaps the drawing and carries the live state across", () => {
+    const off = renderWidgetStateIcon("air_compressor", <PlugWidgetIcon on={false} />);
+    expect(off.type).toBe(CUSTOM_ICON_REGISTRY.air_compressor.component);
+    expect(off.props).toMatchObject({ on: false });
+
+    // The regression: previewProps say `{ on: false }`, so the compressor
+    // never lit up when the plug was switched on.
+    const on = renderWidgetStateIcon("air_compressor", <PlugWidgetIcon on={true} />);
+    expect(on.props).toMatchObject({ on: true });
+    expect(svgOf(on).getAttribute("class")).toContain("text-active");
+  });
+
+  it("translates the state into the printer's four-valued vocabulary", () => {
+    const on = renderWidgetStateIcon("printer_3d", <PlugWidgetIcon on={true} />);
+    expect(svgOf(on).getAttribute("data-state")).toBe("on");
+    const off = renderWidgetStateIcon("printer_3d", <PlugWidgetIcon on={false} />);
+    expect(svgOf(off).getAttribute("data-state")).toBe("off");
+  });
+
+  it("fills a drawing's own boolean from whichever one its widget computed", () => {
+    // The picker offers every icon under "other", so a gate can be given the
+    // plug: `open` has to reach the drawing that reads `on`, and back.
+    const plugOnGate = renderWidgetStateIcon("plug", <GateWidgetIcon open={true} />);
+    expect(plugOnGate.props).toMatchObject({ on: true });
+
+    const gateOnPlug = renderWidgetStateIcon("gate", <PlugWidgetIcon on={false} />);
+    expect(gateOnPlug.props).toMatchObject({ open: false });
+  });
+
+  it("leaves a stateless drawing stateless", () => {
+    // Sensor icons take no props: nothing to fill in, and nothing invented.
+    expect(customIconProps(CUSTOM_ICON_REGISTRY.multi_sensor, {})).toEqual({});
+  });
+
+  it("keeps the numeric state of a cover, which has no boolean to inherit", () => {
+    const cover = renderWidgetStateIcon("pool_cover", <PoolCoverIcon position={40} />);
+    expect(cover.props).toMatchObject({ position: 40 });
   });
 });

--- a/ui/src/components/dashboard/presentation/resolveWidgetPresentation.test.tsx
+++ b/ui/src/components/dashboard/presentation/resolveWidgetPresentation.test.tsx
@@ -221,10 +221,45 @@ describe("resolveWidgetPresentation", () => {
     });
   });
 
-  it("renders the custom widget icon override instead of the type default (#318)", () => {
-    const p = resolveWidgetPresentation(makeWidget({ icon: "light_bulb" }), makeEquipment(), t);
-    const node = p!.icon({ surface: "desktop" }) as { type: unknown };
-    expect(node.type).toBe(CUSTOM_ICON_REGISTRY.light_bulb.component);
+  describe("custom widget icon (#318)", () => {
+    function iconOf(widget: DashboardWidget, equipment: EquipmentWithDetails) {
+      const p = resolveWidgetPresentation(widget, equipment, t);
+      return p!.icon({ surface: "desktop" }) as { type: unknown; props: Record<string, unknown> };
+    }
+
+    it("renders the custom widget icon override instead of the type default", () => {
+      const node = iconOf(makeWidget({ icon: "light_bulb" }), makeEquipment());
+      expect(node.type).toBe(CUSTOM_ICON_REGISTRY.light_bulb.component);
+    });
+
+    it("draws it from the equipment's state, not from the picker's preview", () => {
+      // The compressor's previewProps are `{ on: false }` and the plug's are
+      // `{ on: true }`: rendering those froze the drawing on every tile, which
+      // is exactly what a user switching the compressor on could not see.
+      const off = iconOf(makeWidget({ icon: "air_compressor" }), makeEquipment());
+      expect(off.props.on).toBe(false);
+
+      const running = makeEquipment({ dataBindings: [dataBinding({ value: true })] });
+      expect(iconOf(makeWidget({ icon: "air_compressor" }), running).props.on).toBe(true);
+      expect(iconOf(makeWidget({ icon: "plug" }), makeEquipment()).props.on).toBe(false);
+    });
+
+    it("speaks the printer's own state vocabulary", () => {
+      const running = makeEquipment({ dataBindings: [dataBinding({ value: true })] });
+      expect(iconOf(makeWidget({ icon: "printer_3d" }), running).props.state).toBe("on");
+      expect(iconOf(makeWidget({ icon: "printer_3d" }), makeEquipment()).props.state).toBe("off");
+    });
+
+    it("agrees with the state pill beside it on every migrated type", () => {
+      // One rule per type: the drawing reads the descriptor's own isActive, so
+      // an icon saying OFF next to a pill saying ON is not representable.
+      for (const type of ["switch", "pool_pump"] as const) {
+        const eq = makeEquipment({ type, dataBindings: [dataBinding({ value: true })] });
+        const p = resolveWidgetPresentation(makeWidget({ icon: "light_bulb" }), eq, t);
+        const node = p!.icon({ surface: "desktop" }) as { props: Record<string, unknown> };
+        expect(node.props.on, type).toBe(p!.isActive);
+      }
+    });
   });
 });
 

--- a/ui/src/components/dashboard/presentation/resolveWidgetPresentation.tsx
+++ b/ui/src/components/dashboard/presentation/resolveWidgetPresentation.tsx
@@ -1,10 +1,10 @@
-import { createElement, type ReactNode } from "react";
+import { createElement } from "react";
 import { Tv } from "lucide-react";
 import type { TFunction } from "i18next";
 import type { DashboardWidget, EquipmentWithDetails } from "../../../types";
-import { CUSTOM_ICON_REGISTRY } from "../widget-icons";
+import { CUSTOM_ICON_REGISTRY, customIconProps } from "../widget-icons";
 import { PlugWidgetIcon, PoolPumpIcon } from "../WidgetIcons";
-import type { IconCtx, WidgetControl, WidgetPresentation } from "./types";
+import type { WidgetControl, WidgetPresentation } from "./types";
 import {
   findToggleBinding,
   formatRuntime,
@@ -22,14 +22,20 @@ import {
 // that need store-derived context (e.g. sensor battery alerts) will receive
 // it as an explicit argument when they migrate.
 
-/** Custom widget icon (#318) wins over the type default on every surface. */
-function iconWithOverride(
+/**
+ * Custom widget icon (#318) wins over the type default on every surface —
+ * and follows the same state the type default would have shown. It reads the
+ * descriptor's own `isActive`, so there is one on/off rule per type and the
+ * drawing can never disagree with the state pill beside it.
+ */
+function withCustomIcon(
   widget: DashboardWidget,
-  typeIcon: (ctx: IconCtx) => ReactNode,
-): (ctx: IconCtx) => ReactNode {
+  presentation: WidgetPresentation,
+): WidgetPresentation {
   const custom = widget.icon ? CUSTOM_ICON_REGISTRY[widget.icon] : undefined;
-  if (!custom) return typeIcon;
-  return () => createElement(custom.component, custom.previewProps);
+  if (!custom) return presentation;
+  const props = customIconProps(custom, { on: presentation.isActive });
+  return { ...presentation, icon: () => createElement(custom.component, props) };
 }
 
 /** Build the single toggle control, or none when no togglable order exists. */
@@ -43,36 +49,30 @@ function toggleControlOf(
   return [{ kind: "toggle", alias: binding.alias, on, ...toggleValues(binding) }];
 }
 
-function resolveSwitch(
-  widget: DashboardWidget,
-  equipment: EquipmentWithDetails,
-): WidgetPresentation {
+function resolveSwitch(equipment: EquipmentWithDetails): WidgetPresentation {
   const on = isOnFromStateBinding(equipment);
   return {
-    icon: iconWithOverride(widget, () => <PlugWidgetIcon on={on} />),
+    icon: () => <PlugWidgetIcon on={on} />,
     isActive: on,
     state: { primary: on ? "ON" : "OFF" },
     controls: toggleControlOf(equipment, on, ["light_toggle", "toggle_power"]),
   };
 }
 
-function resolveMediaPlayer(
-  widget: DashboardWidget,
-  equipment: EquipmentWithDetails,
-): WidgetPresentation {
+function resolveMediaPlayer(equipment: EquipmentWithDetails): WidgetPresentation {
   const powerBinding = equipment.dataBindings.find((b) => b.alias === "power");
   const sourceBinding = equipment.dataBindings.find((b) => b.alias === "input_source");
   const on = powerBinding?.value === true;
   const source = typeof sourceBinding?.value === "string" ? sourceBinding.value : null;
   const toggle = equipment.orderBindings.find((ob) => ob.alias === "power");
   return {
-    icon: iconWithOverride(widget, (ctx) => (
+    icon: (ctx) => (
       <Tv
         size={ctx.surface === "mobile-card" ? 96 : 64}
         strokeWidth={1}
         className={on ? "text-primary" : "text-text-tertiary"}
       />
-    )),
+    ),
     isActive: on,
     state: { primary: on ? (source ?? "ON") : "OFF" },
     controls: toggle
@@ -81,16 +81,13 @@ function resolveMediaPlayer(
   };
 }
 
-function resolvePoolPump(
-  widget: DashboardWidget,
-  equipment: EquipmentWithDetails,
-): WidgetPresentation {
+function resolvePoolPump(equipment: EquipmentWithDetails): WidgetPresentation {
   const on = isOnFromStateBinding(equipment);
   const runtime = equipment.computedData?.find((c) => c.alias === "runtime_daily");
   const secondary =
     typeof runtime?.value === "number" ? [formatRuntime(runtime.value)] : undefined;
   return {
-    icon: iconWithOverride(widget, () => <PoolPumpIcon on={on} />),
+    icon: () => <PoolPumpIcon on={on} />,
     isActive: on,
     state: { primary: on ? "ON" : "OFF", secondary },
     // Category-first incl. pool_pump_toggle so an unrelated boolean order on
@@ -117,13 +114,18 @@ export function resolveWidgetPresentation(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _t: TFunction,
 ): WidgetPresentation | null {
+  const byType = resolveByType(equipment);
+  return byType && withCustomIcon(widget, byType);
+}
+
+function resolveByType(equipment: EquipmentWithDetails): WidgetPresentation | null {
   switch (equipment.type) {
     case "switch":
-      return resolveSwitch(widget, equipment);
+      return resolveSwitch(equipment);
     case "media_player":
-      return resolveMediaPlayer(widget, equipment);
+      return resolveMediaPlayer(equipment);
     case "pool_pump":
-      return resolvePoolPump(widget, equipment);
+      return resolvePoolPump(equipment);
     default:
       return null;
   }

--- a/ui/src/components/dashboard/widget-icons.ts
+++ b/ui/src/components/dashboard/widget-icons.ts
@@ -1,4 +1,4 @@
-import { createElement, type ComponentType } from "react";
+import { createElement, type ComponentType, type ReactElement } from "react";
 import {
   Lightbulb,
   LampDesk,
@@ -95,11 +95,29 @@ export function shutterLevel(position: number): number {
 // Custom SVG icon registry — rich icons with state
 // ============================================================
 
+/**
+ * The props a drawing is rendered from: whatever state the equipment's own
+ * icon is given (`{ on }`, `{ open }`, `{ position }`…). Deliberately open:
+ * each equipment type owns its vocabulary, the registry only adapts it.
+ */
+export type IconStateProps = Record<string, unknown>;
+
 export interface CustomIconEntry {
   label: string;
-  component: ComponentType<Record<string, unknown>>;
-  /** Default props for preview (static state) */
-  previewProps: Record<string, unknown>;
+  component: ComponentType<IconStateProps>;
+  /**
+   * Frozen props for the ICON PICKER's thumbnail, and nothing else. A live
+   * tile renders the drawing from the equipment's real state — rendering
+   * previewProps there is what made a hand-picked plug glow whatever the
+   * relay was doing.
+   */
+  previewProps: IconStateProps;
+  /**
+   * Adapt the live state to this drawing's own vocabulary. Only needed when
+   * the props are not the boolean ones filled in by `customIconProps` — the
+   * 3D printer's four-valued `state` is the one case.
+   */
+  fromState?: (state: IconStateProps) => IconStateProps;
   /** Categories this icon applies to (for filtering in picker) */
   types: string[];
 }
@@ -217,6 +235,10 @@ export const CUSTOM_ICON_REGISTRY: Record<string, CustomIconEntry> = {
     label: "Imprimante 3D",
     component: Printer3DIcon as ComponentType<Record<string, unknown>>,
     previewProps: { state: "off" },
+    // The one drawing whose prop is not a boolean. A plug only ever knows
+    // whether the machine is powered: `printing` and `error` would need data
+    // no relay exposes, so they stay out of reach from a dashboard tile.
+    fromState: (state) => ({ state: state.on === true ? "on" : "off" }),
     types: ["switch"],
   },
   motion_sensor: {
@@ -307,13 +329,28 @@ export const ICON_MAP: Record<string, LucideIcon> = {
 };
 
 export const ICON_CATEGORIES: { label: string; icons: string[] }[] = [
-  { label: "Lighting", icons: ["Lightbulb", "LampDesk", "LampFloor", "Lamp", "Sun", "Sparkles", "SunDim"] },
+  {
+    label: "Lighting",
+    icons: ["Lightbulb", "LampDesk", "LampFloor", "Lamp", "Sun", "Sparkles", "SunDim"],
+  },
   { label: "Shutters / Doors", icons: ["DoorOpen", "DoorClosed", "ArrowUpDown", "Lock", "Unlock"] },
-  { label: "Climate", icons: ["Thermometer", "Flame", "Snowflake", "Fan", "Wind", "Droplets", "CloudRain"] },
+  {
+    label: "Climate",
+    icons: ["Thermometer", "Flame", "Snowflake", "Fan", "Wind", "Droplets", "CloudRain"],
+  },
   { label: "Security", icons: ["Shield", "ShieldCheck", "Camera", "Bell", "Eye", "AlertTriangle"] },
-  { label: "Sensors", icons: ["Gauge", "Activity", "Zap", "Power", "Battery", "BatteryCharging", "Signal", "Wifi"] },
-  { label: "Rooms", icons: ["Home", "Sofa", "Bed", "CookingPot", "Bath", "Car", "Trees", "Flower2"] },
-  { label: "General", icons: ["Star", "Heart", "CircleDot", "ToggleLeft", "Settings", "Radio", "Monitor"] },
+  {
+    label: "Sensors",
+    icons: ["Gauge", "Activity", "Zap", "Power", "Battery", "BatteryCharging", "Signal", "Wifi"],
+  },
+  {
+    label: "Rooms",
+    icons: ["Home", "Sofa", "Bed", "CookingPot", "Bath", "Car", "Trees", "Flower2"],
+  },
+  {
+    label: "General",
+    icons: ["Star", "Heart", "CircleDot", "ToggleLeft", "Settings", "Radio", "Monitor"],
+  },
 ];
 
 const EQUIPMENT_DEFAULT_ICONS: Partial<Record<EquipmentType, string>> = {
@@ -376,4 +413,41 @@ export function renderWidgetIcon(
 ) {
   const Icon = getWidgetIcon(iconName, equipmentTypeOrFamily);
   return createElement(Icon, props);
+}
+
+/**
+ * Boolean props the drawings use for "this appliance is doing something".
+ * A custom icon can be picked for any equipment (the picker offers every
+ * drawing under "other"), so whichever one its type computed fills in the
+ * ones this particular drawing reads. Numeric state (`level`, `position`)
+ * is NOT cross-filled: those value spaces differ per family.
+ */
+const ACTIVITY_PROPS = ["on", "open", "active", "deployed", "warm", "comfort"] as const;
+
+/** Props to render a custom drawing with, from the state its widget resolved. */
+export function customIconProps(entry: CustomIconEntry, state: IconStateProps): IconStateProps {
+  const filled: IconStateProps = { ...state };
+  const source = ACTIVITY_PROPS.find((key) => state[key] !== undefined);
+  if (source !== undefined) {
+    const active = Boolean(state[source]);
+    for (const key of ACTIVITY_PROPS) {
+      if (filled[key] === undefined) filled[key] = active;
+    }
+  }
+  return entry.fromState ? entry.fromState(filled) : filled;
+}
+
+/**
+ * Render a dashboard widget's icon: the hand-picked drawing when the widget
+ * has one (#318), else the type's own element unchanged. The custom drawing
+ * inherits the very props the type icon was built with, so both follow the
+ * equipment's state — there is no second rule to keep in sync.
+ */
+export function renderWidgetStateIcon(
+  iconKey: string | undefined,
+  typeIcon: ReactElement,
+): ReactElement {
+  const entry = iconKey ? CUSTOM_ICON_REGISTRY[iconKey] : undefined;
+  if (!entry) return typeIcon;
+  return createElement(entry.component, customIconProps(entry, typeIcon.props as IconStateProps));
 }

--- a/ui/src/components/equipments/useEquipmentState.ts
+++ b/ui/src/components/equipments/useEquipmentState.ts
@@ -186,6 +186,7 @@ export function useEquipmentState(equipment: EquipmentWithDetails) {
     isWaterHeater,
     stateBinding,
     isOn,
+    gateIsOpen,
     shutterPosition,
     hasShutterState,
     shutterIsOpen,


### PR DESCRIPTION
## Summary

Two dashboard defects reported from the same phone screen.

**A hand-picked widget icon never moved.** Switching the air compressor or the 3D printer on left the drawing exactly as it was. The cause is not those two icons: every custom icon was rendered from its registry `previewProps`, the frozen props that exist for the picker's thumbnail, so a socket given the "Prise" icon rendered lit forever and a gate given a drawing never opened. `ui/src/components/dashboard/presentation/resolveWidgetPresentation.tsx:32` did it for the migrated types, `EquipmentWidget.tsx:72`, `MobileWidgetCard.tsx` (11 branches) and `WidgetDetailSheet.tsx` (9 branches) for the rest.

Both SVGs added in #876 already honour their state prop — nothing was wrong with the drawings.

**The timed tile (spec 174 phase 2) cut its own button in half on a phone.** It stacks an illustration, a state pill and a control row inside the shared 160 px shell. Measured in Chrome at 390 px, the stack ran 14 px past the card and `overflow-hidden` did the rest. The shared `WidgetCard` is not the culprit and is not touched: the tile simply asked for three rows where two fit.

## Changes

**Icons follow the equipment** (`fix(ui): draw a hand-picked widget icon from the equipment's real state`)

- `renderWidgetStateIcon(iconKey, typeIcon)` swaps the component and carries the type icon's own props across, so the custom drawing is rendered from the very state the built-in one would have shown — no second on/off rule to keep in sync (the lesson of #744 and #832).
- The spec 149 resolver applies the override once, centrally, from the descriptor's `isActive` — the same value that drives the state pill beside it, so icon and pill cannot disagree.
- `customIconProps` fills a drawing's own boolean from whichever one its widget computed (`open` → `on` and back), because the picker offers every icon under **Other icons**. Numeric state (`level`, `position`) is deliberately not cross-filled: those value spaces differ per family.
- The 3D printer declares `fromState`: its prop is four-valued, and a plug only ever knows whether the machine is powered.
- `previewProps` now serve the picker alone, and say so in their doc comment.
- `useEquipmentState` returns `gateIsOpen` so the detail sheet can read the gate's state from the same hook instead of restating the rule.

**The timed tile fits** (`fix(ui): stop the timed tile clipping its own button on a phone`)

- The rows now have a priority: the illustration is the flexible one (`flex-1 min-h-0`) and the only thing dropped at phone width; the state and the controls are `shrink-0` and always land inside the card.
- On a 240 px desktop tile nothing moves — the illustration is untouched and its row absorbs the slack exactly as before.

**Docs**: `docs/user/dashboard.md` and `docs/user/dashboard.fr.md` — a chosen icon follows the equipment; the picker's thumbnails are static previews.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `cd ui && npx tsc -b --noEmit` — clean
- [x] `npx vitest run` — 2498 passed, 2 skipped
- [x] `cd ui && npx vitest run` — 1081 passed (10 new)
- [x] `npx eslint src/ --ext .ts` — clean
- [x] `cd ui && npx eslint .` — clean
- [x] `check-docs-parity.sh`, `check-docs-impact.sh`, `check-specs-index.sh folders` — all green
- [x] New coverage in the pure helpers: `renderWidgetStateIcon` / `customIconProps` (the swap, the printer's vocabulary, the boolean fill, a stateless sensor icon, a cover's numeric state) and the resolver (the drawing agrees with the pill on every migrated type).
- [x] Layout measured in Chrome against the built stylesheet, at 390 px and 1280 px: the arm button went from **14 px past the card's bottom edge** to **13 px inside it** (6 px inside in the worst case — a wrapped "No timed command" plus the cancel button), with the desktop tile identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)