### PR TITLE
fix(ui): keep the sensor readings whole on a narrow tile

### DIFF
--- a/ui/src/components/dashboard/EquipmentWidget.test.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.test.tsx
@@ -52,6 +52,33 @@ function makeEquipment(over: Partial<EquipmentWithDetails> = {}): EquipmentWithD
   };
 }
 
+function tempSensor(): EquipmentWithDetails {
+  return makeEquipment({
+    id: "eq-2",
+    name: "Temperature",
+    type: "sensor",
+    orderBindings: [],
+    dataBindings: [
+      {
+        id: "db-2",
+        equipmentId: "eq-2",
+        deviceDataId: "dd-2",
+        alias: "temperature",
+        deviceId: "dev-2",
+        deviceName: "Sensor",
+        key: "temperature",
+        type: "number",
+        category: "temperature",
+        value: 21.5,
+        unit: "°C",
+        lastUpdated: "2026-01-01T00:00:00Z",
+        lastChanged: "2026-01-01T00:00:00Z",
+        stale: false,
+      },
+    ] as EquipmentWithDetails["dataBindings"],
+  });
+}
+
 function makeWidget(over: Partial<DashboardWidget> = {}): DashboardWidget {
   return {
     id: "w-1",
@@ -104,38 +131,40 @@ describe("EquipmentWidget", () => {
   });
 
   it("dispatches another category (sensor) without crashing and shows its label", () => {
-    const sensor = makeEquipment({
-      id: "eq-2",
-      name: "Temperature",
-      type: "sensor",
-      orderBindings: [],
-      dataBindings: [
-        {
-          id: "db-2",
-          equipmentId: "eq-2",
-          deviceDataId: "dd-2",
-          alias: "temperature",
-          deviceId: "dev-2",
-          deviceName: "Sensor",
-          key: "temperature",
-          type: "number",
-          category: "temperature",
-          value: 21.5,
-          unit: "°C",
-          lastUpdated: "2026-01-01T00:00:00Z",
-          lastChanged: "2026-01-01T00:00:00Z",
-          stale: false,
-        },
-      ] as EquipmentWithDetails["dataBindings"],
-    });
     render(
       <EquipmentWidget
         widget={makeWidget({ equipmentId: "eq-2", label: "Living room temp" })}
-        equipment={sensor}
+        equipment={tempSensor()}
         onExecuteOrder={vi.fn()}
       />,
     );
     expect(screen.getByText("Living room temp")).toBeTruthy();
+  });
+
+  it("never lets the readings be the column that gives ground", () => {
+    // There is no layout engine here, so what is pinned is the rule the fix
+    // rests on. Measured in a browser on a 224 px card: the readings needed
+    // 51 px and their `1fr` track handed them 39, because an item that
+    // scrolls has an automatic minimum size of zero — "16.8°C" was cut and a
+    // scrollbar appeared under it. `min-w-fit` gives the minimum back, and
+    // the picto may scale down to 72 px, so the empty spacer yields first and
+    // the drawing second.
+    const { container } = render(
+      <EquipmentWidget
+        widget={makeWidget({ equipmentId: "eq-2" })}
+        equipment={tempSensor()}
+        onExecuteOrder={vi.fn()}
+      />,
+    );
+
+    const zone2 = container.querySelector(".grid");
+    const readings = zone2?.lastElementChild;
+    expect(readings?.className).toContain("min-w-fit");
+    expect(readings?.className).toContain("overflow-x-hidden");
+
+    const picto = zone2?.children[1];
+    expect(picto?.className).toContain("min-w-[72px]");
+    expect(picto?.className).toContain("[&>svg]:max-w-full");
   });
 
   // Spec 139 — two widgets on homonym equipments are told apart by their zone,

--- a/ui/src/components/dashboard/EquipmentWidget.tsx
+++ b/ui/src/components/dashboard/EquipmentWidget.tsx
@@ -1106,11 +1106,24 @@ function SensorEquipmentWidget({
 
   return (
     <WidgetCard label={label} sublabel={sublabel}>
-      {/* Zone 2: Picto + État — centered vertically (no bottom controls) */}
+      {/* Zone 2: Picto + État — centered vertically (no bottom controls).
+       *
+       * The readings, unlike the one short word the other tiles put in this
+       * track, need a real width, and `overflow-y-auto` was quietly taking it
+       * away: an item that scrolls has an automatic minimum size of zero, so
+       * the track collapsed to its `1fr` share. Measured on a 224 px card:
+       * 39 px of empty spacer, 120 px of picto, 39 px left for a column that
+       * needed 51 — "16.8°C" was cut, and the horizontal axis (`visible`
+       * beside a scrollable one, so `auto`) grew a scrollbar to say so.
+       *
+       * `min-w-fit` gives the column its minimum back, and the picto may now
+       * scale down to 72 px. The empty spacer therefore yields first, the
+       * drawing slides left and shrinks next, and the readings are the last
+       * thing on the tile to lose any ground. */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center flex-1 min-h-0">
         <div />
-        {sensorIcon}
-        <div className="flex flex-col items-start pl-2 overflow-y-auto max-h-full">
+        <div className="min-w-[72px] [&>svg]:max-w-full [&>svg]:h-auto">{sensorIcon}</div>
+        <div className="flex flex-col items-start pl-2 min-w-fit max-h-full overflow-y-auto overflow-x-hidden">
           <SensorValues
             sensorBindings={filteredBindings}
             batteryBindings={batteryBindings}


### PR DESCRIPTION
Reported from a narrowed window: a sensor tile cut "16.8°C" mid-value and grew a small horizontal scrollbar under it, while a third of the tile sat empty to the left of the picto.


## What was actually wrong

Not the `1fr auto 1fr` grid the tiles share — `overflow-y-auto` on the readings column. An item that scrolls has an automatic minimum size of zero, so the track stopped asking for the width its content needs and collapsed to a bare `1fr` share, the same share as the empty spacer facing it. Measured on a 224 px card: **39 px of spacer, 120 px of picto, 39 px for a column that needed 51**. The scrollbar was the second half of the same rule: a `visible` axis computes to `auto` next to a scrollable one.

## The fix

- `min-w-fit` on the readings gives the track its minimum back.
- The picto sits in a wrapper that may scale it down to 72 px.
- `overflow-x-hidden` retires the phantom scrollbar; vertical scrolling for a sensor with many readings is untouched.

The order in which things give ground is now: the empty spacer, then the drawing, then — only if there is genuinely nothing left — the readings.

## Verified in a browser, against a live instance

| card | tracks before | tracks after |
| --- | --- | --- |
| 224 px (viewport 750) | 39 / 120 / 39, readings clipped, scrollbar | 27 / 120 / 51, whole |
| 195 px (viewport 660) | 26 / 120 / 26, clipped | 0 / 117 / 51, whole |
| wide tile | unchanged | unchanged |

The mobile card stacks its readings under the picto and was never affected.

`tsc -b`, `eslint`, and `vitest run src/components/dashboard` (17 files, 173 tests) all pass. The new test fails on `main` and passes here.

Docs-Impact: none — a sensor tile lays out its readings correctly on a narrow window; no documented behaviour changes.

### Before:
<img width="224" height="241" alt="pr938-avant" src="https://github.com/user-attachments/assets/70978b97-6889-447a-8931-6813eac20106" />

### After:
<img width="224" height="241" alt="pr938-apres" src="https://github.com/user-attachments/assets/f8315c83-566b-4502-bb69-c76e5230479d" />
