### PR TITLE
fix: ask the docker daemon, not the CLI, before falling back to it

### DIFF
--- a/scripts/run-gitleaks.sh
+++ b/scripts/run-gitleaks.sh
@@ -8,6 +8,13 @@
 # Docker image `zricethezav/gitleaks:latest`. If neither is available,
 # prints a hint and exits 0 — security is enforced again by the
 # .github/workflows/gitleaks.yml CI job so the local hook is best-effort.
+#
+# The Docker branch asks the DAEMON, not the CLI. `command -v docker` is true
+# on any machine where Docker Desktop is installed, including when it is not
+# running, so the fallback ran `docker run`, failed to connect, and returned
+# non-zero — turning "best-effort" into "no commit until you start Docker".
+# `docker info` is the cheapest question that actually means "can I run a
+# container right now".
 
 set -euo pipefail
 
@@ -53,7 +60,7 @@ run_docker() {
 
 if command -v gitleaks >/dev/null 2>&1; then
   run_local
-elif command -v docker >/dev/null 2>&1; then
+elif docker info >/dev/null 2>&1; then
   run_docker
 else
   echo "gitleaks: neither the host binary nor Docker is available — skipping scan." >&2


### PR DESCRIPTION
## The bug

`scripts/run-gitleaks.sh` says what it intends to do:

> If neither is available, prints a hint and exits 0 — security is enforced again by the `.github/workflows/gitleaks.yml` CI job so the local hook is best-effort.

It then tested `command -v docker`, which is true on any machine where Docker Desktop is **installed**, including when it is not **running**. So the fallback ran `docker run`, failed with `Cannot connect to the Docker daemon`, and returned non-zero.

The `pre-commit` hook turned "best-effort" into "no commit until you start Docker". Hit while committing on a machine with no `gitleaks` binary and Docker Desktop stopped.

## The fix

Ask the daemon, not the CLI: `docker info` is the cheapest question that actually means "can I run a container right now".

```diff
-elif command -v docker >/dev/null 2>&1; then
+elif docker info >/dev/null 2>&1; then
```

## Test plan

- [x] Daemon stopped, no `gitleaks` binary: the script prints its hint and **exits 0**, so the hook lets the commit through. This commit was made that way — the hook is the test.
- [ ] Daemon running: unchanged code path, not exercised here (no daemon available at the time). The branch body is untouched; only the condition guarding it changed.

CI still runs real gitleaks on every push and pull request, which is where the guarantee actually lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)