### PR TITLE
ci: pin GitHub-owned actions by SHA, as third-party actions already are (#927)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
     name: Backend (lint, typecheck, test)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm
@@ -53,8 +53,8 @@ jobs:
     name: Frontend (lint, typecheck, build)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm
@@ -73,7 +73,7 @@ jobs:
     name: Specs completeness
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0 # need main's history for the merge-base diff
       - name: Every new spec folder has spec.md + architecture.md + plan.md
@@ -87,7 +87,7 @@ jobs:
     # the rest of docs/, at the moment the author still has the context: in the
     # PR, not at the tag where sixteen commits have to be reconstructed.
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0 # need main's history for the merge-base diff
       - name: EN/FR pages move together
@@ -111,7 +111,7 @@ jobs:
     # the CDN has caught up. Exits immediately on a PR that leaves the registry
     # alone, so it costs nothing to the other 99% of pull requests.
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0 # need main's history for the merge-base diff
       - name: A bumped entry matches its published release

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,10 +34,10 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -47,6 +47,6 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,9 +21,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.12'
 
@@ -34,7 +34,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: site/
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,7 +19,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Full history so gitleaks can scan more than HEAD on push.
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Check release-notes entry
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -93,9 +93,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm
@@ -126,7 +126,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
@@ -211,7 +211,7 @@ jobs:
       packages: write
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
@@ -366,7 +366,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -423,7 +423,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
         with:
           package-name: sowel
           package-type: container


### PR DESCRIPTION
## What this changes

All 22 remaining `uses:` references now carry a commit SHA and a trailing comment naming the tag it resolved from, matching the style the repository already used.

| Action | Refs | Pinned to |
|---|---|---|
| `actions/checkout` | 13 | `3d3c42e5` # v7 |
| `actions/setup-node` | 3 | `82076278` # v7 |
| `github/codeql-action/{init,analyze}` | 2 | `cdf488f5` # v4 |
| `actions/setup-python` | 1 | `5fda3b95` # v7 |
| `actions/upload-pages-artifact` | 1 | `fc324d35` # v5 |
| `actions/deploy-pages` | 1 | `368f8252` # v5 |
| `actions/delete-package-versions` | 1 | `e5bc658c` # v5 |

## Why

This was not an oversight so much as an unwritten rule. Every **third-party** action here was already pinned by SHA (gitleaks, the three `docker/*` actions); everything left on a floating tag belonged to a GitHub-owned org. That split is defensible, but it was implicit, and an implicit exemption is indistinguishable from a gap. This settles it in the stricter direction.

A tag is a mutable pointer: `@v7` resolves to whatever commit the owner has it pointing at *when the workflow runs*, so pinning that way names code rather than pinning it. The blast radius is concrete here. `release.yml` checks out through `actions/checkout` in jobs that also authenticate to ghcr.io through `docker/login-action`, so code substituted under a moved tag would execute holding registry push credentials, which is the position needed to publish a poisoned `ghcr.io/mchacher/sowel` image to every installation.

It is the same threat model spec 089 already applies to plugin distribution, where a `sha256` is mandatory for every registry entry and a mismatched tarball is refused, precisely because a version number is not a content guarantee. A commit SHA is that guarantee for a workflow dependency.

The realistic likelihood remains low for actions published by GitHub itself. The argument for doing it anyway is that the rule now holds without exceptions, so the next reviewer does not have to work out which half of the file is intentional.

## Verification

- Each SHA was resolved through the GitHub API, then **verified back against its tag after rewriting**, including the three pins that already existed. All 12 distinct references match.
- No `uses:` reference resolves to a mutable tag any more.
- All five workflow files still parse as YAML with their job counts unchanged.
- The rewrite only touched `uses:` lines that were not already pinned, so the existing pins and their comments are untouched.

## Dependabot

Already configured for the `github-actions` ecosystem, weekly and grouped into a single PR. Dependabot updates SHA pins in place and keeps the version comment, so the pins will not go stale. No change needed.

Closes #927

🤖 Generated with [Claude Code](https://claude.com/claude-code)
