### PR TITLE
chore(registry): bump pool-pump-schedule to 1.8.3

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -330,7 +330,7 @@
     "icon": "Waves",
     "author": "mchacher",
     "repo": "mchacher/sowel-recipe-pool-pump-schedule",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "tags": ["pool", "pump", "heating", "schedule", "automation", "temperature", "solar", "energy"],
     "i18n": {
       "fr": {
@@ -340,7 +340,7 @@
     },
     "sowelVersion": ">=1.52.0",
     "owner": "mchacher",
-    "sha256": "2edc6bdecc47e3bc48928377263aa55f3ce839d8b1bb467aa46d9c6aa5d49d1a"
+    "sha256": "9c390eb3ef97eda046d520e561cd945df1e5993823e1594f76eb3ed12edabc1e"
   },
   {
     "id": "freecooling",


### PR DESCRIPTION
Registry hash bump for [sowel-recipe-pool-pump-schedule v1.8.3](https://github.com/mchacher/sowel-recipe-pool-pump-schedule/releases/tag/v1.8.3) (spec 089).

What the release fixes: a pump claim the arbiter denied (`override-active`, the 2 h suspension after a manual order) was kept by the recipe as if it were live, so the pump never asked for solar surplus again until the instance was restarted. With a heater configured that could last for days — four on the reference installation, 2026-09-08 → 09-12, with 10–15 kWh exported daily. Issue mchacher/sowel-recipe-pool-pump-schedule#26, PR #27.

- `version` 1.8.2 → 1.8.3, `sha256` recomputed from the release asset, `bash scripts/check-registry-bump.sh` green locally.

Docs-Impact: none — registry data only, the recipe's own README carries the behaviour note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)