### PR TITLE
fix(api): serve the health detail only to an authenticated caller (#926)

### DIFF
--- a/.claude/skills/sowel-debug/reference.md
+++ b/.claude/skills/sowel-debug/reference.md
@@ -83,8 +83,10 @@ curl -s "http://localhost:3000/api/v1/logs" \
 ## Diagnostic Commands
 
 ```bash
-# Health check
-curl -s http://localhost:3000/api/v1/health | python3 -m json.tool
+# Health check — the token is required for the detail (integrations, device
+# counts, version); without it the endpoint answers liveness only (#926).
+curl -s http://localhost:3000/api/v1/health \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
 
 # Integration status
 curl -s http://localhost:3000/api/v1/integrations \

--- a/docs/technical/api-reference.fr.md
+++ b/docs/technical/api-reference.fr.md
@@ -552,11 +552,34 @@ Backup et restauration complète de la configuration, admin uniquement.
 
 ## Health
 
-Aucune authentification requise.
+Aucune authentification requise, mais la réponse en dépend.
 
-| Method | Path             | Description                                                                                                                              |
-| ------ | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET`  | `/api/v1/health` | Vérification de santé du système. Retourne le statut, l'uptime, les statuts d'intégration, le nombre de devices et la version du moteur. |
+| Method | Path             | Description                                                                                             |
+| ------ | ---------------- | ------------------------------------------------------------------------------------------------------- |
+| `GET`  | `/api/v1/health` | Vérification de santé du système. Répond toujours `200`, jamais `401`. Voir les deux formes ci-dessous. |
+
+**Anonyme** — la vivacité seule, ce dont une sonde de démarrage ou un moniteur d'uptime a besoin :
+
+```json
+{ "status": "ok", "uptime": { "ms": 10212688, "human": "2h 50m" } }
+```
+
+**Authentifié** — envoyez un JWT ou un token d'API dans l'en-tête `Authorization` pour obtenir en
+plus les statuts d'intégration, le nombre de devices et la version du moteur :
+
+```json
+{
+  "status": "ok",
+  "uptime": { "ms": 10212688, "human": "2h 50m" },
+  "integrations": { "zigbee2mqtt": { "status": "connected" } },
+  "devices": { "total": 110, "online": 100, "offline": 4, "unknown": 6 },
+  "version": "1.69.0"
+}
+```
+
+La version du moteur et la liste des plugins installés sont du matériau de reconnaissance, elles ne
+sont donc pas servies anonymement (issue #926). Un token absent, malformé ou expiré retombe sur la
+forme anonyme au lieu d'échouer : un moniteur n'est jamais cassé par un identifiant périmé.
 
 ---
 

--- a/docs/technical/api-reference.md
+++ b/docs/technical/api-reference.md
@@ -636,11 +636,34 @@ Admin-only full configuration backup and restore.
 
 ## Health
 
-No authentication required.
+No authentication required, but the payload depends on it.
 
-| Method | Path             | Description                                                                                           |
-| ------ | ---------------- | ----------------------------------------------------------------------------------------------------- |
-| `GET`  | `/api/v1/health` | System health check. Returns status, uptime, integration statuses, device counts, and engine version. |
+| Method | Path             | Description                                                                       |
+| ------ | ---------------- | --------------------------------------------------------------------------------- |
+| `GET`  | `/api/v1/health` | System health check. Always answers `200`, never `401`. See the two shapes below. |
+
+**Anonymous** — liveness only, which is what a readiness probe or an uptime monitor needs:
+
+```json
+{ "status": "ok", "uptime": { "ms": 10212688, "human": "2h 50m" } }
+```
+
+**Authenticated** — send a JWT or an API token in the `Authorization` header to also get the
+integration statuses, the device counts and the engine version:
+
+```json
+{
+  "status": "ok",
+  "uptime": { "ms": 10212688, "human": "2h 50m" },
+  "integrations": { "zigbee2mqtt": { "status": "connected" } },
+  "devices": { "total": 110, "online": 100, "offline": 4, "unknown": 6 },
+  "version": "1.69.0"
+}
+```
+
+The engine version and the installed plugin list are reconnaissance material, so they are not
+served anonymously (issue #926). A token that is absent, malformed or expired degrades to the
+anonymous shape rather than failing, so a monitor is never broken by a stale credential.
 
 ---
 

--- a/docs/technical/deployment.fr.md
+++ b/docs/technical/deployment.fr.md
@@ -103,10 +103,12 @@ docker logs -f sowel          # live logs from stdout
 docker logs --tail 100 sowel  # last 100 lines
 ```
 
-Ou via l'API :
+Ou via l'API. En anonyme, seule la vivacité est retournée ; passez un token pour obtenir en plus
+les statuts d'intégration, le nombre de devices et la version du moteur :
 
 ```bash
 curl -s http://localhost:3000/api/v1/health | jq
+curl -s -H "Authorization: Bearer $SOWEL_TOKEN" http://localhost:3000/api/v1/health | jq
 ```
 
 ### Redémarrer

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -109,10 +109,12 @@ docker logs -f sowel          # live logs from stdout
 docker logs --tail 100 sowel  # last 100 lines
 ```
 
-Or via the API:
+Or via the API. Anonymously this reports liveness only; pass a token to also get the
+integration statuses, the device counts and the engine version:
 
 ```bash
 curl -s http://localhost:3000/api/v1/health | jq
+curl -s -H "Authorization: Bearer $SOWEL_TOKEN" http://localhost:3000/api/v1/health | jq
 ```
 
 ### Restart

--- a/src/api/routes/health.test.ts
+++ b/src/api/routes/health.test.ts
@@ -1,0 +1,99 @@
+import Fastify from "fastify";
+import { describe, it, expect } from "vitest";
+import { createLogger } from "../../core/logger.js";
+import { registerHealthRoutes } from "./health.js";
+import type { JwtPayload } from "../../auth/auth-service.js";
+
+// Issue #926 — `/api/v1/health` stays in PUBLIC_ROUTES so readiness probes and
+// uptime monitors keep working without credentials, but the reconnaissance
+// material (engine version, installed plugin list, device counts) is served
+// only to an authenticated caller. The auth middleware skips public routes
+// entirely, so the route resolves the bearer token itself.
+
+const logger = createLogger("silent").logger;
+
+const ADMIN: JwtPayload = { userId: "u1", role: "admin" } as JwtPayload;
+
+/** Accepts exactly one JWT ("good-jwt") and one API token ("swl_good"). */
+const authService = {
+  verifyAccessToken: (token: string): JwtPayload => {
+    if (token !== "good-jwt") throw new Error("invalid or expired");
+    return ADMIN;
+  },
+  verifyApiToken: (token: string): JwtPayload | null => (token === "swl_good" ? ADMIN : null),
+} as never;
+
+function buildApp() {
+  const app = Fastify({ logger: false });
+  registerHealthRoutes(app, {
+    deviceManager: {
+      getStatusCounts: () => ({ online: 100, offline: 4, unknown: 6 }),
+      getDeviceCount: () => 110,
+    } as never,
+    integrationRegistry: {
+      getAllInfo: () => [
+        { id: "zigbee2mqtt", status: "connected" },
+        { id: "somfy-rts", status: "connected" },
+      ],
+    } as never,
+    authService,
+    logger,
+  });
+  return app;
+}
+
+async function get(headers?: Record<string, string>) {
+  const app = buildApp();
+  const res = await app.inject({ method: "GET", url: "/api/v1/health", headers });
+  await app.close();
+  return res;
+}
+
+describe("GET /api/v1/health", () => {
+  it("answers an anonymous caller with liveness only", async () => {
+    const res = await get();
+    expect(res.statusCode).toBe(200);
+
+    const body = res.json();
+    expect(body.status).toBe("ok");
+    expect(body.uptime).toMatchObject({ ms: expect.any(Number), human: expect.any(String) });
+
+    // The three fields the issue is about. A leaked version pins the instance
+    // to an exact release; the plugin ids reveal the protocols in play.
+    expect(body).not.toHaveProperty("version");
+    expect(body).not.toHaveProperty("integrations");
+    expect(body).not.toHaveProperty("devices");
+  });
+
+  it("serves the full payload to a JWT caller", async () => {
+    const res = await get({ authorization: "Bearer good-jwt" });
+    expect(res.statusCode).toBe(200);
+
+    const body = res.json();
+    expect(body.status).toBe("ok");
+    expect(body.version).toEqual(expect.any(String));
+    expect(body.integrations).toEqual({
+      zigbee2mqtt: { status: "connected" },
+      "somfy-rts": { status: "connected" },
+    });
+    expect(body.devices).toEqual({ total: 110, online: 100, offline: 4, unknown: 6 });
+  });
+
+  it("serves the full payload to an API-token caller", async () => {
+    const res = await get({ authorization: "Bearer swl_good" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().integrations).toHaveProperty("zigbee2mqtt");
+  });
+
+  // A monitor configured with a token that later expires must keep reporting
+  // the instance as up, so a bad token degrades to anonymous, never to a 401.
+  it.each([
+    ["an expired JWT", "Bearer stale-jwt"],
+    ["a revoked API token", "Bearer swl_revoked"],
+    ["a malformed header", "good-jwt"],
+  ])("degrades to liveness for %s instead of rejecting", async (_label, authorization) => {
+    const res = await get({ authorization });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).not.toHaveProperty("version");
+  });
+});

--- a/src/api/routes/health.ts
+++ b/src/api/routes/health.ts
@@ -3,6 +3,8 @@ import { resolve } from "node:path";
 import type { FastifyInstance } from "fastify";
 import type { DeviceManager } from "../../devices/device-manager.js";
 import type { IntegrationRegistry } from "../../integrations/integration-registry.js";
+import type { AuthService } from "../../auth/auth-service.js";
+import { optionalAuth } from "../../auth/auth-middleware.js";
 import type { Logger } from "../../core/logger.js";
 
 const pkg = JSON.parse(
@@ -12,33 +14,49 @@ const pkg = JSON.parse(
 interface HealthDeps {
   deviceManager: DeviceManager;
   integrationRegistry: IntegrationRegistry;
+  authService: AuthService;
   logger: Logger;
 }
 
 const startTime = Date.now();
 
 export function registerHealthRoutes(app: FastifyInstance, deps: HealthDeps): void {
-  const { deviceManager, integrationRegistry } = deps;
+  const { deviceManager, integrationRegistry, authService } = deps;
 
-  app.get("/api/v1/health", async () => {
-    const statusCounts = deviceManager.getStatusCounts();
-    const totalDevices = deviceManager.getDeviceCount();
+  // The route stays in PUBLIC_ROUTES: `scripts/install.sh` polls it to decide
+  // when a fresh stack is ready, and uptime monitors need it to answer without
+  // credentials. What varies is the payload, not the access (issue #926).
+  //
+  // Anonymously it reports liveness and nothing else. The engine version, the
+  // installed plugin list and the device counts are reconnaissance material —
+  // the version pins the instance to an exact release, the plugin ids reveal
+  // which protocols and vendor clouds are in play — so they are served only to
+  // a caller that proves it is already inside.
+  app.get("/api/v1/health", async (request) => {
     const uptimeMs = Date.now() - startTime;
+    const liveness = {
+      status: "ok",
+      uptime: {
+        ms: uptimeMs,
+        human: formatUptime(uptimeMs),
+      },
+    };
 
+    // Never rejects: an absent, malformed or expired token yields the anonymous
+    // payload rather than a 401, so a monitor is not broken by a stale token.
+    if (!optionalAuth(request, authService)) return liveness;
+
+    const statusCounts = deviceManager.getStatusCounts();
     const integrations: Record<string, { status: string }> = {};
     for (const info of integrationRegistry.getAllInfo()) {
       integrations[info.id] = { status: info.status };
     }
 
     return {
-      status: "ok",
-      uptime: {
-        ms: uptimeMs,
-        human: formatUptime(uptimeMs),
-      },
+      ...liveness,
       integrations,
       devices: {
-        total: totalDevices,
+        total: deviceManager.getDeviceCount(),
         online: statusCounts.online ?? 0,
         offline: statusCounts.offline ?? 0,
         unknown: statusCounts.unknown ?? 0,

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -321,7 +321,7 @@ export async function createServer(deps: ServerDeps) {
   app.get("/api/v1/openapi.json", async () => app.swagger());
 
   // Register routes
-  registerHealthRoutes(app, { deviceManager, integrationRegistry, logger });
+  registerHealthRoutes(app, { deviceManager, integrationRegistry, authService, logger });
   registerAuthRoutes(app, { authService, userManager, auditLogger, logger });
   registerMeRoutes(app, { authService, mfaService, userManager, auditLogger, logger });
   registerMfaRoutes(app, { authService, mfaService, userManager, auditLogger, logger });

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { WebSocket } from "ws";
 import type { EventBus } from "../core/event-bus.js";
 import type { AuthService } from "../auth/auth-service.js";
+import { verifyBearerToken } from "../auth/auth-middleware.js";
 import type { LogRingBuffer } from "../core/log-buffer.js";
 import type { Logger } from "../core/logger.js";
 import type { EngineEvent, UserRole } from "../shared/types.js";
@@ -374,22 +375,15 @@ export function registerWebSocket(app: FastifyInstance, deps: WebSocketDeps): vo
       return;
     }
 
-    let role: UserRole;
-    try {
-      if (token.startsWith("swl_") || token.startsWith("wch_") || token.startsWith("cbl_")) {
-        const result = authService.verifyApiToken(token);
-        if (!result) {
-          socket.close(4001, "Invalid token");
-          return;
-        }
-        role = result.role;
-      } else {
-        role = authService.verifyAccessToken(token).role;
-      }
-    } catch {
+    // Both failure paths close the same way, so the shared verification covers
+    // this handshake as it does the HTTP middleware — one place knows which
+    // prefixes name an API token (#926).
+    const verified = verifyBearerToken(token, authService);
+    if (!verified.ok) {
       socket.close(4001, "Invalid token");
       return;
     }
+    const role: UserRole = verified.payload.role;
 
     // Default subscription: system events only
     const state: ClientState = { socket, role, topics: new Set(["system"]), pending: [] };

--- a/src/auth/auth-middleware.test.ts
+++ b/src/auth/auth-middleware.test.ts
@@ -89,7 +89,10 @@ describe("auth-middleware", () => {
         logger,
       });
       // Fake protected route
-      app.get("/api/v1/test", async (req: FastifyRequest) => ({ auth: req.auth }));
+      app.get("/api/v1/test", async (req: FastifyRequest) => ({
+        auth: req.auth,
+        kind: req.tokenKind,
+      }));
       app.get("/api/v1/health", async () => ({ status: "ok" }));
       app.post("/api/v1/auth/setup", async () => ({ ok: true }));
       app.get("/non-api/foo", async () => ({ ok: true }));
@@ -136,6 +139,46 @@ describe("auth-middleware", () => {
         headers: { authorization: "Bearer swl_deadbeef" },
       });
       expect(res.statusCode).toBe(401);
+    });
+
+    // Characterization (#926): the token verification moved into the shared
+    // `verifyBearerToken`, used by this middleware, the WebSocket handshake and
+    // the public health route. The middleware is the only caller that turns a
+    // failure into a message, and it distinguishes two — nothing asserted that
+    // before, so collapsing them would have gone unnoticed.
+    it("keeps the two 401 messages distinct", async () => {
+      vi.mocked(mockAuthService.verifyApiToken).mockReturnValue(null);
+      const apiToken = await app.inject({
+        method: "GET",
+        url: "/api/v1/test",
+        headers: { authorization: "Bearer swl_deadbeef" },
+      });
+      expect(apiToken.json()).toEqual({ error: "Invalid API token" });
+
+      vi.mocked(mockAuthService.verifyAccessToken).mockImplementation(() => {
+        throw new Error("jwt expired");
+      });
+      const jwt = await app.inject({
+        method: "GET",
+        url: "/api/v1/test",
+        headers: { authorization: "Bearer header.payload.signature" },
+      });
+      expect(jwt.json()).toEqual({ error: "Invalid or expired token" });
+    });
+
+    // Spec 113 — the audit logger reads `tokenKind` to record how a mutation
+    // was authenticated, so it must survive the extraction.
+    it.each([
+      ["jwt", "Bearer header.payload.signature"],
+      ["api_token", "Bearer swl_live"],
+    ])("records tokenKind %s", async (kind, authorization) => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/test",
+        headers: { authorization },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().kind).toBe(kind);
     });
 
     it("accepts valid JWT and populates request.auth", async () => {

--- a/src/auth/auth-middleware.ts
+++ b/src/auth/auth-middleware.ts
@@ -39,6 +39,48 @@ export function isPublicRoute(url: string): boolean {
 }
 
 // ============================================================
+// Bearer token verification
+// ============================================================
+
+export type BearerVerification =
+  | { ok: true; payload: JwtPayload; kind: "jwt" | "api_token" }
+  | { ok: false; reason: "invalid_api_token" | "invalid_token" };
+
+/**
+ * Verify a raw bearer token value (the part after `Bearer `).
+ *
+ * Shared by the auth middleware, which turns a failure into a 401, and by the
+ * public routes that vary their payload with authentication instead of
+ * rejecting (issue #926) — the middleware skips `PUBLIC_ROUTES` entirely, so
+ * `request.auth` is never populated for them.
+ */
+export function verifyBearerToken(token: string, authService: AuthService): BearerVerification {
+  try {
+    // API token (swl_ = current, wch_ and cbl_ = legacy)
+    if (token.startsWith("swl_") || token.startsWith("wch_") || token.startsWith("cbl_")) {
+      const payload = authService.verifyApiToken(token);
+      if (!payload) return { ok: false, reason: "invalid_api_token" };
+      return { ok: true, payload, kind: "api_token" };
+    }
+    return { ok: true, payload: authService.verifyAccessToken(token), kind: "jwt" };
+  } catch {
+    return { ok: false, reason: "invalid_token" };
+  }
+}
+
+/**
+ * Resolve the caller of a public route, without ever rejecting the request.
+ * Returns null when no bearer header is present or the token does not verify.
+ */
+export function optionalAuth(request: FastifyRequest, authService: AuthService): JwtPayload | null {
+  const header = request.headers.authorization;
+  if (!header || !header.startsWith("Bearer ")) return null;
+
+  const result = verifyBearerToken(header.slice(7), authService);
+  return result.ok ? result.payload : null;
+}
+
+// ============================================================
 // Role gate (spec 131): config is admin-only, standard = usage
 // ============================================================
 
@@ -154,29 +196,16 @@ export function registerAuthMiddleware(
       return reply.code(401).send({ error: "Authentication required" });
     }
 
-    const token = authHeader.slice(7);
+    const result = verifyBearerToken(authHeader.slice(7), authService);
 
-    try {
-      let payload: JwtPayload;
-
-      if (token.startsWith("swl_") || token.startsWith("wch_") || token.startsWith("cbl_")) {
-        // API token (swl_ = current, wch_ and cbl_ = legacy)
-        const result = authService.verifyApiToken(token);
-        if (!result) {
-          return reply.code(401).send({ error: "Invalid API token" });
-        }
-        payload = result;
-        request.tokenKind = "api_token";
-      } else {
-        // JWT
-        payload = authService.verifyAccessToken(token);
-        request.tokenKind = "jwt";
-      }
-
-      request.auth = payload;
-    } catch {
-      return reply.code(401).send({ error: "Invalid or expired token" });
+    if (!result.ok) {
+      const error =
+        result.reason === "invalid_api_token" ? "Invalid API token" : "Invalid or expired token";
+      return reply.code(401).send({ error });
     }
+
+    request.tokenKind = result.kind;
+    request.auth = result.payload;
 
     // Role gate (spec 131): a non-admin may only run the allowlisted usage
     // mutations (actuate + own account); every other write is admin-only.

--- a/ui/src/api/system.ts
+++ b/ui/src/api/system.ts
@@ -174,3 +174,19 @@ export async function setLogLevel(level: LogLevel): Promise<{ level: string; pre
     body: JSON.stringify({ level }),
   });
 }
+
+/**
+ * Engine health. The detailed payload (integrations, device counts, version)
+ * is served only to an authenticated caller since issue #926, so this goes
+ * through `fetchJSON` and not the public wrapper. An anonymous call still
+ * succeeds, it just returns liveness alone.
+ */
+export async function getHealth(): Promise<{
+  status: string;
+  uptime: { ms: number; human: string };
+  integrations?: Record<string, { status: string }>;
+  devices?: { total: number; online: number; offline: number; unknown: number };
+  version?: string;
+}> {
+  return fetchJSON(`${API_BASE}/health`);
+}

--- a/ui/src/store/useWebSocket.test.ts
+++ b/ui/src/store/useWebSocket.test.ts
@@ -227,6 +227,34 @@ describe("connect", () => {
     expect(s.alarms.size).toBe(0);
   });
 
+  it("on open: keeps the known statuses when health answers without integrations (#926)", async () => {
+    // An access token expired past its 15 min TTL now gets the anonymous
+    // payload as a plain 200, not a 401, so `fetchJSON` has nothing to refresh
+    // on. Treating that silence as "nothing is failing" wiped the statuses
+    // `useAggregatedIssues` renders, hiding a live integration failure.
+    api.getHealth.mockResolvedValue({
+      integrations: { zigbee2mqtt: { status: "connected" }, panasonic: { status: "error" } },
+    });
+    const first = connect();
+    first.simulateOpen();
+    await vi.waitFor(() => {
+      expect(useWebSocket.getState().integrationStatuses.panasonic).toBe("error");
+    });
+
+    // Liveness only — the anonymous shape. The battery alert is the observable
+    // proof that the second snapshot was applied: waiting on the call alone
+    // would assert before the `set()` in the `.then()` had run.
+    api.getHealth.mockResolvedValue({ status: "ok", uptime: { ms: 1, human: "1s" } });
+    api.getBatteryAlerts.mockResolvedValue([
+      { deviceDataId: "dd-9", deviceName: "Capteur", value: "5", equipmentNames: [] },
+    ]);
+    const second = connect();
+    second.simulateOpen();
+
+    await vi.waitFor(() => expect(useWebSocket.getState().alarms.size).toBe(1));
+    expect(useWebSocket.getState().integrationStatuses.panasonic).toBe("error");
+  });
+
   it("on open: restores a battery banner headlined by the equipment name (spec 143/#472)", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => ({ json: async () => ({}) })));
     api.getBatteryAlerts.mockResolvedValue([

--- a/ui/src/store/useWebSocket.test.ts
+++ b/ui/src/store/useWebSocket.test.ts
@@ -52,6 +52,9 @@ vi.mock("./useArbiter", () => ({ useArbiter: { getState: () => S.arbiter } }));
 const api = vi.hoisted(() => ({
   getBatteryAlerts: vi.fn(async () => [] as unknown[]),
   getPvHealthAlerts: vi.fn(async () => [] as unknown[]),
+  // Issue #926 — the integration map is behind authentication now, so the
+  // banner restore goes through the api client instead of a bare fetch.
+  getHealth: vi.fn(async () => ({}) as Record<string, unknown>),
 }));
 vi.mock("../api", () => api);
 
@@ -204,18 +207,13 @@ describe("connect", () => {
   });
 
   it("on open: restores integration statuses, without a second alarm for the same failure", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => ({
-        json: async () => ({
-          integrations: { zigbee2mqtt: { status: "connected" }, panasonic: { status: "error" } },
-        }),
-      })),
-    );
+    api.getHealth.mockResolvedValue({
+      integrations: { zigbee2mqtt: { status: "connected" }, panasonic: { status: "error" } },
+    });
     const ws = connect();
     ws.simulateOpen();
 
-    // The health handler resolves through a fetch().then().then() chain.
+    // The health snapshot resolves asynchronously, inside a Promise.all.
     await vi.waitFor(() => {
       expect(useWebSocket.getState().integrationStatuses.zigbee2mqtt).toBe("connected");
     });

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -533,7 +533,14 @@ export const useWebSocket = create<WebSocketState>((set) => ({
             alarms.set(`${PV_HEALTH_ALARM_PREFIX}${alert.equipmentId}`, pvHealthAlarm(alert));
           }
 
-          set({ integrationStatuses: statuses, alarms });
+          // A health snapshot without `integrations` is not "no integration is
+          // failing", it is "this snapshot does not know" — the anonymous
+          // payload (issue #926), which a token expired past its 15 min TTL
+          // now yields as a plain 200. `fetchJSON` only refreshes on a 401, so
+          // there is nothing to retry here, and overwriting would wipe the
+          // statuses that `useAggregatedIssues` renders as the visible issue.
+          // Keep what we had and let the WS events correct it.
+          set(health.integrations ? { integrationStatuses: statuses, alarms } : { alarms });
         })
         .catch(() => {
           // Ignore — will be updated by WS events

--- a/ui/src/store/useWebSocket.ts
+++ b/ui/src/store/useWebSocket.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { BatteryAlert, EngineEvent } from "../types";
-import { getBatteryAlerts, getPvHealthAlerts, type PvHealthAlert } from "../api";
+import { getBatteryAlerts, getHealth, getPvHealthAlerts, type PvHealthAlert } from "../api";
 import { dayParam, type AlarmWording } from "../lib/alarm-message";
 import { useDevices } from "./useDevices";
 import { useZones } from "./useZones";
@@ -500,9 +500,10 @@ export const useWebSocket = create<WebSocketState>((set) => ({
       // the low-battery alerts (spec 143), which outlive both a page reload and
       // a Sowel restart. Resolved together so neither clobbers the other.
       Promise.all([
-        fetch("/api/v1/health")
-          .then((r) => r.json() as Promise<{ integrations?: Record<string, { status: string }> }>)
-          .catch(() => ({}) as { integrations?: Record<string, { status: string }> }),
+        // Authenticated (issue #926): the `integrations` map is served only to
+        // a caller carrying a token, so a bare `fetch` would silently restore
+        // an empty banner.
+        getHealth().catch(() => ({}) as { integrations?: Record<string, { status: string }> }),
         fetchBatteryAlerts(),
         // Spec 162 — standing PV health alerts. Raised exactly once and then
         // persisted server-side, so a session opened after the raise (or after


### PR DESCRIPTION
## The leak

`/api/v1/health` sits in `PUBLIC_ROUTES` and its handler applied no authentication check, so an anonymous caller received the full engine inventory:

```console
$ curl -s https://<instance>/api/v1/health
{"status":"ok","uptime":{"ms":10212688,"human":"2h 50m"},
 "integrations":{"smartthings":{"status":"connected"},"somfy-rts":{"status":"connected"}, ...},
 "devices":{"total":110,"online":100,"offline":4,"unknown":6},
 "version":"1.69.0"}
```

The version pins an instance to an exact release, and the plugin ids say which protocols and vendor clouds are in play. Found by a black-box scan of a live instance.

## The design

The route stays public and still always answers `200`, because `scripts/install.sh` polls it to decide when a fresh stack is ready and uptime monitors need it without credentials. What varies is the payload:

| Caller | Gets |
|---|---|
| Anonymous | `status`, `uptime` |
| Valid JWT or API token | the full payload, unchanged |

A token that is absent, malformed or expired **degrades to the anonymous payload and never yields a 401**, so a monitor is not broken by a stale credential.

The auth middleware skips `PUBLIC_ROUTES` entirely and never populates `request.auth`, so the route has to resolve the bearer token itself. Rather than restate the middleware's prefix logic, verification is extracted into `verifyBearerToken`, with `optionalAuth` layered on top. The WebSocket handshake held a third copy of the same logic and now uses it too, so there is one place that knows which prefixes name an API token.

## The regression the review caught

The first commit broke what it set out to protect, and the second fixes it.

The UI rebuilds its alarm banner from `health.integrations` after each WebSocket reconnect. Moving that call onto the authenticated client was necessary, but a token expired past its 15 minute TTL now returns a plain `200` with no `integrations` key, and `fetchJSON` refreshes on a `401` alone, so nothing retried. The banner treated that silence as "nothing is failing" and wiped the statuses that `useAggregatedIssues` renders.

The window is real rather than theoretical: the WebSocket handshake completes before the route handler closes with 4001, so `onopen` has already fired, and every sibling call in the same `Promise.all` gets a 401 and recovers where this one could not. A snapshot without `integrations` is now left alone for the live events to correct.

## Tests

- `src/api/routes/health.test.ts` — the anonymous shape, both authenticated token kinds, and the three degrade-to-anonymous paths. Four of its six cases fail against the previous handler.
- `ui/src/store/useWebSocket.test.ts` — the banner restore keeps known statuses when health omits them. Fails against the first commit. The existing restore test now exercises the authenticated client and still fails against a bare unauthenticated `fetch`.
- `src/auth/auth-middleware.test.ts` — characterization for the extraction: the two distinct 401 messages and the spec 113 `tokenKind` the audit logger reads. Nothing asserted either before, so collapsing them would have gone unnoticed.

Full backend and UI suites pass. The `reset-mfa-cli` / `user-manager` timeouts seen under parallel load reproduce identically on `main` and pass in isolation.

## Docs

`api-reference` and `deployment` updated in both languages, with the two payload shapes spelled out. The `sowel-debug` skill curled health without a token, so the command an agent runs to read integration statuses would have returned none; fixed, and noted here because it lives outside `docs/` where no parity check would have caught it.

Closes #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)
