### PR TITLE
fix: block the missing .js import extension that only fails at startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ docker compose up -d         # Local docker deployment
 - UUID v4 (`crypto.randomUUID()`) for all entity IDs
 - ISO 8601 dates everywhere
 - All types in `src/shared/types.ts`, discriminated unions for EventBus
+- **Relative imports in `src/` carry an explicit `.js`** (`"./foo.js"`, never `"./foo"`), including `import type`. The backend is `"type": "module"` and runs `node dist/index.js`, so Node ESM demands it — but `moduleResolution: "bundler"` lets `tsc` accept it without, and vitest resolves it too, so a missing extension compiles, lints, passes the whole suite and then throws `ERR_MODULE_NOT_FOUND` at startup. An eslint `no-restricted-syntax` rule blocks it now. The UI is bundled by Vite and is not subject to this.
 
 ### Database
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,36 @@ export default tseslint.config(
       "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
       "@typescript-eslint/no-explicit-any": "warn",
       "no-console": "warn",
+      // The backend is `"type": "module"` and runs `node dist/index.js`, so Node
+      // ESM requires an explicit extension on every relative specifier. But
+      // `moduleResolution: "bundler"` in tsconfig.json lets tsc accept one
+      // without, and vitest resolves it too — so a missing `.js` compiles, lints
+      // and passes the whole suite, then throws ERR_MODULE_NOT_FOUND at startup.
+      // The #923 review caught one that way, by hand, on a shared module the UI
+      // also imports; nothing in CI would have.
+      //
+      // Type-only imports are erased and cannot break startup, and they are
+      // covered anyway: dropping the `type` keyword from an exempt import would
+      // silently arm the failure, which is exactly the edit nobody reviews.
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "ImportDeclaration[source.value=/^\\.\\.?\\//]:not([source.value=/\\.(js|json)$/])",
+          message:
+            'Relative imports need an explicit extension ("./foo.js", not "./foo"): Node ESM refuses it at startup, and tsc under moduleResolution:bundler will not tell you.',
+        },
+        {
+          selector:
+            "ExportNamedDeclaration[source.value=/^\\.\\.?\\//]:not([source.value=/\\.(js|json)$/])",
+          message: 'Relative re-exports need an explicit extension ("./foo.js", not "./foo").',
+        },
+        {
+          selector:
+            "ExportAllDeclaration[source.value=/^\\.\\.?\\//]:not([source.value=/\\.(js|json)$/])",
+          message: 'Relative re-exports need an explicit extension ("./foo.js", not "./foo").',
+        },
+      ],
     },
   },
   {

--- a/src/history/history-query.test.ts
+++ b/src/history/history-query.test.ts
@@ -7,10 +7,10 @@ import {
   querySparkline,
   queryZoneSparkline,
   queryHistorizedAliases,
-} from "./history-query";
-import type { HistoryPoint } from "../shared/types";
-import { createLogger } from "../core/logger";
-import type { InfluxClient } from "../core/influx-client";
+} from "./history-query.js";
+import type { HistoryPoint } from "../shared/types.js";
+import { createLogger } from "../core/logger.js";
+import type { InfluxClient } from "../core/influx-client.js";
 
 const logger = createLogger("silent").logger;
 

--- a/src/shared/local-date.test.ts
+++ b/src/shared/local-date.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { localDateStr } from "./local-date";
+import { localDateStr } from "./local-date.js";
 
 describe("localDateStr", () => {
   it("formats the LOCAL calendar date (zero-padded), not UTC", () => {

--- a/src/shared/order-wire-value.ts
+++ b/src/shared/order-wire-value.ts
@@ -1,4 +1,4 @@
-import type { OrderWireValue } from "./types";
+import type { OrderWireValue } from "./types.js";
 
 /**
  * Wire-value resolution for boolean orders (issue #360).

--- a/src/shared/thermostat-contract.test.ts
+++ b/src/shared/thermostat-contract.test.ts
@@ -6,9 +6,9 @@ import {
   isThermostatCoreAlias,
   isThermostatDevice,
   splitThermostatExtras,
-} from "./thermostat-contract";
-import { computeBindingCandidates } from "./binding-candidates";
-import type { CandidateData, CandidateOrder } from "./binding-candidates";
+} from "./thermostat-contract.js";
+import { computeBindingCandidates } from "./binding-candidates.js";
+import type { CandidateData, CandidateOrder } from "./binding-candidates.js";
 
 // Spec 177 — the thermostat core is declared once; identity and the extras
 // split derive from it. The shapes below mirror what the two plugins Sowel


### PR DESCRIPTION
## The gap

The backend is `"type": "module"` and runs `node dist/index.js`, so Node ESM demands an explicit extension on every relative specifier. But `moduleResolution: "bundler"` in `tsconfig.json` lets `tsc` accept one without, and vitest resolves it too.

So a missing `.js` **compiles, lints, passes 2556 backend tests — and throws `ERR_MODULE_NOT_FOUND` when the container boots.**

The #923 review caught one that way, by hand, on a shared module the UI also imports. Nothing in CI would have, and nothing would have caught the next one.

## The rule

An eslint `no-restricted-syntax` rule refuses a relative `import`, named re-export or `export *` without a `.js` / `.json` extension. No new dependency.

Scoped to `src/`: the UI is bundled by Vite and is not subject to this.

**Type-only imports are covered too**, deliberately. They are erased and cannot break startup, but dropping the `type` keyword from an exempt import would silently arm the failure — and that is exactly the edit nobody reviews.

## Test plan

- [x] The rule **fires on all four offending shapes** — `import`, `import type`, named re-export, `export *` — verified against a probe file.
- [x] It leaves a correct `./foo.js` and a bare `node:fs` alone.
- [x] The nine existing occurrences are fixed (seven in tests, one type-only, none of them live — `main` was not broken).
- [x] `npm run validate` green: 2556 backend, 1109 UI.

The convention is written into `CLAUDE.md` next to the other implementation rules, so an agent reads it before writing the import rather than after the container fails.

Docs-Impact: none — a lint rule and the import extensions it required; no reader-visible behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)