### PR TITLE
docs: shoot documentation screenshots on a local Docker instance

### DIFF
--- a/.claude/skills/sowel-docs/SKILL.md
+++ b/.claude/skills/sowel-docs/SKILL.md
@@ -57,11 +57,13 @@ Screenshots live under `docs/screenshots/` and are referenced from `.md` files v
 5. **Never shoot on a real production instance** and **never use `./scripts/run-swap.sh local`** for screenshots:
    - Real instance data leaks personal names and the actual home topology into public docs.
    - `run-swap.sh local` stops the prod container over SSH, which crashes the real home automation.
-   - Use the demo instance and the anonymized showroom fixture instead — see "Screenshot pipeline" below.
+   - Use a local Docker instance and the anonymized showroom fixture instead — see "Screenshot pipeline" below.
 
 ### Screenshot pipeline (anonymized via demo instance)
 
-The demo instance hosts and the prod backup source are defined in the private ops repo (`../sowel-ops/ops.env`: `SOWEL_PROD_HOST`, `SOWEL_DEMO_SSH`, `SOWEL_DEMO_URL`, `SOWEL_DEMO_COMPOSE_DIR` — see `CLAUDE.md` section "Installation-specific context"). Source it first: `source ../sowel-ops/ops.env`. Two stages:
+Screenshots are shot on a **throwaway Sowel running in Docker on this machine**, never on a real instance. There is no demo host any more: one existed as a Raspberry Pi, and a box that has to be kept alive, reachable and up to date for something needed a few times a year meant every session began by repairing it. `docker-compose.docs.yml` at the repository root replaces it, on port 3001, with its own volumes and no Docker socket.
+
+Only the prod backup source comes from the private ops repo (`../sowel-ops/ops.env`: `SOWEL_PROD_HOST` — see `CLAUDE.md` section "Installation-specific context"). Source it first: `source ../sowel-ops/ops.env`. Two stages:
 
 **1. Build anonymized fixtures from a fresh prod backup**
 
@@ -102,20 +104,30 @@ await page.addStyleTag({
 // then assert it is gone rather than trusting the injection
 ```
 
-**2. Deploy fixture to demo + shoot (per language)**
+**2. Deploy fixture locally + shoot (per language)**
 
 ```bash
-# Full reset of demo
-ssh "$SOWEL_DEMO_SSH" "cd $SOWEL_DEMO_COMPOSE_DIR && docker compose down -v && docker compose pull && docker compose up -d"
-# Wait for /api/v1/auth/status to respond
-# Setup first admin via POST /api/v1/auth/setup
+DOCS=http://localhost:3001
+
+# Full reset — `down -v` wipes only this instance's volumes (own project name)
+docker compose -f docker-compose.docs.yml down -v
+docker compose -f docker-compose.docs.yml pull
+docker compose -f docker-compose.docs.yml up -d
+
+# Wait for the API rather than guessing a delay
+until curl -sf "$DOCS/api/v1/auth/status" >/dev/null; do sleep 2; done
+
+# Setup first admin via POST /api/v1/auth/setup, then log in for a token
 # Restore showroom-fr.zip via POST /api/v1/backup (multipart) — for FR shoot
-# Take FR screenshots on $SOWEL_DEMO_URL (set localStorage sowel_language=fr, reload)
+# Take FR screenshots on $DOCS (set localStorage sowel_language=fr, reload)
 # Restore showroom-en.zip via POST /api/v1/backup — for EN shoot
 # Take EN screenshots
 ```
 
-Demo compose file: `$SOWEL_DEMO_COMPOSE_DIR/docker-compose.yml`. Keep `image: ghcr.io/mchacher/sowel:<version>` aligned with the prod release. Demo port 3001 maps to container 3000.
+Pin the image when documenting a specific release:
+`SOWEL_DOCS_IMAGE=ghcr.io/mchacher/sowel:1.68.0 docker compose -f docker-compose.docs.yml up -d`.
+
+Tear it down when the session is over (`down -v`); it is meant to be disposable, and leaving it running is how it drifts out of date.
 
 ### Playwright MCP recipe (preferred)
 

--- a/docker-compose.docs.yml
+++ b/docker-compose.docs.yml
@@ -1,0 +1,78 @@
+# ============================================================
+# Sowel — local documentation instance
+# Usage: docker compose -f docker-compose.docs.yml up -d
+# ============================================================
+#
+# A throwaway Sowel on this machine, used to shoot documentation screenshots
+# from the anonymized showroom fixture (docs/fixtures/). It replaces the
+# Raspberry Pi that used to play this role: a demo host that has to be kept
+# alive, reachable and up to date is a liability for something needed a few
+# times a year, and every screenshot session began by fixing the Pi.
+#
+# Three deliberate differences with the production compose:
+#
+#   - **Port 3001**, so a `npm run dev` backend can keep 3000.
+#   - **No Docker socket.** Self-update is not needed here, and the mount
+#     grants effective root on this machine (spec 105).
+#   - **Its own project name and volumes**, so `down -v` wipes this instance
+#     and cannot touch a local production-like stack.
+#
+# Reset to zero (this is the point of the file):
+#   docker compose -f docker-compose.docs.yml down -v
+#   docker compose -f docker-compose.docs.yml up -d
+#
+# Pin the image to the release being documented when it matters:
+#   SOWEL_DOCS_IMAGE=ghcr.io/mchacher/sowel:1.68.0 docker compose -f docker-compose.docs.yml up -d
+
+name: sowel-docs
+
+services:
+  sowel:
+    image: ${SOWEL_DOCS_IMAGE:-ghcr.io/mchacher/sowel:latest}
+    container_name: sowel-docs
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      # Explicit, because screenshots show clocks, schedules and energy day
+      # boundaries. Left to auto-derivation it would follow the fixture's
+      # coordinates, which are deliberately neutral (Paris).
+      - TZ=Europe/Paris
+      - INFLUX_URL=http://influxdb:8086
+      - INFLUX_TOKEN=sowel-auto-token
+      - INFLUX_ORG=sowel
+      - INFLUX_BUCKET=sowel
+    volumes:
+      - docs-data:/app/data
+      - docs-plugins:/app/plugins
+    depends_on:
+      - influxdb
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  influxdb:
+    image: influxdb:2.7
+    container_name: sowel-docs-influxdb
+    restart: unless-stopped
+    volumes:
+      - docs-influxdb:/var/lib/influxdb2
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=sowel
+      - DOCKER_INFLUXDB_INIT_PASSWORD=sowel-auto-password
+      - DOCKER_INFLUXDB_INIT_ORG=sowel
+      - DOCKER_INFLUXDB_INIT_BUCKET=sowel
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=sowel-auto-token
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+volumes:
+  docs-data:
+  docs-plugins:
+  docs-influxdb:

--- a/docs/fixtures/README.md
+++ b/docs/fixtures/README.md
@@ -38,24 +38,32 @@ The script:
 
 Edit `scripts/doc/build-fixtures.py` to tweak the anonymization or translation maps.
 
-## Restoring a fixture on a demo instance
+## Restoring a fixture on a local instance
+
+`docker-compose.docs.yml` at the repository root starts a throwaway Sowel on
+port 3001, with its own volumes and no Docker socket. Nothing else is needed:
+there is no demo host to keep alive.
 
 ```bash
-# Reset the demo instance to zero
-ssh <demo-host> 'cd <demo-compose-dir> && docker compose down -v && docker compose up -d'
+# Reset to zero — `down -v` wipes only this instance's volumes
+docker compose -f docker-compose.docs.yml down -v
+docker compose -f docker-compose.docs.yml up -d
 
-# Wait for the wizard to come up, create an admin via the UI, then:
-TOKEN=$(curl -s -X POST http://<demo-host>:3001/api/v1/auth/login \
+# Wait for the API, then create the first admin through the setup wizard
+until curl -sf http://localhost:3001/api/v1/auth/status >/dev/null; do sleep 2; done
+
+TOKEN=$(curl -s -X POST http://localhost:3001/api/v1/auth/login \
   -H "Content-Type: application/json" \
   --data-raw '{"username":"admin","password":"<your-admin-pw>"}' \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['accessToken'])")
 
-curl -X POST http://<demo-host>:3001/api/v1/backup \
+curl -X POST http://localhost:3001/api/v1/backup \
   -H "Authorization: Bearer $TOKEN" \
   -F "file=@docs/fixtures/showroom-fr.zip"
 ```
 
-The instance restarts with the fixture state; integrations stay disabled, so no MQTT or cloud poll runs.
+The instance restarts with the fixture state; integrations stay disabled, so no
+MQTT or cloud poll runs. Tear it down with `down -v` when you are done.
 
 ## When to regenerate
 

--- a/scripts/ops.env.example
+++ b/scripts/ops.env.example
@@ -13,7 +13,5 @@
 SOWEL_PROD_SSH="user@your-prod-host"      # SSH target (key-based auth)
 SOWEL_PROD_HOST="your-prod-host:3000"     # host:port of the Sowel API/UI
 
-# Demo instance used for documentation screenshots (optional)
-SOWEL_DEMO_SSH="user@your-demo-host"
-SOWEL_DEMO_URL="http://your-demo-host:3001"
-SOWEL_DEMO_COMPOSE_DIR="/home/user/sowel-demo"
+# Documentation screenshots need no host here: they are shot on a throwaway
+# Sowel run locally with `docker compose -f docker-compose.docs.yml up -d`.


### PR DESCRIPTION
## What

The screenshot pipeline depended on a Raspberry Pi demo host reached over SSH. That host is gone, and the dependency was a liability anyway: a box kept alive, reachable and up to date for something needed a few times a year meant every screenshot session began by repairing it.

- **`docker-compose.docs.yml`** — a throwaway Sowel on this machine. Port 3001 so a `npm run dev` backend keeps 3000; its own project name and volumes so `down -v` wipes this instance and nothing else; **no Docker socket** (spec 105: the mount grants effective root, and self-update is not needed here). `SOWEL_DOCS_IMAGE` pins a release when documenting one.
- **`sowel-docs` skill** — stage 2 of the pipeline now resets, waits on `/api/v1/auth/status` rather than guessing a delay, restores the fixture and shoots on `localhost:3001`. The rule that matters is unchanged and now easier to obey: never shoot on a real instance.
- **`scripts/ops.env.example`** — the three `SOWEL_DEMO_*` variables go; nothing consumes them any more. `run-swap.sh` and `shadow-deploy.sh` never did.
- **`docs/fixtures/README.md`** — the restore procedure is local, with no host to fill in.

Specs 104 and 119 still name the Pi. They are the record of what happened at the time, not instructions, and rewriting them would be dishonest.

The matching private change (`sowel-ops`: the demo section of `CLAUDE.ops.md`, the three variables in `ops.env`) goes with it.

## Test plan

- [x] `docker compose -f docker-compose.docs.yml config` valid
- [x] `prettier --check`, EN/FR parity, specs index

Docs-Impact: none — the screenshot tooling and its notes; no reader-visible product behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)