### PR TITLE
chore(registry): add the simulator at 0.2.0

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -602,5 +602,19 @@
     "sowelVersion": ">=1.43.0",
     "owner": "adn-dev-adrien",
     "sha256": "02b9e67a9aeb3f905d7039051bfe84e953a0b72d6e446ba386931977eb76d244"
+  },
+  {
+    "id": "simulator",
+    "type": "integration",
+    "name": "Simulator",
+    "description": "A simulated home: occupants on an agenda, sun, weather, thermal, a pool, PV and loads, published as ordinary devices",
+    "icon": "House",
+    "author": "mchacher",
+    "repo": "mchacher/sowel-plugin-simulator",
+    "version": "0.2.0",
+    "tags": ["demo", "simulator", "showroom", "testing", "screenshots"],
+    "sowelVersion": ">=1.68.0",
+    "owner": "mchacher",
+    "sha256": "6b6d2b81b9c612c98e14f19066a7a8debaa301dce3108342ef163b47e9fc30bb"
   }
 ]


### PR DESCRIPTION
First release of [`sowel-plugin-simulator`](https://github.com/mchacher/sowel-plugin-simulator), the plugin behind the public showroom — and behind the documentation screenshot pipeline, which has wanted a live instance for a while (`sowel-docs` says it plainly: an inert instance cannot photograph a live one).

It publishes a simulated home as ordinary devices: sixteen rooms over four levels, four occupants on weekday and weekend agendas, a pool with a cover that actually stops evaporation, a thermodynamic water heater with the 230 V surplus contact spec 152 models, PV and household loads. Ninety-two devices. Sowel's own recipes and the capacity arbiter do the automation on top; nothing in the plugin knows what a recipe is.

| | |
| --- | --- |
| `version` | 0.2.0, matching the published tag |
| `owner` | `mchacher` — reads as official |
| `sha256` | `6b6d2b81…` from `node scripts/backfill-registry-sha256.mjs` |
| `sowelVersion` | `>=1.68.0` |

## Why this is presented rather than merged

**It is the only part of the showroom project that touches this repository**, and merging it propagates to every Sowel instance within the hour via the CDN cache. Everything else lives in the three showroom repos, which run the published image unmodified.

Nothing here depends on the entry: an instance that never installs the plugin is unaffected, and the install flow refuses any entry missing `sha256` or `owner` — both are present.

## Verified

Installed on a stock Sowel 1.68.0 and walked end to end: 92 devices online, 21 of 22 recipe instances started, `sim.motion` firing the motion-light recipe with the journal attributing the lamp to it, and the capacity arbiter granting the water heater its surplus on a forced sunny sky while correctly reserving its own grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)