### PR TITLE
fix: drop the two remaining per-item process loops in the check scripts

### DIFF
--- a/scripts/check-specs-complete.sh
+++ b/scripts/check-specs-complete.sh
@@ -30,11 +30,16 @@ BASE="$(git merge-base "${BASE_REF}" HEAD)"
 # PR creates. Robust to how the files were added (plain add or rename).
 base_dirs="$(git ls-tree -d --name-only "${BASE}" -- specs/ 2>/dev/null || true)"
 
+# A `printf | grep` per folder is two processes each, ~1.9 s at 175 folders, to
+# answer a set membership question. Flatten once and let the shell match.
+base_flat=" $(printf '%s' "${base_dirs}" | tr '\n' ' ') "
+
 new_dirs=""
 for dir in $(git ls-tree -d --name-only HEAD -- specs/); do
-  if printf '%s\n' "${base_dirs}" | grep -qxF "${dir}"; then
-    continue # folder already existed — not a new feature spec
-  fi
+  case "${base_flat}" in
+    # folder already existed — not a new feature spec
+    *" ${dir} "*) continue ;;
+  esac
   new_dirs="${new_dirs} ${dir}"
 done
 

--- a/scripts/check-specs-index.sh
+++ b/scripts/check-specs-index.sh
@@ -140,12 +140,22 @@ if [ "${MODE}" = "all" ] || [ "${MODE}" = "released" ]; then
   require_file "${INDEX_EN}"
   require_file "${NOTES}"
 
+  # Two passes, not two greps per listed spec. Same reasoning as the folders
+  # assertion above: this is an intersection of two sets, and `all` was still
+  # taking ~1.8 s because this half kept a process per element.
+  # `|| true` on each stage: grep exits 1 on no match, and pipefail would then
+  # kill the script mid-check without printing anything.
+  unreleased="$( { grep -E "${ROW}.*Unreleased" "${INDEX_EN}" || true; } |
+    { grep -oE "${ROW}" || true; } | tr -d '| ')"
+  # `awk '{print $2}'` keeps a letter suffix that a `tr -d` would eat (048a).
+  cited=" $( { grep -oiE "spec [0-9]{3}[a-z]?\b" "${NOTES}" || true; } |
+    awk '{print $2}' | sort -u | tr '\n' ' ') "
+
   stale=""
-  for num in $( { grep -oE "${ROW}" "${INDEX_EN}" || true; } | tr -d '| '); do
-    grep -qE "^\| ${num} \|.*Unreleased" "${INDEX_EN}" || continue
-    if grep -qiE "spec ${num}\b" "${NOTES}"; then
-      stale="${stale} ${num}"
-    fi
+  for num in ${unreleased}; do
+    case "${cited}" in
+      *" ${num} "*) stale="${stale} ${num}" ;;
+    esac
   done
 
   if [ -n "${stale}" ]; then


### PR DESCRIPTION
Follow-up to #917, which fixed one assertion and left two siblings with the same shape. The sweep was prompted by "is it slow anywhere else" — it is, in exactly two more places, and nowhere outside this repository.

## What was slow

- **`check-specs-index.sh` in its default `all` mode**, still ~1.8 s. The `folders` half was fixed in #917; the `released` half ran **two greps per listed spec** — 350 processes — to intersect "rows that say Unreleased" with "specs cited in the release notes".
- **`check-specs-complete.sh`**, ~1.9 s. A `printf | grep` per spec folder to ask whether that folder existed at the merge base, two processes each at 175 folders.

Both are set operations. Neither needs a process per element.

| Script | Before | After |
| --- | --- | --- |
| `check-specs-index.sh` (`all`) | 1.81 s | 0.07 s |
| `check-specs-complete.sh` | 1.87 s | 0.14 s |

One detail worth naming: the cited spec numbers are extracted with `awk '{print $2}'` rather than a `tr -d`, because a `tr -d` of letters would eat the suffix of a spec like `048a` and silently stop matching it.

## Test plan

- [x] The 14 tests in `src/tooling/check-specs-index.test.ts` pass. They cover **both** assertions, including "still refuses a tag whose index claims a shipped spec is unreleased" and the letter-suffix case.
- [x] `check-specs-complete.sh` has no test, so it was verified by hand: a new spec folder holding only `spec.md` is still refused **by name**, and the same folder with all three files passes.
- [x] `npm run validate` green (2501 backend + 1071 UI), pushed through the `pre-push` hook.

## Sweep result

Every other repository was checked. `folio` and `passepartout` have a `release.sh` and nothing of this shape. No other repository has a `scripts/` directory at all. The three showroom repositories carry a copy of `check-specs-index.sh` and `check-specs-complete.sh` and get the same fix in their own pull requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)